### PR TITLE
fix(skills): support parsing multiline YAML strings in SKILL.md frontmatter

### DIFF
--- a/backend/packages/harness/deerflow/skills/parser.py
+++ b/backend/packages/harness/deerflow/skills/parser.py
@@ -39,27 +39,46 @@ def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None
         current_key = None
         current_value = []
         is_multiline = False
+        multiline_style = None
+        indent_level = None
 
         for line in lines:
-            if not line.strip():
-                if is_multiline:
+            if is_multiline:
+                if not line.strip():
                     current_value.append("")
-                continue
+                    continue
 
-            # Check if line is indented (part of multiline string)
-            if is_multiline and (line.startswith("  ") or line.startswith("\t")):
-                current_value.append(line.strip())
-                continue
+                current_indent = len(line) - len(line.lstrip())
 
-            # If we reach here, it's a new key or the end of multiline
+                if indent_level is None:
+                    if current_indent > 0:
+                        indent_level = current_indent
+                        current_value.append(line[indent_level:])
+                        continue
+                elif current_indent >= indent_level:
+                    current_value.append(line[indent_level:])
+                    continue
+
+            # If we reach here, it's either a new key or the end of multiline
             if current_key and is_multiline:
-                metadata[current_key] = " ".join(current_value).strip()
+                if multiline_style == "|":
+                    metadata[current_key] = "\n".join(current_value).rstrip()
+                else:
+                    text = "\n".join(current_value).rstrip()
+                    # Replace single newlines with spaces for folded blocks
+                    metadata[current_key] = re.sub(r"(?<!\n)\n(?!\n)", " ", text)
+
                 current_key = None
                 current_value = []
                 is_multiline = False
+                multiline_style = None
+                indent_level = None
+
+            if not line.strip():
+                continue
 
             if ":" in line:
-                # Handle nested dicts simply by ignoring indentation for now, 
+                # Handle nested dicts simply by ignoring indentation for now,
                 # or just extracting top-level keys
                 key, value = line.split(":", 1)
                 key = key.strip()
@@ -68,12 +87,18 @@ def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None
                 if value in (">", "|"):
                     current_key = key
                     is_multiline = True
+                    multiline_style = value
                     current_value = []
+                    indent_level = None
                 else:
                     metadata[key] = value
 
         if current_key and is_multiline:
-            metadata[current_key] = " ".join(current_value).strip()
+            if multiline_style == "|":
+                metadata[current_key] = "\n".join(current_value).rstrip()
+            else:
+                text = "\n".join(current_value).rstrip()
+                metadata[current_key] = re.sub(r"(?<!\n)\n(?!\n)", " ", text)
 
         # Extract required fields
         name = metadata.get("name")

--- a/backend/tests/test_skills_parser.py
+++ b/backend/tests/test_skills_parser.py
@@ -93,6 +93,27 @@ class TestParseSkillFile:
         assert result is not None
         assert result.description == "A skill: does things"
 
+    def test_multiline_yaml_folded_description(self, tmp_path):
+        skill_file = _write_skill(
+            tmp_path,
+            "---\nname: multiline-skill\ndescription: >\n   This is a multiline\n   description for a skill.\n\n   It spans multiple lines.\nlicense: MIT\n---\n\nBody\n",
+        )
+        result = parse_skill_file(skill_file, "public")
+        assert result is not None
+        assert result.name == "multiline-skill"
+        assert result.description == "This is a multiline description for a skill.\n\nIt spans multiple lines."
+        assert result.license == "MIT"
+
+    def test_multiline_yaml_literal_description(self, tmp_path):
+        skill_file = _write_skill(
+            tmp_path,
+            "---\nname: pipe-skill\ndescription: |\n    First line.\n    Second line.\n---\n\nBody\n",
+        )
+        result = parse_skill_file(skill_file, "public")
+        assert result is not None
+        assert result.name == "pipe-skill"
+        assert result.description == "First line.\nSecond line."
+
     def test_empty_front_matter_returns_none(self, tmp_path):
         skill_file = _write_skill(tmp_path, "---\n\n---\n\nBody\n")
         assert parse_skill_file(skill_file, "public") is None


### PR DESCRIPTION
The naive YAML frontmatter parser in `skills/parser.py` splits by newlines and colons, which breaks completely when encountering multiline YAML strings (like `description: >` or `description: |`). 

This PR updates the parser to natively support basic multiline string blocks (using indentation rules) without introducing any heavy external dependencies like `pyyaml` or `ruamel.yaml`, ensuring compatibility with the existing isolated environment.