### PR TITLE
fix: 修复因权限不足导致无法启动问题

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - ./conf.yaml:/app/conf.yaml
     restart: unless-stopped
+    privileged: true
     networks:
       - deer-flow-network
 
@@ -28,6 +29,7 @@ services:
     depends_on:
       - backend
     restart: unless-stopped
+    privileged: true
     networks:
       - deer-flow-network
 


### PR DESCRIPTION
### 1.  image: deer-flow-backend , error: 

```
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 270, in __call__
    await wrap(partial(self.listen_for_disconnect, receive))
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 266, in wrap
    await func()
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 234, in listen_for_disconnect
    message = await receive()
              ^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py", line 531, in receive
    await self.message_event.wait()
  File "/usr/local/lib/python3.12/asyncio/locks.py", line 212, in wait
    await fut
asyncio.exceptions.CancelledError: Cancelled by cancel scope 7f7221eedbb0

During handling of the above exception, another exception occurred:

  + Exception Group Traceback (most recent call last):
  |   File "/app/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 76, in collapse_excgroups
  |     yield
  |   File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 263, in __call__
  |     async with anyio.create_task_group() as task_group:
  |                ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/app/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 767, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/app/.venv/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    |     result = await app(  # type: ignore[func-returns-value]
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/app/.venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    |     return await self.app(scope, receive, send)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/app/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    |     await super().__call__(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/applications.py", line 112, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 187, in __call__
    |     raise exc
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 165, in __call__
    |     await self.app(scope, receive, _send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 93, in __call__
    |     await self.simple_response(scope, receive, send, request_headers=headers)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 144, in simple_response
    |     await self.app(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 714, in __call__
    |     await self.middleware_stack(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 734, in app
    |     await route.handle(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 288, in handle
    |     await self.app(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 76, in app
    |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    |     raise exc
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    |     await app(scope, receive, sender)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 74, in app
    |     await response(scope, receive, send)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 262, in __call__
    |     with collapse_excgroups():
    |          ^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
    |     self.gen.throw(value)
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    |     raise exc
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 266, in wrap
    |     await func()
    |   File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 246, in stream_response
    |     async for chunk in self.body_iterator:
    |   File "/app/src/server/app.py", line 100, in _astream_workflow_generator
    |     async for agent, _, event_data in graph.astream(
    |   File "/app/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2759, in astream
    |     async for _ in runner.atick(
    |   File "/usr/local/lib/python3.12/asyncio/base_events.py", line 867, in run_in_executor
    |     executor.submit(func, *args), loop=self)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 180, in submit
    |     self._adjust_thread_count()
    |   File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 203, in _adjust_thread_count
    |     t.start()
    |   File "/usr/local/lib/python3.12/threading.py", line 994, in start
    |     _start_new_thread(self._bootstrap, ())
    | RuntimeError: can't start new thread
    | During task with name 'coordinator' and id 'dfb0e773-8968-9070-399b-5c401bfd84a5'
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/protocols/http/h11_impl.py", line 403, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
    return await self.app(scope, receive, send)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/.venv/lib/python3.12/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/applications.py", line 112, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 187, in __call__
    raise exc
  File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/errors.py", line 165, in __call__
    await self.app(scope, receive, _send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 93, in __call__
    await self.simple_response(scope, receive, send, request_headers=headers)
  File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/cors.py", line 144, in simple_response
    await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 714, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 734, in app
    await route.handle(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 288, in handle
    await self.app(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 76, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    raise exc
  File "/app/.venv/lib/python3.12/site-packages/starlette/_exception_handler.py", line 42, in wrapped_app
    await app(scope, receive, sender)
  File "/app/.venv/lib/python3.12/site-packages/starlette/routing.py", line 74, in app
    await response(scope, receive, send)
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 262, in __call__
    with collapse_excgroups():
         ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/app/.venv/lib/python3.12/site-packages/starlette/_utils.py", line 82, in collapse_excgroups
    raise exc
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 266, in wrap
    await func()
  File "/app/.venv/lib/python3.12/site-packages/starlette/responses.py", line 246, in stream_response
    async for chunk in self.body_iterator:
  File "/app/src/server/app.py", line 100, in _astream_workflow_generator
    async for agent, _, event_data in graph.astream(
  File "/app/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2759, in astream
    async for _ in runner.atick(
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 867, in run_in_executor
    executor.submit(func, *args), loop=self)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 180, in submit
    self._adjust_thread_count()
  File "/usr/local/lib/python3.12/concurrent/futures/thread.py", line 203, in _adjust_thread_count
    t.start()
  File "/usr/local/lib/python3.12/threading.py", line 994, in start
    _start_new_thread(self._bootstrap, ())
RuntimeError: can't start new thread
During task with name 'coordinator' and id 'dfb0e773-8968-9070-399b-5c401bfd84a5
```

### 2. image: deer-flow-frontend , error:

```
  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f51ef4e024a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f51ef4e0305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f446f88a24a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f446f88a305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f8f6dc1424a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f8f6dc14305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f0c1187b24a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f0c1187b305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f6ab4fb324a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f6ab4fb3305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f1a00c7824a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f1a00c78305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f65e015d24a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f65e015d305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f1583b6b24a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f1583b6b305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]

  #  /nodejs/bin/node[1]: std::unique_ptr<long unsigned int> node::WorkerThreadsTaskRunner::DelayedTaskScheduler::Start() at ../src/node_platform.cc:68
  #  Assertion failed: (0) == (uv_thread_create(t.get(), start_thread, this))

----- Native stack trace -----

 1: 0xcc7f77 node::Assert(node::AssertionInfo const&) [/nodejs/bin/node]
 2: 0xd468fe node::WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(int) [/nodejs/bin/node]
 3: 0xd469dc node::NodePlatform::NodePlatform(int, v8::TracingController*, v8::PageAllocator*) [/nodejs/bin/node]
 4: 0xc7d177  [/nodejs/bin/node]
 5: 0xc7e6d4 node::Start(int, char**) [/nodejs/bin/node]
 6: 0x7f4e5ee4424a  [/lib/x86_64-linux-gnu/libc.so.6]
 7: 0x7f4e5ee44305 __libc_start_main [/lib/x86_64-linux-gnu/libc.so.6]
 8: 0xbd182e _start [/nodejs/bin/node]
```
