### PR TITLE
fix: prevent window undefined error during SSR in config utils

### DIFF
--- a/frontend/src/core/config/index.ts
+++ b/frontend/src/core/config/index.ts
@@ -2,10 +2,13 @@ import { env } from "@/env";
 
 export function getBackendBaseURL() {
   if (env.NEXT_PUBLIC_BACKEND_BASE_URL) {
-    return new URL(
-      env.NEXT_PUBLIC_BACKEND_BASE_URL,
-      window.location.origin,
-    ).toString();
+    if (typeof window !== "undefined") {
+      return new URL(
+        env.NEXT_PUBLIC_BACKEND_BASE_URL,
+        window.location.origin,
+      ).toString();
+    }
+    return env.NEXT_PUBLIC_BACKEND_BASE_URL;
   } else {
     return "";
   }
@@ -13,10 +16,13 @@ export function getBackendBaseURL() {
 
 export function getLangGraphBaseURL(isMock?: boolean) {
   if (env.NEXT_PUBLIC_LANGGRAPH_BASE_URL) {
-    return new URL(
-      env.NEXT_PUBLIC_LANGGRAPH_BASE_URL,
-      window.location.origin,
-    ).toString();
+    if (typeof window !== "undefined") {
+      return new URL(
+        env.NEXT_PUBLIC_LANGGRAPH_BASE_URL,
+        window.location.origin,
+      ).toString();
+    }
+    return env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
   } else if (isMock) {
     if (typeof window !== "undefined") {
       return `${window.location.origin}/mock/api`;


### PR DESCRIPTION
## Summary
- Fixed SSR (Server-Side Rendering) error where `window` is undefined in config utilities
- Added proper browser environment check before accessing `window` object

## Test plan
- [ ] Verify frontend builds without SSR window errors