### PR TITLE
fix(gateway): enable direct local CORS

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from app.gateway.config import get_gateway_config
 from app.gateway.routers import (
@@ -26,6 +27,8 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_CORS_ORIGIN_REGEX = r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$"
 
 
 @asynccontextmanager
@@ -75,6 +78,8 @@ def create_app() -> FastAPI:
     Returns:
         Configured FastAPI application instance.
     """
+
+    config = get_gateway_config()
 
     app = FastAPI(
         title="DeerFlow API Gateway",
@@ -146,7 +151,17 @@ This gateway provides custom endpoints for models, MCP configuration, skills, an
         ],
     )
 
-    # CORS is handled by nginx - no need for FastAPI middleware
+    # Nginx owns CORS for proxied traffic on :2026, but the gateway can also be
+    # accessed directly during local development. Keep direct access usable for
+    # custom localhost ports while still honoring explicit CORS_ORIGINS entries.
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=config.cors_origins,
+        allow_origin_regex=_LOCAL_CORS_ORIGIN_REGEX,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     # Include routers
     # Models API is mounted at /api/models

--- a/backend/app/gateway/config.py
+++ b/backend/app/gateway/config.py
@@ -2,26 +2,33 @@ import os
 
 from pydantic import BaseModel, Field
 
+_DEFAULT_CORS_ORIGINS = ["http://localhost:3000"]
+
 
 class GatewayConfig(BaseModel):
     """Configuration for the API Gateway."""
 
     host: str = Field(default="0.0.0.0", description="Host to bind the gateway server")
     port: int = Field(default=8001, description="Port to bind the gateway server")
-    cors_origins: list[str] = Field(default_factory=lambda: ["http://localhost:3000"], description="Allowed CORS origins")
+    cors_origins: list[str] = Field(default_factory=lambda: list(_DEFAULT_CORS_ORIGINS), description="Allowed CORS origins")
 
 
 _gateway_config: GatewayConfig | None = None
+
+
+def _parse_cors_origins(cors_origins_str: str) -> list[str]:
+    origins = [origin.strip() for origin in cors_origins_str.split(",") if origin.strip()]
+    return origins or list(_DEFAULT_CORS_ORIGINS)
 
 
 def get_gateway_config() -> GatewayConfig:
     """Get gateway config, loading from environment if available."""
     global _gateway_config
     if _gateway_config is None:
-        cors_origins_str = os.getenv("CORS_ORIGINS", "http://localhost:3000")
+        cors_origins_str = os.getenv("CORS_ORIGINS", ",".join(_DEFAULT_CORS_ORIGINS))
         _gateway_config = GatewayConfig(
             host=os.getenv("GATEWAY_HOST", "0.0.0.0"),
             port=int(os.getenv("GATEWAY_PORT", "8001")),
-            cors_origins=cors_origins_str.split(","),
+            cors_origins=_parse_cors_origins(cors_origins_str),
         )
     return _gateway_config


### PR DESCRIPTION
Enable FastAPI CORS middleware for direct gateway access.
Allow localhost/127.0.0.1 on custom dev ports and trim CORS_ORIGINS entries.
Fixes #47