### PR TITLE
fix(scripts): lsof -nP -iTCP hangs indefinitely on macOS (#1400)

### DIFF
--- a/scripts/wait-for-port.sh
+++ b/scripts/wait-for-port.sh
@@ -21,27 +21,16 @@ elapsed=0
 interval=1
 
 is_port_listening() {
-    if command -v lsof >/dev/null 2>&1; then
-        if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    # HTTP check (fast, no macOS lsof hang)
+    if command -v curl >/dev/null 2>&1; then
+        if curl -sf --max-time 1 "http://127.0.0.1:$PORT/" >/dev/null 2>&1; then
             return 0
         fi
     fi
 
-    if command -v ss >/dev/null 2>&1; then
-        if ss -ltn "( sport = :$PORT )" 2>/dev/null | tail -n +2 | grep -q .; then
-            return 0
-        fi
-    fi
-
-    if command -v netstat >/dev/null 2>&1; then
-        if netstat -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|[.:])${PORT}$"; then
-            return 0
-        fi
-    fi
-
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" >/dev/null 2>&1
-        return $?
+    # TCP check via bash built-in (no lsof needed)
+    if bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" >/dev/null 2>&1; then
+        return 0
     fi
 
     return 1


### PR DESCRIPTION
## Summary

Resolves #1400 where `make dev` hangs indefinitely at \"Starting LangGraph server...\" on macOS due to an `lsof` infinite loop.

## Changes

- Replaced `lsof -nP` with a faster HTTP check via `curl` and a TCP fallback using bash built-in (`/dev/tcp`).
- Removed `ss` and `netstat` legacy checks that are slower and unnecessary when `/dev/tcp` is available.

This improves cross-platform reliability for all `wait-for-port.sh` executions during local startup.