### PR TITLE
docs: sync README table of contents with current sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ DeerFlow has newly integrated the intelligent search and crawling toolset indepe
 
 - [🦌 DeerFlow - 2.0](#-deerflow---20)
   - [Official Website](#official-website)
+  - [Coding Plan from ByteDance Volcengine](#coding-plan-from-bytedance-volcengine)
   - [InfoQuest](#infoquest)
   - [Table of Contents](#table-of-contents)
   - [One-Line Agent Setup](#one-line-agent-setup)
@@ -59,6 +60,8 @@ DeerFlow has newly integrated the intelligent search and crawling toolset indepe
       - [MCP Server](#mcp-server)
       - [IM Channels](#im-channels)
       - [LangSmith Tracing](#langsmith-tracing)
+      - [Langfuse Tracing](#langfuse-tracing)
+      - [Using Both Providers](#using-both-providers)
   - [From Deep Research to Super Agent Harness](#from-deep-research-to-super-agent-harness)
   - [Core Features](#core-features)
     - [Skills \& Tools](#skills--tools)


### PR DESCRIPTION
## Summary
- add the missing "Coding Plan from ByteDance Volcengine" entry to the README table of contents
- add the missing advanced-section links for Langfuse tracing and the combined tracing setup
- keep the change scoped to TOC sync only so README navigation matches the current document structure

## Validation
- manually verified each added anchor targets an existing README heading