### PR TITLE
fix: API-launched subagent runs fail with GraphRecursionError and mis…

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -331,7 +331,7 @@ def make_lead_agent(config: RunnableConfig):
             middleware=_build_middlewares(config, model_name=model_name),
             system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"])),
             state_schema=ThreadState,
-        )
+        ).with_config({"recursion_limit": 10_000})
 
     # Default lead agent (unchanged behavior)
     return create_agent(
@@ -340,4 +340,4 @@ def make_lead_agent(config: RunnableConfig):
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
         system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, agent_name=agent_name),
         state_schema=ThreadState,
-    )
+    ).with_config({"recursion_limit": 10_000})

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -229,7 +229,7 @@ class SubagentExecutor:
 
             # Build config with thread_id for sandbox access and recursion limit
             run_config: RunnableConfig = {
-                "recursion_limit": self.config.max_turns,
+                "recursion_limit": self.config.max_turns * 10,  # Each turn ≈ 3-5 node hops
             }
             context = {}
             if self.thread_id:

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -86,6 +86,8 @@ def task_tool(
         sandbox_state = runtime.state.get("sandbox")
         thread_data = runtime.state.get("thread_data")
         thread_id = runtime.context.get("thread_id") if runtime.context else None
+        if thread_id is None:
+            thread_id = runtime.config.get("configurable", {}).get("thread_id")
 
         # Try to get parent model from configurable
         metadata = runtime.config.get("metadata", {})


### PR DESCRIPTION
…sing thread_id

Three related bugs cause all headless/programmatic deep research runs via the REST API to fail while the web UI works fine:

1. task_tool.py only reads thread_id from runtime.context, but the REST API path puts it in config.configurable. Subagents get no thread_id and crash with "Thread ID is required in runtime context or config.configurable". Fixed by adding a fallback to config.configurable, matching the pattern already used by ThreadDataMiddleware.

2. executor.py sets recursion_limit = max_turns (50), but LangGraph counts every node hop (3-5 per turn), not agent turns. This starves subagents after ~10 real turns. Fixed by multiplying by 10 for headroom.

3. make_lead_agent() returns the graph without a recursion_limit override. The web UI streaming path gets 10,000 from the LangChain factory, but API runs get the LangGraph default of 25. Fixed by chaining .with_config({"recursion_limit": 10_000}).