### PR TITLE
fix: normalize line endings for consistent chunk splitting

### DIFF
--- a/web/src/core/api/chat.ts
+++ b/web/src/core/api/chat.ts
@@ -101,7 +101,8 @@ async function* chatReplayStream(
   const text = await fetchReplay(replayFilePath, {
     abortSignal: options.abortSignal,
   });
-  const chunks = text.split("\n\n");
+  const normalizedText = text.replace(/\r\n/g, "\n");
+  const chunks = normalizedText.split("\n\n");
   for (const chunk of chunks) {
     const [eventRaw, dataRaw] = chunk.split("\n") as [string, string];
     const [, event] = eventRaw.split("event: ", 2) as [string, string];


### PR DESCRIPTION
# 修改前
原有的分词逻辑在 web/src/core/api/chat.ts 的 fetchReplayTitle() 内判断类型时，有时会因为多了个‘\r’回车符而分词失败，最终导致无法replay
![Pasted image 20250523152412](https://github.com/user-attachments/assets/0bf179d4-0d43-4674-8726-473479dd5b5f)
![Pasted image 20250523153500](https://github.com/user-attachments/assets/bebcec56-6347-4174-8c98-076fcab59e96)

![Pasted image 20250523105727](https://github.com/user-attachments/assets/7825569a-911c-4b88-a9e0-625669ff30e3)

# 修改后
统一替换掉'\r'符号，使replay功能正常
![Pasted image 20250523154233](https://github.com/user-attachments/assets/4e6c3117-4d7d-48aa-b4e0-a24869a4bdc2)
