### PR TITLE
fix(stream-bridge): guarantee END sentinel delivery to prevent resource leaks

### DIFF
--- a/backend/packages/harness/deerflow/runtime/stream_bridge/memory.py
+++ b/backend/packages/harness/deerflow/runtime/stream_bridge/memory.py
@@ -46,16 +46,28 @@ class MemoryStreamBridge(StreamBridge):
         queue = self._get_or_create_queue(run_id)
         entry = StreamEvent(id=self._next_id(run_id), event=event, data=data)
         try:
-            await asyncio.wait_for(queue.put(entry), timeout=_PUBLISH_TIMEOUT)
-        except TimeoutError:
+            queue.put_nowait(entry)
+        except asyncio.QueueFull:
             logger.warning("Stream bridge queue full for run %s — dropping event %s", run_id, event)
 
     async def publish_end(self, run_id: str) -> None:
+        # END sentinel must never be dropped — it is the only way subscribe()
+        # exits. Block (with periodic logging) until queue has space. Prevents
+        # resource leaks from hanging SSE connections and orphaned queues.
         queue = self._get_or_create_queue(run_id)
-        try:
-            await asyncio.wait_for(queue.put(END_SENTINEL), timeout=_PUBLISH_TIMEOUT)
-        except TimeoutError:
-            logger.warning("Stream bridge queue full for run %s — dropping END sentinel", run_id)
+        attempt = 0
+        while True:
+            try:
+                queue.put_nowait(END_SENTINEL)
+                return
+            except asyncio.QueueFull:
+                attempt += 1
+                if attempt % 10 == 1:
+                    logger.warning(
+                        "Stream bridge queue full for run %s — waiting to deliver END sentinel (attempt %d)",
+                        run_id, attempt,
+                    )
+                await asyncio.sleep(1.0)
 
     async def subscribe(
         self,


### PR DESCRIPTION
Fixes #1689

## Problem

When the stream bridge queue is full (256 events),  discards the END sentinel after a 30s timeout. Since  only exits upon receiving , losing it causes:

- SSE connections to hang indefinitely
-  and  never cleaned up
- Accumulating resource leak under sustained load (long agent runs with slow consumers)

## Root Cause

 used the same  strategy as . But END sentinel is not a normal event — it is the only way subscribe() knows to exit.

## Fix

- : use  instead of  — drops events immediately when queue is full, no 30s stall per dropped event
- : retry loop that blocks until queue has space, with periodic warning logs every 10 seconds. END sentinel is **never** dropped.

## Testing
- Syntax validated via ast.parse
- Single file change, no new dependencies