### PR TITLE
fix(agents): patch _run in ToolInterceptor to ensure interrupt triggering

### DIFF
--- a/src/agents/tool_interceptor.py
+++ b/src/agents/tool_interceptor.py
@@ -163,11 +163,8 @@ class ToolInterceptor:
         # Also ensure the tool's _run method is updated if it exists
         if hasattr(tool, '_run'):
             logger.debug(f"Also wrapping _run method for tool '{safe_tool_name}'")
-            # We wrap it to match the signature, though intercepted_func handles *args, **kwargs
-            def intercepted_run(*args: Any, **kwargs: Any) -> Any:
-                return intercepted_func(*args, **kwargs)
-            
-            object.__setattr__(tool, "_run", intercepted_run)
+            # Wrap _run to ensure interception is applied regardless of invocation method
+            object.__setattr__(tool, "_run", intercepted_func)
 
         return tool
 

--- a/tests/unit/agents/test_tool_interceptor_fix.py
+++ b/tests/unit/agents/test_tool_interceptor_fix.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Bytedance Ltd. and/or its affiliates
+# SPDX-License-Identifier: MIT
 
 import unittest
 from unittest.mock import MagicMock
@@ -30,6 +32,22 @@ class TestToolInterceptorFix(unittest.TestCase):
         # Verify the original function was called
         # If interception works, intercepted_func calls original_func
         mock_func.assert_called_once()
+
+    def test_run_method_without_interrupt(self):
+        """Test that tools not in interrupt list work normally via .run()"""
+        mock_func = MagicMock(return_value="Result")
+        tool = Tool(name="other_tool", func=mock_func, description="test")
+        
+        interceptor = ToolInterceptor(interrupt_before_tools=["resolve_company_name"])
+        wrapped_tool = ToolInterceptor.wrap_tool(tool, interceptor)
+        
+        with unittest.mock.patch("src.agents.tool_interceptor.interrupt") as mock_interrupt:
+            result = wrapped_tool.run("input")
+            
+        # Verify interrupt was NOT called for non-intercepted tool
+        mock_interrupt.assert_not_called()
+        assert result == "Result"
+        mock_func.assert_called_once()
         
     def test_interceptor_resolve_company_name_example(self):
         """Test specific resolve_company_name logic capability using interceptor subclassing or custom logic simulation."""
@@ -49,6 +67,3 @@ class TestToolInterceptorFix(unittest.TestCase):
              wrapped_tool.run("query")
              
         mock_func.assert_called_once()
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
Fixes #752 
This pull request updates the tool interception mechanism to ensure that both the `func` and `_run` methods of a `Tool` are properly wrapped, preventing bypass of interception logic when tools are invoked via their `.run()` method. It also adds unit tests to verify this behavior.

Enhancements to tool interception logic:

* Updated the `ToolInterceptor.wrap_tool` method to also wrap the tool's `_run` method, ensuring interception logic is applied even when tools are executed using `.run()`. This prevents the original `_run` (and thus the original `func`) from being called directly, which could bypass interception.

Testing improvements:

* Added a new unit test file `test_tool_interceptor_fix.py` with tests that verify the interception mechanism works when tools are called via `.run()`, including specific cases for tools named `"resolve_company_name"`.