### PR TITLE
fix: use webpack for repo-local dev launcher

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -28,7 +28,9 @@ for arg in "$@"; do
 done
 
 if $DEV_MODE; then
-    FRONTEND_CMD="pnpm run dev"
+    # Turbopack currently triggers hydration mismatch overlays on the workspace chat page.
+    # Use webpack for the repo-local dev entrypoint until the underlying mismatch is fixed.
+    FRONTEND_CMD="pnpm exec next dev --webpack"
 else
     if command -v python3 >/dev/null 2>&1; then
         PYTHON_BIN="python3"


### PR DESCRIPTION
## Summary
- switch the repo-local `make dev` frontend launcher from Turbopack to webpack
- keep the change scoped to `scripts/serve.sh` so production and direct `pnpm dev` flows stay untouched

## Why
The workspace chat page triggers a React hydration mismatch in the default repo-local dev flow because `make dev` launches the frontend with `next dev --turbo`. Running the same page under webpack dev mode avoids the mismatch and removes the dev overlay.

## Reproduction
1. Run `make dev` from the repo root on `main`
2. Open `/workspace/chats/new`
3. Open the Next.js issues overlay
4. Observe the hydration mismatch on Radix-generated ids in the prompt input / command palette UI

## Verification
- `logs/frontend.log` shows `Next.js 16.1.7 (webpack)` after the change
- `curl -I http://localhost:2026/workspace/chats/new` returns `200 OK` while `make dev` is running
- browser reload of `/workspace/chats/new` loads without the hydration mismatch console error