### PR TITLE
fix: fix the bug introduced by coordinator messages update

### DIFF
--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -243,16 +243,12 @@ def coordinator_node(
             "Coordinator response contains no tool calls. Terminating workflow execution."
         )
         logger.debug(f"Coordinator response: {response}")
-    old_messages = state.get("messages", [])
-    new_messages = old_messages + [
-        {
-            "role": "assistant",
-            "content": response.content,
-        }
-    ]
+    messages = state.get("messages", [])
+    if response.content:
+        messages.append(HumanMessage(content=response.content, name="coordinator"))
     return Command(
         update={
-            "messages": new_messages,
+            "messages": messages,
             "locale": locale,
             "research_topic": research_topic,
             "resources": configurable.resources,


### PR DESCRIPTION
Fix the bug that deep-thinking feature doesn't work, and the bug was introduced by coordinator messages update PR.

We should not add an assistant message if the content is empty, if we add an empty assistant message, the reasoning model won't output reasoning content appropriately.

![Uploading 21b4392e0a2e82e215205d91d92c9f3f.png…]()

