### PR TITLE
fix: use shell fallback instead of hardcoded /bin/zsh in LocalSandbox

### DIFF
--- a/backend/src/sandbox/local/local_sandbox.py
+++ b/backend/src/sandbox/local/local_sandbox.py
@@ -138,13 +138,19 @@ class LocalSandbox(Sandbox):
         """Detect available shell executable with fallback.
 
         Returns the first available shell in order of preference:
-        /bin/zsh → /bin/bash → /bin/sh. This ensures compatibility
-        across different environments (macOS, Docker containers, etc.).
+        /bin/zsh → /bin/bash → /bin/sh → first `sh` found on PATH.
+        Raises a RuntimeError if no suitable shell is found.
         """
         for shell in ("/bin/zsh", "/bin/bash", "/bin/sh"):
             if os.path.isfile(shell) and os.access(shell, os.X_OK):
                 return shell
-        return shutil.which("sh") or "/bin/sh"
+        shell_from_path = shutil.which("sh")
+        if shell_from_path is not None:
+            return shell_from_path
+        raise RuntimeError(
+            "No suitable shell executable found. Tried /bin/zsh, /bin/bash, "
+            "/bin/sh, and `sh` on PATH."
+        )
 
     def execute_command(self, command: str) -> str:
         # Resolve container paths in command before execution


### PR DESCRIPTION
## Problem

`LocalSandbox.execute_command()` hardcodes `executable="/bin/zsh"` ([local_sandbox.py#L141](https://github.com/bytedance/deer-flow/blob/main/backend/src/sandbox/local/local_sandbox.py#L141)).

Docker containers based on `python:3.12-slim` (used in the project's own `backend/Dockerfile`) do not include zsh, causing all skill executions that use the local sandbox to fail with a "shell not found" error when running via Docker.

Reported in #935.

## Solution

- Add a `_get_shell()` static method that detects the first available shell with fallback order: `/bin/zsh` → `/bin/bash` → `/bin/sh`
- Replace the hardcoded `/bin/zsh` with a dynamic call to `self._get_shell()`
- Uses `os.path.isfile()` + `os.access()` for reliable detection, with `shutil.which()` as a last resort

## Changes

- `backend/src/sandbox/local/local_sandbox.py`: +15 lines, -1 line

## Testing

- Verified the fix detects `/bin/zsh` on macOS (existing behavior preserved)
- Verified fallback to `/bin/sh` works in environments without zsh
- No breaking changes to existing functionality

Closes #935