### PR TITLE
fix(web): render messages from unknown agents as fallback bubbles (#456)

### DIFF
--- a/web/src/app/chat/components/message-list-view.tsx
+++ b/web/src/app/chat/components/message-list-view.tsx
@@ -142,12 +142,20 @@ function MessageListItem({
     return researchIds.includes(messageId);
   }, [researchIds, messageId]);
   if (message) {
+    // Research-phase agents are rendered inside ResearchCard, skip them here
+    const isResearchAgent =
+      message.agent === "researcher" ||
+      message.agent === "coder" ||
+      message.agent === "reporter" ||
+      message.agent === "analyst";
     if (
-      message.role === "user" ||
-      message.agent === "coordinator" ||
-      message.agent === "planner" ||
-      message.agent === "podcast" ||
-      startOfResearch
+      !isResearchAgent &&
+      (message.role === "user" ||
+        message.agent === "coordinator" ||
+        message.agent === "planner" ||
+        message.agent === "podcast" ||
+        startOfResearch ||
+        message.content)
     ) {
       let content: React.ReactNode;
       if (message.agent === "planner") {

--- a/web/src/core/messages/types.ts
+++ b/web/src/core/messages/types.ts
@@ -13,7 +13,8 @@ export interface Message {
     | "coder"
     | "reporter"
     | "podcast"
-    | "analyst";
+    | "analyst"
+    | (string & {});
   role: MessageRole;
   isStreaming?: boolean;
   content: string;

--- a/web/src/core/store/store.ts
+++ b/web/src/core/store/store.ts
@@ -469,13 +469,20 @@ export function useRenderableMessageIds() {
           return true;
         }
 
-        // For user and coordinator messages, only include if they have content
-        // This prevents empty dividers from appearing in the UI
-        if (message.role === "user" || message.agent === "coordinator") {
-          return !!message.content;
+        // Research-phase agents (researcher, coder, reporter, analyst) are rendered
+        // inside ResearchCard via researchActivityIds, not in the main message list
+        const isResearchAgent =
+          message.agent === "researcher" ||
+          message.agent === "coder" ||
+          message.agent === "reporter" ||
+          message.agent === "analyst";
+        if (isResearchAgent) {
+          return false;
         }
 
-        return false;
+        // All other messages (user, coordinator, unknown agents) render if they have content
+        // This prevents empty dividers while ensuring unknown agent messages (#456) are shown
+        return !!message.content;
       });
     }),
   );


### PR DESCRIPTION
## Problem

When the backend returns an unrecognized agent name (e.g. `"unknown"`), the message was silently dropped in `MessageListItem` because the rendering condition only matched known agents (`coordinator`, `planner`, `podcast`). This caused empty cards in the UI.

The root cause is in `_get_agent_name()` (`src/server/app.py`), which returns `"unknown"` as a fallback when the agent tuple is empty or metadata lacks `langgraph_node`. The frontend type definition and rendering logic didn't account for this.

## Fix

Three minimal changes:

1. **`web/src/core/messages/types.ts`**: Add `(string & {})` fallback to `Message.agent` union type so unknown agent names are accepted without type errors while preserving autocomplete for known agents.

2. **`web/src/core/store/store.ts`**: Add fallback in `useRenderableMessageIds` — any message with content from unrecognized agents now passes the filter.

3. **`web/src/app/chat/components/message-list-view.tsx`**: Add `message.content` as a fallback condition in `MessageListItem` so messages with content are rendered as regular message bubbles.

## Verification

- Confirmed `_get_agent_name()` returns `"unknown"` for empty agent tuples and missing metadata
- Verified main branch `useRenderableMessageIds` filters out unknown agent messages (`return false`)
- Verified fix branch correctly passes unknown agent messages with content through the filter
- `pnpm lint` passes with no new errors

Closes #456