### PR TITLE
Relax upload permissions for aio sandbox sync

### DIFF
--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -43,8 +43,16 @@ def _make_file_sandbox_writable(file_path: os.PathLike[str] | str) -> None:
     world-writable access here prevents permission mismatches between the
     gateway user and the sandbox runtime user.
     """
-    current_mode = stat.S_IMODE(os.stat(file_path).st_mode)
-    os.chmod(file_path, current_mode | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    file_stat = os.lstat(file_path)
+    if stat.S_ISLNK(file_stat.st_mode):
+        logger.warning("Skipping sandbox chmod for symlinked upload path: %s", file_path)
+        return
+
+    writable_mode = (
+        stat.S_IMODE(file_stat.st_mode) | stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
+    )
+    chmod_kwargs = {"follow_symlinks": False} if os.chmod in os.supports_follow_symlinks else {}
+    os.chmod(file_path, writable_mode, **chmod_kwargs)
 
 
 @router.post("", response_model=UploadResponse)

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -1,4 +1,5 @@
 import asyncio
+import stat
 from io import BytesIO
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -118,6 +119,34 @@ def test_upload_files_does_not_adjust_permissions_for_local_sandbox(tmp_path):
 
     assert result.success is True
     make_writable.assert_not_called()
+
+
+def test_make_file_sandbox_writable_adds_write_bits_for_regular_files(tmp_path):
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"pdf-bytes")
+    os_chmod_mode = stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH
+    file_path.chmod(os_chmod_mode)
+
+    uploads._make_file_sandbox_writable(file_path)
+
+    updated_mode = stat.S_IMODE(file_path.stat().st_mode)
+    assert updated_mode & stat.S_IWUSR
+    assert updated_mode & stat.S_IWGRP
+    assert updated_mode & stat.S_IWOTH
+
+
+def test_make_file_sandbox_writable_skips_symlinks(tmp_path):
+    file_path = tmp_path / "target-link.txt"
+    file_path.write_text("hello", encoding="utf-8")
+    symlink_stat = MagicMock(st_mode=stat.S_IFLNK)
+
+    with (
+        patch.object(uploads.os, "lstat", return_value=symlink_stat),
+        patch.object(uploads.os, "chmod") as chmod,
+    ):
+        uploads._make_file_sandbox_writable(file_path)
+
+    chmod.assert_not_called()
 
 
 def test_upload_files_rejects_dotdot_and_dot_filenames(tmp_path):


### PR DESCRIPTION
## Summary

This PR addresses the upload permission issue discussed in #1398 for non-local sandbox providers such as AIO sandbox.

### Changes
- ensure uploaded host-side files are made writable before syncing them into non-local sandboxes
- apply the same permission adjustment to converted markdown companion files
- add regression tests covering:
  - permission adjustment for non-local sandbox uploads
  - no permission adjustment for local sandbox uploads

## Why

In AIO sandbox mode, the gateway writes the authoritative host-side file first, and the sandbox runtime may later rewrite the same mounted path.

If the host-side file is created with restrictive permissions, the sandbox runtime user can hit `Permission denied` when trying to overwrite that mounted file.

This change makes the uploaded file writable before calling `sandbox.update_file(...)`, which keeps the mounted file path writable for the sandbox runtime.

## Testing

### Passed
- `cd backend && uv run pytest tests/test_uploads_router.py -q`
- `cd backend && uv run ruff check app/gateway/routers/uploads.py tests/test_uploads_router.py`

### Note
- `cd backend && uv run pytest` was also run, and current `origin/main` still has existing Windows baseline failures unrelated to this change.
