### PR TITLE
Fix bash path validation for HTTPS URLs

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/bash_path_validation.py
+++ b/backend/packages/harness/deerflow/sandbox/bash_path_validation.py
@@ -1,0 +1,8 @@
+import re
+
+_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![:/\w])/(?:[^\s\"'`;&|<>()]+)")
+
+
+def extract_absolute_path_candidates(command: str) -> list[str]:
+    """Extract local absolute-path candidates from a shell command string."""
+    return _ABSOLUTE_PATH_PATTERN.findall(command)

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -8,6 +8,7 @@ from langgraph.typing import ContextT
 
 from deerflow.agents.thread_state import ThreadDataState, ThreadState
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX
+from deerflow.sandbox.bash_path_validation import extract_absolute_path_candidates
 from deerflow.sandbox.exceptions import (
     SandboxError,
     SandboxNotFoundError,
@@ -17,7 +18,6 @@ from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import get_sandbox_provider
 from deerflow.sandbox.security import LOCAL_HOST_BASH_DISABLED_MESSAGE, is_host_bash_allowed
 
-_ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![:\w])/(?:[^\s\"'`;&|<>()]+)")
 _LOCAL_BASH_SYSTEM_PATH_PREFIXES = (
     "/bin/",
     "/usr/bin/",
@@ -518,7 +518,7 @@ def validate_local_bash_command_paths(command: str, thread_data: ThreadDataState
     unsafe_paths: list[str] = []
     allowed_paths = _get_mcp_allowed_paths()
 
-    for absolute_path in _ABSOLUTE_PATH_PATTERN.findall(command):
+    for absolute_path in extract_absolute_path_candidates(command):
         # Check for MCP filesystem server allowed paths
         if any(absolute_path.startswith(path) or absolute_path == path.rstrip("/") for path in allowed_paths):
             _reject_path_traversal(absolute_path)

--- a/backend/tests/test_bash_path_validation.py
+++ b/backend/tests/test_bash_path_validation.py
@@ -1,0 +1,12 @@
+from deerflow.sandbox.bash_path_validation import extract_absolute_path_candidates
+
+
+def test_extract_absolute_path_candidates_keeps_unix_paths() -> None:
+    assert extract_absolute_path_candidates("cat /etc/passwd >/mnt/user-data/workspace/out.txt") == [
+        "/etc/passwd",
+        "/mnt/user-data/workspace/out.txt",
+    ]
+
+
+def test_extract_absolute_path_candidates_ignores_https_urls() -> None:
+    assert extract_absolute_path_candidates("curl -X POST https://example.com/api/v1/risk/check") == []

--- a/backend/tests/test_bash_path_validation.py
+++ b/backend/tests/test_bash_path_validation.py
@@ -10,3 +10,76 @@ def test_extract_absolute_path_candidates_keeps_unix_paths() -> None:
 
 def test_extract_absolute_path_candidates_ignores_https_urls() -> None:
     assert extract_absolute_path_candidates("curl -X POST https://example.com/api/v1/risk/check") == []
+
+
+# ---------------------------------------------------------------------------
+# Additional edge-case coverage
+# ---------------------------------------------------------------------------
+
+
+def test_ignores_http_urls() -> None:
+    assert extract_absolute_path_candidates("curl http://internal.service/health") == []
+
+
+def test_ignores_ftp_urls() -> None:
+    assert extract_absolute_path_candidates("wget ftp://files.example.com/pub/data.tar.gz") == []
+
+
+def test_ignores_port_slash_path() -> None:
+    # The /path portion after a port number is preceded by a digit (\w) so it must be excluded.
+    assert extract_absolute_path_candidates("curl http://localhost:8080/api/v1/endpoint") == []
+
+
+def test_empty_command_returns_empty_list() -> None:
+    assert extract_absolute_path_candidates("") == []
+
+
+def test_command_with_no_paths_returns_empty_list() -> None:
+    assert extract_absolute_path_candidates("echo hello world") == []
+
+
+def test_path_after_pipe_operator() -> None:
+    result = extract_absolute_path_candidates("cat /etc/hosts | grep localhost")
+    assert "/etc/hosts" in result
+
+
+def test_path_after_semicolon_is_detected() -> None:
+    # Semicolons terminate a path token but don't prevent detection of the path that follows.
+    result = extract_absolute_path_candidates("echo done; cat /tmp/output.txt")
+    assert "/tmp/output.txt" in result
+
+
+def test_multiple_paths_in_copy_command() -> None:
+    result = extract_absolute_path_candidates("cp /src/data/input.csv /dst/results/output.csv")
+    assert "/src/data/input.csv" in result
+    assert "/dst/results/output.csv" in result
+
+
+def test_path_as_first_token() -> None:
+    result = extract_absolute_path_candidates("/usr/bin/python3 script.py")
+    assert "/usr/bin/python3" in result
+
+
+def test_redirect_target_path_is_extracted() -> None:
+    result = extract_absolute_path_candidates("echo hello > /tmp/out.txt")
+    assert "/tmp/out.txt" in result
+
+
+def test_word_char_prefix_excludes_embedded_slash() -> None:
+    # "abc/def" — preceded by a word char, so no absolute path detected.
+    assert extract_absolute_path_candidates("abc/def/ghi") == []
+
+
+def test_mixed_url_and_local_path() -> None:
+    result = extract_absolute_path_candidates("curl https://example.com/download -o /tmp/file.bin")
+    assert result == ["/tmp/file.bin"]
+
+
+def test_path_with_dots_and_underscores() -> None:
+    result = extract_absolute_path_candidates("cat /mnt/user-data/uploads/my_file.md")
+    assert "/mnt/user-data/uploads/my_file.md" in result
+
+
+def test_virtual_upload_path_is_extracted() -> None:
+    result = extract_absolute_path_candidates("python /mnt/user-data/workspace/process.py")
+    assert "/mnt/user-data/workspace/process.py" in result


### PR DESCRIPTION
## Summary
- stop treating the path segment of https://... arguments as a local absolute path candidate
- isolate bash path candidate extraction in a small helper module so the behavior is easy to test
- add a regression test covering both normal Unix paths and HTTPS URL arguments

Fixes #1385

## Validation
- ./.venv/Scripts/python.exe -m pytest tests/test_bash_path_validation.py -q
- ./.venv/Scripts/python.exe -m ruff check packages/harness/deerflow/sandbox/bash_path_validation.py packages/harness/deerflow/sandbox/tools.py tests/test_bash_path_validation.py
