### PR TITLE
fix: correct typo in MongoDB connection string within .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,5 @@ VOLCENGINE_TTS_ACCESS_TOKEN=xxx
 # Enable LangGraph checkpoint saver, supports MongoDB, Postgres
 #LANGGRAPH_CHECKPOINT_SAVER=true
 # Set the database URL for saving checkpoints
-#LANGGRAPH_CHECKPOINT_DB_URL="ongodb://localhost:27017/
+#LANGGRAPH_CHECKPOINT_DB_URL="mongodb://localhost:27017/
 #LANGGRAPH_CHECKPOINT_DB_URL=postgresql://localhost:5432/postgres

--- a/.env.example
+++ b/.env.example
@@ -60,5 +60,5 @@ VOLCENGINE_TTS_ACCESS_TOKEN=xxx
 # Enable LangGraph checkpoint saver, supports MongoDB, Postgres
 #LANGGRAPH_CHECKPOINT_SAVER=true
 # Set the database URL for saving checkpoints
-#LANGGRAPH_CHECKPOINT_DB_URL="mongodb://localhost:27017/
+#LANGGRAPH_CHECKPOINT_DB_URL=mongodb://localhost:27017/
 #LANGGRAPH_CHECKPOINT_DB_URL=postgresql://localhost:5432/postgres


### PR DESCRIPTION
- Changes 'ongodb' to 'mongodb' in LANGGRAPH_CHECKPOINT_DB_URL example.
- This ensures the example configuration is valid and can be used directly.