### PR TITLE
fix: allow the first activity to be reporting

### DIFF
--- a/web/src/app/chat/components/research-block.tsx
+++ b/web/src/app/chat/components/research-block.tsx
@@ -65,8 +65,10 @@ export function ResearchBlock({
 
   // When the research id changes, set the active tab to activities
   useEffect(() => {
-    setActiveTab("activities");
-  }, [researchId]);
+    if (!hasReport) {
+      setActiveTab("activities");
+    }
+  }, [hasReport, researchId]);
 
   return (
     <div className={cn("h-full w-full", className)}>

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -182,24 +182,17 @@ function appendMessage(message: Message) {
     message.agent === "reporter" ||
     message.agent === "researcher"
   ) {
+    if (!getOngoingResearchId()) {
+      const id = message.id;
+      appendResearch(id);
+      openResearch(id);
+    }
     appendResearchActivity(message);
   }
   useStore.getState().appendMessage(message);
 }
 
 function updateMessage(message: Message) {
-  if (
-    message.agent === "researcher" ||
-    message.agent === "coder" ||
-    message.agent === "reporter"
-  ) {
-    const id = message.id;
-    if (!getOngoingResearchId()) {
-      appendResearch(id);
-      openResearch(id);
-    }
-  }
-
   if (
     getOngoingResearchId() &&
     message.agent === "reporter" &&
@@ -244,12 +237,15 @@ function appendResearchActivity(message: Message) {
   const researchId = getOngoingResearchId();
   if (researchId) {
     const researchActivityIds = useStore.getState().researchActivityIds;
-    useStore.setState({
-      researchActivityIds: new Map(researchActivityIds).set(researchId, [
-        ...researchActivityIds.get(researchId)!,
-        message.id,
-      ]),
-    });
+    const current = researchActivityIds.get(researchId)!;
+    if (!current.includes(message.id)) {
+      useStore.setState({
+        researchActivityIds: new Map(researchActivityIds).set(researchId, [
+          ...current,
+          message.id,
+        ]),
+      });
+    }
     if (message.agent === "reporter") {
       useStore.setState({
         researchReportIds: new Map(useStore.getState().researchReportIds).set(


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/47b8ba5f-7da6-4304-a18c-9a1f57cd1031)

When the question is simple enough to answer directly, the research team(using DeepSeek V3) will specify the reporter as the only assignee. In this case, the web UI will not render.

This PR has fixed this issue.