### PR TITLE
fix(config): update SSR fallback in getBaseOrigin function

### DIFF
--- a/frontend/src/core/config/index.ts
+++ b/frontend/src/core/config/index.ts
@@ -4,7 +4,8 @@ function getBaseOrigin() {
   if (typeof window !== "undefined") {
     return window.location.origin;
   }
-  return undefined;
+  // Fallback for SSR
+  return "http://localhost:2026";
 }
 
 export function getBackendBaseURL() {


### PR DESCRIPTION
This pull request updates the fallback behavior of the `getBaseOrigin` function to improve support for server-side rendering (SSR) environments. Instead of returning `undefined` when `window` is not available, it now returns a default local origin.

Configuration improvement:

* Updated the fallback in `getBaseOrigin` within `frontend/src/core/config/index.ts` to return `"http://localhost:2026"` for SSR scenarios instead of `undefined`.