### PR TITLE
[codex] 支持自定义智能体中文展示名

### DIFF
--- a/backend/src/agents/lead_agent/agent.py
+++ b/backend/src/agents/lead_agent/agent.py
@@ -269,6 +269,11 @@ def make_lead_agent(config: RunnableConfig):
     agent_name = cfg.get("agent_name")
 
     agent_config = load_agent_config(agent_name) if not is_bootstrap else None
+    agent_display_name = (
+        cfg.get("agent_display_name")
+        or (agent_config.display_name if agent_config else None)
+        or agent_name
+    )
     # Custom agent model or fallback to global/default model resolution
     agent_model_name = agent_config.model if agent_config and agent_config.model else _resolve_model_name()
 
@@ -327,6 +332,11 @@ def make_lead_agent(config: RunnableConfig):
         model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort),
         tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled),
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
-        system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, agent_name=agent_name),
+        system_prompt=apply_prompt_template(
+            subagent_enabled=subagent_enabled,
+            max_concurrent_subagents=max_concurrent_subagents,
+            agent_name=agent_name,
+            agent_display_name=agent_display_name,
+        ),
         state_schema=ThreadState,
     )

--- a/backend/src/agents/lead_agent/prompt.py
+++ b/backend/src/agents/lead_agent/prompt.py
@@ -366,7 +366,14 @@ def get_agent_soul(agent_name: str | None) -> str:
     return ""
 
 
-def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagents: int = 3, *, agent_name: str | None = None, available_skills: set[str] | None = None) -> str:
+def apply_prompt_template(
+    subagent_enabled: bool = False,
+    max_concurrent_subagents: int = 3,
+    *,
+    agent_name: str | None = None,
+    agent_display_name: str | None = None,
+    available_skills: set[str] | None = None,
+) -> str:
     # Get memory context
     memory_context = _get_memory_context(agent_name)
 
@@ -397,7 +404,7 @@ def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagen
 
     # Format the prompt with dynamic skills and memory
     prompt = SYSTEM_PROMPT_TEMPLATE.format(
-        agent_name=agent_name or "DeerFlow 2.0",
+        agent_name=agent_display_name or agent_name or "DeerFlow 2.0",
         soul=get_agent_soul(agent_name),
         skills_section=skills_section,
         memory_context=memory_context,

--- a/backend/src/config/__init__.py
+++ b/backend/src/config/__init__.py
@@ -1,3 +1,12 @@
+from .agent_identity import (
+    build_agent_slug,
+    build_unique_agent_slug,
+    display_name_key,
+    normalize_agent_display_name,
+    normalize_agent_slug,
+    validate_agent_display_name,
+    validate_agent_slug,
+)
 from .app_config import get_app_config
 from .extensions_config import ExtensionsConfig, get_extensions_config
 from .memory_config import MemoryConfig, get_memory_config
@@ -7,8 +16,13 @@ from .tracing_config import get_tracing_config, is_tracing_enabled
 
 __all__ = [
     "get_app_config",
+    "build_agent_slug",
+    "build_unique_agent_slug",
+    "display_name_key",
     "Paths",
     "get_paths",
+    "normalize_agent_display_name",
+    "normalize_agent_slug",
     "SkillsConfig",
     "ExtensionsConfig",
     "get_extensions_config",
@@ -16,4 +30,6 @@ __all__ = [
     "get_memory_config",
     "get_tracing_config",
     "is_tracing_enabled",
+    "validate_agent_display_name",
+    "validate_agent_slug",
 ]

--- a/backend/src/config/agent_identity.py
+++ b/backend/src/config/agent_identity.py
@@ -1,0 +1,90 @@
+"""Shared agent identity rules for internal slugs and user-visible names."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+
+DISPLAY_NAME_MAX_LENGTH = 80
+AGENT_SLUG_PATTERN = re.compile(r"^[a-z0-9-]+$")
+_ASCII_SLUG_CHUNK_RE = re.compile(r"[^a-z0-9]+")
+
+
+def normalize_agent_display_name(value: str) -> str:
+    """Normalize a user-visible agent name for validation and comparisons."""
+    return unicodedata.normalize("NFKC", value).strip()
+
+
+def display_name_key(value: str) -> str:
+    """Return a normalized key for display-name uniqueness checks."""
+    return normalize_agent_display_name(value).casefold()
+
+
+def validate_agent_display_name(value: str) -> str:
+    """Validate and return a normalized user-visible agent name."""
+    normalized = normalize_agent_display_name(value)
+    if not normalized:
+        raise ValueError("Agent display name cannot be empty.")
+    if len(normalized) > DISPLAY_NAME_MAX_LENGTH:
+        raise ValueError(f"Agent display name must be at most {DISPLAY_NAME_MAX_LENGTH} characters.")
+    if any(ch in {"/", "\\"} for ch in normalized):
+        raise ValueError("Agent display name cannot contain '/' or '\\'.")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in normalized):
+        raise ValueError("Agent display name cannot contain control characters.")
+    return normalized
+
+
+def normalize_agent_slug(value: str) -> str:
+    """Normalize an internal slug used in routes and filesystem paths."""
+    return value.strip().lower()
+
+
+def validate_agent_slug(value: str) -> str:
+    """Validate and return a normalized internal agent slug."""
+    normalized = normalize_agent_slug(value)
+    if not AGENT_SLUG_PATTERN.fullmatch(normalized):
+        raise ValueError("Agent slug must contain only lowercase letters, digits, and hyphens.")
+    return normalized
+
+
+def is_valid_agent_slug(value: str) -> bool:
+    """Check whether a string is already a valid internal slug."""
+    try:
+        validate_agent_slug(value)
+    except ValueError:
+        return False
+    return True
+
+
+def build_agent_slug(display_name: str) -> str:
+    """Build a deterministic ASCII slug from a display name."""
+    normalized_display_name = validate_agent_display_name(display_name)
+    ascii_slug = _ASCII_SLUG_CHUNK_RE.sub("-", normalized_display_name.lower()).strip("-")
+    if ascii_slug:
+        return ascii_slug
+    digest = hashlib.sha1(normalized_display_name.encode("utf-8")).hexdigest()[:10]
+    return f"agent-{digest}"
+
+
+def build_unique_agent_slug(
+    display_name: str,
+    existing_slugs: set[str],
+    explicit_slug: str | None = None,
+) -> str:
+    """Build a stable slug that does not collide with existing slugs."""
+    base_slug = validate_agent_slug(explicit_slug) if explicit_slug is not None else build_agent_slug(display_name)
+    if base_slug not in existing_slugs:
+        return base_slug
+
+    suffix = hashlib.sha1(validate_agent_display_name(display_name).encode("utf-8")).hexdigest()[:6]
+    candidate = f"{base_slug}-{suffix}"
+    if candidate not in existing_slugs:
+        return candidate
+
+    counter = 2
+    while True:
+        numbered = f"{candidate}-{counter}"
+        if numbered not in existing_slugs:
+            return numbered
+        counter += 1

--- a/backend/src/config/agents_config.py
+++ b/backend/src/config/agents_config.py
@@ -1,27 +1,33 @@
 """Configuration and loaders for custom agents."""
 
 import logging
-import re
 from typing import Any
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
+from src.config.agent_identity import validate_agent_slug
 from src.config.paths import get_paths
 
 logger = logging.getLogger(__name__)
 
 SOUL_FILENAME = "SOUL.md"
-AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
 
 
 class AgentConfig(BaseModel):
     """Configuration for a custom agent."""
 
     name: str
+    display_name: str | None = None
     description: str = ""
     model: str | None = None
     tool_groups: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _fill_display_name(self) -> "AgentConfig":
+        if self.display_name is None:
+            self.display_name = self.name
+        return self
 
 
 def load_agent_config(name: str | None) -> AgentConfig | None:
@@ -41,8 +47,7 @@ def load_agent_config(name: str | None) -> AgentConfig | None:
     if name is None:
         return None
 
-    if not AGENT_NAME_PATTERN.match(name):
-        raise ValueError(f"Invalid agent name '{name}'. Must match pattern: {AGENT_NAME_PATTERN.pattern}")
+    name = validate_agent_slug(name)
     agent_dir = get_paths().agent_dir(name)
     config_file = agent_dir / "config.yaml"
 

--- a/backend/src/gateway/routers/agents.py
+++ b/backend/src/gateway/routers/agents.py
@@ -1,26 +1,31 @@
 """CRUD API for custom agents."""
 
 import logging
-import re
 import shutil
 
 import yaml
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from src.config.agent_identity import (
+    build_unique_agent_slug,
+    display_name_key,
+    is_valid_agent_slug,
+    validate_agent_display_name,
+    validate_agent_slug,
+)
 from src.config.agents_config import AgentConfig, list_custom_agents, load_agent_config, load_agent_soul
 from src.config.paths import get_paths
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["agents"])
 
-AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
-
 
 class AgentResponse(BaseModel):
     """Response model for a custom agent."""
 
-    name: str = Field(..., description="Agent name (hyphen-case)")
+    name: str = Field(..., description="Stable agent slug used in routes and storage")
+    display_name: str = Field(..., description="Human-readable agent name shown in the UI")
     description: str = Field(default="", description="Agent description")
     model: str | None = Field(default=None, description="Optional model override")
     tool_groups: list[str] | None = Field(default=None, description="Optional tool group whitelist")
@@ -36,7 +41,8 @@ class AgentsListResponse(BaseModel):
 class AgentCreateRequest(BaseModel):
     """Request body for creating a custom agent."""
 
-    name: str = Field(..., description="Agent name (must match ^[A-Za-z0-9-]+$, stored as lowercase)")
+    name: str = Field(..., description="Legacy display name or explicit slug when used with display_name")
+    display_name: str | None = Field(default=None, description="Human-readable agent name shown in the UI")
     description: str = Field(default="", description="Agent description")
     model: str | None = Field(default=None, description="Optional model override")
     tool_groups: list[str] | None = Field(default=None, description="Optional tool group whitelist")
@@ -46,31 +52,56 @@ class AgentCreateRequest(BaseModel):
 class AgentUpdateRequest(BaseModel):
     """Request body for updating a custom agent."""
 
+    display_name: str | None = Field(default=None, description="Updated human-readable name")
     description: str | None = Field(default=None, description="Updated description")
     model: str | None = Field(default=None, description="Updated model override")
     tool_groups: list[str] | None = Field(default=None, description="Updated tool group whitelist")
     soul: str | None = Field(default=None, description="Updated SOUL.md content")
 
 
-def _validate_agent_name(name: str) -> None:
-    """Validate agent name against allowed pattern.
+def _validate_agent_name(name: str) -> str:
+    """Validate the internal agent slug used in paths and storage.
 
     Args:
-        name: The agent name to validate.
+        name: The agent slug to validate.
 
     Raises:
         HTTPException: 422 if the name is invalid.
     """
-    if not AGENT_NAME_PATTERN.match(name):
-        raise HTTPException(
-            status_code=422,
-            detail=f"Invalid agent name '{name}'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).",
-        )
+    try:
+        return validate_agent_slug(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
-def _normalize_agent_name(name: str) -> str:
-    """Normalize agent name to lowercase for filesystem storage."""
-    return name.lower()
+def _validate_display_name(name: str) -> str:
+    """Validate the human-readable name shown to users."""
+    try:
+        return validate_agent_display_name(name)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def _list_existing_slugs() -> set[str]:
+    return {agent.name for agent in list_custom_agents()}
+
+
+def _display_name_exists(display_name: str, *, exclude_slug: str | None = None) -> bool:
+    target = display_name_key(display_name)
+    for agent in list_custom_agents():
+        if exclude_slug is not None and agent.name == exclude_slug:
+            continue
+        if display_name_key(agent.display_name or agent.name) == target:
+            return True
+    return False
+
+
+def _resolve_create_identity(request: AgentCreateRequest) -> tuple[str, str]:
+    raw_display_name = request.display_name if request.display_name is not None else request.name
+    display_name = _validate_display_name(raw_display_name)
+    explicit_slug = request.name if request.display_name is not None or is_valid_agent_slug(request.name) else None
+    slug = build_unique_agent_slug(display_name, _list_existing_slugs(), explicit_slug=explicit_slug)
+    return slug, display_name
 
 
 def _agent_config_to_response(agent_cfg: AgentConfig, include_soul: bool = False) -> AgentResponse:
@@ -81,6 +112,7 @@ def _agent_config_to_response(agent_cfg: AgentConfig, include_soul: bool = False
 
     return AgentResponse(
         name=agent_cfg.name,
+        display_name=agent_cfg.display_name or agent_cfg.name,
         description=agent_cfg.description,
         model=agent_cfg.model,
         tool_groups=agent_cfg.tool_groups,
@@ -125,10 +157,10 @@ async def check_agent_name(name: str) -> dict:
     Raises:
         HTTPException: 422 if the name is invalid.
     """
-    _validate_agent_name(name)
-    normalized = _normalize_agent_name(name)
-    available = not get_paths().agent_dir(normalized).exists()
-    return {"available": available, "name": normalized}
+    display_name = _validate_display_name(name)
+    available = not _display_name_exists(display_name)
+    generated_slug = build_unique_agent_slug(display_name, _list_existing_slugs())
+    return {"available": available, "name": generated_slug, "display_name": display_name}
 
 
 @router.get(
@@ -149,8 +181,7 @@ async def get_agent(name: str) -> AgentResponse:
     Raises:
         HTTPException: 404 if agent not found.
     """
-    _validate_agent_name(name)
-    name = _normalize_agent_name(name)
+    name = _validate_agent_name(name)
 
     try:
         agent_cfg = load_agent_config(name)
@@ -181,8 +212,9 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
     Raises:
         HTTPException: 409 if agent already exists, 422 if name is invalid.
     """
-    _validate_agent_name(request.name)
-    normalized_name = _normalize_agent_name(request.name)
+    normalized_name, display_name = _resolve_create_identity(request)
+    if _display_name_exists(display_name):
+        raise HTTPException(status_code=409, detail=f"Agent display name '{display_name}' already exists")
 
     agent_dir = get_paths().agent_dir(normalized_name)
 
@@ -193,7 +225,7 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
         agent_dir.mkdir(parents=True, exist_ok=True)
 
         # Write config.yaml
-        config_data: dict = {"name": normalized_name}
+        config_data: dict = {"name": normalized_name, "display_name": display_name}
         if request.description:
             config_data["description"] = request.description
         if request.model is not None:
@@ -243,8 +275,7 @@ async def update_agent(name: str, request: AgentUpdateRequest) -> AgentResponse:
     Raises:
         HTTPException: 404 if agent not found.
     """
-    _validate_agent_name(name)
-    name = _normalize_agent_name(name)
+    name = _validate_agent_name(name)
 
     try:
         agent_cfg = load_agent_config(name)
@@ -255,11 +286,20 @@ async def update_agent(name: str, request: AgentUpdateRequest) -> AgentResponse:
 
     try:
         # Update config if any config fields changed
-        config_changed = any(v is not None for v in [request.description, request.model, request.tool_groups])
+        config_changed = any(v is not None for v in [request.display_name, request.description, request.model, request.tool_groups])
 
         if config_changed:
+            next_display_name = (
+                _validate_display_name(request.display_name)
+                if request.display_name is not None
+                else (agent_cfg.display_name or agent_cfg.name)
+            )
+            if _display_name_exists(next_display_name, exclude_slug=name):
+                raise HTTPException(status_code=409, detail=f"Agent display name '{next_display_name}' already exists")
+
             updated: dict = {
                 "name": agent_cfg.name,
+                "display_name": next_display_name,
                 "description": request.description if request.description is not None else agent_cfg.description,
             }
             new_model = request.model if request.model is not None else agent_cfg.model
@@ -367,8 +407,7 @@ async def delete_agent(name: str) -> None:
     Raises:
         HTTPException: 404 if agent not found.
     """
-    _validate_agent_name(name)
-    name = _normalize_agent_name(name)
+    name = _validate_agent_name(name)
 
     agent_dir = get_paths().agent_dir(name)
 

--- a/backend/src/tools/builtins/setup_agent_tool.py
+++ b/backend/src/tools/builtins/setup_agent_tool.py
@@ -6,6 +6,7 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import ToolRuntime
 from langgraph.types import Command
 
+from src.config.agent_identity import validate_agent_display_name, validate_agent_slug
 from src.config.paths import get_paths
 
 logger = logging.getLogger(__name__)
@@ -25,15 +26,19 @@ def setup_agent(
     """
 
     agent_name: str | None = runtime.context.get("agent_name")
+    agent_display_name: str | None = runtime.context.get("agent_display_name")
 
     try:
         paths = get_paths()
+        if agent_name is not None:
+            agent_name = validate_agent_slug(agent_name)
         agent_dir = paths.agent_dir(agent_name) if agent_name else paths.base_dir
         agent_dir.mkdir(parents=True, exist_ok=True)
 
         if agent_name:
             # If agent_name is provided, we are creating a custom agent in the agents/ directory
-            config_data: dict = {"name": agent_name}
+            display_name = validate_agent_display_name(agent_display_name or agent_name)
+            config_data: dict = {"name": agent_name, "display_name": display_name}
             if description:
                 config_data["description"] = description
 

--- a/backend/tests/test_agent_identity.py
+++ b/backend/tests/test_agent_identity.py
@@ -1,0 +1,56 @@
+from src.config.agent_identity import (
+    build_agent_slug,
+    build_unique_agent_slug,
+    normalize_agent_display_name,
+    normalize_agent_slug,
+    validate_agent_display_name,
+    validate_agent_slug,
+)
+
+
+def test_validate_agent_display_name_accepts_chinese():
+    assert validate_agent_display_name("研究助手") == "研究助手"
+
+
+def test_validate_agent_display_name_rejects_path_separators():
+    try:
+        validate_agent_display_name("研究/助手")
+    except ValueError as exc:
+        assert "cannot contain" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_build_agent_slug_uses_ascii_slug_when_possible():
+    assert build_agent_slug("Code Reviewer") == "code-reviewer"
+
+
+def test_build_agent_slug_falls_back_to_stable_hash_for_non_ascii():
+    assert build_agent_slug("研究助手") == "agent-347704096c"
+
+
+def test_build_unique_agent_slug_adds_deterministic_suffix_on_collision():
+    assert (
+        build_unique_agent_slug(
+            "Code Reviewer",
+            {"code-reviewer"},
+        )
+        == "code-reviewer-c10b8b"
+    )
+
+
+def test_normalize_agent_display_name_trims_whitespace():
+    assert normalize_agent_display_name("  研究助手  ") == "研究助手"
+
+
+def test_normalize_agent_slug_lowercases_ascii_slug():
+    assert normalize_agent_slug("Code-Reviewer") == "code-reviewer"
+
+
+def test_validate_agent_slug_rejects_non_ascii_slug():
+    try:
+        validate_agent_slug("研究助手")
+    except ValueError as exc:
+        assert "lowercase letters" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -76,6 +76,7 @@ class TestAgentConfig:
 
         cfg = AgentConfig(name="my-agent")
         assert cfg.name == "my-agent"
+        assert cfg.display_name == "my-agent"
         assert cfg.description == ""
         assert cfg.model is None
         assert cfg.tool_groups is None
@@ -85,11 +86,13 @@ class TestAgentConfig:
 
         cfg = AgentConfig(
             name="code-reviewer",
+            display_name="Code Reviewer",
             description="Specialized for code review",
             model="deepseek-v3",
             tool_groups=["file:read", "bash"],
         )
         assert cfg.name == "code-reviewer"
+        assert cfg.display_name == "Code Reviewer"
         assert cfg.model == "deepseek-v3"
         assert cfg.tool_groups == ["file:read", "bash"]
 
@@ -152,6 +155,23 @@ class TestLoadAgentConfig:
             cfg = load_agent_config("inferred-name")
 
         assert cfg.name == "inferred-name"
+        assert cfg.display_name == "inferred-name"
+
+    def test_load_config_preserves_display_name(self, tmp_path):
+        config_dict = {
+            "name": "research-assistant",
+            "display_name": "研究助手",
+            "description": "帮你做研究",
+        }
+        _write_agent(tmp_path, "research-assistant", config_dict)
+
+        with patch("src.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from src.config.agents_config import load_agent_config
+
+            cfg = load_agent_config("research-assistant")
+
+        assert cfg.name == "research-assistant"
+        assert cfg.display_name == "研究助手"
 
     def test_load_config_with_tool_groups(self, tmp_path):
         config_dict = {"name": "restricted", "tool_groups": ["file:read", "file:write"]}
@@ -388,13 +408,35 @@ class TestAgentsAPI:
         assert response.status_code == 201
         data = response.json()
         assert data["name"] == "code-reviewer"
+        assert data["display_name"] == "code-reviewer"
         assert data["description"] == "Reviews code"
         assert data["soul"] == "You are a code reviewer."
 
-    def test_create_agent_invalid_name(self, agent_client):
-        payload = {"name": "Code Reviewer!", "soul": "test"}
+    def test_create_agent_invalid_display_name(self, agent_client):
+        payload = {"name": "Code/Reviewer", "soul": "test"}
         response = agent_client.post("/api/agents", json=payload)
         assert response.status_code == 422
+
+    def test_create_agent_with_chinese_display_name(self, agent_client):
+        payload = {
+            "name": "研究助手",
+            "description": "帮助用户做研究",
+            "soul": "你是研究助手",
+        }
+        response = agent_client.post("/api/agents", json=payload)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "agent-347704096c"
+        assert data["display_name"] == "研究助手"
+
+    def test_check_agent_name_returns_generated_slug_for_display_name(self, agent_client):
+        response = agent_client.get("/api/agents/check", params={"name": "研究助手"})
+        assert response.status_code == 200
+        assert response.json() == {
+            "available": True,
+            "name": "agent-347704096c",
+            "display_name": "研究助手",
+        }
 
     def test_create_duplicate_agent_409(self, agent_client):
         payload = {"name": "my-agent", "soul": "test"}
@@ -421,6 +463,7 @@ class TestAgentsAPI:
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == "test-agent"
+        assert data["display_name"] == "test-agent"
         assert data["soul"] == "Hello world"
 
     def test_get_missing_agent_404(self, agent_client):
@@ -440,6 +483,14 @@ class TestAgentsAPI:
         response = agent_client.put("/api/agents/desc-agent", json={"description": "new desc"})
         assert response.status_code == 200
         assert response.json()["description"] == "new desc"
+
+    def test_update_agent_display_name(self, agent_client):
+        agent_client.post("/api/agents", json={"name": "desc-agent", "soul": "p"})
+
+        response = agent_client.put("/api/agents/desc-agent", json={"display_name": "研究助手"})
+        assert response.status_code == 200
+        assert response.json()["name"] == "desc-agent"
+        assert response.json()["display_name"] == "研究助手"
 
     def test_update_missing_agent_404(self, agent_client):
         response = agent_client.put("/api/agents/ghost-agent", json={"soul": "new"})
@@ -474,13 +525,17 @@ class TestAgentsAPI:
         assert data["tool_groups"] == ["file:read", "bash"]
 
     def test_create_persists_files_on_disk(self, agent_client, tmp_path):
-        agent_client.post("/api/agents", json={"name": "disk-check", "soul": "disk soul"})
+        agent_client.post("/api/agents", json={"name": "研究助手", "soul": "disk soul"})
 
-        agent_dir = tmp_path / "agents" / "disk-check"
+        agent_dir = tmp_path / "agents" / "agent-347704096c"
         assert agent_dir.exists()
         assert (agent_dir / "config.yaml").exists()
         assert (agent_dir / "SOUL.md").exists()
         assert (agent_dir / "SOUL.md").read_text() == "disk soul"
+        assert yaml.safe_load((agent_dir / "config.yaml").read_text(encoding="utf-8")) == {
+            "name": "agent-347704096c",
+            "display_name": "研究助手",
+        }
 
     def test_delete_removes_files_from_disk(self, agent_client, tmp_path):
         agent_client.post("/api/agents", json={"name": "remove-me", "soul": "bye"})

--- a/backend/tests/test_setup_agent_tool.py
+++ b/backend/tests/test_setup_agent_tool.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import yaml
+
+from src.config.paths import Paths
+from src.tools.builtins.setup_agent_tool import setup_agent
+
+
+def test_setup_agent_persists_display_name_for_custom_agent(tmp_path: Path):
+    runtime = SimpleNamespace(
+        context={
+            "agent_name": "agent-347704096c",
+            "agent_display_name": "研究助手",
+        },
+        tool_call_id="tool-1",
+    )
+
+    with patch("src.tools.builtins.setup_agent_tool.get_paths", return_value=Paths(base_dir=tmp_path)):
+        result = setup_agent.func(
+            soul="你是研究助手",
+            description="帮助用户做研究",
+            runtime=runtime,
+        )
+
+    assert result.update["created_agent_name"] == "agent-347704096c"
+
+    config = yaml.safe_load((tmp_path / "agents" / "agent-347704096c" / "config.yaml").read_text(encoding="utf-8"))
+    assert config == {
+        "name": "agent-347704096c",
+        "display_name": "研究助手",
+        "description": "帮助用户做研究",
+    }

--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -94,7 +94,7 @@ export default function AgentChatPage() {
             <div className="flex shrink-0 items-center gap-1.5 rounded-md border px-2 py-1">
               <BotIcon className="text-primary h-3.5 w-3.5" />
               <span className="text-xs font-medium">
-                {agent?.name ?? agent_name}
+                {agent?.display_name ?? agent?.name ?? agent_name}
               </span>
             </div>
 

--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -24,8 +24,6 @@ import { cn } from "@/lib/utils";
 
 type Step = "name" | "chat";
 
-const NAME_RE = /^[A-Za-z0-9-]+$/;
-
 export default function NewAgentPage() {
   const { t } = useI18n();
   const router = useRouter();
@@ -36,6 +34,7 @@ export default function NewAgentPage() {
   const [nameError, setNameError] = useState("");
   const [isCheckingName, setIsCheckingName] = useState(false);
   const [agentName, setAgentName] = useState("");
+  const [agentDisplayName, setAgentDisplayName] = useState("");
   const [agent, setAgent] = useState<Agent | null>(null);
   // ── Step 2: chat ───────────────────────────────────────────────────────────
 
@@ -47,6 +46,8 @@ export default function NewAgentPage() {
     context: {
       mode: "flash",
       is_bootstrap: true,
+      agent_name: agentName,
+      agent_display_name: agentDisplayName,
     },
     onToolEnd({ name }) {
       if (name !== "setup_agent" || !agentName) return;
@@ -63,10 +64,6 @@ export default function NewAgentPage() {
   const handleConfirmName = useCallback(async () => {
     const trimmed = nameInput.trim();
     if (!trimmed) return;
-    if (!NAME_RE.test(trimmed)) {
-      setNameError(t.agents.nameStepInvalidError);
-      return;
-    }
     setNameError("");
     setIsCheckingName(true);
     try {
@@ -75,24 +72,37 @@ export default function NewAgentPage() {
         setNameError(t.agents.nameStepAlreadyExistsError);
         return;
       }
-    } catch {
-      setNameError(t.agents.nameStepCheckError);
+      setAgentName(result.name);
+      setAgentDisplayName(result.display_name);
+      setStep("chat");
+      await sendMessage(
+        threadId,
+        {
+          text: t.agents.nameStepBootstrapMessage.replace(
+            "{name}",
+            result.display_name,
+          ),
+          files: [],
+        },
+        {
+          agent_name: result.name,
+          agent_display_name: result.display_name,
+        },
+      );
+      return;
+    } catch (error) {
+      setNameError(
+        error instanceof Error ? error.message : t.agents.nameStepCheckError,
+      );
       return;
     } finally {
       setIsCheckingName(false);
     }
-    setAgentName(trimmed);
-    setStep("chat");
-    await sendMessage(threadId, {
-      text: t.agents.nameStepBootstrapMessage.replace("{name}", trimmed),
-      files: [],
-    });
   }, [
     nameInput,
     sendMessage,
     threadId,
     t.agents.nameStepBootstrapMessage,
-    t.agents.nameStepInvalidError,
     t.agents.nameStepAlreadyExistsError,
     t.agents.nameStepCheckError,
   ]);
@@ -211,7 +221,7 @@ export default function NewAgentPage() {
                     <p className="font-semibold">{t.agents.agentCreated}</p>
                     <div className="flex gap-2">
                       <Button
-                        onClick={() =>
+                  onClick={() =>
                           router.push(
                             `/workspace/agents/${agentName}/chats/new`,
                           )

--- a/frontend/src/components/workspace/agent-welcome.tsx
+++ b/frontend/src/components/workspace/agent-welcome.tsx
@@ -14,7 +14,7 @@ export function AgentWelcome({
   agent: Agent | null | undefined;
   agentName: string;
 }) {
-  const displayName = agent?.name ?? agentName;
+  const displayName = agent?.display_name ?? agent?.name ?? agentName;
   const description = agent?.description;
 
   return (

--- a/frontend/src/components/workspace/agents/agent-card.tsx
+++ b/frontend/src/components/workspace/agents/agent-card.tsx
@@ -62,7 +62,7 @@ export function AgentCard({ agent }: AgentCardProps) {
               </div>
               <div className="min-w-0">
                 <CardTitle className="truncate text-base">
-                  {agent.name}
+                  {agent.display_name}
                 </CardTitle>
                 {agent.model && (
                   <Badge variant="secondary" className="mt-0.5 text-xs">

--- a/frontend/src/core/agents/api.ts
+++ b/frontend/src/core/agents/api.ts
@@ -53,7 +53,7 @@ export async function deleteAgent(name: string): Promise<void> {
 
 export async function checkAgentName(
   name: string,
-): Promise<{ available: boolean; name: string }> {
+): Promise<{ available: boolean; name: string; display_name: string }> {
   const res = await fetch(
     `${getBackendBaseURL()}/api/agents/check?name=${encodeURIComponent(name)}`,
   );
@@ -63,5 +63,9 @@ export async function checkAgentName(
       err.detail ?? `Failed to check agent name: ${res.statusText}`,
     );
   }
-  return res.json() as Promise<{ available: boolean; name: string }>;
+  return res.json() as Promise<{
+    available: boolean;
+    name: string;
+    display_name: string;
+  }>;
 }

--- a/frontend/src/core/agents/types.ts
+++ b/frontend/src/core/agents/types.ts
@@ -1,5 +1,6 @@
 export interface Agent {
   name: string;
+  display_name: string;
   description: string;
   model: string | null;
   tool_groups: string[] | null;
@@ -8,6 +9,7 @@ export interface Agent {
 
 export interface CreateAgentRequest {
   name: string;
+  display_name?: string;
   description?: string;
   model?: string | null;
   tool_groups?: string[] | null;
@@ -15,6 +17,7 @@ export interface CreateAgentRequest {
 }
 
 export interface UpdateAgentRequest {
+  display_name?: string | null;
   description?: string | null;
   model?: string | null;
   tool_groups?: string[] | null;

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -182,11 +182,10 @@ export const enUS: Translations = {
       "Describe the agent you want — I'll help you create it through conversation.",
     nameStepTitle: "Name your new Agent",
     nameStepHint:
-      "Letters, digits, and hyphens only — stored lowercase (e.g. code-reviewer)",
-    nameStepPlaceholder: "e.g. code-reviewer",
+      "Use a natural display name in any supported language — the internal ID is generated automatically",
+    nameStepPlaceholder: "e.g. Research Assistant",
     nameStepContinue: "Continue",
-    nameStepInvalidError:
-      "Invalid name — use only letters, digits, and hyphens",
+    nameStepInvalidError: "Invalid name — please choose a different display name",
     nameStepAlreadyExistsError: "An agent with this name already exists",
     nameStepCheckError: "Could not verify name availability — please try again",
     nameStepBootstrapMessage:

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -172,10 +172,10 @@ export const zhCN: Translations = {
     createPageSubtitle: "描述你想要的智能体，我来帮你通过对话创建。",
     nameStepTitle: "给新智能体起个名字",
     nameStepHint:
-      "只允许字母、数字和连字符，存储时自动转为小写（例如 code-reviewer）",
-    nameStepPlaceholder: "例如 code-reviewer",
+      "支持中文、英文和数字等自然名称；系统会自动生成内部标识",
+    nameStepPlaceholder: "例如 研究助手",
     nameStepContinue: "继续",
-    nameStepInvalidError: "名称无效，只允许字母、数字和连字符",
+    nameStepInvalidError: "名称无效，请换一个名称",
     nameStepAlreadyExistsError: "已存在同名智能体",
     nameStepCheckError: "无法验证名称可用性，请稍后重试",
     nameStepBootstrapMessage:

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -331,8 +331,8 @@ export function useThreadStream({
               recursion_limit: 1000,
             },
             context: {
-              ...extraContext,
               ...context,
+              ...extraContext,
               thinking_enabled: context.mode !== "flash",
               is_plan_mode: context.mode === "pro" || context.mode === "ultra",
               subagent_enabled: context.mode === "ultra",


### PR DESCRIPTION
## 背景

当前自定义智能体把 `name` 同时当成展示名称、目录名、路由 key 和运行时查找键。前端新建页、后端 agents API 和运行时配置加载都限制了 `^[A-Za-z0-9-]+$`，所以中文名不是只在某一个入口被拦住，而是在整条链路上都走不通。

这次改动没有直接放开内部 `name` 去承载中文，而是把“给用户看的名称”和“系统内部用的稳定标识”拆开，避免把中文支持变成目录、路由和兼容性上的长期隐患。

## 这次改了什么

- 新增 agent identity 规则层，统一处理展示名校验、内部 slug 生成和冲突规避。
- 自定义智能体从单一 `name` 调整为 `name + display_name`：
  - `name` 继续作为内部 slug，用于目录、路由和运行时查找。
  - `display_name` 用于 UI 展示，支持中文等自然语言名称。
- 更新 agents API 和配置加载逻辑：
  - 创建时允许传入中文展示名，并自动生成稳定 slug。
  - 列表、详情和更新接口返回/维护 `display_name`。
  - 老数据没有 `display_name` 时自动回退为 `name`，保持兼容。
- 更新 bootstrap 创建链路：
  - `setup_agent` 会持久化 `display_name`。
  - 新建页把展示名和内部 slug 一起传入上下文。
- 更新前端展示逻辑：Agents 列表、欢迎区和 agent 聊天页优先显示 `display_name`，路由仍然使用 slug。
- 补充后端测试，覆盖 identity 规则、`setup_agent` 持久化和 custom agent 的创建/更新兼容行为。

## 验证

- `uv run --python 3.12 pytest tests/test_custom_agent.py tests/test_agent_identity.py tests/test_setup_agent_tool.py -q`
- `pnpm typecheck`
- `pnpm lint`
- 本地真实验证：
  - 在 UI 新建页输入中文名称，能够通过校验并进入 bootstrap 对话页。
  - 通过真实 API 创建中文展示名 agent 后，在 Agents 列表页和 `/workspace/agents/agent-1930ef4898/chats/new` 页面确认中文展示正常，同时 URL 仍然保持 slug。
