### PR TITLE
fix: env parameters exception when configuring SSE or HTTP MCP server

### DIFF
--- a/docs/mcp_integrations.md
+++ b/docs/mcp_integrations.md
@@ -46,7 +46,18 @@ For `sse` type:
 {
   "transport": "sse",
   "url": "http://localhost:3000/sse",
-  "env": {
+  "headers": {
+    "API_KEY": "value"
+  }
+}
+```
+
+For `streamable_http` type:
+```json
+{
+  "transport": "streamable_http",
+  "url": "http://localhost:3000/mcp",
+  "headers": {
     "API_KEY": "value"
   }
 }

--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -451,7 +451,7 @@ async def _setup_and_execute_agent_step(
                 mcp_servers[server_name] = {
                     k: v
                     for k, v in server_config.items()
-                    if k in ("transport", "command", "args", "url", "env")
+                    if k in ("transport", "command", "args", "url", "env", "headers")
                 }
                 for tool_name in server_config["enabled_tools"]:
                     enabled_tools[tool_name] = server_name

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -552,6 +552,7 @@ async def mcp_server_metadata(request: MCPServerMetadataRequest):
             args=request.args,
             url=request.url,
             env=request.env,
+            headers=request.headers,
             timeout_seconds=timeout,
         )
 
@@ -562,6 +563,7 @@ async def mcp_server_metadata(request: MCPServerMetadataRequest):
             args=request.args,
             url=request.url,
             env=request.env,
+            headers=request.headers,
             tools=tools,
         )
 

--- a/src/server/mcp_request.py
+++ b/src/server/mcp_request.py
@@ -10,7 +10,10 @@ class MCPServerMetadataRequest(BaseModel):
     """Request model for MCP server metadata."""
 
     transport: str = Field(
-        ..., description="The type of MCP server connection (stdio or sse)"
+        ...,
+        description=(
+            "The type of MCP server connection (stdio or sse or streamable_http)"
+        ),
     )
     command: Optional[str] = Field(
         None, description="The command to execute (for stdio type)"
@@ -21,7 +24,12 @@ class MCPServerMetadataRequest(BaseModel):
     url: Optional[str] = Field(
         None, description="The URL of the SSE server (for sse type)"
     )
-    env: Optional[Dict[str, str]] = Field(None, description="Environment variables")
+    env: Optional[Dict[str, str]] = Field(
+        None, description="Environment variables (for stdio type)"
+    )
+    headers: Optional[Dict[str, str]] = Field(
+        None, description="HTTP headers (for sse/streamable_http type)"
+    )
     timeout_seconds: Optional[int] = Field(
         None, description="Optional custom timeout in seconds for the operation"
     )
@@ -31,7 +39,10 @@ class MCPServerMetadataResponse(BaseModel):
     """Response model for MCP server metadata."""
 
     transport: str = Field(
-        ..., description="The type of MCP server connection (stdio or sse)"
+        ...,
+        description=(
+            "The type of MCP server connection (stdio or sse or streamable_http)"
+        ),
     )
     command: Optional[str] = Field(
         None, description="The command to execute (for stdio type)"
@@ -42,7 +53,12 @@ class MCPServerMetadataResponse(BaseModel):
     url: Optional[str] = Field(
         None, description="The URL of the SSE server (for sse type)"
     )
-    env: Optional[Dict[str, str]] = Field(None, description="Environment variables")
+    env: Optional[Dict[str, str]] = Field(
+        None, description="Environment variables (for stdio type)"
+    )
+    headers: Optional[Dict[str, str]] = Field(
+        None, description="HTTP headers (for sse/streamable_http type)"
+    )
     tools: List = Field(
         default_factory=list, description="Available tools from the MCP server"
     )

--- a/src/server/mcp_utils.py
+++ b/src/server/mcp_utils.py
@@ -47,17 +47,19 @@ async def load_mcp_tools(
     args: Optional[List[str]] = None,
     url: Optional[str] = None,
     env: Optional[Dict[str, str]] = None,
+    headers: Optional[Dict[str, str]] = None,
     timeout_seconds: int = 60,  # Longer default timeout for first-time executions
 ) -> List:
     """
     Load tools from an MCP server.
 
     Args:
-        server_type: The type of MCP server connection (stdio or sse)
+        server_type: The type of MCP server connection (stdio, sse, or streamable_http)
         command: The command to execute (for stdio type)
         args: Command arguments (for stdio type)
-        url: The URL of the SSE server (for sse type)
-        env: Environment variables
+        url: The URL of the SSE/HTTP server (for sse/streamable_http type)
+        env: Environment variables (for stdio type)
+        headers: HTTP headers (for sse/streamable_http type)
         timeout_seconds: Timeout in seconds (default: 60 for first-time executions)
 
     Returns:
@@ -90,7 +92,7 @@ async def load_mcp_tools(
                 )
 
             return await _get_tools_from_client_session(
-                sse_client(url=url), timeout_seconds
+                sse_client(url=url, headers=headers, timeout=timeout_seconds), timeout_seconds
             )
 
         elif server_type == "streamable_http":
@@ -100,7 +102,7 @@ async def load_mcp_tools(
                 )
 
             return await _get_tools_from_client_session(
-                streamablehttp_client(url=url), timeout_seconds
+                streamablehttp_client(url=url, headers=headers, timeout=timeout_seconds), timeout_seconds,
             )
 
         else:

--- a/tests/unit/server/test_mcp_utils.py
+++ b/tests/unit/server/test_mcp_utils.py
@@ -86,10 +86,15 @@ async def test_load_mcp_tools_sse_success(mock_sse_client, mock_get_tools):
     result = await mcp_utils.load_mcp_tools(
         server_type="sse",
         url="http://localhost:1234",
+        headers={"Authorization": "Bearer 1234567890"},
         timeout_seconds=7,
     )
     assert result == ["toolB"]
-    mock_sse_client.assert_called_once_with(url="http://localhost:1234")
+    mock_sse_client.assert_called_once_with(
+        url="http://localhost:1234",
+        headers={"Authorization": "Bearer 1234567890"},
+        timeout=7,
+    )
     mock_get_tools.assert_awaited_once_with(mock_client, 7)
 
 

--- a/web/src/core/mcp/types.ts
+++ b/web/src/core/mcp/types.ts
@@ -12,6 +12,7 @@ export interface GenericMCPServerMetadata<T extends string> {
   transport: T;
   enabled: boolean;
   env?: Record<string, string>;
+  headers?: Record<string, string>;
   tools: MCPToolMetadata[];
   createdAt: number;
   updatedAt: number;
@@ -28,8 +29,9 @@ export type SimpleStdioMCPServerMetadata = Omit<
   "enabled" | "tools" | "createdAt" | "updatedAt"
 >;
 
-export interface SSEMCPServerMetadata extends GenericMCPServerMetadata<"sse"|"streamable_http"> {
-  transport: "sse"|"streamable_http"
+export interface SSEMCPServerMetadata
+  extends GenericMCPServerMetadata<"sse" | "streamable_http"> {
+  transport: "sse" | "streamable_http";
   url: string;
 }
 

--- a/web/src/core/store/settings-store.ts
+++ b/web/src/core/store/settings-store.ts
@@ -94,7 +94,7 @@ export const getChatStreamSettings = () => {
   if (mcpServers.length > 0) {
     mcpSettings = {
       servers: mcpServers.reduce((acc, cur) => {
-        const { transport, env } = cur;
+        const { transport, env, headers } = cur;
         let server: SimpleMCPServerMetadata;
         if (transport === "stdio") {
           server = {
@@ -108,7 +108,7 @@ export const getChatStreamSettings = () => {
           server = {
             name: cur.name,
             transport,
-            env,
+            headers,
             url: cur.url,
           };
         }


### PR DESCRIPTION
# Description
In the `langchain_mcp_adapters` library, `_create_streamable_http_session` and `_create_stdio_session` do not have env parameters
<img width="1614" height="792" alt="image" src="https://github.com/user-attachments/assets/b688cc02-28d8-421b-9eb4-4495705973b6" />

However, in the configuration of the MCP server obtained in `_setup_and_execute_agent_step`, the env parameter is carried regardless of whether it is SSE or HTTP.
So when running, this error will appear：
```
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/src/server/app.py", line 349, in _astream_workflow_generator
    async for event in _stream_graph_events(
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/src/server/app.py", line 242, in _stream_graph_events
    async for agent, _, event_data in graph_instance.astream(
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/.venv/lib/python3.12/site-packages/langgraph/pregel/__init__.py", line 2759, in astream
    async for _ in runner.atick(
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/src/graph/nodes.py", line 489, in researcher_node
    return await _setup_and_execute_agent_step(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/src/graph/nodes.py", line 463, in _setup_and_execute_agent_step
    all_tools = await client.get_tools()
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/.venv/lib/python3.12/site-packages/langchain_mcp_adapters/client.py", line 142, in get_tools
    tools_list = await asyncio.gather(*load_mcp_tool_tasks)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/.venv/lib/python3.12/site-packages/langchain_mcp_adapters/tools.py", line 168, in load_mcp_tools
    async with create_session(connection) as tool_session:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/Desktop/ai_agent/deer-flow/.venv/lib/python3.12/site-packages/langchain_mcp_adapters/sessions.py", line 385, in create_session
    async with _create_streamable_http_session(**params) as session:
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/contextlib.py", line 334, in helper
    return _AsyncGeneratorContextManager(func, args, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/anoyer/.local/share/uv/python/cpython-3.12.11-macos-aarch64-none/lib/python3.12/contextlib.py", line 105, in __init__
    self.gen = func(*args, **kwds)
               ^^^^^^^^^^^^^^^^^^^
TypeError: _create_streamable_http_session() got an unexpected keyword argument 'env'
During task with name 'researcher' and id '28b7d245-801d-4b4f-f239-ce925497019e'
```

The reason for this is that the front end always carries the env configuration when configuring the mcp server

<img width="1664" height="1208" alt="image" src="https://github.com/user-attachments/assets/3acebf72-514b-4991-95f1-13830aa393c5" />

# Change
1. fix issue: "_create _steamable_ http_ session() got an unexpected keyword argument 'env'" 
2. support header configuration for sse and http

