### PR TITLE
feat(frontend): add conversation export (Markdown and JSON)

### DIFF
--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -9,6 +9,7 @@ import {
   useSpecificChatMode,
   useThreadChat,
 } from "@/components/workspace/chats";
+import { ExportButton } from "@/components/workspace/export-button";
 import { InputBox } from "@/components/workspace/input-box";
 import { MessageList } from "@/components/workspace/messages";
 import { ThreadContext } from "@/components/workspace/messages/context";
@@ -84,7 +85,8 @@ export default function ChatPage() {
             <div className="flex w-full items-center text-sm font-medium">
               <ThreadTitle threadId={threadId} thread={thread} />
             </div>
-            <div>
+            <div className="flex items-center gap-1">
+              {!isNewThread && <ExportButton thread={thread} />}
               <ArtifactTrigger />
             </div>
           </header>

--- a/frontend/src/components/workspace/export-button.tsx
+++ b/frontend/src/components/workspace/export-button.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import type { BaseStream, Message } from "@langchain/langgraph-sdk";
+import { DownloadIcon, FileJsonIcon, FileTextIcon } from "lucide-react";
+import { useCallback } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useI18n } from "@/core/i18n/hooks";
+import { extractTextFromMessage } from "@/core/messages/utils";
+import type { AgentThreadState } from "@/core/threads";
+
+import { Tooltip } from "./tooltip";
+
+function downloadFile(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+function threadToMarkdown(
+  title: string,
+  messages: Message[],
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${title}\n`);
+  lines.push(
+    `Exported from DeerFlow on ${new Date().toLocaleDateString()}\n`,
+  );
+  lines.push("---\n");
+
+  for (const message of messages) {
+    if (message.type === "human") {
+      const text = extractTextFromMessage(message);
+      if (text) {
+        lines.push(`## User\n`);
+        lines.push(`${text}\n`);
+        lines.push("---\n");
+      }
+    } else if (message.type === "ai") {
+      const text = extractTextFromMessage(message);
+      if (text) {
+        lines.push(`## Assistant\n`);
+        lines.push(`${text}\n`);
+        lines.push("---\n");
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function threadToJSON(
+  title: string,
+  messages: Message[],
+): string {
+  const data = {
+    title,
+    exportedAt: new Date().toISOString(),
+    messages: messages.map((msg) => ({
+      id: msg.id,
+      type: msg.type,
+      content: extractTextFromMessage(msg),
+    })),
+  };
+  return JSON.stringify(data, null, 2);
+}
+
+function sanitizeFilename(title: string): string {
+  return title
+    .replace(/[^a-zA-Z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .toLowerCase()
+    .slice(0, 50);
+}
+
+export function ExportButton({
+  thread,
+}: {
+  thread: BaseStream<AgentThreadState>;
+}) {
+  const { t } = useI18n();
+  const title = thread.values?.title ?? t.pages.untitled;
+  const messages = thread.messages;
+
+  const handleExportMarkdown = useCallback(() => {
+    const md = threadToMarkdown(title, messages);
+    const filename = `${sanitizeFilename(title)}.md`;
+    downloadFile(md, filename, "text/markdown");
+  }, [title, messages]);
+
+  const handleExportJSON = useCallback(() => {
+    const json = threadToJSON(title, messages);
+    const filename = `${sanitizeFilename(title)}.json`;
+    downloadFile(json, filename, "application/json");
+  }, [title, messages]);
+
+  if (!messages || messages.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <Tooltip content={t.export.exportConversation}>
+        <DropdownMenuTrigger asChild>
+          <Button size="icon-sm" variant="ghost">
+            <DownloadIcon size={14} />
+          </Button>
+        </DropdownMenuTrigger>
+      </Tooltip>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={handleExportMarkdown}>
+          <FileTextIcon size={14} />
+          {t.export.asMarkdown}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={handleExportJSON}>
+          <FileJsonIcon size={14} />
+          {t.export.asJSON}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -213,6 +213,13 @@ export const enUS: Translations = {
     about: "About DeerFlow",
   },
 
+  // Export
+  export: {
+    exportConversation: "Export conversation",
+    asMarkdown: "Markdown (.md)",
+    asJSON: "JSON (.json)",
+  },
+
   // Conversation
   conversation: {
     noMessages: "No messages yet",

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -151,6 +151,13 @@ export interface Translations {
     about: string;
   };
 
+  // Export
+  export: {
+    exportConversation: string;
+    asMarkdown: string;
+    asJSON: string;
+  };
+
   // Conversation
   conversation: {
     noMessages: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -202,6 +202,13 @@ export const zhCN: Translations = {
     about: "关于 DeerFlow",
   },
 
+  // Export
+  export: {
+    exportConversation: "导出对话",
+    asMarkdown: "Markdown (.md)",
+    asJSON: "JSON (.json)",
+  },
+
   // Conversation
   conversation: {
     noMessages: "还没有消息",


### PR DESCRIPTION
## Summary

Re-implements conversation export for DeerFlow 2.0. The v1 export feature (PR #756, merged Dec 2025) was lost in the ground-up rewrite.

Adds a download dropdown to the conversation header with two formats:
- **Markdown** - clean research report with user/assistant sections
- **JSON** - structured data for programmatic use

Client-side only, no backend changes.

## Why this matters

| Source | Evidence | Engagement |
|--------|----------|------------|
| [#51](https://github.com/bytedance/deer-flow/issues/51) | "Can't the generated report be downloaded?" | 3 thumbs up |
| [#67](https://github.com/bytedance/deer-flow/issues/67) | "Support for message history" | 3 thumbs up, 1 heart |
| [PR #756](https://github.com/bytedance/deer-flow/pull/756) | v1 multi-format export, merged Dec 2025 | Merged by @WillemJiang |

@MagicCube confirmed in #51: "We're going to export report as PDF and MSOffice documents." The v1 export was used and valued. This brings it back for v2 with a simpler initial scope.

## Changes

- **New:** `export-button.tsx` - dropdown with Markdown/JSON export, client-side file download via Blob API
- **Modified:** `page.tsx` - adds ExportButton to thread header next to ArtifactTrigger (hidden for new threads)
- **Modified:** i18n types + en-US + zh-CN - adds `export.exportConversation`, `export.asMarkdown`, `export.asJSON`

## Screenshots

**Conversation header (before - no export button):**

![workspace-before](https://files.catbox.moe/77q9wa.png)

The export dropdown button renders next to the Artifacts trigger in the thread header. It is hidden when no messages exist (new thread state shown above). When a conversation has messages, the download icon appears and offers Markdown or JSON export.

## Testing

- `pnpm lint` passes
- `pnpm typecheck` passes
- Installed and ran DeerFlow locally to verify the conversation header layout

This contribution was developed with AI assistance (Claude Code).

Closes #51