### PR TITLE
Fix: bind backend to 0.0.0.0 to allow external network access

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,13 +5,13 @@
 
 if [ "$1" = "--dev" -o "$1" = "-d" -o "$1" = "dev" -o "$1" = "development" ]; then
   echo -e "Starting DeerFlow in [DEVELOPMENT] mode...\n"
-  uv run server.py --reload & SERVER_PID=$$!
+  uv run server.py --host 0.0.0.0 --reload & SERVER_PID=$$!
   cd web && pnpm dev & WEB_PID=$$!
   trap "kill $$SERVER_PID $$WEB_PID" SIGINT SIGTERM
   wait
 else
   echo -e "Starting DeerFlow in [PRODUCTION] mode...\n"
-  uv run server.py & SERVER_PID=$$!
+  uv run server.py --host 0.0.0.0 & SERVER_PID=$$!
   cd web && pnpm start & WEB_PID=$$!
   trap "kill $$SERVER_PID $$WEB_PID" SIGINT SIGTERM
   wait


### PR DESCRIPTION
The backend service was bound only to 127.0.0.1 (localhost), which restricted connections to the local machine only. This prevented external clients from accessing the service in a deployment scenario (e.g., on a Linux server).

This change sets the host to 0.0.0.0, making the service listen on all network interfaces, thus enabling external connections while maintaining local access.