### PR TITLE
fix(docker): update nginx configuration and simplify docker script

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -66,7 +66,7 @@ services:
     ports:
       - "2026:2026"
     volumes:
-      - ./nginx/${NGINX_CONF:-nginx.local.conf}:/etc/nginx/nginx.conf:ro
+      - ./nginx/${NGINX_CONF:-nginx.conf}:/etc/nginx/nginx.conf:ro
     depends_on:
       - frontend
       - gateway

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,10 +30,6 @@ http {
         server frontend:3000;
     }
 
-    upstream provisioner {
-        server provisioner:8002;
-    }
-
     # ── Main server (path-based routing) ─────────────────────────────────
     server {
         listen 2026 default_server;
@@ -189,8 +185,11 @@ http {
         }
 
         # ── Provisioner API (sandbox management) ────────────────────────
+        # Use a variable so nginx resolves provisioner at request time (not startup).
+        # This allows nginx to start even when provisioner container is not running.
         location /api/sandboxes {
-            proxy_pass http://provisioner;
+            set $provisioner_upstream provisioner:8002;
+            proxy_pass http://$provisioner_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -95,7 +95,6 @@ init() {
 # Start Docker development environment
 start() {
     local sandbox_mode
-    local nginx_conf
     local services
 
     echo "=========================================="
@@ -106,10 +105,8 @@ start() {
     sandbox_mode="$(detect_sandbox_mode)"
 
     if [ "$sandbox_mode" = "provisioner" ]; then
-        nginx_conf="nginx.conf"
         services="frontend gateway langgraph provisioner nginx"
     else
-        nginx_conf="nginx.local.conf"
         services="frontend gateway langgraph nginx"
     fi
 
@@ -129,7 +126,7 @@ start() {
     fi
     
     echo "Building and starting containers..."
-    cd "$DOCKER_DIR" && NGINX_CONF="$nginx_conf" $COMPOSE_CMD up --build -d --remove-orphans $services
+    cd "$DOCKER_DIR" && $COMPOSE_CMD up --build -d --remove-orphans $services
     echo ""
     echo "=========================================="
     echo "  DeerFlow Docker is starting!"


### PR DESCRIPTION
This pull request updates the NGINX configuration and Docker setup to simplify and improve the handling of the provisioner service, particularly ensuring that NGINX can start even if the provisioner container is not running. The changes remove unnecessary complexity around selecting NGINX config files and improve the reliability of the proxy setup.

**NGINX configuration improvements:**

* Updated `docker/nginx/nginx.conf` to remove the static `upstream provisioner` block and instead use a variable (`$provisioner_upstream`) in the `proxy_pass` directive for `/api/sandboxes`. This change allows NGINX to resolve the `provisioner` service at request time, so NGINX can start even if the provisioner container is not running at startup. [[1]](diffhunk://#diff-4a09c0a0fa902cb0f31dbe2d49b7e9455ad37b89f60dab3857fa7b2fe3d9481eL33-L36) [[2]](diffhunk://#diff-4a09c0a0fa902cb0f31dbe2d49b7e9455ad37b89f60dab3857fa7b2fe3d9481eR188-R192)

**Docker Compose and script simplification:**

* Simplified the NGINX config file selection in `docker/docker-compose-dev.yaml` by always using `nginx.conf` as the default, removing the conditional logic that previously selected between `nginx.local.conf` and `nginx.conf`.
* Cleaned up `scripts/docker.sh` by removing logic related to setting the `NGINX_CONF` environment variable and the associated config file selection, since only one config file is now used. [[1]](diffhunk://#diff-82f30b5a775d634a158a3dc34ca5c94366c413f08d636e6a7dba05eec34bde6fL98) [[2]](diffhunk://#diff-82f30b5a775d634a158a3dc34ca5c94366c413f08d636e6a7dba05eec34bde6fL109-L112) [[3]](diffhunk://#diff-82f30b5a775d634a158a3dc34ca5c94366c413f08d636e6a7dba05eec34bde6fL132-R129)