### PR TITLE
fix(docker): restore gateway env vars and fix langgraph empty arg issue

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,6 +99,8 @@ services:
     environment:
       - CI=true
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - DEER_FLOW_CONFIG_PATH=/app/backend/config.yaml
+      - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/backend/extensions_config.json
       - DEER_FLOW_CHANNELS_LANGGRAPH_URL=${DEER_FLOW_CHANNELS_LANGGRAPH_URL:-http://langgraph:2024}
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}
       # DooD path/network translation
@@ -125,7 +127,7 @@ services:
         UV_IMAGE: ${UV_IMAGE:-ghcr.io/astral-sh/uv:0.7.20}
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
     container_name: deer-flow-langgraph
-    command: sh -c 'cd /app/backend && allow_blocking="" && if [ "$${LANGGRAPH_ALLOW_BLOCKING:-0}" = "1" ]; then allow_blocking="--allow-blocking"; fi && uv run langgraph dev --no-browser $${allow_blocking} --no-reload --host 0.0.0.0 --port 2024 --n-jobs-per-worker $${LANGGRAPH_JOBS_PER_WORKER:-10}'
+    command: sh -c 'cd /app/backend && args="--no-browser --no-reload --host 0.0.0.0 --port 2024 --n-jobs-per-worker $${LANGGRAPH_JOBS_PER_WORKER:-10}" && if [ "$${LANGGRAPH_ALLOW_BLOCKING:-0}" = "1" ]; then args="$$args --allow-blocking"; fi && uv run langgraph dev $$args'
     volumes:
       - ${DEER_FLOW_CONFIG_PATH}:/app/backend/config.yaml:ro
       - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/backend/extensions_config.json:ro


### PR DESCRIPTION
## Summary

Two production `docker-compose.yaml` bugs that prevent `make up` from working correctly.

### Bug 1: Gateway missing container-path env var overrides

**Root cause:** `DEER_FLOW_CONFIG_PATH` and `DEER_FLOW_EXTENSIONS_CONFIG_PATH` overrides were added to the gateway service in fb2d99f (#1836, fixes #1829), but were **accidentally reverted** by ca2fb95 (#1847) which modified the same file without preserving these lines.

Without these overrides, the gateway container reads the host filesystem path from `.env` (injected via `env_file:`), which does not exist inside the container, causing `FileNotFoundError` on startup.

The langgraph service already has these overrides set correctly (lines 154-155), confirming this is an oversight in the gateway section.

### Bug 2: Langgraph command fails when LANGGRAPH_ALLOW_BLOCKING is unset

**Root cause:** When `allow_blocking` is empty (the default), `$${allow_blocking}` expands to nothing, inserting a bare space between `--no-browser` and `--no-reload`. The langgraph CLI then receives `' --no-reload'` (with leading space) as an unexpected extra argument:

```
Error: Got unexpected extra argument ( --no-reload)
```

**Fix:** Build the full args string first with all required flags, then conditionally append `--allow-blocking`. This avoids any empty variable interpolation in the middle of the command.

### Reproduction

```bash
git checkout main
make up
# gateway: FileNotFoundError (DEER_FLOW_CONFIG_PATH points to host path)
# langgraph: Got unexpected extra argument ( --no-reload)
```

### After fix

All four containers start successfully and all endpoints return HTTP 200.