### PR TITLE
fix: add missing translation for chat.page

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -75,6 +75,9 @@
     "copyright": "DeerFlow"
   },
   "chat": {
+    "page": {
+        "starOnGitHub": "Star on GitHub"
+    },
     "welcome": {
       "greeting": "👋 Hello, there!",
       "description": "Welcome to 🦌 DeerFlow, a deep research assistant built on cutting-edge language models, helps you search on web, browse information, and handle complex tasks."

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -76,6 +76,8 @@
   },
   "chat": {
     "page": {
+        "loading": "Loading DeerFlow...",
+        "welcomeUser": "Welcome, {username}",
         "starOnGitHub": "Star on GitHub"
     },
     "welcome": {


### PR DESCRIPTION
Fixed a `MISSING_MESSAGE` error that was occurring on the chat page due to missing translation keys for `chat.page` in the internationalization messages.
**Error Details：**
Error: MISSING_MESSAGE: Could not resolve chat.page in messages for locale en.

<img width="1024" height="568" alt="a62a8a99610cf3e1c5e5bdc4fc0e82f6" src="https://github.com/user-attachments/assets/a1be9869-463b-4b12-aea8-595bcb29af5c" />
