### PR TITLE
fix: docker-compose 挂载目录问题修复（fix(langgraph): correct config.yaml mount path in docker-compose）

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -121,8 +121,8 @@ services:
     container_name: deer-flow-langgraph
     command: sh -c "cd /app/backend && uv run langgraph dev --no-browser --allow-blocking --no-reload --host 0.0.0.0 --port 2024 --n-jobs-per-worker 10"
     volumes:
-      - ${DEER_FLOW_CONFIG_PATH}:/app/config.yaml:ro
-      - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/extensions_config.json:ro
+      - ${DEER_FLOW_CONFIG_PATH}:/app/backend/config.yaml:ro
+      - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/backend/extensions_config.json:ro
       - ${DEER_FLOW_HOME}:/app/backend/.deer-flow
       - ../skills:/app/skills:ro
       - ../backend/.langgraph_api:/app/backend/.langgraph_api
@@ -144,8 +144,8 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
-      - DEER_FLOW_CONFIG_PATH=/app/config.yaml
-      - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/extensions_config.json
+      - DEER_FLOW_CONFIG_PATH=/app/backend/config.yaml
+      - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/backend/extensions_config.json
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_HOME}
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_REPO_ROOT}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal


### PR DESCRIPTION
The LangGraph service was mounting config.yaml to /app/config.yaml,
but the working directory is /app/backend, causing FileNotFoundError
when make_lead_agent tries to load the config.

This fixes the /threads/{thread_id}/history endpoint 500 error
and any other endpoints that require loading the agent config.

Changed mount paths:
- /app/config.yaml → /app/backend/config.yaml
- /app/extensions_config.json → /app/backend/extensions_config.json

LangGraph 服务之前将 config.yaml 挂载到了 /app/config.yaml，
但工作目录却是 /app/backend，导致 make_lead_agent 在加载配置时出现 FileNotFoundError 错误。
此修复解决了 /threads/{thread_id}/history 接口的 500 错误，
以及任何其他需要加载代理配置的接口。

挂载路径已更改：
- /app/config.yaml → /app/backend/config.yaml
- /app/extensions_config.json → /app/backend/extensions_config.json