### PR TITLE
fix: display direct_response message in frontend (#763)

### DIFF
--- a/web/src/core/messages/merge-message.ts
+++ b/web/src/core/messages/merge-message.ts
@@ -62,6 +62,11 @@ export function mergeMessage(message: Message, event: ChatEvent) {
           toolCall.args = safeParseToolArgs(toolCall.argsChunks.join(""));
           delete toolCall.argsChunks;
         }
+        // Handle direct_response tool: extract message content for display
+        if (toolCall.name === "direct_response" && toolCall.args?.message) {
+          message.content = toolCall.args.message as string;
+          message.contentChunks = [message.content];
+        }
       });
     }
   }


### PR DESCRIPTION
## Summary

Fix greeting/small talk messages not displaying in frontend (related to #763).

## Changes

In [merge-message.ts](cci:7://file:///d:/Desktop/deer-flow/web/src/core/messages/merge-message.ts:0:0-0:0), when [direct_response](cci:1://file:///d:/Desktop/deer-flow/src/graph/nodes.py:65:0-71:10) tool call completes, extract the `message` field from tool args and display it as the message content.

## Root Cause

PR #755 added [direct_response](cci:1://file:///d:/Desktop/deer-flow/src/graph/nodes.py:65:0-71:10) tool for handling greetings, but frontend didn't extract and display the message content from tool call args.

## Known Limitation

The greeting response **cannot be streamed** because [direct_response](cci:1://file:///d:/Desktop/deer-flow/src/graph/nodes.py:65:0-71:10) uses tool calling mechanism where args are JSON format, not natural language text that can be streamed directly.

If streaming greeting response is needed in the future, the design should be changed to let coordinator generate text content directly instead of using tool calls.