### PR TITLE
Feat: flake nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,24 @@ cd deer-flow/web
 pnpm install
 ```
 
+### Using Nix flakes (optional)
+
+If you have Nix and flakes enabled, you can setup all the dependencies with one command:
+
+```bash
+git clone https://github.com/bytedance/deer-flow.git
+cd deer-flow
+
+# drops you into a shell with Python/uv, Node.js, pnpm & marp-cli
+nix develop
+
+# then in one terminal:
+uv run server.py --reload
+
+# and in another:
+pnpm --dir web dev
+```
+
 ### Configurations
 
 Please refer to the [Configuration Guide](docs/configuration_guide.md) for more details.

--- a/README_es.md
+++ b/README_es.md
@@ -105,6 +105,24 @@ cd deer-flow/web
 pnpm install
 ```
 
+### Uso de Nix flakes (opcional)
+
+Si tienes Nix y flakes habilitados, puedes configurar todas las dependencias con un solo comando:
+
+```bash
+git clone https://github.com/bytedance/deer-flow.git
+cd deer-flow
+
+# Entra en el entorno con Python/uv, Node.js, pnpm y marp-cli
+nix develop
+
+# En una terminal:
+uv run server.py --reload
+
+# En otra:
+pnpm --dir web dev
+```
+
 ### Configuraciones
 
 Por favor, consulta la [Guía de Configuración](docs/configuration_guide.md) para más detalles.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,236 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1742669843,
+        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1746328495,
+        "narHash": "sha256-uKCfuDs7ZM3QpCE/jnfubTg459CnKnJG/LwqEVEdEiw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "979daf34c8cacebcd917d540070b52a3c2b9b16e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1744599653,
+        "narHash": "sha256-nysSwVVjG4hKoOjhjvE6U5lIKA8sEr1d1QzEfZsannU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7dba6dbc73120e15b558754c26024f6c93015dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-build-systems",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743438845,
+        "narHash": "sha256-1GSaoubGtvsLRwoYwHjeKYq40tLwvuFFVhGrG8J9Oek=",
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "rev": "8063ec98edc459571d042a640b1c5e334ecfca1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "uv2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746146146,
+        "narHash": "sha256-60+mzI2lbgn+G8F5mz+cmkDvHFn4s5oqcOna1SzYy74=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "3e9623bdd86a3c545e82b7f97cfdba5f07232d9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "pyproject-build-systems",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "pyproject-build-systems",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744279763,
+        "narHash": "sha256-0k6eJPWfI56e9WbjNFTKKYoP8YX31gXHOcKz/zeLdBs=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "2b0fbb003988891c44b01b3e556f5fac817253ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    },
+    "uv2nix_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4",
+        "pyproject-nix": "pyproject-nix_3"
+      },
+      "locked": {
+        "lastModified": 1747441483,
+        "narHash": "sha256-W8BFXk5R0TuJcjIhcGoMpSOaIufGXpizK0pm+uTqynA=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "582024dc64663e9f88d467c2f7f7b20d278349de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,110 @@
+{
+  description = "uv2nix Flake for DeerFlow";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+
+    # The three uv2nix building blocks
+    pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+    pyproject-build-systems.url = "github:pyproject-nix/build-system-pkgs";
+    uv2nix.url = "github:pyproject-nix/uv2nix";
+  };
+
+  outputs = inputs @ {
+    flake-parts,
+    nixpkgs,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      imports = [flake-parts.flakeModules.easyOverlay];
+
+      systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
+
+      perSystem = {
+        self',
+        system,
+        pkgs,
+        lib,
+        ...
+      }: let
+        python = pkgs.python312;
+        workspace = inputs.uv2nix.lib.workspace.loadWorkspace {workspaceRoot = ./.;};
+        # Prefer pre-built wheels for speed.
+        # If a package no longer ships a wheel for your Python version,
+        #   – switch to "sdist" to build from source, OR
+        #   – keep "wheel" and pull from your own binary cache (Cachix, Hydra, …).
+        overlay = workspace.mkPyprojectOverlay {sourcePreference = "wheel";};
+
+        baseSet = pkgs.callPackage inputs.pyproject-nix.build.packages {inherit python;};
+
+        # Custom overrides for sdists that require the legacy setuptools.
+        # These only apply when the builder falls back to an sdist build.
+        pyprojectOverrides = final: prev: rec {
+          # helper that injects the legacy build-system
+          _legacy = bs: (final.resolveBuildSystem bs);
+
+          sgmllib3k = prev.sgmllib3k.overrideAttrs (old: {
+            nativeBuildInputs =
+              (old.nativeBuildInputs or [])
+              ++ [
+                (_legacy {
+                  setuptools = [];
+                  wheel = [];
+                })
+              ];
+          });
+
+          peewee = prev.peewee.overrideAttrs (old: {
+            nativeBuildInputs =
+              (old.nativeBuildInputs or [])
+              ++ [
+                (_legacy {
+                  setuptools = [];
+                  wheel = [];
+                })
+              ];
+          });
+        };
+
+        pythonSet =
+          baseSet.overrideScope
+          (lib.composeManyExtensions [
+            inputs.pyproject-build-systems.overlays.default
+            overlay
+            pyprojectOverrides
+          ]);
+        
+        # Build a fully-deterministic virtual-env named "venv" containing only the deps in workspace.deps.default
+        venv = pythonSet.mkVirtualEnv "venv" workspace.deps.default;
+        
+        # Choose Node.js 22 for the web UI
+        node = pkgs.nodejs_22;
+        
+        # Override pnpm to use that same Node.js interpreter
+        pnpm = pkgs.pnpm.override {nodejs = node;};
+
+
+        # Common toolkit for all shells:
+        # - uv          (Python env manager)
+        # - the venv    (interpreter + all locked Python deps)
+        # - marp-cli    (for PPT generation)
+        # - node + pnpm (for building the frontend)
+        commonPkgs = [pkgs.uv venv pkgs.marp-cli node pnpm];
+      in {
+        overlayAttrs = pythonSet.overlay;
+
+        devShells.common = pkgs.mkShell {packages = commonPkgs;};
+
+        devShells.default = pkgs.mkShell {
+          packages = commonPkgs ++ [pkgs.git];
+          shellHook = ''
+            export UV_PYTHON_DOWNLOADS=never
+            export UV_PYTHON="${venv}/bin/python"
+            export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+            unset PYTHONPATH
+          '';
+        };
+      };
+    };
+}


### PR DESCRIPTION
Introduce a single-file flake.nix that bootstraps the entire DeerFlow tool-chain (Python 3.12 + uv, pinned Python deps, Node 22 + pnpm, marp-cli) with nix develop. This helps developers that use the nix package manager to work and deploy local the project.

Also documentation updated in English and Spanish sections to show how to use it.


#### ✨ What’s new

| Item          | Description                                                                                                             |
|---------------|-------------------------------------------------------------------------------------------------------------------------|
| `flake.nix`   | Full **uv2nix** workflow: loads `pyproject.toml`, builds a deterministic virtual-env, adds Node 22, pnpm, marp-cli, and exposes two `devShell`s (`common`, `default`). |
| `flake.lock`  | Auto-generated lock file; guarantees identical dependency graphs for everyone.                                          |
| Docs          | `README.md` + `es` gain “Using Nix flakes” snippets that show the two-terminal workflow (`uv run` / `pnpm dev`). |


#### 🛠️ How it works

1. **uv2nix** parses `pyproject.toml` and resolves wheels (or sdists → source builds) into a pinned virtual-env. 
2. `devShells.default` drops contributors into a shell containing:  
   - `python` @ 3.12, managed by **uv**  
   - all project + dev + test dependencies  
   - `node` 22 + `pnpm`  
   - `marp-cli` for slide/PPT generation  
3. Helper env-vars (`UV_PYTHON`, `SSL_CERT_FILE`, etc.) are set in `shellHook` so tools *Just Work™*.


#### 🚀 Future-ready (but dev-only today)

The flake already defines:

- overlayAttrs — package overlay for downstream consumers.
- Multiple systems: x86_64-linux, aarch64-linux, x86_64-darwin, aarch64-darwin.

Which means it is possible later:

- Promote packages.${system}.default to build artefacts (wheels, OCI images).
- Expose checks.${system} so CI runs tests/linters via nix build .#checks.
- Provide nix build .#dockerImage (or similar) for container deployments.
- And much more.

It has been tested on an x86 machine on the unstable NixOS channel. It has support for Mac using Darwin, and ARM (not yet tested).

This flakes rellys on this projects:

[github:pyproject-nix/uv2nix](https://github.com/pyproject-nix/uv2nix)
[github:pyproject-nix/pyproject.nix](https://github.com/pyproject-nix/pyproject.nix)
[github:pyproject-nix/build-system-pkgs](https://github.com/pyproject-nix/build-system-pkgs)




