### PR TITLE
fix: improve Windows compatibility in config upgrade script

### DIFF
--- a/scripts/config-upgrade.sh
+++ b/scripts/config-upgrade.sh
@@ -11,6 +11,14 @@ set -e
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EXAMPLE="$REPO_ROOT/config.example.yaml"
 
+to_python_path() {
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$1"
+    else
+        printf '%s' "$1"
+    fi
+}
+
 # Resolve config.yaml location: env var > backend/ > repo root
 if [ -n "$DEER_FLOW_CONFIG_PATH" ] && [ -f "$DEER_FLOW_CONFIG_PATH" ]; then
     CONFIG="$DEER_FLOW_CONFIG_PATH"
@@ -34,15 +42,22 @@ if [ -z "$CONFIG" ]; then
     exit 0
 fi
 
+PY_CONFIG="$(to_python_path "$CONFIG")"
+PY_EXAMPLE="$(to_python_path "$EXAMPLE")"
+
 # Use inline Python to do migrations + recursive merge with PyYAML
-cd "$REPO_ROOT/backend" && uv run python3 -c "
-import sys, shutil, copy, re
+cd "$REPO_ROOT/backend" && \
+PYTHONIOENCODING=utf-8:replace \
+PY_CONFIG="$PY_CONFIG" \
+PY_EXAMPLE="$PY_EXAMPLE" \
+uv run python3 -c "
+import copy, os, shutil, sys
 from pathlib import Path
 
 import yaml
 
-config_path = Path('$CONFIG')
-example_path = Path('$EXAMPLE')
+config_path = Path(os.environ['PY_CONFIG'])
+example_path = Path(os.environ['PY_EXAMPLE'])
 
 with open(config_path, encoding='utf-8') as f:
     raw_text = f.read()


### PR DESCRIPTION
## What
Improve Windows compatibility in `scripts/config-upgrade.sh`.

## Why
On Windows, the config upgrade script can fail when it is executed from Git Bash:
- POSIX paths may be passed directly into Windows Python
- Unicode output can break under non-UTF-8 console encodings

## How
- convert config file paths with `cygpath -m` before passing them to Python
- pass converted paths through environment variables instead of string interpolation
- set `PYTHONIOENCODING=utf-8:replace` when invoking Python

## Testing
- ran `./scripts/config-upgrade.sh` from Git Bash on Windows
- verified the script completed successfully and handled the current config without path or encoding errors
