### PR TITLE
Normalize text-only OpenAI payload content

### DIFF
--- a/backend/packages/harness/deerflow/models/patched_openai.py
+++ b/backend/packages/harness/deerflow/models/patched_openai.py
@@ -1,4 +1,4 @@
-"""Patched ChatOpenAI that preserves thought_signature for Gemini thinking models.
+"""Patched ChatOpenAI for OpenAI-compatible provider quirks.
 
 When using Gemini with thinking enabled via an OpenAI-compatible gateway (e.g.
 Vertex AI, Google AI Studio, or any proxy), the API requires that the
@@ -14,9 +14,13 @@ signature.  That causes an HTTP 400 ``INVALID_ARGUMENT`` error:
     Unable to submit request because function call `<tool>` in the N. content
     block is missing a `thought_signature`.
 
-This module fixes the problem by overriding ``_get_request_payload`` to
-re-inject tool-call signatures back into the outgoing payload for any assistant
-message that originally carried them.
+Some OpenAI-compatible providers also reject text-only content part arrays and
+expect plain string message content instead. This module fixes both issues by
+overriding ``_get_request_payload`` to:
+
+- collapse text-only content-part arrays back into plain strings
+- re-inject tool-call signatures back into the outgoing payload for any
+  assistant message that originally carried them
 """
 
 from __future__ import annotations
@@ -76,6 +80,11 @@ class PatchedChatOpenAI(ChatOpenAI):
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
 
         payload_messages = payload.get("messages", [])
+        for payload_msg in payload_messages:
+            content = payload_msg.get("content")
+            normalized_content = _normalize_text_only_content(content)
+            if normalized_content is not content:
+                payload_msg["content"] = normalized_content
 
         if len(payload_messages) == len(original_messages):
             for payload_msg, orig_msg in zip(payload_messages, original_messages):
@@ -132,3 +141,48 @@ def _restore_tool_call_signatures(payload_msg: dict, orig_msg: AIMessage) -> Non
         sig = raw_tc.get("thought_signature") or raw_tc.get("thoughtSignature")
         if sig:
             payload_tc["thought_signature"] = sig
+
+
+def _normalize_text_only_content(content: Any) -> Any:
+    """Collapse text-only content arrays into a provider-friendly plain string."""
+    if isinstance(content, dict):
+        part_type = content.get("type")
+        text = content.get("text")
+        if part_type in {"text", "input_text", "output_text"} and isinstance(text, str):
+            return text
+        return content
+
+    if not isinstance(content, list):
+        return content
+
+    if not content:
+        return ""
+
+    parts: list[str] = []
+    pending_text = ""
+
+    for item in content:
+        if isinstance(item, str):
+            pending_text += item
+            continue
+
+        if not isinstance(item, dict):
+            return content
+
+        part_type = item.get("type")
+        if part_type not in {"text", "input_text", "output_text"}:
+            return content
+
+        text = item.get("text")
+        if not isinstance(text, str):
+            return content
+
+        if pending_text:
+            parts.append(pending_text)
+            pending_text = ""
+        parts.append(text)
+
+    if pending_text:
+        parts.append(pending_text)
+
+    return "\n".join(part for part in parts if part)

--- a/backend/tests/test_patched_openai.py
+++ b/backend/tests/test_patched_openai.py
@@ -2,15 +2,15 @@
 
 These tests verify that _restore_tool_call_signatures correctly re-injects
 ``thought_signature`` onto tool-call objects stored in
-``additional_kwargs["tool_calls"]``, covering id-based matching, positional
-fallback, camelCase keys, and several edge-cases.
+``additional_kwargs["tool_calls"]``, and that text-only content blocks are
+collapsed back into plain strings for stricter OpenAI-compatible providers.
 """
 
 from __future__ import annotations
 
 from langchain_core.messages import AIMessage
 
-from deerflow.models.patched_openai import _restore_tool_call_signatures
+from deerflow.models.patched_openai import _normalize_text_only_content, _restore_tool_call_signatures
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -44,6 +44,39 @@ PAYLOAD_TC_2 = {
 
 def _ai_msg_with_raw_tool_calls(raw_tool_calls: list[dict]) -> AIMessage:
     return AIMessage(content="", additional_kwargs={"tool_calls": raw_tool_calls})
+
+
+def test_normalize_text_only_content_returns_plain_string():
+    content = [{"type": "text", "text": "hello"}]
+
+    assert _normalize_text_only_content(content) == "hello"
+
+
+def test_normalize_text_only_content_handles_single_text_block_object():
+    content = {"type": "text", "text": "hello"}
+
+    assert _normalize_text_only_content(content) == "hello"
+
+
+def test_normalize_text_only_content_merges_string_chunks_and_text_blocks():
+    content = ["prefix", "-continued", {"type": "text", "text": "block text"}]
+
+    assert _normalize_text_only_content(content) == "prefix-continued\nblock text"
+
+
+def test_normalize_text_only_content_preserves_multimodal_payloads():
+    content = [
+        {"type": "text", "text": "describe this"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+    ]
+
+    assert _normalize_text_only_content(content) == content
+
+
+def test_normalize_text_only_content_rejects_unknown_block_shapes():
+    content = [{"type": "text", "value": "missing text field"}]
+
+    assert _normalize_text_only_content(content) == content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR improves `PatchedChatOpenAI` for stricter OpenAI-compatible providers, and is intended to address the compatibility issue discussed in #1373.

Some providers reject text-only structured content such as:
- `{"type":"text","text":"hello"}`
- `[{"type":"text","text":"hello"}]`

and expect plain string content instead.

This change updates the OpenAI payload patching logic to:
- collapse single text-block objects into plain strings
- collapse text-only content-part arrays into plain strings
- preserve mixed multimodal payloads as-is
- keep the existing Gemini `thought_signature` restoration behavior unchanged
- add regression tests for the new normalization behavior

## Testing

### Passed
- `cd backend && .venv\Scripts\python.exe -m pytest tests/test_patched_openai.py -q`
- `cd backend && .venv\Scripts\python.exe -m ruff check packages/harness/deerflow/models/patched_openai.py tests/test_patched_openai.py`

### Full backend test run
- `cd backend && .venv\Scripts\python.exe -m pytest`

The full backend suite still has the same existing Windows baseline failures on the current upstream codebase, mainly around:
- `fcntl`-only imports
- missing `bash` on Windows
- symlink privilege requirements
- POSIX path assertions

The targeted tests for this change pass, and this PR does not introduce new failures in the checked area.
