### PR TITLE
fix: add --n-jobs-per-worker 10 to local dev Makefile

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,7 +2,7 @@ install:
 	uv sync
 
 dev:
-	uv run langgraph dev --no-browser --allow-blocking --no-reload
+	uv run langgraph dev --no-browser --allow-blocking --no-reload --n-jobs-per-worker 10
 
 gateway:
 	PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001


### PR DESCRIPTION
## Summary

- #1623 added `--n-jobs-per-worker 10` to both Docker Compose files but missed the `backend/Makefile` used by `make dev`
- Without this flag, `langgraph dev` defaults `n_jobs_per_worker` to **1** (see `langgraph_api/cli.py`), so all conversation runs are serialised and concurrent requests block
- This one-line change mirrors the Docker configuration

## Test plan

- [ ] Run `make dev` in `backend/`, confirm `--n-jobs-per-worker 10` appears in the process args
- [ ] Send 2+ concurrent requests to the LangGraph server and verify they are processed in parallel