### PR TITLE
fix(sandbox): serialize concurrent exec_command calls in AioSandbox

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
@@ -69,14 +69,9 @@ class AioSandbox(Sandbox):
                 output = result.data.output if result.data else ""
 
                 if output and _ERROR_OBSERVATION_SIGNATURE in output:
-                    logger.warning(
-                        "ErrorObservation detected in sandbox output, "
-                        "retrying with a fresh session"
-                    )
+                    logger.warning("ErrorObservation detected in sandbox output, retrying with a fresh session")
                     fresh_id = str(uuid.uuid4())
-                    result = self._client.shell.exec_command(
-                        command=command, id=fresh_id
-                    )
+                    result = self._client.shell.exec_command(command=command, id=fresh_id)
                     output = result.data.output if result.data else ""
 
                 return output if output else "(no output)"

--- a/backend/tests/test_aio_sandbox.py
+++ b/backend/tests/test_aio_sandbox.py
@@ -70,11 +70,7 @@ class TestErrorObservationRetry:
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return SimpleNamespace(
-                    data=SimpleNamespace(
-                        output="'ErrorObservation' object has no attribute 'exit_code'"
-                    )
-                )
+                return SimpleNamespace(data=SimpleNamespace(output="'ErrorObservation' object has no attribute 'exit_code'"))
             return SimpleNamespace(data=SimpleNamespace(output="success"))
 
         sandbox._client.shell.exec_command = mock_exec
@@ -90,9 +86,7 @@ class TestErrorObservationRetry:
         def mock_exec(command, **kwargs):
             calls.append(kwargs)
             if len(calls) == 1:
-                return SimpleNamespace(
-                    data=SimpleNamespace(output="'ErrorObservation' object has no attribute 'exit_code'")
-                )
+                return SimpleNamespace(data=SimpleNamespace(output="'ErrorObservation' object has no attribute 'exit_code'"))
             return SimpleNamespace(data=SimpleNamespace(output="ok"))
 
         sandbox._client.shell.exec_command = mock_exec
@@ -126,9 +120,7 @@ class TestListDirSerialization:
         """list_dir should hold the lock during execution."""
         lock_was_held = []
 
-        original_exec = MagicMock(
-            return_value=SimpleNamespace(data=SimpleNamespace(output="/a\n/b"))
-        )
+        original_exec = MagicMock(return_value=SimpleNamespace(data=SimpleNamespace(output="/a\n/b")))
 
         def tracking_exec(command, **kwargs):
             lock_was_held.append(sandbox._lock.locked())


### PR DESCRIPTION
## Summary

Adds a `threading.Lock` to `AioSandbox` to prevent concurrent `exec_command` calls from corrupting the container's single persistent shell session. Also adds `ErrorObservation` detection with fresh-session retry as a safety net for multi-process scenarios.

## Problem

When LangGraph's `ToolNode` issues parallel `tool_calls` in a single agent step, multiple `exec_command` requests hit the AIO sandbox container simultaneously. The container's shell session server can't handle concurrent submissions - the second request corrupts session state for both callers, returning `'ErrorObservation' object has no attribute 'exit_code'` as command output. Subsequent commands on the same session also fail (cascade effect).

Root cause: `AioSandboxProvider` (`aio_sandbox_provider.py:93,97`) has thread locks for sandbox lifecycle (acquire/release), but the `AioSandbox` instance itself had no concurrency protection on its shell commands.

## Changes

**`backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py`:**
- Add `threading.Lock` to serialize `execute_command` and `list_dir` (both call `shell.exec_command`)
- Detect `ErrorObservation` in output and retry with a fresh session UUID (defense-in-depth for cross-process races)

**`backend/tests/test_aio_sandbox.py` (new):**
- `TestExecuteCommandSerialization` - verifies concurrent threads don't interleave inside `execute_command`
- `TestErrorObservationRetry` - verifies retry with fresh session ID on corruption, and no retry on clean output
- `TestListDirSerialization` - verifies `list_dir` also holds the lock

## Testing

```
$ PYTHONPATH=. uv run pytest tests/test_aio_sandbox.py -v
5 passed in 0.30s
```

Existing `test_aio_sandbox_provider.py` tests also pass (5/5).

Fixes #1433

This contribution was developed with AI assistance (Claude Code).