### PR TITLE
fix: log the exeption of graph execution

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -4,7 +4,7 @@
 import base64
 import json
 import logging
-from typing import Annotated, List, cast
+from typing import Annotated, Any, List, cast
 from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException, Query
@@ -244,25 +244,36 @@ async def _stream_graph_events(
     graph_instance, workflow_input, workflow_config, thread_id
 ):
     """Stream events from the graph and process them."""
-    async for agent, _, event_data in graph_instance.astream(
-        workflow_input,
-        config=workflow_config,
-        stream_mode=["messages", "updates"],
-        subgraphs=True,
-    ):
-        if isinstance(event_data, dict):
-            if "__interrupt__" in event_data:
-                yield _create_interrupt_event(thread_id, event_data)
-            continue
+    try:
+        async for agent, _, event_data in graph_instance.astream(
+            workflow_input,
+            config=workflow_config,
+            stream_mode=["messages", "updates"],
+            subgraphs=True,
+        ):
+            if isinstance(event_data, dict):
+                if "__interrupt__" in event_data:
+                    yield _create_interrupt_event(thread_id, event_data)
+                continue
 
-        message_chunk, message_metadata = cast(
-            tuple[BaseMessage, dict[str, any]], event_data
+            message_chunk, message_metadata = cast(
+                tuple[BaseMessage, dict[str, Any]], event_data
+            )
+
+            async for event in _process_message_chunk(
+                message_chunk, message_metadata, thread_id, agent
+            ):
+                yield event
+    except Exception as e:
+        logger.exception(f"Error during graph execution: {str(e)}")
+        yield _make_event(
+            "error",
+            {
+                "thread_id": thread_id,
+                "error": str(e),
+            },
         )
 
-        async for event in _process_message_chunk(
-            message_chunk, message_metadata, thread_id, agent
-        ):
-            yield event
 
 
 async def _astream_workflow_generator(


### PR DESCRIPTION
fix #470 
This pull request introduces improved error handling for the graph event streaming logic in `src/server/app.py`. The main change is the addition of a try/except block to catch and log exceptions during graph execution, ensuring that errors are reported back to the client in a structured way. There are also minor type annotation updates for consistency.

**Error handling improvements:**

* Wrapped the body of `_stream_graph_events` in a try/except block to catch exceptions, log them, and yield a structured error event to the client. [[1]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7R247) [[2]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7L259-R276)

**Type annotation updates:**

* Changed the type annotation from `any` to `Any` in the cast for `message_metadata` for consistency with Python typing conventions. [[1]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7L7-R7) [[2]](diffhunk://#diff-f5582720a2c21fe3f110577d491f104e06109eea939c2336dbf8ae7fbf60d6a7L259-R276)