### PR TITLE
fix: Add --user root to Docker sandbox for proper permissions

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
@@ -228,6 +228,8 @@ class LocalContainerBackend(SandboxBackend):
         # Docker-specific security options
         if self._runtime == "docker":
             cmd.extend(["--security-opt", "seccomp=unconfined"])
+            # Run as root to allow installing tools inside the sandbox
+            cmd.extend(["--user", "root"])
 
         cmd.extend(
             [


### PR DESCRIPTION
## 变更描述

在启动 Docker 沙箱容器时添加 `--user root` 标志，确保有足够的权限安装工具和访问文件。

## 变更类型

- [x] Bug 修复

## 测试

- [x] 已通过 `make lint`
- [x] 已在本地测试沙箱功能