### PR TITLE
docs: add code formatting step to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,15 +250,26 @@ Nginx (port 2026) ← Unified entry point
 
 2. **Make your changes** with hot-reload enabled
 
-3. **Test your changes** thoroughly
+3. **Format and lint your code** (CI will reject unformatted code):
+   ```bash
+   # Backend
+   cd backend
+   make format   # ruff check --fix + ruff format
 
-4. **Commit your changes**:
+   # Frontend
+   cd frontend
+   pnpm format:write   # Prettier
+   ```
+
+4. **Test your changes** thoroughly
+
+5. **Commit your changes**:
    ```bash
    git add .
    git commit -m "feat: description of your changes"
    ```
 
-5. **Push and create a Pull Request**:
+6. **Push and create a Pull Request**:
    ```bash
    git push origin feature/your-feature-name
    ```
@@ -284,8 +295,9 @@ Every pull request runs the backend regression workflow at [.github/workflows/ba
 
 ## Code Style
 
-- **Backend (Python)**: We use `ruff` for linting and formatting
-- **Frontend (TypeScript)**: We use ESLint and Prettier
+- **Backend (Python)**: We use `ruff` for linting and formatting. Run `make format` before committing.
+- **Frontend (TypeScript)**: We use ESLint and Prettier. Run `pnpm format:write` before committing.
+- CI enforces formatting — PRs with unformatted code will fail the lint check.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Add a formatting step to the Development Workflow in CONTRIBUTING.md, so contributors know to run `make format` / `pnpm format:write` before submitting PRs.

- Add step 3 (format and lint) to the workflow
- Update Code Style section with specific commands and CI enforcement note

## Test plan
- [x] Documentation-only change