### PR TITLE
fix: add Podman DNS resolver fallback to nginx config

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -14,8 +14,9 @@ http {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
-    # Docker internal DNS (for resolving k3s hostname)
-    resolver 127.0.0.11 valid=10s ipv6=off;
+    # Container DNS — Docker (127.0.0.11) and Podman (10.89.3.1)
+    # nginx tries resolvers in order; the unreachable one is silently skipped.
+    resolver 127.0.0.11 10.89.3.1 valid=10s ipv6=off;
 
     # Upstream servers (using Docker service names)
     # NOTE: add `resolve` so nginx re-resolves container IPs after restarts.


### PR DESCRIPTION
## Summary

The production `nginx.conf` hardcodes Docker's embedded DNS resolver (`127.0.0.11`), which does not exist in Podman environments. This causes upstream service name resolution to fail with `connection refused` / `operation timed out` errors, resulting in 502 Bad Gateway responses.

- Add Podman's default bridge DNS gateway (`10.89.3.1`) as a fallback resolver
- nginx tries resolvers in order — the unreachable one is silently skipped
- Works on both Docker and Podman without any configuration changes

## Test plan

- [x] Verified on Podman Desktop (macOS) — services resolve correctly, health endpoint returns 200
- [x] Verified behavior matches Docker — `127.0.0.11` is tried first, `10.89.3.1` fallback is only used when Docker DNS is unavailable
- [ ] CI regression tests pass