### PR TITLE
fix: handle empty agent tuple in streaming workflow

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -153,9 +153,13 @@ async def _astream_workflow_generator(
         message_chunk, message_metadata = cast(
             tuple[BaseMessage, dict[str, any]], event_data
         )
+        # Handle empty agent tuple gracefully
+        agent_name = "unknown"
+        if agent and len(agent) > 0:
+            agent_name = agent[0].split(":")[0] if ":" in agent[0] else agent[0]
         event_stream_message: dict[str, any] = {
             "thread_id": thread_id,
-            "agent": agent[0].split(":")[0],
+            "agent": agent_name,
             "id": message_chunk.id,
             "role": "assistant",
             "content": message_chunk.content,


### PR DESCRIPTION
Prevents IndexError when agent[0] is accessed on empty tuple, resolving display issues tested using Gemini 2.0 Flash model.

Fixes #425