### PR TITLE
fix: replace print() with logging across middlewares, skills, and sandbox

### DIFF
--- a/backend/src/agents/lead_agent/prompt.py
+++ b/backend/src/agents/lead_agent/prompt.py
@@ -1,7 +1,10 @@
+import logging
 from datetime import datetime
 
 from src.config.agents_config import load_agent_soul
 from src.skills import load_skills
+
+logger = logging.getLogger(__name__)
 
 
 def _build_subagent_section(max_concurrent: int) -> str:
@@ -310,7 +313,7 @@ def _get_memory_context(agent_name: str | None = None) -> str:
 </memory>
 """
     except Exception as e:
-        print(f"Failed to load memory context: {e}")
+        logger.warning("Failed to load memory context: %s", e)
         return ""
 
 

--- a/backend/src/agents/middlewares/clarification_middleware.py
+++ b/backend/src/agents/middlewares/clarification_middleware.py
@@ -1,5 +1,6 @@
 """Middleware for intercepting clarification requests and presenting them to the user."""
 
+import logging
 from collections.abc import Callable
 from typing import override
 
@@ -9,6 +10,8 @@ from langchain_core.messages import ToolMessage
 from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
+
+logger = logging.getLogger(__name__)
 
 
 class ClarificationMiddlewareState(AgentState):
@@ -101,8 +104,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
         args = request.tool_call.get("args", {})
         question = args.get("question", "")
 
-        print("[ClarificationMiddleware] Intercepted clarification request")
-        print(f"[ClarificationMiddleware] Question: {question}")
+        logger.debug("Intercepted clarification request, question: %s", question)
 
         # Format the clarification message
         formatted_message = self._format_clarification_message(args)

--- a/backend/src/agents/middlewares/thread_data_middleware.py
+++ b/backend/src/agents/middlewares/thread_data_middleware.py
@@ -1,3 +1,4 @@
+import logging
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
@@ -6,6 +7,8 @@ from langgraph.runtime import Runtime
 
 from src.agents.thread_state import ThreadDataState
 from src.config.paths import Paths, get_paths
+
+logger = logging.getLogger(__name__)
 
 
 class ThreadDataMiddlewareState(AgentState):
@@ -81,7 +84,7 @@ class ThreadDataMiddleware(AgentMiddleware[ThreadDataMiddlewareState]):
         else:
             # Eager initialization: create directories immediately
             paths = self._create_thread_directories(thread_id)
-            print(f"Created thread data directories for thread {thread_id}")
+            logger.debug("Created thread data directories for thread %s", thread_id)
 
         return {
             "thread_data": {

--- a/backend/src/agents/middlewares/title_middleware.py
+++ b/backend/src/agents/middlewares/title_middleware.py
@@ -1,5 +1,6 @@
 """Middleware for automatic thread title generation."""
 
+import logging
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
@@ -8,6 +9,8 @@ from langgraph.runtime import Runtime
 
 from src.config.title_config import get_title_config
 from src.models import create_chat_model
+
+logger = logging.getLogger(__name__)
 
 
 class TitleMiddlewareState(AgentState):
@@ -73,7 +76,7 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             # Limit to max characters
             return title[: config.max_chars] if len(title) > config.max_chars else title
         except Exception as e:
-            print(f"Failed to generate title: {e}")
+            logger.warning("Failed to generate title: %s", e)
             # Fallback: use first part of user message (by character count)
             fallback_chars = min(config.max_chars, 50)  # Use max_chars or 50, whichever is smaller
             if len(user_msg) > fallback_chars:
@@ -85,7 +88,7 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         """Generate and set thread title after the first agent response."""
         if self._should_generate_title(state):
             title = await self._generate_title(state)
-            print(f"Generated thread title: {title}")
+            logger.info("Generated thread title: %s", title)
 
             # Store title in state (will be persisted by checkpointer if configured)
             return {"title": title}

--- a/backend/src/agents/middlewares/view_image_middleware.py
+++ b/backend/src/agents/middlewares/view_image_middleware.py
@@ -1,5 +1,6 @@
 """Middleware for injecting image details into conversation before LLM call."""
 
+import logging
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
@@ -8,6 +9,8 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 
 from src.agents.thread_state import ViewedImageData
+
+logger = logging.getLogger(__name__)
 
 
 class ViewImageMiddlewareState(AgentState):
@@ -181,7 +184,7 @@ class ViewImageMiddleware(AgentMiddleware[ViewImageMiddlewareState]):
         # Create a new human message with mixed content (text + images)
         human_msg = HumanMessage(content=image_content)
 
-        print("[ViewImageMiddleware] Injecting image details message with images before LLM call")
+        logger.debug("Injecting image details message with images before LLM call")
 
         # Return state update with the new message
         return {"messages": [human_msg]}

--- a/backend/src/sandbox/local/local_sandbox_provider.py
+++ b/backend/src/sandbox/local/local_sandbox_provider.py
@@ -1,6 +1,10 @@
+import logging
+
 from src.sandbox.local.local_sandbox import LocalSandbox
 from src.sandbox.sandbox import Sandbox
 from src.sandbox.sandbox_provider import SandboxProvider
+
+logger = logging.getLogger(__name__)
 
 _singleton: LocalSandbox | None = None
 
@@ -34,7 +38,7 @@ class LocalSandboxProvider(SandboxProvider):
                 mappings[container_path] = str(skills_path)
         except Exception as e:
             # Log but don't fail if config loading fails
-            print(f"Warning: Could not setup skills path mapping: {e}")
+            logger.warning("Could not setup skills path mapping: %s", e)
 
         return mappings
 

--- a/backend/src/skills/loader.py
+++ b/backend/src/skills/loader.py
@@ -1,8 +1,11 @@
+import logging
 import os
 from pathlib import Path
 
 from .parser import parse_skill_file
 from .types import Skill
+
+logger = logging.getLogger(__name__)
 
 
 def get_skills_root_path() -> Path:
@@ -86,7 +89,7 @@ def load_skills(skills_path: Path | None = None, use_config: bool = True, enable
             skill.enabled = extensions_config.is_skill_enabled(skill.name, skill.category)
     except Exception as e:
         # If config loading fails, default to all enabled
-        print(f"Warning: Failed to load extensions config: {e}")
+        logger.warning("Failed to load extensions config: %s", e)
 
     # Filter by enabled status if requested
     if enabled_only:

--- a/backend/src/skills/parser.py
+++ b/backend/src/skills/parser.py
@@ -1,7 +1,10 @@
+import logging
 import re
 from pathlib import Path
 
 from .types import Skill
+
+logger = logging.getLogger(__name__)
 
 
 def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None = None) -> Skill | None:
@@ -61,5 +64,5 @@ def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None
         )
 
     except Exception as e:
-        print(f"Error parsing skill file {skill_file}: {e}")
+        logger.error("Error parsing skill file %s: %s", skill_file, e)
         return None


### PR DESCRIPTION
## Summary

- Replace all remaining `print()` calls with proper Python `logging` across middlewares, skills, and sandbox modules
- Companion to #1116 (memory module logging) — together these two PRs eliminate all `print()` usage in the agents, middlewares, skills, and sandbox subsystems

## Changes

| File | `print()` removed | Log levels |
|------|-------------------|------------|
| `title_middleware.py` | 2 | `warning`, `info` |
| `clarification_middleware.py` | 2 → 1 consolidated | `debug` |
| `thread_data_middleware.py` | 1 | `debug` |
| `view_image_middleware.py` | 1 | `debug` |
| `lead_agent/prompt.py` | 1 | `warning` |
| `skills/loader.py` | 1 | `warning` |
| `skills/parser.py` | 1 | `error` |
| `sandbox/local/local_sandbox_provider.py` | 1 | `warning` |

## Log Level Rationale

- **`debug`**: Middleware operational details (clarification intercepts, image injection, directory creation)
- **`info`**: Title generation results
- **`warning`**: Non-critical failures (title generation fallback, config loading, path mapping)
- **`error`**: Skill file parsing errors

## Test Plan

- [ ] Verify Python syntax with `ast.parse()` — passed for all 8 files
- [ ] Run `make test` in backend to confirm no regression
- [ ] Verify log output at each level in development