### PR TITLE
fix: include soul field in GET /api/agents list response

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -24,7 +24,7 @@ class AgentResponse(BaseModel):
     description: str = Field(default="", description="Agent description")
     model: str | None = Field(default=None, description="Optional model override")
     tool_groups: list[str] | None = Field(default=None, description="Optional tool group whitelist")
-    soul: str | None = Field(default=None, description="SOUL.md content (included on GET /{name})")
+    soul: str | None = Field(default=None, description="SOUL.md content")
 
 
 class AgentsListResponse(BaseModel):
@@ -92,17 +92,17 @@ def _agent_config_to_response(agent_cfg: AgentConfig, include_soul: bool = False
     "/agents",
     response_model=AgentsListResponse,
     summary="List Custom Agents",
-    description="List all custom agents available in the agents directory.",
+    description="List all custom agents available in the agents directory, including their soul content.",
 )
 async def list_agents() -> AgentsListResponse:
     """List all custom agents.
 
     Returns:
-        List of all custom agents with their metadata (without soul content).
+        List of all custom agents with their metadata and soul content.
     """
     try:
         agents = list_custom_agents()
-        return AgentsListResponse(agents=[_agent_config_to_response(a) for a in agents])
+        return AgentsListResponse(agents=[_agent_config_to_response(a, include_soul=True) for a in agents])
     except Exception as e:
         logger.error(f"Failed to list agents: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to list agents: {str(e)}")

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -439,6 +439,15 @@ class TestAgentsAPI:
         assert "agent-one" in names
         assert "agent-two" in names
 
+    def test_list_agents_includes_soul(self, agent_client):
+        agent_client.post("/api/agents", json={"name": "soul-agent", "soul": "My soul content"})
+
+        response = agent_client.get("/api/agents")
+        assert response.status_code == 200
+        agents = response.json()["agents"]
+        soul_agent = next(a for a in agents if a["name"] == "soul-agent")
+        assert soul_agent["soul"] == "My soul content"
+
     def test_get_agent(self, agent_client):
         agent_client.post("/api/agents", json={"name": "test-agent", "soul": "Hello world"})
 


### PR DESCRIPTION
Fixes #1819

## Problem
`GET /api/agents` always returned `soul: null` for every agent in the list, even after updating the soul via `PUT /api/agents/{name}`. This was confusing because:
- `PUT /api/agents/{name}` returns the soul correctly
- `GET /api/agents/{name}` returns the soul correctly
- But `GET /api/agents` silently returned `soul: null` for all agents

The root cause was that `list_agents()` called `_agent_config_to_response(a)` without passing `include_soul=True`, so the soul content was never loaded.

## Solution
Pass `include_soul=True` to `_agent_config_to_response()` in the list endpoint, so that `GET /api/agents` returns the soul content for each agent (consistent with `GET /api/agents/{name}`).

Updated the `AgentResponse.soul` field description and the list endpoint description to reflect the change.

## Testing
- Added `test_list_agents_includes_soul` test that creates an agent with soul content and verifies the list endpoint returns it.
- All 47 existing tests continue to pass.