### PR TITLE
fix(sandbox): prevent URLs from being parsed as absolute paths in bash tool

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -15,7 +15,7 @@ from deerflow.sandbox.exceptions import (
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import get_sandbox_provider
 
-_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![:\w])/(?:[^\s\"'`;&|<>()]+)")
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![:\w/])/(?:[^\s\"'`;&|<>()]+)")
 _LOCAL_BASH_SYSTEM_PATH_PREFIXES = (
     "/bin/",
     "/usr/bin/",

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -229,6 +229,19 @@ def test_validate_local_bash_command_paths_blocks_host_paths() -> None:
         validate_local_bash_command_paths("cat /etc/passwd", _THREAD_DATA)
 
 
+def test_validate_local_bash_command_paths_allows_urls() -> None:
+    """URLs should not be parsed as local absolute paths."""
+    # This should not raise an exception about "/xxx.net/api/v1/workflow/run"
+    validate_local_bash_command_paths(
+        "curl -X POST https://xxx.net/api/v1/workflow/run",
+        _THREAD_DATA,
+    )
+    validate_local_bash_command_paths(
+        "wget http://example.com/some/path/file.zip",
+        _THREAD_DATA,
+    )
+
+
 def test_validate_local_bash_command_paths_allows_virtual_and_system_paths() -> None:
     validate_local_bash_command_paths(
         "/bin/echo ok > /mnt/user-data/workspace/out.txt && cat /dev/null",


### PR DESCRIPTION
**Description** 
 
 This PR fixes an issue in the sandbox path validation logic where URLs embedded within bash commands were incorrectly identified and parsed as local absolute paths, causing command execution failures.
 
 **Why is this change necessary?** 
 
 Currently, the `validate_local_bash_command_paths` method in the sandbox uses the `_ABSOLUTE_PATH_PATTERN` regex to extract and validate absolute paths from bash commands. The previous regex `(?<![:\w])/(?:[^\s\"'\`;&|<>()]+)` utilized a negative lookbehind to ignore slashes preceded by a colon or an alphanumeric character. 
 
 However, when executing commands containing URLs (e.g., `curl -X POST https://xxx.net/api/v1/workflow/run`), the double slash `//` in the URL structure bypassed the lookbehind check. The regex would erroneously match the string starting from the second slash (i.e., `/xxx.net/api/v1/workflow/run`) and treat it as a local absolute path. Since this "path" typically does not exist or falls outside allowed directories, it triggered a `PermissionError` and blocked perfectly safe network requests.
 
 **How does this PR solve the problem?** 
 
 - **Regex Refinement**: Updated `_ABSOLUTE_PATH_PATTERN` to `(?<![:\w/])/(?:[^\s\"'\`;&|<>()]+)`.
 - **Negative Lookbehind Enhancement**: By adding the forward slash `/` to the exclusion list in the negative lookbehind, the regex now explicitly prevents matching slashes that are immediately preceded by another slash. 
 - **Preserved Functionality**: This subtle change successfully ignores the path segments of `http://` and `https://` URLs without breaking the extraction of valid local absolute paths or parameters (like `--path=/usr/bin` or `//etc/hosts`).
 
 **Impact & Testing** 
 
 - Fixes the bug that prevents the execution of bash commands containing network URLs (like `curl` or `wget`).
 - Maintains strict security validation for actual local absolute paths accessed within the sandbox.
 - **Added Comprehensive Unit Tests** (`test_sandbox_tools_security.py`): 
   - Added `test_validate_local_bash_command_paths_allows_urls` to verify that `http://` and `https://` URLs pass validation without raising exceptions.
   - Ensured existing path traversal and permission tests continue to pass seamlessly.
 
 **Checklist:** 
 
 - [x] Updated absolute path extraction regex to ignore URLs
 - [x] Added unit tests specifically for URL handling in bash commands
 - [x] Ensured no regression on existing local path validation logic
 - [x] Passed local test suite (`uv run pytest`) successfully