### PR TITLE
feat: add support for Azure OpenAI

### DIFF
--- a/src/llms/llm.py
+++ b/src/llms/llm.py
@@ -2,18 +2,19 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, AzureChatOpenAI
+from langchain_core.language_models.chat_models import BaseChatModel
 
 from src.config import load_yaml_config
 from src.config.agents import LLMType
 
 # Cache for LLM instances
-_llm_cache: dict[LLMType, ChatOpenAI] = {}
+_llm_cache: dict[LLMType, BaseChatModel] = {}
 
 
-def _create_llm_use_conf(llm_type: LLMType, conf: Dict[str, Any]) -> ChatOpenAI:
+def _create_llm_use_conf(llm_type: LLMType, conf: Dict[str, Any]) -> BaseChatModel:
     llm_type_map = {
         "reasoning": conf.get("REASONING_MODEL"),
         "basic": conf.get("BASIC_MODEL"),
@@ -24,6 +25,50 @@ def _create_llm_use_conf(llm_type: LLMType, conf: Dict[str, Any]) -> ChatOpenAI:
         raise ValueError(f"Unknown LLM type: {llm_type}")
     if not isinstance(llm_conf, dict):
         raise ValueError(f"Invalid LLM Conf: {llm_type}")
+
+    is_azure = "api_version" in llm_conf or (
+        llm_conf.get("base_url") and "azure.com" in llm_conf.get("base_url", "")
+    )
+
+    if is_azure:
+        azure_init_params = {}
+        if llm_conf.get("base_url"):
+            azure_init_params["azure_endpoint"] = llm_conf.get("base_url")
+        if llm_conf.get("api_version"):
+            azure_init_params["openai_api_version"] = llm_conf.get("api_version")
+        if llm_conf.get("model"):
+            azure_init_params["azure_deployment"] = llm_conf.get("model")
+        if llm_conf.get("api_key"):
+            azure_init_params["openai_api_key"] = llm_conf.get("api_key")
+
+        for param_key in ["temperature", "max_tokens", "timeout", "max_retries"]:
+            if param_key in llm_conf:
+                azure_init_params[param_key] = llm_conf[param_key]
+
+        required_azure_keys = [
+            "azure_endpoint",
+            "openai_api_version",
+            "azure_deployment",
+            "openai_api_key",
+        ]
+        for key in required_azure_keys:
+            if key not in azure_init_params or azure_init_params[key] is None:
+                original_key = key
+                if key == "azure_endpoint":
+                    original_key = "base_url"
+                elif key == "openai_api_version":
+                    original_key = "api_version"
+                elif key == "azure_deployment":
+                    original_key = "model (deployment name)"
+                elif key == "openai_api_key":
+                    original_key = "api_key"
+                raise ValueError(
+                    f"Missing or None value for required Azure configuration: '{original_key}' (maps to '{key}') for LLM type '{llm_type}'. "
+                    f"Current llm_conf for this type: {llm_conf}"
+                )
+
+        return AzureChatOpenAI(**azure_init_params)
+
     return ChatOpenAI(**llm_conf)
 
 


### PR DESCRIPTION

This PR adds support for using **Azure OpenAI**, which is currently not supported as of the time of this PR. Users can now provide their Azure credentials and use any deployed model from their Azure OpenAI instance.

It also **closes [issue #45](https://github.com/bytedance/deer-flow/issues/45)**.

#### Configuration Instructions:

Update your `conf.yaml`:

```yaml
BASIC_MODEL:
  base_url: $AZURE_API_BASE
  model: $MODEL
  api_key: $AZURE_API_KEY
  api_version: $API_VERSION
```

Define credentials in your `.env` file:

```env
AZURE_API_BASE=https://azure-xxxxxx-ai-services.cognitiveservices.azure.com/  # your Azure API base URL
AZURE_API_KEY=xxxx  # your API key
API_VERSION=2024-02-15-preview  # API version
MODEL=gpt-4o  # your deployed model (change if not using gpt-4o)
```