### PR TITLE
fix(docker): add Claude and Codex CLI auth mounts to dev compose

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -124,6 +124,19 @@ services:
       - ~/.cache/uv:/root/.cache/uv
       # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
       - /var/run/docker.sock:/var/run/docker.sock
+      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
+      - type: bind
+        source: ${HOME:?HOME must be set}/.claude
+        target: /root/.claude
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ${HOME:?HOME must be set}/.codex
+        target: /root/.codex
+        read_only: true
+        bind:
+          create_host_path: true
     working_dir: /app
     environment:
       - CI=true
@@ -160,6 +173,19 @@ services:
       - ~/.cache/uv:/root/.cache/uv
       # DooD: same as gateway — AioSandboxProvider runs inside LangGraph process.
       - /var/run/docker.sock:/var/run/docker.sock
+      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
+      - type: bind
+        source: ${HOME:?HOME must be set}/.claude
+        target: /root/.claude
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ${HOME:?HOME must be set}/.codex
+        target: /root/.codex
+        read_only: true
+        bind:
+          create_host_path: true
     working_dir: /app
     environment:
       - CI=true


### PR DESCRIPTION
## Problem

`docker-compose-dev.yaml` does not mount `~/.claude` and `~/.codex` into the gateway and langgraph containers, while `docker-compose.yaml` (production) does. This causes `CodexChatModel` and Claude Code auto-auth to fail with a validation error in dev mode (`make docker-start`):

```
HTTP 400: {"detail":"1 validation error for CodexChatModel\n Value error, Codex CLI credential not found.
Expected ~/.codex/auth.json or CODEX_AUTH_PATH."}
```

## Fix

Add the same `~/.claude` and `~/.codex` bind mounts to both `gateway` and `langgraph` services in `docker-compose-dev.yaml`, matching the production compose pattern:

- `type: bind` with `create_host_path: true` (creates empty dir if missing — no startup error)
- `read_only: true` (credentials are read-only inside containers)

## Changes

- `docker/docker-compose-dev.yaml`: Added CLI auth bind mounts to gateway and langgraph services (+26 lines)

## Verification

- YAML validated via `yaml.safe_load()`
- Mount pattern matches `docker-compose.yaml` (production) exactly

Fixes #1246