### PR TITLE
fix(gateway): preserve context-only run config

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -166,6 +166,43 @@ def build_run_config(
     return config
 
 
+_CONTEXT_CONFIGURABLE_KEYS = {
+    "model_name",
+    "mode",
+    "thinking_enabled",
+    "reasoning_effort",
+    "is_plan_mode",
+    "subagent_enabled",
+    "max_concurrent_subagents",
+}
+
+
+def merge_context_overrides(config: dict[str, Any], context: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge DeerFlow-specific context overrides without mixing LangGraph modes.
+
+    LangGraph >= 0.6.0 rejects requests that include both ``context`` and
+    ``configurable``. When the incoming request already uses ``context``, keep
+    these overrides in ``config["context"]``. Otherwise, map the allowlisted
+    agent settings into ``configurable`` for the legacy path.
+    """
+    if not context:
+        return config
+
+    if "context" in config and "configurable" not in config:
+        merged_context = {**config["context"]}
+        for key in _CONTEXT_CONFIGURABLE_KEYS:
+            if key in context:
+                merged_context.setdefault(key, context[key])
+        config["context"] = merged_context
+        return config
+
+    configurable = config.setdefault("configurable", {})
+    for key in _CONTEXT_CONFIGURABLE_KEYS:
+        if key in context:
+            configurable.setdefault(key, context[key])
+    return config
+
+
 # ---------------------------------------------------------------------------
 # Run lifecycle
 # ---------------------------------------------------------------------------
@@ -290,19 +327,7 @@ async def start_run(
     # Only agent-relevant keys are forwarded; unknown keys (e.g. thread_id) are ignored.
     context = getattr(body, "context", None)
     if context:
-        _CONTEXT_CONFIGURABLE_KEYS = {
-            "model_name",
-            "mode",
-            "thinking_enabled",
-            "reasoning_effort",
-            "is_plan_mode",
-            "subagent_enabled",
-            "max_concurrent_subagents",
-        }
-        configurable = config.setdefault("configurable", {})
-        for key in _CONTEXT_CONFIGURABLE_KEYS:
-            if key in context:
-                configurable.setdefault(key, context[key])
+        config = merge_context_overrides(config, context)
 
     stream_modes = normalize_stream_modes(body.stream_mode)
 

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -278,6 +278,32 @@ def test_context_does_not_override_existing_configurable():
     assert config["configurable"]["subagent_enabled"] is True
 
 
+def test_merge_context_overrides_keeps_context_mode():
+    """When request config already uses context, do not reintroduce configurable."""
+    from app.gateway.services import merge_context_overrides
+
+    config = {
+        "recursion_limit": 100,
+        "context": {"thread_id": "thread-1", "user_id": "u-42"},
+        "tags": ["prod"],
+    }
+
+    merged = merge_context_overrides(
+        config,
+        {
+            "model_name": "deepseek-v3",
+            "thinking_enabled": True,
+            "thread_id": "should-be-ignored",
+        },
+    )
+
+    assert "configurable" not in merged
+    assert merged["context"]["thread_id"] == "thread-1"
+    assert merged["context"]["user_id"] == "u-42"
+    assert merged["context"]["model_name"] == "deepseek-v3"
+    assert merged["context"]["thinking_enabled"] is True
+
+
 # ---------------------------------------------------------------------------
 # build_run_config — context / configurable precedence (LangGraph >= 0.6.0)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- keep DeerFlow context overrides inside `config["context"]` when the incoming request already uses LangGraph's context mode
- avoid reintroducing `configurable` in that path, which can violate LangGraph's context/configurable exclusivity
- add a regression test covering the context-only merge path

## Testing
- `git diff --check`
- `uv run pytest -q tests/test_gateway_services.py` *(dependency bootstrap started, but failed on a `python-telegram-bot` wheel download timeout in this environment)*