### PR TITLE
feat(cron): add cron scheduling system for reminders and recurring tasks

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -553,6 +553,17 @@ def _channel_storage_user_id(msg: InboundMessage) -> str | None:
     return None
 
 
+def _source_channel_for_run(msg: InboundMessage) -> str:
+    """Encode the inbound channel so scheduled tasks can deliver back to it."""
+    conv_type = "chat"
+    if msg.channel_name == "dingtalk":
+        raw = str(msg.metadata.get("conversation_type") or "").strip()
+        conv_type = "group" if raw == "2" else "p2p"
+    elif msg.channel_name in {"discord", "slack"}:
+        conv_type = "channel"
+    return f"im:{msg.channel_name}:{conv_type}:{msg.chat_id}"
+
+
 def _resolve_slash_skill_command(
     text: str,
     available_skills: set[str] | None = None,
@@ -871,6 +882,7 @@ class ChannelManager:
             run_context_identity["user_id"] = run_user_id
         if msg.user_id:
             run_context_identity["channel_user_id"] = msg.user_id
+        run_context_identity["source_channel"] = _source_channel_for_run(msg)
 
         run_context = _merge_dicts(
             DEFAULT_RUN_CONTEXT,

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -23,6 +23,7 @@ from app.gateway.routers import (
     memory,
     models,
     runs,
+    scheduled_jobs,
     skills,
     suggestions,
     thread_runs,
@@ -223,8 +224,36 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("Channel service started: %s", channel_service.get_status())
         except Exception:
             logger.exception("No IM channels configured or channel service failed to start")
+            channel_service = None
+
+        # Start the scheduled-jobs scheduler. Wire the running channel
+        # service's MessageBus so IM deliveries route through the existing
+        # channels (zero-footprint — no edits to app.channels).
+        try:
+            from app.scheduled_jobs import start_scheduler
+
+            bus = getattr(channel_service, "bus", None) if channel_service else None
+            await start_scheduler(app, bus=bus)
+        except Exception:
+            logger.exception("Scheduled jobs scheduler failed to start")
 
         yield
+
+        # Stop the scheduler first so in-flight jobs drain before channels tear down.
+        try:
+            from app.scheduled_jobs import stop_scheduler
+
+            await asyncio.wait_for(
+                stop_scheduler(),
+                timeout=_SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Scheduler shutdown exceeded %.1fs; proceeding with worker exit.",
+                _SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.exception("Failed to stop scheduled jobs scheduler")
 
         try:
             await auth.close_oidc_service()
@@ -392,6 +421,7 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
 
     # User-facing IM channel connection API is mounted at /api/channels
     app.include_router(channel_connections.router)
+    app.include_router(scheduled_jobs.router)
 
     # Channels API is mounted at /api/channels
     app.include_router(channels.router)

--- a/backend/app/gateway/routers/scheduled_jobs.py
+++ b/backend/app/gateway/routers/scheduled_jobs.py
@@ -1,0 +1,527 @@
+"""HTTP API for user-owned scheduled jobs.
+
+Endpoints:
+
+- ``GET    /api/scheduled_jobs``                — list caller's jobs
+- ``POST   /api/scheduled_jobs``                — create a new job
+- ``GET    /api/scheduled_jobs/{job_id}``       — fetch one job
+- ``PATCH  /api/scheduled_jobs/{job_id}``       — edit name/description/trigger/enabled
+- ``DELETE /api/scheduled_jobs/{job_id}``       — hard-delete
+- ``POST   /api/scheduled_jobs/{job_id}/run``   — manual trigger (force/due)
+- ``GET    /api/scheduled_jobs/{job_id}/runs``  — execution history
+- ``GET    /api/scheduled_jobs/quota``          — current quota usage
+
+All endpoints rely on ``ScheduledJobRepository`` AUTO-sentinel user-id
+resolution. The repository pulls ``user_id`` from the request-scoped
+ContextVar, which the auth middleware sets at request entry — so callers
+cannot read or mutate another user's jobs.
+
+Per-user quota is enforced on create: max ``MAX_ENABLED_JOBS_PER_USER``
+(20) enabled jobs, and the tightest cron cadence allowed is
+``MIN_CRON_INTERVAL_SECONDS`` (30 minutes).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_job_runs import ScheduledJobRunRepository
+from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+from deerflow.runtime.user_context import reset_current_user, set_current_user
+from deerflow.scheduler.triggers import (
+    AtTrigger,
+    CronTrigger,
+    EveryTrigger,
+    parse_user_when,
+)
+from deerflow.utils.time import coerce_datetime
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/scheduled_jobs", tags=["scheduled-jobs"])
+
+
+async def _require_user(request: Request):
+    """Pull the authenticated user from request.state.
+
+    Production auth middleware sets ``request.state.user`` and
+    ``request.state.auth_source``. We skip the cookie-decode fallback
+    that ``get_current_user_from_request`` does (it's only useful when
+    middleware failed to populate state) and just read state directly —
+    cheaper and works for both prod and the stub test middleware.
+    """
+    user = getattr(getattr(request, "state", None), "user", None)
+    if user is None:
+        raise HTTPException(status_code=401, detail="not authenticated")
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Quota / safety limits
+# ---------------------------------------------------------------------------
+
+MAX_ENABLED_JOBS_PER_USER: int = 20
+MIN_CRON_INTERVAL_SECONDS: int = 1800  # 30 minutes — blocks runaway loops
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class TriggerModel(BaseModel):
+    """Free-form trigger descriptor accepted by the create endpoint.
+
+    The API accepts either:
+
+    - ``{"when": "0 9 * * *"}`` — a user-facing string parsed by
+      ``parse_user_when`` (cron / every / at)
+    - ``{"kind": "cron", "expr": "0 9 * * *", "tz": "UTC"}`` — a
+      structured trigger dict (round-trips from GET → PATCH)
+    """
+
+    when: str | None = None
+    kind: Literal["at", "every", "cron"] | None = None
+    # at
+    at: str | None = None
+    # every
+    every_seconds: int | None = None
+    anchor_ms: int | None = None
+    # cron
+    expr: str | None = None
+    tz: str | None = None
+    stagger_ms: int | None = None
+
+
+class CreateJobRequest(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = Field(..., min_length=1)
+    trigger: TriggerModel
+    thread_strategy: Literal["new", "fixed"] = "new"
+    fixed_thread_id: str | None = None
+    agent_name: str | None = None
+    delete_after_run: bool | None = None
+    source_channel: str = "web"
+
+
+class PatchJobRequest(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    description: str | None = None
+    trigger: TriggerModel | None = None
+    thread_strategy: Literal["new", "fixed"] | None = None
+    fixed_thread_id: str | None = None
+    agent_name: str | None = None
+    enabled: bool | None = None
+    delete_after_run: bool | None = None
+
+
+class RunNowRequest(BaseModel):
+    mode: Literal["force", "due"] = "force"
+
+
+class JobResponse(BaseModel):
+    id: str
+    user_id: str
+    name: str
+    description: str
+    trigger_type: str
+    trigger_data: dict[str, Any]
+    thread_strategy: str
+    fixed_thread_id: str | None = None
+    agent_name: str | None = None
+    enabled: bool
+    next_run_at: str
+    last_run_at: str | None = None
+    last_status: str | None = None
+    consecutive_errors: int
+    next_retry_at: str | None = None
+    delete_after_run: bool
+    source_channel: str
+    created_at: str
+    updated_at: str
+
+
+class JobListResponse(BaseModel):
+    jobs: list[JobResponse]
+    count: int
+
+
+class JobRunResponse(BaseModel):
+    id: str
+    job_id: str
+    thread_id: str
+    status: str
+    error_msg: str | None = None
+    token_usage: int
+    duration_ms: int
+    started_at: str
+    finished_at: str | None = None
+
+
+class JobRunListResponse(BaseModel):
+    runs: list[JobRunResponse]
+    count: int
+
+
+class QuotaResponse(BaseModel):
+    enabled_jobs: int
+    max_enabled_jobs: int
+    remaining: int
+
+
+class CreateJobResponse(BaseModel):
+    job: JobResponse
+
+
+class RunNowResponse(BaseModel):
+    run_id: str | None
+    status: str
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_repos() -> tuple[ScheduledJobRepository, ScheduledJobRunRepository]:
+    sf = get_session_factory()
+    if sf is None:
+        raise HTTPException(status_code=503, detail="persistence engine not initialised")
+    return ScheduledJobRepository(sf), ScheduledJobRunRepository(sf)
+
+
+def _trigger_model_to_trigger(model: TriggerModel):
+    """Resolve a TriggerModel from the API into a Trigger instance."""
+    try:
+        if model.when is not None:
+            return parse_user_when(model.when, tz=model.tz or "UTC")
+
+        if model.kind == "at":
+            if not model.at:
+                raise HTTPException(status_code=422, detail="trigger.kind='at' requires trigger.at")
+            return AtTrigger(at=model.at)
+        if model.kind == "every":
+            if not model.every_seconds:
+                raise HTTPException(status_code=422, detail="trigger.kind='every' requires trigger.every_seconds")
+            return EveryTrigger(seconds=model.every_seconds, anchor_ms=model.anchor_ms)
+        if model.kind == "cron":
+            if not model.expr:
+                raise HTTPException(status_code=422, detail="trigger.kind='cron' requires trigger.expr")
+            return CronTrigger(expr=model.expr, tz=model.tz or "UTC", stagger_ms=model.stagger_ms)
+    except ValueError as exc:
+        # Trigger constructors validate ranges (cron syntax, every minimum).
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    raise HTTPException(status_code=422, detail="trigger must have either 'when' or 'kind'")
+
+
+def _enforce_cron_min_interval(trigger) -> None:
+    """Reject cron expressions whose tightest interval is below the floor."""
+    if not isinstance(trigger, CronTrigger):
+        return
+    # Sample the next two runs and measure the gap.
+    now = datetime.now(UTC)
+    n1 = trigger.compute_next(None, now=now, job_id="quota-check")
+    if n1 is None:
+        return
+    n2 = trigger.compute_next(n1, now=n1, job_id="quota-check")
+    if n2 is None:
+        return
+    gap = (n2 - n1).total_seconds()
+    if gap < MIN_CRON_INTERVAL_SECONDS:
+        raise HTTPException(
+            status_code=422,
+            detail=(f"cron cadence too tight: {int(gap)}s between runs; minimum is {MIN_CRON_INTERVAL_SECONDS}s"),
+        )
+
+
+def _row_to_response(row: dict[str, Any]) -> JobResponse:
+    return JobResponse(
+        id=row["id"],
+        user_id=row["user_id"],
+        name=row["name"],
+        description=row["description"],
+        trigger_type=row["trigger_type"],
+        trigger_data=row["trigger_data"],
+        thread_strategy=row["thread_strategy"],
+        fixed_thread_id=row.get("fixed_thread_id"),
+        agent_name=row.get("agent_name"),
+        enabled=row["enabled"],
+        next_run_at=row["next_run_at"],
+        last_run_at=row.get("last_run_at"),
+        last_status=row.get("last_status"),
+        consecutive_errors=row.get("consecutive_errors", 0),
+        next_retry_at=row.get("next_retry_at"),
+        delete_after_run=row["delete_after_run"],
+        source_channel=row["source_channel"],
+        created_at=row["created_at"],
+        updated_at=row.get("updated_at", row["created_at"]),
+    )
+
+
+def _run_row_to_response(row: dict[str, Any]) -> JobRunResponse:
+    return JobRunResponse(
+        id=row["id"],
+        job_id=row["job_id"],
+        thread_id=row["thread_id"],
+        status=row["status"],
+        error_msg=row.get("error_msg"),
+        token_usage=row.get("token_usage", 0),
+        duration_ms=row.get("duration_ms", 0),
+        started_at=row["started_at"],
+        finished_at=row.get("finished_at"),
+    )
+
+
+class _RequestUserShim:
+    """Adapter so ``set_current_user`` accepts the auth ``User`` object.
+
+    ``CurrentUser`` is a structural Protocol requiring only ``.id: str``;
+    the auth ``User`` model already satisfies it. This shim exists only
+    to make the intent explicit at the call site.
+    """
+
+    def __init__(self, user: Any) -> None:
+        self.id: str = str(user.id)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("", response_model=JobListResponse)
+async def list_jobs(
+    request: Request,
+    include_disabled: bool = Query(default=False),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    """List the caller's scheduled jobs."""
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        rows = await jobs_repo.list_jobs(
+            include_disabled=include_disabled,
+            limit=limit,
+            offset=offset,
+        )
+    finally:
+        reset_current_user(token)
+
+    return JobListResponse(jobs=[_row_to_response(r) for r in rows], count=len(rows))
+
+
+@router.post("", response_model=CreateJobResponse, status_code=201)
+async def create_job(request: Request, body: CreateJobRequest):
+    """Create a new scheduled job for the caller.
+
+    Enforces:
+
+    - Per-user enabled-job cap (``MAX_ENABLED_JOBS_PER_USER``)
+    - Minimum cron cadence (``MIN_CRON_INTERVAL_SECONDS``)
+    - One-shot ``at`` defaults to ``delete_after_run=True``; recurring
+      triggers default to ``False``. Caller may override.
+    """
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    trigger = _trigger_model_to_trigger(body.trigger)
+    _enforce_cron_min_interval(trigger)
+
+    # Resolve delete_after_run default
+    if body.delete_after_run is None:
+        delete_after_run = isinstance(trigger, AtTrigger)
+    else:
+        delete_after_run = body.delete_after_run
+
+    now = datetime.now(UTC)
+    job_id = jobs_repo.new_job_id()
+    next_run_at = trigger.compute_next(None, now=now, job_id=job_id)
+    if next_run_at is None:
+        raise HTTPException(status_code=422, detail="trigger has no upcoming run time")
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        current_count = await jobs_repo.count_enabled_jobs()
+        if current_count >= MAX_ENABLED_JOBS_PER_USER:
+            raise HTTPException(
+                status_code=429,
+                detail=(f"enabled-job quota exhausted: {current_count}/{MAX_ENABLED_JOBS_PER_USER}"),
+            )
+
+        row = await jobs_repo.create_job(
+            name=body.name,
+            description=body.description,
+            trigger_type=trigger.type,
+            trigger_data=trigger.to_dict(),
+            next_run_at=next_run_at,
+            thread_strategy=body.thread_strategy,
+            fixed_thread_id=body.fixed_thread_id,
+            agent_name=body.agent_name,
+            delete_after_run=delete_after_run,
+            source_channel=body.source_channel,
+            job_id=job_id,
+        )
+    finally:
+        reset_current_user(token)
+
+    return CreateJobResponse(job=_row_to_response(row))
+
+
+@router.get("/quota", response_model=QuotaResponse)
+async def get_quota(request: Request):
+    """Return the caller's quota usage."""
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        used = await jobs_repo.count_enabled_jobs()
+    finally:
+        reset_current_user(token)
+
+    return QuotaResponse(
+        enabled_jobs=used,
+        max_enabled_jobs=MAX_ENABLED_JOBS_PER_USER,
+        remaining=max(0, MAX_ENABLED_JOBS_PER_USER - used),
+    )
+
+
+@router.get("/{job_id}", response_model=JobResponse)
+async def get_job(request: Request, job_id: str):
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        row = await jobs_repo.get_job(job_id)
+    finally:
+        reset_current_user(token)
+
+    if row is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return _row_to_response(row)
+
+
+@router.patch("/{job_id}", response_model=JobResponse)
+async def patch_job(request: Request, job_id: str, body: PatchJobRequest):
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        existing = await jobs_repo.get_job(job_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="job not found")
+
+        trigger_type = None
+        trigger_data = None
+        next_run_at = None
+        if body.trigger is not None:
+            new_trigger = _trigger_model_to_trigger(body.trigger)
+            _enforce_cron_min_interval(new_trigger)
+            trigger_type = new_trigger.type
+            trigger_data = new_trigger.to_dict()
+            next_run_at = new_trigger.compute_next(None, now=datetime.now(UTC), job_id=job_id)
+            if next_run_at is None:
+                raise HTTPException(status_code=422, detail="trigger has no upcoming run time")
+
+        updated = await jobs_repo.update_job_spec(
+            job_id,
+            name=body.name,
+            description=body.description,
+            trigger_type=trigger_type,
+            trigger_data=trigger_data,
+            next_run_at=next_run_at,
+            thread_strategy=body.thread_strategy,
+            fixed_thread_id=body.fixed_thread_id,
+            agent_name=body.agent_name,
+            enabled=body.enabled,
+            delete_after_run=body.delete_after_run,
+        )
+    finally:
+        reset_current_user(token)
+
+    if updated is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return _row_to_response(updated)
+
+
+@router.delete("/{job_id}", status_code=204)
+async def delete_job(request: Request, job_id: str):
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        ok = await jobs_repo.delete_job(job_id)
+    finally:
+        reset_current_user(token)
+
+    if not ok:
+        raise HTTPException(status_code=404, detail="job not found")
+
+
+@router.post("/{job_id}/run", response_model=RunNowResponse)
+async def run_job_now(request: Request, job_id: str, body: RunNowRequest):
+    """Trigger an immediate manual run.
+
+    Implementation note: PR #4 only persists the intent — it does not
+    actually invoke the executor. The Scheduler tick loop will pick the
+    job up within 1 second if ``mode=force`` (we set ``next_run_at=now``
+    in that case). For ``mode=due`` we leave the schedule alone.
+    """
+    user = await _require_user(request)
+    jobs_repo, _ = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        existing = await jobs_repo.get_job(job_id)
+        if existing is None:
+            raise HTTPException(status_code=404, detail="job not found")
+
+        if body.mode == "force":
+            await jobs_repo.update_scheduling_state(
+                job_id,
+                next_run_at=datetime.now(UTC),
+            )
+            return RunNowResponse(run_id=None, status="queued", message="job scheduled for immediate execution")
+        # mode == "due"
+        next_run_at = coerce_datetime(existing.get("next_run_at"))
+        if next_run_at is not None and next_run_at <= datetime.now(UTC):
+            return RunNowResponse(run_id=None, status="queued", message="job already due")
+        return RunNowResponse(run_id=None, status="skipped", message="job not due yet")
+    finally:
+        reset_current_user(token)
+
+
+@router.get("/{job_id}/runs", response_model=JobRunListResponse)
+async def list_job_runs(
+    request: Request,
+    job_id: str,
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+):
+    user = await _require_user(request)
+    _, runs_repo = _get_repos()
+
+    token = set_current_user(_RequestUserShim(user))
+    try:
+        rows = await runs_repo.list_runs_for_job(job_id, limit=limit, offset=offset)
+    finally:
+        reset_current_user(token)
+
+    return JobRunListResponse(
+        runs=[_run_row_to_response(r) for r in rows],
+        count=len(rows),
+    )

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -135,6 +135,7 @@ _CONTEXT_CONFIGURABLE_KEYS: frozenset[str] = frozenset(
         "max_concurrent_subagents",
         "agent_name",
         "is_bootstrap",
+        "source_channel",
     }
 )
 

--- a/backend/app/scheduled_jobs/__init__.py
+++ b/backend/app/scheduled_jobs/__init__.py
@@ -1,0 +1,29 @@
+"""Scheduled jobs application layer.
+
+Wires the harness-level ``Scheduler`` to deer-flow's application-layer
+concerns: user-context setup, ``DeerFlowClient`` invocation, run-record
+persistence, and result delivery.
+
+This module is the bridge between:
+
+- ``deerflow.scheduler`` (harness, app-agnostic, owns the tick loop)
+- ``app.gateway`` (HTTP API surface for /scheduled_jobs endpoints)
+- ``app.channels`` (IM delivery, reused via MessageBus)
+
+Public surface:
+
+- ``AgentJobExecutor``: the ``JobExecutor`` implementation injected into
+  ``Scheduler`` at lifespan startup.
+- ``start_scheduler(app)`` / ``stop_scheduler()``: lifespan hooks.
+- ``CronUser``: minimal ``CurrentUser`` shim used by the executor to
+  set ``ContextVar`` user identity per job.
+
+Design note: this module is the *only* place where the harness
+``Scheduler`` is instantiated. The Gateway lifespan calls
+``start_scheduler(app)``; everything else is internal.
+"""
+
+from app.scheduled_jobs.executor import AgentJobExecutor, CronUser
+from app.scheduled_jobs.lifecycle import start_scheduler, stop_scheduler
+
+__all__ = ["AgentJobExecutor", "CronUser", "start_scheduler", "stop_scheduler"]

--- a/backend/app/scheduled_jobs/delivery.py
+++ b/backend/app/scheduled_jobs/delivery.py
@@ -1,0 +1,110 @@
+"""Delivery dispatcher routes scheduled-job results to the right sink.
+
+The dispatcher is the only ``DeliverySink`` the executor talks to. It
+inspects ``job["source_channel"]`` and dispatches:
+
+- ``"web"``                  → ``InAppNotifier`` (logs for now; PR #8 will
+                               persist a notifications row when the Web
+                               UI lands)
+- ``"im:<platform>:..."``    → ``IMPusher`` (publishes via MessageBus)
+- anything else              → log a warning and no-op
+
+Falls back to ``LoggingDeliverySink`` semantics when both sub-sinks are
+missing — keeps the executor contract intact.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.scheduled_jobs.im_pusher import IMPusher
+
+logger = logging.getLogger(__name__)
+
+
+class InAppNotifier:
+    """Web in-app notification sink.
+
+    MVP behaviour: log only. PR #8 will swap this for a real
+    notifications table write when the Web bell UI ships.
+    """
+
+    async def deliver(
+        self,
+        *,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None = None,
+    ) -> None:
+        preview = (result_text or "")[:80].replace("\n", " ")
+        logger.info(
+            "scheduled_job in-app notification: job=%s user=%s status=%s preview=%r",
+            job.get("id"),
+            job.get("user_id"),
+            status,
+            preview,
+        )
+
+
+class DeliveryDispatcher:
+    """Routes by ``source_channel`` to the right sink.
+
+    Satisfies the ``DeliverySink`` protocol so the executor doesn't need
+    to know about IM vs Web vs anything else.
+    """
+
+    def __init__(
+        self,
+        *,
+        im_pusher: IMPusher | None = None,
+        in_app: InAppNotifier | None = None,
+    ) -> None:
+        self._im = im_pusher
+        self._in_app = in_app or InAppNotifier()
+
+    async def deliver(
+        self,
+        *,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None = None,
+    ) -> None:
+        source = job.get("source_channel", "web")
+
+        if source == "web":
+            await self._in_app.deliver(
+                job=job,
+                thread_id=thread_id,
+                result_text=result_text,
+                status=status,
+                error_msg=error_msg,
+            )
+            return
+
+        if source.startswith("im:"):
+            if self._im is None:
+                logger.warning(
+                    "im source_channel but no IMPusher configured; falling back to log: job=%s source=%s",
+                    job.get("id"),
+                    source,
+                )
+                return
+            await self._im.push(
+                job=job,
+                thread_id=thread_id,
+                result_text=result_text,
+                status=status,
+                error_msg=error_msg,
+            )
+            return
+
+        logger.warning(
+            "unknown source_channel %r for job %s; delivery skipped",
+            source,
+            job.get("id"),
+        )

--- a/backend/app/scheduled_jobs/executor.py
+++ b/backend/app/scheduled_jobs/executor.py
@@ -1,0 +1,328 @@
+"""Application-layer JobExecutor that runs scheduled jobs as Agent turns.
+
+The executor is the **only** place where user-context manipulation
+meets Agent invocation. The contract:
+
+1. Resolve ``thread_id`` (new each run, or fixed — a fixed job with no
+   pinned id generates one on its first run and writes it back so every
+   later run reuses the same thread and accumulates context)
+2. Insert a ``running`` row in ``scheduled_job_runs``
+3. ``set_current_user(CronUser(job["user_id"]))``
+4. Call ``DeerFlowClient.chat()`` via ``asyncio.to_thread`` so the
+   synchronous client doesn't block the event loop
+5. Reset the user context in a ``finally`` block (no leak across jobs)
+6. ``mark_terminal`` on the run row with the outcome
+7. Delegate delivery to ``deliver_result`` (PR #6 fills in IM push)
+
+⚠ The executor must NEVER call ``DeerFlowClient`` without first setting
+the user context — that would let one user's scheduled job read
+another user's Memory / Sandbox / Uploads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from deerflow.persistence.scheduled_job_runs import ScheduledJobRunRepository
+from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+from deerflow.runtime.user_context import reset_current_user, set_current_user
+from deerflow.scheduler.core import ExecutionResult
+
+logger = logging.getLogger(__name__)
+
+
+class CronUser:
+    """Minimal ``CurrentUser`` shim.
+
+    ``deerflow.runtime.user_context.CurrentUser`` is a structural Protocol
+    that requires only an ``id: str`` attribute. This concrete class
+    satisfies it without forcing the scheduler to depend on the auth
+    subsystem's full ``User`` model.
+    """
+
+    def __init__(self, user_id: str) -> None:
+        self.id: str = user_id
+
+    def __repr__(self) -> str:  # pragma: no cover - debug only
+        return f"CronUser(id={self.id!r})"
+
+
+# ---------------------------------------------------------------------------
+# Delivery protocol
+# ---------------------------------------------------------------------------
+
+
+class DeliverySink(Protocol):
+    """Where execution results get delivered.
+
+    PR #3 ships a stub that only logs. PR #6 fills in ``IMPusher`` (which
+    routes through ``MessageBus.publish_outbound``) and ``InAppNotifier``
+    (which writes a row to a notifications table for the Web UI bell).
+    """
+
+    async def deliver(
+        self,
+        *,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None = None,
+    ) -> None: ...
+
+
+class LoggingDeliverySink:
+    """Default sink: log the delivery, do nothing else.
+
+    Used until PR #6 ships the real IM / in-app delivery. Lets the
+    scheduler run end-to-end without depending on MessageBus.
+    """
+
+    async def deliver(
+        self,
+        *,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None = None,
+    ) -> None:
+        preview = (result_text or "")[:80].replace("\n", " ")
+        logger.info(
+            "scheduled_job delivery stub: job=%s user=%s source=%s status=%s preview=%r",
+            job.get("id"),
+            job.get("user_id"),
+            job.get("source_channel"),
+            status,
+            preview,
+        )
+        if error_msg:
+            logger.warning("scheduled_job error detail: %s", error_msg)
+
+
+# ---------------------------------------------------------------------------
+# Client factory
+# ---------------------------------------------------------------------------
+
+
+ClientFactory = Callable[..., Any]
+
+
+def _default_client_factory(
+    *,
+    agent_name: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Construct a ``DeerFlowClient``. Imported lazily so the executor
+    module loads even when the full client stack isn't needed (e.g.
+    unit tests with a fake factory).
+
+    ``subagent_enabled`` defaults to ``True`` so scheduled jobs can
+    delegate heavy research/report work to a subagent via the ``task``
+    tool. This keeps the lead agent's context clean (tool output from a
+    long web-research job does not pollute the main thread state) and
+    gives the job its own recursion budget — subagent ``max_turns=150``
+    vs the lead graph's ``recursion_limit=100``. The lead agent still
+    decides whether to delegate based on the job's ``description``, so
+    simple jobs (e.g. a one-line reminder) are unaffected — they simply
+    never call ``task``. An explicit ``subagent_enabled`` in ``kwargs``
+    is respected (escape hatch for future per-job control).
+    """
+    from deerflow.client import DeerFlowClient
+
+    kwargs.setdefault("subagent_enabled", True)
+    return DeerFlowClient(agent_name=agent_name, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# AgentJobExecutor
+# ---------------------------------------------------------------------------
+
+
+class AgentJobExecutor:
+    """``JobExecutor`` implementation backed by ``DeerFlowClient``.
+
+    Construct once at Gateway lifespan startup with the shared
+    repositories + delivery sink. The Scheduler calls
+    ``execute(job_dict)`` per due job.
+    """
+
+    def __init__(
+        self,
+        jobs_repo: ScheduledJobRepository,
+        runs_repo: ScheduledJobRunRepository,
+        *,
+        delivery: DeliverySink | None = None,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        self._jobs_repo = jobs_repo
+        self._runs_repo = runs_repo
+        self._delivery = delivery or LoggingDeliverySink()
+        self._client_factory = client_factory or _default_client_factory
+        # Cache DeerFlowClient by agent_name so we don't reload config
+        # on every job. ``None`` means "default agent".
+        self._clients: dict[str | None, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Public API (called by Scheduler)
+    # ------------------------------------------------------------------
+
+    async def execute(self, job: dict[str, Any]) -> ExecutionResult:
+        job_id = job["id"]
+        user_id = job["user_id"]
+        description = job.get("description", "")
+        agent_name = job.get("agent_name")
+        thread_strategy = job.get("thread_strategy", "new")
+        fixed_thread_id = job.get("fixed_thread_id")
+
+        # Resolve thread (pins fixed_thread_id on the first fixed run)
+        thread_id = await self._resolve_thread_id(job_id, thread_strategy, fixed_thread_id)
+
+        # Create run record
+        started_at = datetime.now(UTC)
+        run = await self._runs_repo.create_run(
+            job_id=job_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            started_at=started_at,
+        )
+
+        # Set user context for the duration of this execution.
+        # ``asyncio.to_thread`` copies the current context to the worker
+        # thread, so ``get_effective_user_id()`` inside DeerFlowClient
+        # (called by middlewares / tools) resolves correctly.
+        token = set_current_user(CronUser(user_id))
+        try:
+            client = self._get_or_create_client(agent_name)
+            # DeerFlowClient.chat is synchronous — run it in a thread.
+            result_text = await asyncio.to_thread(
+                client.chat,
+                description,
+                thread_id=thread_id,
+            )
+        except Exception as exc:
+            await self._finish_failure(run["id"], job, thread_id, exc, started_at)
+            return ExecutionResult(
+                status="error",
+                thread_id=thread_id,
+                error_msg=str(exc),
+                duration_ms=int((datetime.now(UTC) - started_at).total_seconds() * 1000),
+            )
+        finally:
+            reset_current_user(token)
+
+        await self._finish_success(run["id"], job, thread_id, result_text, started_at)
+        return ExecutionResult(
+            status="ok",
+            thread_id=thread_id,
+            duration_ms=int((datetime.now(UTC) - started_at).total_seconds() * 1000),
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _resolve_thread_id(
+        self,
+        job_id: str,
+        strategy: str,
+        fixed_thread_id: str | None,
+    ) -> str:
+        """Resolve the thread_id for this run.
+
+        - ``fixed`` with a pinned ``fixed_thread_id`` → reuse it verbatim.
+        - ``new`` (or ``fixed`` on its very first run, before any id is
+          pinned) → spawn a fresh thread.
+
+        On that first ``fixed`` run we also **write the generated id back**
+        to the job's ``fixed_thread_id`` column so every subsequent run
+        lands in the same thread and accumulates conversation history /
+        context across executions. Without this pin, each run would get a
+        brand-new thread and ``fixed`` would silently behave like ``new``.
+
+        The write-back is best-effort: if it raises, this run proceeds
+        with the fresh thread and the next run retries the pin.
+        ``user_id=None`` (admin scope) because the scheduler is cross-user
+        and the owning user is already captured on the job row.
+
+        Note: the actual thread row in LangGraph's checkpointer is created
+        on first ``chat()`` call with this id.
+        """
+        if strategy == "fixed" and fixed_thread_id:
+            return fixed_thread_id
+
+        thread_id = str(uuid.uuid4())
+        if strategy == "fixed":
+            try:
+                await self._jobs_repo.update_job_spec(
+                    job_id,
+                    fixed_thread_id=thread_id,
+                    user_id=None,
+                )
+            except Exception:
+                logger.exception(
+                    "failed to pin fixed_thread_id for job %s; this run uses a fresh thread and the next run will retry the pin",
+                    job_id,
+                )
+        return thread_id
+
+    def _get_or_create_client(self, agent_name: str | None) -> Any:
+        if agent_name not in self._clients:
+            self._clients[agent_name] = self._client_factory(agent_name=agent_name)
+        return self._clients[agent_name]
+
+    async def _finish_success(
+        self,
+        run_id: str,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        started_at: datetime,
+    ) -> None:
+        duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
+        await self._runs_repo.mark_terminal(
+            run_id,
+            status="ok",
+            token_usage=0,  # TODO: extract from result (DeerFlowClient.chat doesn't return usage)
+            duration_ms=duration_ms,
+        )
+        try:
+            await self._delivery.deliver(
+                job=job,
+                thread_id=thread_id,
+                result_text=result_text,
+                status="ok",
+            )
+        except Exception:
+            logger.exception("delivery failed for job %s", job.get("id"))
+
+    async def _finish_failure(
+        self,
+        run_id: str,
+        job: dict[str, Any],
+        thread_id: str,
+        exc: BaseException,
+        started_at: datetime,
+    ) -> None:
+        duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
+        await self._runs_repo.mark_terminal(
+            run_id,
+            status="error",
+            error_msg=str(exc),
+            duration_ms=duration_ms,
+        )
+        try:
+            await self._delivery.deliver(
+                job=job,
+                thread_id=thread_id,
+                result_text="",
+                status="error",
+                error_msg=str(exc),
+            )
+        except Exception:
+            logger.exception("failure-delivery failed for job %s", job.get("id"))

--- a/backend/app/scheduled_jobs/im_pusher.py
+++ b/backend/app/scheduled_jobs/im_pusher.py
@@ -1,0 +1,207 @@
+"""Pushes scheduled-job results to IM channels via the shared MessageBus.
+
+Zero-footprint design: this module does **not** modify ``app/channels/``.
+It only consumes the existing ``MessageBus.publish_outbound`` pub/sub
+API. Each IM platform's ``Channel.send()`` is the actual transmitter;
+we just route the right ``OutboundMessage`` to the bus.
+
+Source-channel format (parsed by ``parse_source_channel``):
+
+- ``"web"``                                     → in-app notification
+- ``"im:dingtalk:group:<chat_id>"``             → DingTalk group
+- ``"im:dingtalk:p2p:<staff_id>"``              → DingTalk DM
+- ``"im:feishu:group:<chat_id>"``               → Feishu group
+- ``"im:feishu:p2p:<user_id>"``                 → Feishu DM
+- ``"im:slack:<channel_id>"``                   → Slack channel
+- ``"im:telegram:<chat_id>"``                   → Telegram chat
+- ``"im:discord:<channel_id>"``                 → Discord channel
+
+When the parsed platform is unknown or the bus is missing, the pusher
+logs and degrades gracefully — never blocks the scheduler.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol
+
+from app.channels.message_bus import OutboundMessage
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Source-channel parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_source_channel(source: str) -> tuple[str | None, str | None, str | None]:
+    """Split ``"im:<platform>:<conv>:<chat_id>"`` into a 3-tuple.
+
+    Returns ``(platform, conversation_type, chat_id)``. For non-IM
+    sources (e.g. ``"web"``) returns ``(None, None, None)``.
+    """
+    if not source or source == "web":
+        return None, None, None
+    if not source.startswith("im:"):
+        logger.warning("unrecognised source_channel: %r", source)
+        return None, None, None
+
+    parts = source.split(":", 3)
+    if len(parts) < 4:
+        logger.warning("malformed im source_channel: %r", source)
+        return None, None, None
+
+    # parts = ["im", platform, conv_type, chat_id]
+    _, platform, conv_type, chat_id = parts
+    return platform, conv_type, chat_id
+
+
+# ---------------------------------------------------------------------------
+# Bus protocol (for test injection)
+# ---------------------------------------------------------------------------
+
+
+class _BusLike(Protocol):
+    """Minimal protocol IMPusher needs from MessageBus."""
+
+    async def publish_outbound(self, msg: OutboundMessage) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# IMPusher
+# ---------------------------------------------------------------------------
+
+
+class IMPusher:
+    """Routes scheduled-job results to IM channels via the shared bus.
+
+    Construct once at Gateway lifespan startup with the running
+    ChannelService's bus. When the bus is None (channels disabled) the
+    pusher logs and no-ops — never raises.
+    """
+
+    def __init__(self, bus: _BusLike | None) -> None:
+        self._bus = bus
+
+    async def push(
+        self,
+        *,
+        job: dict[str, Any],
+        thread_id: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None = None,
+    ) -> None:
+        """Build an OutboundMessage and publish it.
+
+        Behaviour:
+
+        - ``source_channel == "web"`` → no-op (in-app sink handles it)
+        - bus is None → log and return (channels disabled in this deploy)
+        - parse error → log and return
+        - publish raises → log and swallow (do not block the scheduler)
+        """
+        source = job.get("source_channel", "web")
+        platform, conv_type, chat_id = parse_source_channel(source)
+        if platform is None:
+            # Not an IM push target — the in-app sink handles Web notifications
+            return
+
+        if self._bus is None:
+            logger.info(
+                "im_pusher skipped (no bus): job=%s platform=%s chat=%s",
+                job.get("id"),
+                platform,
+                chat_id,
+            )
+            return
+
+        text = self._compose_message(
+            job_name=job.get("name", "scheduled task"),
+            result_text=result_text,
+            status=status,
+            error_msg=error_msg,
+        )
+        if not text:
+            return
+
+        outbound = self._build_outbound(
+            platform=platform,
+            conv_type=conv_type,
+            chat_id=chat_id or "",
+            thread_id=thread_id,
+            text=text,
+            owner_user_id=job.get("user_id"),
+            job_id=job.get("id"),
+        )
+
+        try:
+            await self._bus.publish_outbound(outbound)
+        except Exception:
+            logger.exception(
+                "im_pusher publish failed: job=%s platform=%s",
+                job.get("id"),
+                platform,
+            )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _compose_message(
+        *,
+        job_name: str,
+        result_text: str,
+        status: str,
+        error_msg: str | None,
+    ) -> str:
+        """Format the human-readable message that goes to the IM chat."""
+        if status == "ok":
+            body = result_text.strip() if result_text else "(no output)"
+            return f"📋 {job_name}\n\n{body}"
+        if status in ("error", "timeout"):
+            return f"⚠️ {job_name} failed ({status}): {error_msg or 'unknown error'}"
+        if status == "skipped":
+            return f"⏭️ {job_name} skipped: {error_msg or 'no reason'}"
+        # Unknown status — best-effort log
+        return f"{job_name}: {status}"
+
+    @staticmethod
+    def _build_outbound(
+        *,
+        platform: str,
+        conv_type: str | None,
+        chat_id: str,
+        thread_id: str,
+        text: str,
+        owner_user_id: str | None,
+        job_id: str | None,
+    ) -> OutboundMessage:
+        """Build the OutboundMessage, applying per-platform metadata.
+
+        Per-platform notes (from inspecting each ``Channel.send()``):
+
+        - **dingtalk**: needs ``metadata["conversation_type"]`` set to
+          ``"group"`` or ``"p2p"`` to route correctly. ``chat_id`` is the
+          group conversation id (group) or staff_id (p2p).
+        - **feishu / slack / telegram / discord / wecom / wechat**: route
+          purely off ``chat_id`` (no metadata required). Future platform-
+          specific tweaks should be added here as needed.
+        """
+        metadata: dict[str, Any] = {}
+        if platform == "dingtalk" and conv_type:
+            metadata["conversation_type"] = conv_type
+
+        # Stable thread_id required by OutboundMessage schema; if the job
+        # produced a fresh thread per run, use that. The IM channels use
+        # this for audit / reply-threading but not for delivery routing.
+        return OutboundMessage(
+            channel_name=platform,
+            chat_id=chat_id,
+            thread_id=thread_id,
+            text=text,
+            metadata=metadata,
+            owner_user_id=owner_user_id,
+        )

--- a/backend/app/scheduled_jobs/lifecycle.py
+++ b/backend/app/scheduled_jobs/lifecycle.py
@@ -1,0 +1,93 @@
+"""Gateway lifespan hooks for the scheduler.
+
+The Gateway calls ``start_scheduler(app, bus=...)`` in its ``lifespan``
+and ``stop_scheduler()`` in the finally block. This is the **only**
+wiring point between the application and the harness ``Scheduler`` —
+keeping the integration footprint to a single line each.
+
+Singleton state lives at module level because FastAPI lifespan runs
+once per worker and the Gateway is currently single-worker (see the
+``GATEWAY_WORKERS`` note in ``docker-compose.yaml``).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.scheduled_jobs.delivery import DeliveryDispatcher, InAppNotifier
+from app.scheduled_jobs.executor import AgentJobExecutor
+from app.scheduled_jobs.im_pusher import IMPusher
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_job_runs import ScheduledJobRunRepository
+from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+from deerflow.scheduler.core import DEFAULT_MAX_CONCURRENT, Scheduler
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton — set by start_scheduler, cleared by stop_scheduler.
+_scheduler: Scheduler | None = None
+
+
+async def start_scheduler(
+    app: Any | None = None,
+    *,
+    bus: Any | None = None,
+    max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+) -> None:
+    """Build and start the scheduler singleton.
+
+    Args:
+        app: FastAPI app instance (unused for now, reserved for future
+            wiring such as binding a shutdown handler).
+        bus: optional ``MessageBus`` from the running ``ChannelService``.
+            When provided, the scheduler's delivery dispatcher routes
+            IM results to ``bus.publish_outbound``. When None (channels
+            disabled), IM deliveries degrade to log-only.
+        max_concurrent: hard cap on simultaneous job executions.
+
+    Idempotent — calling twice is a no-op.
+    """
+    global _scheduler
+    if _scheduler is not None:
+        return
+
+    session_factory = get_session_factory()
+    if session_factory is None:
+        logger.warning("persistence engine not initialised — scheduler will not start")
+        return
+
+    jobs_repo = ScheduledJobRepository(session_factory)
+    runs_repo = ScheduledJobRunRepository(session_factory)
+
+    # Wire up delivery: IM via shared bus (if available), Web via log-only notifier
+    im_pusher = IMPusher(bus) if bus is not None else None
+    dispatcher = DeliveryDispatcher(im_pusher=im_pusher, in_app=InAppNotifier())
+
+    executor = AgentJobExecutor(jobs_repo, runs_repo, delivery=dispatcher)
+
+    _scheduler = Scheduler(
+        jobs_repo,
+        executor,
+        max_concurrent=max_concurrent,
+    )
+    await _scheduler.start()
+    logger.info(
+        "scheduled_jobs: scheduler wired into Gateway lifespan (im_bus=%s)",
+        "attached" if bus is not None else "none",
+    )
+
+
+async def stop_scheduler() -> None:
+    """Stop the scheduler singleton if running. Safe to call multiple times."""
+    global _scheduler
+    if _scheduler is None:
+        return
+    await _scheduler.stop()
+    _scheduler = None
+    logger.info("scheduled_jobs: scheduler stopped")
+
+
+def get_scheduler() -> Scheduler | None:
+    """Test/diagnostic accessor for the running scheduler singleton."""
+    return _scheduler

--- a/backend/packages/harness/deerflow/persistence/models/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/models/__init__.py
@@ -8,6 +8,9 @@ The actual ORM classes have moved to entity-specific subpackages:
 - ``deerflow.persistence.run``
 - ``deerflow.persistence.feedback``
 - ``deerflow.persistence.user``
+- ``deerflow.persistence.channel_connections``
+- ``deerflow.persistence.scheduled_jobs``
+- ``deerflow.persistence.scheduled_job_runs``
 
 ``RunEventRow`` remains in ``deerflow.persistence.models.run_event`` because
 its storage implementation lives in ``deerflow.runtime.events.store.db`` and
@@ -23,6 +26,8 @@ from deerflow.persistence.channel_connections.model import (
 from deerflow.persistence.feedback.model import FeedbackRow
 from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.persistence.run.model import RunRow
+from deerflow.persistence.scheduled_job_runs.model import ScheduledJobRunRow
+from deerflow.persistence.scheduled_jobs.model import ScheduledJobRow
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.persistence.user.model import UserRow
 
@@ -34,6 +39,8 @@ __all__ = [
     "FeedbackRow",
     "RunEventRow",
     "RunRow",
+    "ScheduledJobRow",
+    "ScheduledJobRunRow",
     "ThreadMetaRow",
     "UserRow",
 ]

--- a/backend/packages/harness/deerflow/persistence/scheduled_job_runs/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_job_runs/__init__.py
@@ -1,0 +1,6 @@
+"""Scheduled job runs (execution history) persistence layer."""
+
+from deerflow.persistence.scheduled_job_runs.model import ScheduledJobRunRow
+from deerflow.persistence.scheduled_job_runs.repository import ScheduledJobRunRepository
+
+__all__ = ["ScheduledJobRunRepository", "ScheduledJobRunRow"]

--- a/backend/packages/harness/deerflow/persistence/scheduled_job_runs/model.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_job_runs/model.py
@@ -1,0 +1,55 @@
+"""ORM model for the ``scheduled_job_runs`` table.
+
+Each row is a single execution attempt of a scheduled job. Status flows:
+
+    running → ok | error | skipped | timeout
+
+Rows are append-only — never updated in place except to flip ``running``
+to a terminal state and fill ``finished_at``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class ScheduledJobRunRow(Base):
+    """A single execution attempt of a scheduled job."""
+
+    __tablename__ = "scheduled_job_runs"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    job_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("scheduled_jobs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Redundant with job.user_id but stored here so list queries don't
+    # need to join — repository enforces user_id at write time.
+    user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    thread_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    # running | ok | error | skipped | timeout
+
+    error_msg: Mapped[str | None] = mapped_column(Text, nullable=True)
+    token_usage: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    duration_ms: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=_utc_now)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("idx_scheduled_job_runs_job_started", "job_id", "started_at"),
+        Index("idx_scheduled_job_runs_user_started", "user_id", "started_at"),
+    )

--- a/backend/packages/harness/deerflow/persistence/scheduled_job_runs/repository.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_job_runs/repository.py
@@ -1,0 +1,165 @@
+"""SQL repository for the ``scheduled_job_runs`` table.
+
+The repository trusts that the caller has already validated ``user_id``
+against the parent job (which is enforced by ``ScheduledJobRepository``).
+``user_id`` is stored on the run row at creation time and used in
+subsequent list queries to avoid joins.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.scheduled_job_runs.model import ScheduledJobRunRow
+from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_datetime, coerce_iso
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _row_to_dict(row: ScheduledJobRunRow) -> dict[str, Any]:
+    data = row.to_dict()
+    for key in ("started_at", "finished_at"):
+        value = data.get(key)
+        if isinstance(value, datetime):
+            data[key] = coerce_iso(value)
+    return data
+
+
+class ScheduledJobRunRepository:
+    """Persistence facade for scheduled job execution history."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self.session_factory = session_factory
+
+    @staticmethod
+    def _new_id() -> str:
+        return uuid.uuid4().hex
+
+    async def create_run(
+        self,
+        *,
+        job_id: str,
+        user_id: str,
+        thread_id: str,
+        status: str = "running",
+        started_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Begin a new run record. ``user_id`` is required — the caller
+        must have it in hand (from the parent job row, not the ContextVar,
+        because the scheduler runs across users).
+        """
+        row = ScheduledJobRunRow(
+            id=self._new_id(),
+            job_id=job_id,
+            user_id=user_id,
+            thread_id=thread_id,
+            status=status,
+            started_at=coerce_datetime(started_at) or _utc_now(),
+        )
+        async with self.session_factory() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return _row_to_dict(row)
+
+    async def mark_terminal(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        error_msg: str | None = None,
+        token_usage: int | None = None,
+        duration_ms: int | None = None,
+        finished_at: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        """Flip a run from ``running`` to a terminal status and stamp
+        ``finished_at``. ``status`` must be one of ``ok`` / ``error`` /
+        ``skipped`` / ``timeout``.
+        """
+        values: dict[str, Any] = {
+            "status": status,
+            "finished_at": coerce_datetime(finished_at) or _utc_now(),
+        }
+        if error_msg is not None:
+            values["error_msg"] = error_msg
+        if token_usage is not None:
+            values["token_usage"] = int(token_usage)
+        if duration_ms is not None:
+            values["duration_ms"] = int(duration_ms)
+
+        async with self.session_factory() as session:
+            await session.execute(update(ScheduledJobRunRow).where(ScheduledJobRunRow.id == run_id).values(**values))
+            await session.commit()
+            row = await session.get(ScheduledJobRunRow, run_id)
+            return _row_to_dict(row) if row else None
+
+    async def list_runs_for_job(
+        self,
+        job_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> list[dict[str, Any]]:
+        """List execution history for one job, scoped to ``user_id``.
+
+        ``user_id`` defaults to AUTO and must match the run row's
+        ``user_id`` field. Pass ``None`` for admin scope (across users).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="list_runs_for_job")
+        async with self.session_factory() as session:
+            stmt = select(ScheduledJobRunRow).where(ScheduledJobRunRow.job_id == job_id)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRunRow.user_id == effective_uid)
+            stmt = stmt.order_by(ScheduledJobRunRow.started_at.desc()).limit(limit).offset(offset)
+            result = await session.execute(stmt)
+            return [_row_to_dict(row) for row in result.scalars()]
+
+    async def list_recent_runs(
+        self,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> list[dict[str, Any]]:
+        """List recent runs across all of the user's jobs, newest first.
+
+        ``user_id=None`` returns runs across all users (admin scope).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="list_recent_runs")
+        async with self.session_factory() as session:
+            stmt = select(ScheduledJobRunRow)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRunRow.user_id == effective_uid)
+            stmt = stmt.order_by(ScheduledJobRunRow.started_at.desc()).limit(limit).offset(offset)
+            result = await session.execute(stmt)
+            return [_row_to_dict(row) for row in result.scalars()]
+
+    async def sum_token_usage_since(
+        self,
+        *,
+        since: datetime,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> int:
+        """Sum token usage for ``user_id`` since ``since``. Used for
+        per-user daily quota checks.
+
+        ``user_id=None`` sums across all users (admin scope).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="sum_token_usage_since")
+        async with self.session_factory() as session:
+            stmt = select(func.coalesce(func.sum(ScheduledJobRunRow.token_usage), 0)).where(ScheduledJobRunRow.started_at >= coerce_datetime(since))
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRunRow.user_id == effective_uid)
+            return int((await session.execute(stmt)).scalar() or 0)

--- a/backend/packages/harness/deerflow/persistence/scheduled_jobs/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_jobs/__init__.py
@@ -1,0 +1,18 @@
+"""Scheduled jobs persistence layer.
+
+Two tables back the user-owned scheduled job feature:
+
+- ``scheduled_jobs``: the job definition (trigger, payload, scheduling state)
+- ``scheduled_job_runs``: per-execution history rows
+
+All repository methods accept a ``user_id`` keyword argument that defaults
+to ``AUTO`` — resolved from the request-scoped ContextVar via
+``deerflow.runtime.user_context``. Pass an explicit ``str`` to override
+(tests, admin tools), or ``None`` to opt out of the WHERE clause
+(migrations only).
+"""
+
+from deerflow.persistence.scheduled_jobs.model import ScheduledJobRow
+from deerflow.persistence.scheduled_jobs.repository import ScheduledJobRepository
+
+__all__ = ["ScheduledJobRepository", "ScheduledJobRow"]

--- a/backend/packages/harness/deerflow/persistence/scheduled_jobs/model.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_jobs/model.py
@@ -1,0 +1,90 @@
+"""ORM model for the ``scheduled_jobs`` table.
+
+A scheduled job is a user-owned, time-triggered Agent execution. The job
+specification (trigger, payload, scheduling state) lives here; per-run
+execution records live in ``scheduled_job_runs``.
+
+Key fields:
+
+- ``user_id``: owning DeerFlow user. All queries are scoped by this via the
+  AUTO sentinel in ``ScheduledJobRepository``.
+- ``trigger_type`` / ``trigger_data``: discriminated trigger (at / every / cron).
+  ``trigger_data`` is a JSON blob carrying trigger-specific fields (``at``
+  ISO timestamp, ``every_seconds`` + ``anchor_ms``, ``expr`` + ``tz`` +
+  ``stagger_ms``).
+- ``thread_strategy``: ``"new"`` (fresh thread per run) or ``"fixed"``
+  (always reuse ``fixed_thread_id``).
+- ``source_channel``: where the job was created. Drives delivery routing:
+  ``"web"`` → in-app notification, ``"im:<platform>:<conv>:<chat_id>"``
+  → IM push via existing ``app/channels`` infrastructure.
+- ``delete_after_run``: one-shot (``at``) jobs default to ``True``;
+  recurring (``every`` / ``cron``) jobs default to ``False``. Set
+  explicitly on creation.
+- ``next_run_at``: indexed. The scheduler reads ``WHERE enabled AND
+  next_run_at <= now`` to find due jobs.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, Index, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class ScheduledJobRow(Base):
+    """A user-owned scheduled job definition plus scheduling state."""
+
+    __tablename__ = "scheduled_jobs"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+
+    # Human description
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Trigger (discriminated union: at / every / cron)
+    trigger_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    trigger_data: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+
+    # Execution target
+    thread_strategy: Mapped[str] = mapped_column(String(16), nullable=False, default="new")
+    fixed_thread_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    agent_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    # Scheduling state
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    next_run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_status: Mapped[str | None] = mapped_column(String(16), nullable=True)
+
+    # Error backoff state
+    consecutive_errors: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Lifecycle
+    delete_after_run: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Source / delivery routing
+    source_channel: Mapped[str] = mapped_column(String(128), nullable=False, default="web")
+
+    # Audit
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=_utc_now)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=_utc_now,
+        onupdate=_utc_now,
+    )
+
+    __table_args__ = (
+        Index("idx_scheduled_jobs_due", "enabled", "next_run_at"),
+        Index("idx_scheduled_jobs_user_enabled", "user_id", "enabled"),
+    )

--- a/backend/packages/harness/deerflow/persistence/scheduled_jobs/repository.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_jobs/repository.py
@@ -1,0 +1,348 @@
+"""SQL repository for the ``scheduled_jobs`` table.
+
+All public methods take a ``user_id`` keyword argument that defaults to
+``AUTO`` (resolved from the request-scoped ContextVar). This forces every
+caller to either (a) let user context propagate naturally, (b) override
+with an explicit ``str`` for tests / admin tools, or (c) explicitly opt
+out with ``user_id=None`` for migrations. See
+``deerflow.runtime.user_context.resolve_user_id``.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.scheduled_jobs.model import ScheduledJobRow
+from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_datetime, coerce_iso
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _row_to_dict(row: ScheduledJobRow) -> dict[str, Any]:
+    """Serialise a row to a plain dict suitable for API responses.
+
+    Datetimes are normalised to ISO 8601 strings. ``trigger_data`` is
+    passed through as-is (already JSON-shaped).
+    """
+    data = row.to_dict()
+    for key in ("next_run_at", "last_run_at", "next_retry_at", "created_at", "updated_at"):
+        value = data.get(key)
+        if isinstance(value, datetime):
+            data[key] = coerce_iso(value)
+    return data
+
+
+class ScheduledJobRepository:
+    """Persistence facade for scheduled jobs.
+
+    Construct with the shared session factory from
+    ``deerflow.persistence.engine``. Do not instantiate per-request — the
+    factory is cheap to share and pools connections.
+    """
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self.session_factory = session_factory
+
+    @staticmethod
+    def _new_id() -> str:
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def new_job_id() -> str:
+        """Return an id callers can use before computing job-id based schedules."""
+        return ScheduledJobRepository._new_id()
+
+    # ------------------------------------------------------------------
+    # Create
+    # ------------------------------------------------------------------
+
+    async def create_job(
+        self,
+        *,
+        name: str,
+        description: str,
+        trigger_type: str,
+        trigger_data: dict[str, Any],
+        next_run_at: datetime,
+        thread_strategy: str = "new",
+        fixed_thread_id: str | None = None,
+        agent_name: str | None = None,
+        delete_after_run: bool = False,
+        source_channel: str = "web",
+        enabled: bool = True,
+        job_id: str | None = None,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any]:
+        """Insert a new scheduled job.
+
+        ``user_id`` defaults to AUTO — resolved from the request ContextVar.
+        """
+        effective_uid = resolve_user_id(user_id, method_name="create_job")
+        row = ScheduledJobRow(
+            id=job_id or self._new_id(),
+            user_id=effective_uid,
+            name=name,
+            description=description,
+            trigger_type=trigger_type,
+            trigger_data=dict(trigger_data),
+            thread_strategy=thread_strategy,
+            fixed_thread_id=fixed_thread_id,
+            agent_name=agent_name,
+            enabled=enabled,
+            next_run_at=coerce_datetime(next_run_at) or _utc_now(),
+            delete_after_run=delete_after_run,
+            source_channel=source_channel,
+        )
+        async with self.session_factory() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return _row_to_dict(row)
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    async def get_job(
+        self,
+        job_id: str,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any] | None:
+        """Return one job by id, scoped to ``user_id``.
+
+        Returns ``None`` when the row does not exist or (when
+        ``user_id`` is not ``None``) belongs to a different user.
+
+        ``user_id=None`` is the admin escape hatch — returns the row
+        regardless of owner (used by the scheduler, which is
+        cross-user).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="get_job")
+        async with self.session_factory() as session:
+            row = await session.get(ScheduledJobRow, job_id)
+            if row is None:
+                return None
+            if effective_uid is not None and row.user_id != effective_uid:
+                return None
+            return _row_to_dict(row)
+
+    async def list_jobs(
+        self,
+        *,
+        include_disabled: bool = False,
+        limit: int = 100,
+        offset: int = 0,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> list[dict[str, Any]]:
+        """List jobs owned by ``user_id``, newest first.
+
+        ``user_id=None`` is the admin escape hatch — returns jobs across
+        all users (no WHERE clause). Use sparingly.
+        """
+        effective_uid = resolve_user_id(user_id, method_name="list_jobs")
+        async with self.session_factory() as session:
+            stmt = select(ScheduledJobRow)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRow.user_id == effective_uid)
+            if not include_disabled:
+                stmt = stmt.where(ScheduledJobRow.enabled.is_(True))
+            stmt = stmt.order_by(ScheduledJobRow.created_at.desc()).limit(limit).offset(offset)
+            result = await session.execute(stmt)
+            return [_row_to_dict(row) for row in result.scalars()]
+
+    async def list_due_jobs(
+        self,
+        *,
+        now: datetime | None = None,
+        limit: int = 200,
+    ) -> list[dict[str, Any]]:
+        """Return all enabled jobs with ``next_run_at <= now``.
+
+        ⚠ **Admin scope** — does NOT filter by user_id. The scheduler runs
+        across all users. Per-user isolation is enforced at execution time
+        via ``set_current_user(job.user_id)`` in the executor.
+        """
+        cutoff = coerce_datetime(now) or _utc_now()
+        async with self.session_factory() as session:
+            stmt = select(ScheduledJobRow).where(ScheduledJobRow.enabled.is_(True)).where(ScheduledJobRow.next_run_at <= cutoff).order_by(ScheduledJobRow.next_run_at.asc()).limit(limit)
+            result = await session.execute(stmt)
+            return [_row_to_dict(row) for row in result.scalars()]
+
+    async def list_all_enabled_jobs(self) -> list[dict[str, Any]]:
+        """All enabled jobs, regardless of user. Used at scheduler startup
+        to rebuild the in-memory schedule.
+
+        ⚠ **Admin scope** — does NOT filter by user_id.
+        """
+        async with self.session_factory() as session:
+            stmt = select(ScheduledJobRow).where(ScheduledJobRow.enabled.is_(True)).order_by(ScheduledJobRow.next_run_at.asc())
+            result = await session.execute(stmt)
+            return [_row_to_dict(row) for row in result.scalars()]
+
+    async def count_enabled_jobs(
+        self,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> int:
+        """Count enabled jobs for ``user_id``. Used for per-user quota
+        enforcement (e.g. "max 20 enabled jobs per user").
+
+        ``user_id=None`` counts across all users (admin scope).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="count_enabled_jobs")
+        async with self.session_factory() as session:
+            stmt = select(func.count()).select_from(ScheduledJobRow).where(ScheduledJobRow.enabled.is_(True))
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRow.user_id == effective_uid)
+            return int((await session.execute(stmt)).scalar() or 0)
+
+    # ------------------------------------------------------------------
+    # Update
+    # ------------------------------------------------------------------
+
+    async def update_scheduling_state(
+        self,
+        job_id: str,
+        *,
+        next_run_at: datetime | None = None,
+        last_run_at: datetime | None = None,
+        last_status: str | None = None,
+        consecutive_errors: int | None = None,
+        next_retry_at: datetime | None = None,
+        enabled: bool | None = None,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any] | None:
+        """Patch scheduling-state fields. ``None`` arguments are ignored.
+
+        Returns the updated row dict, or ``None`` when the job does not
+        exist / belongs to another user.
+        """
+        effective_uid = resolve_user_id(user_id, method_name="update_scheduling_state")
+        values: dict[str, Any] = {}
+        if next_run_at is not None:
+            values["next_run_at"] = coerce_datetime(next_run_at)
+        if last_run_at is not None:
+            values["last_run_at"] = coerce_datetime(last_run_at)
+        if last_status is not None:
+            values["last_status"] = last_status
+        if consecutive_errors is not None:
+            values["consecutive_errors"] = consecutive_errors
+        if next_retry_at is not None:
+            values["next_retry_at"] = coerce_datetime(next_retry_at)
+        if enabled is not None:
+            values["enabled"] = enabled
+        if not values:
+            return await self.get_job(job_id, user_id=user_id)
+
+        async with self.session_factory() as session:
+            stmt = update(ScheduledJobRow).where(ScheduledJobRow.id == job_id)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRow.user_id == effective_uid)
+            stmt = stmt.values(**values)
+            await session.execute(stmt)
+            await session.commit()
+        return await self.get_job(job_id, user_id=user_id)
+
+    async def update_job_spec(
+        self,
+        job_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        trigger_type: str | None = None,
+        trigger_data: dict[str, Any] | None = None,
+        next_run_at: datetime | None = None,
+        thread_strategy: str | None = None,
+        fixed_thread_id: str | None = None,
+        agent_name: str | None = None,
+        enabled: bool | None = None,
+        delete_after_run: bool | None = None,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any] | None:
+        """Patch user-editable job fields (name, trigger, etc).
+
+        Used by the PATCH endpoint. Mutating ``trigger_type`` /
+        ``trigger_data`` also recomputes ``next_run_at`` unless caller
+        provides one.
+        """
+        effective_uid = resolve_user_id(user_id, method_name="update_job_spec")
+        values: dict[str, Any] = {}
+        if name is not None:
+            values["name"] = name
+        if description is not None:
+            values["description"] = description
+        if trigger_type is not None:
+            values["trigger_type"] = trigger_type
+        if trigger_data is not None:
+            values["trigger_data"] = dict(trigger_data)
+        if thread_strategy is not None:
+            values["thread_strategy"] = thread_strategy
+        if fixed_thread_id is not None:
+            values["fixed_thread_id"] = fixed_thread_id
+        if agent_name is not None:
+            values["agent_name"] = agent_name
+        if enabled is not None:
+            values["enabled"] = enabled
+        if delete_after_run is not None:
+            values["delete_after_run"] = delete_after_run
+        if next_run_at is not None:
+            values["next_run_at"] = coerce_datetime(next_run_at)
+
+        if not values:
+            return await self.get_job(job_id, user_id=user_id)
+
+        async with self.session_factory() as session:
+            stmt = update(ScheduledJobRow).where(ScheduledJobRow.id == job_id)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRow.user_id == effective_uid)
+            stmt = stmt.values(**values)
+            await session.execute(stmt)
+            await session.commit()
+        return await self.get_job(job_id, user_id=user_id)
+
+    # ------------------------------------------------------------------
+    # Delete
+    # ------------------------------------------------------------------
+
+    async def delete_job(
+        self,
+        job_id: str,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> bool:
+        """Hard-delete a job. Returns True if a row was removed.
+
+        ``user_id=None`` is the admin scope (scheduler auto-delete on
+        one-shot completion).
+        """
+        effective_uid = resolve_user_id(user_id, method_name="delete_job")
+        async with self.session_factory() as session:
+            stmt = delete(ScheduledJobRow).where(ScheduledJobRow.id == job_id)
+            if effective_uid is not None:
+                stmt = stmt.where(ScheduledJobRow.user_id == effective_uid)
+            result = await session.execute(stmt)
+            await session.commit()
+            return (result.rowcount or 0) > 0
+
+    async def disable_job(
+        self,
+        job_id: str,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any] | None:
+        """Soft-disable a job (set ``enabled=False``). Used when an AT job
+        completes with ``delete_after_run=False``.
+        """
+        return await self.update_scheduling_state(job_id, enabled=False, user_id=user_id)

--- a/backend/packages/harness/deerflow/scheduler/__init__.py
+++ b/backend/packages/harness/deerflow/scheduler/__init__.py
@@ -1,0 +1,38 @@
+"""Lightweight, zero-dependency scheduler for scheduled jobs.
+
+This package implements the scheduling primitives shared by the
+``scheduled_jobs`` feature:
+
+- ``cron_parser``: parses and evaluates 5-field cron expressions without
+  pulling in ``croniter`` or ``croniter``-like deps.
+- ``time_parser``: parses user-facing time strings (ISO 8601, relative
+  like ``"20m"``, epoch milliseconds).
+- ``triggers``: AtTrigger / EveryTrigger / CronTrigger implementations
+  of the ``Trigger`` protocol.
+- ``stagger``: deterministic per-job top-of-hour jitter.
+- ``retry``: exponential backoff schedule for consecutive errors.
+- ``core``: the asyncio scheduler loop that owns the in-memory job table
+  and dispatches due jobs.
+
+Design constraint: this package MUST NOT import from ``app.*`` — it
+lives in the harness layer and stays reusable. Application concerns
+(Gateway lifespan wiring, IM delivery) live in ``app.scheduled_jobs``.
+"""
+
+from deerflow.scheduler.core import Scheduler
+from deerflow.scheduler.triggers import (
+    AtTrigger,
+    CronTrigger,
+    EveryTrigger,
+    Trigger,
+    parse_user_when,
+)
+
+__all__ = [
+    "AtTrigger",
+    "CronTrigger",
+    "EveryTrigger",
+    "Scheduler",
+    "Trigger",
+    "parse_user_when",
+]

--- a/backend/packages/harness/deerflow/scheduler/core.py
+++ b/backend/packages/harness/deerflow/scheduler/core.py
@@ -1,0 +1,398 @@
+"""Asyncio scheduler loop that owns the in-memory job table.
+
+The scheduler is the heart of the ``scheduled_jobs`` feature. It runs a
+1-second tick loop that:
+
+1. Queries ``ScheduledJobRepository.list_due_jobs`` for everything with
+   ``next_run_at <= now``.
+2. Spawns a bounded coroutine per due job (``Semaphore`` cap).
+3. Each coroutine calls the injected ``JobExecutor.execute`` (which
+   lives in ``app.scheduled_jobs`` and is responsible for user-context
+   setup + Agent invocation + delivery).
+4. After execution, recomputes ``next_run_at`` (and applies error
+   backoff if the run failed), then persists via the repository.
+
+Design constraints:
+
+- **No imports from ``app.*``**: this module lives in the harness layer.
+  The executor is injected by the application layer at startup.
+- **Crash-safe**: all scheduling state lives in SQLite. The in-memory
+  ``_jobs`` dict is just a cache for the tick loop. On restart,
+  ``_load_jobs_from_db`` rebuilds it.
+- **No thundering herd on restart**: missed ``at`` runs are marked
+  skipped (not replayed); recurring jobs recompute the next slot from
+  ``now``.
+- **Per-job isolation**: if one job's executor raises, others continue
+  unaffected (``asyncio.create_task`` + try/except per job).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol
+
+from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+from deerflow.scheduler.retry import error_backoff_delay
+from deerflow.scheduler.triggers import (
+    AtTrigger,
+    Trigger,
+    trigger_from_persisted,
+)
+from deerflow.utils.time import coerce_datetime
+
+logger = logging.getLogger(__name__)
+
+
+# Hard cap on concurrent job executions across the whole scheduler.
+DEFAULT_MAX_CONCURRENT: int = 8
+
+# Hard timeout for a single job execution. The executor may impose a
+# tighter per-job timeout; this is the scheduler backstop.
+DEFAULT_JOB_TIMEOUT_SECONDS: int = 300  # 5 minutes
+
+
+@dataclass
+class ExecutionResult:
+    """Result returned by ``JobExecutor.execute``.
+
+    ``status`` is one of ``"ok"``, ``"error"``, ``"skipped"``.
+    """
+
+    status: str
+    thread_id: str | None = None
+    error_msg: str | None = None
+    token_usage: int = 0
+    duration_ms: int = 0
+
+
+class JobExecutor(Protocol):
+    """Application-layer executor. Constructed in ``app.scheduled_jobs``
+    and injected into the Scheduler at lifespan startup.
+
+    Implementations are responsible for:
+
+    - Setting up user context (``set_current_user(job["user_id"])``)
+    - Invoking the Agent (``DeerFlowClient.chat``)
+    - Persisting a run record
+    - Delivering the result to the source channel
+    """
+
+    async def execute(self, job: dict[str, Any]) -> ExecutionResult: ...
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _trigger_from_job(job: dict[str, Any]) -> Trigger:
+    """Reconstruct a Trigger from a job row dict."""
+    return trigger_from_persisted(
+        trigger_type=job["trigger_type"],
+        trigger_data=job["trigger_data"] if isinstance(job["trigger_data"], dict) else {},
+    )
+
+
+class Scheduler:
+    """In-process asyncio scheduler.
+
+    Construct once at application startup (in the Gateway lifespan) and
+    call ``start``. Stopping is graceful: ``stop`` cancels the tick loop
+    but does not abort in-flight executions.
+    """
+
+    def __init__(
+        self,
+        repo: ScheduledJobRepository,
+        executor: JobExecutor,
+        *,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+        job_timeout_seconds: int = DEFAULT_JOB_TIMEOUT_SECONDS,
+        tick_interval_seconds: float = 1.0,
+    ) -> None:
+        self._repo = repo
+        self._executor = executor
+        self._max_concurrent = max_concurrent
+        self._job_timeout_seconds = job_timeout_seconds
+        self._tick_interval = tick_interval_seconds
+
+        self._semaphore = asyncio.Semaphore(max_concurrent)
+        self._lock = asyncio.Lock()  # guards mutations to _inflight
+        self._inflight: set[str] = set()  # job_ids currently executing
+
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Load jobs from DB and start the tick loop. Idempotent."""
+        if self._task is not None:
+            return
+        await self._recover_missed_runs()
+        self._stop_event.clear()
+        self._task = asyncio.create_task(self._loop(), name="deerflow-scheduler-tick")
+        logger.info("scheduler started (max_concurrent=%d)", self._max_concurrent)
+
+    async def stop(self) -> None:
+        """Signal the tick loop to exit. Waits for it to drain."""
+        if self._task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._task, timeout=10.0)
+        except TimeoutError:
+            logger.warning("scheduler tick loop did not exit cleanly, cancelling")
+            self._task.cancel()
+        self._task = None
+        logger.info("scheduler stopped")
+
+    # ------------------------------------------------------------------
+    # Recovery
+    # ------------------------------------------------------------------
+
+    async def _recover_missed_runs(self) -> None:
+        """On startup, find jobs whose ``next_run_at`` is in the past and
+        either:
+
+        - mark them skipped (one-shot ``at`` jobs that missed their window)
+        - recompute the next slot (recurring jobs)
+
+        We do NOT replay missed runs — that would cause a thundering herd
+        after a Gateway restart with many stale jobs.
+        """
+        now = _utc_now()
+        due = await self._repo.list_all_enabled_jobs()
+        skipped = 0
+        rescheduled = 0
+        for job in due:
+            next_run_at = coerce_datetime(job.get("next_run_at"))
+            if next_run_at is None or next_run_at > now:
+                continue
+
+            trigger = _trigger_from_job(job)
+            if isinstance(trigger, AtTrigger):
+                # Missed one-shot: mark disabled so it stops appearing in
+                # list_due_jobs. The repository row is preserved (audit).
+                await self._repo.update_scheduling_state(
+                    job["id"],
+                    enabled=False,
+                    last_status="skipped",
+                    user_id=None,  # admin scope — scheduler is cross-user
+                )
+                skipped += 1
+                continue
+
+            new_next = trigger.compute_next(now, now=now, job_id=job["id"])
+            if new_next is None:
+                # Should not happen for recurring triggers, but be safe.
+                await self._repo.disable_job(job["id"], user_id=None)
+                continue
+            await self._repo.update_scheduling_state(
+                job["id"],
+                next_run_at=new_next,
+                user_id=None,
+            )
+            rescheduled += 1
+
+        if skipped or rescheduled:
+            logger.info(
+                "scheduler recovery: %d one-shot skipped, %d recurring rescheduled",
+                skipped,
+                rescheduled,
+            )
+
+    # ------------------------------------------------------------------
+    # Tick loop
+    # ------------------------------------------------------------------
+
+    async def _loop(self) -> None:
+        """Tick every ``tick_interval`` seconds until ``stop`` is called."""
+        while not self._stop_event.is_set():
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("scheduler tick failed")
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._tick_interval)
+            except TimeoutError:
+                continue
+
+    async def _tick(self) -> None:
+        """Find due jobs and dispatch each in its own task."""
+        now = _utc_now()
+        due = await self._repo.list_due_jobs(now=now)
+        if not due:
+            return
+
+        for job in due:
+            job_id = job["id"]
+            async with self._lock:
+                if job_id in self._inflight:
+                    # Previous execution still running — skip this slot.
+                    continue
+                self._inflight.add(job_id)
+            # Optimistically bump next_run_at so subsequent ticks don't
+            # re-pick this job while it's running. The executor will
+            # overwrite this with the real value after completion.
+            trigger = _trigger_from_job(job)
+            # Anchor the next slot on the time this run was *scheduled*
+            # to fire (job["next_run_at"]), not the current tick time.
+            # For unanchored ``every`` jobs this keeps the cadence strict
+            # instead of drifting by the execution duration each cycle;
+            # for ``cron``/anchored triggers the result is identical.
+            # This value also stands in as the fallback next_run_at if
+            # ``_finalise`` later fails to persist (see _run_job_safely).
+            fired_at = coerce_datetime(job.get("next_run_at")) or now
+            tentative_next = trigger.compute_next(fired_at, now=now, job_id=job_id)
+            if tentative_next is not None:
+                await self._repo.update_scheduling_state(
+                    job_id,
+                    next_run_at=tentative_next,
+                    user_id=None,
+                )
+            asyncio.create_task(self._run_job_safely(job))
+
+    async def _run_job_safely(self, job: dict[str, Any]) -> None:
+        """Wrap a single job execution with concurrency limit, timeout,
+        and exception isolation.
+        """
+        job_id = job["id"]
+        async with self._semaphore:
+            started_at = _utc_now()
+            try:
+                result = await asyncio.wait_for(
+                    self._executor.execute(job),
+                    timeout=self._job_timeout_seconds,
+                )
+                await self._finalise(job, result, started_at)
+            except TimeoutError:
+                logger.warning("job %s timed out after %ds", job_id, self._job_timeout_seconds)
+                await self._finalise(
+                    job,
+                    ExecutionResult(
+                        status="timeout",
+                        error_msg=f"timed out after {self._job_timeout_seconds}s",
+                        duration_ms=int((_utc_now() - started_at).total_seconds() * 1000),
+                    ),
+                    started_at,
+                )
+            except Exception as exc:
+                logger.exception("job %s executor raised", job_id)
+                await self._finalise(
+                    job,
+                    ExecutionResult(
+                        status="error",
+                        error_msg=str(exc),
+                        duration_ms=int((_utc_now() - started_at).total_seconds() * 1000),
+                    ),
+                    started_at,
+                )
+            finally:
+                async with self._lock:
+                    self._inflight.discard(job_id)
+
+    async def _finalise(
+        self,
+        job: dict[str, Any],
+        result: ExecutionResult,
+        started_at: datetime,
+    ) -> None:
+        """After execution, update scheduling state and recompute next run.
+
+        Delegates to ``_persist_run_outcome`` for the actual logic.
+        Persistence here is **best-effort**: if the repo write raises,
+        the exception is logged and swallowed so the tick loop and
+        sibling jobs are unaffected. The job's ``next_run_at`` already
+        holds the optimistic tentative value from ``_tick``, so the job
+        simply fires again on that slot; on the next scheduler start
+        ``_recover_missed_runs`` recomputes any slot that drifted into
+        the past. This avoids the previous failure mode where a raised
+        ``_finalise`` was re-invoked with an ``error`` status by
+        ``_run_job_safely``'s except branch (double-counting failures
+        and leaving ``last_status`` stale).
+        """
+        job_id = job["id"]
+        try:
+            await self._persist_run_outcome(job, result)
+        except Exception:
+            logger.exception(
+                "job %s: failed to persist scheduling state after run (status=%s); next_run_at keeps its tentative value and self-heals on the next slot or restart",
+                job_id,
+                result.status,
+            )
+
+    async def _persist_run_outcome(
+        self,
+        job: dict[str, Any],
+        result: ExecutionResult,
+    ) -> None:
+        """Compute and write the post-run scheduling state. May raise.
+
+        Logic:
+
+        - ``ok`` / ``skipped``: reset consecutive_errors, no retry slot
+        - ``error`` / ``timeout``: increment consecutive_errors, schedule
+          a retry slot via exponential backoff
+        - One-shot ``at`` job: if ``delete_after_run``, hard-delete;
+          otherwise disable
+        - Recurring job: compute next natural slot; if a retry slot is
+          active, take the earlier of the two
+        """
+        job_id = job["id"]
+        now = _utc_now()
+        trigger = _trigger_from_job(job)
+        is_one_shot = isinstance(trigger, AtTrigger)
+
+        # Compute new error counter
+        current_errors = int(job.get("consecutive_errors") or 0)
+        if result.status in ("error", "timeout"):
+            new_errors = current_errors + 1
+            retry_at = now + error_backoff_delay(new_errors)
+        else:
+            new_errors = 0
+            retry_at = None
+
+        # Compute natural next slot (None for one-shot after firing).
+        # Anchor on the slot that just fired (job["next_run_at"]), not
+        # the finish time — otherwise unanchored ``every`` jobs drift by
+        # their execution duration every cycle.
+        fired_at = coerce_datetime(job.get("next_run_at")) or now
+        natural_next = trigger.compute_next(fired_at, now=now, job_id=job_id)
+
+        # One-shot handling
+        if is_one_shot and natural_next is None:
+            delete_after = bool(job.get("delete_after_run"))
+            if delete_after:
+                await self._repo.delete_job(job_id, user_id=None)
+                logger.info("one-shot job %s auto-deleted after run", job_id)
+            else:
+                await self._repo.update_scheduling_state(
+                    job_id,
+                    enabled=False,
+                    last_run_at=now,
+                    last_status=result.status,
+                    consecutive_errors=new_errors,
+                    user_id=None,
+                )
+            return
+
+        # Recurring: pick the earlier of natural_next and retry_at
+        candidates = [dt for dt in (natural_next, retry_at) if dt is not None]
+        next_run_at = min(candidates) if candidates else now + timedelta(minutes=1)
+
+        await self._repo.update_scheduling_state(
+            job_id,
+            next_run_at=next_run_at,
+            last_run_at=now,
+            last_status=result.status,
+            consecutive_errors=new_errors,
+            next_retry_at=retry_at,
+            user_id=None,
+        )

--- a/backend/packages/harness/deerflow/scheduler/cron_parser.py
+++ b/backend/packages/harness/deerflow/scheduler/cron_parser.py
@@ -1,0 +1,289 @@
+"""Self-contained 5-field cron expression parser and evaluator.
+
+Zero external dependencies. Supports the standard Vixie cron syntax:
+
+- ``*``                   — wildcard
+- ``N``                   — single integer
+- ``a-b``                 — inclusive range
+- ``a,b,c``               — list
+- ``*/N``                 — step from the field minimum
+- ``a-b/N``               — step within a range
+- ``a/N``                 — step from ``a`` to field max
+
+Five fields, in order: ``minute hour day-of-month month day-of-week``.
+Day-of-week uses the Vixie cron convention: Sunday=0 through Saturday=6.
+
+Day-of-month and day-of-week use Vixie cron OR semantics: when both
+fields are non-wildcard, a date matches when **either** field matches
+(not both). To require both, schedule on one field and guard in the job
+prompt; this matches ``croniter`` / system cron behaviour.
+
+Public API:
+
+- ``parse_cron_expr(expr)`` → tuple of 5 sets
+- ``compute_next_cron(fields, after, tz_name)`` → ``datetime | None``
+- ``compute_previous_cron(fields, before, tz_name)`` → ``datetime | None``
+
+Implementation note: ``compute_next_cron`` uses a bounded minute-by-minute
+scan (worst case ~525,600 iterations for a 1-year window) instead of a
+calendar-aware algorithm. This is fast enough (<10ms typical) and
+sidesteps timezone / DST corner cases.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+# (lo, hi) for each of the 5 cron fields in canonical order
+_FIELD_RANGES: tuple[tuple[int, int], ...] = (
+    (0, 59),  # minute
+    (0, 23),  # hour
+    (1, 31),  # day-of-month
+    (1, 12),  # month
+    (0, 6),  # day-of-week (Sun=0 .. Sat=6)
+)
+
+# Worst-case scan window. ``0 0 29 2 *`` (Feb 29) needs up to 4 years in
+# the rare case the cursor lands just past one occurrence, but a 1-year
+# window is enough for almost every realistic expression; callers should
+# surface "never fires" to the user instead of looping forever.
+_MAX_SCAN_MINUTES = 366 * 24 * 60
+
+
+class CronParseError(ValueError):
+    """Raised when a cron expression is syntactically invalid."""
+
+
+def _parse_field(field: str, lo: int, hi: int) -> set[int]:
+    """Parse a single cron field into the set of matching integers.
+
+    Raises ``CronParseError`` for any malformed input or value outside
+    ``[lo, hi]``.
+    """
+    field = field.strip()
+    if not field:
+        raise CronParseError("empty cron field")
+
+    # Whole-field wildcard short-circuit
+    if field == "*":
+        return set(range(lo, hi + 1))
+
+    result: set[int] = set()
+    for part in field.split(","):
+        part = part.strip()
+        if not part:
+            raise CronParseError(f"empty list element in cron field {field!r}")
+
+        # Step syntax: */N, a-b/N, a/N
+        if "/" in part:
+            base, _, step_str = part.partition("/")
+            try:
+                step = int(step_str)
+            except ValueError as exc:
+                raise CronParseError(f"invalid step {step_str!r} in {part!r}") from exc
+            if step <= 0:
+                raise CronParseError(f"step must be positive in {part!r}")
+
+            if base == "*":
+                start, end = lo, hi
+            elif "-" in base:
+                start_str, _, end_str = base.partition("-")
+                try:
+                    start, end = int(start_str), int(end_str)
+                except ValueError as exc:
+                    raise CronParseError(f"invalid range {base!r}") from exc
+                if start > end:
+                    raise CronParseError(f"range start must be <= end in {base!r}")
+            else:
+                try:
+                    start = int(base)
+                except ValueError as exc:
+                    raise CronParseError(f"invalid step base {base!r}") from exc
+                end = hi
+
+            result.update(range(start, end + 1, step))
+            continue
+
+        # Bare wildcard as list element (uncommon, but be permissive)
+        if part == "*":
+            result.update(range(lo, hi + 1))
+            continue
+
+        # Range syntax: a-b
+        if "-" in part:
+            start_str, _, end_str = part.partition("-")
+            try:
+                start, end = int(start_str), int(end_str)
+            except ValueError as exc:
+                raise CronParseError(f"invalid range {part!r}") from exc
+            if start > end:
+                raise CronParseError(f"range start must be <= end in {part!r}")
+            result.update(range(start, end + 1))
+            continue
+
+        # Bare integer
+        try:
+            result.add(int(part))
+        except ValueError as exc:
+            raise CronParseError(f"invalid value {part!r}") from exc
+
+    invalid = {v for v in result if not (lo <= v <= hi)}
+    if invalid:
+        raise CronParseError(f"cron field {field!r} has out-of-range values {sorted(invalid)} (allowed {lo}..{hi})")
+    return result
+
+
+def parse_cron_expr(expr: str) -> tuple[set[int], set[int], set[int], set[int], set[int]]:
+    """Parse a 5-field cron expression.
+
+    Returns a 5-tuple of integer sets in canonical order: minute, hour,
+    day-of-month, month, day-of-week.
+    """
+    fields = expr.split()
+    if len(fields) != 5:
+        raise CronParseError(f"cron expression must have exactly 5 fields, got {len(fields)}: {expr!r}")
+    return tuple(  # type: ignore[return-value]
+        _parse_field(field, lo, hi) for field, (lo, hi) in zip(fields, _FIELD_RANGES)
+    )
+
+
+def _resolve_timezone(tz_name: str | None) -> ZoneInfo:
+    """Resolve a timezone name. Falls back to UTC for invalid names."""
+    if not tz_name or tz_name.upper() == "UTC":
+        return ZoneInfo("UTC")
+    try:
+        return ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        logger.warning("unknown timezone %r, falling back to UTC", tz_name)
+        return ZoneInfo("UTC")
+
+
+def _dom_dow_match(
+    candidate: datetime,
+    dom_set: set[int],
+    mon_set: set[int],
+    dow_set: set[int],
+) -> bool:
+    """Apply Vixie cron OR semantics for day-of-month and day-of-week.
+
+    Per the original cron spec, when both fields are restricted (non-
+    wildcard), the date matches when **either** matches. When only one is
+    restricted, only that one matters.
+
+    Day-of-week semantics: cron uses Vixie convention ``Sun=0..Sat=6``,
+    while Python ``datetime.weekday()`` uses ``Mon=0..Sun=6``. We convert
+    the cron set to Python weekday values once per match.
+    """
+    if candidate.month not in mon_set:
+        return False
+
+    # Convert cron dow (Sun=0..Sat=6) → Python weekday (Mon=0..Sun=6)
+    python_dow_set = {(d + 6) % 7 for d in dow_set}
+
+    dom_is_wildcard = len(dom_set) == 31  # full range 1..31
+    dow_is_wildcard = len(dow_set) == 7  # full range 0..6
+
+    dom_match = candidate.day in dom_set
+    dow_match = candidate.weekday() in python_dow_set
+
+    if dom_is_wildcard and dow_is_wildcard:
+        return True
+    if dom_is_wildcard:
+        return dow_match
+    if dow_is_wildcard:
+        return dom_match
+    # Both restricted → OR
+    return dom_match or dow_match
+
+
+def compute_next_cron(
+    fields: Iterable[set[int]],
+    after: datetime,
+    tz_name: str = "UTC",
+) -> datetime | None:
+    """Return the next datetime strictly after ``after`` that matches.
+
+    ``after`` should be timezone-aware. If naive, it is treated as UTC.
+    The returned datetime is timezone-aware in ``tz_name``.
+
+    Returns ``None`` when no match exists within ~1 year (e.g. ``0 0 29 2 *``
+    just past Feb 29 in a non-leap year may need to scan 4+ years).
+    """
+    minute_set, hour_set, dom_set, mon_set, dow_set = fields
+    tz = _resolve_timezone(tz_name)
+
+    # Normalise the cursor to the target timezone.
+    if after.tzinfo is None:
+        after = after.replace(tzinfo=UTC)
+    candidate = (after + timedelta(minutes=1)).astimezone(tz)
+    candidate = candidate.replace(second=0, microsecond=0)
+
+    for _ in range(_MAX_SCAN_MINUTES):
+        if candidate.minute in minute_set and candidate.hour in hour_set and _dom_dow_match(candidate, dom_set, mon_set, dow_set):
+            return candidate
+        candidate += timedelta(minutes=1)
+    return None
+
+
+def compute_previous_cron(
+    fields: Iterable[set[int]],
+    before: datetime,
+    tz_name: str = "UTC",
+) -> datetime | None:
+    """Return the most recent datetime strictly before ``before`` that
+    matched. Used by stagger to verify whether a candidate slot is a
+    natural cron hit.
+    """
+    minute_set, hour_set, dom_set, mon_set, dow_set = fields
+    tz = _resolve_timezone(tz_name)
+
+    if before.tzinfo is None:
+        before = before.replace(tzinfo=UTC)
+    candidate = (before - timedelta(minutes=1)).astimezone(tz)
+    candidate = candidate.replace(second=0, microsecond=0)
+
+    for _ in range(_MAX_SCAN_MINUTES):
+        if candidate.minute in minute_set and candidate.hour in hour_set and _dom_dow_match(candidate, dom_set, mon_set, dow_set):
+            return candidate
+        candidate -= timedelta(minutes=1)
+    return None
+
+
+def is_recurring_top_of_hour(fields: Iterable[set[int]]) -> bool:
+    """Detect whether a cron expression fires at the top of every hour.
+
+    Used by stagger to decide whether to apply the default 5-minute
+    anti-thundering-herd jitter. The pattern is::
+
+        minute == {0}                 # exactly minute 0
+        AND hour is wildcard          # any hour
+        AND dom / mon / dow are wildcard
+
+    Examples that return True:
+        ``0 * * * *``       every hour on the hour
+        ``0 */2 * * *``     every 2 hours on the hour
+        ``0 0,12 * * *``    midnight and noon (NOT top-of-hour recurring —
+                            hour list is explicit, not wildcard)
+
+    The last case is intentionally excluded because staggering a fixed
+    hour list would shift it away from the user's intent.
+    """
+    minute_set, hour_set, dom_set, mon_set, dow_set = fields
+    if minute_set != {0}:
+        return False
+    # Hour wildcard: either full range or */N stepping (covers every N hours)
+    if hour_set == set(range(0, 24)):
+        return True
+    # Detect */N stepping: must be an arithmetic progression from 0 with step
+    sorted_hours = sorted(hour_set)
+    if len(sorted_hours) >= 2 and sorted_hours[0] == 0:
+        step = sorted_hours[1] - sorted_hours[0]
+        if step > 1 and all(sorted_hours[i + 1] - sorted_hours[i] == step for i in range(len(sorted_hours) - 1)):
+            return True
+    return False

--- a/backend/packages/harness/deerflow/scheduler/retry.py
+++ b/backend/packages/harness/deerflow/scheduler/retry.py
@@ -1,0 +1,36 @@
+"""Exponential backoff schedule for consecutive job errors.
+
+    attempt 1 → 30s
+    attempt 2 → 1m
+    attempt 3 → 5m
+    attempt 4 → 15m
+    attempt 5+ → 60m (capped)
+
+The schedule resets after a successful run.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+# Ordered list of backoffs by consecutive error count (1-indexed).
+DEFAULT_BACKOFFS: tuple[timedelta, ...] = (
+    timedelta(seconds=30),
+    timedelta(minutes=1),
+    timedelta(minutes=5),
+    timedelta(minutes=15),
+    timedelta(hours=1),
+)
+
+
+def error_backoff_delay(consecutive_errors: int) -> timedelta:
+    """Return the backoff delay before the next retry attempt.
+
+    ``consecutive_errors`` is 1-indexed: the first failure returns the
+    first backoff slot. Errors beyond the list length return the last
+    slot (capped).
+    """
+    if consecutive_errors <= 0:
+        return timedelta(0)
+    idx = min(consecutive_errors - 1, len(DEFAULT_BACKOFFS) - 1)
+    return DEFAULT_BACKOFFS[idx]

--- a/backend/packages/harness/deerflow/scheduler/stagger.py
+++ b/backend/packages/harness/deerflow/scheduler/stagger.py
@@ -1,0 +1,30 @@
+"""Deterministic per-job top-of-hour stagger.
+
+Recurring top-of-hour cron jobs (``0 * * * *``,
+``0 */2 * * *``, etc.) get a stable per-job offset within a configurable
+window (default 5 minutes). The offset is derived from a SHA-256 hash of
+the job id, so the same job always lands at the same offset — restarting
+the scheduler does not reshuffle every job's schedule.
+
+Why hash instead of random:
+- Deterministic — restart-safe and reproducible
+- Spread out — SHA-256 distributes job ids uniformly across the window
+- No coordination — each scheduler instance computes the same offset
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+DEFAULT_TOP_OF_HOUR_STAGGER_MS: int = 5 * 60 * 1000
+
+
+def stable_offset_ms(job_id: str, stagger_ms: int) -> int:
+    """Return a deterministic offset in ``[0, stagger_ms)`` for ``job_id``.
+
+    Returns ``0`` when ``stagger_ms <= 1`` (effectively no staggering).
+    """
+    if stagger_ms <= 1:
+        return 0
+    digest = hashlib.sha256(job_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % stagger_ms

--- a/backend/packages/harness/deerflow/scheduler/time_parser.py
+++ b/backend/packages/harness/deerflow/scheduler/time_parser.py
@@ -1,0 +1,124 @@
+"""Parser for user-facing time strings.
+
+Supports three input shapes:
+
+1. **Relative durations** — ``"20m"``, ``"1h"``, ``"30s"``, ``"2d"``,
+   ``"1w"``. Resolved against a reference ``now`` to produce an absolute
+   timestamp.
+2. **ISO 8601 timestamps** — ``"2026-06-20T09:00:00Z"``,
+   ``"2026-06-20T17:00:00+08:00"``, ``"2026-06-20"`` (date only, midnight
+   UTC). Strings without a timezone are treated as UTC.
+3. **Epoch milliseconds** — ``"1718841600000"`` (rare; useful when an
+   external system supplies an integer timestamp).
+
+This module is deliberately small and stateless: the parser takes a
+string + optional reference time and returns a ``datetime`` (or raises
+``ValueError``). Callers compose it into higher-level triggers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+
+_RELATIVE_RE = re.compile(r"^(\d+)\s*([smhdw])$", re.IGNORECASE)
+_UNIT_TO_TIMEDELTA: dict[str, timedelta] = {
+    "s": timedelta(seconds=1),
+    "m": timedelta(minutes=1),
+    "h": timedelta(hours=1),
+    "d": timedelta(days=1),
+    "w": timedelta(weeks=1),
+}
+
+# ISO 8601 timezone suffix: Z, +HH:MM, +HHMM, -HH:MM, -HHMM
+_ISO_TZ_RE = re.compile(r"(Z|[+-]\d{2}:?\d{2})$", re.IGNORECASE)
+_ISO_DATE_ONLY_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_ISO_DATETIME_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T")
+
+
+class TimeParseError(ValueError):
+    """Raised when a time string cannot be parsed."""
+
+
+def parse_relative_duration(expr: str) -> timedelta:
+    """Parse a relative duration string like ``"20m"`` into a timedelta.
+
+    Raises ``TimeParseError`` if the string is not a valid relative
+    duration. Callers that want to distinguish "this is relative" from
+    "this is ISO" should call this first and fall back to
+    ``parse_absolute_time`` on failure.
+    """
+    expr = expr.strip()
+    match = _RELATIVE_RE.match(expr)
+    if not match:
+        raise TimeParseError(f"not a relative duration: {expr!r}")
+    value = int(match.group(1))
+    unit = match.group(2).lower()
+    return value * _UNIT_TO_TIMEDELTA[unit]
+
+
+def is_relative_duration(expr: str) -> bool:
+    """Cheap check: does this string look like a relative duration?"""
+    return bool(_RELATIVE_RE.match(expr.strip()))
+
+
+def parse_absolute_time(expr: str) -> datetime:
+    """Parse an ISO 8601 timestamp or epoch-millisecond string.
+
+    Strings without a timezone are normalised to UTC. Returns a
+    timezone-aware ``datetime``.
+    """
+    raw = expr.strip()
+    if not raw:
+        raise TimeParseError("empty time string")
+
+    # Epoch milliseconds (pure digits, length > 9 to avoid confusing with year)
+    if raw.isdigit() and len(raw) >= 10:
+        try:
+            epoch_ms = int(raw)
+        except ValueError as exc:
+            raise TimeParseError(f"invalid epoch ms: {expr!r}") from exc
+        return datetime.fromtimestamp(epoch_ms / 1000.0, tz=UTC)
+
+    # Date only: "2026-06-20" → midnight UTC
+    if _ISO_DATE_ONLY_RE.match(raw):
+        raw = f"{raw}T00:00:00Z"
+    elif _ISO_DATETIME_RE.match(raw) and not _ISO_TZ_RE.search(raw):
+        # Datetime without timezone → treat as UTC
+        raw = f"{raw}Z"
+
+    # Python's fromisoformat handles Z suffix in 3.11+, but for older
+    # versions we normalise Z → +00:00.
+    iso_normalised = raw.replace("Z", "+00:00").replace("z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(iso_normalised)
+    except ValueError as exc:
+        raise TimeParseError(f"unrecognized time string: {expr!r}") from exc
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def parse_time_expr(expr: str, *, now: datetime | None = None) -> datetime:
+    """Parse a user-facing time string into an absolute datetime.
+
+    Accepts relative durations (``"20m"``) or absolute timestamps (ISO
+    8601, epoch ms). Relative durations are resolved against ``now``
+    (defaults to current UTC time).
+    """
+    reference = now or datetime.now(UTC)
+    if reference.tzinfo is None:
+        reference = reference.replace(tzinfo=UTC)
+
+    try:
+        duration = parse_relative_duration(expr)
+        return reference + duration
+    except TimeParseError:
+        pass
+
+    return parse_absolute_time(expr)

--- a/backend/packages/harness/deerflow/scheduler/triggers.py
+++ b/backend/packages/harness/deerflow/scheduler/triggers.py
@@ -1,0 +1,351 @@
+"""Trigger types for scheduled jobs.
+
+Three trigger shapes are supported, discriminated by ``type``:
+
+- ``AtTrigger``: one-shot absolute time (ISO 8601, epoch ms, or relative
+  duration like ``"20m"``). Returns ``None`` from ``compute_next`` after
+  the first run.
+- ``EveryTrigger``: fixed interval in seconds, optionally anchored to a
+  specific epoch-ms timestamp. Uses the anchor (not last_run_at) so
+  restarts don't drift the schedule.
+- ``CronTrigger``: standard 5-field cron expression with optional
+  timezone and per-job stagger window.
+
+All triggers implement the ``Trigger`` protocol and round-trip through
+``to_dict`` / ``from_dict`` for JSON persistence in
+``scheduled_jobs.trigger_data``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any, Protocol, runtime_checkable
+
+from deerflow.scheduler.cron_parser import (
+    compute_next_cron,
+    is_recurring_top_of_hour,
+    parse_cron_expr,
+)
+from deerflow.scheduler.stagger import DEFAULT_TOP_OF_HOUR_STAGGER_MS, stable_offset_ms
+from deerflow.scheduler.time_parser import is_relative_duration, parse_time_expr
+
+logger = logging.getLogger(__name__)
+
+
+# Minimum interval for EveryTrigger — prevents runaway loops.
+MIN_EVERY_SECONDS: int = 30
+
+
+@runtime_checkable
+class Trigger(Protocol):
+    """A scheduling trigger.
+
+    Implementations must be JSON-serialisable via ``to_dict`` /
+    ``from_dict``. ``compute_next`` is pure: it must not depend on
+    external state, only on ``last_run``, ``now``, and ``job_id``.
+    """
+
+    type: str
+
+    def compute_next(
+        self,
+        last_run: datetime | None,
+        *,
+        now: datetime,
+        job_id: str = "",
+    ) -> datetime | None:
+        """Return the next run time strictly after ``last_run``.
+
+        Return ``None`` when the trigger will never fire again (one-shot
+        triggers after first run).
+        """
+        ...
+
+    def to_dict(self) -> dict[str, Any]: ...
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Trigger: ...
+
+    def human_readable(self) -> str:
+        """User-facing description, e.g. ``"every day at 09:00"``."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# AtTrigger
+# ---------------------------------------------------------------------------
+
+
+class AtTrigger:
+    """One-shot trigger that fires once at a specific absolute time.
+
+    The constructor accepts either a ``datetime`` or a string (ISO 8601,
+    epoch ms, or relative duration like ``"20m"``). Relative durations
+    are resolved against the current UTC time at construction.
+
+    After firing once, ``compute_next`` returns ``None`` permanently.
+    """
+
+    type: str = "at"
+
+    def __init__(self, at: datetime | str) -> None:
+        if isinstance(at, datetime):
+            if at.tzinfo is None:
+                at = at.replace(tzinfo=UTC)
+            self.at_time: datetime = at
+            self._at_input: str = at.isoformat()
+        else:
+            self.at_time = parse_time_expr(at)
+            self._at_input = at
+
+    def compute_next(self, last_run: datetime | None, *, now: datetime, job_id: str = "") -> datetime | None:
+        # Already fired → never again
+        if last_run is not None:
+            return None
+        # In the past relative to now → still return it; the scheduler
+        # decides whether to fire immediately or skip. This keeps the
+        # trigger pure (a function of inputs).
+        return self.at_time
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": "at", "at": self._at_input}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AtTrigger:
+        return cls(at=data["at"])
+
+    def human_readable(self) -> str:
+        return f"once at {self.at_time.isoformat()}"
+
+
+# ---------------------------------------------------------------------------
+# EveryTrigger
+# ---------------------------------------------------------------------------
+
+
+class EveryTrigger:
+    """Fixed-interval trigger.
+
+    ``every_seconds`` must be >= ``MIN_EVERY_SECONDS`` (30). ``anchor_ms``
+    is an optional epoch-millisecond timestamp that anchors the schedule
+    so that scheduler restarts don't drift the cadence; when omitted,
+    the trigger falls back to ``last_run + every_seconds`` (or
+    ``now + every_seconds`` on first run).
+    """
+
+    type: str = "every"
+
+    def __init__(self, seconds: int, anchor_ms: int | None = None) -> None:
+        if seconds < MIN_EVERY_SECONDS:
+            raise ValueError(f"every interval must be >= {MIN_EVERY_SECONDS}s (got {seconds}s)")
+        self.every_seconds = int(seconds)
+        self.anchor_ms = anchor_ms
+
+    def _anchor_dt(self, fallback: datetime) -> datetime:
+        if self.anchor_ms is None:
+            return fallback
+        return datetime.fromtimestamp(self.anchor_ms / 1000.0, tz=UTC)
+
+    def compute_next(self, last_run: datetime | None, *, now: datetime, job_id: str = "") -> datetime | None:
+        # No anchor → simple "last_run + interval" cadence (or "now +
+        # interval" for first run). Drift across restarts is acceptable
+        # because the user did not pin a schedule.
+        if self.anchor_ms is None:
+            base = last_run or now
+            if base.tzinfo is None:
+                base = base.replace(tzinfo=UTC)
+            return base + timedelta(seconds=self.every_seconds)
+
+        # Anchored schedule: compute the next slot aligned to the anchor.
+        anchor = self._anchor_dt(now)
+        if now < anchor:
+            return anchor
+
+        # Use last_run if available, otherwise now. Using ``now`` (not
+        # anchor) for first-run ensures we skip already-missed historical
+        # slots rather than scheduling a run in the past.
+        base = last_run or now
+        if base.tzinfo is None:
+            base = base.replace(tzinfo=UTC)
+        elapsed = (base - anchor).total_seconds()
+        steps = int(elapsed // self.every_seconds) + 1
+        next_dt = anchor + timedelta(seconds=steps * self.every_seconds)
+        # Guarantee strictly-after last_run
+        if last_run is not None and next_dt <= last_run:
+            next_dt = last_run + timedelta(seconds=self.every_seconds)
+        return next_dt
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "kind": "every",
+            "every_seconds": self.every_seconds,
+        }
+        if self.anchor_ms is not None:
+            data["anchor_ms"] = self.anchor_ms
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EveryTrigger:
+        return cls(
+            seconds=int(data["every_seconds"]),
+            anchor_ms=int(data["anchor_ms"]) if data.get("anchor_ms") is not None else None,
+        )
+
+    def human_readable(self) -> str:
+        if self.every_seconds >= 3600 and self.every_seconds % 3600 == 0:
+            hours = self.every_seconds // 3600
+            return f"every {hours} hour{'s' if hours > 1 else ''}"
+        if self.every_seconds >= 60 and self.every_seconds % 60 == 0:
+            minutes = self.every_seconds // 60
+            return f"every {minutes} minute{'s' if minutes > 1 else ''}"
+        return f"every {self.every_seconds} seconds"
+
+
+# ---------------------------------------------------------------------------
+# CronTrigger
+# ---------------------------------------------------------------------------
+
+
+class CronTrigger:
+    """5-field cron trigger with timezone and optional stagger.
+
+    ``stagger_ms`` controls per-job jitter applied to the next-run
+    timestamp:
+
+    - ``None``: auto — apply default 5-minute stagger only to recurring
+      top-of-hour expressions (``0 * * * *``, ``0 */N * * *``)
+    - ``0``: disable staggering (run exactly on schedule)
+    - ``> 0``: explicit stagger window in milliseconds
+    """
+
+    type: str = "cron"
+
+    def __init__(
+        self,
+        expr: str,
+        tz: str = "UTC",
+        stagger_ms: int | None = None,
+    ) -> None:
+        self.expr = expr
+        self.tz = tz
+        self.stagger_ms = stagger_ms
+        self._fields = parse_cron_expr(expr)
+
+    @property
+    def fields(self) -> tuple[set[int], set[int], set[int], set[int], set[int]]:
+        return self._fields  # type: ignore[return-value]
+
+    def _resolved_stagger_ms(self) -> int:
+        if self.stagger_ms is not None:
+            return self.stagger_ms
+        if is_recurring_top_of_hour(self._fields):
+            return DEFAULT_TOP_OF_HOUR_STAGGER_MS
+        return 0
+
+    def _apply_stagger(self, base: datetime, job_id: str) -> datetime:
+        stagger_ms = self._resolved_stagger_ms()
+        if stagger_ms <= 1:
+            return base
+        offset_ms = stable_offset_ms(job_id, stagger_ms)
+        return base + timedelta(milliseconds=offset_ms)
+
+    def compute_next(
+        self,
+        last_run: datetime | None,
+        *,
+        now: datetime,
+        job_id: str = "",
+    ) -> datetime | None:
+        base_next = compute_next_cron(self._fields, last_run or now, self.tz)
+        if base_next is None:
+            return None
+        return self._apply_stagger(base_next, job_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        data: dict[str, Any] = {"kind": "cron", "expr": self.expr, "tz": self.tz}
+        if self.stagger_ms is not None:
+            data["stagger_ms"] = self.stagger_ms
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CronTrigger:
+        return cls(
+            expr=data["expr"],
+            tz=data.get("tz", "UTC"),
+            stagger_ms=int(data["stagger_ms"]) if data.get("stagger_ms") is not None else None,
+        )
+
+    def human_readable(self) -> str:
+        return f"cron {self.expr!r} ({self.tz})"
+
+
+# ---------------------------------------------------------------------------
+# Convenience: dispatch helpers
+# ---------------------------------------------------------------------------
+
+
+_TRIGGER_CLASSES: dict[str, type[Trigger]] = {
+    "at": AtTrigger,
+    "every": EveryTrigger,
+    "cron": CronTrigger,
+}
+
+
+def trigger_from_dict(data: dict[str, Any]) -> Trigger:
+    """Reconstruct a Trigger from its persisted dict form.
+
+    ``data`` must contain a ``kind`` field set to ``"at"`` / ``"every"`` /
+    ``"cron"``.
+    """
+    kind = data.get("kind")
+    if kind not in _TRIGGER_CLASSES:
+        raise ValueError(f"unknown trigger kind: {kind!r}")
+    cls = _TRIGGER_CLASSES[kind]
+    return cls.from_dict(data)  # type: ignore[attr-defined]
+
+
+def trigger_from_persisted(trigger_type: str, trigger_data: dict[str, Any]) -> Trigger:
+    """Reconstruct from the (trigger_type, trigger_data) pair stored in
+    ``scheduled_jobs``. The ``kind`` field inside ``trigger_data`` is
+    authoritative; ``trigger_type`` is the column value used for indexing.
+    """
+    # Defensive: some writers may store trigger_data without an explicit
+    # ``kind``. Fall back to the trigger_type column.
+    data = dict(trigger_data)
+    if "kind" not in data:
+        data["kind"] = trigger_type
+    return trigger_from_dict(data)
+
+
+def parse_user_when(when: str, *, tz: str = "UTC") -> Trigger:
+    """Parse a free-form user string into the right Trigger subclass.
+
+    Heuristics:
+
+    - ``"every <duration>"`` (e.g. ``"every 5m"``, ``"every 1h"``) → EveryTrigger
+    - 5 whitespace-separated tokens → CronTrigger
+    - Relative duration alone (``"20m"``, ``"1h"``) → AtTrigger
+    - ISO 8601 / epoch ms → AtTrigger
+    """
+    raw = when.strip()
+    if not raw:
+        raise ValueError("empty schedule expression")
+
+    lower = raw.lower()
+    if lower.startswith("every "):
+        rest = raw[len("every ") :].strip()
+        if not is_relative_duration(rest):
+            raise ValueError(f"invalid 'every' interval: {rest!r}")
+        # Reuse the relative-duration parser to extract seconds.
+        from deerflow.scheduler.time_parser import parse_relative_duration
+
+        duration = parse_relative_duration(rest)
+        seconds = int(duration.total_seconds())
+        return EveryTrigger(seconds=seconds)
+
+    if len(raw.split()) == 5:
+        return CronTrigger(expr=raw, tz=tz)
+
+    # Default: treat as a one-shot AtTrigger (relative or absolute)
+    return AtTrigger(at=raw)

--- a/backend/packages/harness/deerflow/tools/builtins/scheduled_task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/scheduled_task_tool.py
@@ -1,0 +1,509 @@
+"""Agent tool for managing scheduled tasks from chat.
+
+The scheduler itself lives in the Gateway process. This tool is only the
+model-facing control surface for the current chat user: create, list, and
+delete persisted scheduled jobs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import UTC, datetime, tzinfo
+from pathlib import Path
+from typing import Any, Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langgraph.types import Command
+
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+from deerflow.runtime.user_context import resolve_runtime_user_id
+from deerflow.scheduler.triggers import (
+    AtTrigger,
+    CronTrigger,
+    Trigger,
+    parse_user_when,
+    trigger_from_persisted,
+)
+from deerflow.tools.types import Runtime
+from deerflow.utils.time import coerce_datetime
+
+logger = logging.getLogger(__name__)
+
+MAX_ENABLED_JOBS_PER_USER: int = 20
+MIN_CRON_INTERVAL_SECONDS: int = 1800
+DEFAULT_TIMEZONE_ENV: str = "DEERFLOW_TIMEZONE"
+DEFAULT_LIST_LIMIT: int = 20
+MAX_LIST_LIMIT: int = 50
+
+_WINDOWS_TIMEZONE_TO_IANA: dict[str, str] = {
+    "AUS Eastern Standard Time": "Australia/Sydney",
+    "Atlantic Standard Time": "America/Halifax",
+    "Central Standard Time": "America/Chicago",
+    "China Standard Time": "Asia/Shanghai",
+    "Eastern Standard Time": "America/New_York",
+    "GMT Standard Time": "Europe/London",
+    "Korea Standard Time": "Asia/Seoul",
+    "Mountain Standard Time": "America/Denver",
+    "Pacific Standard Time": "America/Los_Angeles",
+    "Romance Standard Time": "Europe/Paris",
+    "Singapore Standard Time": "Asia/Singapore",
+    "Taipei Standard Time": "Asia/Taipei",
+    "Tokyo Standard Time": "Asia/Tokyo",
+    "US Mountain Standard Time": "America/Phoenix",
+    "UTC": "UTC",
+    "W. Europe Standard Time": "Europe/Berlin",
+    "\u4e2d\u56fd\u6807\u51c6\u65f6\u95f4": "Asia/Shanghai",
+    "\u534f\u8c03\u4e16\u754c\u65f6": "UTC",
+}
+
+
+@tool("scheduled_task", parse_docstring=True)
+async def scheduled_task(
+    action: Literal["create", "list", "delete"],
+    runtime: Runtime,
+    name: str | None = None,
+    when: str | None = None,
+    description: str | None = None,
+    job_id: str | None = None,
+    agent_name: str | None = None,
+    thread_strategy: Literal["new", "fixed"] = "new",
+    delete_after_run: bool | None = None,
+    timezone: str | None = None,
+    include_disabled: bool = False,
+    limit: int = DEFAULT_LIST_LIMIT,
+) -> Command:
+    """Create, list, or delete scheduled tasks for the current user.
+
+    Use this tool when the user wants to manage automatic scheduled work.
+    For deletion, list tasks first unless the user already provided the
+    exact task ID. Do not guess IDs from memory.
+
+    Args:
+        action: Operation to perform. Use "create" to create a task,
+            "list" to show existing tasks, or "delete" to delete by ID.
+        name: Short human-readable task name for action="create".
+        when: Schedule expression for action="create". Accepts relative
+            durations such as "20m", recurring intervals such as "every 1h",
+            or a 5-field cron expression such as "0 9 * * *".
+        description: Prompt the Agent should run for action="create".
+        job_id: Exact scheduled task ID for action="delete".
+        agent_name: Optional custom agent to run for action="create".
+        thread_strategy: Use "new" to create a fresh thread per run, or
+            "fixed" to reuse one thread across runs.
+        delete_after_run: Override lifecycle for action="create". When
+            omitted, one-shot tasks delete after running and recurring tasks do not.
+        timezone: IANA timezone for wall-clock schedules and displayed times,
+            for example "Asia/Shanghai". Defaults to the backend runtime timezone.
+        include_disabled: Include disabled tasks when action="list".
+        limit: Maximum number of tasks to show when action="list".
+
+    Returns:
+        Command with a ToolMessage describing the result.
+    """
+    tool_call_id = runtime.tool_call_id
+    user_id = resolve_runtime_user_id(runtime)
+    display_tz = timezone or _default_timezone()
+
+    sf = get_session_factory()
+    if sf is None:
+        return _err(tool_call_id, "persistence engine not initialised")
+    repo = ScheduledJobRepository(sf)
+
+    if action == "create":
+        return await _create_task(
+            repo,
+            runtime=runtime,
+            tool_call_id=tool_call_id,
+            user_id=user_id,
+            name=name,
+            when=when,
+            description=description,
+            agent_name=agent_name,
+            thread_strategy=thread_strategy,
+            delete_after_run=delete_after_run,
+            display_tz=display_tz,
+        )
+    if action == "list":
+        return await _list_tasks(
+            repo,
+            tool_call_id=tool_call_id,
+            user_id=user_id,
+            include_disabled=include_disabled,
+            limit=limit,
+            display_tz=display_tz,
+        )
+    if action == "delete":
+        return await _delete_task(
+            repo,
+            tool_call_id=tool_call_id,
+            user_id=user_id,
+            job_id=job_id,
+            display_tz=display_tz,
+        )
+    return _err(tool_call_id, f"unsupported action: {action!r}")
+
+
+async def _create_task(
+    repo: ScheduledJobRepository,
+    *,
+    runtime: Runtime,
+    tool_call_id: str,
+    user_id: str,
+    name: str | None,
+    when: str | None,
+    description: str | None,
+    agent_name: str | None,
+    thread_strategy: Literal["new", "fixed"],
+    delete_after_run: bool | None,
+    display_tz: str,
+) -> Command:
+    clean_name = (name or "").strip()
+    clean_when = (when or "").strip()
+    clean_description = (description or "").strip()
+
+    if not clean_name:
+        return _err(tool_call_id, "name is required for action='create'")
+    if len(clean_name) > 200:
+        return _err(tool_call_id, "name exceeds 200 characters")
+    if not clean_when:
+        return _err(tool_call_id, "when is required for action='create'")
+    if not clean_description:
+        return _err(tool_call_id, "description is required for action='create'")
+
+    try:
+        trigger: Trigger = parse_user_when(clean_when, tz=display_tz)
+    except ValueError as exc:
+        return _err(tool_call_id, f"invalid schedule {clean_when!r}: {exc}")
+
+    if isinstance(trigger, CronTrigger):
+        gap = _measure_cron_interval(trigger)
+        if gap is not None and gap < MIN_CRON_INTERVAL_SECONDS:
+            return _err(
+                tool_call_id,
+                f"cron cadence too tight: {int(gap)}s between runs; minimum is {MIN_CRON_INTERVAL_SECONDS}s (30 minutes)",
+            )
+
+    try:
+        enabled_count = await repo.count_enabled_jobs(user_id=user_id)
+    except Exception as exc:
+        logger.exception("scheduled_task quota check failed")
+        return _err(tool_call_id, f"quota check failed: {exc}")
+
+    if enabled_count >= MAX_ENABLED_JOBS_PER_USER:
+        return _err(
+            tool_call_id,
+            f"quota exhausted: {enabled_count}/{MAX_ENABLED_JOBS_PER_USER} enabled jobs; delete an existing task before creating a new one",
+        )
+
+    now = datetime.now(UTC)
+    job_id = repo.new_job_id()
+    next_run_at = trigger.compute_next(None, now=now, job_id=job_id)
+    if next_run_at is None:
+        return _err(tool_call_id, "trigger has no upcoming run time")
+
+    if delete_after_run is None:
+        delete_after_run = isinstance(trigger, AtTrigger)
+
+    source_channel = (runtime.context or {}).get("source_channel", "web")
+    try:
+        job = await repo.create_job(
+            name=clean_name,
+            description=clean_description,
+            trigger_type=trigger.type,
+            trigger_data=trigger.to_dict(),
+            next_run_at=next_run_at,
+            thread_strategy=thread_strategy,
+            agent_name=agent_name,
+            delete_after_run=delete_after_run,
+            source_channel=source_channel,
+            job_id=job_id,
+            user_id=user_id,
+        )
+    except Exception as exc:
+        logger.exception("scheduled_task create failed")
+        return _err(tool_call_id, f"failed to create task: {exc}")
+
+    logger.info(
+        "scheduled_task created via chat: job=%s user=%s source=%s trigger=%s",
+        job["id"],
+        user_id,
+        source_channel,
+        trigger.type,
+    )
+
+    content = (
+        "Scheduled task created.\n"
+        f"Name: {job['name']}\n"
+        f"ID: {job['id']}\n"
+        f"Timezone: {display_tz}\n"
+        f"Schedule: {_human_schedule(trigger, next_run_at, display_tz)}\n"
+        f"Next run (local): {_format_display_datetime(next_run_at, display_tz)}\n"
+        f"Next run (UTC): {next_run_at.astimezone(UTC).isoformat()}\n"
+        f"Deliver to: {_human_source(source_channel)}"
+    )
+    return _ok(tool_call_id, content)
+
+
+async def _list_tasks(
+    repo: ScheduledJobRepository,
+    *,
+    tool_call_id: str,
+    user_id: str,
+    include_disabled: bool,
+    limit: int,
+    display_tz: str,
+) -> Command:
+    safe_limit = min(max(int(limit or DEFAULT_LIST_LIMIT), 1), MAX_LIST_LIMIT)
+    try:
+        rows = await repo.list_jobs(
+            include_disabled=include_disabled,
+            limit=safe_limit,
+            user_id=user_id,
+        )
+    except Exception as exc:
+        logger.exception("scheduled_task list failed")
+        return _err(tool_call_id, f"failed to list tasks: {exc}")
+
+    if not rows:
+        qualifier = "scheduled tasks" if include_disabled else "enabled scheduled tasks"
+        return _ok(tool_call_id, f"No {qualifier} found.")
+
+    lines = [
+        f"Scheduled tasks ({len(rows)} shown):",
+    ]
+    for row in rows:
+        lines.append(_format_job_summary(row, display_tz=display_tz))
+    return _ok(tool_call_id, "\n\n".join(lines))
+
+
+async def _delete_task(
+    repo: ScheduledJobRepository,
+    *,
+    tool_call_id: str,
+    user_id: str,
+    job_id: str | None,
+    display_tz: str,
+) -> Command:
+    clean_job_id = (job_id or "").strip()
+    if not clean_job_id:
+        return _err(tool_call_id, "job_id is required for action='delete'; call action='list' first if needed")
+
+    try:
+        existing = await repo.get_job(clean_job_id, user_id=user_id)
+    except Exception as exc:
+        logger.exception("scheduled_task get before delete failed")
+        return _err(tool_call_id, f"failed to load task before delete: {exc}")
+
+    if existing is None:
+        return _err(tool_call_id, f"scheduled task not found: {clean_job_id}")
+
+    try:
+        deleted = await repo.delete_job(clean_job_id, user_id=user_id)
+    except Exception as exc:
+        logger.exception("scheduled_task delete failed")
+        return _err(tool_call_id, f"failed to delete task: {exc}")
+
+    if not deleted:
+        return _err(tool_call_id, f"scheduled task not found: {clean_job_id}")
+
+    return _ok(
+        tool_call_id,
+        f"Scheduled task deleted.\nName: {existing['name']}\nID: {existing['id']}\nPrevious next run: {_format_optional_datetime(existing.get('next_run_at'), display_tz)}",
+    )
+
+
+def _ok(tool_call_id: str, content: str) -> Command:
+    return Command(update={"messages": [ToolMessage(content=content, tool_call_id=tool_call_id)]})
+
+
+def _err(tool_call_id: str, message: str) -> Command:
+    return Command(update={"messages": [ToolMessage(content=f"Error: {message}", tool_call_id=tool_call_id, status="error")]})
+
+
+def _default_timezone() -> str:
+    """Return the default user-facing timezone name."""
+    return _runtime_timezone() or _configured_timezone() or "UTC"
+
+
+def _configured_timezone() -> str | None:
+    for value in (os.getenv(DEFAULT_TIMEZONE_ENV), os.getenv("TZ")):
+        resolved = _valid_timezone_name(value)
+        if resolved is not None:
+            return resolved
+    return None
+
+
+def _runtime_timezone() -> str | None:
+    local_dt = datetime.now().astimezone()
+    for value in _runtime_timezone_candidates(local_dt):
+        resolved = _valid_timezone_name(value) or _WINDOWS_TIMEZONE_TO_IANA.get(value)
+        if resolved is not None and _valid_timezone_name(resolved) is not None:
+            return resolved
+    return None
+
+
+def _runtime_timezone_candidates(local_dt: datetime):
+    tzinfo_obj = local_dt.tzinfo
+    key = getattr(tzinfo_obj, "key", None)
+    if key:
+        yield key
+
+    try:
+        tzname = local_dt.tzname()
+    except Exception:
+        tzname = None
+    if tzname:
+        yield tzname
+
+    if tzinfo_obj is not None:
+        yield str(tzinfo_obj)
+
+    if os.name == "nt":
+        yield from _windows_registry_timezone_candidates()
+    yield from _linux_localtime_candidates()
+
+
+def _windows_registry_timezone_candidates():
+    try:
+        import winreg
+    except Exception:
+        return
+
+    try:
+        with winreg.OpenKey(
+            winreg.HKEY_LOCAL_MACHINE,
+            r"SYSTEM\CurrentControlSet\Control\TimeZoneInformation",
+        ) as key:
+            for value_name in ("TimeZoneKeyName", "StandardName"):
+                try:
+                    value, _ = winreg.QueryValueEx(key, value_name)
+                except OSError:
+                    continue
+                if value:
+                    yield str(value)
+    except OSError:
+        return
+
+
+def _linux_localtime_candidates():
+    timezone_file = Path("/etc/timezone")
+    try:
+        value = timezone_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        value = ""
+    if value:
+        yield value
+
+    localtime_path = Path("/etc/localtime")
+    try:
+        resolved = str(localtime_path.resolve())
+    except OSError:
+        return
+    marker = "/zoneinfo/"
+    if marker in resolved:
+        yield resolved.split(marker, 1)[1]
+
+
+def _valid_timezone_name(value: str | None) -> str | None:
+    if not value:
+        return None
+    if value.upper() == "UTC":
+        return "UTC"
+    try:
+        ZoneInfo(value)
+    except ZoneInfoNotFoundError:
+        return None
+    return value
+
+
+def _resolve_display_timezone(tz_name: str | None) -> tzinfo:
+    if not tz_name or tz_name.upper() == "UTC":
+        return UTC
+    try:
+        return ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError:
+        logger.warning("unknown display timezone %r, falling back to UTC", tz_name)
+        return UTC
+
+
+def _format_offset(dt: datetime) -> str:
+    offset = dt.strftime("%z")
+    if len(offset) == 5:
+        return f"{offset[:3]}:{offset[3:]}"
+    return offset or "+00:00"
+
+
+def _format_display_datetime(dt: datetime, tz_name: str | None) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    local_dt = dt.astimezone(_resolve_display_timezone(tz_name))
+    tz_label = tz_name or "UTC"
+    return f"{local_dt.strftime('%Y-%m-%d %H:%M:%S')} {_format_offset(local_dt)} ({tz_label})"
+
+
+def _format_optional_datetime(value: object, tz_name: str | None) -> str:
+    dt = coerce_datetime(value)
+    if dt is None:
+        return "none"
+    return _format_display_datetime(dt, tz_name)
+
+
+def _measure_cron_interval(trigger: CronTrigger) -> float | None:
+    """Sample the next two runs to estimate cadence in seconds."""
+    now = datetime.now(UTC)
+    n1 = trigger.compute_next(None, now=now, job_id="quota-check")
+    if n1 is None:
+        return None
+    n2 = trigger.compute_next(n1, now=n1, job_id="quota-check")
+    if n2 is None:
+        return None
+    return (n2 - n1).total_seconds()
+
+
+def _human_schedule(trigger: Trigger, next_run: datetime, tz_name: str | None) -> str:
+    if isinstance(trigger, AtTrigger):
+        return f"once at {_format_display_datetime(trigger.at_time, tz_name)}"
+    return trigger.human_readable()
+
+
+def _human_source(source_channel: str) -> str:
+    if source_channel == "web":
+        return "web notification"
+    if source_channel.startswith("im:"):
+        parts = source_channel.split(":", 3)
+        if len(parts) >= 4:
+            platform = parts[1]
+            conv = parts[2]
+            return f"{platform} {conv}"
+        if len(parts) == 3:
+            return parts[1]
+    return source_channel
+
+
+def _format_job_summary(row: dict[str, Any], *, display_tz: str) -> str:
+    trigger = _trigger_from_row(row)
+    next_run = coerce_datetime(row.get("next_run_at"))
+    status = "enabled" if row.get("enabled") else "disabled"
+    schedule = _human_schedule(trigger, next_run or datetime.now(UTC), display_tz) if trigger else str(row.get("trigger_data") or row.get("trigger_type") or "unknown")
+
+    return (
+        f"- {row.get('name')} [{status}]\n"
+        f"  ID: {row.get('id')}\n"
+        f"  Schedule: {schedule}\n"
+        f"  Next run: {_format_optional_datetime(row.get('next_run_at'), display_tz)}\n"
+        f"  Last status: {row.get('last_status') or 'none'}\n"
+        f"  Deliver to: {_human_source(str(row.get('source_channel') or 'web'))}"
+    )
+
+
+def _trigger_from_row(row: dict[str, Any]) -> Trigger | None:
+    try:
+        data = row.get("trigger_data") if isinstance(row.get("trigger_data"), dict) else {}
+        return trigger_from_persisted(str(row.get("trigger_type") or ""), data)
+    except Exception:
+        logger.warning("failed to reconstruct scheduled task trigger for job %s", row.get("id"), exc_info=True)
+        return None

--- a/backend/packages/harness/deerflow/utils/time.py
+++ b/backend/packages/harness/deerflow/utils/time.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import re
 from datetime import UTC, datetime
 
-__all__ = ["coerce_iso", "now_iso"]
+__all__ = ["coerce_datetime", "coerce_iso", "now_iso"]
 
 _UNIX_TIMESTAMP_PATTERN = re.compile(r"^\d{10}(?:\.\d+)?$")
 """Matches the unix-timestamp string shape historically written by
@@ -73,3 +73,24 @@ def coerce_iso(value: object) -> str:
                 return value
         return value
     return str(value)
+
+
+def coerce_datetime(value: object) -> datetime | None:
+    """Best-effort coerce a stored timestamp to a timezone-aware UTC datetime.
+
+    Companion to :func:`coerce_iso`: same input handling (``datetime``,
+    ISO 8601 strings, legacy unix-timestamp strings, ``None`` / empty),
+    but returns a :class:`~datetime.datetime` (or ``None``) instead of a
+    string. Aware values are normalised to UTC; tz-naive values are
+    assumed UTC. Unparseable inputs return ``None``.
+    """
+    iso = coerce_iso(value)
+    if not iso:
+        return None
+    try:
+        parsed = datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -2775,6 +2775,31 @@ class TestResolveRunParamsUserId:
 
         assert run_context["user_id"] == "123456"
         assert run_context["channel_user_id"] == "123456"
+        assert run_context["source_channel"] == "im:telegram:chat:c"
+
+    def test_feishu_source_channel_reaches_run_context(self, monkeypatch):
+        manager = self._manager()
+        monkeypatch.delenv("DEER_FLOW_AUTH_DISABLED", raising=False)
+        msg = InboundMessage(channel_name="feishu", chat_id="oc_123", user_id="ou_456", text="hi")
+
+        _, _, run_context = manager._resolve_run_params(msg, "thread-1")
+
+        assert run_context["source_channel"] == "im:feishu:chat:oc_123"
+
+    def test_dingtalk_group_source_channel_reaches_run_context(self, monkeypatch):
+        manager = self._manager()
+        monkeypatch.delenv("DEER_FLOW_AUTH_DISABLED", raising=False)
+        msg = InboundMessage(
+            channel_name="dingtalk",
+            chat_id="cid_group",
+            user_id="staff_1",
+            text="hi",
+            metadata={"conversation_type": "2"},
+        )
+
+        _, _, run_context = manager._resolve_run_params(msg, "thread-1")
+
+        assert run_context["source_channel"] == "im:dingtalk:group:cid_group"
 
     @pytest.mark.parametrize(
         "kwargs",

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -582,6 +582,17 @@ def test_merge_run_context_overrides_propagates_user_id():
     assert config["context"]["user_id"] == "channel-user-7"
 
 
+def test_merge_run_context_overrides_propagates_source_channel():
+    """IM-created scheduled tasks need ``source_channel`` on ToolRuntime.context."""
+    from app.gateway.services import build_run_config, merge_run_context_overrides
+
+    config = build_run_config("thread-1", None, None)
+    merge_run_context_overrides(config, {"source_channel": "im:feishu:chat:oc_123"})
+
+    assert config["context"]["source_channel"] == "im:feishu:chat:oc_123"
+    assert config["configurable"]["source_channel"] == "im:feishu:chat:oc_123"
+
+
 def test_merge_run_context_overrides_does_not_clobber_existing_user_id():
     """``merge_run_context_overrides`` must not override an already-stamped
     authenticated ``context.user_id`` with the client-supplied value.

--- a/backend/tests/test_persistence_timezone.py
+++ b/backend/tests/test_persistence_timezone.py
@@ -11,6 +11,8 @@ threads by the local UTC offset.
 """
 
 import re
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -102,5 +104,33 @@ async def test_run_event_store_emits_tz_aware_timestamps(tmp_path):
         events = await store.list_events("t-tz", "r-tz", user_id=None)
         assert events, "expected at least one event"
         _assert_tz_aware(events[0]["created_at"], context="run_event.list.created_at")
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_scheduled_job_repository_stores_next_run_in_utc(tmp_path):
+    from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+
+    repo = ScheduledJobRepository(await _init_sqlite(tmp_path))
+    try:
+        next_run_shanghai = datetime(2026, 6, 21, 20, 6, tzinfo=ZoneInfo("Asia/Shanghai"))
+        row = await repo.create_job(
+            name="sleep reminder",
+            description="remind me to sleep",
+            trigger_type="cron",
+            trigger_data={"kind": "cron", "expr": "6 20 * * *", "tz": "Asia/Shanghai"},
+            next_run_at=next_run_shanghai,
+            user_id="u1",
+        )
+
+        assert row["next_run_at"].startswith("2026-06-21T12:06:00")
+        assert row["next_run_at"].endswith("+00:00")
+
+        not_due = await repo.list_due_jobs(now=datetime(2026, 6, 21, 12, 5, 59, tzinfo=UTC))
+        assert not_due == []
+
+        due = await repo.list_due_jobs(now=datetime(2026, 6, 21, 12, 6, tzinfo=UTC))
+        assert [job["id"] for job in due] == [row["id"]]
     finally:
         await _cleanup()

--- a/backend/tests/test_scheduled_jobs_executor.py
+++ b/backend/tests/test_scheduled_jobs_executor.py
@@ -1,0 +1,233 @@
+"""Unit tests for ``AgentJobExecutor`` thread resolution.
+
+Focus: the ``fixed`` thread-strategy pin behaviour. A fixed-strategy job
+with no pinned ``fixed_thread_id`` must generate a fresh id on its first
+run and write it back so every later run reuses the same thread (and thus
+accumulates conversation history). See ``app/scheduled_jobs/executor.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.scheduled_jobs.executor import AgentJobExecutor
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeJobsRepo:
+    """Records ``update_job_spec`` calls and remembers the pinned id."""
+
+    def __init__(self) -> None:
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+        self.fixed_thread_id: str | None = None
+
+    async def update_job_spec(
+        self,
+        job_id: str,
+        *,
+        fixed_thread_id: str | None = None,
+        user_id: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any] | None:
+        self.updates.append((job_id, {"fixed_thread_id": fixed_thread_id, "user_id": user_id, **kwargs}))
+        if fixed_thread_id is not None:
+            self.fixed_thread_id = fixed_thread_id
+        return {"id": job_id, "fixed_thread_id": self.fixed_thread_id}
+
+
+class _FakeRunsRepo:
+    def __init__(self) -> None:
+        self.created: dict[str, Any] | None = None
+        self.terminal: dict[str, Any] | None = None
+
+    async def create_run(self, **kwargs: Any) -> dict[str, Any]:
+        self.created = kwargs
+        return {"id": "run-1"}
+
+    async def mark_terminal(self, run_id: str, **kwargs: Any) -> dict[str, Any] | None:
+        self.terminal = {"run_id": run_id, **kwargs}
+        return None
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def chat(self, message: str, *, thread_id: str | None = None, **kwargs: Any) -> str:
+        self.calls.append((message, thread_id))
+        return "ok-result"
+
+
+class _NoopDelivery:
+    async def deliver(self, **kwargs: Any) -> None:
+        pass
+
+
+def _build_executor(
+    *,
+    jobs_repo: _FakeJobsRepo | None = None,
+    runs_repo: _FakeRunsRepo | None = None,
+    client: _FakeClient | None = None,
+) -> tuple[AgentJobExecutor, _FakeJobsRepo, _FakeRunsRepo, _FakeClient]:
+    jobs_repo = jobs_repo or _FakeJobsRepo()
+    runs_repo = runs_repo or _FakeRunsRepo()
+    client = client or _FakeClient()
+    executor = AgentJobExecutor(
+        jobs_repo,
+        runs_repo,
+        delivery=_NoopDelivery(),
+        client_factory=lambda **_: client,
+    )
+    return executor, jobs_repo, runs_repo, client
+
+
+# ---------------------------------------------------------------------------
+# _resolve_thread_id — direct unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fixed_without_id_pins_new_thread_id() -> None:
+    """First run of a fixed job with no pinned id generates a fresh id and
+    writes it back so future runs reuse it."""
+    executor, jobs_repo, _, _ = _build_executor()
+
+    thread_id = await executor._resolve_thread_id("job-1", "fixed", None)
+
+    assert thread_id  # a uuid was generated
+    assert jobs_repo.updates == [("job-1", {"fixed_thread_id": thread_id, "user_id": None})]
+    assert jobs_repo.fixed_thread_id == thread_id
+
+
+@pytest.mark.asyncio
+async def test_fixed_with_pinned_id_reuses_without_write() -> None:
+    """A fixed job that already has a pinned id reuses it and does NOT
+    write back (no spurious updates)."""
+    executor, jobs_repo, _, _ = _build_executor()
+
+    thread_id = await executor._resolve_thread_id("job-1", "fixed", "existing-thread")
+
+    assert thread_id == "existing-thread"
+    assert jobs_repo.updates == []
+    assert jobs_repo.fixed_thread_id is None
+
+
+@pytest.mark.asyncio
+async def test_new_strategy_does_not_pin() -> None:
+    """``new`` strategy never writes back — each run is intentionally
+    stateless."""
+    executor, jobs_repo, _, _ = _build_executor()
+
+    thread_id = await executor._resolve_thread_id("job-1", "new", None)
+
+    assert thread_id  # fresh uuid
+    assert jobs_repo.updates == []
+
+
+@pytest.mark.asyncio
+async def test_pinned_thread_survives_across_runs() -> None:
+    """End-to-end intent: the first run pins a thread id, and a
+    subsequent run (job reloaded from DB carrying the pin) reuses it."""
+    executor, jobs_repo, _, _ = _build_executor()
+
+    first = await executor._resolve_thread_id("job-1", "fixed", None)
+    # Simulate the job row being reloaded from the DB carrying the pin.
+    second = await executor._resolve_thread_id("job-1", "fixed", jobs_repo.fixed_thread_id)
+
+    assert second == first
+    assert len(jobs_repo.updates) == 1  # only the first run wrote back
+
+
+# ---------------------------------------------------------------------------
+# execute() — integration of the pin into the full run path
+# ---------------------------------------------------------------------------
+
+
+def _fixed_job(*, fixed_thread_id: str | None) -> dict[str, Any]:
+    return {
+        "id": "job-1",
+        "user_id": "alice",
+        "description": "Summarise my inbox.",
+        "agent_name": None,
+        "thread_strategy": "fixed",
+        "fixed_thread_id": fixed_thread_id,
+    }
+
+
+@pytest.mark.asyncio
+async def test_execute_fixed_job_pins_and_uses_thread_id() -> None:
+    """The pinned thread id flows to both the run record and the agent
+    ``chat`` call."""
+    executor, jobs_repo, runs_repo, client = _build_executor()
+
+    result = await executor.execute(_fixed_job(fixed_thread_id=None))
+
+    assert result.status == "ok"
+    assert result.thread_id == jobs_repo.fixed_thread_id
+    assert runs_repo.created["thread_id"] == jobs_repo.fixed_thread_id
+    assert client.calls == [("Summarise my inbox.", jobs_repo.fixed_thread_id)]
+    assert runs_repo.terminal is not None and runs_repo.terminal["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_execute_fixed_job_with_pinned_id_reuses() -> None:
+    """A fixed job that already carries a pinned id reuses it and does
+    not write back again."""
+    executor, jobs_repo, _, client = _build_executor()
+
+    await executor.execute(_fixed_job(fixed_thread_id="pre-pinned"))
+
+    assert jobs_repo.updates == []
+    assert client.calls[0][1] == "pre-pinned"
+
+
+# ---------------------------------------------------------------------------
+# _default_client_factory — subagent default
+# ---------------------------------------------------------------------------
+
+
+def test_default_client_factory_enables_subagent_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scheduled jobs must run with subagent delegation enabled so heavy
+    research/report tasks can be offloaded via the ``task`` tool without
+    polluting the lead agent's context (see ``executor.py`` docstring)."""
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    import deerflow.client as client_mod
+
+    monkeypatch.setattr(client_mod, "DeerFlowClient", _FakeClient)
+
+    from app.scheduled_jobs.executor import _default_client_factory
+
+    _default_client_factory(agent_name="analyst")
+
+    assert captured.get("subagent_enabled") is True
+    assert captured.get("agent_name") == "analyst"
+
+
+def test_default_client_factory_respects_explicit_subagent_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An explicit ``subagent_enabled`` in kwargs wins over the default —
+    escape hatch for future per-job control."""
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    import deerflow.client as client_mod
+
+    monkeypatch.setattr(client_mod, "DeerFlowClient", _FakeClient)
+
+    from app.scheduled_jobs.executor import _default_client_factory
+
+    _default_client_factory(agent_name=None, subagent_enabled=False)
+
+    assert captured.get("subagent_enabled") is False

--- a/backend/tests/test_scheduled_jobs_router.py
+++ b/backend/tests/test_scheduled_jobs_router.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.gateway.routers import scheduled_jobs as router_mod
+
+
+class _RepoWithJob:
+    def __init__(self, job: dict[str, Any]) -> None:
+        self.job = job
+
+    async def get_job(self, job_id: str) -> dict[str, Any] | None:
+        return self.job
+
+
+def _request(user_id: str = "u1") -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(user=SimpleNamespace(id=user_id)))
+
+
+@pytest.mark.anyio
+async def test_run_job_now_due_parses_offset_datetimes(monkeypatch: pytest.MonkeyPatch) -> None:
+    offset_tz = timezone(timedelta(hours=14))
+    due_instant = (datetime.now(UTC) - timedelta(minutes=1)).astimezone(offset_tz)
+    repo = _RepoWithJob({"id": "job-1", "next_run_at": due_instant.isoformat()})
+
+    monkeypatch.setattr(router_mod, "_get_repos", lambda: (repo, None))
+
+    response = await router_mod.run_job_now(
+        _request(),
+        "job-1",
+        router_mod.RunNowRequest(mode="due"),
+    )
+
+    assert response.status == "queued"
+    assert response.message == "job already due"

--- a/backend/tests/test_scheduled_task_tool.py
+++ b/backend/tests/test_scheduled_task_tool.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from deerflow.scheduler.triggers import CronTrigger
+from deerflow.tools.builtins.scheduled_task_tool import scheduled_task
+
+
+async def _init_sqlite(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'scheduled-task-tool.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    return get_session_factory()
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+def _runtime(user_id: str, *, source_channel: str = "web"):
+    return SimpleNamespace(
+        context={"user_id": user_id, "source_channel": source_channel},
+        tool_call_id=f"call-{user_id}",
+    )
+
+
+def _tool_content(command) -> str:
+    return command.update["messages"][0].content
+
+
+@pytest.mark.anyio
+async def test_scheduled_task_tool_create_list_delete(tmp_path):
+    await _init_sqlite(tmp_path)
+    runtime = _runtime("alice", source_channel="im:feishu:chat:oc_123")
+    try:
+        created = await scheduled_task.coroutine(
+            action="create",
+            runtime=runtime,
+            name="sleep reminder",
+            when="1h",
+            description="Remind me to sleep.",
+            timezone="Asia/Shanghai",
+        )
+
+        created_text = _tool_content(created)
+        assert "Scheduled task created." in created_text
+        assert "sleep reminder" in created_text
+        assert "feishu chat" in created_text
+
+        listed = await scheduled_task.coroutine(
+            action="list",
+            runtime=runtime,
+            timezone="Asia/Shanghai",
+        )
+        listed_text = _tool_content(listed)
+        assert "Scheduled tasks (1 shown):" in listed_text
+        assert "sleep reminder" in listed_text
+
+        job_id = next(line.split(":", 1)[1].strip() for line in listed_text.splitlines() if line.strip().startswith("ID:"))
+        deleted = await scheduled_task.coroutine(
+            action="delete",
+            runtime=runtime,
+            job_id=job_id,
+            timezone="Asia/Shanghai",
+        )
+        assert "Scheduled task deleted." in _tool_content(deleted)
+
+        listed_after_delete = await scheduled_task.coroutine(action="list", runtime=runtime)
+        assert "No enabled scheduled tasks found." in _tool_content(listed_after_delete)
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_scheduled_task_tool_is_user_scoped(tmp_path):
+    await _init_sqlite(tmp_path)
+    alice = _runtime("alice")
+    bob = _runtime("bob")
+    try:
+        await scheduled_task.coroutine(
+            action="create",
+            runtime=alice,
+            name="alice task",
+            when="1h",
+            description="Alice only.",
+        )
+        await scheduled_task.coroutine(
+            action="create",
+            runtime=bob,
+            name="bob task",
+            when="1h",
+            description="Bob only.",
+        )
+
+        alice_list = _tool_content(await scheduled_task.coroutine(action="list", runtime=alice))
+        bob_list = _tool_content(await scheduled_task.coroutine(action="list", runtime=bob))
+        assert "alice task" in alice_list
+        assert "bob task" not in alice_list
+        assert "bob task" in bob_list
+        assert "alice task" not in bob_list
+
+        bob_job_id = next(line.split(":", 1)[1].strip() for line in bob_list.splitlines() if line.strip().startswith("ID:"))
+        cross_delete = await scheduled_task.coroutine(action="delete", runtime=alice, job_id=bob_job_id)
+        assert "Error: scheduled task not found" in _tool_content(cross_delete)
+
+        bob_list_after = _tool_content(await scheduled_task.coroutine(action="list", runtime=bob))
+        assert "bob task" in bob_list_after
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_scheduled_task_tool_cron_initial_stagger_uses_job_id(tmp_path, monkeypatch):
+    from deerflow.persistence.engine import get_session_factory
+    from deerflow.persistence.scheduled_jobs import ScheduledJobRepository
+    from deerflow.tools.builtins import scheduled_task_tool as tool_mod
+
+    fixed_now = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
+    await _init_sqlite(tmp_path)
+    monkeypatch.setattr(tool_mod, "datetime", FixedDateTime)
+    runtime = _runtime("alice")
+    try:
+        created = await scheduled_task.coroutine(
+            action="create",
+            runtime=runtime,
+            name="hourly report",
+            when="0 * * * *",
+            description="Send an hourly report.",
+            timezone="UTC",
+        )
+        assert "Scheduled task created." in _tool_content(created)
+
+        repo = ScheduledJobRepository(get_session_factory())
+        jobs = await repo.list_jobs(user_id="alice")
+        assert len(jobs) == 1
+        job = jobs[0]
+        expected = CronTrigger("0 * * * *", tz="UTC").compute_next(None, now=fixed_now, job_id=job["id"])
+        assert datetime.fromisoformat(job["next_run_at"]) == expected
+    finally:
+        await _cleanup()

--- a/backend/tests/test_scheduler_core.py
+++ b/backend/tests/test_scheduler_core.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+
+from deerflow.scheduler import core as scheduler_core
+from deerflow.scheduler.core import ExecutionResult, Scheduler
+from deerflow.scheduler.triggers import CronTrigger
+
+
+def _cron_job(job_id: str, *, next_run_at: datetime) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "user_id": f"user-{job_id}",
+        "trigger_type": "cron",
+        "trigger_data": {"kind": "cron", "expr": "0 * * * *", "tz": "UTC"},
+        "next_run_at": next_run_at.isoformat(),
+        "consecutive_errors": 0,
+        "delete_after_run": False,
+    }
+
+
+class _RecordingRepo:
+    def __init__(self, jobs: list[dict[str, Any]]) -> None:
+        self.jobs = jobs
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+
+    async def list_all_enabled_jobs(self) -> list[dict[str, Any]]:
+        return list(self.jobs)
+
+    async def list_due_jobs(self, *, now: datetime, limit: int = 200) -> list[dict[str, Any]]:
+        return list(self.jobs)
+
+    async def update_scheduling_state(self, job_id: str, **kwargs: Any) -> dict[str, Any] | None:
+        self.updates.append((job_id, kwargs))
+        return None
+
+    async def delete_job(self, job_id: str, *, user_id: str | None = None) -> bool:
+        return True
+
+    async def disable_job(self, job_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        self.updates.append((job_id, {"enabled": False, "user_id": user_id}))
+        return None
+
+
+class _BlockingExecutor:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+        self.done = asyncio.Event()
+
+    async def execute(self, job: dict[str, Any]) -> ExecutionResult:
+        self.started.set()
+        await self.release.wait()
+        self.done.set()
+        return ExecutionResult(status="ok")
+
+
+@pytest.mark.asyncio
+async def test_recover_missed_runs_uses_job_id_for_cron_stagger(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    monkeypatch.setattr(scheduler_core, "_utc_now", lambda: now)
+    repo = _RecordingRepo(
+        [
+            _cron_job("job-a", next_run_at=now - timedelta(hours=2)),
+            _cron_job("job-b", next_run_at=now - timedelta(hours=2)),
+        ]
+    )
+    scheduler = Scheduler(repo, _BlockingExecutor())
+
+    await scheduler._recover_missed_runs()
+
+    expected_a = CronTrigger("0 * * * *", tz="UTC").compute_next(now, now=now, job_id="job-a")
+    expected_b = CronTrigger("0 * * * *", tz="UTC").compute_next(now, now=now, job_id="job-b")
+    assert repo.updates == [
+        ("job-a", {"next_run_at": expected_a, "user_id": None}),
+        ("job-b", {"next_run_at": expected_b, "user_id": None}),
+    ]
+    assert expected_a != expected_b
+
+
+@pytest.mark.asyncio
+async def test_tick_tentative_bump_uses_job_id_for_cron_stagger(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    monkeypatch.setattr(scheduler_core, "_utc_now", lambda: now)
+    repo = _RecordingRepo([_cron_job("job-a", next_run_at=now - timedelta(minutes=1))])
+    executor = _BlockingExecutor()
+    scheduler = Scheduler(repo, executor)
+
+    await scheduler._tick()
+    await asyncio.wait_for(executor.started.wait(), timeout=1)
+
+    expected = CronTrigger("0 * * * *", tz="UTC").compute_next(now, now=now, job_id="job-a")
+    assert repo.updates[0] == ("job-a", {"next_run_at": expected, "user_id": None})
+
+    executor.release.set()
+    await asyncio.wait_for(executor.done.wait(), timeout=1)
+    for _ in range(10):
+        if len(repo.updates) >= 2:
+            break
+        await asyncio.sleep(0)
+
+
+def _every_job(job_id: str, *, next_run_at: datetime, every_seconds: int = 120) -> dict[str, Any]:
+    return {
+        "id": job_id,
+        "user_id": f"user-{job_id}",
+        "trigger_type": "every",
+        "trigger_data": {"kind": "every", "every_seconds": every_seconds},
+        "next_run_at": next_run_at.isoformat(),
+        "consecutive_errors": 0,
+        "delete_after_run": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_finalise_every_job_anchors_next_run_on_fired_slot(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unanchored ``every`` jobs must keep a strict interval.
+
+    The job was scheduled to fire at 00:00:00 but finished at 00:00:10
+    (10s execution). The next run must be 00:02:00 (fired_at + every),
+    NOT 00:02:10 (finish + every) — otherwise the cadence drifts by the
+    execution duration every cycle. See scheduler/core.py _finalise.
+    """
+    fired_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    finish_at = fired_at + timedelta(seconds=10)
+    monkeypatch.setattr(scheduler_core, "_utc_now", lambda: finish_at)
+
+    repo = _RecordingRepo([])
+    scheduler = Scheduler(repo, _BlockingExecutor())
+    job = _every_job("job-e", next_run_at=fired_at, every_seconds=120)
+
+    await scheduler._finalise(job, ExecutionResult(status="ok"), finish_at)
+
+    expected_next = fired_at + timedelta(seconds=120)
+    assert repo.updates == [
+        (
+            "job-e",
+            {
+                "next_run_at": expected_next,
+                "last_run_at": finish_at,
+                "last_status": "ok",
+                "consecutive_errors": 0,
+                "next_retry_at": None,
+                "user_id": None,
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tick_tentative_bump_anchors_on_fired_slot_for_every(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The optimistic bump also anchors on the fired slot, so the
+    fallback next_run_at (used if _finalise fails to persist) is
+    drift-free for unanchored ``every`` jobs."""
+    fired_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    tick_at = fired_at + timedelta(seconds=5)  # picked up 5s late
+    monkeypatch.setattr(scheduler_core, "_utc_now", lambda: tick_at)
+
+    repo = _RecordingRepo([_every_job("job-e", next_run_at=fired_at, every_seconds=120)])
+    executor = _BlockingExecutor()
+    scheduler = Scheduler(repo, executor)
+
+    await scheduler._tick()
+    await asyncio.wait_for(executor.started.wait(), timeout=1)
+
+    # Bump = fired_at + every (00:02:00), NOT tick_at + every (00:02:05).
+    expected = fired_at + timedelta(seconds=120)
+    assert repo.updates[0] == ("job-e", {"next_run_at": expected, "user_id": None})
+
+    executor.release.set()
+    await asyncio.wait_for(executor.done.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_finalise_swallows_repo_error_without_propagating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A repo write failure during _finalise must not propagate.
+
+    _finalise is best-effort: it logs the failure and leaves next_run_at
+    at its optimistic tentative value (set by _tick), which self-heals on
+    the next slot or scheduler restart. Propagating would otherwise trip
+    _run_job_safely's except branch and re-finalise the same run with an
+    error status (double-counting the failure and leaving last_status stale).
+    """
+    now = datetime(2026, 1, 1, 0, 0, tzinfo=UTC)
+    monkeypatch.setattr(scheduler_core, "_utc_now", lambda: now)
+
+    class _ExplodingRepo(_RecordingRepo):
+        async def update_scheduling_state(self, job_id: str, **kwargs: Any) -> dict[str, Any] | None:
+            raise RuntimeError("db locked")
+
+    repo = _ExplodingRepo([])
+    scheduler = Scheduler(repo, _BlockingExecutor())
+    job = _every_job("job-x", next_run_at=now, every_seconds=60)
+
+    # Must not raise.
+    await scheduler._finalise(job, ExecutionResult(status="ok"), now)

--- a/backend/tests/test_scheduler_triggers.py
+++ b/backend/tests/test_scheduler_triggers.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from deerflow.scheduler.cron_parser import CronParseError, compute_next_cron, parse_cron_expr
+from deerflow.scheduler.stagger import DEFAULT_TOP_OF_HOUR_STAGGER_MS, stable_offset_ms
+from deerflow.scheduler.triggers import CronTrigger
+
+
+def test_cron_trigger_stagger_uses_job_id() -> None:
+    trigger = CronTrigger("0 * * * *", tz="UTC")
+    now = datetime(2026, 1, 1, 0, 10, tzinfo=UTC)
+    base_next = datetime(2026, 1, 1, 1, 0, tzinfo=UTC)
+
+    first_offset = stable_offset_ms("job-a", DEFAULT_TOP_OF_HOUR_STAGGER_MS)
+    second_offset = stable_offset_ms("job-b", DEFAULT_TOP_OF_HOUR_STAGGER_MS)
+    assert first_offset != second_offset
+
+    assert trigger.compute_next(None, now=now, job_id="job-a") == base_next + timedelta(milliseconds=first_offset)
+    assert trigger.compute_next(None, now=now, job_id="job-b") == base_next + timedelta(milliseconds=second_offset)
+
+
+def test_cron_day_of_week_uses_vixie_sunday_zero() -> None:
+    after = datetime(2026, 6, 20, 23, 0, tzinfo=UTC)
+
+    sunday_fields = parse_cron_expr("0 8 * * 0")
+    monday_fields = parse_cron_expr("0 8 * * 1")
+
+    assert compute_next_cron(sunday_fields, after, "UTC") == datetime(2026, 6, 21, 8, 0, tzinfo=UTC)
+    assert compute_next_cron(monday_fields, after, "UTC") == datetime(2026, 6, 22, 8, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("expr", ["5-3 * * * *", "5-3/1 * * * *"])
+def test_cron_parser_rejects_reversed_ranges(expr: str) -> None:
+    with pytest.raises(CronParseError, match="range start must be <= end"):
+        parse_cron_expr(expr)

--- a/backend/tests/test_tool_args_schema_no_pydantic_warning.py
+++ b/backend/tests/test_tool_args_schema_no_pydantic_warning.py
@@ -28,6 +28,7 @@ from deerflow.sandbox.tools import (
     write_file_tool,
 )
 from deerflow.tools.builtins.present_file_tool import present_file_tool
+from deerflow.tools.builtins.scheduled_task_tool import scheduled_task
 from deerflow.tools.builtins.setup_agent_tool import setup_agent
 from deerflow.tools.builtins.task_tool import task_tool
 from deerflow.tools.builtins.update_agent_tool import update_agent
@@ -58,6 +59,7 @@ _TOOL_CASES = [
     (present_file_tool, {"filepaths": ["/tmp/x"], "tool_call_id": "call-1"}),
     (view_image_tool, {"image_path": "/tmp/img.png", "tool_call_id": "call-1"}),
     (task_tool, {"description": "do", "prompt": "go", "subagent_type": "general-purpose", "tool_call_id": "call-1"}),
+    (scheduled_task, {"action": "list"}),
     (skill_manage_tool, {"action": "list", "name": "demo"}),
     (setup_agent, {"soul": "s", "description": "d"}),
     (update_agent, {}),

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 15
+config_version: 16
 
 # ============================================================================
 # Logging
@@ -510,6 +510,7 @@ tool_groups:
   - name: file:read
   - name: file:write
   - name: bash
+  - name: scheduled_tasks
 
 # ============================================================================
 # Tools Configuration
@@ -736,6 +737,12 @@ tools:
   - name: bash
     group: bash
     use: deerflow.sandbox.tools:bash_tool
+
+  # Scheduled task management — create/list/delete user-owned scheduled jobs
+  # from chat; executed by the in-process scheduler (see app.scheduled_jobs).
+  - name: scheduled_task
+    group: scheduled_tasks
+    use: deerflow.tools.builtins.scheduled_task_tool:scheduled_task
 
 # ============================================================================
 # Tool Search Configuration (Deferred Tool Loading)


### PR DESCRIPTION
Add a cron service that enables scheduling reminders and recurring tasks through the DeerFlow agent system. The service persists task definitions to `jobs.json`, loads them on startup, and executes tasks at their scheduled times by invoking the LangGraph agent.

Core implementation:
- CronService uses precise timer-based scheduling: finds the nearest execution time among enabled jobs, then asyncio.sleep() until that moment (zero CPU overhead during idle)
- After execution, recomputes next run time using cadence anchoring to preserve interval consistency and prevent drift
- Hot-reload via mtime detection when jobs.json is modified externally

Task lifecycle:
- One-time tasks (`at`): Auto-deleted on success if `delete_after_run=true`, or disabled on failure for debugging
- Recurring tasks (`every`/`cron`): Never deleted; next run time updated after each execution

Schedule types:
- "at": One-time execution at a specific timestamp
- "every": Recurring execution with a fixed interval (ms)
- "cron": Cron expression with optional timezone (via croniter)

Changes:
- backend/src/cron/: New module with service.py, handler.py, types.py
- backend/src/gateway/routers/cron.py: API endpoints for job CRUD
- backend/src/tools/builtins/cron_tool.py: Agent tool for scheduling
- backend/src/channels/manager.py: Pass additional context (channel_name, chat_id, user_id, thread_ts, topic_id)
- backend/src/gateway/app.py: Mount cron router
- frontend/src/core/threads/: Updated hooks and utils