### PR TITLE
fix(runtime): decouple summarization from state persistence to preserve full conversation history (#1393)

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -2,6 +2,12 @@ import logging
 
 from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
+from langchain_core.messages import RemoveMessage
+from typing import Any
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+from collections.abc import Callable, Awaitable
 from langchain_core.runnables import RunnableConfig
 
 from deerflow.agents.lead_agent.prompt import apply_prompt_template
@@ -37,6 +43,23 @@ def _resolve_model_name(requested_model_name: str | None = None) -> str:
         logger.warning(f"Model '{requested_model_name}' not found in config; fallback to default model '{default_model_name}'.")
     return default_model_name
 
+
+
+class SafeSummarizationMiddleware(SummarizationMiddleware):
+    """Wrapper to prevent SummarizationMiddleware from destructively overwriting state."""
+    
+    def before_model(self, state, runtime):
+        return None
+        
+    async def abefore_model(self, state, runtime):
+        return None
+        
+    async def awrap_model_call(self, request, handler):
+        state_update = await super().abefore_model(request.state, request.runtime)
+        if state_update and "messages" in state_update:
+            messages_to_send = [msg for msg in state_update["messages"] if not isinstance(msg, RemoveMessage)]
+            request = request.override(messages=messages_to_send)
+        return await handler(request)
 
 def _create_summarization_middleware() -> SummarizationMiddleware | None:
     """Create and configure the summarization middleware from config."""
@@ -77,7 +100,7 @@ def _create_summarization_middleware() -> SummarizationMiddleware | None:
     if config.summary_prompt is not None:
         kwargs["summary_prompt"] = config.summary_prompt
 
-    return SummarizationMiddleware(**kwargs)
+    return SafeSummarizationMiddleware(**kwargs)
 
 
 def _create_todo_list_middleware(is_plan_mode: bool) -> TodoMiddleware | None:

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -1,13 +1,8 @@
 import logging
 
 from langchain.agents import create_agent
-from langchain.agents.middleware import SummarizationMiddleware
+from langchain.agents.middleware import SummarizationMiddleware as _BaseSummarizationMiddleware
 from langchain_core.messages import RemoveMessage
-from typing import Any
-from langgraph.prebuilt.tool_node import ToolCallRequest
-from langchain_core.messages import ToolMessage
-from langgraph.types import Command
-from collections.abc import Callable, Awaitable
 from langchain_core.runnables import RunnableConfig
 
 from deerflow.agents.lead_agent.prompt import apply_prompt_template
@@ -45,21 +40,26 @@ def _resolve_model_name(requested_model_name: str | None = None) -> str:
 
 
 
-class SafeSummarizationMiddleware(SummarizationMiddleware):
+class SafeSummarizationMiddleware(_BaseSummarizationMiddleware):
     """Wrapper to prevent SummarizationMiddleware from destructively overwriting state."""
-    
+
     def before_model(self, state, runtime):
         return None
-        
+
     async def abefore_model(self, state, runtime):
         return None
-        
+
     async def awrap_model_call(self, request, handler):
         state_update = await super().abefore_model(request.state, request.runtime)
         if state_update and "messages" in state_update:
             messages_to_send = [msg for msg in state_update["messages"] if not isinstance(msg, RemoveMessage)]
             request = request.override(messages=messages_to_send)
         return await handler(request)
+
+
+# Public module-level symbol used both at runtime and as a patch seam in tests.
+SummarizationMiddleware = SafeSummarizationMiddleware
+
 
 def _create_summarization_middleware() -> SummarizationMiddleware | None:
     """Create and configure the summarization middleware from config."""
@@ -100,7 +100,7 @@ def _create_summarization_middleware() -> SummarizationMiddleware | None:
     if config.summary_prompt is not None:
         kwargs["summary_prompt"] = config.summary_prompt
 
-    return SafeSummarizationMiddleware(**kwargs)
+    return SummarizationMiddleware(**kwargs)
 
 
 def _create_todo_list_middleware(is_plan_mode: bool) -> TodoMiddleware | None:


### PR DESCRIPTION
Fixes #1393 and #1000.\n\nCurrently, the native `SummarizationMiddleware` replaces the conversation history in `state["messages"]` with a generated summary plus a trailing window of messages. This permanently erases the original history from LangGraph checkpoints, causing the frontend to render truncated dialogue histories upon page refresh.\n\nThis patch introduces a `SafeSummarizationMiddleware` wrapper that hijacks `SummarizationMiddleware.abefore_model`. Instead of returning a destructive state update with `RemoveMessage(id=REMOVE_ALL_MESSAGES)`, it captures the summarized window and injects it directly into the `ModelRequest.messages` via `awrap_model_call`. \n\nThis ensures that the token reduction strictly applies to the current inference window passed to the LLM, while leaving the authoritative `state["messages"]` and DB checkpoints completely intact and immutable.