### PR TITLE
fix(feishu): only treat known slash commands as COMMAND type

### DIFF
--- a/backend/app/channels/feishu.py
+++ b/backend/app/channels/feishu.py
@@ -13,6 +13,8 @@ from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMes
 
 logger = logging.getLogger(__name__)
 
+_FEISHU_COMMANDS: frozenset[str] = frozenset({"/new", "/status", "/models", "/memory", "/bootstrap", "/help"})
+
 
 class FeishuChannel(Channel):
     """Feishu/Lark IM channel using the ``lark-oapi`` WebSocket client.
@@ -506,8 +508,9 @@ class FeishuChannel(Channel):
                 logger.info("[Feishu] empty text, ignoring message")
                 return
 
-            # Check if it's a command
-            if text.startswith("/"):
+            # Check if it's a command (only recognised slash commands, not paths like /home/user)
+            first_token = text.split(maxsplit=1)[0].lower()
+            if first_token in _FEISHU_COMMANDS:
                 msg_type = InboundMessageType.COMMAND
             else:
                 msg_type = InboundMessageType.CHAT

--- a/backend/app/channels/feishu.py
+++ b/backend/app/channels/feishu.py
@@ -9,11 +9,9 @@ import threading
 from typing import Any
 
 from app.channels.base import Channel
-from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment, is_slash_command
 
 logger = logging.getLogger(__name__)
-
-_FEISHU_COMMANDS: frozenset[str] = frozenset({"/new", "/status", "/models", "/memory", "/bootstrap", "/help"})
 
 
 class FeishuChannel(Channel):
@@ -509,8 +507,7 @@ class FeishuChannel(Channel):
                 return
 
             # Check if it's a command (only recognised slash commands, not paths like /home/user)
-            first_token = text.split(maxsplit=1)[0].lower()
-            if first_token in _FEISHU_COMMANDS:
+            if is_slash_command(text):
                 msg_type = InboundMessageType.COMMAND
             else:
                 msg_type = InboundMessageType.CHAT

--- a/backend/app/channels/message_bus.py
+++ b/backend/app/channels/message_bus.py
@@ -26,6 +26,17 @@ class InboundMessageType(StrEnum):
     COMMAND = "command"
 
 
+# Canonical set of slash commands recognised across all IM channels.
+# Keep this in sync when adding or removing commands in ChannelManager.
+SLASH_COMMANDS: frozenset[str] = frozenset({"new", "status", "models", "memory", "bootstrap", "help"})
+
+
+def is_slash_command(text: str) -> bool:
+    """Return True if *text* starts with a recognised slash command."""
+    first_token = text.split(maxsplit=1)[0].lower()
+    return first_token.lstrip("/") in SLASH_COMMANDS and first_token.startswith("/")
+
+
 @dataclass
 class InboundMessage:
     """A message arriving from an IM channel toward the agent dispatcher.

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -9,7 +9,7 @@ from typing import Any
 from markdown_to_mrkdwn import SlackMarkdownConverter
 
 from app.channels.base import Channel
-from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment, is_slash_command
 
 logger = logging.getLogger(__name__)
 
@@ -219,7 +219,7 @@ class SlackChannel(Channel):
         channel_id = event.get("channel", "")
         thread_ts = event.get("thread_ts") or event.get("ts", "")
 
-        if text.startswith("/"):
+        if is_slash_command(text):
             msg_type = InboundMessageType.COMMAND
         else:
             msg_type = InboundMessageType.CHAT

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -8,7 +8,7 @@ import threading
 from typing import Any
 
 from app.channels.base import Channel
-from app.channels.message_bus import InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.message_bus import SLASH_COMMANDS, InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +60,8 @@ class TelegramChannel(Channel):
 
         # Command handlers
         app.add_handler(CommandHandler("start", self._cmd_start))
-        app.add_handler(CommandHandler("new", self._cmd_generic))
-        app.add_handler(CommandHandler("status", self._cmd_generic))
-        app.add_handler(CommandHandler("models", self._cmd_generic))
-        app.add_handler(CommandHandler("memory", self._cmd_generic))
-        app.add_handler(CommandHandler("help", self._cmd_generic))
+        for cmd in sorted(SLASH_COMMANDS):
+            app.add_handler(CommandHandler(cmd, self._cmd_generic))
 
         # General message handler
         app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, self._on_text))

--- a/backend/tests/test_feishu_parser.py
+++ b/backend/tests/test_feishu_parser.py
@@ -1,10 +1,11 @@
 import json
+import sys
 from unittest.mock import MagicMock
 
 import pytest
 
 from app.channels.feishu import FeishuChannel
-from app.channels.message_bus import MessageBus
+from app.channels.message_bus import InboundMessageType, MessageBus, is_slash_command
 
 
 def test_feishu_on_message_plain_text():
@@ -89,7 +90,6 @@ def test_feishu_on_message_path_treated_as_chat():
         channel._on_message(event)
 
         mock_make_inbound.assert_called_once()
-        from app.channels.message_bus import InboundMessageType
         assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.CHAT
 
 
@@ -112,5 +112,83 @@ def test_feishu_on_message_slash_new_treated_as_command():
         channel._on_message(event)
 
         mock_make_inbound.assert_called_once()
-        from app.channels.message_bus import InboundMessageType
+        assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.COMMAND
+
+
+# ---------------------------------------------------------------------------
+# is_slash_command unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text", ["/new", "/status", "/models", "/memory", "/bootstrap", "/help"])
+def test_is_slash_command_recognises_known_commands(text):
+    assert is_slash_command(text) is True
+
+
+@pytest.mark.parametrize("text", ["/home/user/file.txt", "/etc/config", "/usr/bin/python"])
+def test_is_slash_command_rejects_paths(text):
+    assert is_slash_command(text) is False
+
+
+def test_is_slash_command_rejects_plain_text():
+    assert is_slash_command("hello world") is False
+
+
+# ---------------------------------------------------------------------------
+# Slack command classification tests
+# ---------------------------------------------------------------------------
+
+
+def _make_slack_channel():
+    """Create a SlackChannel instance with mocked SDK imports."""
+    # Ensure slack_sdk is importable even when not installed
+    if "slack_sdk" not in sys.modules:
+        sys.modules.setdefault("slack_sdk", MagicMock())
+        sys.modules.setdefault("slack_sdk.socket_mode", MagicMock())
+        sys.modules.setdefault("slack_sdk.socket_mode.response", MagicMock())
+    if "markdown_to_mrkdwn" not in sys.modules:
+        sys.modules.setdefault("markdown_to_mrkdwn", MagicMock())
+
+    from app.channels.slack import SlackChannel
+
+    bus = MessageBus()
+    config = {"bot_token": "xoxb-test", "app_token": "xapp-test"}
+    return SlackChannel(bus, config)
+
+
+def test_slack_path_treated_as_chat():
+    channel = _make_slack_channel()
+    event = {
+        "user": "U123",
+        "text": "/home/user/file.txt",
+        "channel": "C123",
+        "ts": "1234567890.123456",
+    }
+
+    with pytest.MonkeyPatch.context() as m:
+        mock_make_inbound = MagicMock()
+        m.setattr(channel, "_make_inbound", mock_make_inbound)
+        m.setattr(channel, "_loop", None)  # prevent asyncio scheduling
+        channel._handle_message_event(event)
+
+        mock_make_inbound.assert_called_once()
+        assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.CHAT
+
+
+def test_slack_slash_new_treated_as_command():
+    channel = _make_slack_channel()
+    event = {
+        "user": "U123",
+        "text": "/new",
+        "channel": "C123",
+        "ts": "1234567890.123456",
+    }
+
+    with pytest.MonkeyPatch.context() as m:
+        mock_make_inbound = MagicMock()
+        m.setattr(channel, "_make_inbound", mock_make_inbound)
+        m.setattr(channel, "_loop", None)
+        channel._handle_message_event(event)
+
+        mock_make_inbound.assert_called_once()
         assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.COMMAND

--- a/backend/tests/test_feishu_parser.py
+++ b/backend/tests/test_feishu_parser.py
@@ -68,3 +68,49 @@ def test_feishu_on_message_rich_text():
         assert "Paragraph 1, part 1. Paragraph 1, part 2." in parsed_text
         assert "@bot  Paragraph 2." in parsed_text
         assert "\n\n" in parsed_text
+
+
+def test_feishu_on_message_path_treated_as_chat():
+    bus = MessageBus()
+    config = {"app_id": "test", "app_secret": "test"}
+    channel = FeishuChannel(bus, config)
+
+    event = MagicMock()
+    event.event.message.chat_id = "chat_1"
+    event.event.message.message_id = "msg_1"
+    event.event.message.root_id = None
+    event.event.sender.sender_id.open_id = "user_1"
+    content_dict = {"text": "/home/user/file.txt"}
+    event.event.message.content = json.dumps(content_dict)
+
+    with pytest.MonkeyPatch.context() as m:
+        mock_make_inbound = MagicMock()
+        m.setattr(channel, "_make_inbound", mock_make_inbound)
+        channel._on_message(event)
+
+        mock_make_inbound.assert_called_once()
+        from app.channels.message_bus import InboundMessageType
+        assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.CHAT
+
+
+def test_feishu_on_message_slash_new_treated_as_command():
+    bus = MessageBus()
+    config = {"app_id": "test", "app_secret": "test"}
+    channel = FeishuChannel(bus, config)
+
+    event = MagicMock()
+    event.event.message.chat_id = "chat_1"
+    event.event.message.message_id = "msg_1"
+    event.event.message.root_id = None
+    event.event.sender.sender_id.open_id = "user_1"
+    content_dict = {"text": "/new"}
+    event.event.message.content = json.dumps(content_dict)
+
+    with pytest.MonkeyPatch.context() as m:
+        mock_make_inbound = MagicMock()
+        m.setattr(channel, "_make_inbound", mock_make_inbound)
+        channel._on_message(event)
+
+        mock_make_inbound.assert_called_once()
+        from app.channels.message_bus import InboundMessageType
+        assert mock_make_inbound.call_args[1]["msg_type"] == InboundMessageType.COMMAND


### PR DESCRIPTION
Fixes #1473

The Feishu handler was classifying any text starting with `/` as a COMMAND, so paths like `/home/user/file.txt` or `/etc/config` would get routed as slash commands instead of chat messages.

Added a module-level `_FEISHU_COMMANDS` frozenset with the six valid commands (`/new`, `/status`, `/models`, `/memory`, `/bootstrap`, `/help`) and replaced the blanket `startswith('/')` check with a lookup against that set. Two unit tests added to cover the regression case and confirm real commands still work.