### PR TITLE
Add OMEGA Memory to example MCP config

### DIFF
--- a/extensions_config.example.json
+++ b/extensions_config.example.json
@@ -36,6 +36,17 @@
       ],
       "env": {},
       "description": "PostgreSQL database access"
+    },
+    "omega-memory": {
+      "enabled": false,
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "omega-memory",
+        "serve"
+      ],
+      "env": {},
+      "description": "Persistent memory for AI agents — context compounds across sessions instead of resetting"
     }
   },
   "skills": {}


### PR DESCRIPTION
## Summary

Adds [OMEGA Memory](https://github.com/omega-memory/omega-memory) to `extensions_config.example.json` as an optional MCP server.

OMEGA gives DeerFlow agents persistent memory across sessions — decisions, preferences, and context compound over time instead of resetting. It's open-source, available on PyPI (`pip install omega-memory`), and works with any MCP-compatible client.

**What it does:**
- Stores and retrieves memories with semantic search (local embeddings)
- Tracks entities, decisions, and user preferences
- Cross-session context so agents don't re-ask the same questions

## Test plan

- [ ] Verified `extensions_config.example.json` is valid JSON
- [ ] `uvx omega-memory serve` starts the MCP server on stdio