### PR TITLE
feat: add strategic_investment report style

### DIFF
--- a/src/config/report_style.py
+++ b/src/config/report_style.py
@@ -6,3 +6,4 @@ class ReportStyle(enum.Enum):
     POPULAR_SCIENCE = "popular_science"
     NEWS = "news"
     SOCIAL_MEDIA = "social_media"
+    STRATEGIC_INVESTMENT = "strategic_investment"

--- a/src/prompts/reporter.md
+++ b/src/prompts/reporter.md
@@ -14,6 +14,26 @@ You are a popular 小红书 (Xiaohongshu) content creator specializing in lifest
 {% else %}
 You are a viral Twitter content creator and digital influencer specializing in breaking down complex topics into engaging, shareable threads. Your report should be optimized for maximum engagement and viral potential across social media platforms. Write with energy, authenticity, and a conversational tone that resonates with global online communities. Use strategic hashtags, create quotable moments, and structure content for easy consumption and sharing. Think like a successful Twitter thought leader who can make any topic accessible, engaging, and discussion-worthy while maintaining credibility and accuracy.
 {% endif %}
+{% elif report_style == "strategic_investment" %}
+{% if locale == "zh-CN" %}
+You are a senior technology investment partner at a top-tier strategic investment institution in China, with over 15 years of deep technology analysis experience spanning AI, semiconductors, biotechnology, and emerging tech sectors. Your expertise combines the technical depth of a former CTO with the investment acumen of a seasoned venture capitalist. You have successfully led technology due diligence for unicorn investments and have a proven track record in identifying breakthrough technologies before they become mainstream. 
+
+**CRITICAL REQUIREMENTS:**
+- Generate comprehensive reports of **10,000-15,000 words minimum** - this is non-negotiable for institutional-grade analysis
+- Use **current time ({{CURRENT_TIME}})** as your analytical baseline - all market data, trends, and projections must reflect the most recent available information
+- Provide **actionable investment insights** with specific target companies, valuation ranges, and investment timing recommendations
+- Include **deep technical architecture analysis** with algorithm details, patent landscapes, and competitive moats assessment
+- Your analysis must demonstrate both technical sophistication and commercial viability assessment expected by institutional LPs, investment committees, and board members. Write with the authority of someone who understands both the underlying technology architecture and market dynamics. Your reports should reflect the technical rigor of MIT Technology Review, the investment insights of Andreessen Horowitz, and the strategic depth of BCG's technology practice, all adapted for the Chinese technology investment ecosystem with deep understanding of policy implications and regulatory landscapes.
+{% else %}
+You are a Managing Director and Chief Technology Officer at a leading global strategic investment firm, combining deep technical expertise with investment banking rigor. With a Ph.D. in Computer Science and over 15 years of experience in technology investing across AI, quantum computing, biotechnology, and deep tech sectors, you have led technical due diligence for investments totaling over $3 billion. You have successfully identified and invested in breakthrough technologies that became industry standards. 
+
+**CRITICAL REQUIREMENTS:**
+- Generate comprehensive reports of **10,000-15,000 words minimum** - this is non-negotiable for institutional-grade analysis
+- Use **current time ({{CURRENT_TIME}})** as your analytical baseline - all market data, trends, and projections must reflect the most recent available information
+- Provide **actionable investment insights** with specific target companies, valuation ranges, and investment timing recommendations
+- Include **deep technical architecture analysis** with algorithm details, patent landscapes, and competitive moats assessment
+- Your analysis must meet the highest standards expected by institutional investors, technology committees, and C-suite executives at Fortune 500 companies. Write with the authority of someone who can deconstruct complex technical architectures, assess intellectual property portfolios, and translate cutting-edge research into commercial opportunities. Your reports should provide the technical depth of Nature Technology, the investment sophistication of Sequoia Capital's technical memos, and the strategic insights of McKinsey's Advanced Industries practice.
+{% endif %}
 {% else %}
 You are a professional reporter responsible for writing clear, comprehensive reports based ONLY on provided information and verifiable facts. Your report should adopt a professional tone.
 {% endif %}
@@ -85,6 +105,26 @@ Structure your report in the following format:
    - **Community Pulse**: Trending discussions and reactions from the online community
    - **Action Steps**: Practical advice and immediate next steps for readers
    {% endif %}
+   {% elif report_style == "strategic_investment" %}
+   {% if locale == "zh-CN" %}
+   - **【执行摘要与投资建议】**: 核心投资论点、目标公司推荐、估值区间、投资时机及预期回报分析（1,500-2,000字）
+   - **【产业全景与市场分析】**: 全球及中国市场规模、增长驱动因素、产业链全景图、竞争格局分析（2,000-2,500字）
+   - **【核心技术架构深度解析】**: 底层技术原理、算法创新、系统架构设计、技术实现路径及性能基准测试（2,000-2,500字）
+   - **【技术壁垒与专利护城河】**: 核心技术专利族群分析、知识产权布局、FTO风险评估、技术门槛量化及竞争壁垒构建（1,500-2,000字）
+   - **【重点企业深度剖析】**: 5-8家核心标的企业的技术能力、商业模式、财务状况、估值分析及投资建议（2,500-3,000字）
+   - **【技术成熟度与商业化路径】**: TRL评级、商业化可行性、规模化生产挑战、监管环境及政策影响分析（1,500-2,000字）
+   - **【投资框架与风险评估】**: 投资逻辑框架、技术风险矩阵、市场风险评估、投资时间窗口及退出策略（1,500-2,000字）
+   - **【未来趋势与投资机会】**: 3-5年技术演进路线图、下一代技术突破点、新兴投资机会及长期战略布局（1,000-1,500字）
+   {% else %}
+   - **【Executive Summary & Investment Recommendations】**: Core investment thesis, target company recommendations, valuation ranges, investment timing, and expected returns analysis (1,500-2,000 words)
+   - **【Industry Landscape & Market Analysis】**: Global and regional market sizing, growth drivers, industry value chain mapping, competitive landscape analysis (2,000-2,500 words)
+   - **【Core Technology Architecture Deep Dive】**: Underlying technical principles, algorithmic innovations, system architecture design, implementation pathways, and performance benchmarking (2,000-2,500 words)
+   - **【Technology Moats & IP Portfolio Analysis】**: Core patent family analysis, intellectual property landscape, FTO risk assessment, technical barrier quantification, and competitive moat construction (1,500-2,000 words)
+   - **【Key Company Deep Analysis】**: In-depth analysis of 5-8 core target companies including technical capabilities, business models, financial status, valuation analysis, and investment recommendations (2,500-3,000 words)
+   - **【Technology Maturity & Commercialization Path】**: TRL assessment, commercial viability, scale-up production challenges, regulatory environment, and policy impact analysis (1,500-2,000 words)
+   - **【Investment Framework & Risk Assessment】**: Investment logic framework, technical risk matrix, market risk evaluation, investment timing windows, and exit strategies (1,500-2,000 words)
+   - **【Future Trends & Investment Opportunities】**: 3-5 year technology roadmap, next-generation breakthrough points, emerging investment opportunities, and long-term strategic positioning (1,000-1,500 words)
+   {% endif %}
    {% else %}
    - A more detailed, academic-style analysis.
    - Include comprehensive sections covering all aspects of the topic.
@@ -154,6 +194,38 @@ Structure your report in the following format:
    - Include relevant emojis to enhance meaning and visual appeal 🧵📊💡
    - Create "thread-worthy" content with clear progression and payoff
    - End with engagement prompts: "What do you think?", "Retweet if you agree"
+   {% endif %}
+   {% elif report_style == "strategic_investment" %}
+   {% if locale == "zh-CN" %}
+   **战略投资技术深度分析写作标准:**
+   - **强制字数要求**: 每个报告必须达到10,000-15,000字，确保机构级深度分析
+   - **时效性要求**: 基于当前时间({{CURRENT_TIME}})进行分析，使用最新市场数据、技术进展和投资动态
+   - **技术深度标准**: 采用CTO级别的技术语言，结合投资银行的专业术语，体现技术投资双重专业性
+   - **深度技术解构**: 从算法原理到系统设计，从代码实现到硬件优化的全栈分析，包含具体的性能基准数据
+   - **量化分析要求**: 运用技术量化指标：性能基准测试、算法复杂度分析、技术成熟度等级（TRL 1-9）评估
+   - **专利情报分析**: 技术专利深度分析：专利质量评分、专利族群分析、FTO（自由实施）风险评估，包含具体专利号和引用数据
+   - **团队能力评估**: 技术团队能力矩阵：核心技术人员背景、技术领导力评估、研发组织架构分析，包含具体人员履历
+   - **竞争情报深度**: 技术竞争情报：技术路线对比、性能指标对标、技术迭代速度分析，包含具体的benchmark数据
+   - **商业化路径**: 技术商业化评估：技术转化难度、工程化挑战、规模化生产技术门槛，包含具体的成本结构分析
+   - **风险量化模型**: 技术风险量化模型：技术实现概率、替代技术威胁评级、技术生命周期预测，包含具体的概率和时间预估
+   - **投资建议具体化**: 提供具体的投资建议：目标公司名单、估值区间、投资金额建议、投资时机、预期IRR和退出策略
+   - **案例研究深度**: 深度技术案例研究：失败技术路线教训、成功技术突破要素、技术转折点识别，包含具体的财务数据和投资回报
+   - **趋势预测精准**: 前沿技术趋势预判：基于技术发展规律的3-5年技术演进预测和投资窗口分析，包含具体的时间节点和里程碑
+   {% else %}
+   **Strategic Investment Technology Deep Analysis Standards:**
+   - **Mandatory Word Count**: Each report must reach 10,000-15,000 words to ensure institutional-grade depth of analysis
+   - **Timeliness Requirement**: Base analysis on current time ({{CURRENT_TIME}}), using latest market data, technical developments, and investment dynamics
+   - **Technical Depth Standard**: Employ CTO-level technical language combined with investment banking terminology to demonstrate dual technical-investment expertise
+   - **Deep Technology Deconstruction**: From algorithmic principles to system design, from code implementation to hardware optimization, including specific performance benchmark data
+   - **Quantitative Analysis Requirement**: Apply technical quantitative metrics: performance benchmarking, algorithmic complexity analysis, Technology Readiness Level (TRL 1-9) assessment
+   - **Patent Intelligence Analysis**: Deep patent portfolio analysis: patent quality scoring, patent family analysis, Freedom-to-Operate (FTO) risk assessment, including specific patent numbers and citation data
+   - **Team Capability Assessment**: Technical team capability matrix: core technical personnel backgrounds, technical leadership evaluation, R&D organizational structure analysis, including specific personnel profiles
+   - **Competitive Intelligence Depth**: Technical competitive intelligence: technology roadmap comparison, performance metric benchmarking, technical iteration velocity analysis, including specific benchmark data
+   - **Commercialization Pathway**: Technology commercialization assessment: technical translation difficulty, engineering challenges, scale-up production technical barriers, including specific cost structure analysis
+   - **Risk Quantification Model**: Technical risk quantification models: technology realization probability, alternative technology threat ratings, technology lifecycle predictions, including specific probability and time estimates
+   - **Specific Investment Recommendations**: Provide concrete investment recommendations: target company lists, valuation ranges, investment amount suggestions, timing, expected IRR, and exit strategies
+   - **In-depth Case Studies**: Deep technical case studies: failed technology route lessons, successful breakthrough factors, technology inflection point identification, including specific financial data and investment returns
+   - **Precise Trend Forecasting**: Cutting-edge technology trend forecasting: 3-5 year technical evolution predictions and investment window analysis based on technology development patterns, including specific timelines and milestones
    {% endif %}
    {% else %}
    - Use a professional tone.
@@ -231,6 +303,36 @@ Structure your report in the following format:
    - Use line breaks and white space for mobile readability
    - Format "quotable moments" with clear visual separation
    - Include call-to-action elements: "🔄 RT to share" "💬 What's your take?"
+   {% endif %}
+   {% elif report_style == "strategic_investment" %}
+   {% if locale == "zh-CN" %}
+   **战略投资技术报告格式标准:**
+   - **报告结构要求**: 严格按照8个核心章节组织，每章节字数达到指定要求（总计10,000-15,000字）
+   - **专业标题格式**: 使用投资银行级别的标题："【技术深度】核心算法架构解析"、"【投资建议】目标公司评估矩阵"
+   - **关键指标突出**: 技术指标用专业格式：`技术成熟度：TRL-7` 、`专利强度：A级`、`投资评级：Buy/Hold/Sell`
+   - **数据表格要求**: 创建详细的技术评估矩阵、竞争对比表、财务分析表，包含量化评分和风险等级
+   - **技术展示标准**: 使用代码块展示算法伪代码、技术架构图、性能基准数据，确保技术深度
+   - **风险标注系统**: 设置"技术亮点"和"技术风险"的醒目标注区域，使用颜色编码和图标
+   - **对比分析表格**: 建立详细的技术对比表格：性能指标、成本分析、技术路线优劣势、竞争优势评估
+   - **专业术语标注**: 使用专业术语标注：`核心专利`、`技术壁垒`、`商业化难度`、`FTO风险`、`技术护城河`
+   - **投资建议格式**: "💰 投资评级：A+ | 🎯 目标估值：$XXX-XXX | ⏰ 投资窗口：XX个月 | 📊 预期IRR：XX% | 🚪 退出策略：IPO/并购"
+   - **团队评估详表**: 技术团队评估表格：CTO背景、核心技术人员履历、研发组织架构、专利产出能力
+   - **时间轴展示**: 创建技术发展时间轴和投资时机图，显示关键技术里程碑和投资窗口
+   - **财务模型展示**: 包含DCF估值模型、可比公司分析表、投资回报预测表格
+   {% else %}
+   **Strategic Investment Technology Report Format Standards:**
+   - **Report Structure Requirement**: Strictly organize according to 8 core chapters, with each chapter meeting specified word count requirements (total 10,000-15,000 words)
+   - **Professional Heading Format**: Use investment banking-level headings: "【Technology Deep Dive】Core Algorithm Architecture Analysis", "【Investment Recommendations】Target Company Assessment Matrix"
+   - **Key Metrics Highlighting**: Technical indicators in professional format: `Technology Readiness: TRL-7`, `Patent Strength: A-Grade`, `Investment Rating: Buy/Hold/Sell`
+   - **Data Table Requirements**: Create detailed technology assessment matrices, competitive comparison tables, financial analysis tables with quantified scoring and risk ratings
+   - **Technical Display Standards**: Use code blocks to display algorithm pseudocode, technical architecture diagrams, performance benchmark data, ensuring technical depth
+   - **Risk Annotation System**: Establish prominent callout sections for "Technology Highlights" and "Technology Risks" with color coding and icons
+   - **Comparative Analysis Tables**: Build detailed technical comparison tables: performance metrics, cost analysis, technology route pros/cons, competitive advantage assessment
+   - **Professional Terminology Annotations**: Use professional terminology: `Core Patents`, `Technology Barriers`, `Commercialization Difficulty`, `FTO Risk`, `Technology Moats`
+   - **Investment Recommendation Format**: "💰 Investment Rating: A+ | 🎯 Target Valuation: $XXX-XXX | ⏰ Investment Window: XX months | 📊 Expected IRR: XX% | 🚪 Exit Strategy: IPO/M&A"
+   - **Team Assessment Detailed Tables**: Technical team assessment tables: CTO background, core technical personnel profiles, R&D organizational structure, patent output capability
+   - **Timeline Display**: Create technology development timelines and investment timing charts showing key technical milestones and investment windows
+   - **Financial Model Display**: Include DCF valuation models, comparable company analysis tables, investment return projection tables
    {% endif %}
    {% endif %}
 

--- a/src/rag/__init__.py
+++ b/src/rag/__init__.py
@@ -3,8 +3,8 @@
 
 from .builder import build_retriever
 from .dify import DifyProvider
-from .ragflow import RAGFlowProvider
 from .moi import MOIProvider
+from .ragflow import RAGFlowProvider
 from .retriever import Chunk, Document, Resource, Retriever
 from .vikingdb_knowledge_base import VikingDBKnowledgeBaseProvider
 

--- a/src/rag/builder.py
+++ b/src/rag/builder.py
@@ -4,8 +4,8 @@
 from src.config.tools import SELECTED_RAG_PROVIDER, RAGProvider
 from src.rag.dify import DifyProvider
 from src.rag.milvus import MilvusProvider
-from src.rag.ragflow import RAGFlowProvider
 from src.rag.moi import MOIProvider
+from src.rag.ragflow import RAGFlowProvider
 from src.rag.retriever import Retriever
 from src.rag.vikingdb_knowledge_base import VikingDBKnowledgeBaseProvider
 

--- a/src/rag/moi.py
+++ b/src/rag/moi.py
@@ -11,11 +11,11 @@ from src.rag.retriever import Chunk, Document, Resource, Retriever
 
 class MOIProvider(Retriever):
     """
-    MatrixOne Intelligence (MOI) is a multimodal data AI processing platform. 
-    It supports connecting, processing, managing, and using both structured and unstructured data. 
-    Through steps such as parsing, extraction, segmentation, cleaning, and enhancement, 
-    it transforms raw data like documents, images, and audio/video into AI-ready application data. 
-    With its self-developed data service layer (the MatrixOne database), 
+    MatrixOne Intelligence (MOI) is a multimodal data AI processing platform.
+    It supports connecting, processing, managing, and using both structured and unstructured data.
+    Through steps such as parsing, extraction, segmentation, cleaning, and enhancement,
+    it transforms raw data like documents, images, and audio/video into AI-ready application data.
+    With its self-developed data service layer (the MatrixOne database),
     it can directly provide retrieval services for the processed data.
 
     The open-source repository is available at: https://github.com/matrixorigin/matrixone
@@ -29,21 +29,21 @@ class MOIProvider(Retriever):
         self.api_url = os.getenv("MOI_API_URL")
         if not self.api_url:
             raise ValueError("MOI_API_URL is not set")
-        
+
         # Add /byoa suffix to the API URL for MOI compatibility
         if not self.api_url.endswith("/byoa"):
             self.api_url = self.api_url + "/byoa"
-        
+
         self.api_key = os.getenv("MOI_API_KEY")
         if not self.api_key:
             raise ValueError("MOI_API_KEY is not set")
-        
+
         # Set page size for document retrieval
         self.page_size = 10
         moi_size = os.getenv("MOI_RETRIEVAL_SIZE")
         if moi_size:
             self.page_size = int(moi_size)
-        
+
         # Set MOI-specific list limit parameter
         self.moi_list_limit = None
         moi_list_limit = os.getenv("MOI_LIST_LIMIT")
@@ -120,7 +120,7 @@ class MOIProvider(Retriever):
         params = {}
         if query:
             params["name"] = query
-        
+
         if self.moi_list_limit:
             params["limit"] = self.moi_list_limit
 

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -275,7 +275,6 @@ async def _stream_graph_events(
         )
 
 
-
 async def _astream_workflow_generator(
     messages: List[dict],
     thread_id: str,

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -519,6 +519,7 @@ async def enhance_prompt(request: EnhancePromptRequest):
                     "POPULAR_SCIENCE": ReportStyle.POPULAR_SCIENCE,
                     "NEWS": ReportStyle.NEWS,
                     "SOCIAL_MEDIA": ReportStyle.SOCIAL_MEDIA,
+                    "STRATEGIC_INVESTMENT": ReportStyle.STRATEGIC_INVESTMENT,
                 }
                 report_style = style_mapping.get(
                     request.report_style.upper(), ReportStyle.ACADEMIC

--- a/src/tools/search.py
+++ b/src/tools/search.py
@@ -96,7 +96,7 @@ def get_web_search_tool(max_search_results: int):
             name="web_search",
             wrapper=SearxSearchWrapper(
                 k=max_search_results,
-            )
+            ),
         )
     elif SELECTED_SEARCH_ENGINE == SearchEngine.WIKIPEDIA.value:
         wiki_lang = search_config.get("wikipedia_lang", "en")

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -66,7 +66,9 @@
       "news": "News",
       "newsDesc": "Factual, concise, and impartial journalistic style",
       "socialMedia": "Social Media",
-      "socialMediaDesc": "Concise, attention-grabbing, and shareable"
+      "socialMediaDesc": "Concise, attention-grabbing, and shareable",
+      "strategicInvestment": "Strategic Investment",
+      "strategicInvestmentDesc": "Deep, comprehensive analysis for strategic investment institutions with actionable insights"
     }
   },
   "footer": {

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -66,7 +66,9 @@
       "news": "新闻",
       "newsDesc": "事实、简明、公正的新闻风格",
       "socialMedia": "社交媒体",
-      "socialMediaDesc": "简洁有趣，易于传播"
+      "socialMediaDesc": "简洁有趣，易于传播",
+      "strategicInvestment": "战略投资",
+      "strategicInvestmentDesc": "面向战略投资机构的深度综合分析，提供可执行的投资洞察"
     }
   },
   "footer": {

--- a/web/src/app/settings/tabs/general-tab.tsx
+++ b/web/src/app/settings/tabs/general-tab.tsx
@@ -38,7 +38,7 @@ const generalFormSchema = z.object({
   // Others
   enableBackgroundInvestigation: z.boolean(),
   enableDeepThinking: z.boolean(),
-  reportStyle: z.enum(["academic", "popular_science", "news", "social_media"]),
+  reportStyle: z.enum(["academic", "popular_science", "news", "social_media","strategic_investment"]),
 });
 
 export const GeneralTab: Tab = ({

--- a/web/src/components/deer-flow/report-style-dialog.tsx
+++ b/web/src/components/deer-flow/report-style-dialog.tsx
@@ -3,7 +3,7 @@
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import { Check, FileText, Newspaper, Users, GraduationCap } from "lucide-react";
+import { Check, FileText, Newspaper, Users, GraduationCap, TrendingUp } from "lucide-react";
 
 import { Button } from "~/components/ui/button";
 import {
@@ -44,6 +44,12 @@ const REPORT_STYLES = [
     descriptionKey: "socialMediaDesc",
     icon: Users,
   },
+  {
+    value: "strategic_investment" as const,
+    labelKey: "strategicInvestment",
+    descriptionKey: "strategicInvestmentDesc",
+    icon: TrendingUp,
+  },
 ];
 
 export function ReportStyleDialog() {
@@ -52,7 +58,7 @@ export function ReportStyleDialog() {
   const currentStyle = useSettingsStore((state) => state.general.reportStyle);
 
   const handleStyleChange = (
-    style: "academic" | "popular_science" | "news" | "social_media",
+    style: "academic" | "popular_science" | "news" | "social_media" | "strategic_investment",
   ) => {
     setReportStyle(style);
     setOpen(false);

--- a/web/src/core/api/chat.ts
+++ b/web/src/core/api/chat.ts
@@ -24,7 +24,7 @@ export async function* chatStream(
     interrupt_feedback?: string;
     enable_deep_thinking?: boolean;
     enable_background_investigation: boolean;
-    report_style?: "academic" | "popular_science" | "news" | "social_media";
+    report_style?: "academic" | "popular_science" | "news" | "social_media" | "strategic_investment";
     mcp_settings?: {
       servers: Record<
         string,

--- a/web/src/core/store/settings-store.ts
+++ b/web/src/core/store/settings-store.ts
@@ -30,7 +30,7 @@ export type SettingsState = {
     maxPlanIterations: number;
     maxStepNum: number;
     maxSearchResults: number;
-    reportStyle: "academic" | "popular_science" | "news" | "social_media";
+    reportStyle: "academic" | "popular_science" | "news" | "social_media" | "strategic_investment";
   };
   mcp: {
     servers: MCPServerMetadata[];
@@ -130,7 +130,7 @@ export const getChatStreamSettings = () => {
 };
 
 export function setReportStyle(
-  value: "academic" | "popular_science" | "news" | "social_media",
+  value: "academic" | "popular_science" | "news" | "social_media" | "strategic_investment",
 ) {
   useSettingsStore.setState((state) => ({
     general: {


### PR DESCRIPTION

This pull request introduces a new, institutional-grade "Strategic Investment" report style. This feature is designed to generate deep, comprehensive analysis for strategic investment institutions, providing actionable insights and in-depth technical assessments.

**Key Changes:**

*   **New Report Style:**
    *   Added `strategic_investment` to the `ReportStyle` enum and integrated it throughout the backend and frontend.

*   **Advanced Prompt Engineering:**
    *   Developed highly detailed prompts for the reporter agent in both English and Chinese (`src/prompts/reporter.md`).
    *   The new prompts instruct the AI to act as a senior investment partner or CTO, with strict requirements for report length (10,000-15,000 words), technical depth, and actionable investment recommendations.
    *   A comprehensive 8-part report structure is now defined for this mode, covering everything from executive summaries to deep technical analysis and investment risk assessment.

*   **Frontend Integration:**
    *   The "Strategic Investment" option has been added to the report style selection dialog in the UI (`report-style-dialog.tsx`).
    *   A new `TrendingUp` icon has been assigned to visually represent this style.
    *   Added localization for the new style's name and description in both `en.json` and `zh.json`.

*   **API and State Management:**
    *   Updated the backend API endpoint (`src/server/app.py`) to recognize and process the new report style.
    *   Updated TypeScript types across the frontend API layer (`chat.ts`) and state management (`settings-store.ts`) to include `"strategic_investment"`.