### PR TITLE
feat(client): add `available_skills` parameter to DeerFlowClient

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -211,6 +211,8 @@ class DeerFlowClient:
             cfg.get("thinking_enabled"),
             cfg.get("is_plan_mode"),
             cfg.get("subagent_enabled"),
+            self._agent_name,
+            frozenset(self._available_skills) if self._available_skills is not None else None,
         )
 
         if self._agent is not None and self._agent_config_key == key:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -475,7 +475,7 @@ class TestEnsureAgent:
         """_ensure_agent does not recreate if config key unchanged."""
         mock_agent = MagicMock()
         client._agent = mock_agent
-        client._agent_config_key = (None, True, False, False)
+        client._agent_config_key = (None, True, False, False, None, None)
 
         config = client._get_runnable_config("t1")
         client._ensure_agent(config)


### PR DESCRIPTION
**Description**

This PR introduces the `available_skills` parameter to the `DeerFlowClient` initialization, allowing developers to dynamically specify and filter the list of available skills at runtime instead of loading all scanned skills by default.

**Why is this change necessary?**

The primary goal of this change is to give developers using `DeerFlowClient` fine-grained control over which skills are injected into a specific agent's system prompt during runtime execution. 

Prior to this, although specific skills could be disabled via the extension configuration file , **developers lacked the ability to dynamically alter the list of available skills at runtime**. 

By introducing this configuration, developers can now explicitly define a set of `available_skills` when instantiating the client, adapting to different scenarios on the fly.

**Importantly, this change is fully backwards compatible and has no impact on existing code.** If the `available_skills` parameter is omitted or explicitly set to `None`, the system falls back to the default behavior of making all scanned skills available.

**How does this PR solve the problem?**

- **Client Initialization Update**: Added a new `available_skills: set[str] | None = None` parameter to the `DeerFlowClient` constructor in `client.py`.
- **Clear Parameter Documentation**: Added explicit docstrings explaining the entry parameter: *"If None (default), all scanned skills are available."*
- **Prompt Injection Routing**: Updated `_ensure_agent` to properly pass the `_available_skills` state down to `apply_prompt_template`, ensuring only the requested skills are rendered in the final system prompt.

**Impact & Testing**

- Empowers developers to build focused agents via the SDK with a strictly defined set of skills dynamically at runtime, reducing prompt size and improving reliability.
- **Zero impact on existing clients**: Existing initializations without the `available_skills` field will parse as `None` and continue to load all skills seamlessly.
- Comprehensive unit tests (`test_client.py`) have been added and updated to verify:
  - Default initialization (`None`) correctly falls back to the default behavior.
  - Explicit sets of skills (e.g., `{"skill1", "skill2"}`) are correctly initialized and passed to the prompt template.
  - Agent reconstruction logic appropriately handles the new skill configuration.

**Checklist:**

- [x] Added `available_skills` parameter to `DeerFlowClient` initialization
- [x] Added clear docstrings explaining the `None` fallback behavior
- [x] Updated agent creation flow to pass `available_skills` to prompt template
- [x] Added comprehensive unit tests in `tests/test_client.py`
- [x] Verified backward compatibility with existing client implementations
- [x] Ran `make format` and `make lint` successfully