### PR TITLE
fix(web): priority displayName for settings name error

### DIFF
--- a/web/src/app/settings/tabs/about-tab.tsx
+++ b/web/src/app/settings/tabs/about-tab.tsx
@@ -12,3 +12,4 @@ export const AboutTab: Tab = () => {
   return <Markdown>{about}</Markdown>;
 };
 AboutTab.icon = BadgeInfo;
+AboutTab.displayName = "About";

--- a/web/src/app/settings/tabs/general-tab.tsx
+++ b/web/src/app/settings/tabs/general-tab.tsx
@@ -179,5 +179,5 @@ export const GeneralTab: Tab = ({
     </div>
   );
 };
-GeneralTab.displayName = "";
+GeneralTab.displayName = "General";
 GeneralTab.icon = Settings;

--- a/web/src/app/settings/tabs/index.tsx
+++ b/web/src/app/settings/tabs/index.tsx
@@ -8,7 +8,7 @@ import { GeneralTab } from "./general-tab";
 import { MCPTab } from "./mcp-tab";
 
 export const SETTINGS_TABS = [GeneralTab, MCPTab, AboutTab].map((tab) => {
-  const name = tab.name ?? tab.displayName;
+  const name = tab.displayName ?? tab.name;
   return {
     ...tab,
     id: name.replace(/Tab$/, "").toLocaleLowerCase(),

--- a/web/src/app/settings/tabs/mcp-tab.tsx
+++ b/web/src/app/settings/tabs/mcp-tab.tsx
@@ -180,6 +180,7 @@ export const MCPTab: Tab = ({ settings, onChange }) => {
 };
 MCPTab.icon = Blocks;
 MCPTab.badge = "Beta";
+MCPTab.displayName = "MCP";
 
 function mergeServers(
   existing: MCPServerMetadata[],


### PR DESCRIPTION
right display.
![image](https://github.com/user-attachments/assets/e12485d9-19d5-4490-b1ca-6ebc4753ebea)

error display on volcengine vefaas.
![image](https://github.com/user-attachments/assets/4f8f54e9-429c-47c9-9474-627a0f8a082e)

fixed: after `pnpm run build`, the "General" name was retained.
![image](https://github.com/user-attachments/assets/3d0f8d61-e342-4dc6-884f-861073963cc0)
