### PR TITLE
fix(tracing): unify Langfuse traces per conversation and add Langfuse config to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # LANGSMITH_API_KEY=your-langsmith-api-key
 # LANGSMITH_PROJECT=your-langsmith-project
 
+# Enable Langfuse to monitor and debug your LLM calls, agent runs, and tool executions.
+# LANGFUSE_TRACING=true
+# LANGFUSE_PUBLIC_KEY=your-langfuse-public-key
+# LANGFUSE_SECRET_KEY=your-langfuse-secret-key
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+
 # GitHub API Token
 # GITHUB_TOKEN=your-github-token
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -22,6 +22,7 @@ from deerflow.config.app_config import AppConfig, get_app_config
 from deerflow.config.memory_config import get_memory_config
 from deerflow.config.summarization_config import get_summarization_config
 from deerflow.models import create_chat_model
+from deerflow.tracing import build_tracing_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +73,12 @@ def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> 
     # Bind "middleware:summarize" tag so RunJournal identifies these LLM calls
     # as middleware rather than lead_agent (SummarizationMiddleware is a
     # LangChain built-in, so we tag the model at creation time).
+    # attach_tracing=False because the graph-level RunnableConfig already
+    # carries tracing callbacks for in-graph models.
     if config.model_name:
-        model = create_chat_model(name=config.model_name, thinking_enabled=False, app_config=app_config)
+        model = create_chat_model(name=config.model_name, thinking_enabled=False, app_config=app_config, attach_tracing=False)
     else:
-        model = create_chat_model(thinking_enabled=False, app_config=app_config)
+        model = create_chat_model(thinking_enabled=False, app_config=app_config, attach_tracing=False)
     model = model.with_config(tags=["middleware:summarize"])
 
     # Prepare kwargs
@@ -379,10 +382,17 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
         }
     )
 
+    # Inject tracing callbacks at graph level so providers like Langfuse
+    # create a single trace per invocation instead of one per model call.
+    tracing_callbacks = build_tracing_callbacks()
+    if tracing_callbacks:
+        existing = config.get("callbacks") or []
+        config["callbacks"] = [*existing, *tracing_callbacks]
+
     if is_bootstrap:
         # Special bootstrap agent with minimal prompt for initial custom agent creation flow
         return create_agent(
-            model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, app_config=resolved_app_config),
+            model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, app_config=resolved_app_config, attach_tracing=False),
             tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled, app_config=resolved_app_config) + [setup_agent],
             middleware=_build_middlewares(config, model_name=model_name, app_config=resolved_app_config),
             system_prompt=apply_prompt_template(
@@ -396,7 +406,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
 
     # Default lead agent (unchanged behavior)
     return create_agent(
-        model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort, app_config=resolved_app_config),
+        model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort, app_config=resolved_app_config, attach_tracing=False),
         tools=get_available_tools(
             model_name=model_name,
             groups=agent_config.tool_groups if agent_config else None,

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -139,10 +139,13 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         prompt, user_msg = self._build_title_prompt(state)
 
         try:
+            # attach_tracing=False because _get_runnable_config() inherits the
+            # parent graph's callbacks; attaching at the model level too would
+            # create duplicate Langfuse spans for the same LLM call.
             if config.model_name:
-                model = create_chat_model(name=config.model_name, thinking_enabled=False)
+                model = create_chat_model(name=config.model_name, thinking_enabled=False, attach_tracing=False)
             else:
-                model = create_chat_model(thinking_enabled=False)
+                model = create_chat_model(thinking_enabled=False, attach_tracing=False)
             response = await model.ainvoke(prompt, config=self._get_runnable_config())
             title = self._parse_title(response.content)
             if title:

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -42,6 +42,7 @@ from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
 from deerflow.runtime.user_context import get_effective_user_id
 from deerflow.skills.storage import get_or_new_skill_storage
+from deerflow.tracing import build_tracing_callbacks
 from deerflow.uploads.manager import (
     claim_unique_filename,
     delete_file_safe,
@@ -202,10 +203,16 @@ class DeerFlowClient:
             "is_plan_mode": overrides.get("plan_mode", self._plan_mode),
             "subagent_enabled": overrides.get("subagent_enabled", self._subagent_enabled),
         }
-        return RunnableConfig(
+        config = RunnableConfig(
             configurable=configurable,
             recursion_limit=overrides.get("recursion_limit", 100),
         )
+        # Inject tracing callbacks at graph level so providers like Langfuse
+        # create a single trace per invocation instead of one per model call.
+        tracing_callbacks = build_tracing_callbacks()
+        if tracing_callbacks:
+            config["callbacks"] = tracing_callbacks
+        return config
 
     def _ensure_agent(self, config: RunnableConfig):
         """Create (or recreate) the agent when config-dependent params change."""
@@ -228,7 +235,7 @@ class DeerFlowClient:
         max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
 
         kwargs: dict[str, Any] = {
-            "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
+            "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled, attach_tracing=False),
             "tools": self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled),
             "middleware": _build_middlewares(config, model_name=model_name, agent_name=self._agent_name, custom_middlewares=self._middlewares),
             "system_prompt": apply_prompt_template(

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -47,11 +47,20 @@ def _enable_stream_usage_by_default(model_use_path: str, model_settings_from_con
         model_settings_from_config["stream_usage"] = True
 
 
-def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *, app_config: AppConfig | None = None, **kwargs) -> BaseChatModel:
+def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *, app_config: AppConfig | None = None, attach_tracing: bool = True, **kwargs) -> BaseChatModel:
     """Create a chat model instance from the config.
 
     Args:
         name: The name of the model to create. If None, the first model in the config will be used.
+        thinking_enabled: Enable the model's extended-thinking mode when supported.
+        app_config: Explicit application config; falls back to the cached global if omitted.
+        attach_tracing: When True (default), attach tracing callbacks (e.g. Langfuse,
+            LangSmith) directly to the model instance so standalone calls (memory updater,
+            title middleware, suggestions, security scanner, ad-hoc utilities) are still
+            traced. Set to False when the model is invoked inside an agent graph whose
+            RunnableConfig already carries graph-level tracing callbacks; otherwise the
+            same LLM call would emit duplicate spans (one from the model, one from the
+            graph config).
 
     Returns:
         A chat model instance.
@@ -149,9 +158,13 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
 
     model_instance = model_class(**kwargs, **model_settings_from_config)
 
-    callbacks = build_tracing_callbacks()
-    if callbacks:
-        existing_callbacks = model_instance.callbacks or []
-        model_instance.callbacks = [*existing_callbacks, *callbacks]
-        logger.debug(f"Tracing attached to model '{name}' with providers={len(callbacks)}")
+    # Attach tracing callbacks for standalone model calls (memory, title,
+    # suggestions, etc.).  Models used inside a graph should pass
+    # attach_tracing=False.
+    if attach_tracing:
+        callbacks = build_tracing_callbacks()
+        if callbacks:
+            existing_callbacks = model_instance.callbacks or []
+            model_instance.callbacks = [*existing_callbacks, *callbacks]
+
     return model_instance

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -23,6 +23,7 @@ from deerflow.agents.thread_state import SandboxState, ThreadDataState, ThreadSt
 from deerflow.config.app_config import AppConfig
 from deerflow.models import create_chat_model
 from deerflow.subagents.config import SubagentConfig
+from deerflow.tracing import build_tracing_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -282,7 +283,7 @@ class SubagentExecutor:
 
         resolved_app_config = self.app_config or get_app_config()
         model_name = _get_model_name(self.config, self.parent_model)
-        model = create_chat_model(name=model_name, thinking_enabled=False, app_config=resolved_app_config)
+        model = create_chat_model(name=model_name, thinking_enabled=False, app_config=resolved_app_config, attach_tracing=False)
 
         from deerflow.agents.middlewares.tool_error_handling_middleware import build_subagent_runtime_middlewares
 
@@ -409,10 +410,18 @@ class SubagentExecutor:
             agent = self._create_agent()
             state = await self._build_initial_state(task)
 
-            # Build config with thread_id for sandbox access and recursion limit
+            # Build config with thread_id for sandbox access and recursion limit.
             run_config: RunnableConfig = {
                 "recursion_limit": self.config.max_turns,
             }
+
+            # Inject tracing callbacks at graph level so providers like
+            # Langfuse create a single trace per subagent run instead of
+            # one trace per LLM call.
+            tracing_callbacks = build_tracing_callbacks()
+            if tracing_callbacks:
+                run_config["callbacks"] = tracing_callbacks
+
             context = {}
             if self.thread_id:
                 run_config["configurable"] = {"thread_id": self.thread_id}

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -52,9 +52,10 @@ def test_internal_make_lead_agent_uses_explicit_app_config(monkeypatch):
 
     captured: dict[str, object] = {}
 
-    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None):
+    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None, attach_tracing=True):
         captured["name"] = name
         captured["app_config"] = app_config
+        captured["attach_tracing"] = attach_tracing
         return object()
 
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
@@ -68,6 +69,7 @@ def test_internal_make_lead_agent_uses_explicit_app_config(monkeypatch):
     assert captured == {
         "name": "explicit-model",
         "app_config": app_config,
+        "attach_tracing": False,
     }
     assert result["model"] is not None
 
@@ -127,7 +129,7 @@ def test_make_lead_agent_disables_thinking_when_model_does_not_support_it(monkey
 
     captured: dict[str, object] = {}
 
-    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None):
+    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None, attach_tracing=True):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort
@@ -171,11 +173,12 @@ def test_make_lead_agent_reads_runtime_options_from_context(monkeypatch):
 
     captured: dict[str, object] = {}
 
-    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None):
+    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, app_config=None, attach_tracing=True):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort
         captured["app_config"] = app_config
+        captured["attach_tracing"] = attach_tracing
         return object()
 
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
@@ -199,6 +202,7 @@ def test_make_lead_agent_reads_runtime_options_from_context(monkeypatch):
         "thinking_enabled": False,
         "reasoning_effort": "high",
         "app_config": app_config,
+        "attach_tracing": False,
     }
     get_available_tools.assert_called_once_with(model_name="context-model", groups=None, subagent_enabled=True, app_config=app_config)
     assert result["model"] is not None
@@ -304,7 +308,7 @@ def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch
     fake_model = MagicMock()
     fake_model.with_config.return_value = fake_model
 
-    def _fake_create_chat_model(*, name=None, thinking_enabled, reasoning_effort=None, app_config=None):
+    def _fake_create_chat_model(*, name=None, thinking_enabled, reasoning_effort=None, app_config=None, attach_tracing=True):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -103,15 +103,26 @@ def test_raises_when_model_not_found(monkeypatch):
         factory_module.create_chat_model(name="ghost-model")
 
 
-def test_appends_all_tracing_callbacks(monkeypatch):
+def test_appends_tracing_callbacks_by_default(monkeypatch):
+    """Standalone models (default attach_tracing=True) get tracing callbacks."""
     cfg = _make_app_config([_make_model("alpha")])
     _patch_factory(monkeypatch, cfg)
-    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: ["smith-callback", "langfuse-callback"])
+    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: ["cb1", "cb2"])
 
-    FakeChatModel.captured_kwargs = {}
     model = factory_module.create_chat_model(name="alpha")
 
-    assert model.callbacks == ["smith-callback", "langfuse-callback"]
+    assert model.callbacks == ["cb1", "cb2"]
+
+
+def test_skips_tracing_callbacks_when_attach_tracing_false(monkeypatch):
+    """Graph-internal models (attach_tracing=False) must not get tracing callbacks."""
+    cfg = _make_app_config([_make_model("alpha")])
+    _patch_factory(monkeypatch, cfg)
+    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: ["cb1", "cb2"])
+
+    model = factory_module.create_chat_model(name="alpha", attach_tracing=False)
+
+    assert not model.callbacks
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -255,6 +255,7 @@ class TestAgentConstruction:
             "name": "parent-model",
             "thinking_enabled": False,
             "app_config": app_config,
+            "attach_tracing": False,
         }
         assert captured["middlewares"] == {
             "app_config": app_config,

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -91,12 +91,41 @@ class TestTitleMiddlewareCoreLogic:
         title = result["title"]
 
         assert title == "短标题"
-        title_middleware_module.create_chat_model.assert_called_once_with(thinking_enabled=False)
+        title_middleware_module.create_chat_model.assert_called_once_with(thinking_enabled=False, attach_tracing=False)
         model.ainvoke.assert_awaited_once()
         assert model.ainvoke.await_args.kwargs["config"] == {
             "run_name": "title_agent",
             "tags": ["middleware:title"],
         }
+
+    def test_generate_title_opts_out_of_model_level_tracing(self, monkeypatch):
+        """The title model must not double-attach tracing.
+
+        ``_get_runnable_config()`` already inherits the parent graph's
+        callbacks (e.g. Langfuse). Building the model with the default
+        ``attach_tracing=True`` would attach the same handler at the model
+        level too, producing duplicate spans for one LLM call.
+        """
+        _set_test_title_config(model_name="title-model", max_chars=20)
+        middleware = TitleMiddleware()
+        model = MagicMock()
+        model.ainvoke = AsyncMock(return_value=AIMessage(content="标题"))
+        create_chat_model_mock = MagicMock(return_value=model)
+        monkeypatch.setattr(title_middleware_module, "create_chat_model", create_chat_model_mock)
+
+        state = {
+            "messages": [
+                HumanMessage(content="问题"),
+                AIMessage(content="回答"),
+            ]
+        }
+        asyncio.run(middleware._agenerate_title_result(state))
+
+        create_chat_model_mock.assert_called_once_with(
+            name="title-model",
+            thinking_enabled=False,
+            attach_tracing=False,
+        )
 
     def test_generate_title_normalizes_structured_message_content(self, monkeypatch):
         _set_test_title_config(max_chars=20)


### PR DESCRIPTION
fixes #1990、#2355

## Summary

Move tracing callbacks from model-level to graph-level RunnableConfig so Langfuse (and other explicit-callback providers) create a single trace per conversation instead of one trace per LLM call.

Add `attach_tracing` parameter to `create_chat_model()` so standalone LLM calls (memory, title, suggestions, security scanner) retain tracing automatically, while graph-internal models opt out to avoid duplicate spans.

## Screenshots

### Before

<img width="1435" height="767" alt="Image" src="https://github.com/user-attachments/assets/2158a20f-3a62-4225-882d-bb6d99961f76" />

<img width="1436" height="770" alt="Image" src="https://github.com/user-attachments/assets/e8770bd0-1329-4c69-9651-228a8998dd25" />

### After

<img width="1436" height="770" alt="langfuse-after" src="https://github.com/user-attachments/assets/b14494e7-923c-431e-916d-f2c8be70f43e" />

![E27079ED-39B0-4E39-A57B-0F517EF2A83F](https://github.com/user-attachments/assets/e59c90b5-a384-4955-a5db-f92c0277a985)
