### PR TITLE
fix: enable DanglingToolCallMiddleware for subagents

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -138,6 +138,6 @@ def build_subagent_runtime_middlewares(*, lazy_init: bool = True) -> list[AgentM
     """Middlewares shared by subagent runtime before subagent-only middlewares."""
     return _build_runtime_middlewares(
         include_uploads=False,
-        include_dangling_tool_call_patch=False,
+        include_dangling_tool_call_patch=True,
         lazy_init=lazy_init,
     )


### PR DESCRIPTION
## Summary

Fixes #1754 - Error code 400 during multi-turn conversations with tool calls.

### Problem

Error message:
```
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'
```

### Root Cause

Subagents were not using the `DanglingToolCallMiddleware`, which handles cases where tool calls are interrupted or fail to receive responses (due to user cancellation, network errors, or subagent timeouts).

When tool calls are interrupted, the message history contains assistant messages with `tool_calls` but missing corresponding `ToolMessage` responses. The OpenAI API rejects such malformed message history.

### Fix

Modified `build_subagent_runtime_middlewares()` in `backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py:141`:

```python
include_dangling_tool_call_patch=True  # Changed from False
```

This ensures that subagents, like the lead agent, will automatically inject synthetic error `ToolMessage`s for any dangling tool calls before sending requests to the LLM API.

### Test Plan

- [x] All existing tests pass (14 tests in `test_dangling_tool_call_middleware.py`)
- [x] The middleware correctly patches dangling tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)