### PR TITLE
fix: let local sandbox tools honor configured mounts

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -76,6 +76,42 @@ def _get_skills_host_path() -> str | None:
     return None
 
 
+def _get_configured_sandbox_mounts() -> list[tuple[str, str, bool]]:
+    """Get configured sandbox mounts as (container_path, host_path, read_only)."""
+    try:
+        from deerflow.config import get_app_config
+
+        mounts: list[tuple[str, str, bool]] = []
+        for mount in get_app_config().sandbox.mounts:
+            container_path = str(mount.container_path).rstrip("/") or "/"
+            mounts.append((container_path, str(mount.host_path), bool(mount.read_only)))
+        return mounts
+    except Exception:
+        return []
+
+
+def _configured_mount_for_path(path: str) -> tuple[str, str, bool] | None:
+    """Resolve a virtual path against configured sandbox mounts."""
+    for container_path, host_path, read_only in sorted(_get_configured_sandbox_mounts(), key=lambda item: len(item[0]), reverse=True):
+        if path == container_path or path.startswith(f"{container_path}/"):
+            return container_path, host_path, read_only
+    return None
+
+
+def _resolve_configured_mount_path(path: str) -> str:
+    """Resolve a configured sandbox mount path to its host path."""
+    mount = _configured_mount_for_path(path)
+    if mount is None:
+        raise FileNotFoundError(f"Configured sandbox mount not available for path: {path}")
+
+    container_path, host_path, _read_only = mount
+    if path == container_path:
+        return host_path
+
+    relative = path[len(container_path) :].lstrip("/")
+    return _join_path_preserving_style(host_path, relative)
+
+
 def _is_skills_path(path: str) -> bool:
     """Check if a path is under the skills container path."""
     skills_prefix = _get_skills_container_path()
@@ -299,6 +335,10 @@ def replace_virtual_path(path: str, thread_data: ThreadDataState | None) -> str:
             rest = path[len(virtual_base) :].lstrip("/")
             return _join_path_preserving_style(actual_base, rest)
 
+    configured_mount = _configured_mount_for_path(path)
+    if configured_mount is not None:
+        return _resolve_configured_mount_path(path)
+
     return path
 
 
@@ -377,6 +417,23 @@ def mask_local_paths_in_output(output: str, thread_data: ThreadDataState | None)
 
             result = pattern.sub(replace_acp, result)
 
+    # Mask configured sandbox mount host paths
+    for container_path, host_path, _read_only in _get_configured_sandbox_mounts():
+        raw_base = str(Path(host_path))
+        resolved_base = str(Path(host_path).resolve())
+        for base in _path_variants(raw_base) | _path_variants(resolved_base):
+            escaped = re.escape(base).replace(r"\\", r"[/\\]")
+            pattern = re.compile(escaped + r"(?:[/\\][^\s\"';&|<>()]*)?")
+
+            def replace_mount(match: re.Match, _base: str = base, _virtual: str = container_path) -> str:
+                matched_path = match.group(0)
+                if matched_path == _base:
+                    return _virtual
+                relative = matched_path[len(_base) :].lstrip("/\\")
+                return f"{_virtual}/{relative}" if relative else _virtual
+
+            result = pattern.sub(replace_mount, result)
+
     # Mask user-data host paths
     if thread_data is None:
         return result
@@ -452,11 +509,18 @@ def validate_local_tool_path(path: str, thread_data: ThreadDataState | None, *, 
             raise PermissionError(f"Write access to ACP workspace is not allowed: {path}")
         return
 
+    configured_mount = _configured_mount_for_path(path)
+    if configured_mount is not None:
+        _container_path, _host_path, mount_read_only = configured_mount
+        if mount_read_only and not read_only:
+            raise PermissionError(f"Write access to read-only mounted path is not allowed: {path}")
+        return
+
     # User-data paths
     if path.startswith(f"{VIRTUAL_PATH_PREFIX}/"):
         return
 
-    raise PermissionError(f"Only paths under {VIRTUAL_PATH_PREFIX}/, {_get_skills_container_path()}/, or {_ACP_WORKSPACE_VIRTUAL_PATH}/ are allowed")
+    raise PermissionError(f"Only paths under {VIRTUAL_PATH_PREFIX}/, {_get_skills_container_path()}/, {_ACP_WORKSPACE_VIRTUAL_PATH}/, or configured sandbox mounts are allowed")
 
 
 def _validate_resolved_user_data_path(resolved: Path, thread_data: ThreadDataState) -> None:

--- a/backend/packages/harness/deerflow/tools/builtins/view_image_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/view_image_tool.py
@@ -9,7 +9,6 @@ from langgraph.types import Command
 from langgraph.typing import ContextT
 
 from deerflow.agents.thread_state import ThreadState
-from deerflow.sandbox.tools import get_thread_data, replace_virtual_path
 
 
 @tool("view_image", parse_docstring=True)
@@ -32,6 +31,8 @@ def view_image_tool(
     Args:
         image_path: Absolute path to the image file. Common formats supported: jpg, jpeg, png, webp.
     """
+    from deerflow.sandbox.tools import get_thread_data, replace_virtual_path
+
     # Replace virtual path with actual path
     # /mnt/user-data/* paths are mapped to thread-specific directories
     thread_data = get_thread_data(runtime)

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -36,6 +36,28 @@ def test_replace_virtual_path_maps_virtual_root_and_subpaths() -> None:
     assert Path(replace_virtual_path("/mnt/user-data", _THREAD_DATA)).as_posix() == "/tmp/deer-flow/threads/t1/user-data"
 
 
+def test_replace_virtual_path_maps_configured_mounts() -> None:
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    config = AppConfig(
+        models=[],
+        sandbox=SandboxConfig(
+            use="deerflow.sandbox.local:LocalSandboxProvider",
+            mounts=[
+                {
+                    "host_path": "/host/videos",
+                    "container_path": "/mnt/videos",
+                    "read_only": True,
+                }
+            ],
+        ),
+    )
+
+    with patch("deerflow.config.get_app_config", return_value=config):
+        assert replace_virtual_path("/mnt/videos/demo.mp4", _THREAD_DATA) == "/host/videos/demo.mp4"
+
+
 # ---------- mask_local_paths_in_output ----------
 
 
@@ -58,6 +80,30 @@ def test_mask_local_paths_in_output_hides_skills_host_paths() -> None:
 
         assert "/home/user/deer-flow/skills" not in masked
         assert "/mnt/skills/public/bootstrap/SKILL.md" in masked
+
+
+def test_mask_local_paths_in_output_hides_configured_mount_host_paths() -> None:
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    config = AppConfig(
+        models=[],
+        sandbox=SandboxConfig(
+            use="deerflow.sandbox.local:LocalSandboxProvider",
+            mounts=[
+                {
+                    "host_path": "/host/videos",
+                    "container_path": "/mnt/videos",
+                    "read_only": True,
+                }
+            ],
+        ),
+    )
+
+    with patch("deerflow.config.get_app_config", return_value=config):
+        masked = mask_local_paths_in_output("Rendered /host/videos/out/demo.mp4", _THREAD_DATA)
+        assert "/host/videos" not in masked
+        assert "/mnt/videos/out/demo.mp4" in masked
 
 
 # ---------- _reject_path_traversal ----------
@@ -109,6 +155,51 @@ def test_validate_local_tool_path_allows_user_data_paths() -> None:
 def test_validate_local_tool_path_allows_user_data_write() -> None:
     # read_only=False (default) should still work for user-data paths
     validate_local_tool_path(f"{VIRTUAL_PATH_PREFIX}/workspace/file.txt", _THREAD_DATA, read_only=False)
+
+
+def test_validate_local_tool_path_allows_configured_mount_read_only_access() -> None:
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    config = AppConfig(
+        models=[],
+        sandbox=SandboxConfig(
+            use="deerflow.sandbox.local:LocalSandboxProvider",
+            mounts=[
+                {
+                    "host_path": "/host/videos",
+                    "container_path": "/mnt/videos",
+                    "read_only": True,
+                }
+            ],
+        ),
+    )
+
+    with patch("deerflow.config.get_app_config", return_value=config):
+        validate_local_tool_path("/mnt/videos/demo.mp4", _THREAD_DATA, read_only=True)
+
+
+def test_validate_local_tool_path_rejects_writes_to_read_only_configured_mount() -> None:
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    config = AppConfig(
+        models=[],
+        sandbox=SandboxConfig(
+            use="deerflow.sandbox.local:LocalSandboxProvider",
+            mounts=[
+                {
+                    "host_path": "/host/videos",
+                    "container_path": "/mnt/videos",
+                    "read_only": True,
+                }
+            ],
+        ),
+    )
+
+    with patch("deerflow.config.get_app_config", return_value=config):
+        with pytest.raises(PermissionError, match="read-only mounted path"):
+            validate_local_tool_path("/mnt/videos/demo.mp4", _THREAD_DATA, read_only=False)
 
 
 def test_validate_local_tool_path_rejects_traversal_in_user_data() -> None:


### PR DESCRIPTION
## Problem

`LocalSandboxProvider` tool helpers (`replace_virtual_path`,
`get_thread_data`, etc.) only understood the built-in `/mnt/user-data`
virtual root.  Paths mounted via `sandbox.mounts` in `config.yaml` were
invisible to these helpers, so tools like `view_image_tool` could not
resolve files placed under custom mount points.

## Solution

- Add `_get_configured_sandbox_mounts()` to `sandbox/tools.py` which
  reads the live `AppConfig` and returns
  `(container_path, host_path, read_only)` tuples for every configured
  mount
- Extend `replace_virtual_path()` to translate paths that fall under a
  configured mount's `container_path` to the corresponding `host_path`
- Lazily import sandbox helpers in `view_image_tool` to avoid a circular
  import that occurred at module load time

## Changes

- `backend/packages/harness/deerflow/sandbox/tools.py`: add
  `_get_configured_sandbox_mounts()`; update `replace_virtual_path()`
- `backend/packages/harness/deerflow/tools/builtins/view_image_tool.py`:
  move `sandbox.tools` imports to function body
- `backend/tests/test_sandbox_tools_security.py`: add tests for
  configured-mount path translation alongside existing `/mnt/user-data`
  tests

Made with [Cursor](https://cursor.com)