### PR TITLE
feat(memory): add delete fact and clear all memory endpoints

### DIFF
--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -1,9 +1,9 @@
 """Memory API router for retrieving and managing global memory data."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from deerflow.agents.memory.updater import get_memory_data, reload_memory_data
+from deerflow.agents.memory.updater import clear_memory, delete_memory_fact, get_memory_data, reload_memory_data
 from deerflow.config.memory_config import get_memory_config
 
 router = APIRouter(prefix="/api", tags=["memory"])
@@ -199,3 +199,53 @@ async def get_memory_status() -> MemoryStatusResponse:
         ),
         data=MemoryResponse(**memory_data),
     )
+
+
+class DeleteFactResponse(BaseModel):
+    """Response model for fact deletion."""
+
+    success: bool = Field(..., description="Whether the fact was deleted")
+
+
+@router.delete(
+    "/memory/facts/{fact_id}",
+    response_model=DeleteFactResponse,
+    summary="Delete Memory Fact",
+    description="Delete a single fact from memory by its ID.",
+)
+async def delete_fact(fact_id: str) -> DeleteFactResponse:
+    """Delete a specific memory fact.
+
+    Args:
+        fact_id: The unique identifier of the fact to delete.
+
+    Returns:
+        Success status.
+
+    Raises:
+        HTTPException: 404 if the fact ID was not found.
+    """
+    success = delete_memory_fact(fact_id)
+    if not success:
+        raise HTTPException(status_code=404, detail=f"Fact with id '{fact_id}' not found")
+    return DeleteFactResponse(success=True)
+
+
+@router.delete(
+    "/memory",
+    response_model=MemoryResponse,
+    summary="Clear All Memory",
+    description="Clear all memory data, resetting user context, history, and facts to empty state.",
+)
+async def clear_all_memory() -> MemoryResponse:
+    """Clear all memory data.
+
+    This resets the entire memory to its initial empty state,
+    removing all user context, history summaries, and facts.
+
+    Returns:
+        The cleared (empty) memory data.
+    """
+    clear_memory()
+    memory_data = get_memory_data()
+    return MemoryResponse(**memory_data)

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -116,6 +116,37 @@ def reload_memory_data(agent_name: str | None = None) -> dict[str, Any]:
     return memory_data
 
 
+def delete_memory_fact(fact_id: str, agent_name: str | None = None) -> bool:
+    """Delete a single fact by ID.
+
+    Args:
+        fact_id: The unique identifier of the fact to delete.
+        agent_name: If provided, deletes from per-agent memory. If None, deletes from global memory.
+
+    Returns:
+        True if the fact was found and deleted, False if not found.
+    """
+    memory_data = get_memory_data(agent_name)
+    original_count = len(memory_data.get("facts", []))
+    memory_data["facts"] = [f for f in memory_data.get("facts", []) if f.get("id") != fact_id]
+    if len(memory_data["facts"]) == original_count:
+        return False
+    return _save_memory_to_file(memory_data, agent_name)
+
+
+def clear_memory(agent_name: str | None = None) -> bool:
+    """Clear all memory data, resetting to the empty state.
+
+    Args:
+        agent_name: If provided, clears per-agent memory. If None, clears global memory.
+
+    Returns:
+        True if memory was cleared successfully, False otherwise.
+    """
+    empty = _create_empty_memory()
+    return _save_memory_to_file(empty, agent_name)
+
+
 def _extract_text(content: Any) -> str:
     """Extract plain text from LLM response content (str or list of content blocks).
 

--- a/backend/tests/test_memory_management.py
+++ b/backend/tests/test_memory_management.py
@@ -1,0 +1,161 @@
+"""Tests for memory management operations (delete fact, clear all)."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from deerflow.agents.memory.updater import (
+    _create_empty_memory,
+    clear_memory,
+    delete_memory_fact,
+)
+
+
+def _make_memory_with_facts() -> dict:
+    return {
+        "version": "1.0",
+        "lastUpdated": "2024-01-15T10:30:00Z",
+        "user": {
+            "workContext": {"summary": "Working on DeerFlow", "updatedAt": "2024-01-15T10:30:00Z"},
+            "personalContext": {"summary": "", "updatedAt": ""},
+            "topOfMind": {"summary": "", "updatedAt": ""},
+        },
+        "history": {
+            "recentMonths": {"summary": "", "updatedAt": ""},
+            "earlierContext": {"summary": "", "updatedAt": ""},
+            "longTermBackground": {"summary": "", "updatedAt": ""},
+        },
+        "facts": [
+            {
+                "id": "fact_001",
+                "content": "User prefers TypeScript",
+                "category": "preference",
+                "confidence": 0.9,
+                "createdAt": "2024-01-15T10:30:00Z",
+                "source": "thread_abc",
+            },
+            {
+                "id": "fact_002",
+                "content": "User works on AI projects",
+                "category": "context",
+                "confidence": 0.85,
+                "createdAt": "2024-01-15T11:00:00Z",
+                "source": "thread_def",
+            },
+            {
+                "id": "fact_003",
+                "content": "User likes dark mode",
+                "category": "preference",
+                "confidence": 0.7,
+                "createdAt": "2024-01-16T09:00:00Z",
+                "source": "thread_ghi",
+            },
+        ],
+    }
+
+
+class TestDeleteMemoryFact:
+    def test_delete_existing_fact(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        memory_data = _make_memory_with_facts()
+        memory_file.write_text(json.dumps(memory_data))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            # Clear the cache so it reads from file
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            result = delete_memory_fact("fact_002")
+            assert result is True
+
+            # Verify the fact was removed
+            updated = json.loads(memory_file.read_text())
+            fact_ids = [f["id"] for f in updated["facts"]]
+            assert "fact_002" not in fact_ids
+            assert "fact_001" in fact_ids
+            assert "fact_003" in fact_ids
+            assert len(updated["facts"]) == 2
+
+    def test_delete_nonexistent_fact(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        memory_data = _make_memory_with_facts()
+        memory_file.write_text(json.dumps(memory_data))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            result = delete_memory_fact("fact_nonexistent")
+            assert result is False
+
+            # Verify no facts were removed
+            updated = json.loads(memory_file.read_text())
+            assert len(updated["facts"]) == 3
+
+    def test_delete_from_empty_facts(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        memory_data = _make_memory_with_facts()
+        memory_data["facts"] = []
+        memory_file.write_text(json.dumps(memory_data))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            result = delete_memory_fact("fact_001")
+            assert result is False
+
+
+class TestClearMemory:
+    def test_clear_resets_to_empty(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        memory_data = _make_memory_with_facts()
+        memory_file.write_text(json.dumps(memory_data))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            result = clear_memory()
+            assert result is True
+
+            # Verify memory is empty
+            updated = json.loads(memory_file.read_text())
+            assert updated["facts"] == []
+            assert updated["user"]["workContext"]["summary"] == ""
+            assert updated["user"]["personalContext"]["summary"] == ""
+            assert updated["user"]["topOfMind"]["summary"] == ""
+            assert updated["history"]["recentMonths"]["summary"] == ""
+
+    def test_clear_updates_last_updated(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        memory_data = _make_memory_with_facts()
+        memory_file.write_text(json.dumps(memory_data))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            clear_memory()
+
+            updated = json.loads(memory_file.read_text())
+            # lastUpdated should be set (not empty)
+            assert updated["lastUpdated"] != ""
+
+    def test_clear_when_already_empty(self, tmp_path: Path) -> None:
+        memory_file = tmp_path / "memory.json"
+        empty = _create_empty_memory()
+        memory_file.write_text(json.dumps(empty))
+
+        with patch("deerflow.agents.memory.updater._get_memory_file_path", return_value=memory_file):
+            from deerflow.agents.memory.updater import _memory_cache
+
+            _memory_cache.clear()
+
+            result = clear_memory()
+            assert result is True

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -1,9 +1,21 @@
 "use client";
 
+import { Trash2Icon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
 import { Streamdown } from "streamdown";
 
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useI18n } from "@/core/i18n/hooks";
-import { useMemory } from "@/core/memory/hooks";
+import { useClearMemory, useDeleteFact, useMemory } from "@/core/memory/hooks";
 import type { UserMemory } from "@/core/memory/types";
 import { streamdownPlugins } from "@/core/streamdown/plugins";
 import { pathOfThread } from "@/core/threads/utils";
@@ -19,13 +31,8 @@ function confidenceToLevelKey(confidence: unknown): {
     return { key: "unknown" };
   }
 
-  // Clamp to [0, 1] since confidence is expected to be a probability-like score.
   const value = Math.min(1, Math.max(0, confidence));
 
-  // 3 levels:
-  // - veryHigh: [0.85, 1]
-  // - high:     [0.65, 0.85)
-  // - normal:   [0, 0.65)
   if (value >= 0.85) return { key: "veryHigh", value };
   if (value >= 0.65) return { key: "high", value };
   return { key: "normal", value };
@@ -114,31 +121,8 @@ function memoryToMarkdown(
     ),
   );
 
-  parts.push(`\n## ${t.settings.memory.markdown.facts}`);
-  if (memory.facts.length === 0) {
-    parts.push(
-      `<span class="text-muted-foreground">${t.settings.memory.markdown.empty}</span>`,
-    );
-  } else {
-    parts.push(
-      [
-        `| ${t.settings.memory.markdown.table.category} | ${t.settings.memory.markdown.table.confidence} | ${t.settings.memory.markdown.table.content} | ${t.settings.memory.markdown.table.source} | ${t.settings.memory.markdown.table.createdAt} |`,
-        "|---|---|---|---|---|",
-        ...memory.facts.map((f) => {
-          const { key, value } = confidenceToLevelKey(f.confidence);
-          const levelLabel =
-            t.settings.memory.markdown.table.confidenceLevel[key];
-          const confidenceText =
-            typeof value === "number" ? `${levelLabel}` : levelLabel;
-          return `| ${upperFirst(f.category)} | ${confidenceText} | ${f.content} | [${t.settings.memory.markdown.table.view}](${pathOfThread(f.source)}) | ${formatTimeAgo(f.createdAt)} |`;
-        }),
-      ].join("\n"),
-    );
-  }
-
   const markdown = parts.join("\n\n");
 
-  // Ensure every level-2 heading (##) is preceded by a horizontal rule.
   const lines = markdown.split("\n");
   const out: string[] = [];
   let i = 0;
@@ -155,9 +139,114 @@ function memoryToMarkdown(
   return out.join("\n");
 }
 
+function FactsTable({
+  facts,
+  t,
+}: {
+  facts: UserMemory["facts"];
+  t: ReturnType<typeof useI18n>["t"];
+}) {
+  const deleteFact = useDeleteFact();
+
+  const handleDelete = useCallback(
+    (factId: string) => {
+      deleteFact.mutate(factId, {
+        onError: () => {
+          toast.error("Failed to delete fact");
+        },
+      });
+    },
+    [deleteFact],
+  );
+
+  if (facts.length === 0) {
+    return (
+      <p className="text-muted-foreground text-sm">
+        {t.settings.memory.markdown.empty}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="pb-2 pr-3 font-medium">
+              {t.settings.memory.markdown.table.category}
+            </th>
+            <th className="pb-2 pr-3 font-medium">
+              {t.settings.memory.markdown.table.confidence}
+            </th>
+            <th className="pb-2 pr-3 font-medium">
+              {t.settings.memory.markdown.table.content}
+            </th>
+            <th className="pb-2 pr-3 font-medium">
+              {t.settings.memory.markdown.table.source}
+            </th>
+            <th className="pb-2 pr-3 font-medium">
+              {t.settings.memory.markdown.table.createdAt}
+            </th>
+            <th className="pb-2 font-medium" />
+          </tr>
+        </thead>
+        <tbody>
+          {facts.map((f) => {
+            const { key } = confidenceToLevelKey(f.confidence);
+            const levelLabel =
+              t.settings.memory.markdown.table.confidenceLevel[key];
+            return (
+              <tr key={f.id} className="border-b last:border-0">
+                <td className="py-2 pr-3">{upperFirst(f.category)}</td>
+                <td className="py-2 pr-3">{levelLabel}</td>
+                <td className="py-2 pr-3">{f.content}</td>
+                <td className="py-2 pr-3">
+                  <a
+                    href={pathOfThread(f.source)}
+                    className="text-primary hover:underline"
+                  >
+                    {t.settings.memory.markdown.table.view}
+                  </a>
+                </td>
+                <td className="py-2 pr-3">{formatTimeAgo(f.createdAt)}</td>
+                <td className="py-2">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-destructive h-7 w-7"
+                    onClick={() => handleDelete(f.id)}
+                    disabled={deleteFact.isPending}
+                  >
+                    <Trash2Icon className="h-4 w-4" />
+                  </Button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function MemorySettingsPage() {
   const { t } = useI18n();
   const { memory, isLoading, error } = useMemory();
+  const clearMemory = useClearMemory();
+  const [showClearDialog, setShowClearDialog] = useState(false);
+
+  const handleClearAll = useCallback(() => {
+    clearMemory.mutate(undefined, {
+      onSuccess: () => {
+        setShowClearDialog(false);
+        toast.success("Memory cleared");
+      },
+      onError: () => {
+        toast.error("Failed to clear memory");
+      },
+    });
+  }, [clearMemory]);
+
   return (
     <SettingsSection
       title={t.settings.memory.title}
@@ -172,14 +261,65 @@ export function MemorySettingsPage() {
           {t.settings.memory.empty}
         </div>
       ) : (
-        <div className="rounded-lg border p-4">
-          <Streamdown
-            className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
-            {...streamdownPlugins}
-          >
-            {memoryToMarkdown(memory, t)}
-          </Streamdown>
-        </div>
+        <>
+          <div className="mb-4 flex justify-end">
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowClearDialog(true)}
+              disabled={clearMemory.isPending}
+            >
+              <Trash2Icon className="mr-2 h-4 w-4" />
+              Clear All Memory
+            </Button>
+          </div>
+          <div className="rounded-lg border p-4">
+            <Streamdown
+              className="size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+              {...streamdownPlugins}
+            >
+              {memoryToMarkdown(memory, t)}
+            </Streamdown>
+
+            {memory.facts.length > 0 && (
+              <>
+                <hr className="my-4" />
+                <h2 className="mb-3 text-lg font-semibold">
+                  {t.settings.memory.markdown.facts}
+                </h2>
+                <FactsTable facts={memory.facts} t={t} />
+              </>
+            )}
+          </div>
+
+          <Dialog open={showClearDialog} onOpenChange={setShowClearDialog}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Clear All Memory</DialogTitle>
+                <DialogDescription>
+                  This will permanently delete all memory data including user
+                  context, history summaries, and facts. This action cannot be
+                  undone.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setShowClearDialog(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={handleClearAll}
+                  disabled={clearMemory.isPending}
+                >
+                  {clearMemory.isPending ? "Clearing..." : "Clear All"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </>
       )}
     </SettingsSection>
   );

--- a/frontend/src/core/memory/api.ts
+++ b/frontend/src/core/memory/api.ts
@@ -7,3 +7,24 @@ export async function loadMemory() {
   const json = await memory.json();
   return json as UserMemory;
 }
+
+export async function deleteMemoryFact(factId: string) {
+  const res = await fetch(
+    `${getBackendBaseURL()}/api/memory/facts/${encodeURIComponent(factId)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to delete fact: ${res.statusText}`);
+  }
+  return res.json() as Promise<{ success: boolean }>;
+}
+
+export async function clearAllMemory() {
+  const res = await fetch(`${getBackendBaseURL()}/api/memory`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to clear memory: ${res.statusText}`);
+  }
+  return res.json() as Promise<UserMemory>;
+}

--- a/frontend/src/core/memory/hooks.ts
+++ b/frontend/src/core/memory/hooks.ts
@@ -1,6 +1,6 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { loadMemory } from "./api";
+import { clearAllMemory, deleteMemoryFact, loadMemory } from "./api";
 
 export function useMemory() {
   const { data, isLoading, error } = useQuery({
@@ -8,4 +8,24 @@ export function useMemory() {
     queryFn: () => loadMemory(),
   });
   return { memory: data ?? null, isLoading, error };
+}
+
+export function useDeleteFact() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (factId: string) => deleteMemoryFact(factId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["memory"] });
+    },
+  });
+}
+
+export function useClearMemory() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => clearAllMemory(),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["memory"] });
+    },
+  });
 }


### PR DESCRIPTION
## Summary

Adds memory management capabilities. The backend API now supports deleting individual facts and clearing all memory. The frontend memory settings page gets interactive delete buttons per fact and a "Clear All Memory" button with confirmation dialog.

## Why this matters

Issue [#1333](https://github.com/bytedance/deer-flow/issues/1333) requests memory clearing/management. The current API only supports reading memory data (`GET /api/memory`) and reloading from file (`POST /api/memory/reload`). There is no way to delete facts or reset memory. The settings page renders memory as read-only markdown.

## Changes

### Backend (harness layer - `deerflow.*`)
- `delete_memory_fact(fact_id)` in `updater.py` - removes a single fact by ID, returns False if not found
- `clear_memory()` in `updater.py` - resets memory to empty state via `_create_empty_memory()` + `_save_memory_to_file()`

### Backend (app layer - `app.*`)
- `DELETE /api/memory/facts/{fact_id}` - returns 200 on success, 404 if fact not found
- `DELETE /api/memory` - clears all memory, returns the empty state

### Frontend
- `deleteMemoryFact()` and `clearAllMemory()` API functions in `core/memory/api.ts`
- `useDeleteFact()` and `useClearMemory()` TanStack Query mutation hooks with cache invalidation
- Interactive `FactsTable` component replaces the markdown table - each row has a trash icon button
- "Clear All Memory" button with confirmation dialog at the top of the memory section

## Testing

6 unit tests covering:
- Delete existing fact (verifies removal + other facts preserved)
- Delete nonexistent fact (returns False, no side effects)
- Delete from empty facts list
- Clear resets to empty state (all sections zeroed)
- Clear updates lastUpdated timestamp
- Clear when already empty (idempotent)

Harness boundary test passes - no `app.*` imports in `deerflow.*`.

## Video Demo

![Demo](https://files.catbox.moe/beo8db.gif)

Fixes #1333

This contribution was developed with AI assistance (Claude Code).