### PR TITLE
Allow concurrently run server.py and web in production mode.

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -10,9 +10,10 @@ IF "%MODE%"=="development" GOTO DEV
 
 :PROD
 echo Starting DeerFlow in [PRODUCTION] mode...
-uv run server.py
+start uv run server.py
 cd web
-pnpm start
+start pnpm dev
+REM Wait for user to close
 GOTO END
 
 :DEV

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -12,7 +12,7 @@ IF "%MODE%"=="development" GOTO DEV
 echo Starting DeerFlow in [PRODUCTION] mode...
 start uv run server.py
 cd web
-start pnpm dev
+start pnpm start
 REM Wait for user to close
 GOTO END
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,6 +11,8 @@ if [ "$1" = "--dev" -o "$1" = "-d" -o "$1" = "dev" -o "$1" = "development" ]; th
   wait
 else
   echo -e "Starting DeerFlow in [PRODUCTION] mode...\n"
-  uv run server.py
-  cd web && pnpm start
+  uv run server.py & SERVER_PID=$$!
+  cd web && pnpm start & WEB_PID=$$!
+  trap "kill $$SERVER_PID $$WEB_PID" SIGINT SIGTERM
+  wait
 fi


### PR DESCRIPTION
When I run `bootstrap.sh` without the `-d` option, surprisingly, only `server.py` is running — the frontend sub-project `web` is not started. Therefore, I recommend optimizing the script, as detailed in the diff.