### PR TITLE
feat(skills): add dependency declaration and auto-install for skills

### DIFF
--- a/backend/packages/harness/deerflow/skills/loader.py
+++ b/backend/packages/harness/deerflow/skills/loader.py
@@ -1,11 +1,53 @@
 import logging
 import os
+import shutil
+import subprocess
+from importlib.util import find_spec
 from pathlib import Path
 
 from .parser import parse_skill_file
 from .types import Skill
 
 logger = logging.getLogger(__name__)
+_CHECKED_SKILL_DEPENDENCIES: set[str] = set()
+
+
+def _has_module_spec(module_name: str) -> bool:
+    try:
+        return find_spec(module_name) is not None
+    except Exception:
+        return False
+
+
+def ensure_skill_dependencies(skill: Skill) -> None:
+    """Ensure declared skill dependencies are installed (pip only)."""
+    skill_key = f"{skill.category}:{skill.name}"
+    if skill_key in _CHECKED_SKILL_DEPENDENCIES:
+        return
+    _CHECKED_SKILL_DEPENDENCIES.add(skill_key)
+
+    dependencies = skill.dependencies
+    if not dependencies or not dependencies.pip:
+        return
+
+    missing_packages: list[str] = []
+    for package in dependencies.pip:
+        if not isinstance(package, str) or not package.strip():
+            continue
+
+        normalized_name = package.replace("-", "_")
+        if not _has_module_spec(package) and not _has_module_spec(normalized_name):
+            missing_packages.append(package)
+
+    if not missing_packages:
+        return
+
+    command = ["uv", "pip", "install", *missing_packages] if shutil.which("uv") else ["pip", "install", *missing_packages]
+    try:
+        subprocess.run(command)
+    except FileNotFoundError:
+        if command[0] == "uv":
+            subprocess.run(["pip", "install", *missing_packages])
 
 
 def get_skills_root_path() -> Path:
@@ -90,6 +132,10 @@ def load_skills(skills_path: Path | None = None, use_config: bool = True, enable
     except Exception as e:
         # If config loading fails, default to all enabled
         logger.warning("Failed to load extensions config: %s", e)
+
+    for skill in skills:
+        if skill.enabled:
+            ensure_skill_dependencies(skill)
 
     # Filter by enabled status if requested
     if enabled_only:

--- a/backend/packages/harness/deerflow/skills/parser.py
+++ b/backend/packages/harness/deerflow/skills/parser.py
@@ -2,7 +2,9 @@ import logging
 import re
 from pathlib import Path
 
-from .types import Skill
+import yaml
+
+from .types import Skill, SkillDependencies
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +102,24 @@ def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None
                 text = "\n".join(current_value).rstrip()
                 metadata[current_key] = re.sub(r"(?<!\n)\n(?!\n)", " ", text)
 
+        dependencies: SkillDependencies | None = None
+        try:
+            yaml_front_matter = yaml.safe_load(front_matter)
+        except Exception:
+            yaml_front_matter = None
+
+        if isinstance(yaml_front_matter, dict):
+            yaml_dependencies = yaml_front_matter.get("dependencies")
+            if isinstance(yaml_dependencies, dict):
+                pip = yaml_dependencies.get("pip")
+                npm = yaml_dependencies.get("npm")
+
+                pip_deps = [pkg for pkg in pip if isinstance(pkg, str)] if isinstance(pip, list) else []
+                npm_deps = [pkg for pkg in npm if isinstance(pkg, str)] if isinstance(npm, list) else []
+
+                if pip_deps or npm_deps:
+                    dependencies = SkillDependencies(pip=pip_deps, npm=npm_deps)
+
         # Extract required fields
         name = metadata.get("name")
         description = metadata.get("description")
@@ -118,6 +138,7 @@ def parse_skill_file(skill_file: Path, category: str, relative_path: Path | None
             relative_path=relative_path or Path(skill_file.parent.name),
             category=category,
             enabled=True,  # Default to enabled, actual state comes from config file
+            dependencies=dependencies,
         )
 
     except Exception as e:

--- a/backend/packages/harness/deerflow/skills/types.py
+++ b/backend/packages/harness/deerflow/skills/types.py
@@ -1,5 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+@dataclass
+class SkillDependencies:
+    pip: list[str] = field(default_factory=list)
+    npm: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -14,6 +20,7 @@ class Skill:
     relative_path: Path  # Relative path from category root to skill directory
     category: str  # 'public' or 'custom'
     enabled: bool = False  # Whether this skill is enabled
+    dependencies: SkillDependencies | None = None
 
     @property
     def skill_path(self) -> str:

--- a/backend/tests/test_skill_dependencies.py
+++ b/backend/tests/test_skill_dependencies.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+from deerflow.skills.loader import _CHECKED_SKILL_DEPENDENCIES, ensure_skill_dependencies
+from deerflow.skills.parser import parse_skill_file
+from deerflow.skills.types import Skill, SkillDependencies
+
+
+def _write_skill(tmp_path: Path, content: str) -> Path:
+    skill_file = tmp_path / "SKILL.md"
+    skill_file.write_text(content, encoding="utf-8")
+    return skill_file
+
+
+def test_parse_skill_with_dependencies(tmp_path: Path) -> None:
+    skill_file = _write_skill(
+        tmp_path,
+        "---\nname: deps-skill\ndescription: Skill with deps\ndependencies:\n  pip:\n    - requests\n    - pydantic-core\n  npm:\n    - lodash\n---\n\n# Deps Skill\n",
+    )
+
+    result = parse_skill_file(skill_file, "public")
+
+    assert result is not None
+    assert result.dependencies is not None
+    assert result.dependencies.pip == ["requests", "pydantic-core"]
+    assert result.dependencies.npm == ["lodash"]
+
+
+def test_parse_skill_without_dependencies_is_backward_compatible(tmp_path: Path) -> None:
+    skill_file = _write_skill(
+        tmp_path,
+        "---\nname: simple-skill\ndescription: No deps\n---\n\n# Simple Skill\n",
+    )
+
+    result = parse_skill_file(skill_file, "public")
+
+    assert result is not None
+    assert result.dependencies is None
+
+
+def test_ensure_skill_dependencies_installs_missing_pip_packages(monkeypatch) -> None:
+    _CHECKED_SKILL_DEPENDENCIES.clear()
+    calls: list[list[str]] = []
+
+    def fake_find_spec(name: str):
+        if name in {"installed_pkg", "hyphen_pkg"}:
+            return object()
+        return None
+
+    def fake_run(command: list[str]) -> None:
+        calls.append(command)
+
+    monkeypatch.setattr("deerflow.skills.loader.find_spec", fake_find_spec)
+    monkeypatch.setattr("deerflow.skills.loader.shutil.which", lambda binary: "/usr/bin/uv" if binary == "uv" else None)
+    monkeypatch.setattr("deerflow.skills.loader.subprocess.run", fake_run)
+
+    skill = Skill(
+        name="deps-check-skill",
+        description="Dependency check",
+        license=None,
+        skill_dir=Path("/tmp/skill"),
+        skill_file=Path("/tmp/skill/SKILL.md"),
+        relative_path=Path("deps-check-skill"),
+        category="public",
+        enabled=True,
+        dependencies=SkillDependencies(pip=["installed_pkg", "hyphen-pkg", "missing-pkg"]),
+    )
+
+    ensure_skill_dependencies(skill)
+    ensure_skill_dependencies(skill)
+
+    assert calls == [["uv", "pip", "install", "missing-pkg"]]

--- a/skills/public/skill-creator/scripts/init_skill.py
+++ b/skills/public/skill-creator/scripts/init_skill.py
@@ -18,6 +18,11 @@ from pathlib import Path
 SKILL_TEMPLATE = """---
 name: {skill_name}
 description: [TODO: Complete and informative explanation of what the skill does and when to use it. Include WHEN to use this skill - specific scenarios, file types, or tasks that trigger it.]
+# dependencies:
+#   pip:
+#     - requests
+#   npm:
+#     - lodash
 ---
 
 # {skill_title}


### PR DESCRIPTION
## Summary

Add a `dependencies` field to SKILL.md frontmatter so skills can declare pip packages they need. The skill loader checks for missing packages on first load and installs them automatically.

## Why this matters

Skills that need Python packages (pandas for data-analysis, matplotlib for chart-visualization) fail silently at runtime with ImportError. There is no way to declare what a skill needs.

| Source | Evidence |
|--------|----------|
| [CrewAI](https://github.com/crewAIInc/crewAI) | Agents declare pip requirements per task |
| skill-creator template | Has TODO items for dependency management |

## Changes

- **types.py**: `SkillDependencies` dataclass with `pip` and `npm` fields, added to `Skill`
- **parser.py**: Secondary pass using `yaml.safe_load()` to extract nested `dependencies` from frontmatter
- **loader.py**: `ensure_skill_dependencies()` checks missing pip packages via `importlib.util.find_spec()`, installs via `uv pip install` with fallback to pip. Caches per skill to avoid redundant installs.
- **skill-creator template**: Commented example of dependencies field

## SKILL.md format

```yaml
dependencies:
  pip:
    - pandas>=2.0
    - matplotlib
```

## Testing

3 new tests + all 19 existing skill tests pass.

- `test_parse_skill_with_dependencies` - parses pip and npm deps from frontmatter
- `test_parse_skill_without_dependencies_is_backward_compatible` - no deps = None  
- `test_ensure_skill_dependencies_installs_missing_pip_packages` - mocked install with caching

This contribution was developed with AI assistance (Codex).