### PR TITLE
docs: Add Governance section — MCP-compatible execution governance for production deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,35 @@ All dict-returning methods are validated against Gateway Pydantic response model
 - [Architecture Overview](backend/CLAUDE.md) - Technical architecture details
 - [Backend Architecture](backend/README.md) - Backend architecture and API reference
 
+## Governance
+
+DeerFlow is a powerful agent harness — but production deployments need execution governance: signed receipts, scope enforcement, and kill switches.
+
+**[Sift](https://sift.walkosystems.com)** is an MCP-compatible governance layer that adds:
+- ✅ Signed authorization receipts before every real-world action
+- ✅ Scope-based ACL enforcement (what each agent is allowed to touch)
+- ✅ Fail-closed behavior — ungoverned actions are blocked, not logged after the fact
+- ✅ Kill switch — stop all agent actions instantly
+
+**Integration (2 minutes):**
+
+Since DeerFlow supports MCP natively, add Sift to your MCP config:
+
+```json
+{
+  "mcpServers": {
+    "sift": {
+      "command": "python",
+      "args": ["/path/to/sift_mcp_server.py"]
+    }
+  }
+}
+```
+
+Then instruct your agent: *"Before any real-world action, call `sift_authorize` to get a signed receipt."*
+
+Every DeerFlow action is now receipted, auditable, and kill-switchable. [Get started →](https://sift.walkosystems.com)
+
 ## Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, workflow, and guidelines.


### PR DESCRIPTION
## What this PR adds

This PR adds a **Governance** section to the README documenting how to integrate [Sift](https://sift.walkosystems.com) — an MCP-compatible execution governance layer — with DeerFlow.

## Why this is relevant

DeerFlow is an increasingly powerful agent harness. As teams move from demos to production, they need:
- **Signed receipts** for every real-world action an agent takes
- **Scope-based ACL enforcement** (limiting what each agent is allowed to touch)
- **Fail-closed behavior** — ungoverned actions should be blocked, not just logged
- **Kill switches** — the ability to instantly halt all agent actions

These are standard production requirements for autonomous systems, and most DeerFlow users won't think about them until something goes wrong.

## Why Sift fits DeerFlow specifically

DeerFlow already supports MCP natively. Sift is an MCP server — so integration is just adding one entry to your existing MCP config. No SDK changes, no agent refactoring. It slots in cleanly alongside DeerFlow's existing tool/MCP architecture.

## What changed

- Added a ## Governance section in README.md, placed before ## Contributing
- No code changes, no behavior changes — documentation only

This is a legitimate contribution intended to help DeerFlow users think about governance before they hit production.