### PR TITLE
fix: remove the unnessary conditional edge #669

### DIFF
--- a/src/graph/builder.py
+++ b/src/graph/builder.py
@@ -63,12 +63,6 @@ def _build_base_graph():
         ["planner", "researcher", "coder"],
     )
     builder.add_edge("reporter", END)
-    # Add conditional edges for coordinator to handle clarification flow
-    builder.add_conditional_edges(
-        "coordinator",
-        lambda state: state.get("goto", "planner"),
-        ["planner", "background_investigator", "coordinator", END],
-    )
     return builder
 
 

--- a/tests/unit/graph/test_builder.py
+++ b/tests/unit/graph/test_builder.py
@@ -96,8 +96,8 @@ def test_build_base_graph_adds_nodes_and_edges(MockStateGraph):
     # Check that all nodes and edges are added
     assert mock_builder.add_edge.call_count >= 2
     assert mock_builder.add_node.call_count >= 8
-    # Now we have 2 conditional edges: research_team and coordinator
-    assert mock_builder.add_conditional_edges.call_count == 2
+    # Now we have 1 conditional edges: research_team 
+    assert mock_builder.add_conditional_edges.call_count == 1
 
 
 @patch("src.graph.builder._build_base_graph")


### PR DESCRIPTION
Fixes #669 
This pull request simplifies the base graph construction logic by removing the conditional edges for the `coordinator` node, and updates the corresponding unit test to reflect this change. The main focus is on streamlining the graph-building process and ensuring the tests accurately match the new implementation.

Graph construction simplification:

* Removed the conditional edges for the `coordinator` node in the `_build_base_graph` function within `src/graph/builder.py`, reducing complexity in the graph flow.

Test updates:

* Updated the test `test_build_base_graph_adds_nodes_and_edges` in `tests/unit/graph/test_builder.py` to expect only one call to `add_conditional_edges` instead of two, aligning the test with the new graph logic.