### PR TITLE
fix(tests): adapt assertions for token usage tracking and PathTraversalError

### DIFF
--- a/backend/tests/test_client_e2e.py
+++ b/backend/tests/test_client_e2e.py
@@ -183,7 +183,8 @@ class TestBasicChat:
                 assert "messages" in event.data
                 assert "artifacts" in event.data
             elif event.type == "end":
-                assert event.data == {}
+                # end event may contain usage stats after token tracking was added
+                assert isinstance(event.data, dict)
 
     @requires_llm
     def test_multi_turn_stateless(self, client):

--- a/backend/tests/test_client_live.py
+++ b/backend/tests/test_client_live.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 
 from deerflow.client import DeerFlowClient, StreamEvent
+from deerflow.uploads.manager import PathTraversalError
 
 # Skip entire module in CI or when no config.yaml exists
 _skip_reason = None
@@ -321,5 +322,5 @@ class TestLiveErrorResilience:
             client.get_artifact("t", "invalid/path")
 
     def test_path_traversal_blocked(self, client):
-        with pytest.raises(PermissionError):
+        with pytest.raises(PathTraversalError):
             client.delete_upload("t", "../../etc/passwd")


### PR DESCRIPTION
## Summary
- `test_client_e2e`: relax end event assertion to accept usage stats dict (after #1218 added token tracking)
- `test_client_live`: use `PathTraversalError` instead of `PermissionError` (after #1202 introduced typed exception)

## Test plan
- [x] `test_client_e2e` — 175 passed
- [x] `test_client_live` — 19 passed