### PR TITLE
fix(nginx): re-resolve upstream DNS in Docker

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -18,16 +18,21 @@ http {
     resolver 127.0.0.11 valid=10s ipv6=off;
 
     # Upstream servers (using Docker service names)
+    # NOTE: add `resolve` so nginx re-resolves container IPs after restarts.
+    # Otherwise nginx may keep stale DNS results and proxy to the wrong container.
     upstream gateway {
-        server gateway:8001;
+        zone gateway 64k;
+        server gateway:8001 resolve;
     }
 
     upstream langgraph {
-        server langgraph:2024;
+        zone langgraph 64k;
+        server langgraph:2024 resolve;
     }
 
     upstream frontend {
-        server frontend:3000;
+        zone frontend 64k;
+        server frontend:3000 resolve;
     }
 
     # ── Main server (path-based routing) ─────────────────────────────────


### PR DESCRIPTION
Fixes #1516

## What
Enable runtime DNS re-resolution for nginx upstreams used in Docker (`gateway`, `langgraph`, `frontend`).

## Why
In Docker dev, containers can be recreated and receive new IPs. With static upstream resolution, nginx may keep stale DNS results and proxy to the wrong container IP, causing persistent `502 Bad Gateway` for `/api/models` and `/api/langgraph/*`, which blocks chat message sending.

## How
Update `docker/nginx/nginx.conf` upstream blocks:
- add `server ... resolve;` to refresh DNS at runtime
- add `zone ...;` because nginx requires upstreams to be in shared memory when using `resolve`

## Testing
- `docker exec deer-flow-nginx nginx -t`
- `curl -i http://localhost:2026/api/models` -> 200
- `curl -i http://localhost:2026/api/langgraph/docs` -> 200