### PR TITLE
fix(scripts): correct Makefile target name in docker.sh restart message

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -234,7 +234,7 @@ restart() {
     echo -e "${GREEN}✓ Docker services restarted${NC}"
     echo ""
     echo "  🌐 Application: http://localhost:2026"
-    echo "  📋 View logs: make docker-dev-logs"
+    echo "  📋 View logs: make docker-logs"
     echo ""
 }
 


### PR DESCRIPTION
## Summary

Fixes #1158

- `docker.sh` `restart()` tells users to run `make docker-dev-logs`, but this target does not exist
- Changed to `make docker-logs` which is the correct Makefile target (line 140)

## Test plan

- [x] Run `make docker-restart` and verify the printed command is `make docker-logs`
- [x] Run `make docker-logs` to confirm it works