### PR TITLE
Support runtime-installed custom skills in Docker

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -29,6 +29,7 @@ from deerflow.config import get_app_config
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX, get_paths
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import SandboxProvider
+from deerflow.skills.loader import get_custom_skills_path
 
 from .aio_sandbox import AioSandbox
 from .backend import SandboxBackend, wait_for_sandbox_ready
@@ -196,8 +197,8 @@ class AioSandboxProvider(SandboxProvider):
             mounts.extend(self._get_thread_mounts(thread_id))
             logger.info(f"Adding thread mounts for thread {thread_id}: {mounts}")
 
-        skills_mount = self._get_skills_mount()
-        if skills_mount:
+        skills_mounts = self._get_skills_mounts()
+        for skills_mount in skills_mounts:
             mounts.append(skills_mount)
             logger.info(f"Adding skills mount: {skills_mount}")
 
@@ -224,7 +225,7 @@ class AioSandboxProvider(SandboxProvider):
         ]
 
     @staticmethod
-    def _get_skills_mount() -> tuple[str, str, bool] | None:
+    def _get_skills_mounts() -> list[tuple[str, str, bool]]:
         """Get the skills directory mount configuration.
 
         Mount source uses DEER_FLOW_HOST_SKILLS_PATH when running inside Docker (DooD)
@@ -233,15 +234,29 @@ class AioSandboxProvider(SandboxProvider):
         try:
             config = get_app_config()
             skills_path = config.skills.get_skills_path()
-            container_path = config.skills.container_path
+            container_path = config.skills.container_path.rstrip("/")
+            mounts: list[tuple[str, str, bool]] = []
 
-            if skills_path.exists():
-                # When running inside Docker with DooD, use host-side skills path.
-                host_skills = os.environ.get("DEER_FLOW_HOST_SKILLS_PATH") or str(skills_path)
-                return (host_skills, container_path, True)  # Read-only for security
+            public_path = skills_path / "public"
+            if public_path.exists():
+                host_skills_root = os.environ.get("DEER_FLOW_HOST_SKILLS_PATH")
+                host_public = os.path.join(host_skills_root, "public") if host_skills_root else str(public_path)
+                mounts.append((host_public, f"{container_path}/public", True))
+
+            custom_path = get_custom_skills_path(skills_path)
+            if custom_path.exists():
+                runtime_custom = get_paths().base_dir / "skills" / "custom"
+                if custom_path.resolve() == runtime_custom.resolve():
+                    host_custom = get_paths().host_base_dir / "skills" / "custom"
+                    mounts.append((str(host_custom), f"{container_path}/custom", True))
+                else:
+                    host_skills_root = os.environ.get("DEER_FLOW_HOST_SKILLS_PATH")
+                    host_custom = os.path.join(host_skills_root, "custom") if host_skills_root else str(custom_path)
+                    mounts.append((host_custom, f"{container_path}/custom", True))
+            return mounts
         except Exception as e:
             logger.warning(f"Could not setup skills mount: {e}")
-        return None
+        return []
 
     # ── Idle timeout management ──────────────────────────────────────────
 

--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox_provider.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import SandboxProvider
+from deerflow.skills.loader import get_custom_skills_path
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +34,25 @@ class LocalSandboxProvider(SandboxProvider):
 
             config = get_app_config()
             skills_path = config.skills.get_skills_path()
-            container_path = config.skills.container_path
+            container_path = config.skills.container_path.rstrip("/")
 
-            # Only add mapping if skills directory exists
-            if skills_path.exists():
+            public_path = skills_path / "public"
+            if public_path.exists():
                 mappings.append(
                     PathMapping(
-                        container_path=container_path,
-                        local_path=str(skills_path),
+                        container_path=f"{container_path}/public",
+                        local_path=str(public_path),
                         read_only=True,  # Skills directory is always read-only
+                    )
+                )
+
+            custom_path = get_custom_skills_path(skills_path)
+            if custom_path.exists():
+                mappings.append(
+                    PathMapping(
+                        container_path=f"{container_path}/custom",
+                        local_path=str(custom_path),
+                        read_only=True,
                     )
                 )
 

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -19,6 +19,7 @@ from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import get_sandbox_provider
 from deerflow.sandbox.search import GrepMatch
 from deerflow.sandbox.security import LOCAL_HOST_BASH_DISABLED_MESSAGE, is_host_bash_allowed
+from deerflow.skills.loader import get_custom_skills_path
 
 _ABSOLUTE_PATH_PATTERN = re.compile(r"(?<![:\w])(?<!:/)/(?:[^\s\"'`;&|<>()]+)")
 _FILE_URL_PATTERN = re.compile(r"\bfile://\S+", re.IGNORECASE)
@@ -59,15 +60,9 @@ def _get_skills_container_path() -> str:
         return _DEFAULT_SKILLS_CONTAINER_PATH
 
 
-def _get_skills_host_path() -> str | None:
-    """Get the skills host filesystem path from config.
-
-    Returns None if the skills directory does not exist or config cannot be
-    loaded.  Only successful lookups are cached; failures are retried on the
-    next call so that a transiently unavailable skills directory does not
-    permanently disable skills access.
-    """
-    cached = getattr(_get_skills_host_path, "_cached", None)
+def _get_skills_host_paths() -> dict[str, str]:
+    """Get the available skills host filesystem paths keyed by category."""
+    cached = getattr(_get_skills_host_paths, "_cached", None)
     if cached is not None:
         return cached
     try:
@@ -75,12 +70,32 @@ def _get_skills_host_path() -> str | None:
 
         config = get_app_config()
         skills_path = config.skills.get_skills_path()
-        if skills_path.exists():
-            value = str(skills_path)
-            _get_skills_host_path._cached = value  # type: ignore[attr-defined]
-            return value
+        values: dict[str, str] = {}
+        public_path = skills_path / "public"
+        if public_path.exists():
+            values["public"] = str(public_path)
+
+        custom_path = get_custom_skills_path(skills_path)
+        if custom_path.exists():
+            values["custom"] = str(custom_path)
+
+        if values:
+            _get_skills_host_paths._cached = values  # type: ignore[attr-defined]
+            return values
     except Exception:
         pass
+    return {}
+
+
+def _get_skills_host_path() -> str | None:
+    """Backward-compatible helper returning the public/root host path when available."""
+    host_paths = _get_skills_host_paths()
+    public = host_paths.get("public")
+    if public:
+        return str(Path(public).parent)
+    custom = host_paths.get("custom")
+    if custom:
+        return str(Path(custom).parent)
     return None
 
 
@@ -103,15 +118,32 @@ def _resolve_skills_path(path: str) -> str:
         FileNotFoundError: If skills directory is not configured or doesn't exist.
     """
     skills_container = _get_skills_container_path()
-    skills_host = _get_skills_host_path()
-    if skills_host is None:
-        raise FileNotFoundError(f"Skills directory not available for path: {path}")
+    skills_hosts = _get_skills_host_paths()
+    if not skills_hosts:
+        legacy_host = _get_skills_host_path()
+        if legacy_host is None:
+            raise FileNotFoundError(f"Skills directory not available for path: {path}")
+        skills_hosts = {
+            "public": _join_path_preserving_style(legacy_host, "public"),
+            "custom": _join_path_preserving_style(legacy_host, "custom"),
+        }
 
     if path == skills_container:
-        return skills_host
+        root_host = _get_skills_host_path()
+        if root_host is None:
+            raise FileNotFoundError(f"Skills directory not available for path: {path}")
+        return root_host
 
     relative = path[len(skills_container) :].lstrip("/")
-    return _join_path_preserving_style(skills_host, relative)
+    category, _, remainder = relative.partition("/")
+    skills_host = skills_hosts.get(category)
+    if skills_host is None:
+        root_host = _get_skills_host_path()
+        if root_host is None:
+            raise FileNotFoundError(f"Skills directory not available for path: {path}")
+        return _join_path_preserving_style(root_host, relative)
+
+    return _join_path_preserving_style(skills_host, remainder)
 
 
 def _is_acp_workspace_path(path: str) -> bool:
@@ -459,21 +491,30 @@ def mask_local_paths_in_output(output: str, thread_data: ThreadDataState | None)
     result = output
 
     # Mask skills host paths
-    skills_host = _get_skills_host_path()
+    skills_hosts = _get_skills_host_paths()
     skills_container = _get_skills_container_path()
-    if skills_host:
+    if not skills_hosts:
+        legacy_host = _get_skills_host_path()
+        if legacy_host:
+            skills_hosts = {
+                "public": _join_path_preserving_style(legacy_host, "public"),
+                "custom": _join_path_preserving_style(legacy_host, "custom"),
+            }
+
+    for category, skills_host in skills_hosts.items():
         raw_base = str(Path(skills_host))
         resolved_base = str(Path(skills_host).resolve())
+        container_base = f"{skills_container}/{category}"
         for base in _path_variants(raw_base) | _path_variants(resolved_base):
             escaped = re.escape(base).replace(r"\\", r"[/\\]")
             pattern = re.compile(escaped + r"(?:[/\\][^\s\"';&|<>()]*)?")
 
-            def replace_skills(match: re.Match, _base: str = base) -> str:
+            def replace_skills(match: re.Match, _base: str = base, _container: str = container_base) -> str:
                 matched_path = match.group(0)
                 if matched_path == _base:
-                    return skills_container
+                    return _container
                 relative = matched_path[len(_base) :].lstrip("/\\")
-                return f"{skills_container}/{relative}" if relative else skills_container
+                return f"{_container}/{relative}" if relative else _container
 
             result = pattern.sub(replace_skills, result)
 
@@ -702,8 +743,14 @@ def replace_virtual_paths_in_command(command: str, thread_data: ThreadDataState 
 
     # Replace skills paths
     skills_container = _get_skills_container_path()
-    skills_host = _get_skills_host_path()
-    if skills_host and skills_container in result:
+    if not _get_skills_host_paths() and _get_skills_host_path() and skills_container in result:
+        skills_pattern = re.compile(rf"{re.escape(skills_container)}(/[^\s\"';&|<>()]*)?")
+
+        def replace_skills_match(match: re.Match) -> str:
+            return _resolve_skills_path(match.group(0))
+
+        result = skills_pattern.sub(replace_skills_match, result)
+    elif _get_skills_host_paths() and skills_container in result:
         skills_pattern = re.compile(rf"{re.escape(skills_container)}(/[^\s\"';&|<>()]*)?")
 
         def replace_skills_match(match: re.Match) -> str:

--- a/backend/packages/harness/deerflow/skills/installer.py
+++ b/backend/packages/harness/deerflow/skills/installer.py
@@ -12,7 +12,7 @@ import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
-from deerflow.skills.loader import get_skills_root_path
+from deerflow.skills.loader import get_runtime_custom_skills_path
 from deerflow.skills.validation import _validate_skill_frontmatter
 
 logger = logging.getLogger(__name__)
@@ -144,8 +144,9 @@ def install_skill_from_archive(
         raise ValueError("File must have .skill extension")
 
     if skills_root is None:
-        skills_root = get_skills_root_path()
-    custom_dir = skills_root / "custom"
+        custom_dir = get_runtime_custom_skills_path()
+    else:
+        custom_dir = skills_root / "custom"
     custom_dir.mkdir(parents=True, exist_ok=True)
 
     with tempfile.TemporaryDirectory() as tmp:

--- a/backend/packages/harness/deerflow/skills/loader.py
+++ b/backend/packages/harness/deerflow/skills/loader.py
@@ -2,6 +2,8 @@ import logging
 import os
 from pathlib import Path
 
+from deerflow.config.paths import get_paths
+
 from .parser import parse_skill_file
 from .types import Skill
 
@@ -22,6 +24,30 @@ def get_skills_root_path() -> Path:
     return skills_dir
 
 
+def get_runtime_skills_root_path() -> Path:
+    """Get the writable runtime skills directory under DEER_FLOW_HOME."""
+    return get_paths().base_dir / "skills"
+
+
+def get_runtime_custom_skills_path() -> Path:
+    """Get the writable runtime custom skills directory."""
+    return get_runtime_skills_root_path() / "custom"
+
+
+def get_custom_skills_path(skills_root: Path | None = None) -> Path:
+    """Return the effective custom skills directory.
+
+    Runtime-installed custom skills under DEER_FLOW_HOME take precedence when
+    present. Otherwise we fall back to the repo/configured ``skills/custom``.
+    """
+    runtime_custom = get_runtime_custom_skills_path()
+    if runtime_custom.exists():
+        return runtime_custom
+
+    root = skills_root or get_skills_root_path()
+    return root / "custom"
+
+
 def load_skills(skills_path: Path | None = None, use_config: bool = True, enabled_only: bool = False) -> list[Skill]:
     """
     Load all skills from the skills directory.
@@ -39,27 +65,30 @@ def load_skills(skills_path: Path | None = None, use_config: bool = True, enable
     Returns:
         List of Skill objects, sorted by name
     """
+    skills = []
+
     if skills_path is None:
         if use_config:
             try:
                 from deerflow.config import get_app_config
 
-                config = get_app_config()
-                skills_path = config.skills.get_skills_path()
+                configured_root = get_app_config().skills.get_skills_path()
             except Exception:
-                # Fallback to default if config fails
-                skills_path = get_skills_root_path()
+                configured_root = get_skills_root_path()
         else:
-            skills_path = get_skills_root_path()
+            configured_root = get_skills_root_path()
 
-    if not skills_path.exists():
-        return []
+        category_paths = {
+            "public": configured_root / "public",
+            "custom": get_custom_skills_path(configured_root),
+        }
+    else:
+        category_paths = {
+            "public": skills_path / "public",
+            "custom": skills_path / "custom",
+        }
 
-    skills = []
-
-    # Scan public and custom directories
-    for category in ["public", "custom"]:
-        category_path = skills_path / category
+    for category, category_path in category_paths.items():
         if not category_path.exists() or not category_path.is_dir():
             continue
 

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -1,6 +1,7 @@
 """Tests for AioSandboxProvider mount helpers."""
 
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -104,6 +105,30 @@ def test_get_thread_mounts_preserves_windows_host_path_style(tmp_path, monkeypat
     assert container_paths["/mnt/user-data/uploads"] == r"C:\Users\demo\deer-flow\backend\.deer-flow\threads\thread-10\user-data\uploads"
     assert container_paths["/mnt/user-data/outputs"] == r"C:\Users\demo\deer-flow\backend\.deer-flow\threads\thread-10\user-data\outputs"
     assert container_paths["/mnt/acp-workspace"] == r"C:\Users\demo\deer-flow\backend\.deer-flow\threads\thread-10\acp-workspace"
+
+
+def test_get_extra_mounts_splits_public_and_runtime_custom_skills(tmp_path, monkeypatch):
+    """Skills mounts should keep repo public skills read-only and runtime custom skills writable on host."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+
+    repo_skills = tmp_path / "repo-skills"
+    runtime_home = tmp_path / "runtime-home"
+    (repo_skills / "public").mkdir(parents=True)
+    (runtime_home / "skills" / "custom").mkdir(parents=True)
+
+    config = SimpleNamespace(
+        skills=SimpleNamespace(container_path="/mnt/skills", get_skills_path=lambda: repo_skills),
+    )
+
+    monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+    monkeypatch.setattr(aio_mod, "get_app_config", lambda: config)
+    monkeypatch.setattr(aio_mod.AioSandboxProvider, "_get_thread_mounts", staticmethod(lambda _thread_id: []))
+
+    mounts = provider._get_extra_mounts("thread-11")
+
+    assert (str(repo_skills / "public"), "/mnt/skills/public", True) in mounts
+    assert (str(runtime_home / "skills" / "custom"), "/mnt/skills/custom", True) in mounts
 
 
 def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatch):

--- a/backend/tests/test_local_sandbox_provider_mounts.py
+++ b/backend/tests/test_local_sandbox_provider_mounts.py
@@ -293,6 +293,26 @@ class TestMultipleMounts:
 
 
 class TestLocalSandboxProviderMounts:
+    def test_setup_path_mappings_splits_public_and_runtime_custom_skills(self, tmp_path, monkeypatch):
+        repo_skills = tmp_path / "repo-skills"
+        runtime_home = tmp_path / "runtime-home"
+        (repo_skills / "public").mkdir(parents=True)
+        (runtime_home / "skills" / "custom").mkdir(parents=True)
+
+        config = SimpleNamespace(
+            skills=SimpleNamespace(container_path="/mnt/skills", get_skills_path=lambda: repo_skills),
+            sandbox=SimpleNamespace(mounts=[]),
+        )
+
+        monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+        with patch("deerflow.config.get_app_config", return_value=config):
+            provider = LocalSandboxProvider()
+
+        assert [m.container_path for m in provider._path_mappings] == [
+            "/mnt/skills/public",
+            "/mnt/skills/custom",
+        ]
+
     def test_setup_path_mappings_uses_configured_skills_container_path_as_reserved_prefix(self, tmp_path):
         skills_dir = tmp_path / "skills"
         skills_dir.mkdir()

--- a/backend/tests/test_skills_installer.py
+++ b/backend/tests/test_skills_installer.py
@@ -225,3 +225,18 @@ class TestInstallSkillFromArchive:
         result = install_skill_from_archive(zip_path, skills_root=skills_root)
         assert result["success"] is True
         assert result["skill_name"] == "my-skill"
+
+    def test_default_install_targets_runtime_custom_skills_dir(self, tmp_path, monkeypatch):
+        """Without an explicit override, runtime installs should land under DEER_FLOW_HOME."""
+        zip_path = self._make_skill_zip(tmp_path, "runtime-skill")
+        repo_skills = tmp_path / "repo-skills"
+        runtime_home = tmp_path / "runtime-home"
+
+        (repo_skills / "public").mkdir(parents=True)
+        monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+
+        result = install_skill_from_archive(zip_path)
+
+        assert result["success"] is True
+        assert not (repo_skills / "custom" / "runtime-skill").exists()
+        assert (runtime_home / "skills" / "custom" / "runtime-skill" / "SKILL.md").exists()

--- a/backend/tests/test_skills_loader.py
+++ b/backend/tests/test_skills_loader.py
@@ -62,3 +62,23 @@ def test_load_skills_skips_hidden_directories(tmp_path: Path):
 
     assert "ok-skill" in names
     assert "secret-skill" not in names
+
+
+def test_load_skills_includes_runtime_custom_skills_from_deer_flow_home(tmp_path: Path, monkeypatch) -> None:
+    """Default loading should merge repo public skills with runtime-installed custom skills."""
+    repo_skills = tmp_path / "repo-skills"
+    runtime_home = tmp_path / "runtime-home"
+
+    _write_skill(repo_skills / "public" / "repo-public", "repo-public", "Repo public skill")
+    _write_skill(runtime_home / "skills" / "custom" / "runtime-skill", "runtime-skill", "Runtime installed skill")
+
+    monkeypatch.setenv("DEER_FLOW_HOME", str(runtime_home))
+    monkeypatch.setattr("deerflow.skills.loader.get_skills_root_path", lambda: repo_skills)
+
+    skills = load_skills(enabled_only=False)
+    by_name = {skill.name: skill for skill in skills}
+
+    assert "repo-public" in by_name
+    assert "runtime-skill" in by_name
+    assert by_name["runtime-skill"].category == "custom"
+    assert by_name["runtime-skill"].get_container_file_path() == "/mnt/skills/custom/runtime-skill/SKILL.md"


### PR DESCRIPTION
## Summary
- install Gateway-uploaded .skill archives into the writable runtime directory under DEER_FLOW_HOME
- load repo skills/public together with runtime skills/custom, and mount them separately in sandbox providers
- keep sandbox path resolution working for /mnt/skills/custom/... and cover the runtime layout with tests

## Testing
- .\\backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/test_skills_loader.py backend/tests/test_skills_installer.py backend/tests/test_aio_sandbox_provider.py backend/tests/test_sandbox_tools_security.py -q
- .\\backend\\.venv\\Scripts\\python.exe -m pytest backend/tests/test_local_sandbox_provider_mounts.py::TestLocalSandboxProviderMounts::test_setup_path_mappings_splits_public_and_runtime_custom_skills -q
- .\\backend\\.venv\\Scripts\\python.exe -m ruff check backend/packages/harness/deerflow/skills/loader.py backend/packages/harness/deerflow/skills/installer.py backend/packages/harness/deerflow/sandbox/local/local_sandbox_provider.py backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py backend/packages/harness/deerflow/sandbox/tools.py backend/tests/test_skills_loader.py backend/tests/test_skills_installer.py backend/tests/test_local_sandbox_provider_mounts.py backend/tests/test_aio_sandbox_provider.py

Fixes #1387