### PR TITLE
docs(api): document recursion_limit for LangGraph API runs

### DIFF
--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -86,6 +86,7 @@ Content-Type: application/json
     ]
   },
   "config": {
+    "recursion_limit": 100,
     "configurable": {
       "model_name": "gpt-4",
       "thinking_enabled": false,
@@ -99,6 +100,21 @@ Content-Type: application/json
 **Stream Mode Compatibility:**
 - Use: `values`, `messages-tuple`, `custom`, `updates`, `events`, `debug`, `tasks`, `checkpoints`
 - Do not use: `tools` (deprecated/invalid in current `langgraph-api` and will trigger schema validation errors)
+
+**Recursion Limit:**
+
+`config.recursion_limit` caps the number of graph steps LangGraph will execute
+in a single run. The `/api/langgraph/*` endpoints go straight to the LangGraph
+server and therefore inherit LangGraph's native default of **25**, which is
+too low for plan-mode or subagent-heavy runs — the agent typically errors out
+with `GraphRecursionError` after the first round of subagent results comes
+back, before the lead agent can synthesize the final answer.
+
+DeerFlow's own Gateway and IM-channel paths mitigate this by defaulting to
+`100` in `build_run_config` (see `backend/app/gateway/services.py`), but
+clients calling the LangGraph API directly must set `recursion_limit`
+explicitly in the request body. `100` matches the Gateway default and is a
+safe starting point; increase it if you run deeply nested subagent graphs.
 
 **Configurable Options:**
 - `model_name` (string): Override the default model
@@ -626,6 +642,14 @@ curl -X POST http://localhost:2026/api/langgraph/threads/abc123/runs \
   -H "Content-Type: application/json" \
   -d '{
     "input": {"messages": [{"role": "user", "content": "Hello"}]},
-    "config": {"configurable": {"model_name": "gpt-4"}}
+    "config": {
+      "recursion_limit": 100,
+      "configurable": {"model_name": "gpt-4"}
+    }
   }'
 ```
+
+> The `/api/langgraph/*` endpoints bypass DeerFlow's Gateway and inherit
+> LangGraph's native `recursion_limit` default of 25, which is too low for
+> plan-mode or subagent runs. Set `config.recursion_limit` explicitly — see
+> the [Create Run](#create-run) section for details.


### PR DESCRIPTION
## Summary

- Document `config.recursion_limit` in the `POST /api/langgraph/threads/{thread_id}/runs` request body example and the cURL snippet at the bottom of `backend/docs/API.md`.
- Add a short "Recursion Limit" note explaining why it matters on this specific code path.

## Why

The `/api/langgraph/*` endpoints are proxied straight through to the LangGraph server (see `docker/nginx/nginx.conf` — `location /api/langgraph/` does `proxy_pass http://langgraph`), so clients hitting this path inherit LangGraph's native `recursion_limit` default of **25** instead of the **100** that `build_run_config` (`backend/app/gateway/services.py:132`) and `DEFAULT_RUN_CONFIG` (`backend/app/channels/manager.py:27`) apply on the Gateway-backed and IM-channel paths.

25 is too low for plan-mode or subagent-heavy runs: in my case, a `thinking_enabled + is_plan_mode + subagent_enabled` research run reliably errored out with `GraphRecursionError: Recursion limit of 25 reached without hitting a stop condition` right after the first batch of subagent `task` tool results came back (step 25), **before** the lead agent could produce its final synthesis message. The subagent transcripts were all intact in checkpoint state, but the main graph never got to wrap them up.

Anyone following the current docs / cURL example verbatim hits the same wall, because neither `backend/docs/API.md` nor the Create Run request body example mention `recursion_limit`. Surfacing it in the documented example — matching the Gateway's internal default of `100` — makes the LangGraph API path behave the same as the other supported entry points out of the box.

## What this PR does not change

- No code changes — this is docs-only.
- The Gateway / IM channel defaults in `build_run_config` and `DEFAULT_RUN_CONFIG` are unchanged.
- No other `API.md` sections were touched.

## Test plan

- [x] `git diff --check` passes (no whitespace errors)
- [x] Markdown renders correctly (checked locally)
- [x] The updated JSON example is valid JSON
- [x] Verified the claim end-to-end on a self-hosted DeerFlow 2.0 deployment: submitting the Create Run example without `recursion_limit` against `/api/langgraph/threads/{tid}/runs` returns `GraphRecursionError` (from `/join`) after step 25 on ultra-mode research; adding `recursion_limit: 100` to the payload makes the run complete normally.

---

🤖 Drafted with [Claude Code](https://claude.com/claude-code) — investigation started from a live `GraphRecursionError` on my jstudio deployment and traced through `services.py` / `channels/manager.py` / `thread_runs.py` / `nginx.local.conf` before noticing the doc gap.