### PR TITLE
fix(tools): move sandbox.tools import in view_image_tool to break circular import

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/view_image_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/view_image_tool.py
@@ -9,7 +9,6 @@ from langgraph.types import Command
 from langgraph.typing import ContextT
 
 from deerflow.agents.thread_state import ThreadState
-from deerflow.sandbox.tools import get_thread_data, replace_virtual_path
 
 
 @tool("view_image", parse_docstring=True)
@@ -32,6 +31,8 @@ def view_image_tool(
     Args:
         image_path: Absolute path to the image file. Common formats supported: jpg, jpeg, png, webp.
     """
+    from deerflow.sandbox.tools import get_thread_data, replace_virtual_path
+
     # Replace virtual path with actual path
     # /mnt/user-data/* paths are mapped to thread-specific directories
     thread_data = get_thread_data(runtime)


### PR DESCRIPTION
## Problem

`view_image_tool.py` had a top-level import of `deerflow.sandbox.tools`, creating a circular dependency chain:

```
sandbox.tools
  -> deerflow.agents.thread_state  (triggers agents/__init__.py)
    -> agents/factory.py
      -> tools/builtins/__init__.py
        -> view_image_tool.py
          -> deerflow.sandbox.tools  <-- circular!
```

This caused `ImportError: cannot import name 'get_thread_data' from partially initialized module 'deerflow.sandbox.tools'` whenever a test directly imported `sandbox.tools`. As a result, `test_sandbox_tools_security.py` has been failing to collect since #1522.

## Fix

Move the `from deerflow.sandbox.tools import get_thread_data, replace_virtual_path` import from the module top-level into the `view_image_tool` function body. This defers the import to call time, when `sandbox.tools` is already fully initialized.

## Test plan

- `tests/test_sandbox_tools_security.py` — previously failed to collect, now passes (91 tests)
- `tests/test_create_deerflow_agent.py` — no regression