### PR TITLE
[codex] add layered memory architecture

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -357,7 +357,12 @@ class ChannelManager:
         user_layer = _as_dict(users_layer.get(msg.user_id))
         return channel_layer, user_layer
 
-    def _resolve_run_params(self, msg: InboundMessage, thread_id: str) -> tuple[str, dict[str, Any], dict[str, Any]]:
+    def _resolve_run_params(
+        self,
+        msg: InboundMessage,
+        thread_id: str,
+        extra_context: dict[str, Any] | None = None,
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
         channel_layer, user_layer = self._resolve_session_layer(msg)
 
         assistant_id = user_layer.get("assistant_id") or channel_layer.get("assistant_id") or self._default_session.get("assistant_id") or self._assistant_id
@@ -371,6 +376,12 @@ class ChannelManager:
             user_layer.get("config"),
         )
 
+        if extra_context:
+            run_config = dict(run_config)
+            configurable = _as_dict(run_config.get("configurable"))
+            configurable.update(extra_context)
+            run_config["configurable"] = configurable
+
         run_context = _merge_dicts(
             DEFAULT_RUN_CONTEXT,
             self._default_session.get("context"),
@@ -378,6 +389,9 @@ class ChannelManager:
             user_layer.get("context"),
             {"thread_id": thread_id},
         )
+
+        if extra_context:
+            run_context.update(extra_context)
 
         return assistant_id, run_config, run_context
 
@@ -490,9 +504,11 @@ class ChannelManager:
         if thread_id is None:
             thread_id = await self._create_thread(client, msg)
 
-        assistant_id, run_config, run_context = self._resolve_run_params(msg, thread_id)
+        runtime_context = {"memory_context": msg.text or ""}
         if extra_context:
-            run_context.update(extra_context)
+            runtime_context.update(extra_context)
+
+        assistant_id, run_config, run_context = self._resolve_run_params(msg, thread_id, extra_context=runtime_context)
         if self._channel_supports_streaming(msg.channel_name):
             await self._handle_streaming_chat(
                 client,

--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -41,6 +41,25 @@ class Fact(BaseModel):
     confidence: float = Field(default=0.5, description="Confidence score (0-1)")
     createdAt: str = Field(default="", description="Creation timestamp")
     source: str = Field(default="unknown", description="Source thread ID")
+    layer: str = Field(default="episodic", description="Layer assigned to the fact")
+
+
+class LayerState(BaseModel):
+    """Model for a memory layer bucket."""
+
+    summary: str = Field(default="", description="Layer summary")
+    updatedAt: str = Field(default="", description="Last update timestamp")
+    factIds: list[str] = Field(default_factory=list, description="Fact identifiers assigned to this layer")
+
+
+class LayerIndex(BaseModel):
+    """Model for layered memory metadata."""
+
+    working: LayerState = Field(default_factory=LayerState)
+    episodic: LayerState = Field(default_factory=LayerState)
+    semantic: LayerState = Field(default_factory=LayerState)
+    preference: LayerState = Field(default_factory=LayerState)
+    project: LayerState = Field(default_factory=LayerState)
 
 
 class MemoryResponse(BaseModel):
@@ -51,6 +70,7 @@ class MemoryResponse(BaseModel):
     user: UserContext = Field(default_factory=UserContext)
     history: HistoryContext = Field(default_factory=HistoryContext)
     facts: list[Fact] = Field(default_factory=list)
+    layers: LayerIndex = Field(default_factory=LayerIndex)
 
 
 class MemoryConfigResponse(BaseModel):
@@ -61,6 +81,8 @@ class MemoryConfigResponse(BaseModel):
     debounce_seconds: int = Field(..., description="Debounce time for memory updates")
     max_facts: int = Field(..., description="Maximum number of facts to store")
     fact_confidence_threshold: float = Field(..., description="Minimum confidence threshold for facts")
+    similarity_weight: float = Field(..., description="Weight applied to context similarity when ranking facts")
+    confidence_weight: float = Field(..., description="Weight applied to confidence when ranking facts")
     injection_enabled: bool = Field(..., description="Whether memory injection is enabled")
     max_injection_tokens: int = Field(..., description="Maximum tokens for memory injection")
 
@@ -164,12 +186,14 @@ async def get_memory_config_endpoint() -> MemoryConfigResponse:
     return MemoryConfigResponse(
         enabled=config.enabled,
         storage_path=config.storage_path,
-        debounce_seconds=config.debounce_seconds,
-        max_facts=config.max_facts,
-        fact_confidence_threshold=config.fact_confidence_threshold,
-        injection_enabled=config.injection_enabled,
-        max_injection_tokens=config.max_injection_tokens,
-    )
+            debounce_seconds=config.debounce_seconds,
+            max_facts=config.max_facts,
+            fact_confidence_threshold=config.fact_confidence_threshold,
+            similarity_weight=config.similarity_weight,
+            confidence_weight=config.confidence_weight,
+            injection_enabled=config.injection_enabled,
+            max_injection_tokens=config.max_injection_tokens,
+        )
 
 
 @router.get(
@@ -194,6 +218,8 @@ async def get_memory_status() -> MemoryStatusResponse:
             debounce_seconds=config.debounce_seconds,
             max_facts=config.max_facts,
             fact_confidence_threshold=config.fact_confidence_threshold,
+            similarity_weight=config.similarity_weight,
+            confidence_weight=config.confidence_weight,
             injection_enabled=config.injection_enabled,
             max_injection_tokens=config.max_injection_tokens,
         ),

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from langgraph.config import get_config
+
 from deerflow.config.agents_config import load_agent_soul
 from deerflow.skills import load_skills
 
@@ -335,11 +337,27 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 """
 
 
-def _get_memory_context(agent_name: str | None = None) -> str:
+def _get_runtime_memory_context() -> str | None:
+    """Read an optional current-context hint from the active runtime config."""
+    try:
+        config = get_config()
+    except Exception:
+        return None
+
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    memory_context = configurable.get("memory_context")
+    if isinstance(memory_context, str):
+        stripped = memory_context.strip()
+        return stripped or None
+    return None
+
+
+def _get_memory_context(agent_name: str | None = None, current_context: str | None = None) -> str:
     """Get memory context for injection into system prompt.
 
     Args:
         agent_name: If provided, loads per-agent memory. If None, loads global memory.
+        current_context: Optional caller-supplied context used to rank memory facts.
 
     Returns:
         Formatted memory context string wrapped in XML tags, or empty string if disabled.
@@ -352,8 +370,15 @@ def _get_memory_context(agent_name: str | None = None) -> str:
         if not config.enabled or not config.injection_enabled:
             return ""
 
+        context_hint = current_context if current_context is not None else _get_runtime_memory_context()
         memory_data = get_memory_data(agent_name)
-        memory_content = format_memory_for_injection(memory_data, max_tokens=config.max_injection_tokens)
+        memory_content = format_memory_for_injection(
+            memory_data,
+            max_tokens=config.max_injection_tokens,
+            current_context=context_hint,
+            similarity_weight=config.similarity_weight,
+            confidence_weight=config.confidence_weight,
+        )
 
         if not memory_content.strip():
             return ""
@@ -444,9 +469,16 @@ def get_deferred_tools_prompt_section() -> str:
     return f"<available-deferred-tools>\n{names}\n</available-deferred-tools>"
 
 
-def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagents: int = 3, *, agent_name: str | None = None, available_skills: set[str] | None = None) -> str:
+def apply_prompt_template(
+    subagent_enabled: bool = False,
+    max_concurrent_subagents: int = 3,
+    *,
+    agent_name: str | None = None,
+    available_skills: set[str] | None = None,
+    memory_context: str | None = None,
+) -> str:
     # Get memory context
-    memory_context = _get_memory_context(agent_name)
+    memory_context = _get_memory_context(agent_name, current_context=memory_context)
 
     # Include subagent section only if enabled (from runtime parameter)
     n = max_concurrent_subagents

--- a/backend/packages/harness/deerflow/agents/memory/__init__.py
+++ b/backend/packages/harness/deerflow/agents/memory/__init__.py
@@ -12,6 +12,14 @@ from deerflow.agents.memory.prompt import (
     format_conversation_for_update,
     format_memory_for_injection,
 )
+from deerflow.agents.memory.layers import (
+    classify_fact_layer,
+    create_empty_layer_index,
+    ensure_layer_index,
+    group_facts_by_layer,
+    layer_label,
+    layer_order_for_context,
+)
 from deerflow.agents.memory.queue import (
     ConversationContext,
     MemoryUpdateQueue,
@@ -31,6 +39,13 @@ __all__ = [
     "FACT_EXTRACTION_PROMPT",
     "format_memory_for_injection",
     "format_conversation_for_update",
+    # Layer helpers
+    "classify_fact_layer",
+    "create_empty_layer_index",
+    "ensure_layer_index",
+    "group_facts_by_layer",
+    "layer_label",
+    "layer_order_for_context",
     # Queue
     "ConversationContext",
     "MemoryUpdateQueue",

--- a/backend/packages/harness/deerflow/agents/memory/layers.py
+++ b/backend/packages/harness/deerflow/agents/memory/layers.py
@@ -1,0 +1,181 @@
+"""Helpers for DeerFlow layered memory organization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+LAYER_NAMES: tuple[str, ...] = ("working", "episodic", "semantic", "preference", "project")
+
+LAYER_LABELS: dict[str, str] = {
+    "working": "Working Memory",
+    "episodic": "Episodic Memory",
+    "semantic": "Semantic Memory",
+    "preference": "Preference Memory",
+    "project": "Project Memory",
+}
+
+_WORKING_HINTS = (
+    "current",
+    "now",
+    "today",
+    "this week",
+    "working on",
+    "task",
+    "todo",
+    "fix",
+    "debug",
+    "retry",
+    "retest",
+    "refactor",
+)
+_PROJECT_HINTS = (
+    "deerflow",
+    "deer-flow",
+    "repo",
+    "repository",
+    "project",
+    "architecture",
+    "workflow",
+    "memory",
+    "backend",
+    "frontend",
+    "test",
+    "build",
+)
+_PREFERENCE_HINTS = (
+    "prefer",
+    "preference",
+    "likes",
+    "liked",
+    "dislike",
+    "prefers",
+    "style",
+    "communication",
+    "concise",
+)
+
+
+def create_empty_layer_index() -> dict[str, dict[str, Any]]:
+    """Create an empty layer index for layered memory storage."""
+    return {layer: {"summary": "", "updatedAt": "", "factIds": []} for layer in LAYER_NAMES}
+
+
+def _normalize_layer_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip().lower()
+    return candidate if candidate in LAYER_NAMES else None
+
+
+def _fact_text(fact: dict[str, Any]) -> str:
+    content = fact.get("content")
+    if isinstance(content, str):
+        return content.strip()
+    return ""
+
+
+def classify_fact_layer(fact: dict[str, Any]) -> str:
+    """Classify a fact into one of the layered memory buckets."""
+    explicit_layer = _normalize_layer_name(fact.get("layer"))
+    if explicit_layer:
+        return explicit_layer
+
+    category = str(fact.get("category", "")).strip().lower()
+    content = _fact_text(fact).lower()
+    source_error = fact.get("sourceError")
+
+    if category == "correction" or (isinstance(source_error, str) and source_error.strip()):
+        return "working"
+    if category == "preference":
+        return "preference"
+    if category == "knowledge":
+        return "semantic"
+    if category == "goal":
+        return "project"
+    if category == "behavior":
+        return "working"
+
+    if any(hint in content for hint in _PREFERENCE_HINTS):
+        return "preference"
+    if any(hint in content for hint in _WORKING_HINTS):
+        return "working"
+    if any(hint in content for hint in _PROJECT_HINTS):
+        return "project"
+
+    return "episodic"
+
+
+def ensure_layer_index(memory_data: dict[str, Any]) -> dict[str, Any]:
+    """Ensure layered memory metadata exists and is synchronized with facts."""
+    if not isinstance(memory_data, dict):
+        return memory_data
+
+    existing_layers = memory_data.get("layers")
+    normalized_layers = create_empty_layer_index()
+    if isinstance(existing_layers, dict):
+        for layer_name, layer_data in existing_layers.items():
+            normalized_name = _normalize_layer_name(layer_name)
+            if not normalized_name or not isinstance(layer_data, dict):
+                continue
+            normalized_layers[normalized_name]["summary"] = str(layer_data.get("summary", "") or "")
+            normalized_layers[normalized_name]["updatedAt"] = str(layer_data.get("updatedAt", "") or "")
+
+    facts = memory_data.get("facts", [])
+    if isinstance(facts, list):
+        for fact in facts:
+            if not isinstance(fact, dict):
+                continue
+            layer_name = classify_fact_layer(fact)
+            fact["layer"] = layer_name
+            fact_id = fact.get("id")
+            if isinstance(fact_id, str) and fact_id:
+                normalized_layers[layer_name]["factIds"].append(fact_id)
+
+    memory_data["layers"] = normalized_layers
+    return memory_data
+
+
+def group_facts_by_layer(memory_data: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    """Collect facts by layer after normalizing the layer index."""
+    normalized = ensure_layer_index(memory_data)
+    grouped: dict[str, list[dict[str, Any]]] = {layer: [] for layer in LAYER_NAMES}
+
+    facts = normalized.get("facts", [])
+    if isinstance(facts, list):
+        for fact in facts:
+            if not isinstance(fact, dict):
+                continue
+            layer_name = _normalize_layer_name(fact.get("layer")) or classify_fact_layer(fact)
+            grouped.setdefault(layer_name, []).append(fact)
+
+    return grouped
+
+
+def layer_order_for_context(current_context: str | None) -> list[str]:
+    """Pick a layer traversal order based on the current context."""
+    context = (current_context or "").lower()
+    order = list(LAYER_NAMES)
+
+    preferred: list[str] = []
+    if any(hint in context for hint in _WORKING_HINTS):
+        preferred.append("working")
+    if any(hint in context for hint in _PROJECT_HINTS):
+        preferred.append("project")
+    if any(hint in context for hint in _PREFERENCE_HINTS):
+        preferred.append("preference")
+
+    if "history" in context or "recall" in context or "remember" in context:
+        preferred.append("episodic")
+
+    seen: set[str] = set()
+    result = []
+    for layer in preferred + order:
+        if layer in seen:
+            continue
+        seen.add(layer)
+        result.append(layer)
+    return result
+
+
+def layer_label(layer_name: str) -> str:
+    return LAYER_LABELS.get(layer_name, layer_name.title())

--- a/backend/packages/harness/deerflow/agents/memory/prompt.py
+++ b/backend/packages/harness/deerflow/agents/memory/prompt.py
@@ -2,7 +2,10 @@
 
 import math
 import re
+from collections import Counter
 from typing import Any
+
+from deerflow.agents.memory.layers import group_facts_by_layer, layer_label, layer_order_for_context, ensure_layer_index
 
 try:
     import tiktoken
@@ -10,6 +13,87 @@ try:
     TIKTOKEN_AVAILABLE = True
 except ImportError:
     TIKTOKEN_AVAILABLE = False
+
+_SIMILARITY_TOKEN_RE = re.compile(r"[A-Za-z0-9_]+(?:[-/][A-Za-z0-9_]+)*")
+_CJK_RANGE = ("\u4e00", "\u9fff")
+_STOPWORDS = {
+    "a",
+    "about",
+    "after",
+    "again",
+    "all",
+    "also",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "because",
+    "been",
+    "before",
+    "but",
+    "by",
+    "can",
+    "could",
+    "do",
+    "does",
+    "doing",
+    "for",
+    "from",
+    "had",
+    "has",
+    "have",
+    "he",
+    "her",
+    "his",
+    "how",
+    "i",
+    "if",
+    "in",
+    "into",
+    "is",
+    "it",
+    "its",
+    "me",
+    "more",
+    "my",
+    "no",
+    "not",
+    "of",
+    "on",
+    "or",
+    "our",
+    "she",
+    "so",
+    "such",
+    "that",
+    "the",
+    "their",
+    "them",
+    "then",
+    "there",
+    "these",
+    "they",
+    "this",
+    "to",
+    "too",
+    "up",
+    "us",
+    "was",
+    "we",
+    "were",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "with",
+    "would",
+    "you",
+    "your",
+}
 
 # Prompt template for updating memory based on conversation
 MEMORY_UPDATE_PROMPT = """You are a memory management system. Your task is to analyze a conversation and update the user's memory profile.
@@ -183,12 +267,176 @@ def _coerce_confidence(value: Any, default: float = 0.0) -> float:
     return max(0.0, min(1.0, confidence))
 
 
-def format_memory_for_injection(memory_data: dict[str, Any], max_tokens: int = 2000) -> str:
+def _normalize_text(value: Any) -> str:
+    """Normalize arbitrary content into a plain text string."""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        pieces: list[str] = []
+        for part in value:
+            if isinstance(part, str):
+                pieces.append(part)
+            elif isinstance(part, dict):
+                text_val = part.get("text")
+                if isinstance(text_val, str):
+                    pieces.append(text_val)
+                else:
+                    nested = part.get("content")
+                    if isinstance(nested, str):
+                        pieces.append(nested)
+        return " ".join(piece for piece in pieces if piece)
+    if isinstance(value, dict):
+        text_val = value.get("text")
+        if isinstance(text_val, str):
+            return text_val
+        nested = value.get("content")
+        if isinstance(nested, str):
+            return nested
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _tokenize_for_similarity(text: str) -> list[str]:
+    """Tokenize text for lightweight relevance scoring."""
+    if not text:
+        return []
+
+    tokens = [token for token in _SIMILARITY_TOKEN_RE.findall(text.lower()) if token not in _STOPWORDS and len(token) > 1]
+    if tokens:
+        return tokens
+
+    cjk_tokens = [char for char in text if _CJK_RANGE[0] <= char <= _CJK_RANGE[1]]
+    return [token for token in cjk_tokens if token.strip()]
+
+
+def _build_document_frequencies(memory_data: dict[str, Any]) -> tuple[Counter[str], int]:
+    """Build document frequencies across all stored memory text."""
+    documents: list[str] = []
+
+    user_data = memory_data.get("user", {})
+    if isinstance(user_data, dict):
+        for section in ("workContext", "personalContext", "topOfMind"):
+            section_data = user_data.get(section, {})
+            if isinstance(section_data, dict):
+                summary = section_data.get("summary", "")
+                if isinstance(summary, str) and summary.strip():
+                    documents.append(summary)
+
+    history_data = memory_data.get("history", {})
+    if isinstance(history_data, dict):
+        for section in ("recentMonths", "earlierContext", "longTermBackground"):
+            section_data = history_data.get(section, {})
+            if isinstance(section_data, dict):
+                summary = section_data.get("summary", "")
+                if isinstance(summary, str) and summary.strip():
+                    documents.append(summary)
+
+    facts_data = memory_data.get("facts", [])
+    if isinstance(facts_data, list):
+        for fact in facts_data:
+            if not isinstance(fact, dict):
+                continue
+            content = fact.get("content")
+            if isinstance(content, str) and content.strip():
+                documents.append(content)
+
+    doc_freq: Counter[str] = Counter()
+    for doc in documents:
+        terms = set(_tokenize_for_similarity(doc))
+        if not terms:
+            continue
+        doc_freq.update(terms)
+
+    return doc_freq, max(len(documents), 1)
+
+
+def _term_idf(term: str, doc_freq: Counter[str], total_docs: int) -> float:
+    """Compute a lightweight inverse document frequency for a term."""
+    return math.log((1.0 + total_docs) / (1.0 + doc_freq.get(term, 0))) + 1.0
+
+
+def _score_fact_for_context(
+    fact: dict[str, Any],
+    context_terms: set[str],
+    doc_freq: Counter[str],
+    total_docs: int,
+    similarity_weight: float,
+    confidence_weight: float,
+) -> float:
+    """Blend fact confidence with relevance to the supplied context."""
+    confidence = _coerce_confidence(fact.get("confidence"), default=0.0)
+    if not context_terms:
+        return confidence
+
+    content = fact.get("content")
+    if not isinstance(content, str) or not content.strip():
+        return confidence * confidence_weight
+
+    fact_terms = set(_tokenize_for_similarity(content))
+    if not fact_terms:
+        return confidence * confidence_weight
+
+    overlap = fact_terms & context_terms
+    if not overlap:
+        return confidence * confidence_weight
+
+    context_weight = sum(_term_idf(term, doc_freq, total_docs) for term in context_terms)
+    if context_weight <= 0:
+        similarity = 0.0
+    else:
+        overlap_weight = sum(_term_idf(term, doc_freq, total_docs) for term in overlap)
+        similarity = overlap_weight / context_weight
+
+    total_weight = similarity_weight + confidence_weight
+    if total_weight <= 0:
+        return confidence
+    return ((similarity * similarity_weight) + (confidence * confidence_weight)) / total_weight
+
+
+def _rank_facts_for_context(
+    facts: list[dict[str, Any]],
+    context_terms: set[str],
+    doc_freq: Counter[str],
+    total_docs: int,
+    similarity_weight: float,
+    confidence_weight: float,
+) -> list[dict[str, Any]]:
+    """Rank facts by a blended context score and stored confidence."""
+    return sorted(
+        facts,
+        key=lambda fact: (
+            _score_fact_for_context(
+                fact,
+                context_terms,
+                doc_freq,
+                total_docs,
+                similarity_weight,
+                confidence_weight,
+            ),
+            _coerce_confidence(fact.get("confidence"), default=0.0),
+            str(fact.get("content", "")).casefold(),
+        ),
+        reverse=True,
+    )
+
+
+def format_memory_for_injection(
+    memory_data: dict[str, Any],
+    max_tokens: int = 2000,
+    current_context: str | None = None,
+    similarity_weight: float = 0.35,
+    confidence_weight: float = 0.65,
+) -> str:
     """Format memory data for injection into system prompt.
 
     Args:
         memory_data: The memory data dictionary.
         max_tokens: Maximum tokens to use (counted via tiktoken for accuracy).
+        current_context: Optional current conversation context used to rank
+            facts by relevance instead of confidence alone.
+        similarity_weight: Weight used for context similarity when ranking facts.
+        confidence_weight: Weight used for stored fact confidence when ranking facts.
 
     Returns:
         Formatted memory string for system prompt injection.
@@ -196,6 +444,7 @@ def format_memory_for_injection(memory_data: dict[str, Any], max_tokens: int = 2
     if not memory_data:
         return ""
 
+    memory_data = ensure_layer_index(memory_data)
     sections = []
 
     # Format user context
@@ -234,54 +483,71 @@ def format_memory_for_injection(memory_data: dict[str, Any], max_tokens: int = 2
         if history_sections:
             sections.append("History:\n" + "\n".join(f"- {s}" for s in history_sections))
 
-    # Format facts (sorted by confidence; include as many as token budget allows)
+    # Format facts grouped by memory layer; include as many as token budget allows
     facts_data = memory_data.get("facts", [])
     if isinstance(facts_data, list) and facts_data:
-        ranked_facts = sorted(
-            (
-                f
-                for f in facts_data
-                if isinstance(f, dict)
-                and isinstance(f.get("content"), str)
-                and f.get("content").strip()
-            ),
-            key=lambda fact: _coerce_confidence(fact.get("confidence"), default=0.0),
-            reverse=True,
-        )
+        context_text = _normalize_text(current_context).strip()
+        context_terms = set(_tokenize_for_similarity(context_text))
+        doc_freq, total_docs = _build_document_frequencies(memory_data)
+        grouped_facts = group_facts_by_layer(memory_data)
+        preferred_layers = layer_order_for_context(context_text)
+        preferred_index = {layer: idx for idx, layer in enumerate(preferred_layers)}
 
-        # Compute token count for existing sections once, then account
-        # incrementally for each fact line to avoid full-string re-tokenization.
-        base_text = "\n\n".join(sections)
-        base_tokens = _count_tokens(base_text) if base_text else 0
-        # Account for the separator between existing sections and the facts section.
-        facts_header = "Facts:\n"
-        separator_tokens = _count_tokens("\n\n" + facts_header) if base_text else _count_tokens(facts_header)
-        running_tokens = base_tokens + separator_tokens
-
-        fact_lines: list[str] = []
-        for fact in ranked_facts:
-            content_value = fact.get("content")
-            if not isinstance(content_value, str):
+        layer_candidates: list[tuple[float, str, list[dict[str, Any]]]] = []
+        for layer_name in preferred_layers:
+            layer_facts = grouped_facts.get(layer_name, [])
+            if not layer_facts:
                 continue
-            content = content_value.strip()
-            if not content:
-                continue
-            category = str(fact.get("category", "context")).strip() or "context"
-            confidence = _coerce_confidence(fact.get("confidence"), default=0.0)
-            line = f"- [{category} | {confidence:.2f}] {content}"
+            ranked_layer_facts = _rank_facts_for_context(
+                layer_facts,
+                context_terms,
+                doc_freq,
+                total_docs,
+                similarity_weight,
+                confidence_weight,
+            )
+            top_score = _score_fact_for_context(
+                ranked_layer_facts[0],
+                context_terms,
+                doc_freq,
+                total_docs,
+                similarity_weight,
+                confidence_weight,
+            )
+            layer_candidates.append((top_score, layer_name, ranked_layer_facts))
 
-            # Each additional line is preceded by a newline (except the first).
-            line_text = ("\n" + line) if fact_lines else line
-            line_tokens = _count_tokens(line_text)
+        layer_candidates.sort(key=lambda item: (-item[0], preferred_index.get(item[1], len(preferred_layers))))
 
-            if running_tokens + line_tokens <= max_tokens:
-                fact_lines.append(line)
-                running_tokens += line_tokens
-            else:
-                break
+        layer_blocks: list[str] = []
+        for _layer_score, layer_name, ranked_layer_facts in layer_candidates:
+            block_text = f"- {layer_label(layer_name)}:"
+            block_updated = False
 
-        if fact_lines:
-            sections.append("Facts:\n" + "\n".join(fact_lines))
+            for fact in ranked_layer_facts:
+                content_value = fact.get("content")
+                if not isinstance(content_value, str):
+                    continue
+                content = content_value.strip()
+                if not content:
+                    continue
+                category = str(fact.get("category", "context")).strip() or "context"
+                confidence = _coerce_confidence(fact.get("confidence"), default=0.0)
+                line = f"  - [{category} | {confidence:.2f}] {content}"
+                candidate_block = f"{block_text}\n{line}"
+                candidate_sections = sections + ["Layered Memory:\n" + "\n".join(layer_blocks + [candidate_block])]
+                candidate_result = "\n\n".join(candidate_sections)
+
+                if _count_tokens(candidate_result) <= max_tokens:
+                    block_text = candidate_block
+                    block_updated = True
+                else:
+                    break
+
+            if block_updated:
+                layer_blocks.append(block_text)
+
+        if layer_blocks:
+            sections.append("Layered Memory:\n" + "\n".join(layer_blocks))
 
     if not sections:
         return ""

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -12,6 +12,7 @@ from deerflow.agents.memory.prompt import (
     MEMORY_UPDATE_PROMPT,
     format_conversation_for_update,
 )
+from deerflow.agents.memory.layers import classify_fact_layer, create_empty_layer_index, ensure_layer_index
 from deerflow.config.memory_config import get_memory_config
 from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
@@ -56,6 +57,7 @@ def _create_empty_memory() -> dict[str, Any]:
             "longTermBackground": {"summary": "", "updatedAt": ""},
         },
         "facts": [],
+        "layers": create_empty_layer_index(),
     }
 
 
@@ -170,7 +172,9 @@ def _load_memory_from_file(agent_name: str | None = None) -> dict[str, Any]:
     try:
         with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
-        return data
+        if not isinstance(data, dict):
+            return _create_empty_memory()
+        return ensure_layer_index(data)
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load memory file: %s", e)
         return _create_empty_memory()
@@ -210,6 +214,7 @@ def _strip_upload_mentions_from_memory(memory_data: dict[str, Any]) -> dict[str,
     if facts:
         memory_data["facts"] = [f for f in facts if not _UPLOAD_SENTENCE_RE.search(f.get("content", ""))]
 
+    ensure_layer_index(memory_data)
     return memory_data
 
 
@@ -235,6 +240,7 @@ def _save_memory_to_file(memory_data: dict[str, Any], agent_name: str | None = N
     file_path = _get_memory_file_path(agent_name)
 
     try:
+        memory_data = ensure_layer_index(memory_data)
         # Ensure directory exists
         file_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -365,6 +371,7 @@ class MemoryUpdater:
         """
         config = get_memory_config()
         now = datetime.utcnow().isoformat() + "Z"
+        current_memory = ensure_layer_index(current_memory)
 
         # Update user sections
         user_updates = update_data.get("user", {})
@@ -410,6 +417,7 @@ class MemoryUpdater:
                 if fact_key is not None and fact_key in existing_fact_keys:
                     continue
 
+                layer_name = classify_fact_layer(fact)
                 fact_entry = {
                     "id": f"fact_{uuid.uuid4().hex[:8]}",
                     "content": normalized_content,
@@ -417,6 +425,7 @@ class MemoryUpdater:
                     "confidence": confidence,
                     "createdAt": now,
                     "source": thread_id or "unknown",
+                    "layer": layer_name,
                 }
                 current_memory["facts"].append(fact_entry)
                 if fact_key is not None:
@@ -431,6 +440,7 @@ class MemoryUpdater:
                 reverse=True,
             )[: config.max_facts]
 
+        ensure_layer_index(current_memory)
         return current_memory
 
 

--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -45,6 +45,18 @@ class MemoryConfig(BaseModel):
         le=1.0,
         description="Minimum confidence threshold for storing facts",
     )
+    similarity_weight: float = Field(
+        default=0.35,
+        ge=0.0,
+        le=1.0,
+        description="Weight applied to context similarity when ranking memory facts",
+    )
+    confidence_weight: float = Field(
+        default=0.65,
+        ge=0.0,
+        le=1.0,
+        description="Weight applied to fact confidence when ranking memory facts",
+    )
     injection_enabled: bool = Field(
         default=True,
         description="Whether to inject memory into system prompt",

--- a/backend/tests/test_lead_agent_memory_context.py
+++ b/backend/tests/test_lead_agent_memory_context.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from deerflow.agents.lead_agent.prompt import _get_memory_context
+from deerflow.config.memory_config import MemoryConfig
+
+
+def test_get_memory_context_uses_runtime_memory_context() -> None:
+    with (
+        patch("deerflow.agents.lead_agent.prompt.get_config", return_value={"configurable": {"memory_context": "DeerFlow retrieval"}}),
+        patch("deerflow.config.memory_config.get_memory_config", return_value=MemoryConfig()),
+        patch("deerflow.agents.memory.get_memory_data", return_value={"facts": []}),
+        patch("deerflow.agents.memory.format_memory_for_injection", return_value="Facts:\n- [context | 0.90] DeerFlow retrieval works"),
+    ):
+        result = _get_memory_context(agent_name=None)
+
+    assert "<memory>" in result
+    assert "DeerFlow retrieval works" in result
+
+
+def test_get_memory_context_forwards_explicit_context_hint() -> None:
+    with (
+        patch("deerflow.agents.lead_agent.prompt.get_config", return_value={}),
+        patch("deerflow.config.memory_config.get_memory_config", return_value=MemoryConfig()),
+        patch("deerflow.agents.memory.get_memory_data", return_value={"facts": []}),
+        patch("deerflow.agents.memory.format_memory_for_injection", return_value="Facts:\n- [context | 0.90] explicit hint") as mock_format,
+    ):
+        _get_memory_context(agent_name=None, current_context="explicit hint")
+
+    assert mock_format.call_args.kwargs["current_context"] == "explicit hint"

--- a/backend/tests/test_memory_prompt_injection.py
+++ b/backend/tests/test_memory_prompt_injection.py
@@ -17,7 +17,9 @@ def test_format_memory_includes_facts_section() -> None:
 
     result = format_memory_for_injection(memory_data, max_tokens=2000)
 
-    assert "Facts:" in result
+    assert "Layered Memory:" in result
+    assert "Semantic Memory:" in result
+    assert "Preference Memory:" in result
     assert "User uses PostgreSQL" in result
     assert "User prefers SQLAlchemy" in result
 
@@ -27,14 +29,36 @@ def test_format_memory_sorts_facts_by_confidence_desc() -> None:
         "user": {},
         "history": {},
         "facts": [
-            {"content": "Low confidence fact", "category": "context", "confidence": 0.4},
+            {"content": "Low confidence fact", "category": "knowledge", "confidence": 0.4},
             {"content": "High confidence fact", "category": "knowledge", "confidence": 0.95},
         ],
     }
 
     result = format_memory_for_injection(memory_data, max_tokens=2000)
 
+    assert "Layered Memory:" in result
     assert result.index("High confidence fact") < result.index("Low confidence fact")
+
+
+def test_format_memory_prefers_context_relevant_facts_when_context_is_provided() -> None:
+    memory_data = {
+        "user": {},
+        "history": {},
+        "facts": [
+            {"content": "User likes photography", "category": "preference", "confidence": 0.98},
+            {"content": "User is working on DeerFlow memory architecture", "category": "context", "confidence": 0.82},
+            {"content": "User prefers concise reviews", "category": "preference", "confidence": 0.9},
+        ],
+    }
+
+    result = format_memory_for_injection(
+        memory_data,
+        max_tokens=2000,
+        current_context="Let's improve the DeerFlow memory architecture and retrieval flow.",
+    )
+
+    assert "Layered Memory:" in result
+    assert result.index("User is working on DeerFlow memory architecture") < result.index("User likes photography")
 
 
 def test_format_memory_respects_budget_when_adding_facts(monkeypatch) -> None:
@@ -119,4 +143,3 @@ def test_format_memory_skips_non_string_content_facts() -> None:
     # The formatted line for a list content would be "- [knowledge | 0.85] ['list']".
     assert "| 0.85]" not in result
     assert "Valid fact" in result
-

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -92,6 +92,8 @@ def test_apply_updates_skips_same_batch_duplicates_and_keeps_source_metadata() -
     ]
     assert all(fact["id"].startswith("fact_") for fact in result["facts"])
     assert all(fact["source"] == "thread-42" for fact in result["facts"])
+    assert result["facts"][0]["layer"] == "preference"
+    assert result["facts"][1]["layer"] == "project"
 
 
 def test_apply_updates_preserves_threshold_and_max_facts_trimming() -> None:
@@ -136,6 +138,29 @@ def test_apply_updates_preserves_threshold_and_max_facts_trimming() -> None:
     ]
     assert all(fact["content"] != "User likes noisy logs" for fact in result["facts"])
     assert result["facts"][1]["source"] == "thread-9"
+    assert result["facts"][0]["layer"] == "preference"
+    assert result["facts"][1]["layer"] in {"project", "episodic", "semantic", "working"}
+
+
+def test_apply_updates_rebuilds_layer_index_from_new_facts() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory()
+    update_data = {
+        "newFacts": [
+            {"content": "User prefers dark mode", "category": "preference", "confidence": 0.95},
+            {"content": "User is debugging DeerFlow memory", "category": "context", "confidence": 0.88},
+        ]
+    }
+
+    with patch(
+        "deerflow.agents.memory.updater.get_memory_config",
+        return_value=_memory_config(max_facts=100, fact_confidence_threshold=0.7),
+    ):
+        result = updater._apply_updates(current_memory, update_data, thread_id="thread-layer")
+
+    assert result["layers"]["preference"]["factIds"]
+    assert result["layers"]["working"]["factIds"] or result["layers"]["project"]["factIds"] or result["layers"]["episodic"]["factIds"]
+    assert all(fact["layer"] in result["layers"] for fact in result["facts"])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_memory_upload_filtering.py
+++ b/backend/tests/test_memory_upload_filtering.py
@@ -211,4 +211,7 @@ class TestStripUploadMentionsFromMemory:
     def test_empty_memory_handled_gracefully(self):
         mem = {"user": {}, "history": {}, "facts": []}
         result = _strip_upload_mentions_from_memory(mem)
-        assert result == {"user": {}, "history": {}, "facts": []}
+        assert result["user"] == {}
+        assert result["history"] == {}
+        assert result["facts"] == []
+        assert "layers" in result


### PR DESCRIPTION
## Summary

This PR upgrades DeerFlow's memory pipeline from a flat fact list into a layered memory architecture.

## What changed

- add layered memory buckets for working, episodic, semantic, preference, and project memory
- classify and normalize facts into layers during memory load, update, and cleanup flows
- make prompt injection group memory by layer and rerank facts using the current runtime context
- expose layer metadata through the memory API
- add coverage for context-aware injection, layered updates, upload filtering, and runtime memory context forwarding

## Validation

- `uv run --directory D:\deer-flow-git\backend python -m pytest tests/test_memory_prompt_injection.py tests/test_memory_updater.py tests/test_lead_agent_memory_context.py tests/test_memory_upload_filtering.py tests/test_channels.py -q`
