### PR TITLE
feat:support config tavily search results

### DIFF
--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -188,7 +188,7 @@ DeerFlow allows you to control which domains are included or excluded in Tavily 
 
 `Tips`: it only supports Tavily currently. 
 
-You can configure domain filtering in your `conf.yaml` file as follows:
+You can configure domain filtering and search results in your `conf.yaml` file as follows:
 
 ```yaml
 SEARCH_ENGINE:
@@ -202,6 +202,12 @@ SEARCH_ENGINE:
   exclude_domains:
     - unreliable-site.com
     - spam-domain.net
+  # Include images in search results, default: false 
+  include_images: true
+  # Include image descriptions in search results, default: false
+  include_image_descriptions: true
+  # Include raw content in search results, default: true
+  include_raw_content: false
 ```
 
 ## RAG (Retrieval-Augmented Generation) Configuration

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -202,10 +202,10 @@ SEARCH_ENGINE:
   exclude_domains:
     - unreliable-site.com
     - spam-domain.net
-  # Include images in search results, default: false 
-  include_images: true
-  # Include image descriptions in search results, default: false
-  include_image_descriptions: true
+  # Include images in search results, default: true
+  include_images: false
+  # Include image descriptions in search results, default: true
+  include_image_descriptions: false
   # Include raw content in search results, default: true
   include_raw_content: false
 ```

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -47,6 +47,11 @@ def get_web_search_tool(max_search_results: int):
         # Only get and apply include/exclude domains for Tavily
         include_domains: Optional[List[str]] = search_config.get("include_domains", [])
         exclude_domains: Optional[List[str]] = search_config.get("exclude_domains", [])
+        include_raw_content = search_config.get("include_raw_content", True)
+        include_images: Optional[bool] = search_config.get("include_images", False)
+        include_image_descriptions: Optional[bool] = (
+            include_images and search_config.get("include_image_descriptions", False)
+        )
 
         logger.info(
             f"Tavily search configuration loaded: include_domains={include_domains}, exclude_domains={exclude_domains}"
@@ -55,9 +60,9 @@ def get_web_search_tool(max_search_results: int):
         return LoggedTavilySearch(
             name="web_search",
             max_results=max_search_results,
-            include_raw_content=True,
-            include_images=True,
-            include_image_descriptions=True,
+            include_raw_content=include_raw_content,
+            include_images=include_images,
+            include_image_descriptions=include_image_descriptions,
             include_domains=include_domains,
             exclude_domains=exclude_domains,
         )

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -48,9 +48,9 @@ def get_web_search_tool(max_search_results: int):
         include_domains: Optional[List[str]] = search_config.get("include_domains", [])
         exclude_domains: Optional[List[str]] = search_config.get("exclude_domains", [])
         include_raw_content = search_config.get("include_raw_content", True)
-        include_images: Optional[bool] = search_config.get("include_images", False)
+        include_images: Optional[bool] = search_config.get("include_images", True)
         include_image_descriptions: Optional[bool] = (
-            include_images and search_config.get("include_image_descriptions", False)
+            include_images and search_config.get("include_image_descriptions", True)
         )
 
         logger.info(

--- a/tests/unit/tools/test_search.py
+++ b/tests/unit/tools/test_search.py
@@ -17,8 +17,8 @@ class TestGetWebSearchTool:
         assert tool.name == "web_search"
         assert tool.max_results == 5
         assert tool.include_raw_content is True
-        assert tool.include_images is False
-        assert tool.include_image_descriptions is False
+        assert tool.include_images is True
+        assert tool.include_image_descriptions is True
 
     @patch("src.tools.search.SELECTED_SEARCH_ENGINE", SearchEngine.DUCKDUCKGO.value)
     def test_get_web_search_tool_duckduckgo(self):

--- a/tests/unit/tools/test_search.py
+++ b/tests/unit/tools/test_search.py
@@ -17,8 +17,8 @@ class TestGetWebSearchTool:
         assert tool.name == "web_search"
         assert tool.max_results == 5
         assert tool.include_raw_content is True
-        assert tool.include_images is True
-        assert tool.include_image_descriptions is True
+        assert tool.include_images is False
+        assert tool.include_image_descriptions is False
 
     @patch("src.tools.search.SELECTED_SEARCH_ENGINE", SearchEngine.DUCKDUCKGO.value)
     def test_get_web_search_tool_duckduckgo(self):


### PR DESCRIPTION
# 目的

支持通过配置文件来配置 tavily 搜索工具的返回结果，解决返回结果中图片过多超 token 问题。https://github.com/bytedance/deer-flow/issues/583

tavily官方接口文档：https://docs.tavily.com/documentation/api-reference/endpoint/search

# 配置使用说明
在`conf.yaml`文件中可配置相关参数，各参数具体含义如下：
```yaml
SEARCH_ENGINE:
  engine: tavily
  # Only include results from these domains (whitelist)
  include_domains:
    - trusted-news.com
    - gov.org
    - reliable-source.edu
  # Exclude results from these domains (blacklist)
  exclude_domains:
    - unreliable-site.com
    - spam-domain.net
  # 搜索结果中是否返回图片，默认为 true
  include_images: false
  # 搜索结果中是否返回图片的标题描述，默认为 true
  include_image_descriptions: false
  # 搜索结果中是否返回去除html标签后的原始网页内容，默认为 true
  include_raw_content: false
```