### PR TITLE
fix: add ~/.codex and ~/.claude bind mounts to docker-compose-dev.yaml

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -124,6 +124,19 @@ services:
       - ~/.cache/uv:/root/.cache/uv
       # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
       - /var/run/docker.sock:/var/run/docker.sock
+      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
+      - type: bind
+        source: ${HOME:?HOME must be set}/.claude
+        target: /root/.claude
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ${HOME:?HOME must be set}/.codex
+        target: /root/.codex
+        read_only: true
+        bind:
+          create_host_path: true
     working_dir: /app
     environment:
       - CI=true
@@ -160,6 +173,19 @@ services:
       - ~/.cache/uv:/root/.cache/uv
       # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
       - /var/run/docker.sock:/var/run/docker.sock
+      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
+      - type: bind
+        source: ${HOME:?HOME must be set}/.claude
+        target: /root/.claude
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ${HOME:?HOME must be set}/.codex
+        target: /root/.codex
+        read_only: true
+        bind:
+          create_host_path: true
     working_dir: /app
     environment:
       - CI=true


### PR DESCRIPTION
## Summary

Fixes #1246

## Problem

`docker-compose-dev.yaml` was missing `~/.codex` and `~/.claude` bind mounts that exist in `docker-compose.yaml` (production). This caused `CodexChatModel` to fail with:

```
Codex CLI credential not found.
Expected ~/.codex/auth.json or CODEX_AUTH_PATH.
```

## Solution

Added the same bind mounts to both `gateway` and `langgraph` services in `docker-compose-dev.yaml`:

```yaml
- type: bind
  source: ${HOME:?HOME must be set}/.claude
  target: /root/.claude
  read_only: true
  bind:
    create_host_path: true
- type: bind
  source: ${HOME:?HOME must be set}/.codex
  target: /root/.codex
  read_only: true
  bind:
    create_host_path: true
```

This matches the production configuration and allows Codex CLI authentication to work in dev mode.