### PR TITLE
fix:the formual display error after report editing

### DIFF
--- a/web/src/core/utils/markdown.ts
+++ b/web/src/core/utils/markdown.ts
@@ -21,6 +21,23 @@ export function normalizeMathForEditor(markdown: string): string {
     .replace(/\\\\\(([^)]*)\\\\\)/g, (_match, content) => `$${content}$`)  // \\(...\\) → $...$
     .replace(/\\\(([^)]*)\\\)/g, (_match, content) => `$${content}$`);    // \(...\) → $...$
   
+  // Replace double backslashes with single in math contexts
+  // For inline math: $...$
+  normalized = normalized.replace(
+    /\$([^\$]+?)\$/g,
+    (match, mathContent) => {
+      return `$${mathContent.replace(/\\\\/g, '\\')}$`;
+    }
+  );
+  
+  // For display math: $$...$$
+  normalized = normalized.replace(
+    /\$\$([\s\S]+?)\$\$/g,
+    (match, mathContent) => {
+      return `$$${mathContent.replace(/\\\\/g, '\\')}$$`;
+    }
+  );
+
   return normalized;
 }
 
@@ -41,6 +58,23 @@ export function normalizeMathForDisplay(markdown: string): string {
     .replace(/\\\\\(([^)]*)\\\\\)/g, (_match, content) => `$$${content}$$`)   // \\(...\\) → $$...$$
     .replace(/\\\(([^)]*)\\\)/g, (_match, content) => `$$${content}$$`);       // \(...\) → $$...$$
   
+  // Replace double backslashes with single in math contexts
+  // For inline math: $...$
+  normalized = normalized.replace(
+    /\$([^\$]+?)\$/g,
+    (match, mathContent) => {
+      return `$${mathContent.replace(/\\\\/g, '\\')}$`;
+    }
+  );
+  
+  // For display math: $$...$$
+  normalized = normalized.replace(
+    /\$\$([\s\S]+?)\$\$/g,
+    (match, mathContent) => {
+      return `$$${mathContent.replace(/\\\\/g, '\\')}$$`;
+    }
+  );
+    
   return normalized;
 }
 

--- a/web/tests/markdown-math-editor.test.ts
+++ b/web/tests/markdown-math-editor.test.ts
@@ -10,6 +10,18 @@ describe("markdown math normalization for editor", () => {
     assert.strictEqual(output, "Here is a formula $$E=mc^2$$ in the text.");
   });
 
+  it("converts LaTeX display delimiters to $ with \\ for editor", () => {
+    const input = "Here is a formula \\(F = k\\frac{q_1q_2}{r^2}\\) in the text.";
+    const output = normalizeMathForEditor(input);
+    assert.strictEqual(output, "Here is a formula $F = k\\frac{q_1q_2}{r^2}$ in the text.");
+  });
+
+  it("converts LaTeX display delimiters to $ with \\\\ for editor", () => {
+    const input = "Here is a formula \\(F = k\\\\frac{q_1q_2}{r^2}\\) in the text.";
+    const output = normalizeMathForEditor(input);
+    assert.strictEqual(output, "Here is a formula $F = k\\frac{q_1q_2}{r^2}$ in the text.");
+  });
+
   it("converts escaped LaTeX display delimiters to $$ for editor", () => {
     const input = "Formula \\\\[x^2 + y^2 = z^2\\\\] here.";
     const output = normalizeMathForEditor(input);


### PR DESCRIPTION
fix #625 
This pull request improves the normalization of LaTeX math expressions in markdown for both editor and display contexts. The main change ensures that double backslashes in math environments are converted to single backslashes, which fixes issues with LaTeX rendering. Additionally, new tests have been added to verify the normalization logic.

### Math normalization improvements

* In `normalizeMathForEditor` and `normalizeMathForDisplay` in `markdown.ts`, added logic to replace double backslashes (`\\`) with single backslashes (`This pull request improves the normalization of LaTeX math expressions in markdown for both editor and display contexts. The main change ensures that double backslashes in math environments are converted to single backslashes, which fixes issues with LaTeX rendering. Additionally, new tests have been added to verify the normalization logic.

### Math normalization improvements

) inside both inline (`$...fix #625 
) and display (`$...$`) math environments. This ensures correct LaTeX rendering in the editor and display. [[1]](diffhunk://#diff-8fa94a24976deb4241359139a531e63d9e5b993807f0d50ae2537638bb5b7e19R24-R40) [[2]](diffhunk://#diff-8fa94a24976deb4241359139a531e63d9e5b993807f0d50ae2537638bb5b7e19R61-R77)

### Test coverage

* Added new tests in `markdown-math-editor.test.ts` to verify that both single and double backslash math delimiters are correctly normalized for the editor. This confirms the correctness of the normalization logic for various LaTeX input cases.