### PR TITLE
fix(frontend): prevent stale "new" thread ID from triggering 422 history requests

### DIFF
--- a/frontend/src/components/workspace/chats/use-thread-chat.ts
+++ b/frontend/src/components/workspace/chats/use-thread-chat.ts
@@ -24,6 +24,14 @@ export function useThreadChat() {
       setThreadId(uuid());
       return;
     }
+    // Guard: after history.replaceState updates the URL from /chats/new to
+    // /chats/{UUID}, Next.js useParams may still return the stale "new" value
+    // because replaceState does not trigger router updates.  Avoid propagating
+    // this invalid thread ID to downstream hooks (e.g. useStream), which would
+    // cause a 422 from LangGraph Server.
+    if (threadIdFromPath === "new") {
+      return;
+    }
     setIsNewThread(false);
     setThreadId(threadIdFromPath);
   }, [pathname, threadIdFromPath]);


### PR DESCRIPTION
## Problem

Every time a new chat is created (both regular and agent chats), a stale `"new"` thread ID leaks into the LangGraph SDK's `useStream` hook, causing it to fire `POST /threads/new/history`, which returns HTTP 422 from LangGraph Server.

This blocks the frontend from rendering the conversation until a page refresh.

## Root Cause

`history.replaceState()` is used to update the URL from `/chats/new` to `/chats/{UUID}` after thread creation (to avoid React re-mount). However, Next.js `useParams()` does not update in response to `replaceState`, so `threadIdFromPath` remains `"new"`. On the next React re-render, the `useEffect` in `useThreadChat` propagates this stale `"new"` string as the thread ID.

## Fix

Added a guard in `useThreadChat`'s `useEffect` to skip the `setThreadId` call when `threadIdFromPath` is the literal string `"new"`, preserving the correct UUID that was already set during thread creation.

## Testing

- Verified that new chat creation no longer produces 422 errors in the network tab
- Verified that existing thread navigation still works correctly
- Verified that the thread title updates properly after stream completion
