### PR TITLE
Fix typo: Offiical to Official

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 > [!NOTE]
 > **DeerFlow 2.0 is a ground-up rewrite.** It shares no code with v1. If you're looking for the original Deep Research framework, it's maintained on the [`1.x` branch](https://github.com/bytedance/deer-flow/tree/main-1.x) — contributions there are still welcome. Active development has moved to 2.0.
 
-## Offiical Website
+## Official Website
 
 Learn more and see **real demos** on our official website.
 


### PR DESCRIPTION
Fixes a typo in the README header where Offiical Website should be Official Website.