### PR TITLE
Add Railway gateway-mode backend deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -59,7 +59,6 @@ tests/
 scripts/
 logs/
 docker/
-skills/
 frontend/.next
 frontend/node_modules
 backend/.venv

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ DeerFlow has newly integrated the intelligent search and crawling toolset indepe
     - [Configuration](#configuration)
     - [Running the Application](#running-the-application)
       - [Option 1: Docker (Recommended)](#option-1-docker-recommended)
-      - [Option 2: Local Development](#option-2-local-development)
+      - [Option 2: Railway Backend Deployment](#option-2-railway-backend-deployment)
+      - [Option 3: Local Development](#option-3-local-development)
     - [Advanced](#advanced)
       - [Sandbox Mode](#sandbox-mode)
       - [MCP Server](#mcp-server)
@@ -243,7 +244,50 @@ Access: http://localhost:2026
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed Docker development guide.
 
-#### Option 2: Local Development
+#### Option 2: Railway Backend Deployment
+
+Railway v1 deployment keeps DeerFlow in **gateway mode** with **no DeerFlow frontend** and **no separate LangGraph service**:
+
+- `deerflow-gateway` is a **private** FastAPI gateway service built from [`railway/gateway.Dockerfile`](railway/gateway.Dockerfile)
+- `deerflow-api` is a **public** nginx proxy built from [`railway/nginx.Dockerfile`](railway/nginx.Dockerfile)
+- nginx preserves the DeerFlow API contract, including `/api/langgraph/*`, while returning a deliberate backend-only response for `/`
+- persistent runtime state lives under `DEER_FLOW_HOME` on a Railway volume
+
+The gateway bootstrap path is [`backend/app/gateway/railway_runtime.py`](backend/app/gateway/railway_runtime.py). On startup it:
+
+- renders [`railway/templates/config.railway.template.yaml`](railway/templates/config.railway.template.yaml) to the runtime `config.yaml`
+- seeds [`railway/templates/extensions_config.railway.template.json`](railway/templates/extensions_config.railway.template.json) into `DEER_FLOW_HOME` only when the volume copy is missing
+- decodes `CODEX_AUTH_JSON_B64` into a runtime-only `CODEX_AUTH_PATH`
+
+Recommended Railway variables for the gateway service:
+
+```bash
+PORT=8001
+DEER_FLOW_PRIMARY_MODEL=codex
+DEER_FLOW_ALLOW_HOST_BASH=true
+GATEWAY_WORKERS=1
+CODEX_AUTH_JSON_B64=<base64-encoded ~/.codex/auth.json>
+OPENAI_API_KEY=<optional fallback>
+GEMINI_API_KEY=<optional fallback>
+```
+
+Recommended Railway variable for the public `deerflow-api` service:
+
+```bash
+GATEWAY_UPSTREAM=${{deerflow-gateway.RAILWAY_PRIVATE_DOMAIN}}:${{deerflow-gateway.PORT}}
+```
+
+`PORT=8001` must be set as a **Railway service variable** on `deerflow-gateway`, not just relied on as a runtime default. Railway private networking expressions resolve `${{deerflow-gateway.PORT}}` from the service variable set, and the public nginx proxy depends on that value when routing to the private gateway.
+
+Railway v1 intentionally stays single-process:
+
+- `gateway replicas = 1`
+- `gateway workers = 1`
+- `checkpointer/store = sqlite`
+
+Do not scale workers or replicas while the runtime still uses the in-memory run registry and memory-backed stream bridge. Move persistence to Postgres before scaling out.
+
+#### Option 3: Local Development
 
 If you prefer running services locally:
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -16,6 +16,7 @@ DeerFlow is a LangGraph-based AI super agent system with a full-stack architectu
 **Runtime Modes**:
 - **Standard mode** (`make dev`): LangGraph Server handles agent execution as a separate process. 4 processes total.
 - **Gateway mode** (`make dev-pro`, experimental): Agent runtime embedded in Gateway via `RunManager` + `run_agent()` + `StreamBridge` (`packages/harness/deerflow/runtime/`). Service manages its own concurrency via async tasks. 3 processes total, no LangGraph Server.
+- **Railway backend mode**: Production-only gateway-mode deployment with a private FastAPI gateway plus a public Railway-specific nginx proxy. No DeerFlow frontend and no standalone LangGraph service.
 
 **Project Structure**:
 ```
@@ -61,6 +62,7 @@ deer-flow/
 │   ├── tests/                 # Test suite
 │   └── docs/                  # Documentation
 ├── frontend/                   # Next.js frontend application
+├── railway/                    # Railway deployment assets (Dockerfiles, bootstrap scripts, nginx/config templates)
 └── skills/                     # Agent skills directory
     ├── public/                # Public skills (committed)
     └── custom/                # Custom skills (gitignored)
@@ -98,6 +100,36 @@ make test       # Run all backend tests
 make lint       # Lint with ruff
 make format     # Format code with ruff
 ```
+
+## Railway Backend v1
+
+Railway deployment keeps DeerFlow in gateway mode and splits the backend into two services:
+
+- `deerflow-gateway`: private FastAPI runtime using [`railway/gateway.Dockerfile`](../railway/gateway.Dockerfile)
+- `deerflow-api`: public nginx proxy using [`railway/nginx.Dockerfile`](../railway/nginx.Dockerfile)
+
+Key deployment rules:
+
+- Do not reuse the stock nginx config. Use [`railway/templates/nginx.railway.conf.template`](../railway/templates/nginx.railway.conf.template), which removes the frontend upstream and keeps only backend routes.
+- Keep `gateway replicas = 1` and `GATEWAY_WORKERS = 1` while the run registry and stream bridge remain in-memory.
+- Keep `checkpointer/store = sqlite` in v1. Move to Postgres before increasing workers or replicas.
+- Mount `DEER_FLOW_HOME` on a Railway volume so memory, thread data, uploads, outputs, ACP workspace, and SQLite-backed runtime state persist across restarts.
+- Bake repo-root `skills/` into the gateway image. Do not rely on Docker bind mounts in Railway.
+- Set `PORT=8001` on `deerflow-gateway` as an explicit Railway service variable so `${{deerflow-gateway.PORT}}` resolves correctly for the public nginx proxy's `GATEWAY_UPSTREAM`.
+
+Gateway bootstrap is handled by [`app/gateway/railway_runtime.py`](app/gateway/railway_runtime.py):
+
+- renders the tracked Railway config template into the runtime `config.yaml`
+- copies the tracked `extensions_config.json` template into `DEER_FLOW_HOME` only if the persistent copy is missing
+- decodes `CODEX_AUTH_JSON_B64` into a runtime-only `CODEX_AUTH_PATH`
+- reorders configured models so the selected primary provider stays first while preserving fallback order
+
+Model/provider expectations for Railway v1:
+
+- Primary model: Codex (`gpt-5.4`) via `CODEX_AUTH_JSON_B64`
+- Fallback order: OpenAI API key, then Gemini API key
+- `DEER_FLOW_PRIMARY_MODEL` chooses which provider is first in the rendered config
+- `DEER_FLOW_ALLOW_HOST_BASH` defaults to `true` for the Railway bootstrap path
 
 Regression tests related to Docker/provisioner behavior:
 - `tests/test_docker_sandbox_mode_detection.py` (mode detection from `config.yaml`)

--- a/backend/app/gateway/railway_runtime.py
+++ b/backend/app/gateway/railway_runtime.py
@@ -1,0 +1,208 @@
+"""Railway runtime bootstrap helpers for the gateway service.
+
+This module prepares the DeerFlow gateway runtime before uvicorn starts:
+
+- render a tracked Railway config template to a concrete config.yaml
+- seed a mutable extensions_config.json into DEER_FLOW_HOME only once
+- decode Codex CLI auth into a runtime-only file when provided
+
+The helpers are importable so backend tests can validate the bootstrap rules
+without shelling out to Railway.
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+PRIMARY_MODEL_ALIASES = {
+    "codex": "codex",
+    "gpt-5.4": "codex",
+    "openai": "openai",
+    "gpt-5": "openai",
+    "gemini": "gemini",
+    "gemini-2.5-pro": "gemini",
+}
+
+MODEL_NAMES = {
+    "codex": "gpt-5.4",
+    "openai": "gpt-5",
+    "gemini": "gemini-2.5-pro",
+}
+
+
+def repo_root() -> Path:
+    """Return the DeerFlow repository root."""
+    return Path(__file__).resolve().parents[3]
+
+
+def templates_dir() -> Path:
+    """Return the Railway templates directory."""
+    return repo_root() / "railway" / "templates"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected YAML object at {path}, got {type(data).__name__}")
+    return data
+
+
+def _resolve_primary_model(raw: str | None) -> str:
+    normalized = (raw or "codex").strip().lower()
+    primary = PRIMARY_MODEL_ALIASES.get(normalized)
+    if primary is None:
+        supported = ", ".join(sorted(PRIMARY_MODEL_ALIASES))
+        raise ValueError(f"Unsupported DEER_FLOW_PRIMARY_MODEL={raw!r}. Supported values: {supported}")
+    return primary
+
+
+def _parse_bool(raw: str | None, *, default: bool) -> bool:
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _decode_codex_auth(env: dict[str, str]) -> str | None:
+    if raw := env.get("CODEX_AUTH_JSON"):
+        json.loads(raw)
+        return raw
+
+    encoded = env.get("CODEX_AUTH_JSON_B64")
+    if not encoded:
+        return None
+
+    decoded = base64.b64decode(encoded.encode("utf-8")).decode("utf-8")
+    json.loads(decoded)
+    return decoded
+
+
+def _filter_and_reorder_models(template_models: list[dict[str, Any]], env: dict[str, str], primary: str) -> list[dict[str, Any]]:
+    codex_auth = _decode_codex_auth(env)
+    available: list[dict[str, Any]] = []
+    for model in template_models:
+        name = model.get("name")
+        if name == MODEL_NAMES["codex"]:
+            if codex_auth:
+                available.append(copy.deepcopy(model))
+            continue
+        if name == MODEL_NAMES["openai"]:
+            if env.get("OPENAI_API_KEY"):
+                available.append(copy.deepcopy(model))
+            continue
+        if name == MODEL_NAMES["gemini"]:
+            if env.get("GEMINI_API_KEY"):
+                available.append(copy.deepcopy(model))
+            continue
+        available.append(copy.deepcopy(model))
+
+    wanted_name = MODEL_NAMES[primary]
+    if not any(model.get("name") == wanted_name for model in available):
+        if primary == "codex":
+            raise ValueError("Primary model 'codex' selected but CODEX_AUTH_JSON_B64/CODEX_AUTH_JSON is missing.")
+        if primary == "openai":
+            raise ValueError("Primary model 'openai' selected but OPENAI_API_KEY is missing.")
+        raise ValueError("Primary model 'gemini' selected but GEMINI_API_KEY is missing.")
+
+    primary_model = next(model for model in available if model.get("name") == wanted_name)
+    fallbacks = [model for model in available if model.get("name") != wanted_name]
+    return [primary_model, *fallbacks]
+
+
+def prepare_gateway_runtime(
+    *,
+    deer_flow_home: Path,
+    config_output_path: Path,
+    extensions_output_path: Path,
+    codex_auth_output_path: Path,
+    config_template_path: Path | None = None,
+    extensions_template_path: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Prepare the runtime files used by the Railway gateway service."""
+    resolved_env = dict(os.environ if env is None else env)
+    primary = _resolve_primary_model(resolved_env.get("DEER_FLOW_PRIMARY_MODEL"))
+
+    config_template = config_template_path or (templates_dir() / "config.railway.template.yaml")
+    extensions_template = extensions_template_path or (templates_dir() / "extensions_config.railway.template.json")
+
+    config_output_path.parent.mkdir(parents=True, exist_ok=True)
+    extensions_output_path.parent.mkdir(parents=True, exist_ok=True)
+    codex_auth_output_path.parent.mkdir(parents=True, exist_ok=True)
+    deer_flow_home.mkdir(parents=True, exist_ok=True)
+
+    config_data = _load_yaml(config_template)
+    template_models = config_data.get("models", [])
+    if not isinstance(template_models, list):
+        raise ValueError(f"Expected 'models' list in {config_template}")
+
+    config_data["models"] = _filter_and_reorder_models(template_models, resolved_env, primary)
+    config_data.setdefault("sandbox", {})["allow_host_bash"] = _parse_bool(
+        resolved_env.get("DEER_FLOW_ALLOW_HOST_BASH"),
+        default=True,
+    )
+
+    config_output_path.write_text(
+        yaml.safe_dump(config_data, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    if not extensions_output_path.exists():
+        extensions_output_path.write_text(extensions_template.read_text(encoding="utf-8"), encoding="utf-8")
+
+    codex_auth = _decode_codex_auth(resolved_env)
+    if codex_auth is not None:
+        codex_auth_output_path.write_text(codex_auth, encoding="utf-8")
+        codex_auth_output_path.chmod(0o600)
+    elif codex_auth_output_path.exists():
+        codex_auth_output_path.unlink()
+
+    logger.info(
+        "Prepared Railway runtime: config=%s extensions=%s primary_model=%s codex_auth=%s",
+        config_output_path,
+        extensions_output_path,
+        MODEL_NAMES[primary],
+        "present" if codex_auth is not None else "absent",
+    )
+
+    return {
+        "primary_model": MODEL_NAMES[primary],
+        "config_path": str(config_output_path),
+        "extensions_path": str(extensions_output_path),
+        "codex_auth_path": str(codex_auth_output_path),
+    }
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    deer_flow_home = Path(os.environ.get("DEER_FLOW_HOME") or os.environ.get("RAILWAY_VOLUME_MOUNT_PATH") or "/data/deerflow")
+    runtime_dir = Path(os.environ.get("DEER_FLOW_RUNTIME_DIR", "/tmp/deerflow-runtime"))
+    config_path = Path(os.environ.get("DEER_FLOW_CONFIG_PATH", str(runtime_dir / "config.yaml")))
+    extensions_path = Path(os.environ.get("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(deer_flow_home / "extensions_config.json")))
+    codex_auth_path = Path(os.environ.get("CODEX_AUTH_PATH", str(runtime_dir / "codex-auth.json")))
+
+    result = prepare_gateway_runtime(
+        deer_flow_home=deer_flow_home,
+        config_output_path=config_path,
+        extensions_output_path=extensions_path,
+        codex_auth_output_path=codex_auth_path,
+    )
+    logger.info("Railway gateway runtime ready with primary model %s", result["primary_model"])
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -61,6 +61,7 @@ models:
 
 **Auth behavior for CLI-backed providers**:
 - `CodexChatModel` loads Codex CLI auth from `~/.codex/auth.json`
+- Set `CODEX_AUTH_PATH` to point at a different credential file when the auth payload is injected at runtime (for example, a Railway bootstrap step that decodes a secret into `/tmp/codex-auth.json`)
 - The Codex Responses endpoint currently rejects `max_tokens` and `max_output_tokens`, so `CodexChatModel` does not expose a request-level token cap
 - `ClaudeChatModel` accepts `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR`, `CLAUDE_CODE_CREDENTIALS_PATH`, or plaintext `~/.claude/.credentials.json`
 - On macOS, DeerFlow does not probe Keychain automatically. Use `scripts/export_claude_code_oauth.py` to export Claude Code auth explicitly when needed

--- a/backend/tests/test_railway_runtime.py
+++ b/backend/tests/test_railway_runtime.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+
+import yaml
+
+from app.gateway.railway_runtime import prepare_gateway_runtime
+
+
+def _write_template_files(tmp_path: Path) -> tuple[Path, Path]:
+    config_template = tmp_path / "config.template.yaml"
+    config_template.write_text(
+        yaml.safe_dump(
+            {
+                "models": [
+                    {"name": "gpt-5.4", "use": "deerflow.models.openai_codex_provider:CodexChatModel", "model": "gpt-5.4"},
+                    {"name": "gpt-5", "use": "langchain_openai:ChatOpenAI", "model": "gpt-5", "api_key": "$OPENAI_API_KEY"},
+                    {"name": "gemini-2.5-pro", "use": "langchain_google_genai:ChatGoogleGenerativeAI", "model": "gemini-2.5-pro", "gemini_api_key": "$GEMINI_API_KEY"},
+                ],
+                "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider", "allow_host_bash": False},
+                "checkpointer": {"type": "sqlite", "connection_string": "checkpoints.db"},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    extensions_template = tmp_path / "extensions.template.json"
+    extensions_template.write_text('{"mcpServers":{},"skills":{}}', encoding="utf-8")
+    return config_template, extensions_template
+
+
+def test_prepare_gateway_runtime_codex_primary_with_fallbacks(tmp_path: Path) -> None:
+    config_template, extensions_template = _write_template_files(tmp_path)
+    home = tmp_path / "home"
+    config_path = tmp_path / "runtime" / "config.yaml"
+    extensions_path = home / "extensions_config.json"
+    codex_auth_path = tmp_path / "runtime" / "codex-auth.json"
+    auth_payload = {"tokens": {"access_token": "token", "refresh_token": "refresh", "account_id": "acct"}}
+
+    result = prepare_gateway_runtime(
+        deer_flow_home=home,
+        config_output_path=config_path,
+        extensions_output_path=extensions_path,
+        codex_auth_output_path=codex_auth_path,
+        config_template_path=config_template,
+        extensions_template_path=extensions_template,
+        env={
+            "DEER_FLOW_PRIMARY_MODEL": "codex",
+            "CODEX_AUTH_JSON_B64": base64.b64encode(json.dumps(auth_payload).encode("utf-8")).decode("utf-8"),
+            "OPENAI_API_KEY": "openai-key",
+            "GEMINI_API_KEY": "gemini-key",
+        },
+    )
+
+    rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert [model["name"] for model in rendered["models"]] == ["gpt-5.4", "gpt-5", "gemini-2.5-pro"]
+    assert rendered["sandbox"]["allow_host_bash"] is True
+    assert json.loads(codex_auth_path.read_text(encoding="utf-8")) == auth_payload
+    assert json.loads(extensions_path.read_text(encoding="utf-8")) == {"mcpServers": {}, "skills": {}}
+    assert result["primary_model"] == "gpt-5.4"
+
+
+def test_prepare_gateway_runtime_respects_existing_extensions_file(tmp_path: Path) -> None:
+    config_template, extensions_template = _write_template_files(tmp_path)
+    home = tmp_path / "home"
+    config_path = tmp_path / "runtime" / "config.yaml"
+    extensions_path = home / "extensions_config.json"
+    codex_auth_path = tmp_path / "runtime" / "codex-auth.json"
+    extensions_path.parent.mkdir(parents=True, exist_ok=True)
+    extensions_path.write_text('{"mcpServers":{"demo":{"enabled":true}},"skills":{}}', encoding="utf-8")
+
+    prepare_gateway_runtime(
+        deer_flow_home=home,
+        config_output_path=config_path,
+        extensions_output_path=extensions_path,
+        codex_auth_output_path=codex_auth_path,
+        config_template_path=config_template,
+        extensions_template_path=extensions_template,
+        env={
+            "DEER_FLOW_PRIMARY_MODEL": "openai",
+            "OPENAI_API_KEY": "openai-key",
+            "DEER_FLOW_ALLOW_HOST_BASH": "false",
+        },
+    )
+
+    rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert [model["name"] for model in rendered["models"]] == ["gpt-5"]
+    assert rendered["sandbox"]["allow_host_bash"] is False
+    assert extensions_path.read_text(encoding="utf-8") == '{"mcpServers":{"demo":{"enabled":true}},"skills":{}}'
+    assert not codex_auth_path.exists()
+
+
+def test_prepare_gateway_runtime_requires_credentials_for_primary_model(tmp_path: Path) -> None:
+    config_template, extensions_template = _write_template_files(tmp_path)
+
+    try:
+        prepare_gateway_runtime(
+            deer_flow_home=tmp_path / "home",
+            config_output_path=tmp_path / "runtime" / "config.yaml",
+            extensions_output_path=tmp_path / "home" / "extensions_config.json",
+            codex_auth_output_path=tmp_path / "runtime" / "codex-auth.json",
+            config_template_path=config_template,
+            extensions_template_path=extensions_template,
+            env={"DEER_FLOW_PRIMARY_MODEL": "codex"},
+        )
+    except ValueError as exc:
+        assert "CODEX_AUTH_JSON_B64" in str(exc)
+    else:
+        raise AssertionError("Expected prepare_gateway_runtime() to reject codex primary without auth")

--- a/railway/gateway.Dockerfile
+++ b/railway/gateway.Dockerfile
@@ -1,0 +1,58 @@
+# Railway gateway image
+
+ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.7.20
+FROM ${UV_IMAGE} AS uv-source
+
+FROM python:3.12-slim-bookworm AS builder
+
+ARG NODE_MAJOR=22
+ARG APT_MIRROR
+ARG UV_INDEX_URL
+
+RUN if [ -n "${APT_MIRROR}" ]; then \
+      sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list.d/debian.sources 2>/dev/null || true; \
+      sed -i "s|deb.debian.org|${APT_MIRROR}|g" /etc/apt/sources.list 2>/dev/null || true; \
+    fi
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    gnupg \
+    ca-certificates \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
+    && apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=uv-source /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+COPY backend ./backend
+COPY skills ./skills
+COPY railway ./railway
+
+RUN sh -c "cd backend && UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple} uv sync"
+
+FROM python:3.12-slim-bookworm
+
+COPY --from=builder /usr/bin/node /usr/bin/node
+COPY --from=builder /usr/lib/node_modules /usr/lib/node_modules
+RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm \
+    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
+
+COPY --from=uv-source /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+COPY --from=builder /app/backend ./backend
+COPY --from=builder /app/skills ./skills
+COPY --from=builder /app/railway ./railway
+
+RUN chmod +x /app/railway/start-gateway.sh
+
+EXPOSE 8001
+
+CMD ["/app/railway/start-gateway.sh"]

--- a/railway/nginx.Dockerfile
+++ b/railway/nginx.Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+
+RUN apk add --no-cache gettext
+
+COPY railway/templates/nginx.railway.conf.template /etc/nginx/nginx.conf.template
+COPY railway/start-nginx.sh /start-nginx.sh
+
+RUN chmod +x /start-nginx.sh
+
+EXPOSE 8080
+
+CMD ["/start-nginx.sh"]

--- a/railway/start-gateway.sh
+++ b/railway/start-gateway.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+export DEER_FLOW_HOME="${DEER_FLOW_HOME:-${RAILWAY_VOLUME_MOUNT_PATH:-/data/deerflow}}"
+export DEER_FLOW_RUNTIME_DIR="${DEER_FLOW_RUNTIME_DIR:-/tmp/deerflow-runtime}"
+export DEER_FLOW_CONFIG_PATH="${DEER_FLOW_CONFIG_PATH:-$DEER_FLOW_RUNTIME_DIR/config.yaml}"
+export DEER_FLOW_EXTENSIONS_CONFIG_PATH="${DEER_FLOW_EXTENSIONS_CONFIG_PATH:-$DEER_FLOW_HOME/extensions_config.json}"
+export CODEX_AUTH_PATH="${CODEX_AUTH_PATH:-$DEER_FLOW_RUNTIME_DIR/codex-auth.json}"
+export GATEWAY_PORT="${GATEWAY_PORT:-${PORT:-8001}}"
+
+mkdir -p "$DEER_FLOW_HOME" "$DEER_FLOW_RUNTIME_DIR"
+
+cd /app/backend
+PYTHONPATH=. uv run python -m app.gateway.railway_runtime
+
+exec sh -c "cd /app/backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port ${GATEWAY_PORT} --workers ${GATEWAY_WORKERS:-1}"

--- a/railway/start-nginx.sh
+++ b/railway/start-nginx.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+export NGINX_LISTEN_PORT="${NGINX_LISTEN_PORT:-${PORT:-8080}}"
+
+if [ -z "${GATEWAY_UPSTREAM:-}" ]; then
+    echo "GATEWAY_UPSTREAM must be set for the Railway nginx service" >&2
+    exit 1
+fi
+
+envsubst '${GATEWAY_UPSTREAM} ${NGINX_LISTEN_PORT}' \
+    < /etc/nginx/nginx.conf.template \
+    > /etc/nginx/nginx.conf
+
+exec nginx -g 'daemon off;'

--- a/railway/templates/config.railway.template.yaml
+++ b/railway/templates/config.railway.template.yaml
@@ -1,0 +1,139 @@
+config_version: 1
+
+log_level: info
+
+models:
+  - name: gpt-5.4
+    display_name: GPT-5.4 (Codex CLI)
+    use: deerflow.models.openai_codex_provider:CodexChatModel
+    model: gpt-5.4
+    default_request_timeout: 600.0
+    max_retries: 3
+    supports_vision: true
+    supports_thinking: true
+    supports_reasoning_effort: true
+
+  - name: gpt-5
+    display_name: GPT-5 (OpenAI API)
+    use: langchain_openai:ChatOpenAI
+    model: gpt-5
+    api_key: $OPENAI_API_KEY
+    request_timeout: 600.0
+    max_retries: 2
+    use_responses_api: true
+    output_version: responses/v1
+    supports_vision: true
+    supports_thinking: true
+    supports_reasoning_effort: true
+
+  - name: gemini-2.5-pro
+    display_name: Gemini 2.5 Pro
+    use: langchain_google_genai:ChatGoogleGenerativeAI
+    model: gemini-2.5-pro
+    gemini_api_key: $GEMINI_API_KEY
+    timeout: 600.0
+    max_retries: 2
+    max_tokens: 8192
+    supports_vision: true
+
+tool_groups:
+  - name: web
+  - name: file:read
+  - name: file:write
+  - name: bash
+
+tools:
+  - name: web_search
+    group: web
+    use: deerflow.community.ddg_search.tools:web_search_tool
+    max_results: 5
+
+  - name: web_fetch
+    group: web
+    use: deerflow.community.jina_ai.tools:web_fetch_tool
+    timeout: 10
+
+  - name: image_search
+    group: web
+    use: deerflow.community.image_search.tools:image_search_tool
+    max_results: 5
+
+  - name: ls
+    group: file:read
+    use: deerflow.sandbox.tools:ls_tool
+
+  - name: read_file
+    group: file:read
+    use: deerflow.sandbox.tools:read_file_tool
+
+  - name: glob
+    group: file:read
+    use: deerflow.sandbox.tools:glob_tool
+    max_results: 200
+
+  - name: grep
+    group: file:read
+    use: deerflow.sandbox.tools:grep_tool
+    max_results: 100
+
+  - name: write_file
+    group: file:write
+    use: deerflow.sandbox.tools:write_file_tool
+
+  - name: str_replace
+    group: file:write
+    use: deerflow.sandbox.tools:str_replace_tool
+
+  - name: bash
+    group: bash
+    use: deerflow.sandbox.tools:bash_tool
+
+tool_search:
+  enabled: false
+
+uploads:
+  pdf_converter: auto
+
+sandbox:
+  use: deerflow.sandbox.local:LocalSandboxProvider
+  allow_host_bash: true
+  bash_output_max_chars: 20000
+  read_file_output_max_chars: 50000
+
+skills:
+  container_path: /mnt/skills
+
+title:
+  enabled: true
+  max_words: 6
+  max_chars: 60
+  model_name: null
+
+summarization:
+  enabled: true
+  trigger:
+    - type: tokens
+      value: 15564
+  keep:
+    type: messages
+    value: 10
+  trim_tokens_to_summarize: 15564
+  summary_prompt: null
+
+memory:
+  enabled: true
+  storage_path: memory.json
+  debounce_seconds: 30
+  model_name: null
+  max_facts: 100
+  fact_confidence_threshold: 0.7
+  injection_enabled: true
+  max_injection_tokens: 2000
+
+checkpointer:
+  type: sqlite
+  connection_string: checkpoints.db
+
+stream_bridge:
+  type: memory
+  queue_maxsize: 256

--- a/railway/templates/extensions_config.railway.template.json
+++ b/railway/templates/extensions_config.railway.template.json
@@ -1,0 +1,4 @@
+{
+  "mcpServers": {},
+  "skills": {}
+}

--- a/railway/templates/nginx.railway.conf.template
+++ b/railway/templates/nginx.railway.conf.template
@@ -1,0 +1,116 @@
+events {
+    worker_connections 1024;
+}
+pid /tmp/nginx.pid;
+
+http {
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+
+    access_log /dev/stdout;
+    error_log /dev/stderr;
+
+    upstream gateway_backend {
+        server ${GATEWAY_UPSTREAM};
+    }
+
+    server {
+        listen ${NGINX_LISTEN_PORT} default_server;
+        listen [::]:${NGINX_LISTEN_PORT} default_server;
+        server_name _;
+
+        proxy_hide_header 'Access-Control-Allow-Origin';
+        proxy_hide_header 'Access-Control-Allow-Methods';
+        proxy_hide_header 'Access-Control-Allow-Headers';
+        proxy_hide_header 'Access-Control-Allow-Credentials';
+
+        add_header 'Access-Control-Allow-Origin' '*' always;
+        add_header 'Access-Control-Allow-Methods' 'GET, POST, PUT, DELETE, PATCH, OPTIONS' always;
+        add_header 'Access-Control-Allow-Headers' '*' always;
+
+        if ($request_method = 'OPTIONS') {
+            return 204;
+        }
+
+        location /api/langgraph/ {
+            rewrite ^/api/langgraph/(.*) /api/$1 break;
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection '';
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_set_header X-Accel-Buffering no;
+            proxy_connect_timeout 600s;
+            proxy_send_timeout 600s;
+            proxy_read_timeout 600s;
+            chunked_transfer_encoding on;
+        }
+
+        location /api/ {
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Connection '';
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_set_header X-Accel-Buffering no;
+            proxy_connect_timeout 600s;
+            proxy_send_timeout 600s;
+            proxy_read_timeout 600s;
+            chunked_transfer_encoding on;
+            client_max_body_size 100M;
+            proxy_request_buffering off;
+        }
+
+        location /health {
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /docs {
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /redoc {
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /openapi.json {
+            proxy_pass http://gateway_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            default_type text/plain;
+            return 404 "DeerFlow backend only\n";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Railway-specific gateway and nginx deployment assets for a DeerFlow backend-only bring-up
- bootstrap a Codex-first runtime config on Railway with optional OpenAI and Gemini fallbacks from environment
- document the Railway deployment shape, persistence rules, and private-networking port requirement

## Validation
- `cd backend && uv run pytest tests/test_railway_runtime.py`
- `cd backend && uv run ruff check app/gateway/railway_runtime.py tests/test_railway_runtime.py`
- `docker build -f railway/gateway.Dockerfile .`
- `docker build -f railway/nginx.Dockerfile .`
- deployed `deerflow-gateway` and `deerflow-api` to Railway project `hidden-industries-agent` production environment
- verified public `/health` and `/api/models`
- verified `/api/langgraph/threads/.../runs/stream` returns SSE frames and `Content-Location`
- verified Codex-backed bash tool execution writes persisted workspace/output markers
- verified uploads, artifacts, `memory.json`, and `checkpoints.db` on the Railway volume
- restarted only `deerflow-gateway` and re-verified streaming, uploads, artifacts, thread history, and memory persistence
