### PR TITLE
default mcp config for every user

### DIFF
--- a/web/public/mcp.json.example
+++ b/web/public/mcp.json.example
@@ -1,0 +1,29 @@
+{
+    "servers": [
+        {
+            "name": "example-sse-mcp-server",
+            "transport": "sse",
+            "url": "https://example.com/mcp",
+            "enabled": true,
+            "env": {},
+            "tools": [],
+            "createdAt": 0,
+            "updatedAt": 0
+        },
+        {
+            "name": "example-stdio-mcp-server",
+            "transport": "stdio",
+            "command": "npx",
+            "args": [
+                "-y",
+                "mcp-remote",
+                "https://example.com/mcp"
+            ],
+            "enabled": true,
+            "env": {},
+            "tools": [],
+            "createdAt": 0,
+            "updatedAt": 0
+        }
+    ]
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import Script from "next/script";
 import { ThemeProviderWrapper } from "~/components/deer-flow/theme-provider-wrapper";
 import { loadConfig } from "~/core/api/config";
 import { env } from "~/env";
+import MCPConfigProvider from "../components/deer-flow/mcp-config-provider";
 
 import { Toaster } from "../components/deer-flow/toaster";
 
@@ -46,7 +47,9 @@ export default async function RootLayout({
         </Script>
       </head>
       <body className="bg-app">
-        <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
+        <MCPConfigProvider>
+          <ThemeProviderWrapper>{children}</ThemeProviderWrapper>
+        </MCPConfigProvider>
         <Toaster />
         {
           // NO USER BEHAVIOR TRACKING OR PRIVATE DATA COLLECTION BY DEFAULT

--- a/web/src/components/deer-flow/mcp-config-provider.tsx
+++ b/web/src/components/deer-flow/mcp-config-provider.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useEffect } from "react";
+import { env } from "../../env";
+import { changeSettings, useSettingsStore } from "../../core/store/settings-store";
+
+export default function MCPConfigProvider({ children }: { children: React.ReactNode }) {
+  useEffect(() => {
+    const configPath = (env as Record<string, any>).NEXT_PUBLIC_MCP_CONFIG_PATH || "/mcp.json";
+    fetch(configPath)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.servers) {
+          changeSettings({
+            ...useSettingsStore.getState(),
+            mcp: { servers: data.servers },
+          });
+        }
+      })
+      .catch(() => {});
+  }, []);
+  return <>{children}</>;
+} 


### PR DESCRIPTION
By default, each user must manually configure the MCP Server to use MCP. This PR allows the front-end service to load a default mcp.json as the default MCP Server list when starting.