### PR TITLE
fix(provider): preserve streamed Codex output when response.completed.output is empty

### DIFF
--- a/backend/packages/harness/deerflow/models/openai_codex_provider.py
+++ b/backend/packages/harness/deerflow/models/openai_codex_provider.py
@@ -227,7 +227,7 @@ class CodexChatModel(BaseChatModel):
                         continue
 
                     event_type = data.get("type")
-                    if event_type in {"response.output_item.added", "response.output_item.done"}:
+                    if event_type == "response.output_item.done":
                         output_index = data.get("output_index")
                         output_item = data.get("item")
                         if isinstance(output_index, int) and isinstance(output_item, dict):
@@ -251,7 +251,9 @@ class CodexChatModel(BaseChatModel):
                 merged_output.extend([None] * (max_index + 1 - len(merged_output)))
 
             for output_index, output_item in streamed_output_items.items():
-                merged_output[output_index] = output_item
+                existing_item = merged_output[output_index]
+                if not isinstance(existing_item, dict):
+                    merged_output[output_index] = output_item
 
             completed_response = dict(completed_response)
             completed_response["output"] = [item for item in merged_output if isinstance(item, dict)]

--- a/backend/tests/test_cli_auth_providers.py
+++ b/backend/tests/test_cli_auth_providers.py
@@ -238,3 +238,34 @@ def test_codex_provider_orders_streamed_output_items_by_output_index(monkeypatch
         "First",
         "Second",
     ]
+
+
+def test_codex_provider_preserves_completed_output_when_stream_only_has_placeholder(monkeypatch):
+    monkeypatch.setattr(
+        CodexChatModel,
+        "_load_codex_auth",
+        lambda self: CodexCliCredential(access_token="token", account_id="acct"),
+    )
+
+    lines = [
+        'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","status":"in_progress","content":[]}}',
+        'data: {"type":"response.completed","response":{"model":"gpt-5.4","output":[{"type":"message","content":[{"type":"output_text","text":"Final from completed"}]}],"usage":{}}}',
+    ]
+
+    monkeypatch.setattr(
+        codex_provider_module.httpx,
+        "Client",
+        lambda *args, **kwargs: _FakeHttpxClient(lines, *args, **kwargs),
+    )
+
+    model = CodexChatModel()
+    response = model._stream_response(headers={}, payload={})
+    parsed = model._parse_response(response)
+
+    assert response["output"] == [
+        {
+            "type": "message",
+            "content": [{"type": "output_text", "text": "Final from completed"}],
+        }
+    ]
+    assert parsed.generations[0].message.content == "Final from completed"


### PR DESCRIPTION
## Summary

- merge streamed `response.output_item.done` items back into the final Codex response when `response.completed.output` is empty
- keep the existing `_parse_response()` flow unchanged by backfilling `response["output"]`
- add regression coverage for both the empty completed-output case and `output_index` ordering

## Problem

When using the Codex CLI provider, the ChatGPT Codex SSE stream can deliver the assistant text in `response.output_item.done` while `response.completed.response.output` remains empty.

DeerFlow currently only parses `response.completed.response.output`, so successful runs can be persisted with an empty AI message body. In the UI this looks like the assistant never replied, even though the model run completed successfully.

## Root Cause

`_stream_response()` waited for `response.completed` but discarded streamed output items emitted earlier in the SSE stream.

## Fix

Collect streamed output items from `response.output_item.added` / `response.output_item.done` and merge them back into the final response by `output_index` before handing the payload to `_parse_response()`.

This preserves the existing parsing path while making the provider compatible with Codex streams where the final completed frame does not include populated `output`.

## Validation

- `uv run pytest tests/test_cli_auth_providers.py -q`
- `uv run pytest tests/test_model_factory.py -q -k codex_provider`
- `uv run ruff check tests/test_cli_auth_providers.py packages/harness/deerflow/models/openai_codex_provider.py`
