### PR TITLE
Fix settings tab display name error in build version

### DIFF
--- a/web/src/app/settings/tabs/about-tab.tsx
+++ b/web/src/app/settings/tabs/about-tab.tsx
@@ -12,3 +12,4 @@ export const AboutTab: Tab = () => {
   return <Markdown>{about}</Markdown>;
 };
 AboutTab.icon = BadgeInfo;
+AboutTab.displayName = "About";

--- a/web/src/app/settings/tabs/general-tab.tsx
+++ b/web/src/app/settings/tabs/general-tab.tsx
@@ -176,5 +176,5 @@ export const GeneralTab: Tab = ({
     </div>
   );
 };
-GeneralTab.displayName = "";
+GeneralTab.displayName = "General";
 GeneralTab.icon = Settings;

--- a/web/src/app/settings/tabs/index.tsx
+++ b/web/src/app/settings/tabs/index.tsx
@@ -8,7 +8,7 @@ import { GeneralTab } from "./general-tab";
 import { MCPTab } from "./mcp-tab";
 
 export const SETTINGS_TABS = [GeneralTab, MCPTab, AboutTab].map((tab) => {
-  const name = tab.name ?? tab.displayName;
+  const name = tab.displayName ?? tab.name;
   return {
     ...tab,
     id: name.replace(/Tab$/, "").toLocaleLowerCase(),

--- a/web/src/app/settings/tabs/mcp-tab.tsx
+++ b/web/src/app/settings/tabs/mcp-tab.tsx
@@ -179,6 +179,7 @@ export const MCPTab: Tab = ({ settings, onChange }) => {
   );
 };
 MCPTab.icon = Blocks;
+MCPTab.displayName = "MCP";
 MCPTab.badge = "Beta";
 
 function mergeServers(


### PR DESCRIPTION
Settings tab display name is changed after building.

This PR fixes it.