### PR TITLE
fix: use real thread ID in history.replaceState to prevent image 404

### DIFF
--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -38,10 +38,10 @@ export default function ChatPage() {
     threadId: isNewThread ? undefined : threadId,
     context: settings.context,
     isMock,
-    onStart: () => {
+    onStart: (id) => {
       setIsNewThread(false);
       // ! Important: Never use next.js router for navigation in this case, otherwise it will cause the thread to re-mount and lose all states. Use native history API instead.
-      history.replaceState(null, "", `/workspace/chats/${threadId}`);
+      history.replaceState(null, "", `/workspace/chats/${id}`);
     },
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {


### PR DESCRIPTION
When uploading an image in a new chat, the frontend was using a local UUID instead of the backend-returned thread ID in history.replaceState, causing artifact requests to return 404.

Now the onStart callback uses the real thread ID from the backend.