### PR TITLE
fix(config): add Docker service name guidance for channel URLs

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -541,6 +541,9 @@ checkpointer:
 
 # channels:
 #   # LangGraph Server URL for thread/message management (default: http://localhost:2024)
+#   # For Docker deployments, use the Docker service name instead of localhost:
+#   #   langgraph_url: http://langgraph:2024
+#   #   gateway_url: http://gateway:8001
 #   langgraph_url: http://localhost:2024
 #   # Gateway API URL for auxiliary queries like /models, /memory (default: http://localhost:8001)
 #   gateway_url: http://localhost:8001


### PR DESCRIPTION
## Summary

Adds inline comments to `config.example.yaml` showing the Docker service names for `langgraph_url` and `gateway_url` in the channels section.

## Problem

When running DeerFlow in Docker with IM channels enabled (Feishu, Slack, Telegram), the default `http://localhost:2024` doesn't resolve from inside Docker containers. Users need to use Docker Compose service names instead - `http://langgraph:2024` and `http://gateway:8001` - which match the service definitions in `docker/docker-compose.yaml` (line 104) and `docker/docker-compose-dev.yaml` (line 156).

## Changes

`config.example.yaml` - added 3 comment lines showing Docker-specific URLs alongside the existing localhost defaults.

Fixes #1421

This contribution was developed with AI assistance (Claude Code).