### PR TITLE
fix(frontend): handle NaN in parseUploadedFiles size parsing

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -373,9 +373,10 @@ export function parseUploadedFiles(content: string): FileInMessage[] {
   let fileMatch;
 
   while ((fileMatch = fileRegex.exec(uploadedFilesContent ?? "")) !== null) {
+    const size = parseInt(fileMatch[2].trim(), 10);
     files.push({
       filename: fileMatch[1].trim(),
-      size: parseInt(fileMatch[2].trim(), 10) ?? 0,
+      size: isNaN(size) ? 0 : size,
       path: fileMatch[3].trim(),
     });
   }


### PR DESCRIPTION
Fixes #1794

## Problem

The `parseUploadedFiles` function in `frontend/src/core/messages/utils.ts`
uses `parseInt(fileMatch[2].trim(), 10) ?? 0` to parse file sizes. However,
the nullish coalescing operator (`??`) only handles `null` and `undefined`,
not `NaN`. When the size string cannot be parsed as a valid integer,
`parseInt` returns `NaN`, which is not caught by `??`, causing the file
size to be `NaN` instead of `0`.

## Root Cause

- `parseInt('invalid', 10)` returns `NaN` (not `null` or `undefined`)
- The `??` operator only checks for `null`/`undefined`, not `NaN`
- Invalid size strings result in `NaN` being stored as the file size

## Fix

Split the parsing into a separate step and use `isNaN()` to explicitly
check for `NaN` values:

```typescript
const size = parseInt(fileMatch[2].trim(), 10);
files.push({
  filename: fileMatch[1].trim(),
  size: isNaN(size) ? 0 : size,
  path: fileMatch[3].trim(),
});
```

This ensures that any non-numeric size values default to `0` instead of
`NaN`.

## Test Case

Before this fix, calling `parseUploadedFiles` with content like:
```
<uploaded_files>- file.txt (invalid_size)
  Path: /path/to/file</uploaded_files>
```

Would result in `{ filename: "file.txt", size: NaN, path: "/path/to/file" }`.

After this fix, the result is:
`{ filename: "file.txt", size: 0, path: "/path/to/file" }`.