### PR TITLE
fix(docker): recover invalid .venv to prevent startup restart loops

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -120,7 +120,7 @@ services:
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
     container_name: deer-flow-gateway
-    command: sh -c "cd backend && (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env' > /app/logs/gateway.log 2>&1"
+    command: sh -c "{ cd backend && (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-include='*.yaml .env'; } > /app/logs/gateway.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
       # Preserve the .venv built during Docker image build — mounting the full backend/
@@ -177,7 +177,7 @@ services:
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
     container_name: deer-flow-langgraph
-    command: sh -c "cd backend && (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && allow_blocking='' && if [ \"\${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run langgraph dev --no-browser \${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker \${LANGGRAPH_JOBS_PER_WORKER:-10} > /app/logs/langgraph.log 2>&1"
+    command: sh -c "cd backend && { (uv sync || (echo '[startup] uv sync failed; recreating .venv and retrying once' && uv venv --allow-existing .venv && uv sync)) && allow_blocking='' && if [ \"\${LANGGRAPH_ALLOW_BLOCKING:-0}\" = '1' ]; then allow_blocking='--allow-blocking'; fi && uv run langgraph dev --no-browser \${allow_blocking} --host 0.0.0.0 --port 2024 --n-jobs-per-worker \${LANGGRAPH_JOBS_PER_WORKER:-10}; } > /app/logs/langgraph.log 2>&1"
     volumes:
       - ../backend/:/app/backend/
       # Preserve the .venv built during Docker image build — mounting the full backend/


### PR DESCRIPTION
## Summary

Fix Docker dev startup loops when a stale/invalid project virtual environment is mounted at `backend/.venv`.

This addresses a common failure mode reported where `gateway` / `langgraph` keep restarting with:

```text
error: Project virtual environment directory `/app/backend/.venv` cannot be used because it is not a valid Python environment (no Python executable was found)
```

## Root Cause

Both services currently run `uv sync` on startup. If the mounted `.venv` exists but is invalid (e.g. stale links after environment/image drift), `uv sync` exits early and the container restarts forever.

## Change

In `docker/docker-compose-dev.yaml`, update startup commands for both `gateway` and `langgraph`:

- Attempt normal `uv sync` first.
- If `uv sync` fails, perform a one-time recovery:
  - `uv venv --allow-existing .venv`
  - retry `uv sync`
- Continue to start the service process as usual.

## Why this approach

- Preserves fast path for healthy environments.
- Adds a bounded, local recovery path for invalid `.venv` state.
- Avoids destructive volume-level operations during normal startup.

## Validation

Local validation on Docker dev:

1. Corrupted both venv volumes to simulate an invalid Python executable state.
2. Ran `make docker-start`.
3. Observed recovery log:
   - `[startup] uv sync failed; recreating .venv and retrying once`
4. Confirmed all services stable via `docker compose ... ps`.
5. Confirmed HTTP checks:
   - `GET /health` -> 200
   - `GET /api/models` -> 200
   - `GET /api/langgraph/docs` -> 200

## Related Issue
 #1822
