### PR TITLE
fix(docker): add self-healing startup command for restart/502 recovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ Docker provides a consistent, isolated environment with all dependencies pre-con
 make docker-init
 # Start Docker services (mode-aware, localhost:2026)
 make docker-start
+# Start services with built-in health check and self-healing
+make docker-start-selfheal
 # Stop Docker development services
 make docker-stop
 # View Docker development logs

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # DeerFlow - Unified Development Environment
 
-.PHONY: help config config-upgrade check install dev dev-daemon start stop up down clean docker-init docker-start docker-stop docker-logs docker-logs-frontend docker-logs-gateway
+.PHONY: help config config-upgrade check install dev dev-daemon start stop up down clean docker-init docker-start docker-start-selfheal docker-stop docker-logs docker-logs-frontend docker-logs-gateway
 
 BASH ?= bash
 
@@ -32,6 +32,7 @@ help:
 	@echo "Docker Development Commands:"
 	@echo "  make docker-init     - Pull the sandbox image"
 	@echo "  make docker-start    - Start Docker services (mode-aware from config.yaml, localhost:2026)"
+	@echo "  make docker-start-selfheal - Start Docker services + health check + auto-repair"
 	@echo "  make docker-stop     - Stop Docker development services"
 	@echo "  make docker-logs     - View Docker development logs"
 	@echo "  make docker-logs-frontend - View Docker frontend logs"
@@ -158,6 +159,10 @@ docker-init:
 # Start Docker development environment
 docker-start:
 	@./scripts/docker.sh start
+
+# Start Docker environment with health-check and self-healing
+docker-start-selfheal:
+	@./scripts/docker-start-selfheal.sh
 
 # Stop Docker development environment
 docker-stop:

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
 ```bash
 make docker-init    # Pull sandbox image (only once or when image updates)
 make docker-start   # Start services (auto-detects sandbox mode from config.yaml)
+make docker-start-selfheal  # Start + health check + auto-repair common restart/502 issues
 ```
 
 `make docker-start` starts `provisioner` only when `config.yaml` uses provisioner mode (`sandbox.use: deerflow.community.aio_sandbox:AioSandboxProvider` with `provisioner_url`).

--- a/scripts/docker-start-selfheal.sh
+++ b/scripts/docker-start-selfheal.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="$PROJECT_ROOT/docker/docker-compose-dev.yaml"
+PROJECT_NAME="deer-flow-dev"
+
+# Keep compose env interpolation stable and reduce noisy warnings.
+export DEER_FLOW_ROOT="${DEER_FLOW_ROOT:-$PROJECT_ROOT}"
+export allow_blocking="${allow_blocking:-}"
+
+log() {
+  printf '[docker-selfheal] %s\n' "$*"
+}
+
+compose() {
+  docker compose -p "$PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
+}
+
+http_ok() {
+  local url="$1"
+  local code
+  code="$(curl -sS -o /dev/null -w '%{http_code}' "$url" || true)"
+  [ "$code" = "200" ]
+}
+
+all_running() {
+  local status
+  status="$(compose ps --services --filter status=running)"
+  echo "$status" | grep -qx 'frontend' \
+    && echo "$status" | grep -qx 'gateway' \
+    && echo "$status" | grep -qx 'langgraph' \
+    && echo "$status" | grep -qx 'nginx'
+}
+
+health_check() {
+  all_running \
+    && http_ok "http://localhost:2026/" \
+    && http_ok "http://localhost:2026/health" \
+    && http_ok "http://localhost:2026/api/models" \
+    && http_ok "http://localhost:2026/api/langgraph/docs"
+}
+
+wait_health() {
+  local attempts="${1:-20}"
+  local sleep_sec="${2:-3}"
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if health_check; then
+      return 0
+    fi
+    log "等待服务健康 (${i}/${attempts})..."
+    sleep "$sleep_sec"
+  done
+  return 1
+}
+
+show_debug() {
+  log "当前容器状态："
+  compose ps || true
+  log "gateway 最近日志："
+  docker logs --tail 80 deer-flow-gateway || true
+  log "langgraph 最近日志："
+  docker logs --tail 80 deer-flow-langgraph || true
+  log "nginx 最近日志："
+  docker logs --tail 80 deer-flow-nginx || true
+}
+
+repair_soft() {
+  log "执行轻修复：重建 gateway/langgraph + 重启 nginx"
+  compose up -d --force-recreate gateway langgraph
+  compose restart nginx
+}
+
+repair_deep() {
+  log "执行深修复：下线并重建 venv volumes 后重启"
+  compose down
+  docker volume rm "${PROJECT_NAME}_gateway-venv" "${PROJECT_NAME}_langgraph-venv" 2>/dev/null || true
+  (cd "$PROJECT_ROOT" && make docker-start)
+  compose restart nginx
+}
+
+main() {
+  log "启动 Docker 服务（make docker-start）"
+  (cd "$PROJECT_ROOT" && make docker-start)
+
+  if wait_health 20 3; then
+    log "服务启动成功，健康检查通过。"
+    exit 0
+  fi
+
+  repair_soft
+  if wait_health 20 3; then
+    log "轻修复后恢复成功。"
+    exit 0
+  fi
+
+  repair_deep
+  if wait_health 30 3; then
+    log "深修复后恢复成功。"
+    exit 0
+  fi
+
+  log "自动修复失败，请查看日志。"
+  show_debug
+  exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a minimal self-healing Docker startup entrypoint for development environments:

- New script: `scripts/docker-start-selfheal.sh`
- New Make target: `make docker-start-selfheal`
- Docs updated in `README.md` and `CONTRIBUTING.md`

The command wraps `make docker-start`, runs health checks, and applies automatic recovery for common Docker dev startup failures.

## Why

Some users report startup loops or 502 after Docker start in local dev (especially after container recreate / volume drift):

- #1334
- #1822

This PR focuses on recovery ergonomics so users can self-recover with one command.

## What it does

1. Runs `make docker-start`
2. Checks all key paths are healthy:
   - `/`
   - `/health`
   - `/api/models`
   - `/api/langgraph/docs`
3. If unhealthy, applies soft repair:
   - recreate `gateway` and `langgraph`
   - restart `nginx`
4. If still unhealthy, applies deep repair:
   - `docker compose down`
   - remove `deer-flow-dev_gateway-venv` + `deer-flow-dev_langgraph-venv` volumes
   - start again
   - restart `nginx`

## Validation

Validated locally on macOS Docker dev:

- `make docker-start-selfheal`
- Verified HTTP 200 for all endpoints listed above
- Verified script exits successfully on healthy startup

## Notes

This does not replace root-cause-specific fixes in runtime components; it adds a safe operational recovery path for local dev startup instability.
