### PR TITLE
fix(frontend): fix new-thread history 404/422 errors (issue #1079)

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/layout.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/layout.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
 import { PromptInputProvider } from "@/components/ai-elements/prompt-input";
 import { ArtifactsProvider } from "@/components/workspace/artifacts";
 import { SubtasksProvider } from "@/core/tasks/context";
@@ -9,8 +12,24 @@ export default function AgentChatLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const { thread_id } = useParams<{ thread_id: string }>();
+  const prevThreadId = useRef(thread_id);
+
+  // Increment only when navigating TO "new" from a non-"new" route.
+  // This forces a full remount of the subtree for a fresh new-chat state,
+  // without remounting when the URL transitions from "new" → actual-id
+  // (which would interrupt streaming).
+  const [generation, setGeneration] = useState(0);
+
+  useEffect(() => {
+    if (thread_id === "new" && prevThreadId.current !== "new") {
+      setGeneration((g) => g + 1);
+    }
+    prevThreadId.current = thread_id;
+  }, [thread_id]);
+
   return (
-    <SubtasksProvider>
+    <SubtasksProvider key={generation}>
       <ArtifactsProvider>
         <PromptInputProvider>{children}</PromptInputProvider>
       </ArtifactsProvider>

--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -43,11 +43,11 @@ export default function AgentChatPage() {
     context: { ...settings.context, agent_name: agent_name },
     onStart: () => {
       setIsNewThread(false);
-      history.replaceState(
-        null,
-        "",
-        `/workspace/agents/${agent_name}/chats/${threadId}`,
-      );
+      // Use router.replace so Next.js Router's internal state is updated.
+      // This ensures subsequent "New Chat" clicks are treated as a real
+      // cross-route navigation (actual-id → "new") rather than a no-op
+      // same-path navigation, which was causing stale content to persist.
+      router.replace(`/workspace/agents/${agent_name}/chats/${threadId}`);
     },
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -91,7 +91,9 @@ export function useThreadStream({
     assistantId: "lead_agent",
     threadId: onStreamThreadId,
     reconnectOnMount: true,
-    fetchStateHistory: { limit: 1 },
+    // Only fetch history when there is a known thread ID; skip for new/uninitialized
+    // threads to avoid spurious 404/422 errors before the thread is created.
+    fetchStateHistory: onStreamThreadId ? { limit: 1 } : false,
     onCreated(meta) {
       handleStreamStart(meta.thread_id);
       setOnStreamThreadId(meta.thread_id);


### PR DESCRIPTION
关联 Issue：#1079

打开 `/workspace/chats/new` 或 `/workspace/agents/{name}/chats/new` 后，首次发送消息时前端会触发非预期的 `POST /threads/{thread_id}/history` 请求，导致：

- 后端日志出现 `404`（线程尚未创建）或 `422`（thread_id 为 `"new"` 字符串，非合法 UUID）
- 前端控制台出现 `Invalid thread ID: must be a UUID` 及 `stream error`

## 根本原因

三处独立但相互关联的前端缺陷共同导致此问题：

1. **`fetchStateHistory` 无条件开启**：`useStream` 的 `fetchStateHistory: { limit: 1 }` 对所有线程一律生效，包括 `threadId` 为 `null/undefined` 的新线程。在线程还未在 LangGraph 侧创建时就发起 history 请求，造成竞态错误。

2. **Agent 聊天页 `onStart` 使用 `history.replaceState`**：绕过了 Next.js Router 内部状态更新。主聊天页面在 PR #1077 已改为 `router.replace`，但 Agent 聊天页面未同步，导致后续"新建会话"点击时路由状态残留。

3. **Agent 聊天 Layout 缺少重挂载逻辑**：主聊天的 Layout 在路由切换到 `"new"` 时会通过 `key={generation}` 强制重挂载子树，清空旧状态；Agent 聊天的 Layout 没有这个机制，导致旧 `useStream` 状态持续存在。

## 修改内容

| 文件 | 修改说明 |
|---|---|
| `frontend/src/core/threads/hooks.ts` | `fetchStateHistory` 改为条件判断：仅在 `onStreamThreadId` 非空时启用，新线程阶段跳过 history 请求 |
| `frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx` | `history.replaceState` → `router.replace`，与主聊天行为保持一致 |
| `frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/layout.tsx` | 新增与主聊天 Layout 相同的 `key={generation}` 重挂载逻辑 |

## 测试方法

1. 打开 `/workspace/chats/new`，发送第一条消息
2. 观察后端日志，确认不再出现 `POST /threads/new/history 422`
3. 在新聊天页发送消息后，点击「新建会话」，再次发送消息，确认状态完全重置
4. 对 Agent 聊天（`/workspace/agents/{name}/chats/new`）重复上述步骤