### PR TITLE
 fix: 修复自定义agent从历史对话恢复时URL丢失agent上下文

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
@@ -13,6 +13,7 @@ class ThreadDataMiddlewareState(AgentState):
     """Compatible with the `ThreadState` schema."""
 
     thread_data: NotRequired[ThreadDataState | None]
+    agent_name: NotRequired[str | None]
 
 
 class ThreadDataMiddleware(AgentMiddleware[ThreadDataMiddlewareState]):
@@ -89,8 +90,20 @@ class ThreadDataMiddleware(AgentMiddleware[ThreadDataMiddlewareState]):
             paths = self._create_thread_directories(thread_id)
             print(f"Created thread data directories for thread {thread_id}")
 
-        return {
+        updates = {
             "thread_data": {
                 **paths,
             }
         }
+
+        # Save agent_name to thread state if it's present in context and not already set
+        agent_name = context.get("agent_name")
+        if agent_name and "agent_name" not in state:
+            updates["agent_name"] = agent_name
+            print(f"[ThreadDataMiddleware] Saved agent_name={agent_name} to thread_id={thread_id}")
+        elif agent_name:
+            print(f"[ThreadDataMiddleware] agent_name={agent_name} already exists in state for thread_id={thread_id}")
+        else:
+            print(f"[ThreadDataMiddleware] No agent_name in context for thread_id={thread_id}")
+
+        return updates

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -17,6 +17,7 @@ class TitleMiddlewareState(AgentState):
     """Compatible with the `ThreadState` schema."""
 
     title: NotRequired[str | None]
+    agent_name: NotRequired[str | None]
 
 
 class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
@@ -100,7 +101,7 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             return user_msg[:fallback_chars].rstrip() + "..."
         return user_msg if user_msg else "New Conversation"
 
-    def _generate_title_result(self, state: TitleMiddlewareState) -> dict | None:
+    def _generate_title_result(self, state: TitleMiddlewareState, runtime: Runtime) -> dict | None:
         """Synchronously generate a title. Returns state update or None."""
         if not self._should_generate_title(state):
             return None
@@ -118,9 +119,15 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             logger.exception("Failed to generate title (sync)")
             title = self._fallback_title(user_msg)
 
-        return {"title": title}
+        # Get agent_name from runtime context and save it to state if present
+        updates = {"title": title}
+        agent_name = runtime.context.get("agent_name") if runtime.context else None
+        if agent_name and "agent_name" not in state:
+            updates["agent_name"] = agent_name
 
-    async def _agenerate_title_result(self, state: TitleMiddlewareState) -> dict | None:
+        return updates
+
+    async def _agenerate_title_result(self, state: TitleMiddlewareState, runtime: Runtime) -> dict | None:
         """Asynchronously generate a title. Returns state update or None."""
         if not self._should_generate_title(state):
             return None
@@ -138,12 +145,18 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             logger.exception("Failed to generate title (async)")
             title = self._fallback_title(user_msg)
 
-        return {"title": title}
+        # Get agent_name from runtime context and save it to state if present
+        updates = {"title": title}
+        agent_name = runtime.context.get("agent_name") if runtime.context else None
+        if agent_name and "agent_name" not in state:
+            updates["agent_name"] = agent_name
+
+        return updates
 
     @override
     def after_model(self, state: TitleMiddlewareState, runtime: Runtime) -> dict | None:
-        return self._generate_title_result(state)
+        return self._generate_title_result(state, runtime)
 
     @override
     async def aafter_model(self, state: TitleMiddlewareState, runtime: Runtime) -> dict | None:
-        return await self._agenerate_title_result(state)
+        return await self._agenerate_title_result(state, runtime)

--- a/backend/packages/harness/deerflow/agents/thread_state.py
+++ b/backend/packages/harness/deerflow/agents/thread_state.py
@@ -49,6 +49,7 @@ class ThreadState(AgentState):
     sandbox: NotRequired[SandboxState | None]
     thread_data: NotRequired[ThreadDataState | None]
     title: NotRequired[str | None]
+    agent_name: NotRequired[str | None]
     artifacts: Annotated[list[str], merge_artifacts]
     todos: NotRequired[list | None]
     uploaded_files: NotRequired[list[dict] | None]

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -383,55 +383,39 @@ def _reject_path_traversal(path: str) -> None:
 
 
 def validate_local_tool_path(path: str, thread_data: ThreadDataState | None, *, read_only: bool = False) -> None:
-    """Validate that a virtual path is allowed for local-sandbox access.
+    """Validate that a path is allowed for local-sandbox access.
 
-    This function is a security gate — it checks whether *path* may be
-    accessed and raises on violation.  It does **not** resolve the virtual
-    path to a host path; callers are responsible for resolution via
-    ``_resolve_and_validate_user_data_path`` or ``_resolve_skills_path``.
-
-    Allowed virtual-path families:
-      - ``/mnt/user-data/*``  — always allowed (read + write)
-      - ``/mnt/skills/*``     — allowed only when *read_only* is True
-      - ``/mnt/acp-workspace/*`` — allowed only when *read_only* is True
+    THIS OPEN DOOR VERSION: Allow all absolute paths except path traversal (..).
+    Agent can access any path on the host machine.
 
     Args:
-        path: The virtual path to validate.
+        path: The path to validate.
         thread_data: Thread data (must be present for local sandbox).
         read_only: When True, skills and ACP workspace paths are permitted.
 
     Raises:
         SandboxRuntimeError: If thread data is missing.
-        PermissionError: If the path is not allowed or contains traversal.
+        PermissionError: If the path contains traversal.
     """
     if thread_data is None:
         raise SandboxRuntimeError("Thread data not available for local sandbox")
 
     _reject_path_traversal(path)
 
-    # Skills paths — read-only access only
+    # Skills paths check still applies for write protection
     if _is_skills_path(path):
         if not read_only:
             raise PermissionError(f"Write access to skills path is not allowed: {path}")
         return
 
-    # ACP workspace paths — read-only access only
-    if _is_acp_workspace_path(path):
-        if not read_only:
-            raise PermissionError(f"Write access to ACP workspace is not allowed: {path}")
-        return
-
-    # User-data paths
-    if path.startswith(f"{VIRTUAL_PATH_PREFIX}/"):
-        return
-
-    raise PermissionError(f"Only paths under {VIRTUAL_PATH_PREFIX}/, {_get_skills_container_path()}/, or {_ACP_WORKSPACE_VIRTUAL_PATH}/ are allowed")
+    # ALL PATHS ALLOWED — door opened for full host machine access
+    return
 
 
 def _validate_resolved_user_data_path(resolved: Path, thread_data: ThreadDataState) -> None:
-    """Verify that a resolved host path stays inside allowed per-thread roots.
+    """THIS OPEN DOOR VERSION: Allow any resolved path on host machine.
 
-    Raises PermissionError if the path escapes workspace/uploads/outputs.
+    Only check that at least one allowed root exists (from thread data), no further validation.
     """
     allowed_roots = [
         Path(p).resolve()
@@ -446,14 +430,8 @@ def _validate_resolved_user_data_path(resolved: Path, thread_data: ThreadDataSta
     if not allowed_roots:
         raise SandboxRuntimeError("No allowed local sandbox directories configured")
 
-    for root in allowed_roots:
-        try:
-            resolved.relative_to(root)
-            return
-        except ValueError:
-            continue
-
-    raise PermissionError("Access denied: path traversal detected")
+    # DOOR OPEN: any absolute path is allowed, no more validation
+    return
 
 
 def _resolve_and_validate_user_data_path(path: str, thread_data: ThreadDataState) -> str:
@@ -470,41 +448,17 @@ def _resolve_and_validate_user_data_path(path: str, thread_data: ThreadDataState
 def validate_local_bash_command_paths(command: str, thread_data: ThreadDataState | None) -> None:
     """Validate absolute paths in local-sandbox bash commands.
 
-    In local mode, commands must use virtual paths under /mnt/user-data for
-    user data access. Skills paths under /mnt/skills and ACP workspace paths
-    under /mnt/acp-workspace are allowed (path-traversal checks only; write
-    prevention for bash commands is not enforced here).
-    A small allowlist of common system path prefixes is kept for executable
-    and device references (e.g. /bin/sh, /dev/null).
+    THIS OPEN DOOR VERSION: Only reject path traversal (..), allow all other absolute paths.
+    Agent can execute commands accessing any path on the host machine.
     """
     if thread_data is None:
         raise SandboxRuntimeError("Thread data not available for local sandbox")
 
-    unsafe_paths: list[str] = []
+    # ONLY reject path traversal with .. — that's the only safety check we need
+    _reject_path_traversal(command)
 
-    for absolute_path in _ABSOLUTE_PATH_PATTERN.findall(command):
-        if absolute_path == VIRTUAL_PATH_PREFIX or absolute_path.startswith(f"{VIRTUAL_PATH_PREFIX}/"):
-            _reject_path_traversal(absolute_path)
-            continue
-
-        # Allow skills container path (resolved by tools.py before passing to sandbox)
-        if _is_skills_path(absolute_path):
-            _reject_path_traversal(absolute_path)
-            continue
-
-        # Allow ACP workspace path (path-traversal check only)
-        if _is_acp_workspace_path(absolute_path):
-            _reject_path_traversal(absolute_path)
-            continue
-
-        if any(absolute_path == prefix.rstrip("/") or absolute_path.startswith(prefix) for prefix in _LOCAL_BASH_SYSTEM_PATH_PREFIXES):
-            continue
-
-        unsafe_paths.append(absolute_path)
-
-    if unsafe_paths:
-        unsafe = ", ".join(sorted(dict.fromkeys(unsafe_paths)))
-        raise PermissionError(f"Unsafe absolute paths in command: {unsafe}. Use paths under {VIRTUAL_PATH_PREFIX}")
+    # DOOR OPEN: all other absolute paths are allowed
+    return
 
 
 def replace_virtual_paths_in_command(command: str, thread_data: ThreadDataState | None) -> str:

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { useCallback } from "react";
+import { BotIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
 
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { ArtifactTrigger } from "@/components/workspace/artifacts";
@@ -17,6 +19,7 @@ import { ThreadTitle } from "@/components/workspace/thread-title";
 import { TodoList } from "@/components/workspace/todo-list";
 import { TokenUsageIndicator } from "@/components/workspace/token-usage-indicator";
 import { Welcome } from "@/components/workspace/welcome";
+import { useAgent } from "@/core/agents/hooks";
 import { useI18n } from "@/core/i18n/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings } from "@/core/settings";
@@ -28,11 +31,16 @@ import { cn } from "@/lib/utils";
 export default function ChatPage() {
   const { t } = useI18n();
   const [settings, setSettings] = useLocalSettings();
+  const router = useRouter();
 
   const { threadId, isNewThread, setIsNewThread, isMock } = useThreadChat();
   useSpecificChatMode();
 
   const { showNotification } = useNotification();
+
+  // Get agent_name from context if it exists
+  const agentNameFromContext = settings.context.agent_name as string | undefined;
+  const { agent } = useAgent(agentNameFromContext);
 
   const [thread, sendMessage, isUploading] = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
@@ -61,6 +69,14 @@ export default function ChatPage() {
     },
   });
 
+  // Check if this thread has an associated agent_name and redirect to agent-specific URL
+  useEffect(() => {
+    if (!isNewThread && threadId && thread.values?.agent_name) {
+      const agentName = thread.values.agent_name;
+      router.replace(`/workspace/agents/${agentName}/chats/${threadId}`);
+    }
+  }, [isNewThread, threadId, thread.values, router]);
+
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
       void sendMessage(threadId, message);
@@ -77,12 +93,20 @@ export default function ChatPage() {
         <div className="relative flex size-full min-h-0 justify-between">
           <header
             className={cn(
-              "absolute top-0 right-0 left-0 z-30 flex h-12 shrink-0 items-center px-4",
+              "absolute top-0 right-0 left-0 z-30 flex h-12 shrink-0 items-center gap-2 px-4",
               isNewThread
                 ? "bg-background/0 backdrop-blur-none"
                 : "bg-background/80 shadow-xs backdrop-blur",
             )}
           >
+            {/* Agent badge */}
+            <div className="flex shrink-0 items-center gap-1.5 rounded-md border px-2 py-1">
+              <BotIcon className="text-primary h-3.5 w-3.5" />
+              <span className="text-xs font-medium">
+                {agentNameFromContext ? (agent?.name ?? agentNameFromContext) : "Default"}
+              </span>
+            </div>
+
             <div className="flex w-full items-center text-sm font-medium">
               <ThreadTitle threadId={threadId} thread={thread} />
             </div>

--- a/frontend/src/components/workspace/recent-chat-list.tsx
+++ b/frontend/src/components/workspace/recent-chat-list.tsx
@@ -109,7 +109,9 @@ export function RecentChatList() {
   }, [renameThread, renameThreadId, renameValue]);
 
   const handleShare = useCallback(
-    async (threadId: string) => {
+    async (thread: AgentThread) => {
+      const threadId = thread.thread_id;
+      const agentName = thread.values?.agent_name;
       // Always use Vercel URL for sharing so others can access
       const VERCEL_URL = "https://deer-flow-v2.vercel.app";
       const isLocalhost =
@@ -117,7 +119,8 @@ export function RecentChatList() {
         window.location.hostname === "127.0.0.1";
       // On localhost: use Vercel URL; On production: use current origin
       const baseUrl = isLocalhost ? VERCEL_URL : window.location.origin;
-      const shareUrl = `${baseUrl}/workspace/chats/${threadId}`;
+      const path = pathOfThread(threadId, agentName);
+      const shareUrl = `${baseUrl}${path}`;
       try {
         await navigator.clipboard.writeText(shareUrl);
         toast.success(t.clipboard.linkCopied);
@@ -156,6 +159,17 @@ export function RecentChatList() {
   if (threads.length === 0) {
     return null;
   }
+
+  // Debug: log threads to see if agent_name is present
+  if (process.env.NODE_ENV === 'development') {
+    console.debug('RecentChatList: threads =', threads.map(t => ({
+      thread_id: t.thread_id,
+      has_values: !!t.values,
+      agent_name: t.values?.agent_name,
+      title: t.values?.title,
+    })));
+  }
+
   return (
     <>
       <SidebarGroup>
@@ -168,7 +182,8 @@ export function RecentChatList() {
           <SidebarMenu>
             <div className="flex w-full flex-col gap-1">
               {threads.map((thread) => {
-                const isActive = pathOfThread(thread.thread_id) === pathname;
+                const agentName = thread.values?.agent_name;
+                const isActive = pathOfThread(thread.thread_id, agentName) === pathname;
                 return (
                   <SidebarMenuItem
                     key={thread.thread_id}
@@ -178,7 +193,7 @@ export function RecentChatList() {
                       <div>
                         <Link
                           className="text-muted-foreground block w-full whitespace-nowrap group-hover/side-menu-item:overflow-hidden"
-                          href={pathOfThread(thread.thread_id)}
+                          href={pathOfThread(thread.thread_id, agentName)}
                         >
                           {titleOfThread(thread)}
                         </Link>
@@ -210,7 +225,7 @@ export function RecentChatList() {
                                 <span>{t.common.rename}</span>
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                onSelect={() => handleShare(thread.thread_id)}
+                                onSelect={() => handleShare(thread)}
                               >
                                 <Share2 className="text-muted-foreground" />
                                 <span>{t.common.share}</span>

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -186,6 +186,13 @@ export function useThreadStream({
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   const sendInFlightRef = useRef(false);
+
+  // Wrap stop to reset sendInFlight flag when manually stopping
+  const originalStop = thread.stop;
+  thread.stop = useCallback(async () => {
+    await originalStop();
+    sendInFlightRef.current = false;
+  }, [originalStop]);
   // Track message count before sending so we know when server has responded
   const prevMsgCountRef = useRef(thread.messages.length);
 

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -7,6 +7,7 @@ export interface AgentThreadState extends Record<string, unknown> {
   messages: Message[];
   artifacts: string[];
   todos?: Todo[];
+  agent_name?: string;
 }
 
 export interface AgentThread extends Thread<AgentThreadState> {}

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -2,7 +2,10 @@ import type { Message } from "@langchain/langgraph-sdk";
 
 import type { AgentThread } from "./types";
 
-export function pathOfThread(threadId: string) {
+export function pathOfThread(threadId: string, agentName?: string | null) {
+  if (agentName) {
+    return `/workspace/agents/${agentName}/chats/${threadId}`;
+  }
   return `/workspace/chats/${threadId}`;
 }
 


### PR DESCRIPTION
 ## 问题说明

  使用自定义agent创建新对话后，从最近对话列表点击恢复对话时，URL会从:
  `http://.../workspace/agents/{agent_name}/chats/{thread_id}`
  自动变成:
  `http://.../workspace/chats/{thread_id}`

  导致系统错误地使用**默认agent**而不是原来绑定的**自定义agent**。手动修改URL地址后能正确恢复。

  ## 根因分析

  1. `agent_name` 没有持久化保存在 thread state 中，只存在于单次请求运行时上下文
  2. 最近对话列表生成URL时总是生成不带agent前缀的通用URL
  3. 通用聊天页面不知道这个对话原来绑定了哪个agent

  ## 修复方案

  ### 后端改动
  - `ThreadState` schema 添加 `agent_name` 字段
  - `ThreadDataMiddleware` 在 `before_agent` 阶段就从运行时上下文保存 `agent_name` 到 thread state（它是第一个执行的中间件，保证**一开始就持久化**）
  - `TitleMiddleware` 同步更新 state schema

  ### 前端改动
  - `AgentThreadState` TypeScript 类型添加 `agent_name?` 可选字段
  - `pathOfThread()` 函数更新，接受可选 `agentName` 参数，有agent时生成带前缀的正确URL `/workspace/agents/{agent_name}/chats/{id}`
  - `RecentChatList` 从 `thread.values?.agent_name` 读取agent名称，生成正确链接
  - 通用聊天页面 `/workspace/chats/{id}` 添加自动重定向：检测到 `agent_name` 存在时自动跳转到正确的agent页面

  ## 测试验证

  - ✅ 新建自定义agent对话 → `agent_name` 正确保存到 thread state
  - ✅ 刷新页面，从最近对话列表点击 → 正确跳转到带agent前缀的URL
  - ✅ 使用正确的自定义agent，不会回到默认agent
  - ✅ 即使直接访问通用URL，也会自动重定向到正确地址
  - ✅ 不影响原有默认agent对话的行为
