### PR TITLE
fix(log): Enable the logging level  when enabling the DEBUG environment variable

### DIFF
--- a/server.py
+++ b/server.py
@@ -79,12 +79,18 @@ if __name__ == "__main__":
     if args.reload:
         reload = True
 
+    # Check for DEBUG environment variable to override log level
+    if os.getenv("DEBUG", "").lower() in ("true", "1", "yes"):
+        log_level = "debug"
+    else:
+        log_level = args.log_level
+
     try:
         logger.info(f"Starting DeerFlow API server on {args.host}:{args.port}")
-        logger.info(f"Log level: {args.log_level.upper()}")
+        logger.info(f"Log level: {log_level.upper()}")
         
         # Set the appropriate logging level for the src package if debug is enabled
-        if args.log_level.lower() == "debug":
+        if log_level.lower() == "debug":
             logging.getLogger("src").setLevel(logging.DEBUG)
             logging.getLogger("langchain").setLevel(logging.DEBUG)
             logging.getLogger("langgraph").setLevel(logging.DEBUG)
@@ -95,7 +101,7 @@ if __name__ == "__main__":
             host=args.host,
             port=args.port,
             reload=reload,
-            log_level=args.log_level,
+            log_level=log_level,
         )
     except Exception as e:
         logger.error(f"Failed to start server: {str(e)}")

--- a/src/server/app.py
+++ b/src/server/app.py
@@ -9,6 +9,19 @@ import os
 from typing import Annotated, Any, List, Optional, cast
 from uuid import uuid4
 
+# Load environment variables from .env file FIRST
+# This must happen before checking DEBUG environment variable
+from dotenv import load_dotenv
+load_dotenv()
+
+# Configure logging based on DEBUG environment variable
+# This must happen early, before other modules are imported
+_debug_mode = os.getenv("DEBUG", "").lower() in ("true", "1", "yes")
+if _debug_mode:
+    logging.getLogger("src").setLevel(logging.DEBUG)
+    logging.getLogger("langchain").setLevel(logging.DEBUG)
+    logging.getLogger("langgraph").setLevel(logging.DEBUG)
+
 from fastapi import FastAPI, HTTPException, Query, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response, StreamingResponse

--- a/src/workflow.py
+++ b/src/workflow.py
@@ -16,7 +16,10 @@ logging.basicConfig(
 
 def enable_debug_logging():
     """Enable debug level logging for more detailed execution information."""
+    # Must also set root logger level to allow DEBUG messages to propagate
     logging.getLogger("src").setLevel(logging.DEBUG)
+    logging.getLogger("langchain").setLevel(logging.DEBUG)
+    logging.getLogger("langgraph").setLevel(logging.DEBUG)
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #790 

This pull request improves how debug logging is configured across the application, ensuring that the `DEBUG` environment variable is respected consistently and early in the startup process. It also loads environment variables from a `.env` file before any logging configuration, which is important for local development and deployment flexibility.

**Environment variable and logging configuration:**

* Ensures environment variables from `.env` are loaded at the very start of `src/server/app.py`, so that settings like `DEBUG` are available before any logging configuration.
* Configures debug logging for `src`, `langchain`, and `langgraph` loggers early in `src/server/app.py` if the `DEBUG` environment variable is set.
* Updates `server.py` to check the `DEBUG` environment variable and override the log level accordingly, ensuring consistent behavior between CLI arguments and environment-based configuration. [[1]](diffhunk://#diff-791d4d41d3718d15d49180f3aacc8370b8cab07383f0d35b2713651cc0adfe46R82-R93) [[2]](diffhunk://#diff-791d4d41d3718d15d49180f3aacc8370b8cab07383f0d35b2713651cc0adfe46L98-R104)
* Updates `enable_debug_logging()` in `src/workflow.py` to also set debug level for `langchain` and `langgraph` loggers, and clarifies the need to set the root logger for debug messages to propagate.