### PR TITLE
fix: frontend supports chinese for listing datasets in RAG

### DIFF
--- a/web/src/components/deer-flow/message-input.tsx
+++ b/web/src/components/deer-flow/message-input.tsx
@@ -21,7 +21,6 @@ import "~/styles/prosemirror.css";
 import { resourceSuggestion } from "./resource-suggestion";
 import React, { forwardRef, useEffect, useMemo, useRef } from "react";
 import type { Resource } from "~/core/messages";
-import { useConfig } from "~/core/api/hooks";
 import { LoadingOutlined } from "@ant-design/icons";
 import type { DeerFlowConfig } from "~/core/config";
 


### PR DESCRIPTION
corresponding issue ：
https://github.com/bytedance/deer-flow/issues/581

causes：
When using the Chinese input method to type a word like '论文', the IME first produces the pinyin 'lun wen' with a space. When the space occurs, the client gets destroyed, and as a result, even subsequent calls to **_list datasets_** will not trigger any rendering.

after fixing：
<img width="1512" height="843" alt="image" src="https://github.com/user-attachments/assets/f6f9cf4f-dd94-407f-b323-1d44b0a095ca" />
