### PR TITLE
fix(config): return full URLs for backend and LangGraph base URLs

### DIFF
--- a/frontend/src/core/config/index.ts
+++ b/frontend/src/core/config/index.ts
@@ -2,7 +2,10 @@ import { env } from "@/env";
 
 export function getBackendBaseURL() {
   if (env.NEXT_PUBLIC_BACKEND_BASE_URL) {
-    return env.NEXT_PUBLIC_BACKEND_BASE_URL;
+    return new URL(
+      env.NEXT_PUBLIC_BACKEND_BASE_URL,
+      window.location.origin,
+    ).toString();
   } else {
     return "";
   }
@@ -10,7 +13,10 @@ export function getBackendBaseURL() {
 
 export function getLangGraphBaseURL(isMock?: boolean) {
   if (env.NEXT_PUBLIC_LANGGRAPH_BASE_URL) {
-    return env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+    return new URL(
+      env.NEXT_PUBLIC_LANGGRAPH_BASE_URL,
+      window.location.origin,
+    ).toString();
   } else if (isMock) {
     if (typeof window !== "undefined") {
       return `${window.location.origin}/mock/api`;


### PR DESCRIPTION
This pull request updates the way backend and LangGraph base URLs are constructed in the `getBackendBaseURL` and `getLangGraphBaseURL` functions. The functions now use the `URL` constructor to resolve the URLs relative to the current window location, ensuring the resulting URLs are always valid and absolute.

**Improvements to URL construction:**

* Updated `getBackendBaseURL` and `getLangGraphBaseURL` in `frontend/src/core/config/index.ts` to use the `URL` constructor for building absolute URLs based on `window.location.origin`, making URL handling more robust and consistent.