### PR TITLE
chore: fix incorrect filename in conf.yaml.example comments

### DIFF
--- a/conf.yaml.example
+++ b/conf.yaml.example
@@ -4,7 +4,7 @@
 # - Replace `api_key` with your own credentials.
 # - Replace `base_url` and `model` name if you want to use a custom model.
 # - Set `verify_ssl` to `false` if your LLM server uses self-signed certificates
-# - A restart is required every time you change the `config.yaml` file.
+# - A restart is required every time you change the `conf.yaml` file.
 
 BASIC_MODEL:
   base_url: https://ark.cn-beijing.volces.com/api/v3


### PR DESCRIPTION
Config is loaded from `conf.yaml` instead of `config.yaml`. 