### PR TITLE
fix(frontend): prevent Enter submit during IME composition

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -20,6 +20,7 @@ import { checkAgentName, getAgent } from "@/core/agents/api";
 import { useI18n } from "@/core/i18n/hooks";
 import { useThreadStream } from "@/core/threads/hooks";
 import { uuid } from "@/core/utils/uuid";
+import { isIMEComposing } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 
 type Step = "name" | "chat";
@@ -98,7 +99,7 @@ export default function NewAgentPage() {
   ]);
 
   const handleNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !isIMEComposing(e)) {
       e.preventDefault();
       void handleConfirmName();
     }

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -34,6 +34,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { isIMEComposing } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import type { ChatStatus, FileUIPart } from "ai";
 import {
@@ -833,7 +834,7 @@ export const PromptInputTextarea = ({
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter") {
-      if (isComposing || e.nativeEvent.isComposing) {
+      if (isIMEComposing(e, isComposing)) {
         return;
       }
       if (e.shiftKey) {

--- a/frontend/src/components/workspace/recent-chat-list.tsx
+++ b/frontend/src/components/workspace/recent-chat-list.tsx
@@ -56,6 +56,7 @@ import {
 import type { AgentThread, AgentThreadState } from "@/core/threads/types";
 import { pathOfThread, titleOfThread } from "@/core/threads/utils";
 import { env } from "@/env";
+import { isIMEComposing } from "@/lib/ime";
 
 export function RecentChatList() {
   const { t } = useI18n();
@@ -271,7 +272,8 @@ export function RecentChatList() {
               onChange={(e) => setRenameValue(e.target.value)}
               placeholder={t.common.rename}
               onKeyDown={(e) => {
-                if (e.key === "Enter") {
+                if (e.key === "Enter" && !isIMEComposing(e)) {
+                  e.preventDefault();
                   handleRenameSubmit();
                 }
               }}

--- a/frontend/src/lib/ime.ts
+++ b/frontend/src/lib/ime.ts
@@ -1,0 +1,10 @@
+import type { KeyboardEvent } from "react";
+
+type IMEKeyboardEvent = KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>;
+
+export function isIMEComposing(
+  event: IMEKeyboardEvent,
+  isComposing = false,
+): boolean {
+  return isComposing || event.nativeEvent.isComposing || event.keyCode === 229;
+}


### PR DESCRIPTION
## Summary
- add a shared IME composition helper that also checks `keyCode === 229`
- prevent Enter from submitting in chat input, chat rename, and new agent name fields while IME composition is active

## Root Cause
Some browser and CJK IME combinations emit the `keydown` event with `isComposing=false` before `compositionend`, so Enter was handled as a submit key too early.

## Testing
- `cd backend && make lint`
- `cd backend && make test`
- `cd frontend && pnpm lint`
- `cd frontend && pnpm typecheck`
