### PR TITLE
fix(frontend): add engines field to enforce Node.js 22+ and pnpm 10+

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,2 +1,3 @@
+engine-strict=true
 public-hoist-pattern[]=*eslint*
 public-hoist-pattern[]=*prettier*

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -106,5 +106,9 @@
   "ct3aMetadata": {
     "initVersion": "7.40.0"
   },
-  "packageManager": "pnpm@10.26.2"
+  "packageManager": "pnpm@10.26.2",
+  "engines": {
+    "node": ">=22.0.0",
+    "pnpm": ">=10.0.0"
+  }
 }


### PR DESCRIPTION
## Summary

- **Issue**: `frontend/package.json` has no `engines` field, so users with incompatible Node.js or pnpm versions can run `pnpm install` without any warning, leading to lock file incompatibility.
- **Root cause**: Missing `engines` field in `frontend/package.json` and no `engine-strict` setting in `.npmrc`.
- **Fix**: Add `engines` field requiring Node.js >= 22 and pnpm >= 10, and enable `engine-strict=true` in `.npmrc`.

Fixes #76

## Problem

The project requires Node.js 22+ and pnpm 10+ (as documented in README and enforced by `make check`), but `frontend/package.json` lacks an `engines` field. This means `pnpm install` silently succeeds with any Node.js version, potentially generating an incompatible lock file.

**Before fix:**
```
$ node -v  # v18.x (wrong version)
$ cd frontend && pnpm install
Done in 19.6s  # No warning, silently succeeds
# Lock file generated with wrong version, causes issues for other contributors
```

## Changes

- `frontend/package.json` — Add `engines` field: `{ "node": ">=22.0.0", "pnpm": ">=10.0.0" }`
- `frontend/.npmrc` — Add `engine-strict=true` to enforce the engines check

**After fix:**
```
$ node -v  # v18.x (wrong version)
$ cd frontend && pnpm install
ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
Your Node version is incompatible with "deer-flow-frontend".
Expected version: >=22.0.0
Got: v18.x.x
```

## Test plan

- [x] Verified `pnpm install` succeeds with Node.js 22+ (current version)
- [x] Verified `pnpm install` rejects incompatible Node.js version with `ERR_PNPM_UNSUPPORTED_ENGINE`
- [x] Verified `package.json` remains valid JSON

## Effect on User Experience

**Before:** Users with Node.js < 22 can silently install dependencies, generating incompatible lock files that break the project for other contributors.
**After:** Users with wrong Node.js or pnpm version get a clear error message telling them to install the correct version.