### PR TITLE
optimize docker backend image size(reduced by 60%)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 # Install uv.
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv


### PR DESCRIPTION
It's better to reduce the backend docker image's size. I found that the current backend docker image size is so large.

This is the current docker base image and the resulting image size after the build process.

| Repository | Tag | Image ID | Created | Size |
|------------|-----|----------|---------|------|
| ghcr.io/astral-sh/uv | python3.12-bookworm | aa0a0983c68f | 6 days ago | 1.06GB |
| deer-flow-backend | latest | 4b3ca7e4cee0 | 40 minutes ago | 1.36GB |

Changing the base image significantly reduced the resulting Docker image size, cutting it by at least 60%.

| Repository | Tag | Image ID | Created | Size |
|------------|-----|----------|---------|------|
| ghcr.io/astral-sh/uv | python3.12-bookworm-slim | 481b72cdf2df | 6 days ago | 165MB |
| deer-flow-backend | latest-slim | 5657ac3d2601 | 5 minutes ago | 461MB |