### PR TITLE
feat: add MiniMax as an OpenAI-compatible model provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # GEMINI_API_KEY=your-gemini-api-key
 # DEEPSEEK_API_KEY=your-deepseek-api-key
 # NOVITA_API_KEY=your-novita-api-key  # OpenAI-compatible, see https://novita.ai
+# MINIMAX_API_KEY=your-minimax-api-key  # OpenAI-compatible, see https://platform.minimax.io
 # FEISHU_APP_ID=your-feishu-app-id
 # FEISHU_APP_SECRET=your-feishu-app-secret
 

--- a/README.md
+++ b/README.md
@@ -419,6 +419,8 @@ DeerFlow is model-agnostic — it works with any LLM that implements the OpenAI-
 - **Multimodal inputs** for image understanding and video comprehension
 - **Strong tool-use** for reliable function calling and structured outputs
 
+Models from providers with OpenAI-compatible APIs — such as [MiniMax](https://platform.minimax.io) (204K context window) — can be used by setting the `base_url` in `config.yaml`. See `config.example.yaml` for configuration examples.
+
 ## Embedded Python Client
 
 DeerFlow can be used as an embedded Python library without running the full HTTP services. The `DeerFlowClient` provides direct in-process access to all agent and Gateway capabilities, returning the same response schemas as the HTTP Gateway API:

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -25,7 +25,7 @@ models:
 - DeepSeek (`langchain_deepseek:ChatDeepSeek`)
 - Any LangChain-compatible provider
 
-For OpenAI-compatible gateways (for example Novita), keep using `langchain_openai:ChatOpenAI` and set `base_url`:
+For OpenAI-compatible gateways (for example Novita, MiniMax), keep using `langchain_openai:ChatOpenAI` and set `base_url`:
 
 ```yaml
 models:
@@ -40,6 +40,26 @@ models:
       extra_body:
         thinking:
           type: enabled
+
+  - name: minimax-m2.5
+    display_name: MiniMax M2.5
+    use: langchain_openai:ChatOpenAI
+    model: MiniMax-M2.5
+    api_key: $MINIMAX_API_KEY
+    base_url: https://api.minimax.io/v1
+    max_tokens: 4096
+    temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+    supports_vision: true
+
+  - name: minimax-m2.5-highspeed
+    display_name: MiniMax M2.5 Highspeed
+    use: langchain_openai:ChatOpenAI
+    model: MiniMax-M2.5-highspeed
+    api_key: $MINIMAX_API_KEY
+    base_url: https://api.minimax.io/v1
+    max_tokens: 4096
+    temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+    supports_vision: true
 ```
 
 **Thinking Models**:

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -410,3 +410,91 @@ def test_thinking_shortcut_not_leaked_into_model_when_disabled(monkeypatch):
 
     # The disable path should have set thinking to disabled (not the raw enabled shortcut)
     assert captured.get("thinking") == {"type": "disabled"}
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible providers (MiniMax, Novita, etc.)
+# ---------------------------------------------------------------------------
+
+
+def test_openai_compatible_provider_passes_base_url(monkeypatch):
+    """OpenAI-compatible providers like MiniMax should pass base_url through to the model."""
+    model = ModelConfig(
+        name="minimax-m2.5",
+        display_name="MiniMax M2.5",
+        description=None,
+        use="langchain_openai:ChatOpenAI",
+        model="MiniMax-M2.5",
+        base_url="https://api.minimax.io/v1",
+        api_key="test-key",
+        max_tokens=4096,
+        temperature=1.0,
+        supports_vision=True,
+        supports_thinking=False,
+    )
+    cfg = _make_app_config([model])
+    _patch_factory(monkeypatch, cfg)
+
+    captured: dict = {}
+
+    class CapturingModel(FakeChatModel):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            BaseChatModel.__init__(self, **kwargs)
+
+    monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
+
+    factory_module.create_chat_model(name="minimax-m2.5")
+
+    assert captured.get("model") == "MiniMax-M2.5"
+    assert captured.get("base_url") == "https://api.minimax.io/v1"
+    assert captured.get("api_key") == "test-key"
+    assert captured.get("temperature") == 1.0
+    assert captured.get("max_tokens") == 4096
+
+
+def test_openai_compatible_provider_multiple_models(monkeypatch):
+    """Multiple models from the same OpenAI-compatible provider should coexist."""
+    m1 = ModelConfig(
+        name="minimax-m2.5",
+        display_name="MiniMax M2.5",
+        description=None,
+        use="langchain_openai:ChatOpenAI",
+        model="MiniMax-M2.5",
+        base_url="https://api.minimax.io/v1",
+        api_key="test-key",
+        temperature=1.0,
+        supports_vision=True,
+        supports_thinking=False,
+    )
+    m2 = ModelConfig(
+        name="minimax-m2.5-highspeed",
+        display_name="MiniMax M2.5 Highspeed",
+        description=None,
+        use="langchain_openai:ChatOpenAI",
+        model="MiniMax-M2.5-highspeed",
+        base_url="https://api.minimax.io/v1",
+        api_key="test-key",
+        temperature=1.0,
+        supports_vision=True,
+        supports_thinking=False,
+    )
+    cfg = _make_app_config([m1, m2])
+    _patch_factory(monkeypatch, cfg)
+
+    captured: dict = {}
+
+    class CapturingModel(FakeChatModel):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            BaseChatModel.__init__(self, **kwargs)
+
+    monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
+
+    # Create first model
+    factory_module.create_chat_model(name="minimax-m2.5")
+    assert captured.get("model") == "MiniMax-M2.5"
+
+    # Create second model
+    factory_module.create_chat_model(name="minimax-m2.5-highspeed")
+    assert captured.get("model") == "MiniMax-M2.5-highspeed"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,6 +106,29 @@ models:
   #       thinking:
   #         type: enabled
 
+  # Example: MiniMax (OpenAI-compatible)
+  # MiniMax provides high-performance models with 204K context window
+  # Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+  # - name: minimax-m2.5
+  #   display_name: MiniMax M2.5
+  #   use: langchain_openai:ChatOpenAI
+  #   model: MiniMax-M2.5
+  #   api_key: $MINIMAX_API_KEY
+  #   base_url: https://api.minimax.io/v1
+  #   max_tokens: 4096
+  #   temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+  #   supports_vision: true
+
+  # - name: minimax-m2.5-highspeed
+  #   display_name: MiniMax M2.5 Highspeed
+  #   use: langchain_openai:ChatOpenAI
+  #   model: MiniMax-M2.5-highspeed
+  #   api_key: $MINIMAX_API_KEY
+  #   base_url: https://api.minimax.io/v1
+  #   max_tokens: 4096
+  #   temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+  #   supports_vision: true
+
 # ============================================================================
 # Tool Groups Configuration
 # ============================================================================


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io) as an OpenAI-compatible model provider for DeerFlow. MiniMax offers high-performance LLMs with **204K context windows** via an OpenAI-compatible API, making integration seamless through `langchain_openai:ChatOpenAI`.

### Models Added

| Model | Description |
|-------|-------------|
| `MiniMax-M2.5` | Peak performance, ultimate value — 204K context |
| `MiniMax-M2.5-highspeed` | Same performance, faster and more agile — 204K context |

### Pricing

| Model | Input | Output |
|-------|-------|--------|
| MiniMax-M2.5 | $0.3/M tokens | $1.2/M tokens |
| MiniMax-M2.5-highspeed | $0.6/M tokens | $2.4/M tokens |

## Changes

- **`config.example.yaml`**: Added MiniMax model configuration examples (M2.5 and M2.5-highspeed) following the existing Novita AI pattern
- **`.env.example`**: Added `MINIMAX_API_KEY` environment variable
- **`README.md`**: Mentioned MiniMax in the Recommended Models section
- **`backend/docs/CONFIGURATION.md`**: Added MiniMax configuration example in the OpenAI-compatible providers section
- **`backend/tests/test_model_factory.py`**: Added tests for OpenAI-compatible provider configuration (base_url passthrough, multiple model coexistence)

## Configuration Example

```yaml
models:
  - name: minimax-m2.5
    display_name: MiniMax M2.5
    use: langchain_openai:ChatOpenAI
    model: MiniMax-M2.5
    api_key: $MINIMAX_API_KEY
    base_url: https://api.minimax.io/v1
    max_tokens: 4096
    temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
    supports_vision: true
```

## Notes

- MiniMax uses an OpenAI-compatible API, so no new dependencies are needed — it leverages the existing `langchain_openai` package
- Temperature must be in the range `(0.0, 1.0]` (zero is rejected by the API), so the default is set to `1.0`
- Both models support vision capabilities

## API Documentation

- [OpenAI-compatible API](https://platform.minimax.io/docs/api-reference/text-openai-api)

## Test Plan

- [x] All 425 existing tests pass
- [x] New OpenAI-compatible provider tests pass (base_url passthrough, multiple model selection)
- [x] Configuration can be parsed by DeerFlow's model config system