### PR TITLE
fix: use webpack in the local frontend dev launcher

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -28,7 +28,9 @@ for arg in "$@"; do
 done
 
 if $DEV_MODE; then
-    FRONTEND_CMD="pnpm run dev"
+    # Webpack dev mode is more stable for the workspace routes in this repo.
+    # Turbopack currently triggers hydration mismatch overlays on the chat page.
+    FRONTEND_CMD="pnpm exec next dev --webpack"
 else
     if command -v python3 >/dev/null 2>&1; then
         PYTHON_BIN="python3"


### PR DESCRIPTION
## Summary

- run the frontend started by `make dev` with `next dev --webpack` in `scripts/serve.sh`
- keep the change scoped to the local dev entrypoint; Docker, production mode, and the frontend package scripts are unchanged

## What did NOT change

- no frontend source files changed
- no backend source files changed
- no Docker or nginx configuration changed
- no production-mode launcher behavior changed
- no `package.json` scripts changed

## User-visible changes

- `make dev` now starts the frontend with webpack instead of Turbopack
- the local workspace chat routes no longer hit the hydration mismatch overlay that was showing up in development

## Compatibility / Security impact

- the change only affects local development started through `make dev`
- production mode behavior is unchanged
- Docker development behavior is unchanged
- no security-sensitive code paths were modified

## Test plan

- [x] `bash -n scripts/serve.sh`
- [x] `make check`
- [x] `cd frontend && pnpm check`
- [x] `cd frontend && pnpm exec next dev --webpack --port 3300`
- [x] `curl -I http://127.0.0.1:3300/workspace/chats/new`
- [ ] `cd backend && uv run pytest` (not run; no backend code changes)

## Evidence / Actual results

- `bash -n scripts/serve.sh` exited with code `0`
- `make check` confirmed `Node.js 24.7.0`, `pnpm 10.32.1`, `uv 0.9.22`, and `nginx 1.29.7`
- `cd frontend && pnpm check` exited with code `0`
- `pnpm exec next dev --webpack --port 3300` reported `Next.js 16.1.7 (webpack)` and `Local: http://localhost:3300`
- `curl -I http://127.0.0.1:3300/workspace/chats/new` returned `HTTP/1.1 200 OK`

## Human verification

- start local development with `make dev`
- open `http://localhost:2026/workspace/chats/new`
- confirm the workspace route loads without the previous hydration mismatch overlay on the chat page

## Risks / rollback

- webpack startup can be slower than Turbopack in local development
- this only fixes the `scripts/serve.sh` launcher path; workflows that call `pnpm dev` directly still use Turbopack
- rollback is a one-line revert of the `FRONTEND_CMD` assignment in `scripts/serve.sh`
