### PR TITLE
fix(channels): recover from stale threads after LangGraph restart

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -10,7 +10,7 @@ import time
 from collections.abc import Mapping
 from typing import Any
 
-from langgraph_sdk.errors import ConflictError
+from langgraph_sdk.errors import ConflictError, NotFoundError
 
 from app.channels.message_bus import InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
 from app.channels.store import ChannelStore
@@ -547,13 +547,25 @@ class ChannelManager:
             return
 
         logger.info("[Manager] invoking runs.wait(thread_id=%s, text=%r)", thread_id, msg.text[:100])
-        result = await client.runs.wait(
-            thread_id,
-            assistant_id,
-            input={"messages": [{"role": "human", "content": msg.text}]},
-            config=run_config,
-            context=run_context,
-        )
+        try:
+            result = await client.runs.wait(
+                thread_id,
+                assistant_id,
+                input={"messages": [{"role": "human", "content": msg.text}]},
+                config=run_config,
+                context=run_context,
+            )
+        except NotFoundError:
+            logger.warning("[Manager] thread %s not found (stale). Creating new thread.", thread_id)
+            self.store.remove(msg.channel_name, msg.chat_id, topic_id=getattr(msg, "topic_id", None))
+            thread_id = await self._create_thread(client, msg)
+            result = await client.runs.wait(
+                thread_id,
+                assistant_id,
+                input={"messages": [{"role": "human", "content": msg.text}]},
+                config=run_config,
+                context=run_context,
+            )
 
         response_text = _extract_response_text(result)
         artifacts = _extract_artifacts(result)
@@ -646,6 +658,19 @@ class ChannelManager:
                 )
                 last_published_text = latest_text
                 last_publish_at = now
+        except NotFoundError:
+            logger.warning("[Manager] thread %s not found (stale) during stream. Creating new thread.", thread_id)
+            self.store.remove(msg.channel_name, msg.chat_id, topic_id=getattr(msg, "topic_id", None))
+            thread_id = await self._create_thread(client, msg)
+            # Retry as non-streaming to avoid nested stream complexity
+            result = await client.runs.wait(
+                thread_id,
+                assistant_id,
+                input={"messages": [{"role": "human", "content": msg.text}]},
+                config=run_config,
+                context=run_context,
+            )
+            last_values = result
         except Exception as exc:
             stream_error = exc
             if _is_thread_busy_error(exc):


### PR DESCRIPTION
## Summary

When LangGraph Server restarts (dev hot-reload, deploy, crash), previously created threads become invalid (404). The channel manager stores chat→thread mappings in `store.json` but never validates them — causing every subsequent message to fail with "An internal error occurred."

This is the #1 pain point for IM channel users. After any restart, all Telegram/Slack/Feishu conversations break until someone manually clears `store.json`.

## Fix

Catches `NotFoundError` (404) in both `runs.wait` and `runs.stream` code paths:

1. Detects stale thread (404 from LangGraph)
2. Removes the stale mapping from `store.json`
3. Creates a fresh thread via `_create_thread()`
4. Retries the request transparently

The user sees a normal response instead of an error. Conversation continues seamlessly.

## Changes

- **`manager.py`**: Import `NotFoundError`, add try/except around `runs.wait()` and `runs.stream()` to catch 404 and auto-recover

## Before

```
User: "Hello"
Bot: "Working on it..."
Bot: "An internal error occurred. Please try again."
(repeat forever until store.json manually cleared)
```

## After

```
User: "Hello"
Bot: "Working on it..."
Bot: "Hi! How can I help?"  ← transparent recovery, new thread created
```

## Test plan

- [x] Verified `NotFoundError` import from `langgraph_sdk.errors`
- [x] Verified `store.remove()` exists and works
- [x] Tested scenario: send message → restart DeerFlow → send message → should recover
- [ ] Slack streaming path (same pattern, falls back to `runs.wait` on retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)