### PR TITLE
fix(middleware): handle orphaned tool results in DanglingToolCallMiddleware

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
@@ -8,6 +8,11 @@ This middleware intercepts the model call to detect and patch such gaps by
 inserting synthetic ToolMessages with an error indicator immediately after the
 AIMessage that made the tool calls, ensuring correct message ordering.
 
+It also handles a related issue: when a tool call cycle completes (AIMessage →
+ToolMessage(s)) but the conversation continues with a HumanMessage before the
+AI has a chance to respond. This orphaned tool result pattern also causes LLM
+errors, fixed by injecting a placeholder AIMessage after the last ToolMessage.
+
 Note: Uses wrap_model_call instead of before_model to ensure patches are inserted
 at the correct positions (immediately after each dangling AIMessage), not appended
 to the end of the message list as before_model + add_messages reducer would do.
@@ -21,17 +26,21 @@ from typing import override
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
 
 logger = logging.getLogger(__name__)
 
 
 class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
-    """Inserts placeholder ToolMessages for dangling tool calls before model invocation.
+    """Inserts placeholder messages for incomplete tool call patterns before model invocation.
 
-    Scans the message history for AIMessages whose tool_calls lack corresponding
-    ToolMessages, and injects synthetic error responses immediately after the
-    offending AIMessage so the LLM receives a well-formed conversation.
+    Handles two cases:
+    1. Dangling tool calls: AIMessage has tool_calls with no corresponding ToolMessages.
+       Fix: inject placeholder ToolMessages after the AIMessage.
+    2. Orphaned tool results: a tool call cycle (AIMessage → ToolMessages) completes but
+       is immediately followed by a HumanMessage with no intervening AI response (e.g.,
+       user interrupted before the AI could reply to tool results).
+       Fix: inject a placeholder AIMessage after the last ToolMessage in the group.
     """
 
     @staticmethod
@@ -75,8 +84,13 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
     def _build_patched_messages(self, messages: list) -> list | None:
         """Return a new message list with patches inserted at the correct positions.
 
-        For each AIMessage with dangling tool_calls (no corresponding ToolMessage),
-        a synthetic ToolMessage is inserted immediately after that AIMessage.
+        Phase 1 – dangling tool calls: for each AIMessage whose tool_calls lack a
+        corresponding ToolMessage, insert a synthetic ToolMessage immediately after.
+
+        Phase 2 – orphaned tool results: for each ToolMessage that is directly followed
+        by a HumanMessage (not another ToolMessage or an AIMessage), insert a synthetic
+        AIMessage so the LLM receives a well-formed conversation.
+
         Returns None if no patches are needed.
         """
         # Collect IDs of all existing ToolMessages
@@ -85,34 +99,18 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
             if isinstance(msg, ToolMessage):
                 existing_tool_msg_ids.add(msg.tool_call_id)
 
-        # Check if any patching is needed
-        needs_patch = False
-        for msg in messages:
-            if getattr(msg, "type", None) != "ai":
-                continue
-            for tc in self._message_tool_calls(msg):
-                tc_id = tc.get("id")
-                if tc_id and tc_id not in existing_tool_msg_ids:
-                    needs_patch = True
-                    break
-            if needs_patch:
-                break
-
-        if not needs_patch:
-            return None
-
-        # Build new list with patches inserted right after each dangling AIMessage
-        patched: list = []
+        # --- Phase 1: fix dangling tool calls ---
+        phase1: list = []
         patched_ids: set[str] = set()
-        patch_count = 0
+        phase1_count = 0
         for msg in messages:
-            patched.append(msg)
+            phase1.append(msg)
             if getattr(msg, "type", None) != "ai":
                 continue
             for tc in self._message_tool_calls(msg):
                 tc_id = tc.get("id")
                 if tc_id and tc_id not in existing_tool_msg_ids and tc_id not in patched_ids:
-                    patched.append(
+                    phase1.append(
                         ToolMessage(
                             content="[Tool call was interrupted and did not return a result.]",
                             tool_call_id=tc_id,
@@ -121,10 +119,27 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
                         )
                     )
                     patched_ids.add(tc_id)
-                    patch_count += 1
+                    phase1_count += 1
 
-        logger.warning(f"Injecting {patch_count} placeholder ToolMessage(s) for dangling tool calls")
-        return patched
+        # --- Phase 2: fix orphaned tool results ---
+        # A ToolMessage followed directly by a HumanMessage means the AI never got
+        # to reply after the tool results came back. Inject a placeholder AIMessage.
+        phase2: list = []
+        phase2_count = 0
+        for i, msg in enumerate(phase1):
+            phase2.append(msg)
+            if isinstance(msg, ToolMessage):
+                next_msg = phase1[i + 1] if i + 1 < len(phase1) else None
+                if next_msg is not None and getattr(next_msg, "type", None) == "human":
+                    phase2.append(AIMessage(content="[AI response was interrupted before completing.]"))
+                    phase2_count += 1
+
+        total = phase1_count + phase2_count
+        if total == 0:
+            return None
+
+        logger.warning(f"Injecting {total} placeholder message(s) for dangling/orphaned tool calls ({phase1_count} ToolMessage(s), {phase2_count} AIMessage(s))")
+        return phase2
 
     @override
     def wrap_model_call(

--- a/backend/tests/test_dangling_tool_call_middleware.py
+++ b/backend/tests/test_dangling_tool_call_middleware.py
@@ -79,13 +79,17 @@ class TestBuildPatchedMessagesPatching:
         ]
         patched = mw._build_patched_messages(msgs)
         assert patched is not None
-        # HumanMessage, AIMessage, synthetic ToolMessage, HumanMessage
-        assert len(patched) == 4
+        # Phase 1 injects ToolMessage after the dangling AIMessage.
+        # Phase 2 then injects an AIMessage after that ToolMessage (since it's followed by HumanMessage).
+        # Result: HumanMessage, AIMessage, synthetic ToolMessage, synthetic AIMessage, HumanMessage
+        assert len(patched) == 5
         assert isinstance(patched[0], HumanMessage)
         assert isinstance(patched[1], AIMessage)
         assert isinstance(patched[2], ToolMessage)
         assert patched[2].tool_call_id == "call_1"
-        assert isinstance(patched[3], HumanMessage)
+        assert isinstance(patched[3], AIMessage)
+        assert "interrupted" in patched[3].content.lower()
+        assert isinstance(patched[4], HumanMessage)
 
     def test_mixed_responded_and_dangling(self):
         mw = DanglingToolCallMiddleware()
@@ -177,6 +181,80 @@ class TestWrapModelCall:
 
         handler.assert_called_once_with(patched_request)
         assert result == "response"
+
+
+class TestOrphanedToolResults:
+    """Tests for Phase 2: orphaned tool results (ToolMessage followed by HumanMessage)."""
+
+    def test_completed_cycle_followed_by_human_injects_ai(self):
+        """AI calls tool, tool responds, but user interrupts before AI replies."""
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            HumanMessage(content="search for x"),
+            _ai_with_tool_calls([_tc("web_search", "call_1")]),
+            _tool_msg("call_1", "web_search"),
+            HumanMessage(content="any results?"),
+        ]
+        patched = mw._build_patched_messages(msgs)
+        assert patched is not None
+        # ToolMessage should be followed by a synthetic AIMessage before the HumanMessage
+        tool_idx = next(i for i, m in enumerate(patched) if isinstance(m, ToolMessage))
+        assert isinstance(patched[tool_idx + 1], AIMessage)
+        assert "interrupted" in patched[tool_idx + 1].content.lower()
+        assert isinstance(patched[tool_idx + 2], HumanMessage)
+
+    def test_multiple_tool_messages_in_group_only_one_ai_injected(self):
+        """When AI calls two tools and both respond, only one AIMessage is injected."""
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            _ai_with_tool_calls([_tc("bash", "call_1"), _tc("read", "call_2")]),
+            _tool_msg("call_1", "bash"),
+            _tool_msg("call_2", "read"),
+            HumanMessage(content="what happened?"),
+        ]
+        patched = mw._build_patched_messages(msgs)
+        assert patched is not None
+        synthetic_ais = [m for m in patched if isinstance(m, AIMessage) and "interrupted" in m.content.lower()]
+        assert len(synthetic_ais) == 1
+
+    def test_completed_cycle_at_end_no_patch(self):
+        """Tool results at end of history (no following HumanMessage) need no patch."""
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            _ai_with_tool_calls([_tc("bash", "call_1")]),
+            _tool_msg("call_1", "bash"),
+        ]
+        assert mw._build_patched_messages(msgs) is None
+
+    def test_completed_cycle_followed_by_ai_no_patch(self):
+        """Tool results properly followed by AIMessage need no Phase 2 patch."""
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            _ai_with_tool_calls([_tc("bash", "call_1")]),
+            _tool_msg("call_1", "bash"),
+            AIMessage(content="done"),
+            HumanMessage(content="thanks"),
+        ]
+        assert mw._build_patched_messages(msgs) is None
+
+    def test_issue_1936_scenario(self):
+        """Reproduces the exact scenario from issue #1936:
+        tool result → AI calls tool → tool result → multiple human messages.
+        """
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            _tool_msg("prev_call", "some_tool"),  # [26] previous tool result
+            _ai_with_tool_calls([_tc("web_search", "call_o6ml")]),  # [27] AI requests tool
+            _tool_msg("call_o6ml", "web_search"),  # [28] tool result
+            HumanMessage(content="follow up 1"),  # [29] user interrupted
+            HumanMessage(content="follow up 2"),  # [30]
+        ]
+        patched = mw._build_patched_messages(msgs)
+        assert patched is not None
+        # Synthetic AIMessage should appear after [28] tool result, before [29] human
+        tool_28_idx = next(i for i, m in enumerate(patched) if isinstance(m, ToolMessage) and m.tool_call_id == "call_o6ml")
+        assert isinstance(patched[tool_28_idx + 1], AIMessage)
+        assert "interrupted" in patched[tool_28_idx + 1].content.lower()
 
 
 class TestAwrapModelCall:


### PR DESCRIPTION
Fixes #1936

## Problem

`DanglingToolCallMiddleware` already handles the case where an `AIMessage` has `tool_calls` but no corresponding `ToolMessage` exists (dangling tool call). However, it did not handle a related but distinct problem:

When a tool call cycle **completes** (AIMessage → ToolMessage(s)) but the user sends a follow-up `HumanMessage` before the AI has a chance to respond to the tool results, the conversation history becomes:

```
AI(tool_calls=[A]) → Tool(A) → HumanMessage  ← invalid!
```

Many LLMs require an `AIMessage` between `ToolMessages` and `HumanMessages`. Without it, every subsequent model invocation fails with errors that cannot be recovered from, causing the session to be permanently broken (as reported in the issue).

## Solution

Add a **Phase 2** pass to `_build_patched_messages` that scans the (Phase 1 patched) message list and injects a placeholder `AIMessage` immediately after any `ToolMessage` that is directly followed by a `HumanMessage`.

The two-phase approach ensures correct ordering:
1. Phase 1 injects synthetic `ToolMessage`s for dangling tool calls (existing behavior)
2. Phase 2 injects synthetic `AIMessage`s for orphaned tool results (new behavior)

Phase 2 does **not** inject when a `ToolMessage` is at the end of the list (the model is about to generate a real response) or when it is already followed by an `AIMessage` (valid conversation flow).

## Testing

- All 19 existing tests pass (one test expectation updated to reflect the correct 5-message output instead of 4, since Phase 2 now also injects an `AIMessage` after the Phase 1 synthetic `ToolMessage`)
- 5 new tests added in `TestOrphanedToolResults`:
  - Basic case: completed cycle followed by human message
  - Multiple tool messages in a group (only one `AIMessage` injected)
  - Completed cycle at end of history (no patch needed)
  - Completed cycle followed by `AIMessage` (no Phase 2 patch needed)
  - Exact reproduction of the issue #1936 scenario
