### PR TITLE
fix: the stdio and sse mcp server loading issue

### DIFF
--- a/src/server/mcp_utils.py
+++ b/src/server/mcp_utils.py
@@ -30,7 +30,12 @@ async def _get_tools_from_client_session(
     Raises:
         Exception: If there's an error during the process
     """
-    async with client_context_manager as (read, write, _):
+    async with client_context_manager as context_result:
+        # Access by index to be safe
+        read = context_result[0]
+        write = context_result[1]
+        # Ignore any additional values
+
         async with ClientSession(
             read, write, read_timeout_seconds=timedelta(seconds=timeout_seconds)
         ) as session:


### PR DESCRIPTION
fix #562 
This pull request updates the way context values are unpacked in the `_get_tools_from_client_session` function to improve safety and clarity. Instead of unpacking the context manager's result into named variables directly, it now accesses elements by index, which avoids potential issues if the context manager returns more than three values.

Code safety and clarity improvement:

* Changed unpacking in `src/server/mcp_utils.py` (`_get_tools_from_client_session`) to access context manager results by index, ensuring only the required values (`read` and `write`) are used and ignoring any extras.