### PR TITLE
fix: convert crawl_tool dict return to JSON string for type consistency

### DIFF
--- a/src/tools/crawl.py
+++ b/src/tools/crawl.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
 # SPDX-License-Identifier: MIT
 
+import json
 import logging
 from typing import Annotated
 
@@ -22,7 +23,7 @@ def crawl_tool(
     try:
         crawler = Crawler()
         article = crawler.crawl(url)
-        return {"url": url, "crawled_content": article.to_markdown()[:1000]}
+        return json.dumps({"url": url, "crawled_content": article.to_markdown()[:1000]})
     except BaseException as e:
         error_msg = f"Failed to crawl. Error: {repr(e)}"
         logger.error(error_msg)

--- a/tests/unit/tools/test_crawl.py
+++ b/tests/unit/tools/test_crawl.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock, patch
 
 from src.tools.crawl import crawl_tool
@@ -21,10 +22,11 @@ class TestCrawlTool:
         result = crawl_tool(url)
 
         # Assert
-        assert isinstance(result, dict)
-        assert result["url"] == url
-        assert "crawled_content" in result
-        assert len(result["crawled_content"]) <= 1000
+        assert isinstance(result, str)
+        result_dict = json.loads(result)
+        assert result_dict["url"] == url
+        assert "crawled_content" in result_dict
+        assert len(result_dict["crawled_content"]) <= 1000
         mock_crawler_class.assert_called_once()
         mock_crawler.crawl.assert_called_once_with(url)
         mock_article.to_markdown.assert_called_once()
@@ -45,7 +47,8 @@ class TestCrawlTool:
         result = crawl_tool(url)
 
         # Assert
-        assert result["crawled_content"] == short_content
+        result_dict = json.loads(result)
+        assert result_dict["crawled_content"] == short_content
 
     @patch("src.tools.crawl.Crawler")
     @patch("src.tools.crawl.logger")


### PR DESCRIPTION
Keep fixing #631 
This pull request updates the `crawl_tool` function to return its results as a JSON string instead of a dictionary, and adjusts the unit tests accordingly to handle the new return type. The changes ensure consistent serialization of output and proper validation in tests.

**Core functionality update:**

* Changed the return type of `crawl_tool` in `src/tools/crawl.py` to output a JSON string using `json.dumps` instead of returning a dictionary.

**Testing updates:**

* Updated unit tests in `tests/unit/tools/test_crawl.py` to check for a string return type, parse it with `json.loads`, and validate the contents, ensuring compatibility with the new JSON output format. [[1]](diffhunk://#diff-fa25f202018923ab081f83bdda550e30490e7f38560167be39bbe1bdb63be6aaL24-R29) [[2]](diffhunk://#diff-fa25f202018923ab081f83bdda550e30490e7f38560167be39bbe1bdb63be6aaL48-R51)
* Added `import json` to both `src/tools/crawl.py` and `tests/unit/tools/test_crawl.py` to support serialization and deserialization. [[1]](diffhunk://#diff-db5ded284479c35eede9aa0508cfe15bd8ecad9b6491a6da975cf3a79eb229e2R4) [[2]](diffhunk://#diff-fa25f202018923ab081f83bdda550e30490e7f38560167be39bbe1bdb63be6aaR1)