### PR TITLE
fix(scripts): avoid lsof hang in wait-for-port

### DIFF
--- a/scripts/wait-for-port.sh
+++ b/scripts/wait-for-port.sh
@@ -21,8 +21,14 @@ elapsed=0
 interval=1
 
 is_port_listening() {
-    if command -v lsof >/dev/null 2>&1; then
-        if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if command -v curl >/dev/null 2>&1; then
+        if curl -sf --max-time 1 "http://127.0.0.1:$PORT/" >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    if command -v bash >/dev/null 2>&1; then
+        if bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" >/dev/null 2>&1; then
             return 0
         fi
     fi
@@ -37,11 +43,6 @@ is_port_listening() {
         if netstat -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|[.:])${PORT}$"; then
             return 0
         fi
-    fi
-
-    if command -v timeout >/dev/null 2>&1; then
-        timeout 1 bash -c "exec 3<>/dev/tcp/127.0.0.1/$PORT" >/dev/null 2>&1
-        return $?
     fi
 
     return 1


### PR DESCRIPTION
## Summary
- Replace `lsof -nP -iTCP` with `curl --max-time 1` and `/dev/tcp` probing.
- Keep `ss` and `netstat` as secondary fallbacks.

## Why
`lsof` can hang on macOS during startup detection, which blocks local dev boot.

## Validation
- `bash -n scripts/wait-for-port.sh`
- Smoke test with a temporary `python -m http.server` listener