### PR TITLE
fix(readme): correct typo Offiical to Official

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Learn more and see **real demos** on our official website.
 ## Table of Contents
 
 - [🦌 DeerFlow - 2.0](#-deerflow---20)
-  - [Offiical Website](#offiical-website)
+  - [Official Website](#official-website)
   - [Table of Contents](#table-of-contents)
   - [Quick Start](#quick-start)
     - [Configuration](#configuration)


### PR DESCRIPTION
## Summary
- Fix a typo in the README table of contents.
- Change `Offiical` to `Official` on line 24.
- Keep the change minimal and documentation-only.

## Details
- File changed: [README.md](/Users/bytedance/python-projects/deer-flow/README.md:24)
- Before: `- [Offiical Website](#offiical-website)`
- After: `- [Official Website](#official-website)`

## Impact
- No code or behavior changes.
- Improves documentation correctness and link anchor consistency.

## Testing
- Verified with `git diff` that only one line in `README.md` was modified.