### PR TITLE
fix: prevent DOM error when removing temporary download link (#675)

### DIFF
--- a/web/src/app/chat/components/research-block.tsx
+++ b/web/src/app/chat/components/research-block.tsx
@@ -87,8 +87,13 @@ export function ResearchBlock({
     document.body.appendChild(a);
     a.click();
     setTimeout(() => {
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      try {
+        if (a.parentNode) {
+          a.parentNode.removeChild(a);
+        }
+      } finally {
+        URL.revokeObjectURL(url);
+      }
     }, 0);
   }, [reportId]);
 


### PR DESCRIPTION
Fixes #675 
Add defensive checks before removeChild to prevent 'Failed to execute removeChild' error when the element has already been removed from DOM. Wrap URL.revokeObjectURL in finally block to ensure proper resource cleanup.