### PR TITLE
fix: solves the malformed json output and pydantic validation error

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -104,7 +104,8 @@ def planner_node(
     if AGENT_LLM_MAP["planner"] == "basic":
         llm = get_llm_by_type(AGENT_LLM_MAP["planner"]).with_structured_output(
             Plan,
-            method="json_mode",
+            method="json_schema",
+            strict=True,
         )
     else:
         llm = get_llm_by_type(AGENT_LLM_MAP["planner"])


### PR DESCRIPTION
### Problem:
The `planner` node expects an llm response in a specific json format, but the llm response does not always comply with that format so pydantic raises a model validation error, as reported by users in these issues:
https://github.com/bytedance/deer-flow/issues/151
https://github.com/bytedance/deer-flow/issues/189
https://github.com/bytedance/deer-flow/issues/191
and possibly here:
https://github.com/bytedance/deer-flow/issues/99
https://github.com/bytedance/deer-flow/issues/217
### Fix:
The fixed code modifies the request made by the `planner` node to force the llm response to strictly comply with the pydantic `Plan` model at the sampler level, so this fix works for any model where the sampler respects a strict json response format parameter.