### PR TITLE
fix(tracing): support LANGCHAIN_* env fallback for LangSmith config

### DIFF
--- a/backend/src/config/tracing_config.py
+++ b/backend/src/config/tracing_config.py
@@ -25,13 +25,20 @@ class TracingConfig(BaseModel):
 _tracing_config: TracingConfig | None = None
 
 
-def _env_flag_true(*names: str) -> bool:
-    """Return True when any provided env var is set to a truthy value."""
-    truthy_values = {"1", "true", "yes", "on"}
+_TRUTHY_VALUES = {"1", "true", "yes", "on"}
+
+
+def _env_flag_preferred(*names: str) -> bool:
+    """Return the boolean value of the first env var that is present and non-empty.
+
+    Accepted truthy values (case-insensitive): ``1``, ``true``, ``yes``, ``on``.
+    Any other non-empty value is treated as falsy.  If none of the named
+    variables is set, returns ``False``.
+    """
     for name in names:
         value = os.environ.get(name)
-        if value and value.strip().lower() in truthy_values:
-            return True
+        if value is not None and value.strip():
+            return value.strip().lower() in _TRUTHY_VALUES
     return False
 
 
@@ -46,6 +53,20 @@ def _first_env_value(*names: str) -> str | None:
 
 def get_tracing_config() -> TracingConfig:
     """Get the current tracing configuration from environment variables.
+
+    ``LANGSMITH_*`` variables take precedence over their legacy ``LANGCHAIN_*``
+    counterparts.  For boolean flags (``enabled``), the *first* variable that is
+    present and non-empty in the priority list is the sole authority – its value
+    is parsed and returned without consulting the remaining candidates.  Accepted
+    truthy values are ``1``, ``true``, ``yes``, and ``on`` (case-insensitive);
+    any other non-empty value is treated as falsy.
+
+    Priority order:
+        enabled  : LANGSMITH_TRACING > LANGCHAIN_TRACING_V2 > LANGCHAIN_TRACING
+        api_key  : LANGSMITH_API_KEY  > LANGCHAIN_API_KEY
+        project  : LANGSMITH_PROJECT  > LANGCHAIN_PROJECT   (default: "deer-flow")
+        endpoint : LANGSMITH_ENDPOINT > LANGCHAIN_ENDPOINT  (default: https://api.smith.langchain.com)
+
     Returns:
         TracingConfig with current settings.
     """
@@ -57,7 +78,7 @@ def get_tracing_config() -> TracingConfig:
             return _tracing_config
         _tracing_config = TracingConfig(
             # Keep compatibility with both legacy LANGCHAIN_* and newer LANGSMITH_* variables.
-            enabled=_env_flag_true("LANGSMITH_TRACING", "LANGCHAIN_TRACING_V2", "LANGCHAIN_TRACING"),
+            enabled=_env_flag_preferred("LANGSMITH_TRACING", "LANGCHAIN_TRACING_V2", "LANGCHAIN_TRACING"),
             api_key=_first_env_value("LANGSMITH_API_KEY", "LANGCHAIN_API_KEY"),
             project=_first_env_value("LANGSMITH_PROJECT", "LANGCHAIN_PROJECT") or "deer-flow",
             endpoint=_first_env_value("LANGSMITH_ENDPOINT", "LANGCHAIN_ENDPOINT") or "https://api.smith.langchain.com",

--- a/backend/tests/test_tracing_config.py
+++ b/backend/tests/test_tracing_config.py
@@ -46,6 +46,19 @@ def test_falls_back_to_langchain_env_names(monkeypatch):
     assert tracing_module.is_tracing_enabled() is True
 
 
+def test_langsmith_tracing_false_overrides_langchain_tracing_v2_true(monkeypatch):
+    """LANGSMITH_TRACING=false must win over LANGCHAIN_TRACING_V2=true."""
+    monkeypatch.setenv("LANGSMITH_TRACING", "false")
+    monkeypatch.setenv("LANGCHAIN_TRACING_V2", "true")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "some-key")
+
+    _reset_tracing_cache()
+    cfg = tracing_module.get_tracing_config()
+
+    assert cfg.enabled is False
+    assert tracing_module.is_tracing_enabled() is False
+
+
 def test_defaults_when_project_not_set(monkeypatch):
     monkeypatch.setenv("LANGSMITH_TRACING", "yes")
     monkeypatch.setenv("LANGSMITH_API_KEY", "key")


### PR DESCRIPTION
Fixes #1032 
- add backward-compatible env parsing in tracing_config.py
- support fallback keys: LANGCHAIN_TRACING_V2 / LANGCHAIN_TRACING LANGCHAIN_API_KEY LANGCHAIN_PROJECT LANGCHAIN_ENDPOINT
- keep LANGSMITH_* as preferred source when both are present
- add regression tests in test_tracing_config.py