### PR TITLE
feat: add GLM model configuration examples

### DIFF
--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -36,6 +36,7 @@ models:
 - OpenAI (`langchain_openai:ChatOpenAI`)
 - Anthropic (`langchain_anthropic:ChatAnthropic`)
 - DeepSeek (`langchain_deepseek:ChatDeepSeek`)
+- Zhipu AI GLM (`langchain_openai:ChatOpenAI`)
 - Claude Code OAuth (`deerflow.models.claude_provider:ClaudeChatModel`)
 - Codex CLI (`deerflow.models.openai_codex_provider:CodexChatModel`)
 - Any LangChain-compatible provider

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -137,6 +137,25 @@ models:
   #       thinking:
   #         type: enabled
 
+  # Example: Zhipu AI GLM model (OpenAI-compatible API)
+  # GLM API Docs: https://open.bigmodel.cn/dev/api
+  # - name: glm-5-turbo
+  #   display_name: GLM-5-Turbo
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-5-turbo
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/anthropic/v1
+  #   timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 196608
+  #   temperature: 0.7
+  #   supports_thinking: true
+  #   supports_vision: false
+  #   when_thinking_enabled:
+  #     extra_body:
+  #       thinking:
+  #         type: enabled
+
   # Example: Kimi K2.5 model
   # - name: kimi-k2.5
   #   display_name: Kimi K2.5


### PR DESCRIPTION
## Description

Add configuration examples for Zhipu AI GLM models to `config.example.yaml` and `CONFIGURATION.md`, addressing Issue #1635 where users asked how to configure GLM models.

## Changes

### config.example.yaml
- Add GLM-5-Turbo configuration example using `langchain_openai:ChatOpenAI`
- Includes: `model`, `base_url`, `max_tokens`, `temperature`, `supports_thinking`, `when_thinking_enabled`

### backend/docs/CONFIGURATION.md
- Add Zhipu AI GLM to Supported Providers list

## Configuration Example

```yaml
- name: glm-5-turbo
  display_name: GLM-5-Turbo
  use: langchain_openai:ChatOpenAI
  model: glm-5-turbo
  api_key: $ZHIPU_API_KEY
  base_url: https://open.bigmodel.cn/api/anthropic/v1
  max_tokens: 196608
  temperature: 0.7
  supports_thinking: true
  when_thinking_enabled:
    extra_body:
      thinking:
        type: enabled
```

## Related Issue

fix #1635