### PR TITLE
fix(frontend): UI polish - fix CSS typo, dark mode border, and hardcoded colors

### DIFF
--- a/frontend/src/components/landing/hero.tsx
+++ b/frontend/src/components/landing/hero.tsx
@@ -69,10 +69,7 @@ export function Hero({ className }: { className?: string }) {
             </div>
           </a>
         )}
-        <p
-          className="mt-8 scale-105 text-center text-2xl text-shadow-sm"
-          style={{ color: "rgb(184,184,192)" }}
-        >
+        <p className="text-muted-foreground mt-8 scale-105 text-center text-2xl text-shadow-sm">
           An open-source SuperAgent harness that researches, codes, and creates.
           With
           <br />

--- a/frontend/src/components/landing/sections/case-study-section.tsx
+++ b/frontend/src/components/landing/sections/case-study-section.tsx
@@ -51,7 +51,7 @@ export function CaseStudySection({ className }: { className?: string }) {
       title="Case Studies"
       subtitle="See how DeerFlow is used in the wild"
     >
-      <div className="container-md mt-8 grid grid-cols-1 gap-4 px-20 md:grid-cols-2 lg:grid-cols-3">
+      <div className="container-md mt-8 grid grid-cols-1 gap-4 px-4 md:grid-cols-2 md:px-20 lg:grid-cols-3">
         {caseStudies.map((caseStudy) => (
           <Link
             key={caseStudy.title}

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -166,7 +166,7 @@ export function MessageList({
               results.push(
                 <div
                   key="subtask-count"
-                  className="text-muted-foreground font-norma pt-2 text-sm"
+                  className="text-muted-foreground pt-2 text-sm font-normal"
                 >
                   {t.subtasks.executing(tasks.size)}
                 </div>,

--- a/frontend/src/components/workspace/streaming-indicator.tsx
+++ b/frontend/src/components/workspace/streaming-indicator.tsx
@@ -14,19 +14,19 @@ export function StreamingIndicator({
       <div
         className={cn(
           dotSize,
-          "animate-bouncing rounded-full bg-[#a3a1a1] opacity-100",
+          "animate-bouncing bg-muted-foreground rounded-full opacity-100",
         )}
       />
       <div
         className={cn(
           dotSize,
-          "animate-bouncing rounded-full bg-[#a3a1a1] opacity-100 [animation-delay:0.2s]",
+          "animate-bouncing bg-muted-foreground rounded-full opacity-100 [animation-delay:0.2s]",
         )}
       />
       <div
         className={cn(
           dotSize,
-          "animate-bouncing rounded-full bg-[#a3a1a1] opacity-100 [animation-delay:0.4s]",
+          "animate-bouncing bg-muted-foreground rounded-full opacity-100 [animation-delay:0.4s]",
         )}
       />
     </div>

--- a/frontend/src/components/workspace/welcome.tsx
+++ b/frontend/src/components/workspace/welcome.tsx
@@ -61,7 +61,9 @@ export function Welcome({
       ) : (
         <div className="text-muted-foreground text-sm">
           {t.welcome.description.includes("\n") ? (
-            <pre className="whitespace-pre">{t.welcome.description}</pre>
+            <pre className="font-sans whitespace-pre">
+              {t.welcome.description}
+            </pre>
           ) : (
             <p>{t.welcome.description}</p>
           )}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -273,7 +273,7 @@
   --accent: oklch(0.32 0.0036 106.64);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0.191 22.216 / 10%);
+  --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: transparent;
   --chart-1: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
## Summary

- **Fix CSS class name typo**: `font-norma` → `font-normal` in subtask count display (`message-list.tsx`)
- **Fix dark mode border color inconsistency**: `--border` variable was using a reddish hue (`oklch(1 0.191 22.216 / 10%)`) while all other dark mode neutrals use hue `106.64` or `0`. Changed to neutral `oklch(1 0 0 / 10%)` matching `--sidebar-border`
- **Replace hardcoded colors with design tokens**:
  - Hero description text: inline `style={{ color: "rgb(184,184,192)" }}` → `text-muted-foreground`
  - Streaming indicator dots: `bg-[#a3a1a1]` (3 instances) → `bg-muted-foreground`
- **Fix typography inconsistency**: Added missing `font-sans` class to welcome description `<pre>` tag (the skill-mode `<pre>` already had it)
- **Improve mobile responsiveness**: Case study section `px-20` → `px-4 md:px-20` to prevent excessive padding on small screens

## Visual Changes

| Area | Before | After |
|------|--------|-------|
| Dark mode borders | Subtle reddish tint (hue 22.216) | Clean neutral tone (hue 0) |
| Hero text | Hardcoded `rgb(184,184,192)` ignoring theme | Uses `--muted-foreground` token, respects theme |
| Streaming dots | Hardcoded `#a3a1a1` | Uses `--muted-foreground`, adapts to light/dark |
| Case studies (mobile) | `px-20` (80px) causes horizontal squeeze | `px-4` on mobile, `px-20` on md+ |
| Subtask count text | `font-norma` (no effect) | `font-normal` (correct weight) |
| Welcome description | Monospace font in `<pre>` | Matches sans-serif like skill mode |

## Test Plan

- [x] `pnpm check` (ESLint + TypeScript) passes with zero errors
- [x] `pnpm format:write` (Prettier) — all files formatted correctly
- [ ] Visual inspection of landing page (light & dark mode)
- [ ] Visual inspection of workspace welcome screen
- [ ] Visual inspection of streaming indicator dots
- [ ] Visual inspection of case study section on mobile viewport

Closes #1940
