### PR TITLE
chore: Ignore legacy web folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ logs/
 # pnpm
 .pnpm-store
 sandbox_image_cache.tar
+
+# ignore the legacy `web` folder
+web/


### PR DESCRIPTION
Add rule to ignore the legacy 'web' folder 