### PR TITLE
fix: "parsed json with extra tokens" replace json before js fence

### DIFF
--- a/web/src/core/utils/json.ts
+++ b/web/src/core/utils/json.ts
@@ -7,8 +7,8 @@ export function parseJSON<T>(json: string | null | undefined, fallback: T) {
   try {
     const raw = json
       .trim()
-      .replace(/^```js\s*/, "")
       .replace(/^```json\s*/, "")
+      .replace(/^```js\s*/, "")
       .replace(/^```ts\s*/, "")
       .replace(/^```plaintext\s*/, "")
       .replace(/^```\s*/, "")


### PR DESCRIPTION
Avoid JSON parse error "parsed json with extra tokens"

previously，js fence was replace before json fence, so when there is the text like

````
```json
{
  ...
````

it will become
````
on
{
  ...
````

and yield an error "parsed json with extra tokens" from parse function

The solution is to change the order of replace functions.