### PR TITLE
feat: Implement Milvus retriver for RAG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,29 @@ TAVILY_API_KEY=tvly-xxx
 # RAGFLOW_RETRIEVAL_SIZE=10
 # RAGFLOW_CROSS_LANGUAGES=English,Chinese,Spanish,French,German,Japanese,Korean # Optional. To use RAGFlow's cross-language search, please separate each language with a single comma
 
+
+# RAG_PROVIDER: milvus  (using free milvus instance on zilliz cloud: https://docs.zilliz.com/docs/quick-start )
+# RAG_PROVIDER=milvus
+# MILVUS_URI=<endpoint_of_self_hosted_milvus_or_zilliz_cloud>
+# MILVUS_USER=<username_of_self_hosted_milvus_or_zilliz_cloud>
+# MILVUS_PASSWORD=<password_of_self_hosted_milvus_or_zilliz_cloud>
+# MILVUS_COLLECTION=documents
+# MILVUS_EMBEDDING_PROVIDER=openai # support openai,dashscope
+# MILVUS_EMBEDDING_BASE_URL=
+# MILVUS_EMBEDDING_MODEL=
+# MILVUS_EMBEDDING_API_KEY=
+# MILVUS_AUTO_LOAD_EXAMPLES=true
+
+# RAG_PROVIDER: milvus  (using milvus lite on Mac or Linux)
+# RAG_PROVIDER=milvus
+# MILVUS_URI=./milvus_demo.db
+# MILVUS_COLLECTION=documents
+# MILVUS_EMBEDDING_PROVIDER=openai # support openai,dashscope
+# MILVUS_EMBEDDING_BASE_URL=
+# MILVUS_EMBEDDING_MODEL=
+# MILVUS_EMBEDDING_API_KEY=
+# MILVUS_AUTO_LOAD_EXAMPLES=true
+
 # Optional, volcengine TTS for generating podcast
 VOLCENGINE_TTS_APPID=xxx
 VOLCENGINE_TTS_ACCESS_TOKEN=xxx

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -179,4 +179,40 @@ SEARCH_ENGINE:
   exclude_domains:
     - unreliable-site.com
     - spam-domain.net
+```
 
+## RAG (Retrieval-Augmented Generation) Configuration
+
+DeerFlow supports multiple RAG providers for document retrieval. Configure the RAG provider by setting environment variables.
+
+### Supported RAG Providers
+
+- **RAGFlow**: Document retrieval using RAGFlow API
+- **VikingDB Knowledge Base**: ByteDance's VikingDB knowledge base service
+- **Milvus**: Open-source vector database for similarity search
+
+### Milvus Configuration
+
+To use Milvus as your RAG provider, set the following environment variables:
+
+```bash
+# RAG_PROVIDER: milvus  (using free milvus instance on zilliz cloud: https://docs.zilliz.com/docs/quick-start )
+RAG_PROVIDER=milvus
+MILVUS_URI=<endpoint_of_self_hosted_milvus_or_zilliz_cloud>
+MILVUS_USER=<username_of_self_hosted_milvus_or_zilliz_cloud>
+MILVUS_PASSWORD=<password_of_self_hosted_milvus_or_zilliz_cloud>
+MILVUS_COLLECTION=documents
+MILVUS_EMBEDDING_PROVIDER=openai
+MILVUS_EMBEDDING_BASE_URL=
+MILVUS_EMBEDDING_MODEL=
+MILVUS_EMBEDDING_API_KEY=
+
+# RAG_PROVIDER: milvus  (using milvus lite on Mac or Linux)
+RAG_PROVIDER=milvus
+MILVUS_URI=./milvus_demo.db
+MILVUS_COLLECTION=documents
+MILVUS_EMBEDDING_PROVIDER=openai
+MILVUS_EMBEDDING_BASE_URL=
+MILVUS_EMBEDDING_MODEL=
+MILVUS_EMBEDDING_API_KEY=
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
     "langchain-tavily<0.3",
     "langgraph-checkpoint-mongodb>=0.1.4",
     "langgraph-checkpoint-postgres==2.0.21",
+    "pymilvus>=2.3.0",
+    "langchain-milvus>=0.2.1",
 ]
 
 [project.optional-dependencies]

--- a/src/config/tools.py
+++ b/src/config/tools.py
@@ -24,6 +24,7 @@ SELECTED_SEARCH_ENGINE = os.getenv("SEARCH_API", SearchEngine.TAVILY.value)
 class RAGProvider(enum.Enum):
     RAGFLOW = "ragflow"
     VIKINGDB_KNOWLEDGE_BASE = "vikingdb_knowledge_base"
+    MILVUS = "milvus"
 
 
 SELECTED_RAG_PROVIDER = os.getenv("RAG_PROVIDER")

--- a/src/rag/builder.py
+++ b/src/rag/builder.py
@@ -5,6 +5,7 @@ from src.config.tools import SELECTED_RAG_PROVIDER, RAGProvider
 from src.rag.ragflow import RAGFlowProvider
 from src.rag.retriever import Retriever
 from src.rag.vikingdb_knowledge_base import VikingDBKnowledgeBaseProvider
+from src.rag.milvus import MilvusProvider
 
 
 def build_retriever() -> Retriever | None:
@@ -12,6 +13,8 @@ def build_retriever() -> Retriever | None:
         return RAGFlowProvider()
     elif SELECTED_RAG_PROVIDER == RAGProvider.VIKINGDB_KNOWLEDGE_BASE.value:
         return VikingDBKnowledgeBaseProvider()
+    elif SELECTED_RAG_PROVIDER == RAGProvider.MILVUS.value:
+        return MilvusProvider()
     elif SELECTED_RAG_PROVIDER:
         raise ValueError(f"Unsupported RAG provider: {SELECTED_RAG_PROVIDER}")
     return None

--- a/src/rag/milvus.py
+++ b/src/rag/milvus.py
@@ -1,0 +1,895 @@
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
+
+from langchain_milvus.vectorstores import Milvus as LangchainMilvus
+
+try:
+    from pymilvus import MilvusClient, CollectionSchema, FieldSchema, DataType
+except ImportError:
+    raise ImportError(
+        "pymilvus is required for MilvusProvider. Install it with: pip install pymilvus"
+    )
+
+try:
+    from langchain_openai import OpenAIEmbeddings
+    from openai import OpenAI
+
+    EMBEDDINGS_AVAILABLE = True
+except ImportError:
+    EMBEDDINGS_AVAILABLE = False
+
+from src.rag.retriever import Chunk, Document, Resource, Retriever
+
+logger = logging.getLogger(__name__)
+
+
+def get_bool_env(name: str, default: bool = False) -> bool:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    return str(val).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def get_str_env(name: str, default: str = "") -> str:
+    val = os.getenv(name)
+    return default if val is None else str(val).strip()
+
+
+def get_int_env(name: str, default: int = 0) -> int:
+    val = os.getenv(name)
+    if val is None:
+        return default
+    try:
+        return int(val.strip())
+    except ValueError:
+        logger.warning(
+            f"Invalid integer value for {name}: {val}. Using default {default}."
+        )
+        return default
+
+
+class DashscopeEmbeddings:
+    """Minimal OpenAI-compatible embeddings wrapper.
+
+    Provides the two methods LangChain expects: ``embed_query`` and
+    ``embed_documents``. It delegates to an ``OpenAI``-style client whose
+    ``embeddings.create`` method returns an object whose ``data`` attribute is
+    an iterable of items each exposing an ``embedding`` list.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        self._client: OpenAI = OpenAI(
+            api_key=kwargs.get("api_key", ""), base_url=kwargs.get("base_url", "")
+        )
+        self._model: str = kwargs.get("model", "")
+        self._encoding_format: str = kwargs.get("encoding_format", "float")
+
+    def _embed(self, texts: Sequence[str]) -> List[List[float]]:
+        """Internal helper performing the embedding API call.
+
+        Args:
+            texts: Sequence of input strings.
+
+        Returns:
+            A list of embedding vectors (list[float]).
+        """
+        clean_texts = [t if isinstance(t, str) else str(t) for t in texts]
+        if not clean_texts:
+            return []
+        resp = self._client.embeddings.create(
+            model=self._model,
+            input=clean_texts,
+            encoding_format=self._encoding_format,
+        )
+        return [d.embedding for d in resp.data]
+
+    def embed_query(self, text: str) -> List[float]:
+        """Return a single query embedding.
+
+        Args:
+            text: Query text.
+
+        Returns:
+            Embedding vector for the query (may be empty list on failure).
+        """
+        embeddings = self._embed([text])
+        return embeddings[0] if embeddings else []
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        """Return embeddings for multiple documents (LangChain interface)."""
+        return self._embed(texts)
+
+
+class MilvusRetriever(Retriever):
+    """Retriever implementation backed by a Milvus vector store.
+
+    Responsibilities:
+        * Initialize / lazily connect to Milvus (local Lite or remote server).
+        * Provide methods for inserting content chunks & querying similarity.
+        * Optionally surface example markdown resources found in the project.
+
+    Environment variables (selected):
+        MILVUS_URI: Connection URI or local *.db path for Milvus Lite.
+        MILVUS_COLLECTION: Target collection name (default: documents).
+        MILVUS_TOP_K: Result set size (default: 10).
+        MILVUS_EMBEDDING_PROVIDER: openai | dashscope (default: openai).
+        MILVUS_EMBEDDING_MODEL: Embedding model name.
+        MILVUS_EMBEDDING_DIM: Override embedding dimensionality.
+        MILVUS_AUTO_LOAD_EXAMPLES: Load example *.md files if true.
+        MILVUS_EXAMPLES_DIR: Folder containing example markdown files.
+    """
+
+    def __init__(self) -> None:
+        # --- Connection / collection configuration ---
+        self.uri: str = get_str_env("MILVUS_URI", "http://localhost:19530")
+        self.user: str = get_str_env("MILVUS_USER")
+        self.password: str = get_str_env("MILVUS_PASSWORD")
+        self.collection_name: str = get_str_env("MILVUS_COLLECTION", "documents")
+
+        # --- Search configuration ---
+        top_k_raw = get_str_env("MILVUS_TOP_K", "10")
+        self.top_k: int = int(top_k_raw) if top_k_raw.isdigit() else 10
+
+        # --- Vector field names ---
+        self.vector_field: str = get_str_env("MILVUS_VECTOR_FIELD", "embedding")
+        self.id_field: str = get_str_env("MILVUS_ID_FIELD", "id")
+        self.content_field: str = get_str_env("MILVUS_CONTENT_FIELD", "content")
+        self.title_field: str = get_str_env("MILVUS_TITLE_FIELD", "title")
+        self.url_field: str = get_str_env("MILVUS_URL_FIELD", "url")
+        self.metadata_field: str = get_str_env("MILVUS_METADATA_FIELD", "metadata")
+
+        # --- Embedding configuration ---
+        self.embedding_model = get_str_env("MILVUS_EMBEDDING_MODEL")
+        self.embedding_api_key = get_str_env("MILVUS_EMBEDDING_API_KEY")
+        self.embedding_base_url = get_str_env("MILVUS_EMBEDDING_BASE_URL")
+        self.embedding_dim: int = self._get_embedding_dimension(self.embedding_model)
+        self.embedding_provider = get_str_env("MILVUS_EMBEDDING_PROVIDER", "openai")
+
+        # --- Examples / auto-load configuration ---
+        self.auto_load_examples: bool = get_bool_env("MILVUS_AUTO_LOAD_EXAMPLES", True)
+        self.examples_dir: str = get_str_env("MILVUS_EXAMPLES_DIR", "examples")
+        # chunk size
+        self.chunk_size: int = get_int_env("MILVUS_CHUNK_SIZE", 4000)
+
+        # --- Embedding model initialization ---
+        self._init_embedding_model()
+
+        # Client (MilvusClient or LangchainMilvus) created lazily
+        self.client: Any = None
+
+    def _init_embedding_model(self) -> None:
+        """Initialize the embedding model based on configuration.
+
+        Raises:
+            ImportError: If embedding dependencies are not installed.
+            ValueError: If the embedding provider value is unsupported.
+        """
+        if not EMBEDDINGS_AVAILABLE:
+            raise ImportError(
+                "Embedding dependencies not available. "
+                "Install with: pip install langchain-openai langchain-community"
+            )
+        kwargs = {
+            "api_key": self.embedding_api_key,
+            "model": self.embedding_model,
+            "base_url": self.embedding_base_url,
+            "encoding_format": "float",
+            "dimensions": self.embedding_dim,
+        }
+        if self.embedding_provider.lower() == "openai":
+            self.embedding_model = OpenAIEmbeddings(**kwargs)
+        elif self.embedding_provider.lower() == "dashscope":
+            self.embedding_model = DashscopeEmbeddings(**kwargs)
+        else:
+            raise ValueError(
+                f"Unsupported embedding provider: {self.embedding_provider}. "
+                "Supported providers: openai,dashscope"
+            )
+
+    def _get_embedding_dimension(self, model_name: str) -> int:
+        """Return embedding dimension for the supplied model name.
+
+        Priority order:
+            1. Explicit override via MILVUS_EMBEDDING_DIM.
+            2. Known model dimension mapping.
+            3. Fallback default (1536).
+        """
+        # Common OpenAI embedding model dimensions
+        embedding_dims = {
+            "text-embedding-ada-002": 1536,
+            "text-embedding-v4": 2048,
+        }
+
+        # Check if user has explicitly set the dimension
+        explicit_dim = get_int_env("MILVUS_EMBEDDING_DIM", 0)
+        if explicit_dim > 0:
+            return explicit_dim
+
+        # Return dimension based on model name
+        return embedding_dims.get(model_name, 1536)  # Default to 1536
+
+    def _create_collection_schema(self) -> CollectionSchema:
+        """Build and return a Milvus ``CollectionSchema`` object with metadata field.
+
+        Attempts to use a JSON field for metadata; falls back to VARCHAR if JSON
+        type isn't supported in the deployment.
+        """
+        fields = [
+            FieldSchema(
+                name=self.id_field,
+                dtype=DataType.VARCHAR,
+                max_length=512,
+                is_primary=True,
+                auto_id=False,
+            ),
+            FieldSchema(
+                name=self.vector_field,
+                dtype=DataType.FLOAT_VECTOR,
+                dim=self.embedding_dim,
+            ),
+            FieldSchema(
+                name=self.content_field, dtype=DataType.VARCHAR, max_length=65535
+            ),
+            FieldSchema(name=self.title_field, dtype=DataType.VARCHAR, max_length=512),
+            FieldSchema(name=self.url_field, dtype=DataType.VARCHAR, max_length=1024),
+        ]
+
+        schema = CollectionSchema(
+            fields=fields,
+            description=f"Collection for DeerFlow RAG documents: {self.collection_name}",
+            enable_dynamic_field=True,  # Allow additional dynamic metadata fields
+        )
+        return schema
+
+    def _ensure_collection_exists(self) -> None:
+        """Ensure the configured collection exists (create if missing).
+
+        For Milvus Lite we create the collection manually; for the remote
+        (LangChain) client we rely on LangChain's internal logic.
+        """
+        if self._is_milvus_lite():
+            # For Milvus Lite, use MilvusClient
+            try:
+                # Check if collection exists
+                collections = self.client.list_collections()
+                if self.collection_name not in collections:
+                    # Create collection
+                    schema = self._create_collection_schema()
+                    self.client.create_collection(
+                        collection_name=self.collection_name,
+                        schema=schema,
+                        index_params={
+                            "field_name": self.vector_field,
+                            "index_type": "IVF_FLAT",
+                            "metric_type": "IP",
+                            "params": {"nlist": 1024},
+                        },
+                    )
+                    logger.info("Created Milvus collection: %s", self.collection_name)
+
+            except Exception as e:
+                logger.warning("Could not ensure collection exists: %s", e)
+        else:
+            # For LangChain Milvus, collection creation is handled automatically
+            logger.warning(
+                "Could not ensure collection exists: %s", self.collection_name
+            )
+
+    def _load_example_files(self) -> None:
+        """Load example markdown files into the collection (idempotent).
+
+        Each markdown file is split into chunks and inserted only if a chunk
+        with the derived document id hasn't been previously stored.
+        """
+        try:
+            # Get the project root directory
+            current_file = Path(__file__)
+            project_root = current_file.parent.parent.parent  # Go up to project root
+            examples_path = project_root / self.examples_dir
+
+            if not examples_path.exists():
+                logger.info("Examples directory not found: %s", examples_path)
+                return
+
+            logger.info("Loading example files from: %s", examples_path)
+
+            # Find all markdown files
+            md_files = list(examples_path.glob("*.md"))
+            if not md_files:
+                logger.info("No markdown files found in examples directory")
+                return
+            # Check if files are already loaded
+            existing_docs = self._get_existing_document_ids()
+            loaded_count = 0
+            for md_file in md_files:
+                doc_id = self._generate_doc_id(md_file)
+
+                # Skip if already loaded
+                if doc_id in existing_docs:
+                    continue
+                try:
+                    # Read and process the file
+                    content = md_file.read_text(encoding="utf-8")
+                    title = self._extract_title_from_markdown(content, md_file.name)
+
+                    # Split content into chunks if it's too long
+                    chunks = self._split_content(content)
+
+                    # Insert each chunk
+                    for i, chunk in enumerate(chunks):
+                        chunk_id = f"{doc_id}_chunk_{i}" if len(chunks) > 1 else doc_id
+                        self._insert_document_chunk(
+                            doc_id=chunk_id,
+                            content=chunk,
+                            title=title,
+                            url=f"milvus://{self.collection_name}/{md_file.name}",
+                            metadata={"source": "examples", "file": md_file.name},
+                        )
+
+                    loaded_count += 1
+                    logger.debug("Loaded example markdown: %s", md_file.name)
+
+                except Exception as e:
+                    logger.warning("Error loading %s: %s", md_file.name, e)
+
+            logger.info(
+                "Successfully loaded %d example files into Milvus", loaded_count
+            )
+
+        except Exception as e:
+            logger.error("Error loading example files: %s", e)
+
+    def _generate_doc_id(self, file_path: Path) -> str:
+        """Return a stable identifier derived from name, size & mtime hash."""
+        # Use file name and size for a simple but effective ID
+        file_stat = file_path.stat()
+        content_hash = hashlib.md5(
+            f"{file_path.name}_{file_stat.st_size}_{file_stat.st_mtime}".encode()
+        ).hexdigest()[:8]
+        return f"example_{file_path.stem}_{content_hash}"
+
+    def _extract_title_from_markdown(self, content: str, filename: str) -> str:
+        """Extract the first level-1 heading; else derive from file name."""
+        lines = content.split("\n")
+        for line in lines:
+            line = line.strip()
+            if line.startswith("# "):
+                return line[2:].strip()
+
+        # Fallback to filename without extension
+        return filename.replace(".md", "").replace("_", " ").title()
+
+    def _split_content(self, content: str) -> List[str]:
+        """Split long markdown text into paragraph-based chunks.
+
+        Args:
+            content: Raw markdown string.
+
+        Returns:
+            List of chunk strings preserving paragraph boundaries where possible.
+        """
+        if len(content) <= self.chunk_size:
+            return [content]
+
+        chunks = []
+        paragraphs = content.split("\n\n")
+        current_chunk = ""
+
+        for paragraph in paragraphs:
+            if len(current_chunk) + len(paragraph) <= self.chunk_size:
+                current_chunk += paragraph + "\n\n"
+            else:
+                if current_chunk:
+                    chunks.append(current_chunk.strip())
+                current_chunk = paragraph + "\n\n"
+
+        if current_chunk:
+            chunks.append(current_chunk.strip())
+
+        return chunks
+
+    def _get_existing_document_ids(self) -> Set[str]:
+        """Return set of existing document identifiers in the collection."""
+        try:
+            if self._is_milvus_lite():
+                results = self.client.query(
+                    collection_name=self.collection_name,
+                    filter="",
+                    output_fields=[self.id_field],
+                    limit=10000,
+                )
+                return {
+                    result.get(self.id_field, "")
+                    for result in results
+                    if result.get(self.id_field)
+                }
+            else:
+                # For LangChain Milvus, we can't easily query all IDs
+                # Return empty set to allow re-insertion (LangChain will handle duplicates)
+                return set()
+        except Exception:
+            return set()
+
+    def _insert_document_chunk(
+        self, doc_id: str, content: str, title: str, url: str, metadata: Dict[str, Any]
+    ) -> None:
+        """Insert a single content chunk into Milvus.
+
+        Args:
+            doc_id: Unique identifier for chunk/document.
+            content: Plain text content to embed.
+            title: Document title.
+            url: Source URL or pseudo-URL.
+            metadata: Additional key/value metadata.
+
+        Raises:
+            RuntimeError: On failure to insert the chunk.
+        """
+        try:
+            # Generate embedding
+            embedding = self._get_embedding(content)
+
+            if self._is_milvus_lite():
+                # For Milvus Lite, use MilvusClient
+                data = [
+                    {
+                        self.id_field: doc_id,
+                        self.vector_field: embedding,
+                        self.content_field: content,
+                        self.title_field: title,
+                        self.url_field: url,
+                        **metadata,  # Add metadata fields
+                    }
+                ]
+
+                self.client.insert(collection_name=self.collection_name, data=data)
+            else:
+                # For LangChain Milvus, use add_texts
+                self.client.add_texts(
+                    texts=[content],
+                    metadatas=[
+                        {
+                            self.id_field: doc_id,
+                            self.title_field: title,
+                            self.url_field: url,
+                            **metadata,
+                        }
+                    ],
+                )
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to insert document chunk: {str(e)}")
+
+    def _connect(self) -> None:
+        """Create the underlying Milvus client (idempotent)."""
+        try:
+            # Check if using Milvus Lite (file-based) vs server-based Milvus
+            if self._is_milvus_lite():
+                # Use MilvusClient for Milvus Lite (local file database)
+                self.client = MilvusClient(self.uri)
+                # Ensure collection exists
+                self._ensure_collection_exists()
+            else:
+                connection_args = {
+                    "uri": self.uri,
+                }
+                # Add user/password only if provided
+                if self.user:
+                    connection_args["user"] = self.user
+                if self.password:
+                    connection_args["password"] = self.password
+
+                # Create LangChain client (it will handle collection creation automatically)
+                self.client = LangchainMilvus(
+                    embedding_function=self.embedding_model,
+                    collection_name=self.collection_name,
+                    connection_args=connection_args,
+                    # optional (if collection already exists with different schema, be careful)
+                    drop_old=False,
+                )
+        except Exception as e:
+            raise ConnectionError(f"Failed to connect to Milvus: {str(e)}")
+
+    def _is_milvus_lite(self) -> bool:
+        """Return True if the URI points to a local Milvus Lite file.
+
+        Milvus Lite uses local file paths (often ``*.db``) without an HTTP/HTTPS
+        scheme. We treat any path not containing a protocol and not starting
+        with an HTTP(S) prefix as a Lite instance.
+        """
+        return self.uri.endswith(".db") or (
+            not self.uri.startswith(("http://", "https://")) and "://" not in self.uri
+        )
+
+    def _get_embedding(self, text: str) -> List[float]:
+        """Return embedding for a given text.
+
+        Args:
+            text: Input text to embed.
+
+        Returns:
+            Embedding vector as a list of floats.
+
+        Raises:
+            RuntimeError: If the embedding model fails or returns an invalid response.
+        """
+        try:
+            # Validate input
+            if not isinstance(text, str):
+                raise ValueError(f"Text must be a string, got {type(text)}")
+
+            if not text.strip():
+                raise ValueError("Text cannot be empty or only whitespace")
+            # Unified embedding interface (OpenAIEmbeddings or DashscopeEmbeddings wrapper)
+            embeddings = self.embedding_model.embed_query(text=text.strip())
+
+            # Validate output
+            if not isinstance(embeddings, list) or not embeddings:
+                raise ValueError(f"Invalid embedding format: {type(embeddings)}")
+
+            return embeddings
+        except Exception as e:
+            raise RuntimeError(f"Failed to generate embedding: {str(e)}")
+
+    def list_resources(self, query: Optional[str] = None) -> List[Resource]:
+        """List available resource summaries.
+
+        Strategy:
+            1. If connected to Milvus Lite: query stored document metadata.
+            2. If LangChain client: perform a lightweight similarity search
+               using either the provided ``query`` or a zero vector to fetch
+               candidate docs (mocked in tests).
+            3. Append local markdown example titles (non-ingested) for user
+               discoverability.
+
+        Args:
+            query: Optional search text to bias resource ordering.
+
+        Returns:
+            List of ``Resource`` objects.
+        """
+        resources: List[Resource] = []
+
+        # Ensure connection established
+        if not self.client:
+            try:
+                self._connect()
+            except Exception:
+                # Fall back to only local examples if connection fails
+                return self._list_local_markdown_resources()
+
+        try:
+            if self._is_milvus_lite():
+                # Query limited metadata. Empty filter returns up to limit docs.
+                results = self.client.query(
+                    collection_name=self.collection_name,
+                    filter="source == 'examples'",
+                    output_fields=[self.id_field, self.title_field, self.url_field],
+                    limit=100,
+                )
+                for r in results:
+                    resources.append(
+                        Resource(
+                            uri=r.get(self.url_field, "")
+                            or f"milvus://{r.get(self.id_field,'')}",
+                            title=r.get(self.title_field, "")
+                            or r.get(self.id_field, "Unnamed"),
+                            description="Stored Milvus document",
+                        )
+                    )
+            else:
+                # Use similarity_search_by_vector for lightweight listing.
+                # If a query is provided embed it; else use a zero vector.
+                docs: Iterable[Any] = self.client.similarity_search(
+                    query, k=100, expr="source == 'examples'"  # Limit to 100 results
+                )
+                for d in docs:
+                    meta = getattr(d, "metadata", {}) or {}
+                    # check if the resource is in the list of resources
+                    if resources and any(
+                        r.uri == meta.get(self.url_field, "")
+                        or r.uri == f"milvus://{meta.get(self.id_field,'')}"
+                        for r in resources
+                    ):
+                        continue
+                    resources.append(
+                        Resource(
+                            uri=meta.get(self.url_field, "")
+                            or f"milvus://{meta.get(self.id_field,'')}",
+                            title=meta.get(self.title_field, "")
+                            or meta.get(self.id_field, "Unnamed"),
+                            description="Stored Milvus document",
+                        )
+                    )
+                logger.info(
+                    "Succeed listed %d resources from Milvus collection: %s",
+                    len(resources),
+                    self.collection_name,
+                )
+        except Exception:
+            logger.warning(
+                "Failed to query Milvus for resources, falling back to local examples."
+            )
+            # Fall back to only local examples if connection fails
+            return self._list_local_markdown_resources()
+        return resources
+
+    def _list_local_markdown_resources(self) -> List[Resource]:
+        """Return local example markdown files as ``Resource`` objects.
+
+        These are surfaced even when not ingested so users can choose to load
+        them. Controlled by directory presence only (lightweight)."""
+        current_file = Path(__file__)
+        project_root = current_file.parent.parent.parent  # up to project root
+        examples_path = project_root / self.examples_dir
+        if not examples_path.exists():
+            return []
+
+        md_files = list(examples_path.glob("*.md"))
+        resources: list[Resource] = []
+        for md_file in md_files:
+            try:
+                content = md_file.read_text(encoding="utf-8", errors="ignore")
+                title = self._extract_title_from_markdown(content, md_file.name)
+                uri = f"milvus://{self.collection_name}/{md_file.name}"
+                resources.append(
+                    Resource(
+                        uri=uri,
+                        title=title,
+                        description="Local markdown example (not yet ingested)",
+                    )
+                )
+            except Exception:
+                continue
+        return resources
+
+    def query_relevant_documents(
+        self, query: str, resources: Optional[List[Resource]] = None
+    ) -> List[Document]:
+        """Perform vector similarity search returning rich ``Document`` objects.
+
+        Args:
+            query: Natural language query string.
+            resources: Optional subset filter of ``Resource`` objects; if
+                provided, only documents whose id/url appear in the list will
+                be included.
+
+        Returns:
+            List of aggregated ``Document`` objects; each contains one or more
+            ``Chunk`` instances (one per matched piece of content).
+
+        Raises:
+            RuntimeError: On underlying search errors.
+        """
+        resources = resources or []
+        try:
+            if not self.client:
+                self._connect()
+
+            # Get embeddings for the query
+            query_embedding = self._get_embedding(query)
+
+            # For Milvus Lite, use MilvusClient directly
+            if self._is_milvus_lite():
+                # Perform vector search
+                search_results = self.client.search(
+                    collection_name=self.collection_name,
+                    data=[query_embedding],
+                    anns_field=self.vector_field,
+                    param={"metric_type": "IP", "params": {"nprobe": 10}},
+                    limit=self.top_k,
+                    output_fields=[
+                        self.id_field,
+                        self.content_field,
+                        self.title_field,
+                        self.url_field,
+                    ],
+                )
+
+                documents = {}
+
+                for result_list in search_results:
+                    for result in result_list:
+                        entity = result.get("entity", {})
+                        doc_id = entity.get(self.id_field, "")
+                        content = entity.get(self.content_field, "")
+                        title = entity.get(self.title_field, "")
+                        url = entity.get(self.url_field, "")
+                        score = result.get("distance", 0.0)
+
+                        # Skip if resource filtering is requested and this doc is not in the list
+                        if resources:
+                            doc_in_resources = False
+                            for resource in resources:
+                                if (
+                                    url and url in resource.uri
+                                ) or doc_id in resource.uri:
+                                    doc_in_resources = True
+                                    break
+                            if not doc_in_resources:
+                                continue
+
+                        # Create or update document
+                        if doc_id not in documents:
+                            documents[doc_id] = Document(
+                                id=doc_id, url=url, title=title, chunks=[]
+                            )
+
+                        # Add chunk to document
+                        chunk = Chunk(content=content, similarity=score)
+                        documents[doc_id].chunks.append(chunk)
+
+                return list(documents.values())
+
+            else:
+                # For LangChain Milvus, use similarity search
+                search_results = self.client.similarity_search_with_score(
+                    query=query, k=self.top_k
+                )
+
+                documents = {}
+
+                for doc, score in search_results:
+                    metadata = doc.metadata or {}
+                    doc_id = metadata.get(self.id_field, "")
+                    title = metadata.get(self.title_field, "")
+                    url = metadata.get(self.url_field, "")
+                    content = doc.page_content
+
+                    # Skip if resource filtering is requested and this doc is not in the list
+                    if resources:
+                        doc_in_resources = False
+                        for resource in resources:
+                            if (url and url in resource.uri) or doc_id in resource.uri:
+                                doc_in_resources = True
+                                break
+                        if not doc_in_resources:
+                            continue
+
+                    # Create or update document
+                    if doc_id not in documents:
+                        documents[doc_id] = Document(
+                            id=doc_id, url=url, title=title, chunks=[]
+                        )
+
+                    # Add chunk to document
+                    chunk = Chunk(content=content, similarity=score)
+                    documents[doc_id].chunks.append(chunk)
+
+                return list(documents.values())
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to query documents from Milvus: {str(e)}")
+
+    def create_collection(self) -> None:
+        """Public hook ensuring collection exists (explicit initialization)."""
+        if not self.client:
+            self._connect()
+        else:
+            # If we're using Milvus Lite, ensure collection exists
+            if self._is_milvus_lite():
+                self._ensure_collection_exists()
+
+    def load_examples(self, force_reload: bool = False) -> None:
+        """Load example markdown files, optionally clearing existing ones.
+
+        Args:
+            force_reload: If True existing example documents are deleted first.
+        """
+        if not self.client:
+            self._connect()
+
+        if force_reload:
+            # Clear existing examples
+            self._clear_example_documents()
+
+        self._load_example_files()
+
+    def _clear_example_documents(self) -> None:
+        """Delete previously ingested example documents (Milvus Lite only)."""
+        try:
+            if self._is_milvus_lite():
+                # For Milvus Lite, delete documents with source='examples'
+                # Note: Milvus doesn't support direct delete by filter in all versions
+                # So we'll query and delete by IDs
+                results = self.client.query(
+                    collection_name=self.collection_name,
+                    filter="source == 'examples'",
+                    output_fields=[self.id_field],
+                    limit=10000,
+                )
+
+                if results:
+                    doc_ids = [result[self.id_field] for result in results]
+                    self.client.delete(
+                        collection_name=self.collection_name, ids=doc_ids
+                    )
+                    logger.info("Cleared %d existing example documents", len(doc_ids))
+            else:
+                # For LangChain Milvus, we can't easily delete by metadata
+                logger.info(
+                    "Clearing existing examples not supported for LangChain Milvus client"
+                )
+
+        except Exception as e:
+            logger.warning("Could not clear existing examples: %s", e)
+
+    def get_loaded_examples(self) -> List[Dict[str, str]]:
+        """Return metadata for previously ingested example documents."""
+        try:
+            if not self.client:
+                self._connect()
+
+            if self._is_milvus_lite():
+                results = self.client.query(
+                    collection_name=self.collection_name,
+                    filter="source == 'examples'",
+                    output_fields=[
+                        self.id_field,
+                        self.title_field,
+                        self.url_field,
+                        "source",
+                        "file",
+                    ],
+                    limit=1000,
+                )
+
+                examples = []
+                for result in results:
+                    examples.append(
+                        {
+                            "id": result.get(self.id_field, ""),
+                            "title": result.get(self.title_field, ""),
+                            "file": result.get("file", ""),
+                            "url": result.get(self.url_field, ""),
+                        }
+                    )
+
+                return examples
+            else:
+                # For LangChain Milvus, we can't easily filter by metadata
+                logger.info(
+                    "Getting loaded examples not supported for LangChain Milvus client"
+                )
+                return []
+
+        except Exception as e:
+            logger.error("Error getting loaded examples: %s", e)
+            return []
+
+    def close(self) -> None:
+        """Release underlying client resources (idempotent)."""
+        if hasattr(self, "client") and self.client:
+            try:
+                # For Milvus Lite (MilvusClient), close the connection
+                if self._is_milvus_lite() and hasattr(self.client, "close"):
+                    self.client.close()
+                # For LangChain Milvus, no explicit close method needed
+                self.client = None
+            except Exception:
+                # Ignore errors during cleanup
+                pass
+
+    def __del__(self) -> None:  # pragma: no cover - best-effort cleanup
+        """Best-effort cleanup when instance is garbage collected."""
+        self.close()
+
+
+# Backwards compatibility export (original class name kept for external imports)
+class MilvusProvider(MilvusRetriever):
+    """Backward compatible alias for ``MilvusRetriever`` (original name)."""
+
+    pass
+
+def load_examples() -> None:
+    auto_load_examples = get_bool_env("MILVUS_AUTO_LOAD_EXAMPLES", False)
+    rag_provider = get_str_env("RAG_PROVIDER", "")
+    if rag_provider == "milvus" and auto_load_examples:
+        provider = MilvusProvider()
+        provider.load_examples()

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -27,6 +27,7 @@ from src.ppt.graph.builder import build_graph as build_ppt_graph
 from src.prompt_enhancer.graph.builder import build_graph as build_prompt_enhancer_graph
 from src.prose.graph.builder import build_graph as build_prose_graph
 from src.rag.builder import build_retriever
+from src.rag.milvus import load_examples
 from src.rag.retriever import Resource
 from src.server.chat_request import (
     ChatRequest,
@@ -73,6 +74,10 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],  # Use the configured list of methods
     allow_headers=["*"],  # Now allow all headers, but can be restricted further
 )
+
+# Load examples into Milvus if configured
+load_examples()
+
 in_memory_store = InMemoryStore()
 graph = build_graph_with_memory()
 

--- a/tests/unit/rag/test_milvus.py
+++ b/tests/unit/rag/test_milvus.py
@@ -1,0 +1,278 @@
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.rag.milvus import MilvusRetriever, Resource, Chunk, Document
+
+
+class DummyEmbeddingModel:
+    def __init__(self, dim: int = 4):
+        self.dim = dim
+
+    def embed_query(self, text: str):  # LangChain OpenAIEmbeddings interface subset
+        # return deterministic vector length dim
+        return [float(len(text) % 7 + i) for i in range(self.dim)]
+
+
+@pytest.fixture(autouse=True)
+def patch_env(monkeypatch):
+    """Provide minimal environment variables & ensure deterministic state."""
+    monkeypatch.setenv("MILVUS_EMBEDDING_MODEL", "text-embedding-ada-002")
+    monkeypatch.setenv("MILVUS_TOP_K", "5")
+    monkeypatch.setenv("MILVUS_COLLECTION", "test_collection")
+    # Force using a lite URI path to exercise that branch by default
+    monkeypatch.setenv("MILVUS_URI", "local.db")
+    yield
+
+
+@pytest.fixture
+def lite_retriever(monkeypatch):
+    """MilvusRetriever configured for Milvus Lite with a fake client."""
+
+    # Patch embedding init to avoid external imports
+    monkeypatch.setattr(
+        MilvusRetriever,
+        "_init_embedding_model",
+        lambda self: setattr(self, "embedding_model", DummyEmbeddingModel()),
+    )
+    # Force tiny chunk size for easier splitting tests
+    monkeypatch.setenv("MILVUS_CHUNK_SIZE", "50")
+
+    r = MilvusRetriever()
+
+    # Fake lite client implementing subset of operations
+    class FakeLiteClient:
+        def __init__(self):
+            self.inserted = []
+            self.collections = {r.collection_name}
+
+        # Collection ops
+        def list_collections(self):
+            return list(self.collections)
+
+        def create_collection(self, **kwargs):  # pragma: no cover (not used normally)
+            self.collections.add(kwargs.get("collection_name"))
+
+        # Data ops
+        def insert(self, collection_name, data):
+            self.inserted.extend(data)
+
+        def query(self, collection_name, filter, output_fields, limit):
+            # Return only 'example' docs if filter matches
+            if "source == 'examples'" in filter:
+                return [
+                    {
+                        r.id_field: "example_doc1",
+                        r.title_field: "Example Doc 1",
+                        r.url_field: "milvus://test_collection/doc1.md",
+                    }
+                ]
+            return []
+
+        def search(
+            self, collection_name, data, anns_field, param, limit, output_fields
+        ):
+            # Return a single hit shaped like pymilvus result
+            return [
+                [
+                    {
+                        "entity": {
+                            r.id_field: "docA",
+                            r.content_field: "Relevant content A",
+                            r.title_field: "Title A",
+                            r.url_field: "milvus://test_collection/docA",
+                        },
+                        "distance": 0.87,
+                    }
+                ]
+            ]
+
+        def delete(self, collection_name, ids):  # pragma: no cover
+            pass
+
+        def close(self):  # pragma: no cover
+            pass
+
+    r.client = FakeLiteClient()
+    # Avoid re-building client
+    monkeypatch.setattr(r, "_connect", lambda: None)
+    return r
+
+
+@pytest.fixture
+def remote_retriever(monkeypatch):
+    """MilvusRetriever configured for remote (LangChain) path with fake client."""
+    monkeypatch.setenv("MILVUS_URI", "http://remote-milvus:19530")
+    monkeypatch.setattr(
+        MilvusRetriever,
+        "_init_embedding_model",
+        lambda self: setattr(self, "embedding_model", DummyEmbeddingModel()),
+    )
+    r = MilvusRetriever()
+
+    class FakeDoc:
+        def __init__(self, page_content, metadata):
+            self.page_content = page_content
+            self.metadata = metadata
+
+    class FakeRemoteClient:
+        def similarity_search(self, query, k, expr):
+            return [
+                FakeDoc(
+                    "Example page",  # page_content
+                    {
+                        r.id_field: "ex1",
+                        r.title_field: "Example 1",
+                        r.url_field: "milvus://test_collection/ex1.md",
+                    },
+                )
+            ]
+
+        def similarity_search_with_score(self, query, k):
+            return [
+                (
+                    FakeDoc(
+                        "Remote content",  # page_content
+                        {
+                            r.id_field: "rid1",
+                            r.title_field: "Remote Title",
+                            r.url_field: "milvus://test_collection/rid1",
+                        },
+                    ),
+                    0.42,
+                )
+            ]
+
+        def add_texts(self, texts, metadatas):  # pragma: no cover
+            pass
+
+    r.client = FakeRemoteClient()
+    monkeypatch.setattr(r, "_connect", lambda: None)
+    return r
+
+
+def test_split_content_chunking(lite_retriever):
+    content = "Paragraph1." + "a" * 30 + "\n\n" + "Paragraph2." + "b" * 30
+    chunks = lite_retriever._split_content(content)
+    # Because chunk size = 50, likely split into >=2 chunks
+    assert len(chunks) >= 2
+    assert all(len(c) <= 60 for c in chunks)  # allow small overhead
+
+
+def test_generate_doc_id_stability(tmp_path, lite_retriever):
+    p = tmp_path / "file.md"
+    p.write_text("hello")
+    id1 = lite_retriever._generate_doc_id(p)
+    id2 = lite_retriever._generate_doc_id(p)
+    assert id1 == id2  # stable for unchanged file
+
+
+def test_get_embedding_success(lite_retriever):
+    emb = lite_retriever._get_embedding("hello world")
+    assert isinstance(emb, list) and emb
+
+
+@pytest.mark.parametrize("bad", [None, 123, "   "])
+def test_get_embedding_invalid_inputs_raise(lite_retriever, bad):
+    with pytest.raises(RuntimeError):
+        lite_retriever._get_embedding(bad)  # type: ignore[arg-type]
+
+
+def test_list_resources_lite(lite_retriever):
+    resources = lite_retriever.list_resources()
+    assert resources and isinstance(resources[0], Resource)
+    assert resources[0].uri.startswith("milvus://")
+
+
+def test_query_relevant_documents_lite(lite_retriever):
+    docs = lite_retriever.query_relevant_documents("test query")
+    assert len(docs) == 1
+    d = docs[0]
+    assert isinstance(d, Document)
+    assert d.chunks and isinstance(d.chunks[0], Chunk)
+    assert d.chunks[0].similarity > 0
+
+
+def test_query_relevant_documents_lite_with_resource_filter(lite_retriever):
+    # Resource not matching doc will filter out results
+    res = [Resource(uri="milvus://test_collection/other.md", title="Other")]  # no match
+    docs = lite_retriever.query_relevant_documents("query", res)
+    assert docs == []
+
+    res2 = [Resource(uri="milvus://test_collection/docA", title="Doc A")]
+    docs2 = lite_retriever.query_relevant_documents("query", res2)
+    assert docs2 and docs2[0].id == "docA"
+
+
+def test_list_resources_remote(remote_retriever):
+    resources = remote_retriever.list_resources()
+    assert len(resources) == 1
+    assert resources[0].title == "Example 1"
+
+
+def test_query_relevant_documents_remote(remote_retriever):
+    docs = remote_retriever.query_relevant_documents("some query")
+    assert len(docs) == 1
+    assert docs[0].chunks[0].similarity == 0.42
+
+
+def test_query_relevant_documents_remote_with_filter(remote_retriever):
+    # Provide resource that does not match -> filtered out
+    res = [Resource(uri="milvus://test_collection/other", title="Other")]
+    docs = remote_retriever.query_relevant_documents("q", res)
+    assert docs == []
+
+    # Matching resource
+    res2 = [Resource(uri="milvus://test_collection/rid1", title="Match")]
+    docs2 = remote_retriever.query_relevant_documents("q", res2)
+    assert docs2 and docs2[0].id == "rid1"
+
+
+def test_load_examples_invokes_insert(monkeypatch, lite_retriever):
+    # Patch helpers to avoid real embedding + limit scope to a single artificial file
+    inserted = []
+    monkeypatch.setattr(
+        lite_retriever,
+        "_get_existing_document_ids",
+        lambda: set(),
+    )
+    monkeypatch.setattr(
+        lite_retriever,
+        "_insert_document_chunk",
+        lambda **kwargs: inserted.append(kwargs),
+    )
+
+    # Point examples dir to real repo examples (already present) or create one temp file
+    # Prefer creating a temp examples directory with single file for deterministic count
+    temp_examples = os.path.join(os.getcwd(), "temp_examples")
+    os.makedirs(temp_examples, exist_ok=True)
+    sample = os.path.join(temp_examples, "sample.md")
+    with open(sample, "w", encoding="utf-8") as f:
+        f.write("# Sample Title\n\nContent paragraph one.\n\nSecond paragraph.")
+    monkeypatch.setenv("MILVUS_EXAMPLES_DIR", "temp_examples")
+
+    lite_retriever.examples_dir = "temp_examples"  # reflect override
+    lite_retriever.load_examples()
+    assert inserted, "Expected at least one chunk inserted from example file"
+    # Clean up temp examples directory contents (not directory) for idempotent reruns
+    for fn in os.listdir(temp_examples):  # pragma: no cover (cleanup)
+        try:
+            os.remove(os.path.join(temp_examples, fn))
+        except OSError:
+            pass
+
+
+def test_invalid_embedding_provider(monkeypatch):
+    monkeypatch.setenv("MILVUS_EMBEDDING_PROVIDER", "invalid")
+    monkeypatch.setattr("src.rag.milvus.EMBEDDINGS_AVAILABLE", True, raising=False)
+    # Patch OpenAIEmbeddings symbol expected by init to a dummy so import path works
+    monkeypatch.setattr(
+        "src.rag.milvus.OpenAIEmbeddings", DummyEmbeddingModel, raising=False
+    )
+    with pytest.raises(ValueError, match="Unsupported embedding provider"):
+        MilvusRetriever()

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,7 @@ dependencies = [
     { name = "langchain-deepseek" },
     { name = "langchain-experimental" },
     { name = "langchain-mcp-adapters" },
+    { name = "langchain-milvus" },
     { name = "langchain-openai" },
     { name = "langchain-tavily" },
     { name = "langgraph" },
@@ -370,6 +371,7 @@ dependencies = [
     { name = "mcp" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pymilvus" },
     { name = "python-dotenv" },
     { name = "readabilipy" },
     { name = "socksio" },
@@ -403,6 +405,7 @@ requires-dist = [
     { name = "langchain-deepseek", specifier = ">=0.1.3" },
     { name = "langchain-experimental", specifier = ">=0.3.4" },
     { name = "langchain-mcp-adapters", specifier = ">=0.0.9" },
+    { name = "langchain-milvus", specifier = ">=0.2.1" },
     { name = "langchain-openai", specifier = ">=0.3.8" },
     { name = "langchain-tavily", specifier = "<0.3" },
     { name = "langgraph", specifier = ">=0.3.5" },
@@ -414,6 +417,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.11.0" },
     { name = "numpy", specifier = ">=2.2.3" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pymilvus", specifier = ">=2.3.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.4.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.0.0" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=4.1.0" },
@@ -591,6 +595,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753, upload-time = "2024-09-20T17:08:38.079Z" },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731, upload-time = "2024-09-20T17:44:20.556Z" },
     { url = "https://files.pythonhosted.org/packages/ac/38/08cc303ddddc4b3d7c628c3039a61a3aae36c241ed01393d00c2fd663473/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:411f015496fec93c1c8cd4e5238da364e1da7a124bcb293f085bf2860c32c6f6", size = 1142112, upload-time = "2024-09-20T17:09:28.753Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/b4/35feb8f7cab7239c5b94bd2db71abb3d6adb5f335ad8f131abb6060840b6/grpcio-1.74.0.tar.gz", hash = "sha256:80d1f4fbb35b0742d3e3d3bb654b7381cd5f015f8497279a1e9c21ba623e01b1", size = 12756048, upload-time = "2025-07-24T18:54:23.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/5d/e504d5d5c4469823504f65687d6c8fb97b7f7bf0b34873b7598f1df24630/grpcio-1.74.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:8533e6e9c5bd630ca98062e3a1326249e6ada07d05acf191a77bc33f8948f3d8", size = 5445551, upload-time = "2025-07-24T18:53:23.641Z" },
+    { url = "https://files.pythonhosted.org/packages/43/01/730e37056f96f2f6ce9f17999af1556df62ee8dab7fa48bceeaab5fd3008/grpcio-1.74.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:2918948864fec2a11721d91568effffbe0a02b23ecd57f281391d986847982f6", size = 10979810, upload-time = "2025-07-24T18:53:25.349Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3d/09fd100473ea5c47083889ca47ffd356576173ec134312f6aa0e13111dee/grpcio-1.74.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:60d2d48b0580e70d2e1954d0d19fa3c2e60dd7cbed826aca104fff518310d1c5", size = 5941946, upload-time = "2025-07-24T18:53:27.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/99/12d2cca0a63c874c6d3d195629dcd85cdf5d6f98a30d8db44271f8a97b93/grpcio-1.74.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3601274bc0523f6dc07666c0e01682c94472402ac2fd1226fd96e079863bfa49", size = 6621763, upload-time = "2025-07-24T18:53:29.193Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2c/930b0e7a2f1029bbc193443c7bc4dc2a46fedb0203c8793dcd97081f1520/grpcio-1.74.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:176d60a5168d7948539def20b2a3adcce67d72454d9ae05969a2e73f3a0feee7", size = 6180664, upload-time = "2025-07-24T18:53:30.823Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d5/ff8a2442180ad0867717e670f5ec42bfd8d38b92158ad6bcd864e6d4b1ed/grpcio-1.74.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e759f9e8bc908aaae0412642afe5416c9f983a80499448fcc7fab8692ae044c3", size = 6301083, upload-time = "2025-07-24T18:53:32.454Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/b361d390451a37ca118e4ec7dccec690422e05bc85fba2ec72b06cefec9f/grpcio-1.74.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:9e7c4389771855a92934b2846bd807fc25a3dfa820fd912fe6bd8136026b2707", size = 6994132, upload-time = "2025-07-24T18:53:34.506Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/0c/3a5fa47d2437a44ced74141795ac0251bbddeae74bf81df3447edd767d27/grpcio-1.74.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cce634b10aeab37010449124814b05a62fb5f18928ca878f1bf4750d1f0c815b", size = 6489616, upload-time = "2025-07-24T18:53:36.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/95/ab64703b436d99dc5217228babc76047d60e9ad14df129e307b5fec81fd0/grpcio-1.74.0-cp312-cp312-win32.whl", hash = "sha256:885912559974df35d92219e2dc98f51a16a48395f37b92865ad45186f294096c", size = 3807083, upload-time = "2025-07-24T18:53:37.911Z" },
+    { url = "https://files.pythonhosted.org/packages/84/59/900aa2445891fc47a33f7d2f76e00ca5d6ae6584b20d19af9c06fa09bf9a/grpcio-1.74.0-cp312-cp312-win_amd64.whl", hash = "sha256:42f8fee287427b94be63d916c90399ed310ed10aadbf9e2e5538b3e497d269bc", size = 4490123, upload-time = "2025-07-24T18:53:39.528Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d8/1004a5f468715221450e66b051c839c2ce9a985aa3ee427422061fcbb6aa/grpcio-1.74.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:2bc2d7d8d184e2362b53905cb1708c84cb16354771c04b490485fa07ce3a1d89", size = 5449488, upload-time = "2025-07-24T18:53:41.174Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0e/33731a03f63740d7743dced423846c831d8e6da808fcd02821a4416df7fa/grpcio-1.74.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c14e803037e572c177ba54a3e090d6eb12efd795d49327c5ee2b3bddb836bf01", size = 10974059, upload-time = "2025-07-24T18:53:43.066Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/c6/3d2c14d87771a421205bdca991467cfe473ee4c6a1231c1ede5248c62ab8/grpcio-1.74.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f6ec94f0e50eb8fa1744a731088b966427575e40c2944a980049798b127a687e", size = 5945647, upload-time = "2025-07-24T18:53:45.269Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/83/5a354c8aaff58594eef7fffebae41a0f8995a6258bbc6809b800c33d4c13/grpcio-1.74.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:566b9395b90cc3d0d0c6404bc8572c7c18786ede549cdb540ae27b58afe0fb91", size = 6626101, upload-time = "2025-07-24T18:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ca/4fdc7bf59bf6994aa45cbd4ef1055cd65e2884de6113dbd49f75498ddb08/grpcio-1.74.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1ea6176d7dfd5b941ea01c2ec34de9531ba494d541fe2057c904e601879f249", size = 6182562, upload-time = "2025-07-24T18:53:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/48/2869e5b2c1922583686f7ae674937986807c2f676d08be70d0a541316270/grpcio-1.74.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:64229c1e9cea079420527fa8ac45d80fc1e8d3f94deaa35643c381fa8d98f362", size = 6303425, upload-time = "2025-07-24T18:53:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0e/bac93147b9a164f759497bc6913e74af1cb632c733c7af62c0336782bd38/grpcio-1.74.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:0f87bddd6e27fc776aacf7ebfec367b6d49cad0455123951e4488ea99d9b9b8f", size = 6996533, upload-time = "2025-07-24T18:53:52.747Z" },
+    { url = "https://files.pythonhosted.org/packages/84/35/9f6b2503c1fd86d068b46818bbd7329db26a87cdd8c01e0d1a9abea1104c/grpcio-1.74.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3b03d8f2a07f0fea8c8f74deb59f8352b770e3900d143b3d1475effcb08eec20", size = 6491489, upload-time = "2025-07-24T18:53:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/75/33/a04e99be2a82c4cbc4039eb3a76f6c3632932b9d5d295221389d10ac9ca7/grpcio-1.74.0-cp313-cp313-win32.whl", hash = "sha256:b6a73b2ba83e663b2480a90b82fdae6a7aa6427f62bf43b29912c0cfd1aa2bfa", size = 3805811, upload-time = "2025-07-24T18:53:56.798Z" },
+    { url = "https://files.pythonhosted.org/packages/34/80/de3eb55eb581815342d097214bed4c59e806b05f1b3110df03b2280d6dfd/grpcio-1.74.0-cp313-cp313-win_amd64.whl", hash = "sha256:fd3c71aeee838299c5887230b8a1822795325ddfea635edd82954c1eaa831e24", size = 4489214, upload-time = "2025-07-24T18:53:59.771Z" },
 ]
 
 [[package]]
@@ -936,6 +968,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b9/74/e36003a43136f9095a5f968c730fbfe894f94284ebe6d2b50bb17d41b8b5/langchain_mcp_adapters-0.1.9.tar.gz", hash = "sha256:0018cf7b5f7bc4c044e05ec20fcb9ebe345311c8d1060c61d411188001ab3aab", size = 22101, upload-time = "2025-07-09T15:56:14.455Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/eb/9e98822d3db22beff44449a8f61fca208d4f59d592a7ce67ce4c400b8f8f/langchain_mcp_adapters-0.1.9-py3-none-any.whl", hash = "sha256:fd131009c60c9e5a864f96576bbe757fc1809abd604891cb2e5d6e8aebd6975c", size = 15300, upload-time = "2025-07-09T15:56:13.316Z" },
+]
+
+[[package]]
+name = "langchain-milvus"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "pymilvus" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/dd/5e8b7f6f17da0e54205956feab3f7856cb7dc821dbe817f2990aa028e4cc/langchain_milvus-0.2.1.tar.gz", hash = "sha256:6e60e43959464ae2be9dadceb4fab6b3ddcec5bb1f2d29e898924f1c2651baf1", size = 32639, upload-time = "2025-06-28T09:59:53.826Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/b1/54e176cc8ac80df9a2c4ee9f726d6383fcf9818317c68532cfc90fa91b6c/langchain_milvus-0.2.1-py3-none-any.whl", hash = "sha256:faabf4685c15ef9651605172427073d6ffc52c0f36f3b88842977db883062c99", size = 36110, upload-time = "2025-06-28T09:59:52.965Z" },
 ]
 
 [[package]]
@@ -1325,6 +1370,20 @@ wheels = [
 ]
 
 [[package]]
+name = "milvus-lite"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tqdm" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/b2/acc5024c8e8b6a0b034670b8e8af306ebd633ede777dcbf557eac4785937/milvus_lite-2.5.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6b014453200ba977be37ba660cb2d021030375fa6a35bc53c2e1d92980a0c512", size = 27934713, upload-time = "2025-06-30T04:23:37.028Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2e/746f5bb1d6facd1e73eb4af6dd5efda11125b0f29d7908a097485ca6cad9/milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a", size = 24421451, upload-time = "2025-06-30T04:23:51.747Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/cf/3d1fee5c16c7661cf53977067a34820f7269ed8ba99fe9cf35efc1700866/milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9", size = 45337093, upload-time = "2025-06-30T04:24:06.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/82/41d9b80f09b82e066894d9b508af07b7b0fa325ce0322980674de49106a0/milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c", size = 55263911, upload-time = "2025-06-30T04:24:19.434Z" },
+]
+
+[[package]]
 name = "motor"
 version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1670,6 +1729,20 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.32.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/df/fb4a8eeea482eca989b51cffd274aac2ee24e825f0bf3cbce5281fa1567b/protobuf-6.32.0.tar.gz", hash = "sha256:a81439049127067fc49ec1d36e25c6ee1d1a2b7be930675f919258d03c04e7d2", size = 440614, upload-time = "2025-08-14T21:21:25.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/18/df8c87da2e47f4f1dcc5153a81cd6bca4e429803f4069a299e236e4dd510/protobuf-6.32.0-cp310-abi3-win32.whl", hash = "sha256:84f9e3c1ff6fb0308dbacb0950d8aa90694b0d0ee68e75719cb044b7078fe741", size = 424409, upload-time = "2025-08-14T21:21:12.366Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/59/0a820b7310f8139bd8d5a9388e6a38e1786d179d6f33998448609296c229/protobuf-6.32.0-cp310-abi3-win_amd64.whl", hash = "sha256:a8bdbb2f009cfc22a36d031f22a625a38b615b5e19e558a7b756b3279723e68e", size = 435735, upload-time = "2025-08-14T21:21:15.046Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5b/0d421533c59c789e9c9894683efac582c06246bf24bb26b753b149bd88e4/protobuf-6.32.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:d52691e5bee6c860fff9a1c86ad26a13afbeb4b168cd4445c922b7e2cf85aaf0", size = 426449, upload-time = "2025-08-14T21:21:16.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/7b/607764ebe6c7a23dcee06e054fd1de3d5841b7648a90fd6def9a3bb58c5e/protobuf-6.32.0-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:501fe6372fd1c8ea2a30b4d9be8f87955a64d6be9c88a973996cef5ef6f0abf1", size = 322869, upload-time = "2025-08-14T21:21:18.282Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/2e730bd1c25392fc32e3268e02446f0d77cb51a2c3a8486b1798e34d5805/protobuf-6.32.0-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:75a2aab2bd1aeb1f5dc7c5f33bcb11d82ea8c055c9becbb41c26a8c43fd7092c", size = 322009, upload-time = "2025-08-14T21:21:19.893Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f2/80ffc4677aac1bc3519b26bc7f7f5de7fce0ee2f7e36e59e27d8beb32dd1/protobuf-6.32.0-py3-none-any.whl", hash = "sha256:ba377e5b67b908c8f3072a57b63e2c6a4cbd18aea4ed98d2584350dbf46f2783", size = 169287, upload-time = "2025-08-14T21:21:23.515Z" },
+]
+
+[[package]]
 name = "psycopg"
 version = "3.2.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1776,6 +1849,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
+]
+
+[[package]]
+name = "pymilvus"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grpcio" },
+    { name = "milvus-lite", marker = "sys_platform != 'win32'" },
+    { name = "pandas" },
+    { name = "protobuf" },
+    { name = "python-dotenv" },
+    { name = "setuptools" },
+    { name = "ujson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/21/5c25a975299415a5a8f26d4759ddf7852aefdf3595f002b5203c4aaf5c8e/pymilvus-2.6.0.tar.gz", hash = "sha256:2b2ca487e098abc34231755e33af2f5294e9f6a64d92d03551532defbac0a3fb", size = 1292994, upload-time = "2025-08-06T09:09:01.705Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/a2/dfc2a2225aeb90a7dff9443f2d26fe9d04f6f7bcefe537945b5d5220fddd/pymilvus-2.6.0-py3-none-any.whl", hash = "sha256:d743fdd928c9007184d24a52b4f5dfdd18d405a37b4dba66b5ea4bf196fac526", size = 248299, upload-time = "2025-08-06T09:08:58.272Z" },
 ]
 
 [[package]]
@@ -2104,6 +2195,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2317,6 +2417,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694", size = 194950, upload-time = "2025-01-21T19:49:38.686Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639", size = 346762, upload-time = "2025-01-21T19:49:37.187Z" },
+]
+
+[[package]]
+name = "ujson"
+version = "5.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/00/3110fd566786bfa542adb7932d62035e0c0ef662a8ff6544b6643b3d6fd7/ujson-5.10.0.tar.gz", hash = "sha256:b3cd8f3c5d8c7738257f1018880444f7b7d9b66232c64649f562d7ba86ad4bc1", size = 7154885, upload-time = "2024-05-14T02:02:34.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/a6/fd3f8bbd80842267e2d06c3583279555e8354c5986c952385199d57a5b6c/ujson-5.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:98ba15d8cbc481ce55695beee9f063189dce91a4b08bc1d03e7f0152cd4bbdd5", size = 55642, upload-time = "2024-05-14T02:01:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/47/dd03fd2b5ae727e16d5d18919b383959c6d269c7b948a380fdd879518640/ujson-5.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a9d2edbf1556e4f56e50fab7d8ff993dbad7f54bac68eacdd27a8f55f433578e", size = 51807, upload-time = "2024-05-14T02:01:05.25Z" },
+    { url = "https://files.pythonhosted.org/packages/25/23/079a4cc6fd7e2655a473ed9e776ddbb7144e27f04e8fc484a0fb45fe6f71/ujson-5.10.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6627029ae4f52d0e1a2451768c2c37c0c814ffc04f796eb36244cf16b8e57043", size = 51972, upload-time = "2024-05-14T02:01:06.458Z" },
+    { url = "https://files.pythonhosted.org/packages/04/81/668707e5f2177791869b624be4c06fb2473bf97ee33296b18d1cf3092af7/ujson-5.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f8ccb77b3e40b151e20519c6ae6d89bfe3f4c14e8e210d910287f778368bb3d1", size = 53686, upload-time = "2024-05-14T02:01:07.618Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/50/056d518a386d80aaf4505ccf3cee1c40d312a46901ed494d5711dd939bc3/ujson-5.10.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3caf9cd64abfeb11a3b661329085c5e167abbe15256b3b68cb5d914ba7396f3", size = 58591, upload-time = "2024-05-14T02:01:08.901Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d6/aeaf3e2d6fb1f4cfb6bf25f454d60490ed8146ddc0600fae44bfe7eb5a72/ujson-5.10.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6e32abdce572e3a8c3d02c886c704a38a1b015a1fb858004e03d20ca7cecbb21", size = 997853, upload-time = "2024-05-14T02:01:10.772Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d5/1f2a5d2699f447f7d990334ca96e90065ea7f99b142ce96e85f26d7e78e2/ujson-5.10.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a65b6af4d903103ee7b6f4f5b85f1bfd0c90ba4eeac6421aae436c9988aa64a2", size = 1140689, upload-time = "2024-05-14T02:01:12.214Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2c/6990f4ccb41ed93744aaaa3786394bca0875503f97690622f3cafc0adfde/ujson-5.10.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:604a046d966457b6cdcacc5aa2ec5314f0e8c42bae52842c1e6fa02ea4bda42e", size = 1043576, upload-time = "2024-05-14T02:01:14.39Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f5/a2368463dbb09fbdbf6a696062d0c0f62e4ae6fa65f38f829611da2e8fdd/ujson-5.10.0-cp312-cp312-win32.whl", hash = "sha256:6dea1c8b4fc921bf78a8ff00bbd2bfe166345f5536c510671bccececb187c80e", size = 38764, upload-time = "2024-05-14T02:01:15.83Z" },
+    { url = "https://files.pythonhosted.org/packages/59/2d/691f741ffd72b6c84438a93749ac57bf1a3f217ac4b0ea4fd0e96119e118/ujson-5.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:38665e7d8290188b1e0d57d584eb8110951a9591363316dd41cf8686ab1d0abc", size = 42211, upload-time = "2024-05-14T02:01:17.567Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/69/b3e3f924bb0e8820bb46671979770c5be6a7d51c77a66324cdb09f1acddb/ujson-5.10.0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:618efd84dc1acbd6bff8eaa736bb6c074bfa8b8a98f55b61c38d4ca2c1f7f287", size = 55646, upload-time = "2024-05-14T02:01:19.26Z" },
+    { url = "https://files.pythonhosted.org/packages/32/8a/9b748eb543c6cabc54ebeaa1f28035b1bd09c0800235b08e85990734c41e/ujson-5.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:38d5d36b4aedfe81dfe251f76c0467399d575d1395a1755de391e58985ab1c2e", size = 51806, upload-time = "2024-05-14T02:01:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/39/50/4b53ea234413b710a18b305f465b328e306ba9592e13a791a6a6b378869b/ujson-5.10.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67079b1f9fb29ed9a2914acf4ef6c02844b3153913eb735d4bf287ee1db6e557", size = 51975, upload-time = "2024-05-14T02:01:21.904Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9d/8061934f960cdb6dd55f0b3ceeff207fcc48c64f58b43403777ad5623d9e/ujson-5.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7d0e0ceeb8fe2468c70ec0c37b439dd554e2aa539a8a56365fd761edb418988", size = 53693, upload-time = "2024-05-14T02:01:23.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/7bfa84b28519ddbb67efc8410765ca7da55e6b93aba84d97764cd5794dbc/ujson-5.10.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:59e02cd37bc7c44d587a0ba45347cc815fb7a5fe48de16bf05caa5f7d0d2e816", size = 58594, upload-time = "2024-05-14T02:01:25.554Z" },
+    { url = "https://files.pythonhosted.org/packages/48/eb/85d465abafb2c69d9699cfa5520e6e96561db787d36c677370e066c7e2e7/ujson-5.10.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2a890b706b64e0065f02577bf6d8ca3b66c11a5e81fb75d757233a38c07a1f20", size = 997853, upload-time = "2024-05-14T02:01:27.151Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/76/2a63409fc05d34dd7d929357b7a45e3a2c96f22b4225cd74becd2ba6c4cb/ujson-5.10.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:621e34b4632c740ecb491efc7f1fcb4f74b48ddb55e65221995e74e2d00bbff0", size = 1140694, upload-time = "2024-05-14T02:01:29.113Z" },
+    { url = "https://files.pythonhosted.org/packages/45/ed/582c4daba0f3e1688d923b5cb914ada1f9defa702df38a1916c899f7c4d1/ujson-5.10.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9500e61fce0cfc86168b248104e954fead61f9be213087153d272e817ec7b4f", size = 1043580, upload-time = "2024-05-14T02:01:31.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0c/9837fece153051e19c7bade9f88f9b409e026b9525927824cdf16293b43b/ujson-5.10.0-cp313-cp313-win32.whl", hash = "sha256:4c4fc16f11ac1612f05b6f5781b384716719547e142cfd67b65d035bd85af165", size = 38766, upload-time = "2024-05-14T02:01:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/72/6cb6728e2738c05bbe9bd522d6fc79f86b9a28402f38663e85a28fddd4a0/ujson-5.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:4573fd1695932d4f619928fd09d5d03d917274381649ade4328091ceca175539", size = 42212, upload-time = "2024-05-14T02:01:33.97Z" },
 ]
 
 [[package]]

--- a/web/src/app/chat/components/research-activities-block.tsx
+++ b/web/src/app/chat/components/research-activities-block.tsx
@@ -91,6 +91,9 @@ function ActivityListItem({ messageId }: { messageId: string }) {
   if (message) {
     if (!message.isStreaming && message.toolCalls?.length) {
       for (const toolCall of message.toolCalls) {
+        if (toolCall.result?.startsWith("Error")) {
+          return null;
+        }
         if (toolCall.name === "web_search") {
           return <WebSearchToolCall key={toolCall.id} toolCall={toolCall} />;
         } else if (toolCall.name === "crawl_tool") {
@@ -111,16 +114,16 @@ function ActivityListItem({ messageId }: { messageId: string }) {
 const __pageCache = new LRUCache<string, string>({ max: 100 });
 type SearchResult =
   | {
-      type: "page";
-      title: string;
-      url: string;
-      content: string;
-    }
+    type: "page";
+    title: string;
+    url: string;
+    content: string;
+  }
   | {
-      type: "image";
-      image_url: string;
-      image_description: string;
-    };
+    type: "image";
+    image_url: string;
+    image_description: string;
+  };
 
 function WebSearchToolCall({ toolCall }: { toolCall: ToolCallRuntime }) {
   const t = useTranslations("chat.research");
@@ -317,7 +320,7 @@ function RetrieverToolCall({ toolCall }: { toolCall: ToolCallRuntime }) {
                   />
                 </li>
               ))}
-            {documents.map((doc, i) => (
+            {documents && documents.map((doc, i) => (
               <motion.li
                 key={`search-result-${i}`}
                 className="text-muted-foreground bg-accent flex max-w-40 gap-2 rounded-md px-2 py-1 text-sm"
@@ -330,7 +333,7 @@ function RetrieverToolCall({ toolCall }: { toolCall: ToolCallRuntime }) {
                 }}
               >
                 <FileText size={32} />
-                {doc.title}
+                {doc.title} (chunk-{i},size-{doc.content.length})
               </motion.li>
             ))}
           </ul>


### PR DESCRIPTION
Changes:
1. Implement milvus as RAG provider
2. Support using free milvus instance on zilliz cloud  https://docs.zilliz.com/docs/quick-start
3. Support using Milvus Lite on Mac or Linux
4. Load examples into Milvus if RAG provider is configured with milvus
5. Fix frontend issue when tool calls result rendering in activity block

<img width="929" height="564" alt="image" src="https://github.com/user-attachments/assets/29bb8d7d-7fdb-44a7-9294-8ca8b1565aa8" />

<img width="929" height="564" alt="image" src="https://github.com/user-attachments/assets/ff7484d9-ef13-4f9a-8e7e-77eab3606068" />

@WillemJiang 