### PR TITLE
fix: avoid replaying transient Responses API items through PatchedChatOpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
 
    To route OpenAI models through `/v1/responses`, keep using `langchain_openai:ChatOpenAI` and set `use_responses_api: true` with `output_version: responses/v1`.
 
+   If you are routing Responses API traffic through an OpenAI-compatible gateway that does not persist response items when `store=false` (for example some zero-data-retention proxies), use `deerflow.models.patched_openai:PatchedChatOpenAI` instead. It preserves Gemini `thought_signature` fields and strips transient Responses items such as `reasoning` blocks that cannot be replayed safely in the next turn.
+
    CLI-backed provider examples:
 
    ```yaml

--- a/backend/README.md
+++ b/backend/README.md
@@ -187,6 +187,8 @@ Set your API keys:
 export OPENAI_API_KEY="your-api-key-here"
 ```
 
+If you are routing Responses API traffic through an OpenAI-compatible gateway that does not persist response items when `store=false`, switch `use` to `deerflow.models.patched_openai:PatchedChatOpenAI`. The patched adapter preserves Gemini `thought_signature` fields and strips transient Responses items such as `reasoning` blocks that cannot be replayed safely in the next turn.
+
 ### Running
 
 **Full Application** (from project root):

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -78,6 +78,8 @@ models:
     output_version: responses/v1
 ```
 
+If you are routing Responses API traffic through an OpenAI-compatible gateway that does not persist response items when `store=false`, switch `use` to `deerflow.models.patched_openai:PatchedChatOpenAI`. The patched adapter preserves Gemini `thought_signature` fields and strips transient Responses items such as `reasoning` blocks that cannot be replayed safely in the next turn.
+
 For OpenAI-compatible gateways (for example Novita or OpenRouter), keep using `langchain_openai:ChatOpenAI` and set `base_url`:
 
 ```yaml

--- a/backend/packages/harness/deerflow/models/patched_openai.py
+++ b/backend/packages/harness/deerflow/models/patched_openai.py
@@ -1,4 +1,4 @@
-"""Patched ChatOpenAI that preserves thought_signature for Gemini thinking models.
+"""Patched ChatOpenAI for OpenAI-compatible gateways.
 
 When using Gemini with thinking enabled via an OpenAI-compatible gateway (e.g.
 Vertex AI, Google AI Studio, or any proxy), the API requires that the
@@ -14,9 +14,14 @@ signature.  That causes an HTTP 400 ``INVALID_ARGUMENT`` error:
     Unable to submit request because function call `<tool>` in the N. content
     block is missing a `thought_signature`.
 
-This module fixes the problem by overriding ``_get_request_payload`` to
-re-inject tool-call signatures back into the outgoing payload for any assistant
-message that originally carried them.
+Responses API models have a separate replay issue when ``store`` is disabled:
+LangChain forwards prior ``reasoning`` items back into ``input`` unchanged,
+which makes OpenAI-compatible gateways reject the next turn because those
+opaque ``rs_*`` ids were never persisted server-side.
+
+This module fixes both problems by overriding ``_get_request_payload`` to:
+1. re-inject tool-call signatures for compatible chat-completions payloads
+2. strip non-replayable Responses API items when ``store`` is not enabled
 """
 
 from __future__ import annotations
@@ -27,15 +32,33 @@ from langchain_core.language_models import LanguageModelInput
 from langchain_core.messages import AIMessage
 from langchain_openai import ChatOpenAI
 
+_NON_REPLAYABLE_RESPONSE_ITEM_TYPES = frozenset(
+    {
+        "reasoning",
+        "web_search_call",
+        "file_search_call",
+        "computer_call",
+        "code_interpreter_call",
+        "mcp_call",
+        "mcp_list_tools",
+        "mcp_approval_request",
+        "image_generation_call",
+    }
+)
+
 
 class PatchedChatOpenAI(ChatOpenAI):
-    """ChatOpenAI with ``thought_signature`` preservation for Gemini thinking via OpenAI gateway.
+    """ChatOpenAI patches for OpenAI-compatible gateways.
 
     When using Gemini with thinking enabled via an OpenAI-compatible gateway,
     the API expects ``thought_signature`` to be present on tool-call objects in
     multi-turn conversations.  This patched version restores those signatures
     from ``AIMessage.additional_kwargs["tool_calls"]`` into the serialised
     request payload before it is sent to the API.
+
+    For Responses API models running with ``store`` disabled, it also removes
+    response-only history items such as ``reasoning`` blocks, because replaying
+    their opaque ids in the next turn triggers ``404 Item not found`` errors.
 
     Usage in ``config.yaml``::
 
@@ -61,12 +84,12 @@ class PatchedChatOpenAI(ChatOpenAI):
         stop: list[str] | None = None,
         **kwargs: Any,
     ) -> dict:
-        """Get request payload with ``thought_signature`` preserved on tool-call objects.
+        """Get request payload with gateway-safe history serialization.
 
-        Overrides the parent method to re-inject ``thought_signature`` fields
-        on tool-call objects that were stored in
-        ``additional_kwargs["tool_calls"]`` by LangChain but dropped during
-        serialisation.
+        Overrides the parent method to:
+        1. re-inject ``thought_signature`` fields on tool-call objects that
+           LangChain dropped during serialisation
+        2. remove non-replayable Responses API items when ``store`` is off
         """
         # Capture the original LangChain messages *before* conversion so we can
         # access fields that the serialiser might drop.
@@ -74,6 +97,7 @@ class PatchedChatOpenAI(ChatOpenAI):
 
         # Obtain the base payload from the parent implementation.
         payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        _strip_non_replayable_response_items(payload)
 
         payload_messages = payload.get("messages", [])
 
@@ -91,6 +115,38 @@ class PatchedChatOpenAI(ChatOpenAI):
                 _restore_tool_call_signatures(payload_msg, ai_msg)
 
         return payload
+
+
+def _strip_non_replayable_response_items(payload: dict) -> None:
+    """Drop transient Responses API items that cannot be replayed with ``store=false``.
+
+    OpenAI-compatible Responses API servers return opaque ids for blocks like
+    ``reasoning``. When DeerFlow replays a prior assistant turn, LangChain
+    includes those blocks verbatim in ``input``. If the original response was
+    not stored server-side, the next turn fails with:
+
+        Item with id 'rs_...' not found. Items are not persisted when `store`
+        is set to false.
+
+    Tool-call items are preserved because DeerFlow still needs them to pair
+    with subsequent ``function_call_output`` messages.
+    """
+    if payload.get("store") is True:
+        return
+
+    input_items = payload.get("input")
+    if not isinstance(input_items, list):
+        return
+
+    payload["input"] = [
+        item
+        for item in input_items
+        if not (
+            isinstance(item, dict)
+            and item.get("id")
+            and item.get("type") in _NON_REPLAYABLE_RESPONSE_ITEM_TYPES
+        )
+    ]
 
 
 def _restore_tool_call_signatures(payload_msg: dict, orig_msg: AIMessage) -> None:

--- a/backend/tests/test_patched_openai.py
+++ b/backend/tests/test_patched_openai.py
@@ -1,16 +1,10 @@
-"""Tests for deerflow.models.patched_openai.PatchedChatOpenAI.
-
-These tests verify that _restore_tool_call_signatures correctly re-injects
-``thought_signature`` onto tool-call objects stored in
-``additional_kwargs["tool_calls"]``, covering id-based matching, positional
-fallback, camelCase keys, and several edge-cases.
-"""
+"""Tests for deerflow.models.patched_openai.PatchedChatOpenAI."""
 
 from __future__ import annotations
 
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from deerflow.models.patched_openai import _restore_tool_call_signatures
+from deerflow.models.patched_openai import PatchedChatOpenAI, _restore_tool_call_signatures
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -174,3 +168,67 @@ def test_tool_call_multiple_sequential_signatures():
 
 # Integration behavior for PatchedChatOpenAI is validated indirectly via
 # _restore_tool_call_signatures unit coverage above.
+
+
+def test_responses_payload_strips_reasoning_items_when_store_is_not_enabled():
+    """Transient reasoning items must not be replayed into a later Responses API call."""
+    model = PatchedChatOpenAI(
+        model="gpt-5.4",
+        api_key="test-key",
+        base_url="http://example.invalid/v1",
+        use_responses_api=True,
+        output_version="responses/v1",
+    )
+    messages = [
+        HumanMessage(content="Deploy the application"),
+        AIMessage(
+            content=[
+                {"type": "reasoning", "id": "rs_123", "summary": [], "index": 0},
+                {
+                    "type": "function_call",
+                    "name": "ask_clarification",
+                    "arguments": '{"question":"Where should I deploy it?"}',
+                    "call_id": "call_123",
+                    "id": "fc_123",
+                    "index": 1,
+                },
+            ],
+            tool_calls=[
+                {
+                    "name": "ask_clarification",
+                    "args": {"question": "Where should I deploy it?"},
+                    "id": "call_123",
+                    "type": "tool_call",
+                }
+            ],
+        ),
+        ToolMessage(content="Where should I deploy it?", tool_call_id="call_123", name="ask_clarification"),
+        HumanMessage(content="Vercel preview"),
+    ]
+
+    payload = model._get_request_payload(messages)
+
+    assert all(item.get("type") != "reasoning" for item in payload["input"] if isinstance(item, dict))
+    assert any(item.get("type") == "function_call" and item.get("call_id") == "call_123" for item in payload["input"])
+    assert any(item.get("type") == "function_call_output" and item.get("call_id") == "call_123" for item in payload["input"])
+
+
+def test_responses_payload_keeps_reasoning_items_when_store_is_enabled():
+    """Explicitly stored responses can safely replay their opaque response items."""
+    model = PatchedChatOpenAI(
+        model="gpt-5.4",
+        api_key="test-key",
+        base_url="http://example.invalid/v1",
+        use_responses_api=True,
+        output_version="responses/v1",
+        store=True,
+    )
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content=[{"type": "reasoning", "id": "rs_123", "summary": [], "index": 0}]),
+        HumanMessage(content="Next"),
+    ]
+
+    payload = model._get_request_payload(messages)
+
+    assert any(item.get("type") == "reasoning" and item.get("id") == "rs_123" for item in payload["input"])

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -68,6 +68,9 @@ models:
   #   use_responses_api: true
   #   output_version: responses/v1
   #   supports_vision: true
+  # For OpenAI-compatible gateways that do not persist response items when
+  # `store=false`, change `use` to:
+  #   deerflow.models.patched_openai:PatchedChatOpenAI
 
   # Example: Anthropic Claude model
   # - name: claude-3-5-sonnet


### PR DESCRIPTION
## Summary
This PR makes `PatchedChatOpenAI` safe to use with OpenAI-compatible Responses API gateways that do not persist response items when `store=false`.
Changes:
  - keep the existing Gemini `thought_signature` replay fix
  - strip non-replayable Responses API items such as `reasoning` blocks from replayed
  history when `store` is not enabled
  - preserve replayable tool-call items like `function_call` and `function_call_output`
  - add regression tests for both `store=false` and `store=true`
  - clarify the configuration docs for OpenAI-compatible Responses API gateways
## Root Cause

  In multi-turn conversations, DeerFlow replays prior assistant history back into the next
  Responses API request.

  For some OpenAI-compatible gateways, when `store=false`, response-only items such as
  `reasoning` are not persisted server-side. Replaying those opaque items in the next turn
  can fail with errors like:

  ```text
  Item with id 'rs_...' not found. Items are not persisted when `store` is set to false.

  This surfaced in DeerFlow after clarification/tool-driven turns, where LangChain forwarded
  prior Responses API items back into input unchanged.

  ## Why this fix

  PatchedChatOpenAI already exists to handle OpenAI-compatible gateway quirks, specifically
  Gemini thought_signature replay. Extending it to also sanitize non-replayable Responses
  API items keeps the fix localized to the compatibility layer and avoids changing normal
  thread or frontend behavior.

  The patch:

  - removes transient response items only when store is not explicitly enabled
  - keeps tool-call continuity intact
  - preserves existing behavior when store=true

  ## Tests

  Ran:

  uv run --project backend --group dev python -m pytest backend/tests/test_patched_openai.py
  -q

  Result:

  10 passed

  ## Notes

  This PR intentionally does not include:

  - local environment/port changes
  - frontend thread/navigation changes

  It is scoped only to the confirmed backend compatibility issue.
