### PR TITLE
feat(channels): add message splitting for all IM adapters

### DIFF
--- a/backend/app/channels/feishu.py
+++ b/backend/app/channels/feishu.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from app.channels.base import Channel
 from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.utils import FEISHU_MAX_LENGTH, split_message
 
 logger = logging.getLogger(__name__)
 
@@ -170,33 +171,49 @@ class FeishuChannel(Channel):
             logger.warning("[Feishu] send called but no api_client available")
             return
 
-        logger.info(
-            "[Feishu] sending reply: chat_id=%s, thread_ts=%s, text_len=%d",
-            msg.chat_id,
-            msg.thread_ts,
-            len(msg.text),
-        )
+        # Split long messages to stay within Feishu's character limit.
+        chunks = split_message(msg.text, max_length=FEISHU_MAX_LENGTH)
+        if not chunks:
+            return
 
-        last_exc: Exception | None = None
-        for attempt in range(_max_retries):
-            try:
-                await self._send_card_message(msg)
-                return  # success
-            except Exception as exc:
-                last_exc = exc
-                if attempt < _max_retries - 1:
-                    delay = 2**attempt  # 1s, 2s
-                    logger.warning(
-                        "[Feishu] send failed (attempt %d/%d), retrying in %ds: %s",
-                        attempt + 1,
-                        _max_retries,
-                        delay,
-                        exc,
-                    )
-                    await asyncio.sleep(delay)
+        for chunk in chunks:
+            chunk_msg = OutboundMessage(
+                channel_name=msg.channel_name,
+                chat_id=msg.chat_id,
+                thread_id=msg.thread_id,
+                text=chunk,
+                artifacts=msg.artifacts,
+                attachments=msg.attachments,
+                thread_ts=msg.thread_ts,
+            )
 
-        logger.error("[Feishu] send failed after %d attempts: %s", _max_retries, last_exc)
-        raise last_exc  # type: ignore[misc]
+            logger.info(
+                "[Feishu] sending reply: chat_id=%s, thread_ts=%s, text_len=%d",
+                chunk_msg.chat_id,
+                chunk_msg.thread_ts,
+                len(chunk_msg.text),
+            )
+
+            last_exc: Exception | None = None
+            for attempt in range(_max_retries):
+                try:
+                    await self._send_card_message(chunk_msg)
+                    break
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < _max_retries - 1:
+                        delay = 2**attempt  # 1s, 2s
+                        logger.warning(
+                            "[Feishu] send failed (attempt %d/%d), retrying in %ds: %s",
+                            attempt + 1,
+                            _max_retries,
+                            delay,
+                            exc,
+                        )
+                        await asyncio.sleep(delay)
+            else:
+                logger.error("[Feishu] send failed after %d attempts: %s", _max_retries, last_exc)
+                raise last_exc  # type: ignore[misc]
 
     async def send_file(self, msg: OutboundMessage, attachment: ResolvedAttachment) -> bool:
         if not self._api_client:

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -10,6 +10,7 @@ from markdown_to_mrkdwn import SlackMarkdownConverter
 
 from app.channels.base import Channel
 from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.utils import SLACK_MAX_LENGTH, split_message
 
 logger = logging.getLogger(__name__)
 
@@ -81,52 +82,61 @@ class SlackChannel(Channel):
         if not self._web_client:
             return
 
-        kwargs: dict[str, Any] = {
-            "channel": msg.chat_id,
-            "text": _slack_md_converter.convert(msg.text),
-        }
-        if msg.thread_ts:
-            kwargs["thread_ts"] = msg.thread_ts
+        # Split long messages to stay within Slack's character limit.
+        chunks = split_message(msg.text, max_length=SLACK_MAX_LENGTH)
+        if not chunks:
+            return
 
-        last_exc: Exception | None = None
-        for attempt in range(_max_retries):
-            try:
-                await asyncio.to_thread(self._web_client.chat_postMessage, **kwargs)
-                # Add a completion reaction to the thread root
+        for chunk in chunks:
+            kwargs: dict[str, Any] = {
+                "channel": msg.chat_id,
+                "text": _slack_md_converter.convert(chunk),
+            }
+            if msg.thread_ts:
+                kwargs["thread_ts"] = msg.thread_ts
+
+            last_exc: Exception | None = None
+            for attempt in range(_max_retries):
+                try:
+                    await asyncio.to_thread(self._web_client.chat_postMessage, **kwargs)
+                    break
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < _max_retries - 1:
+                        delay = 2**attempt  # 1s, 2s
+                        logger.warning(
+                            "[Slack] send failed (attempt %d/%d), retrying in %ds: %s",
+                            attempt + 1,
+                            _max_retries,
+                            delay,
+                            exc,
+                        )
+                        await asyncio.sleep(delay)
+            else:
+                logger.error("[Slack] send failed after %d attempts: %s", _max_retries, last_exc)
                 if msg.thread_ts:
-                    await asyncio.to_thread(
-                        self._add_reaction,
-                        msg.chat_id,
-                        msg.thread_ts,
-                        "white_check_mark",
-                    )
-                return
-            except Exception as exc:
-                last_exc = exc
-                if attempt < _max_retries - 1:
-                    delay = 2**attempt  # 1s, 2s
-                    logger.warning(
-                        "[Slack] send failed (attempt %d/%d), retrying in %ds: %s",
-                        attempt + 1,
-                        _max_retries,
-                        delay,
-                        exc,
-                    )
-                    await asyncio.sleep(delay)
+                    try:
+                        await asyncio.to_thread(
+                            self._add_reaction,
+                            msg.chat_id,
+                            msg.thread_ts,
+                            "x",
+                        )
+                    except Exception:
+                        pass
+                raise last_exc  # type: ignore[misc]
 
-        logger.error("[Slack] send failed after %d attempts: %s", _max_retries, last_exc)
-        # Add failure reaction on error
+        # Add completion reaction after all chunks sent
         if msg.thread_ts:
             try:
                 await asyncio.to_thread(
                     self._add_reaction,
                     msg.chat_id,
                     msg.thread_ts,
-                    "x",
+                    "white_check_mark",
                 )
             except Exception:
                 pass
-        raise last_exc  # type: ignore[misc]
 
     async def send_file(self, msg: OutboundMessage, attachment: ResolvedAttachment) -> bool:
         if not self._web_client:

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from app.channels.base import Channel
 from app.channels.message_bus import InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.utils import TELEGRAM_MAX_LENGTH, split_message
 
 logger = logging.getLogger(__name__)
 
@@ -97,35 +98,42 @@ class TelegramChannel(Channel):
             logger.error("Invalid Telegram chat_id: %s", msg.chat_id)
             return
 
-        kwargs: dict[str, Any] = {"chat_id": chat_id, "text": msg.text}
-
-        # Reply to the last bot message in this chat for threading
-        reply_to = self._last_bot_message.get(msg.chat_id)
-        if reply_to:
-            kwargs["reply_to_message_id"] = reply_to
+        # Split long messages to stay within Telegram's 4096-char limit.
+        chunks = split_message(msg.text, max_length=TELEGRAM_MAX_LENGTH)
+        if not chunks:
+            return
 
         bot = self._application.bot
-        last_exc: Exception | None = None
-        for attempt in range(_max_retries):
-            try:
-                sent = await bot.send_message(**kwargs)
-                self._last_bot_message[msg.chat_id] = sent.message_id
-                return
-            except Exception as exc:
-                last_exc = exc
-                if attempt < _max_retries - 1:
-                    delay = 2**attempt  # 1s, 2s
-                    logger.warning(
-                        "[Telegram] send failed (attempt %d/%d), retrying in %ds: %s",
-                        attempt + 1,
-                        _max_retries,
-                        delay,
-                        exc,
-                    )
-                    await asyncio.sleep(delay)
+        reply_to = self._last_bot_message.get(msg.chat_id)
 
-        logger.error("[Telegram] send failed after %d attempts: %s", _max_retries, last_exc)
-        raise last_exc  # type: ignore[misc]
+        for chunk in chunks:
+            kwargs: dict[str, Any] = {"chat_id": chat_id, "text": chunk}
+            if reply_to:
+                kwargs["reply_to_message_id"] = reply_to
+
+            last_exc: Exception | None = None
+            for attempt in range(_max_retries):
+                try:
+                    sent = await bot.send_message(**kwargs)
+                    # Chain replies so multi-part messages thread together
+                    reply_to = sent.message_id
+                    self._last_bot_message[msg.chat_id] = sent.message_id
+                    break
+                except Exception as exc:
+                    last_exc = exc
+                    if attempt < _max_retries - 1:
+                        delay = 2**attempt  # 1s, 2s
+                        logger.warning(
+                            "[Telegram] send failed (attempt %d/%d), retrying in %ds: %s",
+                            attempt + 1,
+                            _max_retries,
+                            delay,
+                            exc,
+                        )
+                        await asyncio.sleep(delay)
+            else:
+                logger.error("[Telegram] send failed after %d attempts: %s", _max_retries, last_exc)
+                raise last_exc  # type: ignore[misc]
 
     async def send_file(self, msg: OutboundMessage, attachment: ResolvedAttachment) -> bool:
         if not self._application:

--- a/backend/app/channels/utils.py
+++ b/backend/app/channels/utils.py
@@ -1,0 +1,59 @@
+"""Shared utilities for channel adapters."""
+
+from __future__ import annotations
+
+
+# Platform message length limits
+TELEGRAM_MAX_LENGTH = 4096
+SLACK_MAX_LENGTH = 12000
+DISCORD_MAX_LENGTH = 2000
+FEISHU_MAX_LENGTH = 30000  # Feishu is generous
+
+
+def split_message(text: str, max_length: int = 4096) -> list[str]:
+    """Split a long message into chunks that fit a platform's character limit.
+
+    Splits at natural boundaries in order of preference:
+    1. Paragraph breaks (double newline)
+    2. Single newlines
+    3. Spaces
+    4. Hard cut (last resort)
+
+    Each chunk is stripped of leading/trailing whitespace.
+
+    Args:
+        text: The message text to split.
+        max_length: Maximum characters per chunk (platform-specific).
+
+    Returns:
+        List of message chunks, each within max_length.
+    """
+    if not text or len(text) <= max_length:
+        return [text] if text else []
+
+    chunks: list[str] = []
+    remaining = text
+
+    while remaining:
+        if len(remaining) <= max_length:
+            chunks.append(remaining)
+            break
+
+        # Try to split at a paragraph break
+        split_at = remaining.rfind("\n\n", 0, max_length)
+        if split_at == -1:
+            # Try single newline
+            split_at = remaining.rfind("\n", 0, max_length)
+        if split_at == -1:
+            # Try space
+            split_at = remaining.rfind(" ", 0, max_length)
+        if split_at == -1:
+            # Hard cut
+            split_at = max_length
+
+        chunk = remaining[:split_at].rstrip()
+        if chunk:
+            chunks.append(chunk)
+        remaining = remaining[split_at:].lstrip()
+
+    return chunks


### PR DESCRIPTION
## Summary

Long agent responses exceed platform character limits, causing silent send failures. For example, Telegram returns `BadRequest: Message is too long` when a response exceeds 4096 characters — which happens frequently with research-heavy tasks.

This PR adds a shared `split_message()` utility and applies it to all three IM adapters.

### Changes

- **`app/channels/utils.py`** (new) — Shared `split_message()` function that splits text at natural boundaries:
  1. Paragraph breaks (`\n\n`)
  2. Single newlines (`\n`)
  3. Spaces
  4. Hard cut (last resort)
  
  Platform limits defined as constants: `TELEGRAM_MAX_LENGTH=4096`, `SLACK_MAX_LENGTH=12000`, `DISCORD_MAX_LENGTH=2000`, `FEISHU_MAX_LENGTH=30000`

- **Telegram adapter** — Splits into chunks, sends sequentially. Multi-part messages chain as replies for readability.

- **Slack adapter** — Splits into chunks, all posted in the same thread. Completion reaction added after all chunks sent.

- **Feishu adapter** — Splits into chunks, each sent as a separate card message.

### Before

```
User: "Research cleaning companies in Florida"
Bot: "Working on it..."
Bot: "An internal error occurred. Please try again."  ← silent BadRequest
```

### After

```
User: "Research cleaning companies in Florida"  
Bot: "Working on it..."
Bot: [Part 1 — 4000 chars of research]
Bot: [Part 2 — remaining 6000 chars, threaded as reply]
Bot: [Part 3 — conclusion]
```

## Test plan

- [x] Telegram: 10K+ char response splits into 3 messages, chained as replies
- [x] Slack: imports and constants verified
- [x] Feishu: imports and constants verified
- [ ] Unit tests for `split_message()` (happy to add if wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)