### PR TITLE
fix(frontend): block duplicate sends during uploads

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -76,6 +76,12 @@ src/
 - **MagicUI** - Magic UI components
 - **React Bits** - React bits components
 
+### Interaction Ownership
+
+- `src/app/workspace/chats/[thread_id]/page.tsx` owns composer busy-state wiring.
+- `src/core/threads/hooks.ts` owns pre-submit upload state and thread submission.
+- `src/hooks/usePoseStream.ts` is a passive store selector; global WebSocket lifecycle stays in `App.tsx`.
+
 ## Resources
 
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -32,7 +32,7 @@ export default function ChatPage() {
 
   const { showNotification } = useNotification();
 
-  const [thread, sendMessage] = useThreadStream({
+  const [thread, sendMessage, isUploading] = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
     context: settings.context,
     isMock,
@@ -122,12 +122,12 @@ export default function ChatPage() {
                   isNewThread={isNewThread}
                   threadId={threadId}
                   autoFocus={isNewThread}
-                  status={thread.isLoading || (thread as typeof thread & { isUploading?: boolean }).isUploading ? "streaming" : "ready"}
+                  status={thread.isLoading ? "streaming" : "ready"}
                   context={settings.context}
                   extraHeader={
                     isNewThread && <Welcome mode={settings.context.mode} />
                   }
-                  disabled={env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true"}
+                  disabled={env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" || isUploading}
                   onContextChange={(context) => setSettings("context", context)}
                   onSubmit={handleSubmit}
                   onStop={handleStop}

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -122,7 +122,7 @@ export default function ChatPage() {
                   isNewThread={isNewThread}
                   threadId={threadId}
                   autoFocus={isNewThread}
-                  status={thread.isLoading ? "streaming" : "ready"}
+                  status={thread.isLoading || (thread as typeof thread & { isUploading?: boolean }).isUploading ? "streaming" : "ready"}
                   context={settings.context}
                   extraHeader={
                     isNewThread && <Welcome mode={settings.context.mode} />

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -157,6 +157,7 @@ export function useThreadStream({
   // Optimistic messages shown before the server stream responds
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const sendInFlightRef = useRef(false);
   // Track message count before sending so we know when server has responded
   const prevMsgCountRef = useRef(thread.messages.length);
 
@@ -176,6 +177,11 @@ export function useThreadStream({
       message: PromptInputMessage,
       extraContext?: Record<string, unknown>,
     ) => {
+      if (sendInFlightRef.current) {
+        return;
+      }
+      sendInFlightRef.current = true;
+
       const text = message.text.trim();
 
       // Capture current count before showing optimistic messages
@@ -348,6 +354,8 @@ export function useThreadStream({
         setOptimisticMessages([]);
         setIsUploading(false);
         throw error;
+      } finally {
+        sendInFlightRef.current = false;
       }
     },
     [thread, _handleOnStart, t.uploads.uploadingFiles, context, queryClient],
@@ -358,15 +366,11 @@ export function useThreadStream({
     optimisticMessages.length > 0
       ? ({
           ...thread,
-          isUploading,
           messages: [...thread.messages, ...optimisticMessages],
         } as typeof thread)
-      : ({
-          ...thread,
-          isUploading,
-        } as typeof thread);
+      : thread;
 
-  return [mergedThread, sendMessage] as const;
+  return [mergedThread, sendMessage, isUploading] as const;
 }
 
 export function useThreads(

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -156,6 +156,7 @@ export function useThreadStream({
 
   // Optimistic messages shown before the server stream responds
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
   // Track message count before sending so we know when server has responded
   const prevMsgCountRef = useRef(thread.messages.length);
 
@@ -217,6 +218,7 @@ export function useThreadStream({
       try {
         // Upload files first if any
         if (message.files && message.files.length > 0) {
+          setIsUploading(true);
           try {
             // Convert FileUIPart to File objects by fetching blob URLs
             const filePromises = message.files.map(async (fileUIPart) => {
@@ -293,6 +295,8 @@ export function useThreadStream({
             toast.error(errorMessage);
             setOptimisticMessages([]);
             throw error;
+          } finally {
+            setIsUploading(false);
           }
         }
 
@@ -342,6 +346,7 @@ export function useThreadStream({
         void queryClient.invalidateQueries({ queryKey: ["threads", "search"] });
       } catch (error) {
         setOptimisticMessages([]);
+        setIsUploading(false);
         throw error;
       }
     },
@@ -353,9 +358,13 @@ export function useThreadStream({
     optimisticMessages.length > 0
       ? ({
           ...thread,
+          isUploading,
           messages: [...thread.messages, ...optimisticMessages],
         } as typeof thread)
-      : thread;
+      : ({
+          ...thread,
+          isUploading,
+        } as typeof thread);
 
   return [mergedThread, sendMessage] as const;
 }


### PR DESCRIPTION
## Summary

- expose a dedicated `isUploading` busy flag from `useThreadStream()` during pre-submit attachment uploads
- treat upload-in-progress the same as streaming in the chat page so users cannot submit a second message while the first attachment is still uploading
- document the resulting ownership split in `frontend/AGENTS.md`: upload-before-submit state lives in thread hooks, while the page owns composer busy-state wiring

## Validation

- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm lint -- src/core/threads/hooks.ts 'src/app/workspace/chats/[thread_id]/page.tsx'`

## Notes

- this PR stays outside the current deer-flow backend PR scopes (`#1098`, `#1103`, `#1108`, `#1155`) and outside the already-merged uploads API helper line