### PR TITLE
fix: Handle API errors during build process

### DIFF
--- a/web/src/core/api/config.ts
+++ b/web/src/core/api/config.ts
@@ -8,10 +8,33 @@ declare global {
   }
 }
 
-export async function loadConfig() {
-  const res = await fetch(resolveServiceURL("./config"));
-  const config = await res.json();
-  return config;
+export async function loadConfig(): Promise<DeerFlowConfig> {
+  try {
+    const res = await fetch(resolveServiceURL("./config"));
+    if (!res.ok) {
+      console.warn(`Failed to fetch config, status: ${res.status}. Using default config.`);
+      // Return a default config if the fetch was not successful (e.g. 404, 500)
+      return getDefaultConfig();
+    }
+    const config = await res.json();
+    return config;
+  } catch (error) {
+    console.warn("Error fetching config:", error, "Using default config.");
+    // Return a default config if the fetch itself fails (e.g. network error)
+    return getDefaultConfig();
+  }
+}
+
+function getDefaultConfig(): DeerFlowConfig {
+  return {
+    rag: {
+      provider: "default", // Or some other sensible default
+    },
+    models: {
+      basic: ["default-basic-model"], // Or empty array
+      reasoning: ["default-reasoning-model"], // Or empty array
+    },
+  };
 }
 
 export function getConfig(): DeerFlowConfig {


### PR DESCRIPTION
Modified the `loadConfig` function to provide a default configuration when the API is unavailable. This prevents build failures when the backend server is not running, allowing the frontend to be built independently.