### PR TITLE
fix(main): Passing the local parameter from the main interactive mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ def ask(
     enable_background_investigation=True,
     enable_clarification=False,
     max_clarification_rounds=None,
+    locale=None,
 ):
     """Run the agent workflow with the given question.
 
@@ -33,6 +34,7 @@ def ask(
         enable_background_investigation: If True, performs web search before planning to enhance context
         enable_clarification: If False (default), skip clarification; if True, enable multi-turn clarification
         max_clarification_rounds: Maximum number of clarification rounds (default: None, uses State default=3)
+        locale: The locale setting (e.g., 'en-US', 'zh-CN')
     """
     asyncio.run(
         run_agent_workflow_async(
@@ -43,6 +45,7 @@ def ask(
             enable_background_investigation=enable_background_investigation,
             enable_clarification=enable_clarification,
             max_clarification_rounds=max_clarification_rounds,
+            locale=locale,
         )
     )
 
@@ -70,6 +73,9 @@ def main(
         message="Select language / 选择语言:",
         choices=["English", "中文"],
     ).execute()
+
+    # Set locale based on language
+    locale = "en-US" if language == "English" else "zh-CN"
 
     # Choose questions based on language
     questions = (
@@ -105,6 +111,7 @@ def main(
         enable_background_investigation=enable_background_investigation,
         enable_clarification=enable_clarification,
         max_clarification_rounds=max_clarification_rounds,
+        locale=locale,
     )
 
 

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -34,6 +34,7 @@ async def run_agent_workflow_async(
     enable_clarification: bool | None = None,
     max_clarification_rounds: int | None = None,
     initial_state: dict | None = None,
+    locale: str | None = None,
 ):
     """Run the agent workflow asynchronously with the given user input.
 
@@ -46,6 +47,7 @@ async def run_agent_workflow_async(
         enable_clarification: If None, use default from State class (False); if True/False, override
         max_clarification_rounds: Maximum number of clarification rounds allowed
         initial_state: Initial state to use (for recursive calls during clarification)
+        locale: The locale setting (e.g., 'en-US', 'zh-CN')
 
     Returns:
         The final state after the workflow completes
@@ -74,6 +76,9 @@ async def run_agent_workflow_async(
 
         if max_clarification_rounds is not None:
             initial_state["max_clarification_rounds"] = max_clarification_rounds
+
+        if locale is not None:
+            initial_state["locale"] = locale
 
     config = {
         "configurable": {
@@ -158,6 +163,7 @@ async def run_agent_workflow_async(
                 enable_clarification=enable_clarification,
                 max_clarification_rounds=max_clarification_rounds,
                 initial_state=current_state,
+                locale=locale,
             )
 
     logger.info("Async workflow completed successfully")


### PR DESCRIPTION
Fixes #788 

This pull request adds support for locale selection to the agent workflow, allowing the application to adapt its behavior based on the user's language preference. The main changes involve passing a new `locale` parameter through the workflow, updating both the main entry point and the asynchronous workflow logic to handle this setting.

**Locale support integration:**

* Added a `locale` parameter to the `ask` function in `main.py`, updated its docstring, and ensured it is passed to the workflow. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R25) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R37) [[3]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R48) [[4]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R114)
* Set the `locale` value in `main.py` based on the user's language choice (`en-US` for English, `zh-CN` for 中文).

**Workflow updates:**

* Added a `locale` parameter to `run_agent_workflow_async` in `src/workflow.py`, updated its docstring, and ensured it is included in recursive workflow calls. [[1]](diffhunk://#diff-8fbde70c7a81353bf436c495bd35f19f29e337cc74b2796d77b0869e4b41bd5aR37) [[2]](diffhunk://#diff-8fbde70c7a81353bf436c495bd35f19f29e337cc74b2796d77b0869e4b41bd5aR50) [[3]](diffhunk://#diff-8fbde70c7a81353bf436c495bd35f19f29e337cc74b2796d77b0869e4b41bd5aR166)
* Updated workflow logic to inject the `locale` value into the initial state if provided, enabling downstream components to access locale information.