### PR TITLE
fix: share .deer-flow in docker-compose-dev for uploads

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -125,7 +125,6 @@ services:
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - gateway-venv:/app/backend/.venv
-      - ../backend/.deer-flow:/app/backend/.deer-flow
       - ../config.yaml:/app/config.yaml
       - ../extensions_config.json:/app/extensions_config.json
       - ../skills:/app/skills
@@ -182,7 +181,6 @@ services:
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - langgraph-venv:/app/backend/.venv
-      - ../backend/.deer-flow:/app/backend/.deer-flow
       - ../config.yaml:/app/config.yaml
       - ../extensions_config.json:/app/extensions_config.json
       - ../skills:/app/skills


### PR DESCRIPTION
## Summary
- mount `backend/.deer-flow` into both `gateway` and `langgraph` in `docker/docker-compose-dev.yaml`
- set `DEER_FLOW_HOME=/app/backend/.deer-flow` for both services in dev compose
- keep uploaded files visible to LangGraph during agent execution in the dev environment

## Scope
This PR only fixes the dev compose setup (`docker/docker-compose-dev.yaml`).
The production compose file already has the corresponding `DEER_FLOW_HOME` and `.deer-flow` wiring on `main`.

## Root cause
In the dev compose setup, `gateway` and `langgraph` did not share the same DeerFlow data directory and also did not set `DEER_FLOW_HOME`. As a result, uploads written by the gateway landed in its container-local data dir while LangGraph scanned a different container-local path.

Fixes #1676