### PR TITLE
fix(middleware): bridge thread_id from config.configurable to runtime.context

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
@@ -73,7 +73,19 @@ class ThreadDataMiddleware(AgentMiddleware[ThreadDataMiddlewareState]):
     def before_agent(self, state: ThreadDataMiddlewareState, runtime: Runtime) -> dict | None:
         thread_id = runtime.context.get("thread_id")
         if thread_id is None:
+            # Fallback: LangGraph HTTP API puts thread_id in config.configurable
+            # but does NOT inject it into runtime.context. Bridge it here once,
+            # so all downstream middlewares and tools can read it normally.
+            from langgraph.config import get_config
+            config = get_config()
+            thread_id = config.get("configurable", {}).get("thread_id")
+        if thread_id is None:
             raise ValueError("Thread ID is required in the context")
+
+        # Global injection: propagate thread_id to runtime.context so every
+        # subsequent middleware and tool (sandbox, uploads, memory, etc.)
+        # can access it via runtime.context.get("thread_id").
+        runtime.context["thread_id"] = thread_id
 
         if self._lazy_init:
             # Lazy initialization: only compute paths, don't create directories


### PR DESCRIPTION
## Summary

When running via LangGraph HTTP API, `thread_id` is placed in `config.configurable` but not injected into `runtime.context`. `ThreadDataMiddleware.before_agent()` only checked `runtime.context`, causing a `ValueError` for every HTTP API request.

## Changes

- `backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py`:
  - Add fallback: `get_config()["configurable"]["thread_id"]` when `runtime.context` doesn't have it
  - Add global injection: write `thread_id` back to `runtime.context` so all downstream middlewares and tools can access it uniformly

## Test plan

- [x] Start LangGraph Server (`make dev`)
- [x] Create a thread via HTTP API and send a message
- [x] Verify sandbox paths are created under `.deer-flow/threads/{thread_id}/`
- [x] Verify no `ValueError` on thread_id resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)