### PR TITLE
fix(memory): skip duplicate fact entries

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -173,6 +173,12 @@ def _strip_upload_mentions_from_memory(memory_data: dict[str, Any]) -> dict[str,
     return memory_data
 
 
+def _fact_content_key(content: Any) -> str | None:
+    if not isinstance(content, str):
+        return None
+    return content.strip()
+
+
 def _save_memory_to_file(memory_data: dict[str, Any], agent_name: str | None = None) -> bool:
     """Save memory data to file and update cache.
 
@@ -343,19 +349,27 @@ class MemoryUpdater:
             current_memory["facts"] = [f for f in current_memory.get("facts", []) if f.get("id") not in facts_to_remove]
 
         # Add new facts
+        existing_fact_keys = {fact_key for fact_key in (_fact_content_key(fact.get("content")) for fact in current_memory.get("facts", [])) if fact_key is not None}
         new_facts = update_data.get("newFacts", [])
         for fact in new_facts:
             confidence = fact.get("confidence", 0.5)
             if confidence >= config.fact_confidence_threshold:
+                content = fact.get("content", "")
+                fact_key = _fact_content_key(content)
+                if fact_key is not None and fact_key in existing_fact_keys:
+                    continue
+
                 fact_entry = {
                     "id": f"fact_{uuid.uuid4().hex[:8]}",
-                    "content": fact.get("content", ""),
+                    "content": content,
                     "category": fact.get("category", "context"),
                     "confidence": confidence,
                     "createdAt": now,
                     "source": thread_id or "unknown",
                 }
                 current_memory["facts"].append(fact_entry)
+                if fact_key is not None:
+                    existing_fact_keys.add(fact_key)
 
         # Enforce max facts limit
         if len(current_memory["facts"]) > config.max_facts:

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -1,0 +1,137 @@
+from unittest.mock import patch
+
+from deerflow.agents.memory.updater import MemoryUpdater
+from deerflow.config.memory_config import MemoryConfig
+
+
+def _make_memory(facts: list[dict[str, object]] | None = None) -> dict[str, object]:
+    return {
+        "version": "1.0",
+        "lastUpdated": "",
+        "user": {
+            "workContext": {"summary": "", "updatedAt": ""},
+            "personalContext": {"summary": "", "updatedAt": ""},
+            "topOfMind": {"summary": "", "updatedAt": ""},
+        },
+        "history": {
+            "recentMonths": {"summary": "", "updatedAt": ""},
+            "earlierContext": {"summary": "", "updatedAt": ""},
+            "longTermBackground": {"summary": "", "updatedAt": ""},
+        },
+        "facts": facts or [],
+    }
+
+
+def _memory_config(**overrides: object) -> MemoryConfig:
+    config = MemoryConfig()
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def test_apply_updates_skips_existing_duplicate_and_preserves_removals() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory(
+        facts=[
+            {
+                "id": "fact_existing",
+                "content": "User likes Python",
+                "category": "preference",
+                "confidence": 0.9,
+                "createdAt": "2026-03-18T00:00:00Z",
+                "source": "thread-a",
+            },
+            {
+                "id": "fact_remove",
+                "content": "Old context to remove",
+                "category": "context",
+                "confidence": 0.8,
+                "createdAt": "2026-03-18T00:00:00Z",
+                "source": "thread-a",
+            },
+        ]
+    )
+    update_data = {
+        "factsToRemove": ["fact_remove"],
+        "newFacts": [
+            {"content": "User likes Python", "category": "preference", "confidence": 0.95},
+        ],
+    }
+
+    with patch(
+        "deerflow.agents.memory.updater.get_memory_config",
+        return_value=_memory_config(max_facts=100, fact_confidence_threshold=0.7),
+    ):
+        result = updater._apply_updates(current_memory, update_data, thread_id="thread-b")
+
+    assert [fact["content"] for fact in result["facts"]] == ["User likes Python"]
+    assert all(fact["id"] != "fact_remove" for fact in result["facts"])
+
+
+def test_apply_updates_skips_same_batch_duplicates_and_keeps_source_metadata() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory()
+    update_data = {
+        "newFacts": [
+            {"content": "User prefers dark mode", "category": "preference", "confidence": 0.91},
+            {"content": "User prefers dark mode", "category": "preference", "confidence": 0.92},
+            {"content": "User works on DeerFlow", "category": "context", "confidence": 0.87},
+        ],
+    }
+
+    with patch(
+        "deerflow.agents.memory.updater.get_memory_config",
+        return_value=_memory_config(max_facts=100, fact_confidence_threshold=0.7),
+    ):
+        result = updater._apply_updates(current_memory, update_data, thread_id="thread-42")
+
+    assert [fact["content"] for fact in result["facts"]] == [
+        "User prefers dark mode",
+        "User works on DeerFlow",
+    ]
+    assert all(fact["id"].startswith("fact_") for fact in result["facts"])
+    assert all(fact["source"] == "thread-42" for fact in result["facts"])
+
+
+def test_apply_updates_preserves_threshold_and_max_facts_trimming() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory(
+        facts=[
+            {
+                "id": "fact_python",
+                "content": "User likes Python",
+                "category": "preference",
+                "confidence": 0.95,
+                "createdAt": "2026-03-18T00:00:00Z",
+                "source": "thread-a",
+            },
+            {
+                "id": "fact_dark_mode",
+                "content": "User prefers dark mode",
+                "category": "preference",
+                "confidence": 0.8,
+                "createdAt": "2026-03-18T00:00:00Z",
+                "source": "thread-a",
+            },
+        ]
+    )
+    update_data = {
+        "newFacts": [
+            {"content": "User prefers dark mode", "category": "preference", "confidence": 0.9},
+            {"content": "User uses uv", "category": "context", "confidence": 0.85},
+            {"content": "User likes noisy logs", "category": "behavior", "confidence": 0.6},
+        ],
+    }
+
+    with patch(
+        "deerflow.agents.memory.updater.get_memory_config",
+        return_value=_memory_config(max_facts=2, fact_confidence_threshold=0.7),
+    ):
+        result = updater._apply_updates(current_memory, update_data, thread_id="thread-9")
+
+    assert [fact["content"] for fact in result["facts"]] == [
+        "User likes Python",
+        "User uses uv",
+    ]
+    assert all(fact["content"] != "User likes noisy logs" for fact in result["facts"])
+    assert result["facts"][1]["source"] == "thread-9"


### PR DESCRIPTION
## Summary
- skip appending duplicate fact content when applying memory updates
- preserve existing fact removal and max-facts trimming behavior
- add focused regression coverage for existing duplicates, same-batch duplicates, and max-facts trimming

## End-user benefit
Without this fix, repeated memory updates can accumulate the same fact content over and over, which bloats the stored memory and degrades later memory injection quality. This change keeps the fact list concise while preserving the existing update flow.

## Testing
- `backend/.venv/bin/python -m pytest backend/tests/test_memory_updater.py -q`