### PR TITLE
fix: use /tmp/nginx.pid to avoid permission denied errors

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,7 +1,7 @@
 events {
     worker_connections 1024;
 }
-
+pid /tmp/nginx.pid;
 http {
     # Basic settings
     sendfile on;

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -1,7 +1,7 @@
 events {
     worker_connections 1024;
 }
-
+pid /tmp/nginx.pid;
 http {
     # Basic settings
     sendfile on;


### PR DESCRIPTION
Fixes #870
## Summary
- Set `pid /tmp/nginx.pid;` in `docker/nginx/nginx.conf` and `docker/nginx/nginx.local.conf` to prevent permission denied errors when nginx attempts to write its PID file to the default location as a non-root user.

## Test plan
- [x] Build and run the Docker container to verify nginx starts without permission denied errors
- [x] Confirm nginx PID file is created at `/tmp/nginx.pid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)