### PR TITLE
fix(frontend): guard against non-array tool_calls and string args in steps panel

### DIFF
--- a/frontend/src/components/workspace/messages/message-group.tsx
+++ b/frontend/src/components/workspace/messages/message-group.tsx
@@ -374,10 +374,25 @@ function ToolCall({
   } else if (name === "bash") {
     const description: string | undefined = (args as { description: string })
       ?.description;
-    if (!description) {
-      return t.toolCalls.executeCommand;
-    }
     const command: string | undefined = (args as { command: string })?.command;
+    if (!description) {
+      return (
+        <ChainOfThoughtStep
+          key={id}
+          label={t.toolCalls.executeCommand}
+          icon={SquareTerminalIcon}
+        >
+          {command && (
+            <CodeBlock
+              className="mx-0 cursor-pointer border-none px-0"
+              showLineNumbers={false}
+              language="bash"
+              code={command}
+            />
+          )}
+        </ChainOfThoughtStep>
+      );
+    }
     return (
       <ChainOfThoughtStep
         key={id}
@@ -455,16 +470,48 @@ function convertToSteps(messages: Message[]): CoTStep[] {
         };
         steps.push(step);
       }
-      for (const tool_call of message.tool_calls ?? []) {
+      const toolCalls = Array.isArray(message.tool_calls)
+        ? message.tool_calls
+        : [];
+      for (const tool_call of toolCalls) {
+        if (!tool_call || typeof tool_call !== "object") {
+          continue;
+        }
+        if (typeof tool_call.name !== "string") {
+          continue;
+        }
         if (tool_call.name === "task") {
           continue;
         }
+        const normalizeToolCallArgs = (
+          value: unknown,
+        ): Record<string, unknown> => {
+          if (
+            value &&
+            typeof value === "object" &&
+            !Array.isArray(value)
+          ) {
+            return value as Record<string, unknown>;
+          }
+          return {};
+        };
+        const rawArgs = tool_call.args;
+        const parsedArgs: Record<string, unknown> =
+          typeof rawArgs === "string"
+            ? (() => {
+                try {
+                  return normalizeToolCallArgs(JSON.parse(rawArgs));
+                } catch {
+                  return {};
+                }
+              })()
+            : normalizeToolCallArgs(rawArgs);
         const step: CoTToolCallStep = {
           id: tool_call.id,
           messageId: message.id,
           type: "toolCall",
           name: tool_call.name,
-          args: tool_call.args,
+          args: parsedArgs,
         };
         const toolCallId = tool_call.id;
         if (toolCallId) {


### PR DESCRIPTION
Fixes #1876

## Problem

The steps panel in the chat UI splits bash tool call string input into individual characters, each shown as a separate step. This occurs because:

1. `message.tool_calls` can sometimes be a non-array value (e.g. a JSON string during certain streaming states). Using `for...of` on a string iterates over individual characters, each becoming a bogus step entry.
2. Each `tool_call.args` can arrive as a JSON string instead of a parsed object in some edge cases, causing all field lookups (`.description`, `.command`, etc.) to return `undefined`.
3. The bash tool handler returned a bare string (`t.toolCalls.executeCommand`) instead of a `<ChainOfThoughtStep>` JSX element when `description` is absent — inconsistent with all other tool handlers.

## Solution

In `convertToSteps`:
- Guard `message.tool_calls` with `Array.isArray()` before iterating; fall back to `[]` if it is not an array.
- Skip any entries in the array that are not objects (e.g. stray characters from string iteration).
- When `tool_call.args` is a string, attempt to `JSON.parse` it into an object; fall back to `{}` on parse failure.

In the `ToolCall` component (bash case):
- Extract `command` before the early-return check so it is available in both branches.
- Return a proper `<ChainOfThoughtStep>` element (with `t.toolCalls.executeCommand` as the label and the command shown in a `<CodeBlock>`) instead of a bare string when `description` is absent.

## Testing

Manually verified the logic by reading through the `convertToSteps` function and tracing all code paths. No automated test framework is configured for this project.