### PR TITLE
fix: set --n-jobs-per-worker 10 in Docker langgraph command

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -170,7 +170,7 @@ services:
         APT_MIRROR: ${APT_MIRROR:-}
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
     container_name: deer-flow-langgraph
-    command: sh -c "cd backend && uv run langgraph dev --no-browser --allow-blocking --host 0.0.0.0 --port 2024 > /app/logs/langgraph.log 2>&1"
+    command: sh -c "cd backend && uv run langgraph dev --no-browser --allow-blocking --host 0.0.0.0 --port 2024 --n-jobs-per-worker 10 > /app/logs/langgraph.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
       # Preserve the .venv built during Docker image build — mounting the full backend/

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -115,7 +115,7 @@ services:
         APT_MIRROR: ${APT_MIRROR:-}
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
     container_name: deer-flow-langgraph
-    command: sh -c "cd /app/backend && uv run langgraph dev --no-browser --allow-blocking --no-reload --host 0.0.0.0 --port 2024"
+    command: sh -c "cd /app/backend && uv run langgraph dev --no-browser --allow-blocking --no-reload --host 0.0.0.0 --port 2024 --n-jobs-per-worker 10"
     volumes:
       - ${DEER_FLOW_CONFIG_PATH}:/app/config.yaml:ro
       - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/extensions_config.json:ro


### PR DESCRIPTION
## Problem

When running DeerFlow via Docker (`make up` or `make docker-start`), the LangGraph server starts with only **1 background worker**, causing all conversation runs to be processed serially.

If one run is busy (e.g. summarization middleware compressing a long conversation, or a multi-step tool-calling chain), all other threads are completely blocked until it finishes. This makes the system feel unresponsive, especially when switching between conversations.

## Root Cause

`langgraph dev` CLI defaults `n_jobs_per_worker` to `1` when the `--n-jobs-per-worker` flag is not explicitly passed:

```python
# langgraph_api/cli.py
n_jobs_per_worker if n_jobs_per_worker is not None else 1
```

This is inconsistent with the `N_JOBS_PER_WORKER` environment variable default of `10` in `langgraph_api/config/__init__.py`.

Since neither `docker-compose.yaml` nor `docker-compose-dev.yaml` passes this flag, Docker deployments end up with a single worker.

## Fix

Add `--n-jobs-per-worker 10` to the `langgraph dev` command in both Docker Compose files, matching the intended default concurrency.

Workers are activated on demand and idle workers do not consume additional memory, so this change has no resource impact when the system is not under concurrent load.

## Testing

Before fix:
```
Starting 1 background workers
Worker stats: active=0, available=1, max=1
```

After fix:
```
Starting 10 background workers
Worker stats: active=0, available=10, max=10
```

Verified that multiple conversations can now be processed concurrently without blocking each other.