### PR TITLE
Pass agent name into bootstrap thread context

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -87,7 +87,7 @@ export default function NewAgentPage() {
     await sendMessage(threadId, {
       text: t.agents.nameStepBootstrapMessage.replace("{name}", trimmed),
       files: [],
-    });
+    }, { agent_name: trimmed });
   }, [
     nameInput,
     sendMessage,


### PR DESCRIPTION
## Summary
- include gent_name in the initial bootstrap turn sent by the new-agent page
- make sure setup_agent receives the custom agent name even if the bootstrap flow completes on the first automated turn
- keep the change isolated to the new-agent bootstrap entrypoint

Fixes #1488

## Validation
- pnpm typecheck
- pnpm exec eslint src/app/workspace/agents/new/page.tsx
