### PR TITLE
Hide agents routes in static frontend mode

### DIFF
--- a/frontend/src/app/workspace/agents/layout.tsx
+++ b/frontend/src/app/workspace/agents/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+
+import { isStaticWebsiteOnly } from "@/core/config";
+
+export default function AgentsLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  if (isStaticWebsiteOnly()) {
+    redirect("/workspace");
+  }
+
+  return children;
+}

--- a/frontend/src/app/workspace/page.tsx
+++ b/frontend/src/app/workspace/page.tsx
@@ -3,10 +3,10 @@ import path from "path";
 
 import { redirect } from "next/navigation";
 
-import { env } from "@/env";
+import { isStaticWebsiteOnly } from "@/core/config";
 
 export default function WorkspacePage() {
-  if (env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true") {
+  if (isStaticWebsiteOnly()) {
     const firstThread = fs
       .readdirSync(path.resolve(process.cwd(), "public/demo/threads"), {
         withFileTypes: true,

--- a/frontend/src/components/workspace/workspace-nav-chat-list.tsx
+++ b/frontend/src/components/workspace/workspace-nav-chat-list.tsx
@@ -10,11 +10,14 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { isStaticWebsiteOnly } from "@/core/config";
 import { useI18n } from "@/core/i18n/hooks";
 
 export function WorkspaceNavChatList() {
   const { t } = useI18n();
   const pathname = usePathname();
+  const hideAgentsEntry = isStaticWebsiteOnly();
+
   return (
     <SidebarGroup className="pt-1">
       <SidebarMenu>
@@ -26,17 +29,19 @@ export function WorkspaceNavChatList() {
             </Link>
           </SidebarMenuButton>
         </SidebarMenuItem>
-        <SidebarMenuItem>
-          <SidebarMenuButton
-            isActive={pathname.startsWith("/workspace/agents")}
-            asChild
-          >
-            <Link className="text-muted-foreground" href="/workspace/agents">
-              <BotIcon />
-              <span>{t.sidebar.agents}</span>
-            </Link>
-          </SidebarMenuButton>
-        </SidebarMenuItem>
+        {!hideAgentsEntry && (
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              isActive={pathname.startsWith("/workspace/agents")}
+              asChild
+            >
+              <Link className="text-muted-foreground" href="/workspace/agents">
+                <BotIcon />
+                <span>{t.sidebar.agents}</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        )}
       </SidebarMenu>
     </SidebarGroup>
   );

--- a/frontend/src/core/config/index.ts
+++ b/frontend/src/core/config/index.ts
@@ -1,5 +1,9 @@
 import { env } from "@/env";
 
+export function isStaticWebsiteOnly() {
+  return env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true";
+}
+
 export function getBackendBaseURL() {
   if (env.NEXT_PUBLIC_BACKEND_BASE_URL) {
     return env.NEXT_PUBLIC_BACKEND_BASE_URL;


### PR DESCRIPTION
This pull request refactors how the application determines if it should run in "static website only" mode. The logic is now centralized in a new helper function, and this function is used throughout the codebase to improve consistency and maintainability. Additionally, the UI is updated to hide the "Agents" navigation entry when in static website mode, and to redirect users away from the agents section if accessed directly.

Key changes:

**Centralization of configuration logic:**
* Added a new `isStaticWebsiteOnly` helper function in `frontend/src/core/config/index.ts` to encapsulate the logic for checking the static website mode.

**Refactoring and consistency improvements:**
* Replaced direct environment variable checks with the new `isStaticWebsiteOnly` function in `frontend/src/app/workspace/page.tsx`.
* Updated the agents layout in `frontend/src/app/workspace/agents/layout.tsx` to use `isStaticWebsiteOnly` and redirect users to `/workspace` if in static website mode.

**UI updates:**
* Modified `frontend/src/components/workspace/workspace-nav-chat-list.tsx` to conditionally hide the "Agents" sidebar entry when in static website mode, using the new helper function. [[1]](diffhunk://#diff-74fb49a71112bd9a8a2aaa8fdafc9a7d8398867afb5f6f7f2fb9d12288c0e4b0R13-R20) [[2]](diffhunk://#diff-74fb49a71112bd9a8a2aaa8fdafc9a7d8398867afb5f6f7f2fb9d12288c0e4b0R32) [[3]](diffhunk://#diff-74fb49a71112bd9a8a2aaa8fdafc9a7d8398867afb5f6f7f2fb9d12288c0e4b0R44)