### PR TITLE
fix: replace the offline link in the lead_agent prompt

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -269,7 +269,7 @@ You: "Deploying to staging..." [proceed]
 **Example - Inline Citations:**
 ```markdown
 The key AI trends for 2026 include enhanced reasoning capabilities and multimodal integration
-[citation:AI Trends 2026](https://techcrunch.com/ai-trends).
+[citation:AI Trends 2026](https://techcrunch.com/category/artificial-intelligence/).
 Recent breakthroughs in language models have also accelerated progress
 [citation:OpenAI Research](https://openai.com/research).
 ```
@@ -281,7 +281,7 @@ Recent breakthroughs in language models have also accelerated progress
 DeerFlow is an open-source AI agent framework that gained significant traction in early 2026
 [citation:GitHub Repository](https://github.com/bytedance/deer-flow). The project focuses on
 providing a production-ready agent system with sandbox execution and memory management
-[citation:DeerFlow Documentation](https://deer-flow.dev/docs).
+[citation:DeerFlow Documentation](https://github.com/bytedance/deer-flow?tab=readme-ov-file#table-of-contents).
 
 ## Key Analysis
 
@@ -294,10 +294,10 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 
 ### Primary Sources
 - [GitHub Repository](https://github.com/bytedance/deer-flow) - Official source code and documentation
-- [DeerFlow Documentation](https://deer-flow.dev/docs) - Technical specifications
+- [DeerFlow Documentation](https://github.com/bytedance/deer-flow?tab=readme-ov-file#table-of-contents) - Technical specifications
 
 ### Media Coverage
-- [AI Trends 2026](https://techcrunch.com/ai-trends) - Industry analysis
+- [AI Trends 2026](https://techcrunch.com/category/artificial-intelligence/) - Industry analysis
 ```
 
 **CRITICAL: Sources section format:**


### PR DESCRIPTION
# What

Found some offline link in the lead_agent prompt

# How

Use the new link to replace in the lead_agent prompt's link