### PR TITLE
fix: correct placeholder for API key in configuration guide

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -49,7 +49,7 @@ BASIC_MODEL:
 BASIC_MODEL:
   base_url: "https://api.deepseek.com"
   model: "deepseek-chat"
-  api_key: YOU_API_KEY
+  api_key: YOUR_API_KEY
 
 # An example of Google Gemini models using OpenAI-Compatible interface
 BASIC_MODEL:


### PR DESCRIPTION
This PR fixes a typo in the API key placeholder within the configuration guide. The incorrect placeholder YOU_API_KEY has been corrected to YOUR_API_KEY to ensure clarity and accuracy in the documentation.

Changes:

- Updated YOU_API_KEY to YOUR_API_KEY in docs/configuration_guide.md (line 52).

- This small but important correction helps avoid confusion for users when configuring their API keys.