### PR TITLE
fix(memory): fallback to configurable thread_id when runtime context is missing (#1425)

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/memory_middleware.py
@@ -121,6 +121,8 @@ class MemoryMiddleware(AgentMiddleware[MemoryMiddlewareState]):
 
         # Get thread ID from runtime context
         thread_id = runtime.context.get("thread_id") if runtime.context else None
+        if not thread_id and "configurable" in runtime.config:
+            thread_id = runtime.config["configurable"].get("thread_id")
         if not thread_id:
             print("MemoryMiddleware: No thread_id in context, skipping memory update")
             return None


### PR DESCRIPTION
Fixes #1425.\n\n`MemoryMiddleware.after_agent()` was previously skipping memory writes during direct LangGraph `runs.wait` calls because `runtime.context` was missing `thread_id`. \n\nThis change adds a fallback to retrieve `thread_id` from `runtime.config["configurable"]` to ensure that memory updates are enqueued correctly across all execution paths.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*