### PR TITLE
[codex] fix agent gallery after bootstrap creation

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -31,7 +31,7 @@ import { ArtifactsProvider } from "@/components/workspace/artifacts";
 import { MessageList } from "@/components/workspace/messages";
 import { ThreadContext } from "@/components/workspace/messages/context";
 import type { Agent } from "@/core/agents";
-import { checkAgentName, getAgent } from "@/core/agents/api";
+import { checkAgentName, createAgent, getAgent } from "@/core/agents/api";
 import { useI18n } from "@/core/i18n/hooks";
 import { useThreadStream } from "@/core/threads/hooks";
 import { uuid } from "@/core/utils/uuid";
@@ -142,6 +142,17 @@ export default function NewAgentPage() {
       return;
     } finally {
       setIsCheckingName(false);
+    }
+
+    try {
+      await createAgent({
+        name: trimmed,
+        description: "",
+        soul: "",
+      });
+    } catch {
+      setNameError(t.agents.nameStepCheckError);
+      return;
     }
 
     setAgentName(trimmed);


### PR DESCRIPTION
﻿## Summary
- create a placeholder custom agent as soon as the name passes validation in the new-agent flow
- keep the existing bootstrap chat flow so `setup_agent` can still fill in the final SOUL/config later
- prevent the agent gallery from staying empty when the bootstrap conversation starts but never persists the agent

## Root cause
The new-agent UI can start a bootstrap thread under `/workspace/agents/{agent_name}/...` before `setup_agent` actually writes the agent to disk. When that happens, the conversation list makes it look like the agent exists, but `/api/agents` is still empty, so the gallery always shows "还没有自定义智能体".

## Validation
- reproduced the issue locally with the new-agent bootstrap flow
- confirmed the gallery stayed empty while the thread route already existed
- applied this change and verified the created agent now appears in the gallery immediately after naming

Supersedes #1932 because that PR's head branch got stuck after a cross-repo force-push.

Closes #1916.
