### PR TITLE
fix(middleware): return proper content format when no images viewed

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py
@@ -102,7 +102,8 @@ class ViewImageMiddleware(AgentMiddleware[ViewImageMiddlewareState]):
         """
         viewed_images = state.get("viewed_images", {})
         if not viewed_images:
-            return ["No images have been viewed."]
+            # Return a properly formatted text block, not a plain string array
+            return [{"type": "text", "text": "No images have been viewed."}]
 
         # Build the message with image information
         content_blocks: list[str | dict] = [{"type": "text", "text": "Here are the images you've viewed:"}]


### PR DESCRIPTION
## Summary

Fixes #1441

## Problem

When no images have been viewed, `_create_image_details_message()` returned:
```python
return ["No images have been viewed."]
```

This is a plain string array, which OpenAI API rejects with:
```
BadRequestError: expected a string or array of objects, but got `["No images have been viewed."]` instead
```

## Solution

Return a properly formatted content block:
```python
return [{"type": "text", "text": "No images have been viewed."}]
```

## Testing

- The fix ensures message content is always in the correct format for OpenAI API
- This prevents the BadRequestError from occurring when no images have been viewed

## Changes

- `backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py`