### PR TITLE
Add DeerFlowClient for in-process access to DeerFlow features

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,31 @@ DeerFlow is model-agnostic — it works with any LLM that implements the OpenAI-
 - **Multimodal inputs** for image understanding and video comprehension
 - **Strong tool-use** for reliable function calling and structured outputs
 
+## Embedded Python Client
+
+DeerFlow can be used as an embedded Python library without running the full HTTP services. The `DeerFlowClient` provides direct in-process access to all agent and Gateway capabilities:
+
+```python
+from src.client import DeerFlowClient
+
+client = DeerFlowClient()
+
+# Chat
+response = client.chat("Analyze this paper for me", thread_id="my-thread")
+
+# Streaming
+for event in client.stream("hello"):
+    print(event.type, event.data)
+
+# Configuration & management
+print(client.list_models())
+print(client.list_skills())
+client.update_skill("web-search", enabled=True)
+client.upload_files("thread-1", ["./report.pdf"])
+```
+
+See `backend/src/client.py` for full API documentation.
+
 ## Documentation
 
 - [Contributing Guide](CONTRIBUTING.md) - Development environment setup and workflow

--- a/backend/src/client.py
+++ b/backend/src/client.py
@@ -1,0 +1,721 @@
+"""DeerFlowClient — Embedded Python client for DeerFlow agent system.
+
+Provides direct programmatic access to DeerFlow's agent capabilities
+without requiring LangGraph Server or Gateway API processes.
+
+Usage:
+    from src.client import DeerFlowClient
+
+    client = DeerFlowClient()
+    response = client.chat("Analyze this paper for me", thread_id="my-thread")
+    print(response)
+
+    # Streaming
+    for event in client.stream("hello"):
+        print(event)
+"""
+
+import asyncio
+import json
+import logging
+import mimetypes
+import os
+import shutil
+import uuid
+import zipfile
+from collections.abc import Generator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from langchain.agents import create_agent
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+
+from src.agents.lead_agent.agent import _build_middlewares
+from src.agents.lead_agent.prompt import apply_prompt_template
+from src.agents.thread_state import ThreadState
+from src.config.app_config import get_app_config, reload_app_config
+from src.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
+from src.models import create_chat_model
+from src.sandbox.consts import THREAD_DATA_BASE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class StreamEvent:
+    """A single event from the streaming agent response.
+
+    Attributes:
+        type: Event type — "message", "tool_call", "tool_result", "title", or "done".
+        data: Event payload. Contents vary by type.
+    """
+
+    type: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+class DeerFlowClient:
+    """Embedded Python client for DeerFlow agent system.
+
+    Provides direct programmatic access to DeerFlow's agent capabilities
+    without requiring LangGraph Server or Gateway API processes.
+
+    Example::
+
+        from src.client import DeerFlowClient
+
+        client = DeerFlowClient()
+
+        # Simple one-shot
+        print(client.chat("hello"))
+
+        # Streaming
+        for event in client.stream("hello"):
+            print(event.type, event.data)
+
+        # Configuration queries
+        print(client.list_models())
+        print(client.list_skills())
+    """
+
+    def __init__(
+        self,
+        config_path: str | None = None,
+        checkpointer=None,
+        *,
+        model_name: str | None = None,
+        thinking_enabled: bool = True,
+        subagent_enabled: bool = False,
+        plan_mode: bool = False,
+    ):
+        """Initialize the client.
+
+        Loads configuration but defers agent creation to first use.
+
+        Args:
+            config_path: Path to config.yaml. Uses default resolution if None.
+            checkpointer: LangGraph checkpointer instance for state persistence
+                across multiple chat() / stream() calls on the same thread_id.
+            model_name: Override the default model name from config.
+            thinking_enabled: Enable model's extended thinking.
+            subagent_enabled: Enable subagent delegation.
+            plan_mode: Enable TodoList middleware for plan mode.
+        """
+        if config_path is not None:
+            reload_app_config(config_path)
+        self._app_config = get_app_config()
+
+        self._checkpointer = checkpointer
+        self._model_name = model_name
+        self._thinking_enabled = thinking_enabled
+        self._subagent_enabled = subagent_enabled
+        self._plan_mode = plan_mode
+
+        # Lazy agent — created on first call, recreated when config changes.
+        self._agent = None
+        self._agent_config_key: tuple | None = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_runnable_config(self, thread_id: str, **overrides) -> RunnableConfig:
+        """Build a RunnableConfig for agent invocation."""
+        configurable = {
+            "thread_id": thread_id,
+            "model_name": overrides.get("model_name", self._model_name),
+            "thinking_enabled": overrides.get("thinking_enabled", self._thinking_enabled),
+            "is_plan_mode": overrides.get("plan_mode", self._plan_mode),
+            "subagent_enabled": overrides.get("subagent_enabled", self._subagent_enabled),
+        }
+        return RunnableConfig(
+            configurable=configurable,
+            recursion_limit=overrides.get("recursion_limit", 100),
+        )
+
+    def _ensure_agent(self, config: RunnableConfig):
+        """Create (or recreate) the agent when config-dependent params change."""
+        cfg = config.get("configurable", {})
+        key = (
+            cfg.get("model_name"),
+            cfg.get("thinking_enabled"),
+            cfg.get("is_plan_mode"),
+            cfg.get("subagent_enabled"),
+        )
+
+        if self._agent is not None and self._agent_config_key == key:
+            return
+
+        thinking_enabled = cfg.get("thinking_enabled", True)
+        model_name = cfg.get("model_name")
+        subagent_enabled = cfg.get("subagent_enabled", False)
+        max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
+
+        kwargs: dict[str, Any] = {
+            "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
+            "tools": self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled),
+            "middleware": _build_middlewares(config),
+            "system_prompt": apply_prompt_template(
+                subagent_enabled=subagent_enabled,
+                max_concurrent_subagents=max_concurrent_subagents,
+            ),
+            "state_schema": ThreadState,
+        }
+        if self._checkpointer is not None:
+            kwargs["checkpointer"] = self._checkpointer
+
+        self._agent = create_agent(**kwargs)
+        self._agent_config_key = key
+        logger.info("Agent created: model=%s, thinking=%s", model_name, thinking_enabled)
+
+    @staticmethod
+    def _get_tools(*, model_name: str | None, subagent_enabled: bool):
+        """Lazy import to avoid circular dependency at module level."""
+        from src.tools import get_available_tools
+
+        return get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled)
+
+    @staticmethod
+    def _extract_text(content) -> str:
+        """Extract plain text from AIMessage content (str or list of blocks)."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block["text"])
+            return "\n".join(parts) if parts else ""
+        return str(content)
+
+    # ------------------------------------------------------------------
+    # Public API — conversation
+    # ------------------------------------------------------------------
+
+    def stream(
+        self,
+        message: str,
+        *,
+        thread_id: str | None = None,
+        **kwargs,
+    ) -> Generator[StreamEvent, None, None]:
+        """Stream a conversation turn, yielding events incrementally.
+
+        Each call sends one user message and yields events until the agent
+        finishes its turn.
+
+        Args:
+            message: User message text.
+            thread_id: Thread ID for conversation context. Auto-generated if None.
+            **kwargs: Override client defaults (model_name, thinking_enabled,
+                plan_mode, subagent_enabled, recursion_limit).
+
+        Yields:
+            StreamEvent with one of:
+            - type="message"     data={"content": str}
+            - type="tool_call"   data={"name": str, "args": dict, "id": str}
+            - type="tool_result" data={"name": str, "content": str, "tool_call_id": str}
+            - type="title"       data={"title": str}
+            - type="done"        data={}
+        """
+        if thread_id is None:
+            thread_id = str(uuid.uuid4())
+
+        config = self._get_runnable_config(thread_id, **kwargs)
+        self._ensure_agent(config)
+
+        state: dict[str, Any] = {"messages": [HumanMessage(content=message)]}
+        context = {"thread_id": thread_id}
+
+        seen_ids: set[str] = set()
+        last_title: str | None = None
+
+        for chunk in self._agent.stream(state, config=config, context=context, stream_mode="values"):
+            messages = chunk.get("messages", [])
+
+            for msg in messages:
+                msg_id = getattr(msg, "id", None)
+                if msg_id and msg_id in seen_ids:
+                    continue
+                if msg_id:
+                    seen_ids.add(msg_id)
+
+                if isinstance(msg, AIMessage):
+                    if msg.tool_calls:
+                        for tc in msg.tool_calls:
+                            yield StreamEvent(
+                                type="tool_call",
+                                data={"name": tc["name"], "args": tc["args"], "id": tc.get("id")},
+                            )
+
+                    text = self._extract_text(msg.content)
+                    if text:
+                        yield StreamEvent(type="message", data={"content": text})
+
+                elif isinstance(msg, ToolMessage):
+                    yield StreamEvent(
+                        type="tool_result",
+                        data={
+                            "name": getattr(msg, "name", None),
+                            "content": msg.content if isinstance(msg.content, str) else str(msg.content),
+                            "tool_call_id": getattr(msg, "tool_call_id", None),
+                        },
+                    )
+
+            # Title changes
+            title = chunk.get("title")
+            if title and title != last_title:
+                last_title = title
+                yield StreamEvent(type="title", data={"title": title})
+
+        yield StreamEvent(type="done", data={})
+
+    def chat(self, message: str, *, thread_id: str | None = None, **kwargs) -> str:
+        """Send a message and return the final text response.
+
+        Convenience wrapper around :meth:`stream` that collects events and
+        returns only the last AI message text.
+
+        Args:
+            message: User message text.
+            thread_id: Thread ID for conversation context. Auto-generated if None.
+            **kwargs: Override client defaults (same as stream()).
+
+        Returns:
+            The final AI response text, or empty string if no response.
+        """
+        last_text = ""
+        for event in self.stream(message, thread_id=thread_id, **kwargs):
+            if event.type == "message":
+                last_text = event.data.get("content", "")
+        return last_text
+
+    # ------------------------------------------------------------------
+    # Public API — configuration queries
+    # ------------------------------------------------------------------
+
+    def list_models(self) -> list[dict]:
+        """List available models from configuration.
+
+        Returns:
+            List of model config dicts.
+        """
+        return [model.model_dump() for model in self._app_config.models]
+
+    def list_skills(self, enabled_only: bool = False) -> list[dict]:
+        """List available skills.
+
+        Args:
+            enabled_only: If True, only return enabled skills.
+
+        Returns:
+            List of skill info dicts with name, description, category, enabled.
+        """
+        from src.skills.loader import load_skills
+
+        return [
+            {
+                "name": s.name,
+                "description": s.description,
+                "category": s.category,
+                "enabled": s.enabled,
+            }
+            for s in load_skills(enabled_only=enabled_only)
+        ]
+
+    def get_memory(self) -> dict:
+        """Get current memory data.
+
+        Returns:
+            Memory data dict (see src/agents/memory/updater.py for structure).
+        """
+        from src.agents.memory.updater import get_memory_data
+
+        return get_memory_data()
+
+    def get_model(self, name: str) -> dict | None:
+        """Get a specific model's configuration by name.
+
+        Args:
+            name: Model name.
+
+        Returns:
+            Model config dict, or None if not found.
+        """
+        model = self._app_config.get_model_config(name)
+        return model.model_dump() if model is not None else None
+
+    # ------------------------------------------------------------------
+    # Public API — MCP configuration
+    # ------------------------------------------------------------------
+
+    def get_mcp_config(self) -> dict[str, dict]:
+        """Get MCP server configurations.
+
+        Returns:
+            Dict mapping server name to its config dict.
+        """
+        config = get_extensions_config()
+        return {name: server.model_dump() for name, server in config.mcp_servers.items()}
+
+    def update_mcp_config(self, mcp_servers: dict[str, dict]) -> dict[str, dict]:
+        """Update MCP server configurations.
+
+        Writes to extensions_config.json and reloads the cache.
+
+        Args:
+            mcp_servers: Dict mapping server name to config dict.
+                Each value should contain keys like enabled, type, command, args, env, url, etc.
+
+        Returns:
+            The updated MCP config.
+
+        Raises:
+            OSError: If the config file cannot be written.
+        """
+        config_path = ExtensionsConfig.resolve_config_path()
+        if config_path is None:
+            config_path = Path.cwd().parent / "extensions_config.json"
+
+        current_config = get_extensions_config()
+
+        config_data = {
+            "mcpServers": mcp_servers,
+            "skills": {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()},
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f, indent=2)
+
+        reloaded = reload_extensions_config()
+        return {name: server.model_dump() for name, server in reloaded.mcp_servers.items()}
+
+    # ------------------------------------------------------------------
+    # Public API — skills management
+    # ------------------------------------------------------------------
+
+    def get_skill(self, name: str) -> dict | None:
+        """Get a specific skill by name.
+
+        Args:
+            name: Skill name.
+
+        Returns:
+            Skill info dict, or None if not found.
+        """
+        from src.skills.loader import load_skills
+
+        skill = next((s for s in load_skills(enabled_only=False) if s.name == name), None)
+        if skill is None:
+            return None
+        return {
+            "name": skill.name,
+            "description": skill.description,
+            "license": skill.license,
+            "category": skill.category,
+            "enabled": skill.enabled,
+        }
+
+    def update_skill(self, name: str, *, enabled: bool) -> dict:
+        """Update a skill's enabled status.
+
+        Args:
+            name: Skill name.
+            enabled: New enabled status.
+
+        Returns:
+            Updated skill info dict.
+
+        Raises:
+            ValueError: If the skill is not found.
+            OSError: If the config file cannot be written.
+        """
+        from src.skills.loader import load_skills
+
+        skills = load_skills(enabled_only=False)
+        skill = next((s for s in skills if s.name == name), None)
+        if skill is None:
+            raise ValueError(f"Skill '{name}' not found")
+
+        config_path = ExtensionsConfig.resolve_config_path()
+        if config_path is None:
+            config_path = Path.cwd().parent / "extensions_config.json"
+
+        extensions_config = get_extensions_config()
+        extensions_config.skills[name] = SkillStateConfig(enabled=enabled)
+
+        config_data = {
+            "mcpServers": {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()},
+            "skills": {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()},
+        }
+
+        with open(config_path, "w") as f:
+            json.dump(config_data, f, indent=2)
+
+        reload_extensions_config()
+
+        updated = next((s for s in load_skills(enabled_only=False) if s.name == name), None)
+        return {
+            "name": updated.name,
+            "description": updated.description,
+            "license": updated.license,
+            "category": updated.category,
+            "enabled": updated.enabled,
+        }
+
+    def install_skill(self, skill_path: str | Path) -> dict:
+        """Install a skill from a .skill archive (ZIP).
+
+        Args:
+            skill_path: Path to the .skill file.
+
+        Returns:
+            Dict with success, skill_name, message.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file is invalid.
+        """
+        from src.gateway.routers.skills import _validate_skill_frontmatter
+        from src.skills.loader import get_skills_root_path
+
+        path = Path(skill_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Skill file not found: {skill_path}")
+        if not path.is_file():
+            raise ValueError(f"Path is not a file: {skill_path}")
+        if path.suffix != ".skill":
+            raise ValueError("File must have .skill extension")
+        if not zipfile.is_zipfile(path):
+            raise ValueError("File is not a valid ZIP archive")
+
+        skills_root = get_skills_root_path()
+        custom_dir = skills_root / "custom"
+        custom_dir.mkdir(parents=True, exist_ok=True)
+
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with zipfile.ZipFile(path, "r") as zf:
+                zf.extractall(tmp_path)
+
+            items = list(tmp_path.iterdir())
+            if not items:
+                raise ValueError("Skill archive is empty")
+
+            skill_dir = items[0] if len(items) == 1 and items[0].is_dir() else tmp_path
+
+            is_valid, message, skill_name = _validate_skill_frontmatter(skill_dir)
+            if not is_valid:
+                raise ValueError(f"Invalid skill: {message}")
+
+            target = custom_dir / skill_name
+            if target.exists():
+                raise ValueError(f"Skill '{skill_name}' already exists")
+
+            shutil.copytree(skill_dir, target)
+
+        return {"success": True, "skill_name": skill_name, "message": f"Skill '{skill_name}' installed successfully"}
+
+    # ------------------------------------------------------------------
+    # Public API — memory management
+    # ------------------------------------------------------------------
+
+    def reload_memory(self) -> dict:
+        """Reload memory data from file, forcing cache invalidation.
+
+        Returns:
+            The reloaded memory data dict.
+        """
+        from src.agents.memory.updater import reload_memory_data
+
+        return reload_memory_data()
+
+    def get_memory_config(self) -> dict:
+        """Get memory system configuration.
+
+        Returns:
+            Memory config dict.
+        """
+        from src.config.memory_config import get_memory_config
+
+        config = get_memory_config()
+        return {
+            "enabled": config.enabled,
+            "storage_path": config.storage_path,
+            "debounce_seconds": config.debounce_seconds,
+            "max_facts": config.max_facts,
+            "fact_confidence_threshold": config.fact_confidence_threshold,
+            "injection_enabled": config.injection_enabled,
+            "max_injection_tokens": config.max_injection_tokens,
+        }
+
+    def get_memory_status(self) -> dict:
+        """Get memory status: config + current data.
+
+        Returns:
+            Dict with "config" and "data" keys.
+        """
+        return {
+            "config": self.get_memory_config(),
+            "data": self.get_memory(),
+        }
+
+    # ------------------------------------------------------------------
+    # Public API — file uploads
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_uploads_dir(thread_id: str) -> Path:
+        """Get (and create) the uploads directory for a thread."""
+        base = Path(os.getcwd()) / THREAD_DATA_BASE_DIR / thread_id / "user-data" / "uploads"
+        base.mkdir(parents=True, exist_ok=True)
+        return base
+
+    def upload_files(self, thread_id: str, files: list[str | Path]) -> list[dict]:
+        """Upload local files into a thread's uploads directory.
+
+        For PDF, PPT, Excel, and Word files, they are also converted to Markdown.
+
+        Args:
+            thread_id: Target thread ID.
+            files: List of local file paths to upload.
+
+        Returns:
+            List of file info dicts (filename, size, path, virtual_path).
+
+        Raises:
+            FileNotFoundError: If any file does not exist.
+        """
+        from src.gateway.routers.uploads import CONVERTIBLE_EXTENSIONS, convert_file_to_markdown
+
+        uploads_dir = self._get_uploads_dir(thread_id)
+        results: list[dict] = []
+
+        for f in files:
+            src_path = Path(f)
+            if not src_path.exists():
+                raise FileNotFoundError(f"File not found: {f}")
+
+            dest = uploads_dir / src_path.name
+            shutil.copy2(src_path, dest)
+
+            info: dict[str, Any] = {
+                "filename": src_path.name,
+                "size": dest.stat().st_size,
+                "path": f"{THREAD_DATA_BASE_DIR}/{thread_id}/user-data/uploads/{src_path.name}",
+                "virtual_path": f"/mnt/user-data/uploads/{src_path.name}",
+            }
+
+            if src_path.suffix.lower() in CONVERTIBLE_EXTENSIONS:
+                try:
+                    loop = asyncio.get_event_loop()
+                    if loop.is_running():
+                        import concurrent.futures
+                        with concurrent.futures.ThreadPoolExecutor() as pool:
+                            md_path = pool.submit(asyncio.run, convert_file_to_markdown(dest)).result()
+                    else:
+                        md_path = loop.run_until_complete(convert_file_to_markdown(dest))
+                except RuntimeError:
+                    md_path = asyncio.run(convert_file_to_markdown(dest))
+
+                if md_path is not None:
+                    info["markdown_file"] = md_path.name
+                    info["markdown_virtual_path"] = f"/mnt/user-data/uploads/{md_path.name}"
+
+            results.append(info)
+
+        return results
+
+    def list_uploads(self, thread_id: str) -> list[dict]:
+        """List files in a thread's uploads directory.
+
+        Args:
+            thread_id: Thread ID.
+
+        Returns:
+            List of file info dicts.
+        """
+        uploads_dir = self._get_uploads_dir(thread_id)
+        if not uploads_dir.exists():
+            return []
+
+        files = []
+        for fp in sorted(uploads_dir.iterdir()):
+            if fp.is_file():
+                stat = fp.stat()
+                files.append({
+                    "filename": fp.name,
+                    "size": stat.st_size,
+                    "path": f"{THREAD_DATA_BASE_DIR}/{thread_id}/user-data/uploads/{fp.name}",
+                    "virtual_path": f"/mnt/user-data/uploads/{fp.name}",
+                    "extension": fp.suffix,
+                    "modified": stat.st_mtime,
+                })
+        return files
+
+    def delete_upload(self, thread_id: str, filename: str) -> None:
+        """Delete a file from a thread's uploads directory.
+
+        Args:
+            thread_id: Thread ID.
+            filename: Filename to delete.
+
+        Raises:
+            FileNotFoundError: If the file does not exist.
+            PermissionError: If path traversal is detected.
+        """
+        uploads_dir = self._get_uploads_dir(thread_id)
+        file_path = uploads_dir / filename
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"File not found: {filename}")
+
+        try:
+            file_path.resolve().relative_to(uploads_dir.resolve())
+        except ValueError:
+            raise PermissionError("Access denied: path traversal detected")
+
+        file_path.unlink()
+
+    # ------------------------------------------------------------------
+    # Public API — artifacts
+    # ------------------------------------------------------------------
+
+    def get_artifact(self, thread_id: str, path: str) -> tuple[bytes, str]:
+        """Read an artifact file produced by the agent.
+
+        Args:
+            thread_id: Thread ID.
+            path: Virtual path (e.g. "mnt/user-data/outputs/file.txt").
+
+        Returns:
+            Tuple of (file_bytes, mime_type).
+
+        Raises:
+            FileNotFoundError: If the artifact does not exist.
+            ValueError: If the path is invalid.
+        """
+        virtual_prefix = "mnt/user-data"
+        clean_path = path.lstrip("/")
+        if not clean_path.startswith(virtual_prefix):
+            raise ValueError(f"Path must start with /{virtual_prefix}")
+
+        relative = clean_path[len(virtual_prefix):].lstrip("/")
+        base_dir = Path(os.getcwd()) / THREAD_DATA_BASE_DIR / thread_id / "user-data"
+        actual = (base_dir / relative).resolve()
+
+        if not str(actual).startswith(str(base_dir.resolve())):
+            raise PermissionError("Access denied: path traversal detected")
+        if not actual.exists():
+            raise FileNotFoundError(f"Artifact not found: {path}")
+        if not actual.is_file():
+            raise ValueError(f"Path is not a file: {path}")
+
+        mime_type, _ = mimetypes.guess_type(actual)
+        return actual.read_bytes(), mime_type or "application/octet-stream"

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1,0 +1,653 @@
+"""Tests for DeerFlowClient."""
+
+import json
+import tempfile
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage  # noqa: F401
+
+from src.client import DeerFlowClient
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_app_config():
+    """Provide a minimal AppConfig mock."""
+    model = MagicMock()
+    model.name = "test-model"
+    model.model_dump.return_value = {"name": "test-model", "use": "langchain_openai:ChatOpenAI"}
+
+    config = MagicMock()
+    config.models = [model]
+    return config
+
+
+@pytest.fixture
+def client(mock_app_config):
+    """Create a DeerFlowClient with mocked config loading."""
+    with patch("src.client.get_app_config", return_value=mock_app_config):
+        return DeerFlowClient()
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+class TestClientInit:
+    def test_default_params(self, client):
+        assert client._model_name is None
+        assert client._thinking_enabled is True
+        assert client._subagent_enabled is False
+        assert client._plan_mode is False
+        assert client._checkpointer is None
+        assert client._agent is None
+
+    def test_custom_params(self, mock_app_config):
+        with patch("src.client.get_app_config", return_value=mock_app_config):
+            c = DeerFlowClient(
+                model_name="gpt-4",
+                thinking_enabled=False,
+                subagent_enabled=True,
+                plan_mode=True,
+            )
+        assert c._model_name == "gpt-4"
+        assert c._thinking_enabled is False
+        assert c._subagent_enabled is True
+        assert c._plan_mode is True
+
+    def test_custom_config_path(self, mock_app_config):
+        with (
+            patch("src.client.reload_app_config") as mock_reload,
+            patch("src.client.get_app_config", return_value=mock_app_config),
+        ):
+            DeerFlowClient(config_path="/tmp/custom.yaml")
+            mock_reload.assert_called_once_with("/tmp/custom.yaml")
+
+    def test_checkpointer_stored(self, mock_app_config):
+        cp = MagicMock()
+        with patch("src.client.get_app_config", return_value=mock_app_config):
+            c = DeerFlowClient(checkpointer=cp)
+        assert c._checkpointer is cp
+
+
+# ---------------------------------------------------------------------------
+# list_models / list_skills / get_memory
+# ---------------------------------------------------------------------------
+
+class TestConfigQueries:
+    def test_list_models(self, client):
+        models = client.list_models()
+        assert len(models) == 1
+        assert models[0]["name"] == "test-model"
+
+    def test_list_skills(self, client):
+        skill = MagicMock()
+        skill.name = "web-search"
+        skill.description = "Search the web"
+        skill.category = "public"
+        skill.enabled = True
+
+        with patch("src.skills.loader.load_skills", return_value=[skill]) as mock_load:
+            result = client.list_skills()
+            mock_load.assert_called_once_with(enabled_only=False)
+
+        assert len(result) == 1
+        assert result[0] == {
+            "name": "web-search",
+            "description": "Search the web",
+            "category": "public",
+            "enabled": True,
+        }
+
+    def test_list_skills_enabled_only(self, client):
+        with patch("src.skills.loader.load_skills", return_value=[]) as mock_load:
+            client.list_skills(enabled_only=True)
+            mock_load.assert_called_once_with(enabled_only=True)
+
+    def test_get_memory(self, client):
+        memory = {"version": "1.0", "facts": []}
+        with patch("src.agents.memory.updater.get_memory_data", return_value=memory) as mock_mem:
+            result = client.get_memory()
+            mock_mem.assert_called_once()
+        assert result == memory
+
+
+# ---------------------------------------------------------------------------
+# stream / chat
+# ---------------------------------------------------------------------------
+
+def _make_agent_mock(chunks: list[dict]):
+    """Create a mock agent whose .stream() yields the given chunks."""
+    agent = MagicMock()
+    agent.stream.return_value = iter(chunks)
+    return agent
+
+
+class TestStream:
+    def test_basic_message(self, client):
+        """stream() emits message + done for a simple AI reply."""
+        ai = AIMessage(content="Hello!", id="ai-1")
+        chunks = [
+            {"messages": [HumanMessage(content="hi", id="h-1")]},
+            {"messages": [HumanMessage(content="hi", id="h-1"), ai]},
+        ]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("hi", thread_id="t1"))
+
+        types = [e.type for e in events]
+        assert "message" in types
+        assert types[-1] == "done"
+        msg_events = [e for e in events if e.type == "message"]
+        assert msg_events[0].data["content"] == "Hello!"
+
+    def test_tool_call_and_result(self, client):
+        """stream() emits tool_call and tool_result events."""
+        ai = AIMessage(content="", id="ai-1", tool_calls=[{"name": "bash", "args": {"cmd": "ls"}, "id": "tc-1"}])
+        tool = ToolMessage(content="file.txt", id="tm-1", tool_call_id="tc-1", name="bash")
+        ai2 = AIMessage(content="Here are the files.", id="ai-2")
+
+        chunks = [
+            {"messages": [HumanMessage(content="list files", id="h-1"), ai]},
+            {"messages": [HumanMessage(content="list files", id="h-1"), ai, tool]},
+            {"messages": [HumanMessage(content="list files", id="h-1"), ai, tool, ai2]},
+        ]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("list files", thread_id="t2"))
+
+        types = [e.type for e in events]
+        assert "tool_call" in types
+        assert "tool_result" in types
+        assert "message" in types
+        assert types[-1] == "done"
+
+    def test_title_event(self, client):
+        """stream() emits title event when title appears in state."""
+        ai = AIMessage(content="ok", id="ai-1")
+        chunks = [
+            {"messages": [HumanMessage(content="hi", id="h-1"), ai], "title": "Greeting"},
+        ]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("hi", thread_id="t3"))
+
+        title_events = [e for e in events if e.type == "title"]
+        assert len(title_events) == 1
+        assert title_events[0].data["title"] == "Greeting"
+
+    def test_deduplication(self, client):
+        """Messages with the same id are not emitted twice."""
+        ai = AIMessage(content="Hello!", id="ai-1")
+        chunks = [
+            {"messages": [HumanMessage(content="hi", id="h-1"), ai]},
+            {"messages": [HumanMessage(content="hi", id="h-1"), ai]},  # duplicate
+        ]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("hi", thread_id="t4"))
+
+        msg_events = [e for e in events if e.type == "message"]
+        assert len(msg_events) == 1
+
+    def test_auto_thread_id(self, client):
+        """stream() auto-generates a thread_id if not provided."""
+        agent = _make_agent_mock([{"messages": [AIMessage(content="ok", id="ai-1")]}])
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("hi"))
+
+        # Should not raise; done event proves it completed
+        assert events[-1].type == "done"
+
+    def test_list_content_blocks(self, client):
+        """stream() handles AIMessage with list-of-blocks content."""
+        ai = AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "hmm"},
+                {"type": "text", "text": "result"},
+            ],
+            id="ai-1",
+        )
+        chunks = [{"messages": [ai]}]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            events = list(client.stream("hi", thread_id="t5"))
+
+        msg_events = [e for e in events if e.type == "message"]
+        assert len(msg_events) == 1
+        assert msg_events[0].data["content"] == "result"
+
+
+class TestChat:
+    def test_returns_last_message(self, client):
+        """chat() returns the last AI message text."""
+        ai1 = AIMessage(content="thinking...", id="ai-1")
+        ai2 = AIMessage(content="final answer", id="ai-2")
+        chunks = [
+            {"messages": [HumanMessage(content="q", id="h-1"), ai1]},
+            {"messages": [HumanMessage(content="q", id="h-1"), ai1, ai2]},
+        ]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            result = client.chat("q", thread_id="t6")
+
+        assert result == "final answer"
+
+    def test_empty_response(self, client):
+        """chat() returns empty string if no AI message produced."""
+        chunks = [{"messages": []}]
+        agent = _make_agent_mock(chunks)
+
+        with (
+            patch.object(client, "_ensure_agent"),
+            patch.object(client, "_agent", agent),
+        ):
+            result = client.chat("q", thread_id="t7")
+
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _extract_text
+# ---------------------------------------------------------------------------
+
+class TestExtractText:
+    def test_string(self):
+        assert DeerFlowClient._extract_text("hello") == "hello"
+
+    def test_list_text_blocks(self):
+        content = [
+            {"type": "text", "text": "first"},
+            {"type": "thinking", "thinking": "skip"},
+            {"type": "text", "text": "second"},
+        ]
+        assert DeerFlowClient._extract_text(content) == "first\nsecond"
+
+    def test_list_plain_strings(self):
+        assert DeerFlowClient._extract_text(["a", "b"]) == "a\nb"
+
+    def test_empty_list(self):
+        assert DeerFlowClient._extract_text([]) == ""
+
+    def test_other_type(self):
+        assert DeerFlowClient._extract_text(42) == "42"
+
+
+# ---------------------------------------------------------------------------
+# _ensure_agent
+# ---------------------------------------------------------------------------
+
+class TestEnsureAgent:
+    def test_creates_agent(self, client):
+        """_ensure_agent creates an agent on first call."""
+        mock_agent = MagicMock()
+        config = client._get_runnable_config("t1")
+
+        with (
+            patch("src.client.create_chat_model"),
+            patch("src.client.create_agent", return_value=mock_agent),
+            patch("src.client._build_middlewares", return_value=[]),
+            patch("src.client.apply_prompt_template", return_value="prompt"),
+            patch.object(client, "_get_tools", return_value=[]),
+        ):
+            client._ensure_agent(config)
+
+        assert client._agent is mock_agent
+
+    def test_reuses_agent_same_config(self, client):
+        """_ensure_agent does not recreate if config key unchanged."""
+        mock_agent = MagicMock()
+        client._agent = mock_agent
+        client._agent_config_key = (None, True, False, False)
+
+        config = client._get_runnable_config("t1")
+        client._ensure_agent(config)
+
+        # Should still be the same mock — no recreation
+        assert client._agent is mock_agent
+
+
+# ---------------------------------------------------------------------------
+# get_model
+# ---------------------------------------------------------------------------
+
+class TestGetModel:
+    def test_found(self, client):
+        model_cfg = MagicMock()
+        model_cfg.model_dump.return_value = {"name": "test-model"}
+        client._app_config.get_model_config.return_value = model_cfg
+
+        result = client.get_model("test-model")
+        assert result == {"name": "test-model"}
+
+    def test_not_found(self, client):
+        client._app_config.get_model_config.return_value = None
+        assert client.get_model("nonexistent") is None
+
+
+# ---------------------------------------------------------------------------
+# MCP config
+# ---------------------------------------------------------------------------
+
+class TestMcpConfig:
+    def test_get_mcp_config(self, client):
+        server = MagicMock()
+        server.model_dump.return_value = {"enabled": True, "type": "stdio"}
+        ext_config = MagicMock()
+        ext_config.mcp_servers = {"github": server}
+
+        with patch("src.client.get_extensions_config", return_value=ext_config):
+            result = client.get_mcp_config()
+
+        assert "github" in result
+        assert result["github"]["enabled"] is True
+
+    def test_update_mcp_config(self, client):
+        # Set up current config with skills
+        current_config = MagicMock()
+        current_config.skills = {}
+
+        reloaded_server = MagicMock()
+        reloaded_server.model_dump.return_value = {"enabled": True, "type": "sse"}
+        reloaded_config = MagicMock()
+        reloaded_config.mcp_servers = {"new-server": reloaded_server}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            tmp_path = Path(f.name)
+
+        try:
+            with (
+                patch("src.client.ExtensionsConfig.resolve_config_path", return_value=tmp_path),
+                patch("src.client.get_extensions_config", return_value=current_config),
+                patch("src.client.reload_extensions_config", return_value=reloaded_config),
+            ):
+                result = client.update_mcp_config({"new-server": {"enabled": True, "type": "sse"}})
+
+            assert "new-server" in result
+
+            # Verify file was actually written
+            with open(tmp_path) as f:
+                saved = json.load(f)
+            assert "mcpServers" in saved
+        finally:
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Skills management
+# ---------------------------------------------------------------------------
+
+class TestSkillsManagement:
+    def _make_skill(self, name="test-skill", enabled=True):
+        s = MagicMock()
+        s.name = name
+        s.description = "A test skill"
+        s.license = "MIT"
+        s.category = "public"
+        s.enabled = enabled
+        return s
+
+    def test_get_skill_found(self, client):
+        skill = self._make_skill()
+        with patch("src.skills.loader.load_skills", return_value=[skill]):
+            result = client.get_skill("test-skill")
+        assert result is not None
+        assert result["name"] == "test-skill"
+
+    def test_get_skill_not_found(self, client):
+        with patch("src.skills.loader.load_skills", return_value=[]):
+            result = client.get_skill("nonexistent")
+        assert result is None
+
+    def test_update_skill(self, client):
+        skill = self._make_skill(enabled=True)
+        updated_skill = self._make_skill(enabled=False)
+
+        ext_config = MagicMock()
+        ext_config.mcp_servers = {}
+        ext_config.skills = {}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({}, f)
+            tmp_path = Path(f.name)
+
+        try:
+            with (
+                patch("src.skills.loader.load_skills", side_effect=[[skill], [updated_skill]]),
+                patch("src.client.ExtensionsConfig.resolve_config_path", return_value=tmp_path),
+                patch("src.client.get_extensions_config", return_value=ext_config),
+                patch("src.client.reload_extensions_config"),
+            ):
+                result = client.update_skill("test-skill", enabled=False)
+            assert result["enabled"] is False
+        finally:
+            tmp_path.unlink()
+
+    def test_update_skill_not_found(self, client):
+        with patch("src.skills.loader.load_skills", return_value=[]):
+            with pytest.raises(ValueError, match="not found"):
+                client.update_skill("nonexistent", enabled=True)
+
+    def test_install_skill(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # Create a valid .skill archive
+            skill_dir = tmp_path / "my-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text("---\nname: my-skill\ndescription: A skill\n---\nContent")
+
+            archive_path = tmp_path / "my-skill.skill"
+            with zipfile.ZipFile(archive_path, "w") as zf:
+                zf.write(skill_dir / "SKILL.md", "my-skill/SKILL.md")
+
+            skills_root = tmp_path / "skills"
+            (skills_root / "custom").mkdir(parents=True)
+
+            with (
+                patch("src.skills.loader.get_skills_root_path", return_value=skills_root),
+                patch("src.gateway.routers.skills._validate_skill_frontmatter", return_value=(True, "OK", "my-skill")),
+            ):
+                result = client.install_skill(archive_path)
+
+            assert result["success"] is True
+            assert result["skill_name"] == "my-skill"
+            assert (skills_root / "custom" / "my-skill").exists()
+
+    def test_install_skill_not_found(self, client):
+        with pytest.raises(FileNotFoundError):
+            client.install_skill("/nonexistent/path.skill")
+
+    def test_install_skill_bad_extension(self, client):
+        with tempfile.NamedTemporaryFile(suffix=".zip", delete=False) as f:
+            tmp_path = Path(f.name)
+        try:
+            with pytest.raises(ValueError, match=".skill extension"):
+                client.install_skill(tmp_path)
+        finally:
+            tmp_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Memory management
+# ---------------------------------------------------------------------------
+
+class TestMemoryManagement:
+    def test_reload_memory(self, client):
+        data = {"version": "1.0", "facts": []}
+        with patch("src.agents.memory.updater.reload_memory_data", return_value=data):
+            result = client.reload_memory()
+        assert result == data
+
+    def test_get_memory_config(self, client):
+        config = MagicMock()
+        config.enabled = True
+        config.storage_path = ".deer-flow/memory.json"
+        config.debounce_seconds = 30
+        config.max_facts = 100
+        config.fact_confidence_threshold = 0.7
+        config.injection_enabled = True
+        config.max_injection_tokens = 2000
+
+        with patch("src.config.memory_config.get_memory_config", return_value=config):
+            result = client.get_memory_config()
+
+        assert result["enabled"] is True
+        assert result["max_facts"] == 100
+
+    def test_get_memory_status(self, client):
+        config = MagicMock()
+        config.enabled = True
+        config.storage_path = ".deer-flow/memory.json"
+        config.debounce_seconds = 30
+        config.max_facts = 100
+        config.fact_confidence_threshold = 0.7
+        config.injection_enabled = True
+        config.max_injection_tokens = 2000
+
+        data = {"version": "1.0", "facts": []}
+
+        with (
+            patch("src.config.memory_config.get_memory_config", return_value=config),
+            patch("src.agents.memory.updater.get_memory_data", return_value=data),
+        ):
+            result = client.get_memory_status()
+
+        assert "config" in result
+        assert "data" in result
+
+
+# ---------------------------------------------------------------------------
+# Uploads
+# ---------------------------------------------------------------------------
+
+class TestUploads:
+    def test_upload_files(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+
+            # Create a source file
+            src_file = tmp_path / "test.txt"
+            src_file.write_text("hello")
+
+            uploads_dir = tmp_path / "uploads"
+            uploads_dir.mkdir()
+
+            with patch.object(DeerFlowClient, "_get_uploads_dir", return_value=uploads_dir):
+                result = client.upload_files("thread-1", [src_file])
+
+            assert len(result) == 1
+            assert result[0]["filename"] == "test.txt"
+            assert (uploads_dir / "test.txt").exists()
+
+    def test_upload_files_not_found(self, client):
+        with pytest.raises(FileNotFoundError):
+            client.upload_files("thread-1", ["/nonexistent/file.txt"])
+
+    def test_list_uploads(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            uploads_dir = Path(tmp)
+            (uploads_dir / "a.txt").write_text("a")
+            (uploads_dir / "b.txt").write_text("bb")
+
+            with patch.object(DeerFlowClient, "_get_uploads_dir", return_value=uploads_dir):
+                result = client.list_uploads("thread-1")
+
+            assert len(result) == 2
+            names = {f["filename"] for f in result}
+            assert names == {"a.txt", "b.txt"}
+
+    def test_delete_upload(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            uploads_dir = Path(tmp)
+            (uploads_dir / "delete-me.txt").write_text("gone")
+
+            with patch.object(DeerFlowClient, "_get_uploads_dir", return_value=uploads_dir):
+                client.delete_upload("thread-1", "delete-me.txt")
+
+            assert not (uploads_dir / "delete-me.txt").exists()
+
+    def test_delete_upload_not_found(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            with patch.object(DeerFlowClient, "_get_uploads_dir", return_value=Path(tmp)):
+                with pytest.raises(FileNotFoundError):
+                    client.delete_upload("thread-1", "nope.txt")
+
+
+# ---------------------------------------------------------------------------
+# Artifacts
+# ---------------------------------------------------------------------------
+
+class TestArtifacts:
+    def test_get_artifact(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            # Simulate thread user-data structure
+            base = Path(tmp)
+            outputs = base / "outputs"
+            outputs.mkdir()
+            (outputs / "result.txt").write_text("hello artifact")
+
+            with patch("src.client.THREAD_DATA_BASE_DIR", ""):
+                with patch("os.getcwd", return_value=tmp):
+                    # Directly test with a simpler path setup
+                    pass
+
+        # Use a controlled setup
+        with tempfile.TemporaryDirectory() as tmp:
+            thread_dir = Path(tmp) / ".deer-flow" / "threads" / "t1" / "user-data" / "outputs"
+            thread_dir.mkdir(parents=True)
+            (thread_dir / "result.txt").write_text("artifact content")
+
+            with patch("os.getcwd", return_value=tmp):
+                with patch("src.client.THREAD_DATA_BASE_DIR", ".deer-flow/threads"):
+                    content, mime = client.get_artifact("t1", "mnt/user-data/outputs/result.txt")
+
+            assert content == b"artifact content"
+            assert "text" in mime
+
+    def test_get_artifact_not_found(self, client):
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                patch("os.getcwd", return_value=tmp),
+                patch("src.client.THREAD_DATA_BASE_DIR", ".deer-flow/threads"),
+            ):
+                with pytest.raises(FileNotFoundError):
+                    client.get_artifact("t1", "mnt/user-data/outputs/nope.txt")
+
+    def test_get_artifact_bad_prefix(self, client):
+        with pytest.raises(ValueError, match="must start with"):
+            client.get_artifact("t1", "bad/path/file.txt")


### PR DESCRIPTION
Add `DeerFlowClient` class that provides direct in-process access to DeerFlow's agent and Gateway capabilities without requiring LangGraph Server or Gateway API processes. This enables users to import and use DeerFlow as a Python library.