### PR TITLE
fix: honor disable_auto_mounts in aio sandbox

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -157,6 +157,7 @@ class AioSandboxProvider(SandboxProvider):
             "container_prefix": sandbox_config.container_prefix or DEFAULT_CONTAINER_PREFIX,
             "idle_timeout": idle_timeout if idle_timeout is not None else DEFAULT_IDLE_TIMEOUT,
             "replicas": replicas if replicas is not None else DEFAULT_REPLICAS,
+            "disable_auto_mounts": getattr(sandbox_config, "disable_auto_mounts", False),
             "mounts": sandbox_config.mounts or [],
             "environment": self._resolve_env_vars(sandbox_config.environment or {}),
             # provisioner URL for dynamic pod management (e.g. http://provisioner:8002)
@@ -190,6 +191,10 @@ class AioSandboxProvider(SandboxProvider):
 
     def _get_extra_mounts(self, thread_id: str | None) -> list[tuple[str, str, bool]]:
         """Collect all extra mounts for a sandbox (thread-specific + skills)."""
+        if self._config.get("disable_auto_mounts", False):
+            logger.info("Automatic sandbox mounts disabled by config")
+            return []
+
         mounts: list[tuple[str, str, bool]] = []
 
         if thread_id:
@@ -636,3 +641,4 @@ class AioSandboxProvider(SandboxProvider):
                 logger.info(f"Destroyed warm-pool sandbox {sandbox_id} during shutdown")
             except Exception as e:
                 logger.error(f"Failed to destroy warm-pool sandbox {sandbox_id} during shutdown: {e}")
+

--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -55,6 +55,10 @@ class SandboxConfig(BaseModel):
         default=None,
         description="Idle timeout in seconds before sandbox is released (default: 600 = 10 minutes). Set to 0 to disable.",
     )
+    disable_auto_mounts: bool = Field(
+        default=False,
+        description="Disable DeerFlow's automatic thread-data and skills mounts for AioSandboxProvider. Only explicitly configured mounts will be used.",
+    )
     mounts: list[VolumeMountConfig] = Field(
         default_factory=list,
         description="List of volume mounts to share directories between host and container",
@@ -65,3 +69,4 @@ class SandboxConfig(BaseModel):
     )
 
     model_config = ConfigDict(extra="allow")
+

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -103,3 +103,31 @@ def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatc
             provider._discover_or_create_with_lock("thread-5", "sandbox-5")
 
     assert unlock_calls == []
+
+
+def test_get_extra_mounts_respects_disable_auto_mounts(tmp_path, monkeypatch):
+    """When disable_auto_mounts is enabled, provider should not inject thread/skills mounts."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._config = {"disable_auto_mounts": True}
+
+    thread_mounts_called = {"value": False}
+    skills_mount_called = {"value": False}
+
+    def fake_thread_mounts(_thread_id: str):
+        thread_mounts_called["value"] = True
+        return [("host-thread", "/mnt/user-data/workspace", False)]
+
+    def fake_skills_mount():
+        skills_mount_called["value"] = True
+        return ("host-skills", "/mnt/skills", True)
+
+    monkeypatch.setattr(aio_mod.AioSandboxProvider, "_get_thread_mounts", staticmethod(fake_thread_mounts))
+    monkeypatch.setattr(aio_mod.AioSandboxProvider, "_get_skills_mount", staticmethod(fake_skills_mount))
+
+    mounts = provider._get_extra_mounts("thread-6")
+
+    assert mounts == []
+    assert thread_mounts_called["value"] is False
+    assert skills_mount_called["value"] is False
+


### PR DESCRIPTION
## Problem

`AioSandboxProvider` unconditionally injects automatic thread-data and
skills bind-mounts into every sandbox container.  In security-sensitive
deployments or custom volume configurations, operators need the ability
to opt out of these automatic mounts and control exactly what is mounted.

## Solution

Add a `disable_auto_mounts: bool` field to `SandboxConfig` (defaults to
`false` — fully backwards-compatible).  When set to `true` in
`config.yaml`:

```yaml
sandbox:
  disable_auto_mounts: true
  mounts:
    - host_path: /custom/data
      container_path: /mnt/data
```

The provider skips the automatic thread-data and skills mounts and only
applies the mounts explicitly listed under `sandbox.mounts`.

## Changes

- `backend/packages/harness/deerflow/config/sandbox_config.py`: add
  `disable_auto_mounts` field
- `backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py`:
  pass `disable_auto_mounts` through to `_load_config`; respect it in
  `_get_extra_mounts`
- `backend/tests/test_aio_sandbox_provider.py`: add regression test
  verifying no automatic mounts are injected when flag is set

Made with [Cursor](https://cursor.com)