### PR TITLE
fix(sandbox): allow read_file and ls to access /mnt/skills paths

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -29,6 +29,62 @@ def _path_variants(path: str) -> set[str]:
     return {path, path.replace("\\", "/"), path.replace("/", "\\")}
 
 
+def _get_skills_container_prefix() -> str:
+    """Get the skills container path prefix from config, defaulting to /mnt/skills."""
+    try:
+        from deerflow.config import get_app_config
+
+        return get_app_config().skills.container_path
+    except (ImportError, AttributeError, OSError):
+        return "/mnt/skills"
+
+
+def _get_skills_local_path() -> Path | None:
+    """Get the resolved local skills directory path from config."""
+    try:
+        from deerflow.config import get_app_config
+
+        skills_path = get_app_config().skills.get_skills_path()
+        if skills_path.exists():
+            return skills_path
+    except (ImportError, AttributeError, OSError):
+        pass
+    return None
+
+
+def _is_skills_path(path: str) -> bool:
+    """Check if path is under the skills virtual mount."""
+    prefix = _get_skills_container_prefix()
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def resolve_local_skills_path(path: str) -> str:
+    """Resolve and validate a local-sandbox skills path (read-only).
+
+    Only paths under the skills container prefix are allowed.
+    Must be called only after _is_skills_path() returns True.
+    Raises PermissionError on path traversal or invalid prefix.
+    """
+    prefix = _get_skills_container_prefix()
+    if not (path == prefix or path.startswith(f"{prefix}/")):
+        raise PermissionError(f"Only paths under {prefix}/ are allowed")
+
+    skills_local = _get_skills_local_path()
+    if skills_local is None:
+        raise SandboxRuntimeError("Skills directory not configured or not found")
+
+    relative = path[len(prefix) :].lstrip("/")
+    allowed_root = skills_local.resolve()
+    resolved = (allowed_root / relative).resolve() if relative else allowed_root
+
+    try:
+        resolved.relative_to(allowed_root)
+    except ValueError:
+        raise PermissionError("Access denied: path traversal detected")
+
+    return str(resolved)
+
+
 def replace_virtual_path(path: str, thread_data: ThreadDataState | None) -> str:
     """Replace virtual /mnt/user-data paths with actual thread data paths.
 
@@ -402,8 +458,11 @@ def ls_tool(runtime: ToolRuntime[ContextT, ThreadState], description: str, path:
         ensure_thread_directories_exist(runtime)
         requested_path = path
         if is_local_sandbox(runtime):
-            thread_data = get_thread_data(runtime)
-            path = resolve_local_tool_path(path, thread_data)
+            if _is_skills_path(path):
+                path = resolve_local_skills_path(path)
+            else:
+                thread_data = get_thread_data(runtime)
+                path = resolve_local_tool_path(path, thread_data)
         children = sandbox.list_dir(path)
         if not children:
             return "(empty)"
@@ -439,8 +498,11 @@ def read_file_tool(
         ensure_thread_directories_exist(runtime)
         requested_path = path
         if is_local_sandbox(runtime):
-            thread_data = get_thread_data(runtime)
-            path = resolve_local_tool_path(path, thread_data)
+            if _is_skills_path(path):
+                path = resolve_local_skills_path(path)
+            else:
+                thread_data = get_thread_data(runtime)
+                path = resolve_local_tool_path(path, thread_data)
         content = sandbox.read_file(path)
         if not content:
             return "(empty)"

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -6,6 +7,7 @@ from deerflow.sandbox.tools import (
     VIRTUAL_PATH_PREFIX,
     mask_local_paths_in_output,
     replace_virtual_path,
+    resolve_local_skills_path,
     resolve_local_tool_path,
     validate_local_bash_command_paths,
 )
@@ -109,3 +111,88 @@ def test_validate_local_bash_command_paths_allows_virtual_and_system_paths() -> 
         "/bin/echo ok > /mnt/user-data/workspace/out.txt && cat /dev/null",
         thread_data,
     )
+
+
+# ── Skills path tests ────────────────────────────────────────────────────
+
+
+def _patch_skills(tmp_path: Path):
+    """Patch helpers to point at a temp skills directory."""
+    return (
+        patch("deerflow.sandbox.tools._get_skills_container_prefix", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_local_path", return_value=tmp_path),
+    )
+
+
+def test_resolve_local_skills_path_resolves_valid_path(tmp_path: Path) -> None:
+    skill_file = tmp_path / "public" / "my-skill" / "SKILL.md"
+    skill_file.parent.mkdir(parents=True)
+    skill_file.touch()
+
+    p1, p2 = _patch_skills(tmp_path)
+    with p1, p2:
+        result = resolve_local_skills_path("/mnt/skills/public/my-skill/SKILL.md")
+
+    assert result == str(skill_file.resolve())
+
+
+def test_resolve_local_skills_path_rejects_traversal(tmp_path: Path) -> None:
+    p1, p2 = _patch_skills(tmp_path)
+    with p1, p2:
+        with pytest.raises(PermissionError, match="path traversal"):
+            resolve_local_skills_path("/mnt/skills/../../../etc/passwd")
+
+
+def test_resolve_local_skills_path_rejects_when_no_skills_dir() -> None:
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_prefix", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_local_path", return_value=None),
+    ):
+        with pytest.raises(Exception, match="Skills directory not configured"):
+            resolve_local_skills_path("/mnt/skills/public/my-skill/SKILL.md")
+
+
+def test_validate_local_bash_command_paths_blocks_skills_paths() -> None:
+    """bash commands must NOT be allowed to access /mnt/skills (prevents write via shell)."""
+    thread_data = {
+        "workspace_path": "/tmp/deer-flow/threads/t1/user-data/workspace",
+        "uploads_path": "/tmp/deer-flow/threads/t1/user-data/uploads",
+        "outputs_path": "/tmp/deer-flow/threads/t1/user-data/outputs",
+    }
+
+    with pytest.raises(PermissionError, match="Unsafe absolute paths"):
+        validate_local_bash_command_paths(
+            "cat /mnt/skills/public/my-skill/SKILL.md",
+            thread_data,
+        )
+
+
+def test_resolve_local_skills_path_resolves_bare_prefix(tmp_path: Path) -> None:
+    """Exact /mnt/skills (no trailing slash) should resolve to skills root."""
+    p1, p2 = _patch_skills(tmp_path)
+    with p1, p2:
+        result = resolve_local_skills_path("/mnt/skills")
+
+    assert result == str(tmp_path.resolve())
+
+
+def test_resolve_local_skills_path_rejects_non_skills_prefix() -> None:
+    """Paths not under skills prefix must be rejected even if called directly."""
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_prefix", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_local_path", return_value=Path("/tmp/fake")),
+    ):
+        with pytest.raises(PermissionError, match="Only paths under"):
+            resolve_local_skills_path("/tmp/evil/path")
+
+
+def test_resolve_local_tool_path_still_rejects_skills_path() -> None:
+    """write_file / str_replace use resolve_local_tool_path which must NOT accept skills paths."""
+    thread_data = {
+        "workspace_path": "/tmp/deer-flow/threads/t1/user-data/workspace",
+        "uploads_path": "/tmp/deer-flow/threads/t1/user-data/uploads",
+        "outputs_path": "/tmp/deer-flow/threads/t1/user-data/outputs",
+    }
+
+    with pytest.raises(PermissionError, match="Only paths under"):
+        resolve_local_tool_path("/mnt/skills/public/my-skill/SKILL.md", thread_data)


### PR DESCRIPTION
## What

Allow local sandbox `read_file` and `ls` tools to access skill files under `/mnt/skills/`.

## Why

The path validation in `resolve_local_tool_path()` only accepted `/mnt/user-data/` prefix, blocking agent access to skill files mounted at `/mnt/skills/`. This caused a permission error when the agent tried to read skill content.

Closes #1177

## How

- Add `resolve_local_skills_path()` for read-only path resolution with traversal protection
- Route `read_file` and `ls` through the new resolver when path starts with `/mnt/skills`
- `write_file`, `str_replace`, and `bash` remain blocked for `/mnt/skills` paths, preserving read-only semantics

## Testing

Added 7 unit tests covering:
- Valid skill path resolution
- Path traversal rejection
- Skills directory not configured
- Bash command blocking for `/mnt/skills`
- Bare `/mnt/skills` prefix (no trailing slash)
- Non-skills prefix rejection
- `write_file`/`str_replace` still reject skills paths

All 505 backend tests pass (`make lint && make test`).