### PR TITLE
fix:The console UI directly throws an error when user input is empty.

### DIFF
--- a/main.py
+++ b/main.py
@@ -140,7 +140,11 @@ if __name__ == "__main__":
         if args.query:
             user_query = " ".join(args.query)
         else:
-            user_query = input("Enter your query: ")
+            # Loop until user provides non-empty input
+            while True:
+                user_query = input("Enter your query: ")
+                if user_query is not None and user_query != "":
+                    break
 
         # Run the agent workflow with the provided parameters
         ask(


### PR DESCRIPTION

Issue:
When running with Console UI, if the user input is empty, an error will be reported directly after pressing Enter and the system will be forced to exit.

<img width="809" height="120" alt="e57dda4e878354fc55e065dac" src="https://github.com/user-attachments/assets/c0cfaa3f-c538-4505-b04e-990e8f92b880" />



Solution:
If the user input is empty, ignore the input and ask the user to input again.
<img width="920" height="167" alt="6d70cf429a3210df71db4a479" src="https://github.com/user-attachments/assets/2ada0a05-5b65-427e-8c2b-28843c0a7fc0" />



