### PR TITLE
docs(SETUP): correct setup documentation links

### DIFF
--- a/backend/docs/SETUP.md
+++ b/backend/docs/SETUP.md
@@ -88,5 +88,5 @@ chmod 600 ../config.yaml  # Protect sensitive configuration
 
 ## See Also
 
-- [Configuration Guide](docs/CONFIGURATION.md) - Detailed configuration options
-- [Architecture Overview](CLAUDE.md) - System architecture
+- [Configuration Guide](CONFIGURATION.md) - Detailed configuration options
+- [Architecture Overview](../CLAUDE.md) - System architecture


### PR DESCRIPTION
  This PR corrects the cross-references in backend/docs/SETUP.md.

  Changes included:

  - Update the Configuration Guide link in the See Also section to point to the
    correct backend configuration document.
  - Update the Architecture Overview link to point to the appropriate backend
    architecture reference.

  这个 PR 修正了 backend/docs/SETUP.md 中的关联文档引用。

  具体包括：

  - 更新 See Also 部分中 Configuration Guide 的链接，使其正确指向后端配置文档。
  - 更新 Architecture Overview 的链接，使其正确指向对应的后端架构说明文档。