### PR TITLE
fix: SSR error when getting origin

### DIFF
--- a/frontend/src/core/config/index.ts
+++ b/frontend/src/core/config/index.ts
@@ -1,10 +1,18 @@
 import { env } from "@/env";
 
+function getBaseOrigin() {
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+
+  return undefined;
+}
+
 export function getBackendBaseURL() {
   if (env.NEXT_PUBLIC_BACKEND_BASE_URL) {
     return new URL(
       env.NEXT_PUBLIC_BACKEND_BASE_URL,
-      window.location.origin,
+      getBaseOrigin(),
     ).toString();
   } else {
     return "";
@@ -15,7 +23,7 @@ export function getLangGraphBaseURL(isMock?: boolean) {
   if (env.NEXT_PUBLIC_LANGGRAPH_BASE_URL) {
     return new URL(
       env.NEXT_PUBLIC_LANGGRAPH_BASE_URL,
-      window.location.origin,
+      getBaseOrigin(),
     ).toString();
   } else if (isMock) {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
This pull request refactors how the base URL is determined in the `frontend/src/core/config/index.ts` file to improve compatibility with environments where the `window` object may not be available (such as server-side rendering). The changes introduce a helper function to safely access the origin.

Refactoring for environment compatibility:

* Added a `getBaseOrigin` helper function that safely returns `window.location.origin` only when running in a browser environment, and updated both `getBackendBaseURL` and `getLangGraphBaseURL` to use this helper instead of directly accessing `window.location.origin`. [[1]](diffhunk://#diff-a66099b348947ab95af275d7a9457d499ac91f5e87b64ec78813650c3155269dR3-R15) [[2]](diffhunk://#diff-a66099b348947ab95af275d7a9457d499ac91f5e87b64ec78813650c3155269dL18-R26)