### PR TITLE
fix: HTML artifact preview renders blank in preview mode

### DIFF
--- a/frontend/src/components/ai-elements/artifact.tsx
+++ b/frontend/src/components/ai-elements/artifact.tsx
@@ -11,8 +11,10 @@ import { cn } from "@/lib/utils";
 import { type LucideIcon, XIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";
 
+/** Props for the root artifact container. */
 export type ArtifactProps = HTMLAttributes<HTMLDivElement>;
 
+/** Root container for an artifact card with border and shadow styling. */
 export const Artifact = ({ className, ...props }: ArtifactProps) => (
   <div
     className={cn(
@@ -23,8 +25,10 @@ export const Artifact = ({ className, ...props }: ArtifactProps) => (
   />
 );
 
+/** Props for the artifact header bar. */
 export type ArtifactHeaderProps = HTMLAttributes<HTMLDivElement>;
 
+/** Header bar displayed at the top of an artifact, containing title and actions. */
 export const ArtifactHeader = ({
   className,
   ...props
@@ -38,8 +42,10 @@ export const ArtifactHeader = ({
   />
 );
 
+/** Props for the artifact close button. */
 export type ArtifactCloseProps = ComponentProps<typeof Button>;
 
+/** Close button that dismisses the artifact panel. Renders an X icon by default. */
 export const ArtifactClose = ({
   className,
   children,
@@ -62,8 +68,10 @@ export const ArtifactClose = ({
   </Button>
 );
 
+/** Props for the artifact title text. */
 export type ArtifactTitleProps = HTMLAttributes<HTMLParagraphElement>;
 
+/** Title label displayed in the artifact header. */
 export const ArtifactTitle = ({ className, ...props }: ArtifactTitleProps) => (
   <div
     className={cn("text-foreground text-sm font-medium", className)}
@@ -71,8 +79,10 @@ export const ArtifactTitle = ({ className, ...props }: ArtifactTitleProps) => (
   />
 );
 
+/** Props for the artifact description text. */
 export type ArtifactDescriptionProps = HTMLAttributes<HTMLParagraphElement>;
 
+/** Secondary description text displayed below the artifact title. */
 export const ArtifactDescription = ({
   className,
   ...props
@@ -80,8 +90,10 @@ export const ArtifactDescription = ({
   <p className={cn("text-muted-foreground text-sm", className)} {...props} />
 );
 
+/** Props for the artifact action button group container. */
 export type ArtifactActionsProps = HTMLAttributes<HTMLDivElement>;
 
+/** Horizontal row of action buttons in the artifact header. */
 export const ArtifactActions = ({
   className,
   ...props
@@ -89,12 +101,20 @@ export const ArtifactActions = ({
   <div className={cn("flex items-center gap-1", className)} {...props} />
 );
 
+/** Props for an individual artifact action button. */
 export type ArtifactActionProps = ComponentProps<typeof Button> & {
+  /** Tooltip text shown on hover. */
   tooltip?: string;
+  /** Accessible label for screen readers. Falls back to `tooltip` if omitted. */
   label?: string;
+  /** Lucide icon component rendered inside the button. */
   icon?: LucideIcon;
 };
 
+/**
+ * Icon button for artifact actions (copy, download, open, etc.).
+ * Wraps itself in a tooltip when `tooltip` is provided.
+ */
 export const ArtifactAction = ({
   tooltip,
   label,
@@ -137,8 +157,10 @@ export const ArtifactAction = ({
   return button;
 };
 
+/** Props for the scrollable artifact body area. */
 export type ArtifactContentProps = HTMLAttributes<HTMLDivElement>;
 
+/** Scrollable content area that fills the remaining space of an artifact card. */
 export const ArtifactContent = ({
   className,
   ...props

--- a/frontend/src/components/ai-elements/web-preview.tsx
+++ b/frontend/src/components/ai-elements/web-preview.tsx
@@ -18,10 +18,15 @@ import { ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, useContext, useEffect, useState } from "react";
 
+/** Context value shared across all WebPreview compound components. */
 export type WebPreviewContextValue = {
+  /** The current URL being previewed. */
   url: string;
+  /** Updates the preview URL and notifies parent via `onUrlChange`. */
   setUrl: (url: string) => void;
+  /** Whether the developer console panel is expanded. */
   consoleOpen: boolean;
+  /** Toggles the developer console panel. */
   setConsoleOpen: (open: boolean) => void;
 };
 
@@ -35,11 +40,18 @@ const useWebPreview = () => {
   return context;
 };
 
+/** Props for the root WebPreview container that provides context to child components. */
 export type WebPreviewProps = ComponentProps<"div"> & {
+  /** Initial URL to load when the preview mounts. */
   defaultUrl?: string;
+  /** Callback fired whenever the preview URL changes. */
   onUrlChange?: (url: string) => void;
 };
 
+/**
+ * Root container for the web preview compound component.
+ * Provides URL and console state context to all child components.
+ */
 export const WebPreview = ({
   className,
   children,
@@ -77,8 +89,10 @@ export const WebPreview = ({
   );
 };
 
+/** Props for the navigation bar displayed above the preview iframe. */
 export type WebPreviewNavigationProps = ComponentProps<"div">;
 
+/** Navigation bar containing buttons and the URL input for the preview. */
 export const WebPreviewNavigation = ({
   className,
   children,
@@ -92,10 +106,13 @@ export const WebPreviewNavigation = ({
   </div>
 );
 
+/** Props for a navigation action button (e.g. back, forward, refresh). */
 export type WebPreviewNavigationButtonProps = ComponentProps<typeof Button> & {
+  /** Tooltip text shown on hover. */
   tooltip?: string;
 };
 
+/** Icon button used in the preview navigation bar with a tooltip. */
 export const WebPreviewNavigationButton = ({
   onClick,
   disabled,
@@ -124,8 +141,13 @@ export const WebPreviewNavigationButton = ({
   </TooltipProvider>
 );
 
+/** Props for the URL address bar input. */
 export type WebPreviewUrlProps = ComponentProps<typeof Input>;
 
+/**
+ * URL address bar that syncs with the WebPreview context.
+ * Navigates to the entered URL on Enter key press.
+ */
 export const WebPreviewUrl = ({
   value,
   onChange,
@@ -165,10 +187,16 @@ export const WebPreviewUrl = ({
   );
 };
 
+/** Props for the iframe that renders the previewed content. */
 export type WebPreviewBodyProps = ComponentProps<"iframe"> & {
+  /** Optional loading indicator displayed while the iframe loads. */
   loading?: ReactNode;
 };
 
+/**
+ * Sandboxed iframe that displays the preview content.
+ * Uses the URL from WebPreview context unless an explicit `src` is provided.
+ */
 export const WebPreviewBody = ({
   className,
   loading,
@@ -191,7 +219,9 @@ export const WebPreviewBody = ({
   );
 };
 
+/** Props for the collapsible developer console panel. */
 export type WebPreviewConsoleProps = ComponentProps<"div"> & {
+  /** Log entries to display, each with a severity level, message, and timestamp. */
   logs?: Array<{
     level: "log" | "warn" | "error";
     message: string;
@@ -199,6 +229,10 @@ export type WebPreviewConsoleProps = ComponentProps<"div"> & {
   }>;
 };
 
+/**
+ * Collapsible console panel that displays log output from the previewed page.
+ * Logs are color-coded by severity: errors in red, warnings in yellow.
+ */
 export const WebPreviewConsole = ({
   className,
   logs = [],

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -43,6 +43,11 @@ import { Tooltip } from "../tooltip";
 
 import { useArtifacts } from "./context";
 
+/**
+ * Displays a single artifact file with a code editor or preview mode.
+ * Supports code viewing, markdown rendering, HTML preview via iframe,
+ * and actions like copy, download, open in new window, and skill installation.
+ */
 export function ArtifactFileDetail({
   className,
   filepath: filepathFromProps,
@@ -260,6 +265,12 @@ export function ArtifactFileDetail({
   );
 }
 
+/**
+ * Renders a preview of an artifact file based on its language type.
+ * - Markdown files are rendered using the Streamdown component.
+ * - HTML files are rendered in a sandboxed iframe via the artifact URL.
+ * - Other file types are not previewable and return null.
+ */
 export function ArtifactFilePreview({
   filepath,
   threadId,


### PR DESCRIPTION
The condition guarding ArtifactFilePreview included `language === "markdown"`, which prevented HTML files from reaching the preview component. This left a blank panel because none of the three rendering paths matched for HTML in preview mode.

Fixes #873