### PR TITLE
fix: LANGSMITH_TRACING in .env ignored due to environment override in docker-compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -149,9 +149,7 @@ services:
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_HOME}
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_REPO_ROOT}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
-      # Disable LangSmith tracing — LANGSMITH_API_KEY is not required.
-      # Set LANGSMITH_TRACING=true and LANGSMITH_API_KEY in .env to enable.
-      - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}
+      # LangSmith tracing: set LANGSMITH_TRACING=true and LANGSMITH_API_KEY in .env to enable.
     env_file:
       - ../.env
     extra_hosts:


### PR DESCRIPTION
## Problem

Setting `LANGSMITH_TRACING=true` in `.env` does not enable LangSmith tracing when running via Docker (`make up`). Tracing stays disabled despite following the documented instructions in the compose file comments.

## Root Cause

`docker-compose.yaml` has this in the `environment` section:

```yaml
environment:
  - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}
env_file:
  - ../.env
```

Docker Compose evaluates `${LANGSMITH_TRACING:-false}` from the **host shell environment**, not from `env_file`. Since most users don't export `LANGSMITH_TRACING` in their shell, it always resolves to `false`.

Additionally, `environment` entries take **precedence** over `env_file` entries ([Docker docs](https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/)), so even though `.env` sets `LANGSMITH_TRACING=true`, the explicit `false` from `environment` wins.

## Fix

Remove the `LANGSMITH_TRACING` entry from `environment`, letting the value from `.env` (loaded via `env_file`) take effect as intended. Users who don't set it in `.env` get the default behavior (tracing disabled, since the variable is absent).

## Verification

Before fix:
```
$ docker exec deer-flow-langgraph env | grep LANGSMITH_TRACING
LANGSMITH_TRACING=false   # despite .env having true
```

After fix:
```
$ docker exec deer-flow-langgraph env | grep LANGSMITH_TRACING
LANGSMITH_TRACING=true    # reads from .env correctly
```