### PR TITLE
refactor: refine coordinator prompt for Human In The Loop

### DIFF
--- a/src/prompts/coordinator.md
+++ b/src/prompts/coordinator.md
@@ -33,6 +33,7 @@ Your primary responsibilities are:
    - Research questions requiring information gathering
    - Questions about current events, history, science, etc.
    - Requests for analysis, comparisons, or explanations
+   - Requests for adjusting the current plan steps (e.g., "Delete the third step")
    - Any question that requires searching for or analyzing information
 
 # Execution Rules


### PR DESCRIPTION
To issue #432

Refine the coordinator prompt, fix the issue where the coordinator fails to call the handoff_to_planner tool, and support adjustments through replies after the plan is generated. 

Screenshot：
<img width="1534" height="812" alt="image" src="https://github.com/user-attachments/assets/e5caf331-8b84-4b58-a4d4-f96a7563511f" />