### PR TITLE
fix(memory): optimize get_memory_queue() with double-checked locking

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/queue.py
@@ -177,10 +177,11 @@ def get_memory_queue() -> MemoryUpdateQueue:
         The memory update queue instance.
     """
     global _memory_queue
-    with _queue_lock:
-        if _memory_queue is None:
-            _memory_queue = MemoryUpdateQueue()
-        return _memory_queue
+    if _memory_queue is None:
+        with _queue_lock:
+            if _memory_queue is None:
+                _memory_queue = MemoryUpdateQueue()
+    return _memory_queue
 
 
 def reset_memory_queue() -> None:


### PR DESCRIPTION
## Title
fix: optimize `get_memory_queue()` singleton with double-checked locking

## Description

Apply double-checked locking pattern to `get_memory_queue()` to eliminate unnecessary lock acquisition after instance initialization.

## Impact 
Subsequent calls after initialization no longer acquire the lock, reducing thread contention.