### PR TITLE
fix(ui): avoid over-segmenting CJK messages

### DIFF
--- a/frontend/src/core/rehype/index.ts
+++ b/frontend/src/core/rehype/index.ts
@@ -3,6 +3,9 @@ import { useMemo } from "react";
 import { visit } from "unist-util-visit";
 import type { BuildVisitor } from "unist-util-visit";
 
+const CJK_TEXT_RE =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
+
 export function rehypeSplitWordsIntoSpans() {
   return (tree: Root) => {
     visit(tree, "element", ((node: Element) => {
@@ -15,6 +18,10 @@ export function rehypeSplitWordsIntoSpans() {
         const newChildren: Array<ElementContent> = [];
         node.children.forEach((child) => {
           if (child.type === "text") {
+            if (CJK_TEXT_RE.test(child.value)) {
+              newChildren.push(child);
+              return;
+            }
             const segmenter = new Intl.Segmenter("zh", { granularity: "word" });
             const segments = segmenter.segment(child.value);
             const words = Array.from(segments)


### PR DESCRIPTION
## Summary
- Skip word-splitting animation for CJK text in the markdown rehype plugin.
- Preserve the existing animated word reveal for other text.

fix https://github.com/bytedance/deer-flow/issues/1746

fix https://github.com/bytedance/deer-flow/issues/1188

## Why
CJK responses could render one character per line when the loading animation segmented the text too aggressively.

## Validation
- `pnpm lint`
- `pnpm typecheck`

<img width="2520" height="1596" alt="image" src="https://github.com/user-attachments/assets/a381e313-8c52-44c2-9a52-e089117c27cf" />

