### PR TITLE
fix: honor disable_auto_mounts in aio sandbox

### DIFF
--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -255,6 +255,10 @@ sandbox:
     - host_path: /path/on/host
       container_path: /path/in/container
       read_only: false
+
+  # Optional: Disable DeerFlow's automatic thread-data and skills mounts.
+  # Use this when you want only the mounts defined above to be attached.
+  # disable_auto_mounts: true
 ```
 
 ### Skills

--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -157,6 +157,7 @@ class AioSandboxProvider(SandboxProvider):
             "container_prefix": sandbox_config.container_prefix or DEFAULT_CONTAINER_PREFIX,
             "idle_timeout": idle_timeout if idle_timeout is not None else DEFAULT_IDLE_TIMEOUT,
             "replicas": replicas if replicas is not None else DEFAULT_REPLICAS,
+            "disable_auto_mounts": getattr(sandbox_config, "disable_auto_mounts", False),
             "mounts": sandbox_config.mounts or [],
             "environment": self._resolve_env_vars(sandbox_config.environment or {}),
             # provisioner URL for dynamic pod management (e.g. http://provisioner:8002)
@@ -190,6 +191,10 @@ class AioSandboxProvider(SandboxProvider):
 
     def _get_extra_mounts(self, thread_id: str | None) -> list[tuple[str, str, bool]]:
         """Collect all extra mounts for a sandbox (thread-specific + skills)."""
+        if self._config.get("disable_auto_mounts", False):
+            logger.info("Automatic sandbox mounts disabled by config")
+            return []
+
         mounts: list[tuple[str, str, bool]] = []
 
         if thread_id:

--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -55,6 +55,10 @@ class SandboxConfig(BaseModel):
         default=None,
         description="Idle timeout in seconds before sandbox is released (default: 600 = 10 minutes). Set to 0 to disable.",
     )
+    disable_auto_mounts: bool = Field(
+        default=False,
+        description="Disable DeerFlow's automatic thread-data and skills mounts for AioSandboxProvider. Only explicitly configured mounts will be used.",
+    )
     mounts: list[VolumeMountConfig] = Field(
         default_factory=list,
         description="List of volume mounts to share directories between host and container",

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -103,3 +103,38 @@ def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatc
             provider._discover_or_create_with_lock("thread-5", "sandbox-5")
 
     assert unlock_calls == []
+
+
+def test_get_extra_mounts_respects_disable_auto_mounts(tmp_path, monkeypatch):
+    """When disabled, the provider should only use explicitly configured mounts."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._config = {"disable_auto_mounts": True}
+
+    thread_mounts_called = {"value": False}
+    skills_mount_called = {"value": False}
+
+    def fake_thread_mounts(_thread_id: str):
+        thread_mounts_called["value"] = True
+        return [("host-thread", "/mnt/user-data/workspace", False)]
+
+    def fake_skills_mount():
+        skills_mount_called["value"] = True
+        return ("host-skills", "/mnt/skills", True)
+
+    monkeypatch.setattr(
+        aio_mod.AioSandboxProvider,
+        "_get_thread_mounts",
+        staticmethod(fake_thread_mounts),
+    )
+    monkeypatch.setattr(
+        aio_mod.AioSandboxProvider,
+        "_get_skills_mount",
+        staticmethod(fake_skills_mount),
+    )
+
+    mounts = provider._get_extra_mounts("thread-6")
+
+    assert mounts == []
+    assert thread_mounts_called["value"] is False
+    assert skills_mount_called["value"] is False

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -398,6 +398,10 @@ sandbox:
 #   #     container_path: /home/user/shared
 #   #     read_only: false
 #
+#   # Optional: Disable DeerFlow's automatic thread-data and skills mounts.
+#   # When true, only the mounts listed above are attached.
+#   # disable_auto_mounts: true
+#
 #   # Optional: Environment variables to inject into the sandbox container
 #   # Values starting with $ will be resolved from host environment variables
 #   # environment:


### PR DESCRIPTION
## What
Add a `sandbox.disable_auto_mounts` option so `AioSandboxProvider` can skip the built-in thread-data and skills mounts when users want a fully custom mount layout.

## Why
Issue #1612 describes a Windows Docker setup where the automatic mounts are not suitable and permissions need to persist across restarts. With this flag, users can keep only the explicit mounts declared in `config.yaml` and avoid the automatic DeerFlow mounts.

## Impact
- Skips automatic thread-data and skills mounts when `disable_auto_mounts: true`
- Leaves explicit `sandbox.mounts` entries untouched
- Documents the new option in the sandbox configuration guide and example config

## Validation
- `ruff check packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py packages/harness/deerflow/config/sandbox_config.py tests/test_aio_sandbox_provider.py`
- `PYTHONPATH=packages/harness pytest tests/test_aio_sandbox_provider.py -q`

Fixes #1612