### PR TITLE
Fix(subagent): Event loop conflict in SubagentExecutor.execute()

### DIFF
--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -76,6 +76,9 @@ _scheduler_pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix="subagent
 # Larger pool to avoid blocking when scheduler submits execution tasks
 _execution_pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix="subagent-exec-")
 
+# Dedicated pool for sync execute() calls made from an already-running event loop.
+_isolated_loop_pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix="subagent-isolated-")
+
 
 def _filter_tools(
     all_tools: list[BaseTool],
@@ -381,23 +384,36 @@ class SubagentExecutor:
         isolation from any parent event loop, preventing conflicts with asyncio
         primitives that may be bound to the parent loop (e.g., httpx clients).
         """
+        try:
+            previous_loop = asyncio.get_event_loop()
+        except RuntimeError:
+            previous_loop = None
+
         # Create and set a new event loop for this thread
         loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
         try:
+            asyncio.set_event_loop(loop)
             return loop.run_until_complete(self._aexecute(task, result_holder))
         finally:
-            # Clean up the loop
             try:
-                # Cancel any pending tasks
                 pending = asyncio.all_tasks(loop)
                 if pending:
                     for task_obj in pending:
                         task_obj.cancel()
                     loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-                loop.close()
+
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.run_until_complete(loop.shutdown_default_executor())
             except Exception:
-                pass
+                logger.debug(
+                    f"[trace={self.trace_id}] Failed while cleaning up isolated event loop for subagent {self.config.name}",
+                    exc_info=True,
+                )
+            finally:
+                try:
+                    loop.close()
+                finally:
+                    asyncio.set_event_loop(previous_loop)
 
     def execute(self, task: str, result_holder: SubagentResult | None = None) -> SubagentResult:
         """Execute a task synchronously (wrapper around async execution).
@@ -418,23 +434,15 @@ class SubagentExecutor:
             SubagentResult with the execution result.
         """
         try:
-            # Check if we're already in a running event loop
             try:
                 loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    # We're being called from within a running event loop.
-                    # We cannot use asyncio.run() here because it would create a new
-                    # loop and conflict with any asyncio primitives (like httpx clients
-                    # or locks) that were created in and bound to the parent loop.
-                    # Instead, run the subagent in a separate thread to ensure it has
-                    # its own isolated event loop.
-                    logger.debug(f"[trace={self.trace_id}] Subagent {self.config.name} detected running event loop, using isolated thread")
-                    with ThreadPoolExecutor(max_workers=1, thread_name_prefix="subagent-isolated-") as executor:
-                        future = executor.submit(self._execute_in_isolated_loop, task, result_holder)
-                        return future.result()
             except RuntimeError:
-                # No event loop running in this thread, safe to use asyncio.run
-                pass
+                loop = None
+
+            if loop is not None and loop.is_running():
+                logger.debug(f"[trace={self.trace_id}] Subagent {self.config.name} detected running event loop, using isolated thread")
+                future = _isolated_loop_pool.submit(self._execute_in_isolated_loop, task, result_holder)
+                return future.result()
 
             # Standard path: no running event loop, use asyncio.run
             return asyncio.run(self._aexecute(task, result_holder))

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -433,6 +433,42 @@ class TestSyncExecutionPath:
         assert result.status == SubagentStatus.COMPLETED
         assert result.result == "Thread pool result"
 
+    @pytest.mark.anyio
+    async def test_execute_in_running_event_loop_uses_isolated_thread(self, classes, base_config, mock_agent, msg):
+        """Test that execute() uses the isolated-thread path inside a running loop."""
+        SubagentExecutor = classes["SubagentExecutor"]
+        SubagentStatus = classes["SubagentStatus"]
+
+        execution_threads = []
+        final_state = {
+            "messages": [
+                msg.human("Task"),
+                msg.ai("Async loop result", "msg-1"),
+            ]
+        }
+
+        async def mock_astream(*args, **kwargs):
+            execution_threads.append(threading.current_thread().name)
+            yield final_state
+
+        mock_agent.astream = mock_astream
+
+        executor = SubagentExecutor(
+            config=base_config,
+            tools=[],
+            thread_id="test-thread",
+        )
+
+        with patch.object(executor, "_create_agent", return_value=mock_agent):
+            with patch.object(executor, "_execute_in_isolated_loop", wraps=executor._execute_in_isolated_loop) as isolated:
+                result = executor.execute("Task")
+
+        assert isolated.call_count == 1
+        assert execution_threads
+        assert all(name.startswith("subagent-isolated-") for name in execution_threads)
+        assert result.status == SubagentStatus.COMPLETED
+        assert result.result == "Async loop result"
+
     def test_execute_handles_asyncio_run_failure(self, classes, base_config):
         """Test handling when asyncio.run() itself fails."""
         SubagentExecutor = classes["SubagentExecutor"]


### PR DESCRIPTION
## Summary

Fixes event loop conflict when `SubagentExecutor.execute()` is called from within an already-running event loop.

## Problem

When the parent agent runs in an async context (e.g., with httpx clients bound to its event loop), calling `asyncio.run()` in `execute()` creates a new event loop. This causes conflicts with asyncio primitives that were created in and bound to the parent loop, resulting in errors like:

```
RuntimeError: <asyncio.locks.Event object> is bound to a different event loop
```

This manifests as sub-task cards not appearing in Ultra mode or web UI becoming unresponsive when multiple subagents run in parallel.

## Solution

Detect if we're already in a running event loop, and if so, run the subagent in a separate thread with its own isolated event loop via `_execute_in_isolated_loop()`.

## Changes

- Add `_execute_in_isolated_loop()` method for isolated execution in a fresh event loop
- Modify `execute()` to detect running event loops and use isolated thread when necessary
- Proper cleanup of the isolated event loop after execution

## Related Issues

- Fixes #1223 - 3个子任务并行运行时web端卡住的问题

## Testing

This fix has been tested with:
- Ultra mode with multiple subagents
- MiniMax model (Anthropic-compatible API)
- Scenarios where parent agent has active httpx clients