### PR TITLE
fix(ui): preserve chat history spacing under follow-up suggestions

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { BotIcon, PlusSquare } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { Button } from "@/components/ui/button";
@@ -27,6 +27,7 @@ import { env } from "@/env";
 import { cn } from "@/lib/utils";
 
 export default function AgentChatPage() {
+  const [followupsVisible, setFollowupsVisible] = useState(false);
   const { t } = useI18n();
   const router = useRouter();
 
@@ -128,6 +129,7 @@ export default function AgentChatPage() {
                 className={cn("size-full", !isNewThread && "pt-10")}
                 threadId={threadId}
                 thread={thread}
+                paddingBottom={followupsVisible ? 256 : 160}
               />
             </div>
 
@@ -172,6 +174,7 @@ export default function AgentChatPage() {
                     )
                   }
                   disabled={env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true"}
+                  onFollowupsVisibilityChange={setFollowupsVisible}
                   onContextChange={(context) => setSettings("context", context)}
                   onSubmit={handleSubmit}
                   onStop={handleStop}

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import { ArtifactTrigger } from "@/components/workspace/artifacts";
@@ -26,6 +26,7 @@ import { env } from "@/env";
 import { cn } from "@/lib/utils";
 
 export default function ChatPage() {
+  const [followupsVisible, setFollowupsVisible] = useState(false);
   const { t } = useI18n();
   const { threadId, isNewThread, setIsNewThread, isMock } = useThreadChat();
   const [settings, setSettings] = useThreadSettings(threadId);
@@ -97,6 +98,7 @@ export default function ChatPage() {
                 className={cn("size-full", !isNewThread && "pt-10")}
                 threadId={threadId}
                 thread={thread}
+                paddingBottom={followupsVisible ? 256 : 160}
               />
             </div>
             <div className="absolute right-0 bottom-0 left-0 z-30 flex justify-center px-4">
@@ -140,6 +142,7 @@ export default function ChatPage() {
                     env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
                     isUploading
                   }
+                  onFollowupsVisibilityChange={setFollowupsVisible}
                   onContextChange={(context) => setSettings("context", context)}
                   onSubmit={handleSubmit}
                   onStop={handleStop}

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -108,6 +108,7 @@ export function InputBox({
   isNewThread,
   threadId,
   initialValue,
+  onFollowupsVisibilityChange,
   onContextChange,
   onSubmit,
   onStop,
@@ -127,6 +128,7 @@ export function InputBox({
   isNewThread?: boolean;
   threadId: string;
   initialValue?: string;
+  onFollowupsVisibilityChange?: (visible: boolean) => void;
   onContextChange?: (
     context: Omit<
       AgentThreadContext,
@@ -157,6 +159,22 @@ export function InputBox({
   const [pendingSuggestion, setPendingSuggestion] = useState<string | null>(
     null,
   );
+
+  const showFollowups =
+    !disabled &&
+    !isNewThread &&
+    !followupsHidden &&
+    (followupsLoading || followups.length > 0);
+
+  useEffect(() => {
+    onFollowupsVisibilityChange?.(showFollowups);
+  }, [onFollowupsVisibilityChange, showFollowups]);
+
+  useEffect(() => {
+    return () => {
+      onFollowupsVisibilityChange?.(false);
+    };
+  }, [onFollowupsVisibilityChange]);
 
   useEffect(() => {
     if (models.length === 0) {
@@ -769,10 +787,7 @@ export function InputBox({
         )}
       </PromptInput>
 
-      {!disabled &&
-        !isNewThread &&
-        !followupsHidden &&
-        (followupsLoading || followups.length > 0) && (
+      {showFollowups && (
           <div className="absolute -top-20 right-0 left-0 z-20 flex items-center justify-center">
             <div className="flex items-center gap-2">
               {followupsLoading ? (


### PR DESCRIPTION
## Summary
- lift follow-up suggestion visibility from `InputBox` to the page so the chat layout can react to it
- increase `MessageList` bottom padding while follow-up suggestions are visible in both regular chats and agent chats
- keep the existing default spacing when no follow-up panel is shown

## Testing
- `git diff --check`
- `pnpm exec tsc --noEmit` *(fails in the current workspace because frontend dependencies are not installed; the run reports widespread missing modules such as `react`, `next`, and `lucide-react`, so no project-local typecheck signal was available yet)*

Closes #1770.
