### PR TITLE
fix: align google_api_key to gemini_api_key in config example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,7 +86,7 @@ models:
   #   display_name: Gemini 2.5 Pro
   #   use: langchain_google_genai:ChatGoogleGenerativeAI
   #   model: gemini-2.5-pro
-  #   google_api_key: $GOOGLE_API_KEY
+  #   gemini_api_key: $GEMINI_API_KEY
   #   max_tokens: 8192
   #   supports_vision: true
 


### PR DESCRIPTION
Fixes #1364

The config.example.yaml used google_api_key: $GOOGLE_API_KEY but
the entire codebase references GEMINI_API_KEY (.env.example, image-
generation, video-generation scripts). This was the only place with
the wrong variable name.