### PR TITLE
fix: Add runtime parameter to compress_messages method(#803)

### DIFF
--- a/src/utils/context_manager.py
+++ b/src/utils/context_manager.py
@@ -3,6 +3,8 @@ import copy
 import logging
 from typing import List
 
+from langgraph.runtime import Runtime 
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -144,7 +146,7 @@ class ContextManager:
         """
         return self.count_tokens(messages) > self.token_limit
 
-    def compress_messages(self, state: dict, runtime=None) -> List[BaseMessage]:
+    def compress_messages(self, state: dict, runtime: Runtime | None = None) -> dict:
         """
         Compress messages to fit within token limit
 


### PR DESCRIPTION
Fixes #803 
    The compress_messages method was being called by PreModelHookMiddleware
    with both state and runtime parameters, but only accepted state parameter.
    This caused a TypeError when the middleware executed the pre_model_hook.

    Added optional runtime parameter to compress_messages signature to match
    the expected interface while maintaining backward compatibility.