### PR TITLE
fix(frontend): render all tool calls in the frontend #796

### DIFF
--- a/web/src/app/chat/components/research-activities-block.tsx
+++ b/web/src/app/chat/components/research-activities-block.tsx
@@ -104,21 +104,24 @@ const ActivityListItem = React.memo(({ messageId }: { messageId: string }) => {
   const message = useMessage(messageId);
   if (message) {
     if (!message.isStreaming && message.toolCalls?.length) {
-      for (const toolCall of message.toolCalls) {
-        if (typeof toolCall.result === "string" && toolCall.result?.startsWith("Error")) {
-          return null;
-        }
-        if (toolCall.name === "web_search") {
-          return <WebSearchToolCall key={toolCall.id} toolCall={toolCall} />;
-        } else if (toolCall.name === "crawl_tool") {
-          return <CrawlToolCall key={toolCall.id} toolCall={toolCall} />;
-        } else if (toolCall.name === "python_repl_tool") {
-          return <PythonToolCall key={toolCall.id} toolCall={toolCall} />;
-        } else if (toolCall.name === "local_search_tool") {
-          return <RetrieverToolCall key={toolCall.id} toolCall={toolCall} />;
-        } else {
-          return <MCPToolCall key={toolCall.id} toolCall={toolCall} />;
-        }
+      const toolCallComponents = message.toolCalls
+        .filter(toolCall => !(typeof toolCall.result === "string" && toolCall.result?.startsWith("Error")))
+        .map(toolCall => {
+          if (toolCall.name === "web_search") {
+            return <WebSearchToolCall key={toolCall.id} toolCall={toolCall} />;
+          } else if (toolCall.name === "crawl_tool") {
+            return <CrawlToolCall key={toolCall.id} toolCall={toolCall} />;
+          } else if (toolCall.name === "python_repl_tool") {
+            return <PythonToolCall key={toolCall.id} toolCall={toolCall} />;
+          } else if (toolCall.name === "local_search_tool") {
+            return <RetrieverToolCall key={toolCall.id} toolCall={toolCall} />;
+          } else {
+            return <MCPToolCall key={toolCall.id} toolCall={toolCall} />;
+          }
+        });
+      
+      if (toolCallComponents.length > 0) {
+        return <>{toolCallComponents}</>;
       }
     }
   }


### PR DESCRIPTION
Fixes #796 
This pull request refines how activity list items are rendered in the research activities block by improving error handling and component rendering logic. Instead of returning nothing when an error is detected in any tool call, the component now filters out only the tool calls with errors and continues to display the valid ones.

**Rendering improvements:**

* Modified `ActivityListItem` in `research-activities-block.tsx` to filter out tool calls with error results (those whose result starts with "Error") and render only the valid tool calls as components, instead of returning `null` if any error is present. [[1]](diffhunk://#diff-6c103332093b5c5f3846dfffdd2634e2a3031b57c14e1ba201c3aacf9e69ae47L107-R109) [[2]](diffhunk://#diff-6c103332093b5c5f3846dfffdd2634e2a3031b57c14e1ba201c3aacf9e69ae47R121-R124)