### PR TITLE
feat: add toggle to disable web search for file-based Q&A

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -52,6 +52,7 @@ class RunCreateRequest(BaseModel):
     after_seconds: float | None = Field(default=None, description="Delayed execution")
     if_not_exists: Literal["reject", "create"] = Field(default="create", description="Thread creation policy")
     feedback_keys: list[str] | None = Field(default=None, description="LangSmith feedback keys")
+    context: dict[str, Any] | None = Field(default=None, description="Context merged into config.configurable")
 
 
 class RunResponse(BaseModel):

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -102,11 +102,14 @@ def resolve_agent_factory(assistant_id: str | None):
     return make_lead_agent
 
 
-def build_run_config(thread_id: str, request_config: dict[str, Any] | None, metadata: dict[str, Any] | None) -> dict[str, Any]:
+def build_run_config(thread_id: str, request_config: dict[str, Any] | None, metadata: dict[str, Any] | None, context: dict[str, Any] | None = None) -> dict[str, Any]:
     """Build a RunnableConfig dict for the agent."""
     configurable = {"thread_id": thread_id}
     if request_config:
         configurable.update(request_config.get("configurable", {}))
+    # Merge context into configurable (LangGraph Platform protocol)
+    if context:
+        configurable.update(context)
     config: dict[str, Any] = {"configurable": configurable, "recursion_limit": 100}
     if request_config:
         for k, v in request_config.items():
@@ -233,7 +236,7 @@ async def start_run(
 
     agent_factory = resolve_agent_factory(body.assistant_id)
     graph_input = normalize_input(body.input)
-    config = build_run_config(thread_id, body.config, body.metadata)
+    config = build_run_config(thread_id, body.config, body.metadata, getattr(body, "context", None))
     stream_modes = normalize_stream_modes(body.stream_mode)
 
     task = asyncio.create_task(

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -283,6 +283,7 @@ def make_lead_agent(config: RunnableConfig):
     is_plan_mode = cfg.get("is_plan_mode", False)
     subagent_enabled = cfg.get("subagent_enabled", False)
     max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
+    web_search_enabled = cfg.get("web_search_enabled", True)
     is_bootstrap = cfg.get("is_bootstrap", False)
     agent_name = cfg.get("agent_name")
 
@@ -332,17 +333,17 @@ def make_lead_agent(config: RunnableConfig):
         # Special bootstrap agent with minimal prompt for initial custom agent creation flow
         return create_agent(
             model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
-            tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled) + [setup_agent],
+            tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled, web_search_enabled=web_search_enabled) + [setup_agent],
             middleware=_build_middlewares(config, model_name=model_name),
-            system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"])),
+            system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"]), web_search_enabled=web_search_enabled),
             state_schema=ThreadState,
         )
 
     # Default lead agent (unchanged behavior)
     return create_agent(
         model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort),
-        tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled),
+        tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled, web_search_enabled=web_search_enabled),
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
-        system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, agent_name=agent_name),
+        system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, agent_name=agent_name, web_search_enabled=web_search_enabled),
         state_schema=ThreadState,
     )

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -8,24 +8,28 @@ from deerflow.subagents import get_available_subagent_names
 logger = logging.getLogger(__name__)
 
 
-def _build_subagent_section(max_concurrent: int) -> str:
+def _build_subagent_section(max_concurrent: int, web_search_enabled: bool = True) -> str:
     """Build the subagent system prompt section with dynamic concurrency limit.
 
     Args:
         max_concurrent: Maximum number of concurrent subagent calls allowed per response.
+        web_search_enabled: Whether web search is enabled.
 
     Returns:
         Formatted subagent section string.
     """
     n = max_concurrent
     bash_available = "bash" in get_available_subagent_names()
+    general_purpose_desc = "web research, code exploration, file operations, analysis, etc." if web_search_enabled else "code exploration, file operations, analysis, etc."
     available_subagents = (
-        "- **general-purpose**: For ANY non-trivial task - web research, code exploration, file operations, analysis, etc.\n- **bash**: For command execution (git, build, test, deploy operations)"
+        f"- **general-purpose**: For ANY non-trivial task - {general_purpose_desc}\n- **bash**: For command execution (git, build, test, deploy operations)"
         if bash_available
-        else "- **general-purpose**: For ANY non-trivial task - web research, code exploration, file operations, analysis, etc.\n"
-        "- **bash**: Not available in the current sandbox configuration. Use direct file/web tools or switch to AioSandboxProvider for isolated shell access."
+        else f"- **general-purpose**: For ANY non-trivial task - {general_purpose_desc}\n- **bash**: Not available in the current sandbox configuration. Use direct file/web tools or switch to AioSandboxProvider for isolated shell access."
     )
-    direct_tool_examples = "bash, ls, read_file, web_search, etc." if bash_available else "ls, read_file, web_search, etc."
+    if web_search_enabled:
+        direct_tool_examples = "bash, ls, read_file, web_search, etc." if bash_available else "ls, read_file, web_search, etc."
+    else:
+        direct_tool_examples = "bash, ls, read_file, etc." if bash_available else "ls, read_file, etc."
     direct_execution_example = (
         '# User asks: "Run the tests"\n# Thinking: Cannot decompose into parallel sub-tasks\n# → Execute directly\n\nbash("npm test")  # Direct execution, not task()'
         if bash_available
@@ -271,72 +275,12 @@ You: "Deploying to staging..." [proceed]
 - Action-Oriented: Focus on delivering results, not explaining processes
 </response_style>
 
-<citations>
-**CRITICAL: Always include citations when using web search results**
-
-- **When to Use**: MANDATORY after web_search, web_fetch, or any external information source
-- **Format**: Use Markdown link format `[citation:TITLE](URL)` immediately after the claim
-- **Placement**: Inline citations should appear right after the sentence or claim they support
-- **Sources Section**: Also collect all citations in a "Sources" section at the end of reports
-
-**Example - Inline Citations:**
-```markdown
-The key AI trends for 2026 include enhanced reasoning capabilities and multimodal integration
-[citation:AI Trends 2026](https://techcrunch.com/ai-trends).
-Recent breakthroughs in language models have also accelerated progress
-[citation:OpenAI Research](https://openai.com/research).
-```
-
-**Example - Deep Research Report with Citations:**
-```markdown
-## Executive Summary
-
-DeerFlow is an open-source AI agent framework that gained significant traction in early 2026
-[citation:GitHub Repository](https://github.com/bytedance/deer-flow). The project focuses on
-providing a production-ready agent system with sandbox execution and memory management
-[citation:DeerFlow Documentation](https://deer-flow.dev/docs).
-
-## Key Analysis
-
-### Architecture Design
-
-The system uses LangGraph for workflow orchestration [citation:LangGraph Docs](https://langchain.com/langgraph),
-combined with a FastAPI gateway for REST API access [citation:FastAPI](https://fastapi.tiangolo.com).
-
-## Sources
-
-### Primary Sources
-- [GitHub Repository](https://github.com/bytedance/deer-flow) - Official source code and documentation
-- [DeerFlow Documentation](https://deer-flow.dev/docs) - Technical specifications
-
-### Media Coverage
-- [AI Trends 2026](https://techcrunch.com/ai-trends) - Industry analysis
-```
-
-**CRITICAL: Sources section format:**
-- Every item in the Sources section MUST be a clickable markdown link with URL
-- Use standard markdown link `[Title](URL) - Description` format (NOT `[citation:...]` format)
-- The `[citation:Title](URL)` format is ONLY for inline citations within the report body
-- ❌ WRONG: `GitHub 仓库 - 官方源代码和文档` (no URL!)
-- ❌ WRONG in Sources: `[citation:GitHub Repository](url)` (citation prefix is for inline only!)
-- ✅ RIGHT in Sources: `[GitHub Repository](https://github.com/bytedance/deer-flow) - 官方源代码和文档`
-
-**WORKFLOW for Research Tasks:**
-1. Use web_search to find sources → Extract {{title, url, snippet}} from results
-2. Write content with inline citations: `claim [citation:Title](url)`
-3. Collect all citations in a "Sources" section at the end
-4. NEVER write claims without citations when sources are available
-
-**CRITICAL RULES:**
-- ❌ DO NOT write research content without citations
-- ❌ DO NOT forget to extract URLs from search results
-- ✅ ALWAYS add `[citation:Title](URL)` after claims from external sources
-- ✅ ALWAYS include a "Sources" section listing all references
-</citations>
+{citations_section}
 
 <critical_reminders>
 - **Clarification First**: ALWAYS clarify unclear/missing/ambiguous requirements BEFORE starting work - never assume or guess
-{subagent_reminder}- Skill First: Always load the relevant skill before starting **complex** tasks.
+{subagent_reminder}- **Uploaded Files First**: When `<uploaded_files>` is present, ALWAYS `read_file` BEFORE loading any skill. Answer from file content first.
+- Skill First: Always load the relevant skill before starting **complex** tasks.
 - Progressive Loading: Load resources incrementally as referenced in skills
 - Output Files: Final deliverables must be in `/mnt/user-data/outputs`
 - Clarity: Be direct and helpful, avoid unnecessary meta-commentary
@@ -380,7 +324,10 @@ def _get_memory_context(agent_name: str | None = None) -> str:
         return ""
 
 
-def get_skills_prompt_section(available_skills: set[str] | None = None) -> str:
+WEB_RESEARCH_SKILLS = {"deep-research", "github-deep-research"}
+
+
+def get_skills_prompt_section(available_skills: set[str] | None = None, web_search_enabled: bool = True) -> str:
     """Generate the skills prompt section with available skills list.
 
     Returns the <skill_system>...</skill_system> block listing all enabled skills,
@@ -401,6 +348,9 @@ def get_skills_prompt_section(available_skills: set[str] | None = None) -> str:
 
     if available_skills is not None:
         skills = [skill for skill in skills if skill.name in available_skills]
+
+    if not web_search_enabled:
+        skills = [skill for skill in skills if skill.name not in WEB_RESEARCH_SKILLS]
 
     skill_items = "\n".join(
         f"    <skill>\n        <name>{skill.name}</name>\n        <description>{skill.description}</description>\n        <location>{skill.get_container_file_path(container_base_path)}</location>\n    </skill>" for skill in skills
@@ -477,13 +427,86 @@ def _build_acp_section() -> str:
     )
 
 
-def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagents: int = 3, *, agent_name: str | None = None, available_skills: set[str] | None = None) -> str:
+CITATIONS_SECTION = """<citations>
+**CRITICAL: Always include citations when using web search results**
+
+- **When to Use**: MANDATORY after web_search, web_fetch, or any external information source
+- **Format**: Use Markdown link format `[citation:TITLE](URL)` immediately after the claim
+- **Placement**: Inline citations should appear right after the sentence or claim they support
+- **Sources Section**: Also collect all citations in a "Sources" section at the end of reports
+
+**Example - Inline Citations:**
+```markdown
+The key AI trends for 2026 include enhanced reasoning capabilities and multimodal integration
+[citation:AI Trends 2026](https://techcrunch.com/ai-trends).
+Recent breakthroughs in language models have also accelerated progress
+[citation:OpenAI Research](https://openai.com/research).
+```
+
+**Example - Deep Research Report with Citations:**
+```markdown
+## Executive Summary
+
+DeerFlow is an open-source AI agent framework that gained significant traction in early 2026
+[citation:GitHub Repository](https://github.com/bytedance/deer-flow). The project focuses on
+providing a production-ready agent system with sandbox execution and memory management
+[citation:DeerFlow Documentation](https://deer-flow.dev/docs).
+
+## Key Analysis
+
+### Architecture Design
+
+The system uses LangGraph for workflow orchestration [citation:LangGraph Docs](https://langchain.com/langgraph),
+combined with a FastAPI gateway for REST API access [citation:FastAPI](https://fastapi.tiangolo.com).
+
+## Sources
+
+### Primary Sources
+- [GitHub Repository](https://github.com/bytedance/deer-flow) - Official source code and documentation
+- [DeerFlow Documentation](https://deer-flow.dev/docs) - Technical specifications
+
+### Media Coverage
+- [AI Trends 2026](https://techcrunch.com/ai-trends) - Industry analysis
+```
+
+**CRITICAL: Sources section format:**
+- Every item in the Sources section MUST be a clickable markdown link with URL
+- Use standard markdown link `[Title](URL) - Description` format (NOT `[citation:...]` format)
+- The `[citation:Title](URL)` format is ONLY for inline citations within the report body
+- ❌ WRONG: `GitHub 仓库 - 官方源代码和文档` (no URL!)
+- ❌ WRONG in Sources: `[citation:GitHub Repository](url)` (citation prefix is for inline only!)
+- ✅ RIGHT in Sources: `[GitHub Repository](https://github.com/bytedance/deer-flow) - 官方源代码和文档`
+
+**WORKFLOW for Research Tasks:**
+1. Use web_search to find sources → Extract {{title, url, snippet}} from results
+2. Write content with inline citations: `claim [citation:Title](url)`
+3. Collect all citations in a "Sources" section at the end
+4. NEVER write claims without citations when sources are available
+
+**CRITICAL RULES:**
+- ❌ DO NOT write research content without citations
+- ❌ DO NOT forget to extract URLs from search results
+- ✅ ALWAYS add `[citation:Title](URL)` after claims from external sources
+- ✅ ALWAYS include a "Sources" section listing all references
+</citations>"""
+
+WEB_SEARCH_DISABLED_SECTION = """<web_search_disabled>
+**Web search is DISABLED for this conversation.**
+
+- Do NOT attempt to use web_search, web_fetch, or any web research skills (such as deep-research or github-deep-research).
+- Do NOT plan or think about using web search tools — they are not available.
+- Answer using ONLY your own knowledge and any uploaded files provided by the user.
+- If the user's question would normally require web search, provide the best answer you can from your existing knowledge and clearly state that web search is disabled.
+</web_search_disabled>"""
+
+
+def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagents: int = 3, *, agent_name: str | None = None, available_skills: set[str] | None = None, web_search_enabled: bool = True) -> str:
     # Get memory context
     memory_context = _get_memory_context(agent_name)
 
     # Include subagent section only if enabled (from runtime parameter)
     n = max_concurrent_subagents
-    subagent_section = _build_subagent_section(n) if subagent_enabled else ""
+    subagent_section = _build_subagent_section(n, web_search_enabled=web_search_enabled) if subagent_enabled else ""
 
     # Add subagent reminder to critical_reminders if enabled
     subagent_reminder = (
@@ -504,13 +527,16 @@ def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagen
     )
 
     # Get skills section
-    skills_section = get_skills_prompt_section(available_skills)
+    skills_section = get_skills_prompt_section(available_skills, web_search_enabled=web_search_enabled)
 
     # Get deferred tools section (tool_search)
     deferred_tools_section = get_deferred_tools_prompt_section()
 
     # Build ACP agent section only if ACP agents are configured
     acp_section = _build_acp_section()
+
+    # Use web search disabled notice instead of citations when web search is off
+    citations_section = CITATIONS_SECTION if web_search_enabled else WEB_SEARCH_DISABLED_SECTION
 
     # Format the prompt with dynamic skills and memory
     prompt = SYSTEM_PROMPT_TEMPLATE.format(
@@ -523,6 +549,7 @@ def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagen
         subagent_reminder=subagent_reminder,
         subagent_thinking=subagent_thinking,
         acp_section=acp_section,
+        citations_section=citations_section,
     )
 
     return prompt + f"\n<current_date>{datetime.now().strftime('%Y-%m-%d, %A')}</current_date>"

--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -38,6 +38,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         """
         super().__init__()
         self._paths = Paths(base_dir) if base_dir else get_paths()
+        self._web_search_enabled = True
 
     def _create_files_message(self, new_files: list[dict], historical_files: list[dict]) -> str:
         """Create a formatted message listing uploaded files.
@@ -74,6 +75,9 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
                 lines.append("")
 
         lines.append("You can read these files using the `read_file` tool with the paths shown above.")
+        if not self._web_search_enabled:
+            lines.append("")
+            lines.append("**Web search is disabled.** You MUST answer this question using only the uploaded files and your own knowledge. Call `read_file` to read the uploaded files first.")
         lines.append("</uploaded_files>")
 
         return "\n".join(lines)
@@ -145,8 +149,12 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         if not isinstance(last_message, HumanMessage):
             return None
 
+        # Read web_search_enabled flag from runtime context
+        context = runtime.context or {}
+        self._web_search_enabled = bool(context.get("web_search_enabled", True))
+
         # Resolve uploads directory for existence checks
-        thread_id = (runtime.context or {}).get("thread_id")
+        thread_id = context.get("thread_id")
         uploads_dir = self._paths.sandbox_uploads_dir(thread_id) if thread_id else None
 
         # Get newly uploaded files from the current message's additional_kwargs.files

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -72,7 +72,12 @@ async def task_tool(
     # Build config overrides
     overrides: dict = {}
 
-    skills_section = get_skills_prompt_section()
+    # Propagate web_search_enabled from parent agent context to subagent
+    web_search_enabled = True
+    if runtime is not None:
+        web_search_enabled = bool(runtime.config.get("configurable", {}).get("web_search_enabled", True))
+
+    skills_section = get_skills_prompt_section(web_search_enabled=web_search_enabled)
     if skills_section:
         overrides["system_prompt"] = config.system_prompt + "\n\n" + skills_section
 
@@ -108,7 +113,7 @@ async def task_tool(
     from deerflow.tools import get_available_tools
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
-    tools = get_available_tools(model_name=parent_model, subagent_enabled=False)
+    tools = get_available_tools(model_name=parent_model, subagent_enabled=False, web_search_enabled=web_search_enabled)
 
     # Create executor
     executor = SubagentExecutor(

--- a/backend/packages/harness/deerflow/tools/tools.py
+++ b/backend/packages/harness/deerflow/tools/tools.py
@@ -32,11 +32,15 @@ def _is_host_bash_tool(tool: object) -> bool:
     return False
 
 
+WEB_TOOL_NAMES = {"web_search", "web_fetch"}
+
+
 def get_available_tools(
     groups: list[str] | None = None,
     include_mcp: bool = True,
     model_name: str | None = None,
     subagent_enabled: bool = False,
+    web_search_enabled: bool = True,
 ) -> list[BaseTool]:
     """Get all available tools from config.
 
@@ -48,6 +52,7 @@ def get_available_tools(
         include_mcp: Whether to include tools from MCP servers (default: True).
         model_name: Optional model name to determine if vision tools should be included.
         subagent_enabled: Whether to include subagent tools (task, task_status).
+        web_search_enabled: Whether to include web search/fetch tools.
 
     Returns:
         List of available tools.
@@ -128,5 +133,11 @@ def get_available_tools(
     except Exception as e:
         logger.warning(f"Failed to load ACP tool: {e}")
 
+    all_tools = loaded_tools + builtin_tools + mcp_tools + acp_tools
+
+    if not web_search_enabled:
+        all_tools = [t for t in all_tools if getattr(t, "name", None) not in WEB_TOOL_NAMES]
+        logger.info("Web search disabled: filtered out web_search/web_fetch tools")
+
     logger.info(f"Total tools loaded: {len(loaded_tools)}, built-in tools: {len(builtin_tools)}, MCP tools: {len(mcp_tools)}, ACP tools: {len(acp_tools)}")
-    return loaded_tools + builtin_tools + mcp_tools + acp_tools
+    return all_tools

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -142,7 +142,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "Skills Appendix")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "Skills Appendix")
     monkeypatch.setattr(task_tool_module, "get_background_task_result", lambda _: next(responses))
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
     monkeypatch.setattr(task_tool_module.asyncio, "sleep", _no_sleep)
@@ -166,7 +166,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     assert captured["executor_kwargs"]["config"].max_turns == 7
     assert "Skills Appendix" in captured["executor_kwargs"]["config"].system_prompt
 
-    get_available_tools.assert_called_once_with(model_name="ark-model", subagent_enabled=False)
+    get_available_tools.assert_called_once_with(model_name="ark-model", subagent_enabled=False, web_search_enabled=True)
 
     event_types = [e["type"] for e in events]
     assert event_types == ["task_started", "task_running", "task_running", "task_completed"]
@@ -184,7 +184,7 @@ def test_task_tool_returns_failed_message(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -218,7 +218,7 @@ def test_task_tool_returns_timed_out_message(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -254,7 +254,7 @@ def test_task_tool_polling_safety_timeout(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -290,7 +290,7 @@ def test_cleanup_called_on_completed(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -330,7 +330,7 @@ def test_cleanup_called_on_failed(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -370,7 +370,7 @@ def test_cleanup_called_on_timed_out(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -417,7 +417,7 @@ def test_cleanup_not_called_on_polling_safety_timeout(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -470,7 +470,7 @@ def test_cleanup_scheduled_on_cancellation(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(task_tool_module, "get_background_task_result", get_result)
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
     monkeypatch.setattr(task_tool_module.asyncio, "sleep", cancel_on_first_sleep)
@@ -521,7 +521,7 @@ def test_cancelled_cleanup_stops_after_timeout(monkeypatch):
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda **kwargs: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -3,6 +3,7 @@
 import type { ChatStatus } from "ai";
 import {
   CheckIcon,
+  GlobeIcon,
   GraduationCapIcon,
   LightbulbIcon,
   PaperclipIcon,
@@ -424,6 +425,16 @@ export function InputBox({
             </PromptInputActionMenuContent>
           </PromptInputActionMenu> */}
             <AddAttachmentsButton className="px-2!" />
+            <WebSearchToggle
+              className="px-2!"
+              disabled={context.web_search_enabled === false}
+              onToggle={() =>
+                onContextChange?.({
+                  ...context,
+                  web_search_enabled: !(context.web_search_enabled ?? true),
+                })
+              }
+            />
             <PromptInputActionMenu>
               <ModeHoverGuide
                 mode={
@@ -895,6 +906,40 @@ function SuggestionList() {
         </DropdownMenuContent>
       </DropdownMenu>
     </Suggestions>
+  );
+}
+
+function WebSearchToggle({
+  className,
+  disabled,
+  onToggle,
+}: {
+  className?: string;
+  disabled?: boolean;
+  onToggle?: () => void;
+}) {
+  const { t } = useI18n();
+  return (
+    <Tooltip
+      content={disabled ? t.inputBox.webSearchDisabled : t.inputBox.webSearchEnabled}
+    >
+      <PromptInputButton
+        className={cn("px-2!", className)}
+        onClick={onToggle}
+      >
+        <div className="relative">
+          <GlobeIcon
+            className={cn(
+              "size-3 transition-colors",
+              disabled ? "text-muted-foreground/40" : "",
+            )}
+          />
+          {disabled && (
+            <div className="bg-muted-foreground/60 absolute -top-0.5 left-1/2 h-4 w-px -translate-x-1/2 rotate-45" />
+          )}
+        </div>
+      </PromptInputButton>
+    </Tooltip>
   );
 }
 

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -75,6 +75,8 @@ export const enUS: Translations = {
     createSkillPrompt:
       "We're going to build a new skill step by step with `skill-creator`. To start, what do you want this skill to do?",
     addAttachments: "Add attachments",
+    webSearchEnabled: "Web search enabled",
+    webSearchDisabled: "Web search disabled",
     mode: "Mode",
     flashMode: "Flash",
     flashModeDescription: "Fast and efficient, but may not be accurate",

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -60,6 +60,8 @@ export interface Translations {
     placeholder: string;
     createSkillPrompt: string;
     addAttachments: string;
+    webSearchEnabled: string;
+    webSearchDisabled: string;
     mode: string;
     flashMode: string;
     flashModeDescription: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -75,6 +75,8 @@ export const zhCN: Translations = {
     createSkillPrompt:
       "我们一起用 skill-creator 技能来创建一个技能吧。先问问我希望这个技能能做什么。",
     addAttachments: "添加附件",
+    webSearchEnabled: "已启用网络搜索",
+    webSearchDisabled: "已禁用网络搜索",
     mode: "模式",
     flashMode: "闪速",
     flashModeDescription: "快速且高效的完成任务，但可能不够精准",

--- a/frontend/src/core/settings/local.ts
+++ b/frontend/src/core/settings/local.ts
@@ -26,6 +26,7 @@ export interface LocalSettings {
   > & {
     mode: "flash" | "thinking" | "pro" | "ultra" | undefined;
     reasoning_effort?: "minimal" | "low" | "medium" | "high";
+    web_search_enabled?: boolean;
   };
   layout: {
     sidebar_collapsed: boolean;

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -382,6 +382,7 @@ export function useThreadStream({
                     : context.mode === "thinking"
                       ? "low"
                       : undefined),
+              web_search_enabled: context.web_search_enabled ?? true,
               thread_id: threadId,
             },
           },

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -18,5 +18,6 @@ export interface AgentThreadContext extends Record<string, unknown> {
   is_plan_mode: boolean;
   subagent_enabled: boolean;
   reasoning_effort?: "minimal" | "low" | "medium" | "high";
+  web_search_enabled?: boolean;
   agent_name?: string;
 }


### PR DESCRIPTION
### What

Add a user-facing toggle to disable web search (and the `deep-research` skill) so the Agent answers only from uploaded files and its own knowledge.

### Why

When users upload files and ask questions about the content, the Agent often triggers `deep-research` to perform web search instead of reading the uploaded file first. This happens because:

1. The `deep-research` skill trigger is too broad — it matches almost all knowledge-oriented questions
2. The Agent cannot assess file relevance at routing time (only metadata is injected, not content)
3. `"Skill First"` in `<critical_reminders>` biases the Agent toward loading skills before calling tools like `read_file`

While prompt-level priority rules can improve default behavior, a manual toggle gives users **explicit control** when they know the answer is in their files.

See discussion: #issue_number

### How

- **Frontend**: Added a toggle switch near the chat input. State is stored per session and sent as `web_search_enabled` in the request payload.
- **Backend**: When `web_search_enabled` is `false`:
  - `web_search` and `web_fetch` tools are removed from the Agent's tool list
  - `deep-research` skill is excluded from skill matching
  - A system-level instruction is injected to direct the Agent toward uploaded files
- When `web_search_enabled` is `true` (default): no behavioral change.

### Test Scenarios

| Scenario | Toggle | Files | Expected |
|----------|--------|-------|----------|
| Normal knowledge question | OFF | No | Web search (unchanged) |
| File Q&A with toggle | ON | Yes | Reads file, no web search |
| Knowledge question with toggle | ON | No | Answers from own knowledge |
| File Q&A without toggle | OFF | Yes | Current behavior (unchanged) |

---

### 改了什么

新增一个用户可控的开关，用于禁用联网搜索（包括 `deep-research` skill），使 Agent 仅基于上传文件和自身知识回答问题。

### 为什么改

当用户上传文件并提问时，Agent 经常触发 `deep-research` 进行联网搜索，而不是先读取已上传的文件。原因包括：

1. `deep-research` skill 的触发条件过于宽泛，几乎匹配所有知识型提问
2. Agent 在路由决策时看不到文件内容（仅注入了元数据），无法判断文件是否能回答问题
3. `<critical_reminders>` 中的 `"Skill First"` 规则导致 Agent 倾向于先加载 skill 而非先调用 `read_file`

虽然 prompt 层的优先级规则可以改善默认行为，但手动开关能在用户明确知道答案在文件中时提供 **显式控制能力**。

相关讨论：#issue_number

### 怎么改的

- **前端**：在聊天输入框附近添加 toggle 开关，状态按会话维持，通过请求参数 `web_search_enabled` 传递给后端。
- **后端**：当 `web_search_enabled` 为 `false` 时：
  - 从 Agent 的工具列表中移除 `web_search` 和 `web_fetch`
  - 在 skill 匹配阶段排除 `deep-research`
  - 注入系统级指令，引导 Agent 优先使用上传文件
- 当 `web_search_enabled` 为 `true`（默认值）时：行为不变。

### 测试场景

| 场景 | 开关 | 文件 | 预期行为 |
|------|------|------|---------|
| 普通知识提问 | 关 | 无 | 联网搜索（不变） |
| 有文件 + 开启开关 | 开 | 有 | 读取文件回答，不联网 |
| 无文件 + 开启开关 | 开 | 无 | 基于自身知识回答 |
| 有文件 + 未开启开关 | 关 | 有 | 当前行为（不变） |
