### PR TITLE
fix(web): enable runtime API URL detection for cross-machine access (#777)

### DIFF
--- a/web/src/core/api/resolve-service-url.ts
+++ b/web/src/core/api/resolve-service-url.ts
@@ -3,8 +3,25 @@
 
 import { env } from "~/env";
 
+function getBaseURL(): string {
+  // If NEXT_PUBLIC_API_URL is explicitly configured, use it
+  if (env.NEXT_PUBLIC_API_URL) {
+    return env.NEXT_PUBLIC_API_URL;
+  }
+
+  // Runtime detection: use the same hostname as the current page with port 8000
+  // This allows cross-machine access without rebuilding (Issue #777)
+  if (typeof window !== "undefined") {
+    const { protocol, hostname } = window.location;
+    return `${protocol}//${hostname}:8000/api/`;
+  }
+
+  // Fallback for SSR or when window is not available
+  return "http://localhost:8000/api/";
+}
+
 export function resolveServiceURL(path: string) {
-  let BASE_URL = env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000/api/";
+  let BASE_URL = getBaseURL();
   if (!BASE_URL.endsWith("/")) {
     BASE_URL += "/";
   }


### PR DESCRIPTION
fixes #777 

When NEXT_PUBLIC_API_URL is not explicitly configured, the frontend now automatically detects the API URL based on the current page's hostname. This allows accessing DeerFlow from other machines without rebuilding the frontend.

- Add getBaseURL() helper with runtime window.location detection
- Use same protocol and hostname with default port 8000
- Preserve explicit NEXT_PUBLIC_API_URL configuration when set
- Fallback to localhost:8000 for SSR scenarios