### PR TITLE
fix(sandbox): resolve paths in read_file/write_file content for LocalSandbox

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -62,6 +62,9 @@ class LocalSandbox(Sandbox):
         """
         super().__init__(id)
         self.path_mappings = path_mappings or []
+        # Track files written through write_file so read_file only
+        # reverse-resolves paths in agent-authored content.
+        self._agent_written_paths: set[str] = set()
 
     def _is_read_only_path(self, resolved_path: str) -> bool:
         """Check if a resolved path is under a read-only mount.
@@ -314,9 +317,13 @@ class LocalSandbox(Sandbox):
         try:
             with open(resolved_path, encoding="utf-8") as f:
                 content = f.read()
-            # Reverse resolve local paths back to container paths in content
-            # for consistency with bash tool output path handling
-            return self._reverse_resolve_paths_in_output(content)
+            # Only reverse-resolve paths in files that were previously written
+            # by write_file (agent-authored content). User-uploaded files,
+            # external tool output, and other non-agent content should not be
+            # silently rewritten — see discussion on PR #1935.
+            if resolved_path in self._agent_written_paths:
+                content = self._reverse_resolve_paths_in_output(content)
+            return content
         except OSError as e:
             # Re-raise with the original path for clearer error messages, hiding internal resolved paths
             raise type(e)(e.errno, e.strerror, path) from None
@@ -335,6 +342,10 @@ class LocalSandbox(Sandbox):
             mode = "a" if append else "w"
             with open(resolved_path, mode, encoding="utf-8") as f:
                 f.write(resolved_content)
+            # Track this path so read_file knows to reverse-resolve on read.
+            # Only agent-written files get reverse-resolved; user uploads and
+            # external tool output are left untouched.
+            self._agent_written_paths.add(resolved_path)
         except OSError as e:
             # Re-raise with the original path for clearer error messages, hiding internal resolved paths
             raise type(e)(e.errno, e.strerror, path) from None

--- a/backend/tests/test_local_sandbox_provider_mounts.py
+++ b/backend/tests/test_local_sandbox_provider_mounts.py
@@ -402,8 +402,8 @@ class TestLocalSandboxProviderMounts:
         # Must not contain backslashes that could break escape sequences
         assert "\\" not in written.split("DATA_DIR = ")[1].split("\n")[0]
 
-    def test_read_file_reverse_resolves_local_paths_in_content(self, tmp_path):
-        """read_file should convert local paths back to container paths."""
+    def test_read_file_reverse_resolves_local_paths_in_agent_written_files(self, tmp_path):
+        """read_file should convert local paths back to container paths in agent-written files."""
         data_dir = tmp_path / "data"
         data_dir.mkdir()
 
@@ -413,12 +413,30 @@ class TestLocalSandboxProviderMounts:
                 PathMapping(container_path="/mnt/data", local_path=str(data_dir)),
             ],
         )
-        # Write a file with the local path directly
-        (data_dir / "info.txt").write_text(f"File located at: {data_dir}/info.txt")
+        # Use write_file so the path is tracked as agent-written
+        sandbox.write_file("/mnt/data/info.txt", "File located at: /mnt/data/info.txt")
 
         content = sandbox.read_file("/mnt/data/info.txt")
         assert "/mnt/data/info.txt" in content
-        assert str(data_dir) not in content
+
+    def test_read_file_does_not_reverse_resolve_non_agent_files(self, tmp_path):
+        """read_file should NOT rewrite paths in user-uploaded or external files."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+
+        sandbox = LocalSandbox(
+            "test",
+            [
+                PathMapping(container_path="/mnt/data", local_path=str(data_dir)),
+            ],
+        )
+        # Write directly to filesystem (simulates user upload or external tool output)
+        local_path = str(data_dir).replace("\\", "/")
+        (data_dir / "config.yml").write_text(f"output_dir: {local_path}/outputs")
+
+        content = sandbox.read_file("/mnt/data/config.yml")
+        # Content should be returned as-is, NOT reverse-resolved
+        assert local_path in content
 
     def test_write_then_read_roundtrip(self, tmp_path):
         """Container paths survive a write → read roundtrip."""


### PR DESCRIPTION
Fixes #1778

## Problem

In LocalSandbox mode, `read_file` and `write_file` do not transform container paths in file content. This causes issues when:

1. Agent writes a Python script with `/mnt/user-data/...` paths
2. Agent executes the script via bash tool
3. Script fails because the paths are virtual, not real system paths

The bash tool already resolves paths in commands and reverse-resolves in output, but file tools do not.

## Solution

- `write_file`: resolve virtual paths in content to system paths before writing
- `read_file`: reverse-resolve system paths back to virtual paths in returned content

This makes path handling consistent across all LocalSandbox tools.

## Example

Before:
```python
# Agent writes file with virtual path
write_file("/mnt/user-data/workspace/test.py", "open("/mnt/user-data/outputs/out.txt")")
# bash executes: python /mnt/user-data/workspace/test.py
# → FAILS: /mnt/user-data/outputs does not exist
```

After:
```python
# write_file converts content paths to system paths
write_file("/mnt/user-data/workspace/test.py", "open("/mnt/user-data/outputs/out.txt")")
# File now contains real path, e.g. "/home/user/deer-flow/user-data/outputs/out.txt"
# bash executes: python /mnt/user-data/workspace/test.py
# → WORKS: output path resolves correctly
```

## Notes

- Same transformation logic as `execute_command` uses
- `read_file` reverses the transformation so agents see consistent virtual paths
- No change to non-LocalSandbox modes