### PR TITLE
chore(ci): align workflow action versions

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -13,17 +13,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - name: Install the latest version of uv
+      - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
 
       - name: Install dependencies
         working-directory: backend
@@ -37,7 +35,7 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

This PR aligns CI setup versions in `lint-check.yml` with the existing choices in `backend-unit-tests.yml`.

Changes:
- update `actions/checkout` from `v4` to `v6`
- update `actions/setup-python` from `v5` to `v6`
- remove `version: latest` from `astral-sh/setup-uv@v7`

This keeps the shared setup steps consistent across workflows and avoids unnecessary tool-version drift in CI.

Closes #1483.

## Testing

- parsed `.github/workflows/lint-check.yml` and `.github/workflows/backend-unit-tests.yml` successfully with Ruby's YAML loader
