### PR TITLE
fix: missing i18n message

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -75,6 +75,9 @@
     "copyright": "DeerFlow"
   },
   "chat": {
+    "page": {
+      "starOnGitHub": "Star DeerFlow on GitHub"
+    },
     "welcome": {
       "greeting": "👋 Hello, there!",
       "description": "Welcome to 🦌 DeerFlow, a deep research assistant built on cutting-edge language models, helps you search on web, browse information, and handle complex tasks."


### PR DESCRIPTION
Fix missing translation key ```chat.page```

Error Detail
<img width="1934" height="1042" alt="image" src="https://github.com/user-attachments/assets/afc57223-8043-4f83-a1c5-51bc6b656454" />
