### PR TITLE
[Fix] fix logic error in investigation_node

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -50,16 +50,20 @@ def background_investigation_node(
     logger.info("background investigation node is running.")
     configurable = Configuration.from_runnable_config(config)
     query = state["messages"][-1].content
-    if SELECTED_SEARCH_ENGINE == SearchEngine.TAVILY:
+    if SELECTED_SEARCH_ENGINE == SearchEngine.TAVILY.value:
         searched_content = LoggedTavilySearch(
             max_results=configurable.max_search_results
         ).invoke({"query": query})
-        background_investigation_results = None
+        background_investigation_results = []
         if isinstance(searched_content, list):
-            background_investigation_results = [
-                {"title": elem["title"], "content": elem["content"]}
-                for elem in searched_content
-            ]
+            for elem in searched_content:
+                if elem.get("type") == "page":
+                    background_investigation_results.append(
+                        {
+                            "title": elem.get("title", ""),
+                            "content": elem.get("content", ""),
+                        }
+                    )
         else:
             logger.error(
                 f"Tavily search returned malformed response: {searched_content}"


### PR DESCRIPTION
###  Fix logic error in investigation_node
#### 1. fix comparing `str` with `enum` (always False)
```bash
import enum
class SearchEngine(enum.Enum):
    TAVILY = "tavily"
    DUCKDUCKGO = "duckduckgo"
    BRAVE_SEARCH = "brave_search"
    ARXIV = "arxiv"
# correct
assert("tavily" == SearchEngine.TAVILY.value)
# assert failed
assert("tavily" == SearchEngine.TAVILY)
```
#### 2. fix crash when accessing  `title` field for image result