### PR TITLE
fix: “web_search” tool name mismatch issue

### DIFF
--- a/src/prompts/researcher.md
+++ b/src/prompts/researcher.md
@@ -14,7 +14,7 @@ You have access to two types of tools:
    {% if resources %}
    - **local_search_tool**: For retrieving information from the local knowledge base when user mentioned in the messages.
    {% endif %}
-   - **web_search_tool**: For performing web searches
+   - **web_search**: For performing web searches (NOT "web_search_tool")
    - **crawl_tool**: For reading content from URLs
 
 2. **Dynamic Loaded Tools**: Additional tools that may be available depending on the configuration. These tools are loaded dynamically and will appear in your available tools list. Examples include:
@@ -37,7 +37,7 @@ You have access to two types of tools:
 3. **Plan the Solution**: Determine the best approach to solve the problem using the available tools.
 4. **Execute the Solution**:
    - Forget your previous knowledge, so you **should leverage the tools** to retrieve the information.
-   - Use the {% if resources %}**local_search_tool** or{% endif %}**web_search_tool** or other suitable search tool to perform a search with the provided keywords.
+   - Use the {% if resources %}**local_search_tool** or{% endif %}**web_search** or other suitable search tool to perform a search with the provided keywords.
    - When the task includes time range requirements:
      - Incorporate appropriate time-based search parameters in your queries (e.g., "after:2020", "before:2023", or specific date ranges)
      - Ensure search results respect the specified time constraints.


### PR DESCRIPTION


### Fix Tool Name Mismatch Issue

#### Problem Description
The tool name `web_search` was incorrectly referenced as `web_search_tool` or `search` in the code, causing runtime errors such as:
- `Error: web_search_tool is not a valid tool, try one of [web_search, crawl_tool]`
- `Error: search is not a valid tool, try one of [web_search, crawl_tool]`

#### Fix Details
1. Corrected the tool name references in the prompts file:
   - Replaced `web_search_tool` with the correct `web_search`.
2. Added a clear explanation of the tool names in the prompts file to ensure the model understands the correct tool names.
3. Verified all other references to tool names in the code for consistency.

#### Testing
- Local testing confirmed that the errors no longer occur.
- Verified that the model correctly calls `web_search` and `crawl_tool`.

#### Impact
- This fix primarily affects the tool invocation logic and should not introduce any side effects to other functionalities.

