### PR TITLE
fix: add line breaks to mcp edit dialog

### DIFF
--- a/web/src/app/settings/dialogs/add-mcp-server-dialog.tsx
+++ b/web/src/app/settings/dialogs/add-mcp-server-dialog.tsx
@@ -138,7 +138,7 @@ export function AddMCPServerDialog({
 
         <main>
           <Textarea
-            className="h-[360px]"
+            className="h-[360px] break-all"
             placeholder={
               'Example:\n\n{\n  "mcpServers": {\n    "My Server": {\n      "command": "python",\n      "args": [\n        "-m", "mcp_server"\n      ],\n      "env": {\n        "API_KEY": "YOUR_API_KEY"\n      }\n    }\n  }\n}'
             }


### PR DESCRIPTION
long url will cause display issue
before:
![image](https://github.com/user-attachments/assets/1c2886b7-cf4a-4cb8-b454-7d82cfb434b2)
after:
 
![image](https://github.com/user-attachments/assets/dbcab3dd-67ef-4d81-8c25-91f1a81ed1af)

