### PR TITLE
docs: add deployment note for Linux servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ This project also includes a Web UI, offering a more dynamic and engaging intera
 # On Windows
 bootstrap.bat -d
 ```
+> [!Note]
+> By default, the backend server binds to 127.0.0.1 (localhost) for security reasons. If you need to allow external connections (e.g., when deploying on Linux server), you can modify the server host to 0.0.0.0 in the bootstrap script(uv run server.py --host 0.0.0.0).
+> Please ensure your environment is properly secured before exposing the service to external networks.
 
 Open your browser and visit [`http://localhost:3000`](http://localhost:3000) to explore the web UI.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -134,6 +134,9 @@ uv run main.py
 # 在Windows上
 bootstrap.bat -d
 ```
+> [! 注意]
+> 出于安全考虑，后端服务器默认绑定到 127.0.0.1 (localhost)。如果您需要允许外部连接（例如，在Linux服务器上部署时），您可以修改启动脚本中的主机地址为 0.0.0.0。（uv run server.py --host 0.0.0.0）
+> 请注意，在将服务暴露给外部网络之前，请务必确保您的环境已经过适当的安全加固。
 
 打开浏览器并访问[`http://localhost:3000`](http://localhost:3000)探索 Web UI。
 


### PR DESCRIPTION
- allow external connections by changing the host to 0.0.0.0.
- security warning to remind users to secure their environment before exposing the service.