### PR TITLE
feat: polish the mcp-server configure feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ AGENT_RECURSION_LIMIT=30
 # Example: ALLOWED_ORIGINS=http://localhost:3000,http://example.com
 ALLOWED_ORIGINS=http://localhost:3000
 
+# Enable or disable MCP server configuration, the default is false.
+# Please enable this feature before securing your front-end and back-end in an internal environment.
+# Otherwise, you system could be compromised.
+ENABLE_MCP_SERVER_CONFIGURATION=false
+
 # Search Engine, Supported values: tavily (recommended), duckduckgo, brave_search, arxiv
 SEARCH_API=tavily
 TAVILY_API_KEY=tvly-xxx

--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,7 @@ AGENT_RECURSION_LIMIT=30
 ALLOWED_ORIGINS=http://localhost:3000
 
 # Enable or disable MCP server configuration, the default is false.
-# Please enable this feature before securing your front-end and back-end in an internal environment.
+# Please enable this feature before securing your front-end and back-end in a managed environment.
 # Otherwise, you system could be compromised.
 ENABLE_MCP_SERVER_CONFIGURATION=false
 

--- a/docs/mcp_integrations.md
+++ b/docs/mcp_integrations.md
@@ -1,5 +1,8 @@
 # MCP Integrations
 
+This feature is diabled by default. You can enable it by setting the environment ENABLE_MCP_SERVER_CONFIGURATION
+Please enable this feature before securing your frond-end and back-end in an internal environment.q
+
 ## Example of MCP Server Configuration
 
 ```json

--- a/docs/mcp_integrations.md
+++ b/docs/mcp_integrations.md
@@ -1,7 +1,10 @@
-# MCP Integrations
+# MCP Integrations（Beta）
 
-This feature is diabled by default. You can enable it by setting the environment ENABLE_MCP_SERVER_CONFIGURATION
-Please enable this feature before securing your frond-end and back-end in an internal environment.q
+Now This feature is diabled by default. You can enable it by setting the environment ENABLE_MCP_SERVER_CONFIGURATION to be true
+
+> [!WARNING]
+> Please enable this feature before securing your frond-end and back-end in a managed environment.
+> Otherwise, you system could be compromised.
 
 ## Example of MCP Server Configuration
 

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -385,7 +385,7 @@ async def mcp_server_metadata(request: MCPServerMetadataRequest):
     ]:
         raise HTTPException(
             status_code=403,
-            detail="MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable.",
+            detail="MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable MCP features.",
         )
 
     try:

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -71,6 +71,20 @@ graph = build_graph_with_memory()
 
 @app.post("/api/chat/stream")
 async def chat_stream(request: ChatRequest):
+    # Check if MCP server configuration is enabled
+    mcp_enabled = os.getenv("ENABLE_MCP_SERVER_CONFIGURATION", "false").lower() in [
+        "true",
+        "1",
+        "yes",
+    ]
+
+    # Validate MCP settings if provided
+    if request.mcp_settings and not mcp_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable MCP features.",
+        )
+
     thread_id = request.thread_id
     if thread_id == "__default__":
         thread_id = str(uuid4())
@@ -84,7 +98,7 @@ async def chat_stream(request: ChatRequest):
             request.max_search_results,
             request.auto_accepted_plan,
             request.interrupt_feedback,
-            request.mcp_settings,
+            request.mcp_settings if mcp_enabled else {},
             request.enable_background_investigation,
             request.report_style,
             request.enable_deep_thinking,
@@ -363,6 +377,17 @@ async def enhance_prompt(request: EnhancePromptRequest):
 @app.post("/api/mcp/server/metadata", response_model=MCPServerMetadataResponse)
 async def mcp_server_metadata(request: MCPServerMetadataRequest):
     """Get information about an MCP server."""
+    # Check if MCP server configuration is enabled
+    if not os.getenv("ENABLE_MCP_SERVER_CONFIGURATION", "false").lower() in [
+        "true",
+        "1",
+        "yes",
+    ]:
+        raise HTTPException(
+            status_code=403,
+            detail="MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable.",
+        )
+
     try:
         # Set default timeout with a longer value for this endpoint
         timeout = 300  # Default to 300 seconds for this endpoint

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -378,7 +378,7 @@ async def enhance_prompt(request: EnhancePromptRequest):
 async def mcp_server_metadata(request: MCPServerMetadataRequest):
     """Get information about an MCP server."""
     # Check if MCP server configuration is enabled
-    if not os.getenv("ENABLE_MCP_SERVER_CONFIGURATION", "false").lower() in [
+    if os.getenv("ENABLE_MCP_SERVER_CONFIGURATION", "false").lower() not in [
         "true",
         "1",
         "yes",

--- a/tests/unit/server/test_app.py
+++ b/tests/unit/server/test_app.py
@@ -413,6 +413,92 @@ class TestChatStreamEndpoint:
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
+    @patch("src.server.app.graph")
+    def test_chat_stream_with_mcp_settings(self, mock_graph, client):
+        # Mock the async stream
+        async def mock_astream(*args, **kwargs):
+            yield ("agent1", "step1", {"test": "data"})
+
+        mock_graph.astream = mock_astream
+
+        request_data = {
+            "thread_id": "__default__",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "resources": [],
+            "max_plan_iterations": 3,
+            "max_step_num": 10,
+            "max_search_results": 5,
+            "auto_accepted_plan": True,
+            "interrupt_feedback": "",
+            "mcp_settings": {
+                "servers": {
+                "mcp-github-trending": {
+                    "transport": "stdio",
+                    "command": "uvx",
+                    "args": ["mcp-github-trending"],
+                    "env": {
+                    "MCP_SERVER_ID": "mcp-github-trending"
+                    },
+                    "enabled_tools": ["get_github_trending_repositories"],
+                    "add_to_agents": ["researcher"]
+                }
+                }
+            },
+            "enable_background_investigation": False,
+            "report_style": "academic",
+        }
+
+        response = client.post("/api/chat/stream", json=request_data)
+
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable MCP features."
+        )
+
+    @patch("src.server.app.graph")
+    @patch.dict(
+        os.environ,
+        {"ENABLE_MCP_SERVER_CONFIGURATION": "true"},
+    )
+    def test_chat_stream_with_mcp_settings_enabled(self, mock_graph, client):
+        # Mock the async stream
+        async def mock_astream(*args, **kwargs):
+            yield ("agent1", "step1", {"test": "data"})
+
+        mock_graph.astream = mock_astream
+
+        request_data = {
+            "thread_id": "__default__",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "resources": [],
+            "max_plan_iterations": 3,
+            "max_step_num": 10,
+            "max_search_results": 5,
+            "auto_accepted_plan": True,
+            "interrupt_feedback": "",
+            "mcp_settings": {
+                "servers": {
+                "mcp-github-trending": {
+                    "transport": "stdio",
+                    "command": "uvx",
+                    "args": ["mcp-github-trending"],
+                    "env": {
+                    "MCP_SERVER_ID": "mcp-github-trending"
+                    },
+                    "enabled_tools": ["get_github_trending_repositories"],
+                    "add_to_agents": ["researcher"]
+                }
+                }
+            },
+            "enable_background_investigation": False,
+            "report_style": "academic",
+        }
+
+        response = client.post("/api/chat/stream", json=request_data)
+
+        assert response.status_code == 200
+        assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
 
 class TestAstreamWorkflowGenerator:
     @pytest.mark.asyncio

--- a/tests/unit/server/test_app.py
+++ b/tests/unit/server/test_app.py
@@ -260,6 +260,10 @@ class TestEnhancePromptEndpoint:
 
 class TestMCPEndpoint:
     @patch("src.server.app.load_mcp_tools")
+    @patch.dict(
+        os.environ,
+        {"ENABLE_MCP_SERVER_CONFIGURATION": "true"},
+    )
     def test_mcp_server_metadata_success(self, mock_load_tools, client):
         mock_load_tools.return_value = [
             {"name": "test_tool", "description": "Test tool"}
@@ -281,6 +285,10 @@ class TestMCPEndpoint:
         assert len(response_data["tools"]) == 1
 
     @patch("src.server.app.load_mcp_tools")
+    @patch.dict(
+        os.environ,
+        {"ENABLE_MCP_SERVER_CONFIGURATION": "true"},
+    )
     def test_mcp_server_metadata_with_custom_timeout(self, mock_load_tools, client):
         mock_load_tools.return_value = []
 
@@ -296,6 +304,10 @@ class TestMCPEndpoint:
         mock_load_tools.assert_called_once()
 
     @patch("src.server.app.load_mcp_tools")
+    @patch.dict(
+        os.environ,
+        {"ENABLE_MCP_SERVER_CONFIGURATION": "true"},
+    )
     def test_mcp_server_metadata_with_exception(self, mock_load_tools, client):
         mock_load_tools.side_effect = HTTPException(
             status_code=400, detail="MCP Server Error"
@@ -312,6 +324,28 @@ class TestMCPEndpoint:
 
         assert response.status_code == 500
         assert response.json()["detail"] == "Internal Server Error"
+
+    @patch("src.server.app.load_mcp_tools")
+    @patch.dict(
+        os.environ,
+        {"ENABLE_MCP_SERVER_CONFIGURATION": ""},
+    )
+    def test_mcp_server_metadata_with_exception(self, mock_load_tools, client):
+
+        request_data = {
+            "transport": "stdio",
+            "command": "test_command",
+            "args": ["arg1", "arg2"],
+            "env": {"ENV_VAR": "value"},
+        }
+
+        response = client.post("/api/mcp/server/metadata", json=request_data)
+
+        assert response.status_code == 403
+        assert (
+            response.json()["detail"]
+            == "MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable."
+        )
 
 
 class TestRAGEndpoints:

--- a/tests/unit/server/test_app.py
+++ b/tests/unit/server/test_app.py
@@ -346,7 +346,7 @@ class TestMCPEndpoint:
         assert response.status_code == 403
         assert (
             response.json()["detail"]
-            == "MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable."
+            == "MCP server configuration is disabled. Set ENABLE_MCP_SERVER_CONFIGURATION=true to enable MCP features."
         )
 
 
@@ -432,16 +432,14 @@ class TestChatStreamEndpoint:
             "interrupt_feedback": "",
             "mcp_settings": {
                 "servers": {
-                "mcp-github-trending": {
-                    "transport": "stdio",
-                    "command": "uvx",
-                    "args": ["mcp-github-trending"],
-                    "env": {
-                    "MCP_SERVER_ID": "mcp-github-trending"
-                    },
-                    "enabled_tools": ["get_github_trending_repositories"],
-                    "add_to_agents": ["researcher"]
-                }
+                    "mcp-github-trending": {
+                        "transport": "stdio",
+                        "command": "uvx",
+                        "args": ["mcp-github-trending"],
+                        "env": {"MCP_SERVER_ID": "mcp-github-trending"},
+                        "enabled_tools": ["get_github_trending_repositories"],
+                        "add_to_agents": ["researcher"],
+                    }
                 }
             },
             "enable_background_investigation": False,
@@ -479,16 +477,14 @@ class TestChatStreamEndpoint:
             "interrupt_feedback": "",
             "mcp_settings": {
                 "servers": {
-                "mcp-github-trending": {
-                    "transport": "stdio",
-                    "command": "uvx",
-                    "args": ["mcp-github-trending"],
-                    "env": {
-                    "MCP_SERVER_ID": "mcp-github-trending"
-                    },
-                    "enabled_tools": ["get_github_trending_repositories"],
-                    "add_to_agents": ["researcher"]
-                }
+                    "mcp-github-trending": {
+                        "transport": "stdio",
+                        "command": "uvx",
+                        "args": ["mcp-github-trending"],
+                        "env": {"MCP_SERVER_ID": "mcp-github-trending"},
+                        "enabled_tools": ["get_github_trending_repositories"],
+                        "add_to_agents": ["researcher"],
+                    }
                 }
             },
             "enable_background_investigation": False,
@@ -499,6 +495,7 @@ class TestChatStreamEndpoint:
 
         assert response.status_code == 200
         assert response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
 
 class TestAstreamWorkflowGenerator:
     @pytest.mark.asyncio

--- a/tests/unit/server/test_app.py
+++ b/tests/unit/server/test_app.py
@@ -330,7 +330,9 @@ class TestMCPEndpoint:
         os.environ,
         {"ENABLE_MCP_SERVER_CONFIGURATION": ""},
     )
-    def test_mcp_server_metadata_with_exception(self, mock_load_tools, client):
+    def test_mcp_server_metadata_without_enable_configuration(
+        self, mock_load_tools, client
+    ):
 
         request_data = {
             "transport": "stdio",


### PR DESCRIPTION
This pull request introduces a new feature for enabling and managing MCP server configurations, along with corresponding updates to the server logic, environment configuration, documentation, and unit tests. The changes ensure that MCP features are disabled by default and can only be activated in a secure environment by explicitly setting an environment variable.

### Feature: MCP Server Configuration

#### Core functionality changes:
* Added a new environment variable `ENABLE_MCP_SERVER_CONFIGURATION` to control whether MCP server features are enabled. Default is set to `false` in `.env.example`.
* Updated the `chat_stream` and `mcp_server_metadata` endpoints in `src/server/app.py` to validate the status of `ENABLE_MCP_SERVER_CONFIGURATION`. Requests with MCP settings are rejected with a `403 Forbidden` error if the feature is disabled. [[1]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7R74-R87) [[2]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7R380-R390)
* Modified `chat_stream` to pass an empty MCP settings object if the feature is disabled.

#### Documentation updates:
* Updated `docs/mcp_integrations.md` to reflect the beta status of the MCP feature, its default disabled state, and the security recommendation to enable it only in a managed environment.

### Testing Enhancements

#### Unit test additions:
* Added tests in `tests/unit/server/test_app.py` to verify the behavior of endpoints when MCP server configuration is enabled or disabled. These include scenarios such as successful metadata retrieval, handling exceptions, and rejecting requests when the feature is disabled. [[1]](diffhunk://#diff-ae782274ce220d8195bf0a0b763fc8acfcc18bb0c83683a5a41adea6c7641070R263-R266) [[2]](diffhunk://#diff-ae782274ce220d8195bf0a0b763fc8acfcc18bb0c83683a5a41adea6c7641070R288-R291) [[3]](diffhunk://#diff-ae782274ce220d8195bf0a0b763fc8acfcc18bb0c83683a5a41adea6c7641070R307-R310) [[4]](diffhunk://#diff-ae782274ce220d8195bf0a0b763fc8acfcc18bb0c83683a5a41adea6c7641070R328-R351) [[5]](diffhunk://#diff-ae782274ce220d8195bf0a0b763fc8acfcc18bb0c83683a5a41adea6c7641070R416-R501)