### PR TITLE
docs: clarify .env configuration for Docker Compose deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,13 @@
 DEBUG=True
 APP_ENV=development
 
-# docker build args
+# Frontend API URL (used as Docker build arg for Next.js)
+# This is a BUILD-TIME variable: it gets embedded into the frontend JS bundle during build.
+# Default works for local development (localhost). For remote/LAN deployment, change to your host IP or domain:
+#   NEXT_PUBLIC_API_URL=http://192.168.1.100:8000/api
+#   NEXT_PUBLIC_API_URL=https://your-domain.com/api
+# Note: When using docker-compose, only this root .env is used (not web/.env).
+# If you change this value after building, you must rebuild: docker compose build
 NEXT_PUBLIC_API_URL="http://localhost:8000/api"
 
 AGENT_RECURSION_LIMIT=30

--- a/README.md
+++ b/README.md
@@ -523,7 +523,34 @@ docker stop deer-flow-api-app
 
 ### Docker Compose (include both backend and frontend)
 
-DeerFlow provides a docker-compose setup to easily run both the backend and frontend together:
+DeerFlow provides a docker-compose setup to easily run both the backend and frontend together.
+
+#### Configuration
+
+Before building, configure the root `.env` file (copied from `.env.example`):
+
+```bash
+cp .env.example .env
+cp conf.yaml.example conf.yaml
+```
+
+> [!IMPORTANT]
+> The `docker-compose.yml` only uses the **root `.env`** file (not `web/.env`). You do **not** need to create or modify `web/.env` when using Docker Compose.
+
+If you are deploying on a **remote server** or accessing from a **LAN IP** (not `localhost`), you **must** update `NEXT_PUBLIC_API_URL` in the root `.env` to your actual host IP or domain:
+
+```bash
+# Example: accessing from LAN IP
+NEXT_PUBLIC_API_URL=http://192.168.1.100:8000/api
+
+# Example: remote deployment with domain
+NEXT_PUBLIC_API_URL=https://your-domain.com/api
+```
+
+> [!NOTE]
+> `NEXT_PUBLIC_API_URL` is a **build-time** variable for Next.js — it gets embedded into the frontend JavaScript bundle during `docker compose build`. If you change this value later, you must rebuild with `docker compose build` for the change to take effect.
+
+#### Build and Run
 
 ```bash
 # building docker image
@@ -534,7 +561,7 @@ docker compose up
 ```
 
 > [!WARNING]
-> If you want to deploy the deer flow into production environments, please add authentication to the website and evaluate your security check of the MCPServer and Python Repl. 
+> If you want to deploy the deer flow into production environments, please add authentication to the website and evaluate your security check of the MCPServer and Python Repl.
 
 ## Examples
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -476,7 +476,34 @@ docker stop deer-flow-api-app
 
 ### Docker Compose
 
-您也可以使用 docker compose 设置此项目：
+您也可以使用 docker compose 同时运行后端和前端。
+
+#### 配置
+
+构建前，先配置根目录的 `.env` 文件（从 `.env.example` 复制）：
+
+```bash
+cp .env.example .env
+cp conf.yaml.example conf.yaml
+```
+
+> [!IMPORTANT]
+> `docker-compose.yml` 只使用**根目录的 `.env`** 文件（不使用 `web/.env`）。使用 Docker Compose 时，您**不需要**创建或修改 `web/.env`。
+
+如果您在**远程服务器**上部署或通过**局域网 IP**（非 `localhost`）访问，**必须**将根目录 `.env` 中的 `NEXT_PUBLIC_API_URL` 修改为实际的主机 IP 或域名：
+
+```bash
+# 示例：通过局域网 IP 访问
+NEXT_PUBLIC_API_URL=http://192.168.1.100:8000/api
+
+# 示例：使用域名的远程部署
+NEXT_PUBLIC_API_URL=https://your-domain.com/api
+```
+
+> [!NOTE]
+> `NEXT_PUBLIC_API_URL` 是 Next.js 的**构建时**变量——它会在 `docker compose build` 时被嵌入到前端 JavaScript 包中。如果之后修改了此值，必须重新执行 `docker compose build` 才能生效。
+
+#### 构建和运行
 
 ```bash
 # 构建docker镜像


### PR DESCRIPTION
## Summary

Fixes #527

When deploying DeerFlow with `docker-compose`, users are confused by the two `.env` files (root `.env` and `web/.env`) and don't know which one to configure. The documentation doesn't mention that `NEXT_PUBLIC_API_URL` must be updated for remote/LAN deployments.

## Problem

1. `docker-compose.yml` only uses the **root `.env`** file, but this is not documented
2. `web/.env` has detailed comments about `NEXT_PUBLIC_API_URL`, but it's **not used** by Docker Compose — causing confusion
3. README Docker Compose section has no guidance on `.env` configuration
4. `NEXT_PUBLIC_API_URL` is a Next.js **build-time** variable (baked into JS bundle), but this is not mentioned anywhere
5. Root `.env.example` has a minimal comment (`# docker build args`) that doesn't explain the variable's importance

## Changes

- **README.md** & **README_zh.md**: Expanded Docker Compose section with:
  - Explicit note that only root `.env` is used (not `web/.env`)
  - Instructions to update `NEXT_PUBLIC_API_URL` for remote/LAN deployment
  - Explanation that `NEXT_PUBLIC_API_URL` is a build-time variable requiring rebuild
- **`.env.example`**: Improved `NEXT_PUBLIC_API_URL` comments with usage examples and Docker Compose notes

## Verification

Verified by analyzing the actual `docker-compose.yml`, `web/Dockerfile`, and both `.env.example` files to confirm:
- `docker-compose.yml` line 25-26: frontend `env_file` points to root `.env`
- `docker-compose.yml` line 21: `NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL` reads from root `.env`
- `web/Dockerfile` line 23: `ARG NEXT_PUBLIC_API_URL` with no default value
- Next.js `NEXT_PUBLIC_` prefix variables are inlined at build time