### PR TITLE
fix(uploads): fall back to configurable.thread_id when runtime.context lacks thread_id

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -150,6 +150,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         if thread_id is None:
             try:
                 from langgraph.config import get_config
+
                 thread_id = get_config().get("configurable", {}).get("thread_id")
             except RuntimeError:
                 pass  # get_config() raises outside a runnable context (e.g. unit tests)


### PR DESCRIPTION
## Problem

`UploadsMiddleware.before_agent()` resolved the uploads directory from `runtime.context["thread_id"]`. However, `runtime.context` does not always carry `thread_id` — the value may be in `get_config().configurable["thread_id"]` instead, depending on the LangGraph invocation path.

When `thread_id` was absent from `runtime.context`, `uploads_dir` silently became `None`. Here is the three-level failure chain:

**Level 1 — `thread_id` missing → `uploads_dir = None`**

```python
thread_id = (runtime.context or {}).get("thread_id")
uploads_dir = self._paths.sandbox_uploads_dir(thread_id) if thread_id else None
```

`uploads_dir` is a ternary: if `thread_id` is falsy, it assigns `None` directly without calling `sandbox_uploads_dir()`.

**Level 2 — what `uploads_dir` represents**

DeerFlow stores uploaded files in a per-thread directory:

```
backend/.deer-flow/threads/{thread_id}/user-data/uploads/
```

`uploads_dir` is the `Path` object for this directory. It serves two purposes:
1. Tells the middleware where to scan for historical (previously uploaded) files
2. Provides the base path to construct `phys_path = uploads_dir / filename`, which is required to locate the sibling `.md` file for outline extraction

**Level 3 — `uploads_dir = None` → two code blocks silently skipped**

```python
# Historical file scan
if uploads_dir and uploads_dir.exists():   # ← None is falsy, entire block skipped
    for file_path in sorted(uploads_dir.iterdir()):
        ...

# Outline attachment
if uploads_dir:                             # ← None is falsy, entire block skipped
    for file in new_files:
        phys_path = uploads_dir / file["filename"]
        file["outline"] = _extract_outline_for_file(phys_path)
```

Both blocks use `uploads_dir` as a guard condition. With `None`, both are skipped entirely:
- **Historical files**: invisible to the agent (files uploaded in previous turns not listed)
- **Document outline**: not attached (agent sees no section structure or line numbers)

The bare filename and virtual path (`/mnt/user-data/uploads/xxx.pdf`) still appeared in the injected block, so there was no visible error — just silently degraded output. This was a **silent failure**.

Partially addresses #1647. Issue #1647 identifies five root causes for agents ignoring uploaded files. This PR fixes the deepest one: when `uploads_dir` resolves to `None`, the middleware injects only bare filenames with no path context, no historical files, and no document outline — making it structurally impossible for the agent to locate or reason about file content even if it wanted to. The higher-level causes (prompt priority rules, skill trigger scope) remain open.

## Root Cause

`ThreadDataMiddleware` already handles this with the same two-step lookup:

```python
thread_id = context.get("thread_id")
if thread_id is None:
    config = get_config()
    thread_id = config.get("configurable", {}).get("thread_id")
```

`UploadsMiddleware` only checked `runtime.context` and had no fallback.

## Fix

Apply the same fallback pattern. Wrapped in `try/except RuntimeError` because `get_config()` raises `RuntimeError("Called get_config outside of a runnable context")` in test environments where there is no active LangGraph runnable — allowing `thread_id` to remain `None` gracefully in that case.

```python
thread_id = (runtime.context or {}).get("thread_id")
if thread_id is None:
    try:
        from langgraph.config import get_config
        thread_id = get_config().get("configurable", {}).get("thread_id")
    except RuntimeError:
        pass  # get_config() raises outside a runnable context (e.g. unit tests)
```

## How It Was Found

Discovered during live integration testing of PR #1738 — sending a real upload + chat request via curl against a local LangGraph instance and observing middleware debug logs. The unit tests in `test_uploads_middleware_core_logic.py` inject `uploads_dir` directly into the middleware and would not catch this invocation-path-dependent failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)