### PR TITLE
fix(frontend): avoid using route new as thread id

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -1,6 +1,5 @@
 import type { Message } from "@langchain/langgraph-sdk";
 import { FileIcon, Loader2Icon } from "lucide-react";
-import { useParams } from "next/navigation";
 import { memo, useMemo, type ImgHTMLAttributes } from "react";
 import rehypeKatex from "rehype-katex";
 
@@ -39,10 +38,12 @@ export function MessageListItem({
   className,
   message,
   isLoading,
+  threadId,
 }: {
   className?: string;
   message: Message;
   isLoading?: boolean;
+  threadId: string;
 }) {
   const isHuman = message.type === "human";
   return (
@@ -54,6 +55,7 @@ export function MessageListItem({
         className={isHuman ? "w-fit" : "w-full"}
         message={message}
         isLoading={isLoading}
+        threadId={threadId}
       />
       {!isLoading && (
         <MessageToolbar
@@ -111,21 +113,22 @@ function MessageContent_({
   className,
   message,
   isLoading = false,
+  threadId,
 }: {
   className?: string;
   message: Message;
   isLoading?: boolean;
+  threadId: string;
 }) {
   const rehypePlugins = useRehypeSplitWordsIntoSpans(isLoading);
   const isHuman = message.type === "human";
-  const { thread_id } = useParams<{ thread_id: string }>();
   const components = useMemo(
     () => ({
       img: (props: ImgHTMLAttributes<HTMLImageElement>) => (
-        <MessageImage {...props} threadId={thread_id} maxWidth="90%" />
+        <MessageImage {...props} threadId={threadId} maxWidth="90%" />
       ),
     }),
-    [thread_id],
+    [threadId],
   );
 
   const rawContent = extractContentFromMessage(message);
@@ -151,8 +154,8 @@ function MessageContent_({
   }, [rawContent, isHuman]);
 
   const filesList =
-    files && files.length > 0 && thread_id ? (
-      <RichFilesList files={files} threadId={thread_id} />
+    files && files.length > 0 ? (
+      <RichFilesList files={files} threadId={threadId} />
     ) : null;
 
   // Uploading state: mock AI message shown while files upload

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -63,6 +63,7 @@ export function MessageList({
                   key={`${group.id}/${msg.id}`}
                   message={msg}
                   isLoading={thread.isLoading}
+                  threadId={threadId}
                 />
               );
             });


### PR DESCRIPTION
 ## What changed                                                                                                                                                                 
                                                                                                                                                                                  
  Stop message rendering paths from reading `thread_id` directly from the route.                                                                                                  
  Pass the resolved chat `threadId` down from `MessageList` into `MessageListItem` instead, so image/file/artifact URLs use the actual thread id even while the page route is     
  still `/workspace/.../new`.                                                                                                                                                     
                                                                                                                                                                                  
  ## Why                                                                                                                                                                          
                                                                                                                                                                                  
  After #1931, new chats intentionally keep the `/new` route until the server returns the real thread id.                                                                         
  Some message rendering code still read `thread_id` from `useParams()`, so new conversations could send `"new"` to backend thread-scoped endpoints and trigger:                  
                                                                                                                                                                                  
  `HTTP 422: {"detail":"Invalid thread ID: must be a UUID"}`                                                                                                                      
                                                                                                                                                                                  
  ## Scope                                                                                                                                                                        
                                                                                                                                                                                  
  This change only touches frontend message rendering:                                                                                                                            
  - `frontend/src/components/workspace/messages/message-list.tsx`                                                                                                                 
  - `frontend/src/components/workspace/messages/message-list-item.tsx`                                                                                                            
                                                                                                                                                                                  
  ## Validation                                                                                                                                                                   
                                                                                                                                                                                  
  Ran in WSL:                                                                                                                                                                     
                                                                                                                                                                                  
  - `pnpm exec prettier --check src/components/workspace/messages/message-list-item.tsx src/components/workspace/messages/message-list.tsx`                                       
  - `pnpm exec eslint . --ext .ts,.tsx`                                                                                                                                           
  - `pnpm exec tsc --noEmit`                                                                                                                                                      
                                                                                                                                                                                  
  ## Related                                                                                                                                                                      
                                                                                                                                                                                  
  Fixes #1957                                                                                                                                                                     
  Related to #1931