### PR TITLE
fix(backend): preserve viewed image reducer metadata

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py
@@ -1,22 +1,19 @@
 """Middleware for injecting image details into conversation before LLM call."""
 
 import logging
-from typing import NotRequired, override
+from typing import override
 
-from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 
-from deerflow.agents.thread_state import ViewedImageData
+from deerflow.agents.thread_state import ThreadState
 
 logger = logging.getLogger(__name__)
 
 
-class ViewImageMiddlewareState(AgentState):
-    """Compatible with the `ThreadState` schema."""
-
-    viewed_images: NotRequired[dict[str, ViewedImageData] | None]
+class ViewImageMiddlewareState(ThreadState):
+    """Reuse the thread state so reducer-backed keys keep their annotations."""
 
 
 class ViewImageMiddleware(AgentMiddleware[ViewImageMiddlewareState]):

--- a/backend/tests/test_create_deerflow_agent.py
+++ b/backend/tests/test_create_deerflow_agent.py
@@ -1,11 +1,14 @@
 """Tests for create_deerflow_agent SDK entry point."""
 
+from typing import get_type_hints
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from deerflow.agents.factory import create_deerflow_agent
 from deerflow.agents.features import Next, Prev, RuntimeFeatures
+from deerflow.agents.middlewares.view_image_middleware import ViewImageMiddleware
+from deerflow.agents.thread_state import ThreadState
 
 
 def _make_mock_model():
@@ -125,6 +128,13 @@ def test_vision_injects_view_image_tool(mock_create_agent):
     call_kwargs = mock_create_agent.call_args[1]
     tool_names = [t.name for t in call_kwargs["tools"]]
     assert "view_image" in tool_names
+
+
+def test_view_image_middleware_preserves_viewed_images_reducer():
+    middleware_hints = get_type_hints(ViewImageMiddleware.state_schema, include_extras=True)
+    thread_hints = get_type_hints(ThreadState, include_extras=True)
+
+    assert middleware_hints["viewed_images"] == thread_hints["viewed_images"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary
Fix concurrent `viewed_images` state updates for multi-image input by preserving the reducer metadata in the vision middleware state schema.

Problem
When multiple images are processed in the same LangGraph step:

`viewed_images` may receive more than one update in a single step
LangGraph rejects the update with `InvalidUpdateError` ❌
Multi-image input fails before the model can consume the images ❌
<img width="1342" height="690" alt="image" src="https://github.com/user-attachments/assets/daed9c03-c90a-4216-9865-c9adefe652ee" />

Error:
`At key 'viewed_images': Can receive only one value per step. Use an Annotated key to handle multiple values.`

Root cause: `ThreadState.viewed_images` already used an `Annotated` reducer, but `ViewImageMiddlewareState` re-declared `viewed_images` without that reducer metadata. As a result, the composed graph state lost the merge behavior LangGraph requires for concurrent updates.

Fix
Make the vision middleware state reuse the shared `ThreadState` schema instead of redefining `viewed_images`.

This preserves the existing reducer annotation for `viewed_images`, so multiple image updates in the same step are merged correctly rather than rejected as conflicting writes.

Changes (2 files, small targeted fix)
backend/packages/harness/deerflow/agents/middlewares/view_image_middleware.py:

Change `ViewImageMiddlewareState` to inherit from `ThreadState`
Remove the local `viewed_images` field redeclaration that dropped reducer metadata

backend/tests/test_create_deerflow_agent.py:

Add a regression test to verify the middleware state schema preserves the same `viewed_images` annotation as `ThreadState`

Behavior after fix
When multiple images are provided in the same step:

`viewed_images` updates are merged correctly
The middleware can pass multiple viewed images through to the model ✅
The previous `InvalidUpdateError` is avoided ✅

Testing
Verified with:
- `uv run pytest tests/test_create_deerflow_agent.py`
- `make lint`

Results:
- `44 passed`
- lint checks passed successfully
<img width="726" height="348" alt="image" src="https://github.com/user-attachments/assets/4260ee01-b64f-4fc0-8452-cbe6e7850074" />
