### PR TITLE
fix(models): auto-upgrade ChatOpenAI to PatchedChatOpenAI for thinking models

### DIFF
--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -1,6 +1,7 @@
 import logging
 
 from langchain.chat_models import BaseChatModel
+from langchain_openai import ChatOpenAI
 
 from deerflow.config import get_app_config, get_tracing_config, is_tracing_enabled
 from deerflow.reflection import resolve_class
@@ -24,6 +25,25 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
     if model_config is None:
         raise ValueError(f"Model {name} not found in config") from None
     model_class = resolve_class(model_config.use, BaseChatModel)
+
+    # Auto-upgrade to PatchedChatOpenAI when the model supports thinking
+    # (e.g. Gemini via OpenAI-compatible gateway) but the user configured the
+    # stock ChatOpenAI.  The patched version preserves ``thought_signature``
+    # on tool-call objects that Gemini requires in multi-turn conversations.
+    # Without this, the API returns HTTP 400: "function call is missing a
+    # thought_signature".
+    if (
+        model_config.supports_thinking
+        and model_class is ChatOpenAI
+    ):
+        from deerflow.models.patched_openai import PatchedChatOpenAI
+
+        logger.info(
+            "Auto-upgrading model '%s' from ChatOpenAI to PatchedChatOpenAI "
+            "because supports_thinking=true",
+            name,
+        )
+        model_class = PatchedChatOpenAI
     model_settings_from_config = model_config.model_dump(
         exclude_none=True,
         exclude={

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -622,3 +622,49 @@ def test_openai_responses_api_settings_are_passed_to_chatopenai(monkeypatch):
 
     assert captured.get("use_responses_api") is True
     assert captured.get("output_version") == "responses/v1"
+
+
+def test_thinking_model_auto_upgraded_to_patched_openai(monkeypatch):
+    """When supports_thinking=True and use=ChatOpenAI, factory should auto-upgrade to PatchedChatOpenAI."""
+    from deerflow.models.patched_openai import PatchedChatOpenAI
+
+    model = _make_model(
+        name="gemini-thinking",
+        use="langchain_openai:ChatOpenAI",
+        supports_thinking=True,
+        when_thinking_enabled={"extra_body": {"thinking": {"type": "enabled"}}},
+    )
+    cfg = _make_app_config([model])
+    _patch_factory(monkeypatch, cfg)
+
+    resolved_classes = []
+
+    original_resolve = factory_module.resolve_class
+
+    def tracking_resolve(path, base):
+        cls = original_resolve(path, base)
+        resolved_classes.append(cls)
+        return cls
+
+    monkeypatch.setattr(factory_module, "resolve_class", tracking_resolve)
+
+    instance = factory_module.create_chat_model(name="gemini-thinking", thinking_enabled=True)
+    assert isinstance(instance, PatchedChatOpenAI)
+
+
+def test_non_thinking_model_not_upgraded(monkeypatch):
+    """When supports_thinking=False, factory should NOT upgrade to PatchedChatOpenAI."""
+    model = _make_model(
+        name="gpt-4",
+        use="langchain_openai:ChatOpenAI",
+        supports_thinking=False,
+    )
+    cfg = _make_app_config([model])
+    _patch_factory(monkeypatch, cfg)
+
+    instance = factory_module.create_chat_model(name="gpt-4")
+    assert not isinstance(instance, type("PatchedChatOpenAI", (), {}))
+    # Should be the plain ChatOpenAI from langchain_openai
+    from langchain_openai import ChatOpenAI
+
+    assert isinstance(instance, ChatOpenAI)


### PR DESCRIPTION
Fixes #1180

## Problem

When using Gemini with thinking enabled via an OpenAI-compatible gateway (e.g. Vertex AI), the API requires `thought_signature` on tool-call objects in multi-turn conversations.

The project already has `PatchedChatOpenAI` that handles this, but users must manually configure `use: deerflow.models.patched_openai:PatchedChatOpenAI` in their `config.yaml`. If they use the default `langchain_openai:ChatOpenAI`, they get:

```
HTTP 400: Unable to submit request because function call is missing a thought_signature
```

## Fix

In `create_chat_model()`, when `supports_thinking=true` and the resolved class is the stock `ChatOpenAI`, automatically upgrade to `PatchedChatOpenAI`.

This makes thinking models work out-of-the-box without requiring users to know about the patched class.

## Testing

Added two tests:
- `test_thinking_model_auto_upgraded_to_patched_openai`: verifies upgrade happens
- `test_non_thinking_model_not_upgraded`: verifies non-thinking models are unaffected