### PR TITLE
fix: using commit hash as the action version

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -25,19 +25,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Install the latest version of uv
-      uses: astral-sh/setup-uv@v6.3.1
+      uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1 #v6.5.0
       with:
         version: "latest"
 


### PR DESCRIPTION
This pull request updates the versions of several GitHub Actions used in workflow configuration files by pinning them to specific commit SHAs, ensuring more reliable and predictable builds. The main changes are focused on the container and lint workflows.

**Workflow dependency updates:**

* **Container workflow**:
  - Updated `docker/login-action` to use commit SHA for version `v3.4.0` (`.github/workflows/container.yaml`).
  - Updated `docker/metadata-action` to use commit SHA for version `v5.7.0` (`.github/workflows/container.yaml`).
  - Updated `docker/build-push-action` to use commit SHA for version `v6.18.0` (`.github/workflows/container.yaml`).

* **Lint workflow**:
  - Updated `astral-sh/setup-uv` to use commit SHA for version `v6.5.0` (`.github/workflows/lint.yaml`).