### PR TITLE
Fix/aiohttp proxy support

### DIFF
--- a/src/tools/tavily_search/tavily_search_api_wrapper.py
+++ b/src/tools/tavily_search/tavily_search_api_wrapper.py
@@ -70,7 +70,7 @@ class EnhancedTavilySearchAPIWrapper(OriginalTavilySearchAPIWrapper):
                 "include_images": include_images,
                 "include_image_descriptions": include_image_descriptions,
             }
-            async with aiohttp.ClientSession() as session:
+            async with aiohttp.ClientSession(trust_env=True) as session:
                 async with session.post(f"{TAVILY_API_URL}/search", json=params) as res:
                     if res.status == 200:
                         data = await res.text()


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The Tavily search API wrapper was not respecting proxy environment variables (like `HTTP_PROXY`, `HTTPS_PROXY`) when making HTTP requests through aiohttp.ClientSession, which could cause network connectivity issues in environments that require proxy configuration.

### Solution
Added `trust_env=True` parameter to the aiohttp.ClientSession constructor in the Tavily search API wrapper to enable automatic proxy detection from environment variables.

### Changes
- **File**: `src/tools/tavily_search/tavily_search_api_wrapper.py`
- **Line 72**: Added `trust_env=True` to `aiohttp.ClientSession()` in the `raw_results_async` method

### Code Changes
```python
# Before
async with aiohttp.ClientSession() as session:

# After  
async with aiohttp.ClientSession(trust_env=True) as session:
```

### Testing
- [x] Verified that existing functionality remains unchanged
- [x] No breaking changes to existing API

### Related Issues
Fixes network connectivity issues in proxy environments.

### Checklist
- [x] Code follows project style guidelines
- [x] Change is focused and minimal
- [x] No breaking changes
- [x] Maintains backward compatibility