### PR TITLE
feat(skills): add community skill registry with install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,11 @@ install:
 	@echo "  make setup-sandbox"
 	@echo ""
 
+# Install a community skill from a Git repo
+install-skill:
+	@if [ -z "$(URL)" ]; then echo "Usage: make install-skill URL=https://github.com/user/my-skill"; exit 1; fi
+	@$(PYTHON) -c "from deerflow.skills.registry import install_skill_from_repo; print(install_skill_from_repo('$(URL)'))"
+
 # Pre-pull sandbox Docker image (optional but recommended)
 setup-sandbox:
 	@echo "=========================================="

--- a/backend/packages/harness/deerflow/skills/registry.py
+++ b/backend/packages/harness/deerflow/skills/registry.py
@@ -1,0 +1,100 @@
+"""Community skill registry — discover and install skills from Git repositories."""
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from deerflow.skills.loader import get_skills_root_path
+from deerflow.skills.validation import _validate_skill_frontmatter
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/bytedance/deer-flow/main/skills/registry.json"
+
+
+def fetch_registry(registry_url: str | None = None) -> list[dict[str, Any]]:
+    """Fetch the skill registry index from a URL.
+
+    Returns list of skill entries with: name, description, repo, version, tags.
+    Falls back to empty list on network errors.
+    """
+    url = registry_url or DEFAULT_REGISTRY_URL
+    try:
+        import urllib.request
+
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            return json.loads(resp.read().decode())
+    except Exception:
+        logger.warning("Failed to fetch skill registry from %s", url)
+        return []
+
+
+def search_registry(query: str, registry_url: str | None = None) -> list[dict[str, Any]]:
+    """Search the registry for skills matching a query string."""
+    entries = fetch_registry(registry_url)
+    query_lower = query.lower()
+    return [entry for entry in entries if query_lower in entry.get("name", "").lower() or query_lower in entry.get("description", "").lower() or any(query_lower in tag.lower() for tag in entry.get("tags", []))]
+
+
+def install_skill_from_repo(
+    repo_url: str,
+    *,
+    skill_path: str = "",
+    skills_root: Path | None = None,
+) -> dict[str, Any]:
+    """Clone a Git repo and install the skill from it.
+
+    Args:
+        repo_url: GitHub URL or owner/repo shorthand
+        skill_path: Path within the repo to the skill directory (default: repo root)
+        skills_root: Override skills root directory
+
+    Returns:
+        Dict with success, skill_name, message.
+    """
+    if skills_root is None:
+        skills_root = get_skills_root_path()
+
+    if not repo_url.startswith(("http://", "https://", "git@")):
+        repo_url = f"https://github.com/{repo_url}.git"
+    elif not repo_url.endswith(".git"):
+        repo_url = f"{repo_url}.git"
+
+    community_dir = skills_root / "community"
+    community_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp) / "repo"
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, str(tmp_path)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            raise ValueError(f"Failed to clone {repo_url}: {result.stderr.strip()}")
+
+        skill_dir = tmp_path / skill_path if skill_path else tmp_path
+
+        is_valid, message, skill_name = _validate_skill_frontmatter(skill_dir)
+        if not is_valid:
+            raise ValueError(f"Invalid skill: {message}")
+        if not skill_name or "/" in skill_name or "\\" in skill_name or ".." in skill_name:
+            raise ValueError(f"Invalid skill name: {skill_name}")
+
+        target = community_dir / skill_name
+        if target.exists():
+            shutil.rmtree(target)
+
+        shutil.copytree(skill_dir, target, ignore=shutil.ignore_patterns(".git", ".github", "__pycache__"))
+        logger.info("Skill %r installed from %s to %s", skill_name, repo_url, target)
+
+    return {
+        "success": True,
+        "skill_name": skill_name,
+        "message": f"Skill '{skill_name}' installed from {repo_url}",
+    }

--- a/backend/tests/test_skill_registry.py
+++ b/backend/tests/test_skill_registry.py
@@ -1,0 +1,64 @@
+"""Tests for deerflow.skills.registry."""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+from deerflow.skills.registry import install_skill_from_repo, search_registry
+
+
+def test_search_registry():
+    entries = [
+        {"name": "deep-research", "description": "Deep research using web search", "tags": ["research", "web"]},
+        {"name": "image-generation", "description": "Generate AI images", "tags": ["image", "art"]},
+    ]
+
+    with patch("deerflow.skills.registry.fetch_registry", return_value=entries):
+        by_name = search_registry("deep")
+        by_tag = search_registry("art")
+
+    assert [entry["name"] for entry in by_name] == ["deep-research"]
+    assert [entry["name"] for entry in by_tag] == ["image-generation"]
+
+
+def test_install_skill_from_repo(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+    expected_skill = "community-skill"
+
+    def fake_run(args, **kwargs):
+        clone_dir = Path(args[-1])
+        clone_dir.mkdir(parents=True, exist_ok=True)
+        (clone_dir / "SKILL.md").write_text("---\nname: test\ndescription: test\n---\n", encoding="utf-8")
+        (clone_dir / "README.md").write_text("hello", encoding="utf-8")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("deerflow.skills.registry.subprocess.run", side_effect=fake_run),
+        patch("deerflow.skills.registry._validate_skill_frontmatter", return_value=(True, "OK", expected_skill)),
+    ):
+        result = install_skill_from_repo("https://github.com/example/skill", skills_root=skills_root)
+
+    target = skills_root / "community" / expected_skill
+    assert result["success"] is True
+    assert result["skill_name"] == expected_skill
+    assert target.exists()
+    assert (target / "SKILL.md").exists()
+
+
+def test_install_skill_normalizes_url(tmp_path: Path):
+    skills_root = tmp_path / "skills"
+
+    def fake_run(args, **kwargs):
+        clone_dir = Path(args[-1])
+        clone_dir.mkdir(parents=True, exist_ok=True)
+        (clone_dir / "SKILL.md").write_text("---\nname: test\ndescription: test\n---\n", encoding="utf-8")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    with (
+        patch("deerflow.skills.registry.subprocess.run", side_effect=fake_run) as mock_run,
+        patch("deerflow.skills.registry._validate_skill_frontmatter", return_value=(True, "OK", "normalized-skill")),
+    ):
+        install_skill_from_repo("owner/repo", skills_root=skills_root)
+
+    called_args = mock_run.call_args.args[0]
+    assert called_args[4] == "https://github.com/owner/repo.git"

--- a/skills/registry.json
+++ b/skills/registry.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "deep-research",
+    "description": "Deep research using web search and crawling",
+    "category": "public",
+    "builtin": true,
+    "tags": ["research", "search", "web"]
+  },
+  {
+    "name": "podcast-generation",
+    "description": "Generate podcast episodes from research",
+    "category": "public",
+    "builtin": true,
+    "tags": ["audio", "podcast", "content"]
+  },
+  {
+    "name": "data-analysis",
+    "description": "Analyze data files and generate insights",
+    "category": "public",
+    "builtin": true,
+    "tags": ["data", "analysis", "charts"]
+  },
+  {
+    "name": "image-generation",
+    "description": "Generate images using AI models",
+    "category": "public",
+    "builtin": true,
+    "tags": ["image", "generation", "art"]
+  },
+  {
+    "name": "video-generation",
+    "description": "Generate videos from prompts",
+    "category": "public",
+    "builtin": true,
+    "tags": ["video", "generation", "content"]
+  }
+]


### PR DESCRIPTION
## Summary

Add a community skill registry system for discovering and installing skills from Git repositories. This is the foundation of a skill ecosystem, letting the community share, discover, and install skills.

## Why this matters

DeerFlow has 17 built-in skills and a well-designed skill system (SKILL.md format, parser, loader, validation, even a skill-creator skill). But there is no way to discover or install community-created skills. The skill-creator can create them, but they have nowhere to go.

| Source | Evidence |
|--------|----------|
| [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) | Curated skill registry with 5,400+ entries | 
| [r/LangChain comparison](https://www.reddit.com/r/LangChain/comments/1rnc2u9/) | Agent framework comparisons list skill ecosystems as key differentiator |
| skill-creator | Creates skills with no distribution path |

## Changes

- **registry.py**: `fetch_registry()`, `search_registry()`, `install_skill_from_repo()`
  - Fetches JSON index from a URL (default: this repo's skills/registry.json)
  - Searches by name, description, or tags
  - Clones Git repos, validates SKILL.md frontmatter, copies to skills/community/
  - URL normalization: `owner/repo` becomes `https://github.com/owner/repo.git`
- **skills/registry.json**: Initial index with 5 built-in skill entries
- **Makefile**: `make install-skill URL=https://github.com/user/my-skill`

## Usage

```bash
# Install a community skill from a Git repo
make install-skill URL=https://github.com/user/my-deerflow-skill

# Or from shorthand
make install-skill URL=user/my-deerflow-skill
```

Installed skills appear in `skills/community/` and are loaded alongside public and custom skills.

## Testing

3 tests covering search, install, and URL normalization.

This contribution was developed with AI assistance (Codex).