### PR TITLE
fix: add missing config path env vars to gateway service in docker-compose

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -93,6 +93,8 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - DEER_FLOW_CONFIG_PATH=/app/backend/config.yaml
+      - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/backend/extensions_config.json
       - DEER_FLOW_CHANNELS_LANGGRAPH_URL=${DEER_FLOW_CHANNELS_LANGGRAPH_URL:-http://langgraph:2024}
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}
       # DooD path/network translation


### PR DESCRIPTION
Fixes #1829

## Problem
The `gateway` service in `docker/docker-compose.yaml` was missing two environment variables:
- `DEER_FLOW_CONFIG_PATH`
- `DEER_FLOW_EXTENSIONS_CONFIG_PATH`

Without these, the gateway container reads `DEER_FLOW_CONFIG_PATH` from the host's `.env` file, which contains a host filesystem path (e.g. `/home/user/deer-flow/config.yaml`). This path is not accessible inside the container, causing the following error on startup:

```
FileNotFoundError: Config file specified by environment variable `DEER_FLOW_CONFIG_PATH` not found at /home/xxx/godness/deer-flow/config.yaml
RuntimeError: Failed to load configuration during gateway startup
```

## Solution
Added the two missing environment variables to the `gateway` service, pointing to their correct container-internal paths — exactly as they are already configured in the `langgraph` service:

```yaml
- DEER_FLOW_CONFIG_PATH=/app/backend/config.yaml
- DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/backend/extensions_config.json
```

## Testing
- Confirmed `langgraph` service already has these variables set to the same values
- The fix mirrors the existing working configuration in `langgraph`