### PR TITLE
feat: Add OpenClaw integration skill

### DIFF
--- a/skills/public/openclaw-to-deerflow/SKILL.md
+++ b/skills/public/openclaw-to-deerflow/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: openclaw-to-deerflow
+description: "Interact with DeerFlow AI agent platform via OpenClaw's capabilities. Use this skill when you are running inside OpenClaw and want to leverage DeerFlow for complex research tasks, deep research workflows, or when DeerFlow's specialized capabilities (sub-agents, sandbox execution, memory) are needed. Also use when the user wants to delegate research tasks to DeerFlow while continuing to work on other things in OpenClaw."
+---
+
+# OpenClaw to DeerFlow Integration
+
+This skill enables OpenClaw to communicate with a running DeerFlow instance. DeerFlow is an AI agent platform
+built on LangGraph that orchestrates sub-agents for research, code execution, web browsing, and more.
+
+## When to Use This Skill
+
+- User wants deep research capabilities that DeerFlow provides
+- Need to leverage DeerFlow's sandbox execution environment
+- Complex multi-step research tasks requiring sub-agents
+- When DeerFlow's memory and context management is needed
+
+## Architecture
+
+DeerFlow exposes two API surfaces behind an Nginx reverse proxy:
+
+| Service        | Direct Port | Via Proxy                        | Purpose                          |
+|----------------|-------------|----------------------------------|----------------------------------|
+| Gateway API    | 8001        | `$DEERFLOW_GATEWAY_URL`          | REST endpoints (models, skills, memory, uploads) |
+| LangGraph API  | 2024        | `$DEERFLOW_LANGGRAPH_URL`        | Agent threads, runs, streaming   |
+
+## Environment Variables
+
+All URLs are configurable via environment variables. **Read these env vars before making any request.**
+
+| Variable                | Default                                  | Description                        |
+|-------------------------|------------------------------------------|------------------------------------|
+| `DEERFLOW_URL`          | `http://localhost:2026`                  | Unified proxy base URL             |
+| `DEERFLOW_GATEWAY_URL`  | `${DEERFLOW_URL}`                        | Gateway API base (models, skills, memory, uploads) |
+| `DEERFLOW_LANGGRAPH_URL`| `${DEERFLOW_URL}/api/langgraph`         | LangGraph API base (threads, runs) |
+
+When making curl calls, always resolve the URL like this:
+
+```bash
+# Resolve base URLs from env (do this FIRST before any API call)
+DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
+DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
+DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+```
+
+## Available Operations
+
+### 1. Health Check
+
+Verify DeerFlow is running:
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/health"
+```
+
+### 2. Send a Message (Streaming)
+
+This is the primary operation. It creates a thread and streams the agent's response.
+
+**Step 1: Create a thread**
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response: `{"thread_id": "<uuid>", ...}`
+
+**Step 2: Stream a run**
+
+```bash
+curl -s -N -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "lead_agent",
+    "input": {
+      "messages": [
+        {
+          "type": "human",
+          "content": [{"type": "text", "text": "YOUR MESSAGE HERE"}]
+        }
+      ]
+    },
+    "stream_mode": ["values", "messages-tuple"],
+    "stream_subgraphs": true,
+    "config": {
+      "recursion_limit": 1000
+    },
+    "context": {
+      "thinking_enabled": true,
+      "is_plan_mode": true,
+      "subagent_enabled": true,
+      "thread_id": "<thread_id>"
+    }
+  }'
+```
+
+The response is an SSE stream. Each event has the format:
+```
+event: <event_type>
+data: <json_data>
+```
+
+Key event types:
+- `metadata` — run metadata including `run_id`
+- `values` — full state snapshot with `messages` array
+- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `end` — stream is complete
+
+**Context modes** (set via `context`):
+- Flash mode: `thinking_enabled: false, is_plan_mode: false, subagent_enabled: false`
+- Standard mode: `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
+- Pro mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: false`
+- Ultra mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: true`
+
+### 3. Continue a Conversation
+
+To send follow-up messages, reuse the same `thread_id` from step 2 and POST another run
+with the new message.
+
+### 4. List Models
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/models"
+```
+
+Returns: `{"models": [{"name": "...", "provider": "...", ...}, ...]}`
+
+### 5. List Skills
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/skills"
+```
+
+Returns: `{"skills": [{"name": "...", "enabled": true, ...}, ...]}`
+
+### 6. Enable/Disable a Skill
+
+```bash
+curl -s -X PUT "$DEERFLOW_GATEWAY_URL/api/skills/<skill_name>" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+```
+
+### 7. List Agents
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/agents"
+```
+
+Returns: `{"agents": [{"name": "...", ...}, ...]}`
+
+### 8. Get Memory
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/memory"
+```
+
+Returns user context, facts, and conversation history summaries.
+
+### 9. Upload Files to a Thread
+
+```bash
+curl -s -X POST "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads" \
+  -F "files=@/path/to/file.pdf"
+```
+
+Supports PDF, PPTX, XLSX, DOCX — automatically converts to Markdown.
+
+### 10. List Uploaded Files
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
+```
+
+### 11. Get Thread History
+
+```bash
+curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+```
+
+### 12. List Threads
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+```
+
+## Usage Script
+
+For sending messages and collecting the full response, use the helper script:
+
+```bash
+bash /path/to/skills/openclaw-to-deerflow/scripts/chat.sh "Your question here"
+```
+
+## Workflow Example
+
+When a user requests deep research:
+
+1. Check if DeerFlow is running (health check)
+2. Create a new thread
+3. Send the research request with appropriate context mode (pro/ultra for complex tasks)
+4. Stream the response back to the user
+5. Offer to continue the conversation or perform additional research
+
+## Error Handling
+
+- If health check fails, DeerFlow is not running. Inform the user they need to start it.
+- If the stream returns an error event, extract and display the error message.
+- Common issues: port not open, services still starting up, config errors.
+
+## Tips
+
+- For quick questions, use flash mode (fastest, no planning)
+- For research tasks, use pro or ultra mode (enables planning and sub-agents)
+- You can upload files first, then reference them in your message
+- Thread IDs persist — you can return to a conversation later
+- DeerFlow excels at: deep research, report generation, slide creation, web page generation

--- a/skills/public/openclaw-to-deerflow/scripts/chat.sh
+++ b/skills/public/openclaw-to-deerflow/scripts/chat.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# OpenClaw to DeerFlow Chat Script
+# Usage: bash chat.sh "Your message here"
+
+set -e
+
+MESSAGE="$1"
+
+if [ -z "$MESSAGE" ]; then
+    echo "Usage: bash chat.sh \"Your message here\""
+    exit 1
+fi
+
+# Resolve base URLs from env
+DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
+DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
+DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+
+echo "=== Checking DeerFlow health ==="
+HEALTH=$(curl -s "$DEERFLOW_GATEWAY_URL/health")
+if [ $? -ne 0 ]; then
+    echo "Error: DeerFlow is not running at $DEERFLOW_GATEWAY_URL"
+    echo "Please start DeerFlow first (e.g., make dev or make docker-start)"
+    exit 1
+fi
+echo "DeerFlow is healthy: $HEALTH"
+
+echo ""
+echo "=== Creating new thread ==="
+THREAD_RESPONSE=$(curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads" \
+    -H "Content-Type: application/json" \
+    -d '{}')
+
+THREAD_ID=$(echo "$THREAD_RESPONSE" | grep -o '"thread_id":"[^"]*"' | cut -d'"' -f4)
+echo "Created thread: $THREAD_ID"
+
+echo ""
+echo "=== Sending message ==="
+echo "Message: $MESSAGE"
+echo ""
+
+# Stream the response
+curl -s -N -X POST "$DEERFLOW_LANGGRAPH_URL/threads/$THREAD_ID/runs/stream" \
+    -H "Content-Type: application/json" \
+    -d "{
+        \"assistant_id\": \"lead_agent\",
+        \"input\": {
+            \"messages\": [
+                {
+                    \"type\": \"human\",
+                    \"content\": [{\"type\": \"text\", \"text\": \"$MESSAGE\"}]
+                }
+            ]
+        },
+        \"stream_mode\": [\"values\", \"messages-tuple\"],
+        \"stream_subgraphs\": true,
+        \"config\": {
+            \"recursion_limit\": 1000
+        },
+        \"context\": {
+            \"thinking_enabled\": true,
+            \"is_plan_mode\": true,
+            \"subagent_enabled\": true,
+            \"thread_id\": \"$THREAD_ID\"
+        }
+    }" | while read -r line; do
+    # Parse SSE events and extract message content
+    if [[ "$line" == data:* ]]; then
+        data="${line#data: }"
+        # Extract message content from the JSON
+        echo "$data" | grep -o '"content":"[^"]*"' | head -1 || true
+    fi
+done
+
+echo ""
+echo ""
+echo "=== Done ==="
+echo "Thread ID: $THREAD_ID"
+echo "You can continue the conversation by calling this script again with the same THREAD_ID"


### PR DESCRIPTION
## Summary

Add `openclaw-to-deerflow` skill for OpenClaw to communicate with DeerFlow instances. This enables OpenClaw users to leverage DeerFlow's deep research capabilities, sub-agents, and sandbox execution environment.

## Changes

- Added `skills/public/openclaw-to-deerflow/SKILL.md` with full API documentation
- Added `skills/public/openclaw-to-deerflow/scripts/chat.sh` helper script

## Motivation

OpenClaw is a popular AI agent platform, and having integration with DeerFlow allows users to leverage DeerFlow's specialized capabilities:
- Deep research workflows
- Sub-agent orchestration
- Sandbox execution
- Memory and context management

This is similar to the existing `claude-to-deerflow` skill, but specifically designed for OpenClaw agents.

## Testing

The skill follows the same pattern as `claude-to-deerflow` which is already tested and working.
