### PR TITLE
fix: add Windows compatibility for make dev/start commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,11 @@
 .PHONY: help config config-upgrade check install dev dev-daemon start stop up down clean docker-init docker-start docker-stop docker-logs docker-logs-frontend docker-logs-gateway
 
 PYTHON ?= python
+BASH ?= bash
 
 # Detect OS for Windows compatibility
 ifeq ($(OS),Windows_NT)
     SHELL := cmd.exe
-    BASH := bash
-else
-    BASH := bash
 endif
 
 help:


### PR DESCRIPTION
## Summary

Fixes #1288
Related #1278

## Problem

On Windows with MinGW/Git Bash, running `make dev` fails with:

```
process_begin: CreateProcess(NULL, env bash ...) failed.
make (e=2): 系统找不到指定的文件。
```

This happens because Makefile's direct shell script execution (`./scripts/serve.sh`) doesn't work on Windows.

## Solution

Added OS detection in Makefile:

```makefile
# Detect OS for Windows compatibility
ifeq ($(OS),Windows_NT)
    BASH := bash
else
    BASH := bash
endif

dev:
ifeq ($(OS),Windows_NT)
	@echo "Detected Windows - using Git Bash..."
	@$(BASH) ./scripts/serve.sh --dev
else
	@./scripts/serve.sh --dev
endif
```

## Requirements

- Git for Windows (includes Git Bash)
- Run from Git Bash terminal or ensure `bash` is in PATH

## Testing

On Windows:
```bash
mingw32-make dev  # Should now work
```

On Unix:
```bash
make dev  # Unchanged behavior
```