### PR TITLE
fix: improve port detection in WSL

### DIFF
--- a/scripts/wait-for-port.sh
+++ b/scripts/wait-for-port.sh
@@ -20,7 +20,34 @@ SERVICE="${3:-Service}"
 elapsed=0
 interval=1
 
-while ! lsof -i :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; do
+is_port_listening() {
+    if command -v lsof >/dev/null 2>&1; then
+        if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    if command -v ss >/dev/null 2>&1; then
+        if ss -ltn "( sport = :$PORT )" 2>/dev/null | tail -n +2 | grep -q .; then
+            return 0
+        fi
+    fi
+
+    if command -v netstat >/dev/null 2>&1; then
+        if netstat -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|[.:])${PORT}$"; then
+            return 0
+        fi
+    fi
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" >/dev/null 2>&1
+        return $?
+    fi
+
+    return 1
+}
+
+while ! is_port_listening; do
     if [ "$elapsed" -ge "$TIMEOUT" ]; then
         echo ""
         echo "✗ $SERVICE failed to start on port $PORT after ${TIMEOUT}s"


### PR DESCRIPTION
 ## Summary

  Fixes #1057.

  `make dev` could hang at `Waiting for Frontend on port 3000` under WSL even when the frontend had already started
  successfully. The root cause was that `scripts/wait-for-port.sh` only relied on `lsof`, which can fail to detect listening
  ports correctly in some WSL environments.

  This change makes port detection more robust by adding fallback strategies:
  - `lsof`
  - `ss`
  - `netstat`
  - `/dev/tcp` via `bash` + `timeout`

  ## Changes

  - updated `scripts/wait-for-port.sh`
  - added `is_port_listening()` helper
  - kept existing behavior on normal Unix environments
  - added fallback detection paths for WSL-compatible port checks

  ## Testing

  Tested via WSL:

  - `bash -n scripts/wait-for-port.sh`
  - started a temporary local HTTP server and verified `scripts/wait-for-port.sh` detects the listening port successfully
  - injected a failing fake `lsof` into `PATH` and verified the script still succeeds through fallback detection

  ## Result

  `make dev` no longer gets stuck waiting for the frontend in the WSL scenario described in #1057 when `lsof` fails to report
  the listening socket.