### PR TITLE
fix(git):add .gitattributes to avoid 'bash\r' issue

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+# Normalize line endings to LF for all text files
+* text=auto eol=lf
+
+# Shell scripts and makefiles must always use LF
+*.sh text eol=lf
+Makefile text eol=lf
+**/Makefile text eol=lf
+
+# Common config/source files
+*.yml text eol=lf
+*.yaml text eol=lf
+*.toml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.css text eol=lf
+*.scss text eol=lf
+*.html text eol=lf
+*.env text eol=lf
+
+# Windows scripts
+*.bat text eol=crlf
+*.cmd text eol=crlf
+
+# Binary assets
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.mp4 binary
+*.mov binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
Fixes #921
- Added .gitattributes to enforce LF checkouts for scripts and text files, including *.sh and all Makefile paths.
- Kept Windows-specific script behavior for *.bat and *.cmd as CRLF.
- Marked common binary assets as binary to avoid accidental EOL normalization.

Please Run `git add --renormalize . `and re-checkout/commit to normalize existing files if you already checked out the repo 