### PR TITLE
fix(uploads): make uploaded files writable for sandbox runtime users (#1398)

### DIFF
--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -67,6 +67,7 @@ async def upload_files(
             content = await file.read()
             file_path = uploads_dir / safe_filename
             file_path.write_bytes(content)
+            file_path.chmod(0o666)
 
             virtual_path = upload_virtual_path(safe_filename)
 
@@ -87,6 +88,7 @@ async def upload_files(
             if file_ext in CONVERTIBLE_EXTENSIONS:
                 md_path = await convert_file_to_markdown(file_path)
                 if md_path:
+                    md_path.chmod(0o666)
                     md_virtual_path = upload_virtual_path(md_path.name)
 
                     if sandbox_id != "local":


### PR DESCRIPTION
Fixes #1398.\n\nIn AIO sandbox mode, files uploaded by the Gateway are created on the host and then synced to the sandbox. Because the host writes the file first, it may be created with restrictive permissions (e.g. `644` owned by `root:root`), preventing the sandbox runtime user (e.g., `gem`) from overwriting it later via `update_file` or script outputs.\n\nThis patch explicitly applies `chmod(0o666)` to uploaded files and their markdown conversions immediately after they are written to the host-side thread directory, ensuring they remain writable by any user within the mounted sandbox environment.\n\n*(Refactored using the open-source [0-editor](https://github.com/0-protocol/0-editor))*