### PR TITLE
fix(dev): exclude sandbox dirs from gateway hot-reload watcher

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -122,7 +122,7 @@ mkdir -p logs
 
 if $DEV_MODE; then
     LANGGRAPH_EXTRA_FLAGS="--no-reload"
-    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='sandbox/'"
+    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='sandbox/' --reload-exclude='.deer-flow/'"
 else
     LANGGRAPH_EXTRA_FLAGS="--no-reload"
     GATEWAY_EXTRA_FLAGS=""


### PR DESCRIPTION
Fixes #1513

In dev mode, the gateway uses `--reload` which monitors the backend directory for file changes. However, sandbox containers mount their working directories (`.pyc`, `__pycache__`) into the same backend directory, This triggers spurious gateway restarts because the watcher detects compiled files and sandbox dirs.

**Fix:** Add `--reload-exclude` patterns for `.pyc`, `__pycache__`, and `sandbox/` paths so only actual source changes trigger a reload.

**Changes:**
- `scripts/serve.sh`: Added reload-exclude patterns for sandbox artifacts