### PR TITLE
fix(tracing): group Langfuse spans under one trace per agent run

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -297,7 +297,7 @@ Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → 
 - Supports `supports_vision` flag for image understanding models
 - Config values starting with `$` resolved as environment variables
 - Missing provider modules surface actionable install hints from reflection resolvers (for example `uv add langchain-google-genai`)
-- **Tracing is NOT attached at the model level.** Model-level callbacks form a local root callback manager and break trace nesting in Langfuse (every LLM call would become its own root trace).
+- **Tracing attachment is opt-in/opt-out via ``attach_tracing`` (default ``True``).** Standalone callers — anything that invokes a model outside a LangGraph run that already wires Langfuse at the invocation root (e.g. ``MemoryUpdater``, ``security_scanner``, ``SubagentExecutor``, ``DeerFlowClient``) — keep the default so the Langfuse callback is attached directly to the model and those flows still appear in Langfuse. Graph callers that already inject the handler at the invocation root (``make_lead_agent``, the in-graph ``TitleMiddleware``) MUST pass ``attach_tracing=False``; otherwise model-level callbacks form a local root callback manager and break trace nesting (every LLM call becomes its own root trace).
 
 ### Tracing (`packages/harness/deerflow/tracing/factory.py`)
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -297,6 +297,13 @@ Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → 
 - Supports `supports_vision` flag for image understanding models
 - Config values starting with `$` resolved as environment variables
 - Missing provider modules surface actionable install hints from reflection resolvers (for example `uv add langchain-google-genai`)
+- **Tracing is NOT attached at the model level.** Model-level callbacks form a local root callback manager and break trace nesting in Langfuse (every LLM call would become its own root trace).
+
+### Tracing (`packages/harness/deerflow/tracing/factory.py`)
+
+- **Langfuse**: `build_langfuse_handler()` returns a `CallbackHandler` when Langfuse is enabled via `LANGFUSE_TRACING` + keys. It is injected into `config["callbacks"]` at the top of `make_lead_agent(config)` — i.e. at the **graph invocation root**, before `create_agent(...)` runs. This makes a single LangGraph run produce one Langfuse trace with all node / LLM / tool calls as child spans. Works for both standard (LangGraph Server) and Gateway runtime modes because both reuse the same `RunnableConfig` dict for factory construction and graph invocation.
+- **LangSmith**: no application-level wiring needed. When `LANGSMITH_TRACING` (or `LANGCHAIN_TRACING_V2`) is set, `langchain_core.callbacks.manager` auto-injects `LangChainTracer` into the root callback manager of every run.
+- **Out of scope (follow-up)**: subagent traces do not yet link to the parent because `SubagentExecutor` runs subagents on a separate thread pool, breaking asyncio contextvar propagation of the parent run_id.
 
 ### vLLM Provider (`packages/harness/deerflow/models/vllm_provider.py`)
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -18,8 +18,8 @@ from deerflow.agents.thread_state import ThreadState
 from deerflow.config.agents_config import load_agent_config
 from deerflow.config.app_config import get_app_config
 from deerflow.config.summarization_config import get_summarization_config
-from deerflow.tracing import build_langfuse_handler
 from deerflow.models import create_chat_model
+from deerflow.tracing import build_langfuse_handler
 
 logger = logging.getLogger(__name__)
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -59,11 +59,11 @@ def _create_summarization_middleware() -> SummarizationMiddleware | None:
 
     # Prepare model parameter
     if config.model_name:
-        model = create_chat_model(name=config.model_name, thinking_enabled=False)
+        model = create_chat_model(name=config.model_name, thinking_enabled=False, attach_tracing=False)
     else:
         # Use a lightweight model for summarization to save costs
         # Falls back to default model if not explicitly specified
-        model = create_chat_model(thinking_enabled=False)
+        model = create_chat_model(thinking_enabled=False, attach_tracing=False)
 
     # Prepare kwargs
     kwargs = {
@@ -348,7 +348,7 @@ def make_lead_agent(config: RunnableConfig):
     if is_bootstrap:
         # Special bootstrap agent with minimal prompt for initial custom agent creation flow
         return create_agent(
-            model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
+            model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, attach_tracing=False),
             tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled) + [setup_agent],
             middleware=_build_middlewares(config, model_name=model_name),
             system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"])),
@@ -357,7 +357,7 @@ def make_lead_agent(config: RunnableConfig):
 
     # Default lead agent (unchanged behavior)
     return create_agent(
-        model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort),
+        model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort, attach_tracing=False),
         tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled),
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
         system_prompt=apply_prompt_template(

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -18,6 +18,7 @@ from deerflow.agents.thread_state import ThreadState
 from deerflow.config.agents_config import load_agent_config
 from deerflow.config.app_config import get_app_config
 from deerflow.config.summarization_config import get_summarization_config
+from deerflow.tracing import build_langfuse_handler
 from deerflow.models import create_chat_model
 
 logger = logging.getLogger(__name__)
@@ -327,6 +328,19 @@ def make_lead_agent(config: RunnableConfig):
             "subagent_enabled": subagent_enabled,
         }
     )
+
+    # Inject Langfuse callback at the root invocation config so the entire
+    # LangGraph run becomes a single Langfuse trace and all node / LLM / tool
+    # calls nest as child spans. LangSmith needs no wiring here — langchain-core
+    # auto-injects LangChainTracer when LANGSMITH_TRACING is set.
+    langfuse_handler = build_langfuse_handler()
+    if langfuse_handler is not None:
+        existing_callbacks = config.get("callbacks") or []
+        if not isinstance(existing_callbacks, list):
+            existing_callbacks = list(existing_callbacks)
+        if langfuse_handler not in existing_callbacks:
+            config["callbacks"] = [*existing_callbacks, langfuse_handler]
+        logger.info("Langfuse tracing callback attached at graph invocation root")
 
     if is_bootstrap:
         # Special bootstrap agent with minimal prompt for initial custom agent creation flow

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -333,13 +333,16 @@ def make_lead_agent(config: RunnableConfig):
     # LangGraph run becomes a single Langfuse trace and all node / LLM / tool
     # calls nest as child spans. LangSmith needs no wiring here — langchain-core
     # auto-injects LangChainTracer when LANGSMITH_TRACING is set.
+    #
+    # Note: ``make_lead_agent`` is called once per request with a fresh config
+    # dict, so we do not guard against duplicate injection — each invocation
+    # starts clean.
     langfuse_handler = build_langfuse_handler()
     if langfuse_handler is not None:
         existing_callbacks = config.get("callbacks") or []
         if not isinstance(existing_callbacks, list):
             existing_callbacks = list(existing_callbacks)
-        if langfuse_handler not in existing_callbacks:
-            config["callbacks"] = [*existing_callbacks, langfuse_handler]
+        config["callbacks"] = [*existing_callbacks, langfuse_handler]
         logger.info("Langfuse tracing callback attached at graph invocation root")
 
     if is_bootstrap:

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -118,9 +118,13 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
 
         try:
             if config.model_name:
-                model = create_chat_model(name=config.model_name, thinking_enabled=False)
+                # Title model runs as middleware **inside** the lead-agent graph,
+                # which already injects Langfuse at the invocation root. Opt out of
+                # model-level tracing to keep the title call as a child span instead
+                # of a separate root trace.
+                model = create_chat_model(name=config.model_name, thinking_enabled=False, attach_tracing=False)
             else:
-                model = create_chat_model(thinking_enabled=False)
+                model = create_chat_model(thinking_enabled=False, attach_tracing=False)
             response = await model.ainvoke(prompt)
             title = self._parse_title(response.content)
             if title:

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -4,7 +4,6 @@ from langchain.chat_models import BaseChatModel
 
 from deerflow.config import get_app_config
 from deerflow.reflection import resolve_class
-from deerflow.tracing import build_tracing_callbacks
 
 logger = logging.getLogger(__name__)
 
@@ -111,9 +110,8 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
 
     model_instance = model_class(**kwargs, **model_settings_from_config)
 
-    callbacks = build_tracing_callbacks()
-    if callbacks:
-        existing_callbacks = model_instance.callbacks or []
-        model_instance.callbacks = [*existing_callbacks, *callbacks]
-        logger.debug(f"Tracing attached to model '{name}' with providers={len(callbacks)}")
+    # Tracing callbacks (Langfuse) are attached at the graph runnable level in
+    # ``make_lead_agent``, not at the model level. Model-level callbacks would
+    # form their own root callback manager and break trace nesting. LangSmith
+    # is auto-injected by langchain-core when ``LANGSMITH_TRACING`` is set.
     return model_instance

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -29,11 +29,28 @@ def _vllm_disable_chat_template_kwargs(chat_template_kwargs: dict) -> dict:
     return disable_kwargs
 
 
-def create_chat_model(name: str | None = None, thinking_enabled: bool = False, **kwargs) -> BaseChatModel:
+def create_chat_model(
+    name: str | None = None,
+    thinking_enabled: bool = False,
+    attach_tracing: bool = True,
+    **kwargs,
+) -> BaseChatModel:
     """Create a chat model instance from the config.
 
     Args:
         name: The name of the model to create. If None, the first model in the config will be used.
+        thinking_enabled: Whether to enable extended thinking for supported models.
+        attach_tracing: Whether to attach tracing callbacks (e.g. Langfuse) directly to the
+            returned model. Defaults to ``True`` so that **standalone** callers — those that
+            invoke the model outside of a LangGraph run with a Langfuse-aware ``RunnableConfig``
+            (e.g. memory updater, title generation when called outside the graph, security
+            scanner, subagent executor, embedded client) — keep automatic Langfuse coverage.
+
+            Callers that already inject the Langfuse handler at the **graph invocation root**
+            (such as ``make_lead_agent``) MUST pass ``attach_tracing=False`` for any model they
+            build, otherwise model-level callbacks would form a separate root callback manager
+            and break trace nesting (every LLM call would become its own root trace instead of
+            a child span of the agent run).
 
     Returns:
         A chat model instance.
@@ -110,8 +127,23 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
 
     model_instance = model_class(**kwargs, **model_settings_from_config)
 
-    # Tracing callbacks (Langfuse) are attached at the graph runnable level in
-    # ``make_lead_agent``, not at the model level. Model-level callbacks would
-    # form their own root callback manager and break trace nesting. LangSmith
-    # is auto-injected by langchain-core when ``LANGSMITH_TRACING`` is set.
+    # Attach tracing callbacks (Langfuse) for standalone callers. Graph callers
+    # that wire Langfuse at the invocation root (see ``make_lead_agent``) opt
+    # out via ``attach_tracing=False`` so that model-level callbacks do not
+    # form a separate root callback manager and break trace nesting. LangSmith
+    # is auto-injected by langchain-core when ``LANGSMITH_TRACING`` is set and
+    # therefore needs no wiring here.
+    if attach_tracing:
+        from deerflow.tracing import build_langfuse_handler
+
+        try:
+            handler = build_langfuse_handler()
+        except Exception:  # pragma: no cover - defensive: never fail model creation on tracing init
+            logger.warning("Failed to build Langfuse handler for model '%s'; continuing without tracing", name, exc_info=True)
+            handler = None
+        if handler is not None:
+            existing_callbacks = list(model_instance.callbacks or [])
+            if handler not in existing_callbacks:
+                model_instance.callbacks = [*existing_callbacks, handler]
+            logger.debug("Langfuse callback attached to standalone model '%s'", name)
     return model_instance

--- a/backend/packages/harness/deerflow/tracing/__init__.py
+++ b/backend/packages/harness/deerflow/tracing/__init__.py
@@ -1,3 +1,3 @@
-from .factory import build_tracing_callbacks
+from .factory import build_langfuse_handler
 
-__all__ = ["build_tracing_callbacks"]
+__all__ = ["build_langfuse_handler"]

--- a/backend/packages/harness/deerflow/tracing/factory.py
+++ b/backend/packages/harness/deerflow/tracing/factory.py
@@ -9,12 +9,6 @@ from deerflow.config import (
 )
 
 
-def _create_langsmith_tracer(config) -> Any:
-    from langchain_core.tracers.langchain import LangChainTracer
-
-    return LangChainTracer(project_name=config.project)
-
-
 def _create_langfuse_handler(config) -> Any:
     from langfuse import Langfuse
     from langfuse.langchain import CallbackHandler as LangfuseCallbackHandler
@@ -29,26 +23,23 @@ def _create_langfuse_handler(config) -> Any:
     return LangfuseCallbackHandler(public_key=config.public_key)
 
 
-def build_tracing_callbacks() -> list[Any]:
-    """Build callbacks for all explicitly enabled tracing providers."""
+def build_langfuse_handler() -> Any | None:
+    """Build a Langfuse LangChain CallbackHandler if Langfuse tracing is enabled.
+
+    Returns ``None`` when Langfuse is not configured. Raises ``RuntimeError`` if
+    Langfuse is explicitly enabled but its initialization fails.
+
+    LangSmith is intentionally not handled here: when ``LANGSMITH_TRACING`` is
+    set, ``langchain_core.callbacks.manager`` auto-injects ``LangChainTracer``
+    into the root callback manager of every run, so it does not need an
+    application-level callback wiring.
+    """
     validate_enabled_tracing_providers()
-    enabled_providers = get_enabled_tracing_providers()
-    if not enabled_providers:
-        return []
+    if "langfuse" not in get_enabled_tracing_providers():
+        return None
 
     tracing_config = get_tracing_config()
-    callbacks: list[Any] = []
-
-    for provider in enabled_providers:
-        if provider == "langsmith":
-            try:
-                callbacks.append(_create_langsmith_tracer(tracing_config.langsmith))
-            except Exception as exc:  # pragma: no cover - exercised via tests with monkeypatch
-                raise RuntimeError(f"LangSmith tracing initialization failed: {exc}") from exc
-        elif provider == "langfuse":
-            try:
-                callbacks.append(_create_langfuse_handler(tracing_config.langfuse))
-            except Exception as exc:  # pragma: no cover - exercised via tests with monkeypatch
-                raise RuntimeError(f"Langfuse tracing initialization failed: {exc}") from exc
-
-    return callbacks
+    try:
+        return _create_langfuse_handler(tracing_config.langfuse)
+    except Exception as exc:  # pragma: no cover - exercised via tests with monkeypatch
+        raise RuntimeError(f"Langfuse tracing initialization failed: {exc}") from exc

--- a/backend/packages/harness/deerflow/tracing/factory.py
+++ b/backend/packages/harness/deerflow/tracing/factory.py
@@ -26,8 +26,12 @@ def _create_langfuse_handler(config) -> Any:
 def build_langfuse_handler() -> Any | None:
     """Build a Langfuse LangChain CallbackHandler if Langfuse tracing is enabled.
 
-    Returns ``None`` when Langfuse is not configured. Raises ``RuntimeError`` if
-    Langfuse is explicitly enabled but its initialization fails.
+    Returns ``None`` when Langfuse is not configured. Raises ``ValueError`` via
+    ``validate_enabled_tracing_providers()`` when a tracing provider is
+    explicitly enabled but its required environment variables are missing.
+    Raises ``RuntimeError`` when Langfuse is enabled and configured but the
+    ``CallbackHandler`` construction itself fails (e.g. unreachable host or
+    incompatible ``langfuse`` package version).
 
     LangSmith is intentionally not handled here: when ``LANGSMITH_TRACING`` is
     set, ``langchain_core.callbacks.manager`` auto-injects ``LangChainTracer``

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -87,10 +87,11 @@ def test_make_lead_agent_disables_thinking_when_model_does_not_support_it(monkey
 
     captured: dict[str, object] = {}
 
-    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None):
+    def _fake_create_chat_model(*, name, thinking_enabled, reasoning_effort=None, attach_tracing=True):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort
+        captured["attach_tracing"] = attach_tracing
         return object()
 
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
@@ -149,10 +150,11 @@ def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch
     captured: dict[str, object] = {}
     fake_model = object()
 
-    def _fake_create_chat_model(*, name=None, thinking_enabled, reasoning_effort=None):
+    def _fake_create_chat_model(*, name=None, thinking_enabled, reasoning_effort=None, attach_tracing=True):
         captured["name"] = name
         captured["thinking_enabled"] = thinking_enabled
         captured["reasoning_effort"] = reasoning_effort
+        captured["attach_tracing"] = attach_tracing
         return fake_model
 
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)

--- a/backend/tests/test_lead_agent_tracing.py
+++ b/backend/tests/test_lead_agent_tracing.py
@@ -1,0 +1,92 @@
+"""Tests that Langfuse tracing callback is injected at the invocation root config."""
+
+from __future__ import annotations
+
+from deerflow.agents.lead_agent import agent as lead_agent_module
+from deerflow.config.app_config import AppConfig
+from deerflow.config.model_config import ModelConfig
+from deerflow.config.sandbox_config import SandboxConfig
+
+
+def _make_app_config() -> AppConfig:
+    return AppConfig(
+        models=[
+            ModelConfig(
+                name="alpha",
+                display_name="alpha",
+                description=None,
+                use="langchain_openai:ChatOpenAI",
+                model="alpha",
+                supports_thinking=False,
+                supports_vision=False,
+            )
+        ],
+        sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"),
+    )
+
+
+def _patch_common(monkeypatch):
+    import deerflow.tools as tools_module
+
+    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: _make_app_config())
+    monkeypatch.setattr(tools_module, "get_available_tools", lambda **kwargs: [])
+    monkeypatch.setattr(lead_agent_module, "_build_middlewares", lambda config, model_name, agent_name=None: [])
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: object())
+    monkeypatch.setattr(lead_agent_module, "create_agent", lambda **kwargs: object())
+
+
+def _base_config() -> dict:
+    return {
+        "configurable": {
+            "model_name": "alpha",
+            "thinking_enabled": False,
+            "is_plan_mode": False,
+            "subagent_enabled": False,
+        }
+    }
+
+
+def test_make_lead_agent_injects_langfuse_into_invocation_callbacks(monkeypatch):
+    sentinel = object()
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(lead_agent_module, "build_langfuse_handler", lambda: sentinel)
+
+    config = _base_config()
+    lead_agent_module.make_lead_agent(config)
+
+    assert sentinel in config["callbacks"]
+
+
+def test_make_lead_agent_appends_to_existing_callbacks(monkeypatch):
+    sentinel = object()
+    pre_existing = object()
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(lead_agent_module, "build_langfuse_handler", lambda: sentinel)
+
+    config = _base_config()
+    config["callbacks"] = [pre_existing]
+    lead_agent_module.make_lead_agent(config)
+
+    assert config["callbacks"] == [pre_existing, sentinel]
+
+
+def test_make_lead_agent_no_op_when_langfuse_disabled(monkeypatch):
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(lead_agent_module, "build_langfuse_handler", lambda: None)
+
+    config = _base_config()
+    lead_agent_module.make_lead_agent(config)
+
+    assert "callbacks" not in config or not config["callbacks"]
+
+
+def test_make_lead_agent_injects_in_bootstrap_branch(monkeypatch):
+    sentinel = object()
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(lead_agent_module, "build_langfuse_handler", lambda: sentinel)
+
+    config = _base_config()
+    config["configurable"]["is_bootstrap"] = True
+    lead_agent_module.make_lead_agent(config)
+
+    assert sentinel in config["callbacks"]

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -772,3 +772,44 @@ class TestReinforcementHint:
         prompt = model.invoke.call_args[0][0]
         assert "Explicit correction signals were detected" in prompt
         assert "Positive reinforcement signals were detected" in prompt
+
+
+def test_get_model_attaches_langfuse_callback_for_standalone_use(monkeypatch) -> None:
+    """Regression test for the standalone-tracing path.
+
+    ``MemoryUpdater`` runs on a background thread outside of any LangGraph
+    invocation, so it has no graph-level Langfuse handler. The model factory
+    must therefore attach the Langfuse callback directly to the model the
+    updater builds, otherwise memory-update LLM calls disappear from
+    Langfuse entirely (see PR #2001 review feedback)."""
+    from deerflow.models import factory as factory_module
+    import deerflow.tracing as tracing_module
+
+    sentinel_handler = object()
+
+    captured_kwargs: dict = {}
+
+    class _StubModel:
+        def __init__(self, **kwargs):
+            self.callbacks: list = []
+
+    def _fake_create_chat_model(**kwargs):
+        captured_kwargs.update(kwargs)
+        model = _StubModel()
+        # Mimic factory's standalone branch.
+        if kwargs.get("attach_tracing", True):
+            model.callbacks = [sentinel_handler]
+        return model
+
+    # Patch at the symbol the updater module imported, not the factory module.
+    from deerflow.agents.memory import updater as updater_module
+
+    monkeypatch.setattr(updater_module, "create_chat_model", _fake_create_chat_model)
+    monkeypatch.setattr(tracing_module, "build_langfuse_handler", lambda: sentinel_handler)
+
+    updater = MemoryUpdater()
+    model = updater._get_model()
+
+    # Standalone caller — must NOT opt out of tracing.
+    assert captured_kwargs.get("attach_tracing", True) is True
+    assert sentinel_handler in model.callbacks

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -70,10 +70,9 @@ class FakeChatModel(BaseChatModel):
 
 
 def _patch_factory(monkeypatch, app_config: AppConfig, model_class=FakeChatModel):
-    """Patch get_app_config, resolve_class, and tracing for isolated unit tests."""
+    """Patch get_app_config and resolve_class for isolated unit tests."""
     monkeypatch.setattr(factory_module, "get_app_config", lambda: app_config)
     monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: model_class)
-    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: [])
 
 
 # ---------------------------------------------------------------------------
@@ -95,21 +94,22 @@ def test_uses_first_model_when_name_is_none(monkeypatch):
 def test_raises_when_model_not_found(monkeypatch):
     cfg = _make_app_config([_make_model("only-model")])
     monkeypatch.setattr(factory_module, "get_app_config", lambda: cfg)
-    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: [])
 
     with pytest.raises(ValueError, match="ghost-model"):
         factory_module.create_chat_model(name="ghost-model")
 
 
-def test_appends_all_tracing_callbacks(monkeypatch):
+def test_does_not_attach_tracing_callbacks_to_model(monkeypatch):
+    """Tracing callbacks must be attached at the graph level (see make_lead_agent),
+    not at the model level — model-level callbacks form their own root callback
+    manager and break Langfuse trace nesting."""
     cfg = _make_app_config([_make_model("alpha")])
     _patch_factory(monkeypatch, cfg)
-    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: ["smith-callback", "langfuse-callback"])
 
     FakeChatModel.captured_kwargs = {}
     model = factory_module.create_chat_model(name="alpha")
 
-    assert model.callbacks == ["smith-callback", "langfuse-callback"]
+    assert not getattr(model, "callbacks", None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -99,12 +99,59 @@ def test_raises_when_model_not_found(monkeypatch):
         factory_module.create_chat_model(name="ghost-model")
 
 
-def test_does_not_attach_tracing_callbacks_to_model(monkeypatch):
-    """Tracing callbacks must be attached at the graph level (see make_lead_agent),
-    not at the model level — model-level callbacks form their own root callback
-    manager and break Langfuse trace nesting."""
+def test_attaches_langfuse_callback_for_standalone_callers(monkeypatch):
+    """Standalone callers (memory updater, security scanner, subagent executor,
+    embedded client, etc.) invoke models outside a LangGraph run, so they have
+    no graph-level Langfuse handler. ``create_chat_model`` must attach the
+    Langfuse callback directly to the model in that case so those flows still
+    appear in Langfuse instead of being silently dropped."""
     cfg = _make_app_config([_make_model("alpha")])
     _patch_factory(monkeypatch, cfg)
+
+    sentinel_handler = object()
+    monkeypatch.setattr(factory_module, "build_langfuse_handler", lambda: sentinel_handler, raising=False)
+    # Also patch via the import path used inside the function body.
+    import deerflow.tracing as tracing_module
+
+    monkeypatch.setattr(tracing_module, "build_langfuse_handler", lambda: sentinel_handler)
+
+    FakeChatModel.captured_kwargs = {}
+    model = factory_module.create_chat_model(name="alpha")
+
+    assert sentinel_handler in (model.callbacks or [])
+
+
+def test_attach_tracing_false_skips_callback_for_graph_callers(monkeypatch):
+    """Graph callers (``make_lead_agent``, title middleware running inside the
+    graph) inject Langfuse at the invocation root. They MUST opt out of
+    model-level tracing — otherwise the model would form a separate root
+    callback manager and break trace nesting."""
+    cfg = _make_app_config([_make_model("alpha")])
+    _patch_factory(monkeypatch, cfg)
+
+    sentinel_handler = object()
+    import deerflow.tracing as tracing_module
+
+    monkeypatch.setattr(tracing_module, "build_langfuse_handler", lambda: sentinel_handler)
+
+    FakeChatModel.captured_kwargs = {}
+    model = factory_module.create_chat_model(name="alpha", attach_tracing=False)
+
+    assert not getattr(model, "callbacks", None)
+
+
+def test_create_chat_model_survives_tracing_init_failure(monkeypatch):
+    """A failure inside ``build_langfuse_handler`` must not break model creation
+    for standalone callers — tracing is best-effort, model availability is not."""
+    cfg = _make_app_config([_make_model("alpha")])
+    _patch_factory(monkeypatch, cfg)
+
+    def _boom():
+        raise RuntimeError("langfuse unreachable")
+
+    import deerflow.tracing as tracing_module
+
+    monkeypatch.setattr(tracing_module, "build_langfuse_handler", _boom)
 
     FakeChatModel.captured_kwargs = {}
     model = factory_module.create_chat_model(name="alpha")

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -91,7 +91,7 @@ class TestTitleMiddlewareCoreLogic:
         title = result["title"]
 
         assert title == "短标题"
-        title_middleware_module.create_chat_model.assert_called_once_with(thinking_enabled=False)
+        title_middleware_module.create_chat_model.assert_called_once_with(thinking_enabled=False, attach_tracing=False)
         model.ainvoke.assert_awaited_once()
 
     def test_generate_title_normalizes_structured_message_content(self, monkeypatch):

--- a/backend/tests/test_tracing_factory.py
+++ b/backend/tests/test_tracing_factory.py
@@ -35,26 +35,27 @@ def clear_tracing_env(monkeypatch):
     tracing_module._tracing_config = None
 
 
-def test_build_tracing_callbacks_returns_empty_list_when_disabled(monkeypatch):
+def test_build_langfuse_handler_returns_none_when_disabled(monkeypatch):
     monkeypatch.setattr(tracing_factory, "validate_enabled_tracing_providers", lambda: None)
     monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: [])
 
-    callbacks = tracing_factory.build_tracing_callbacks()
-
-    assert callbacks == []
+    assert tracing_factory.build_langfuse_handler() is None
 
 
-def test_build_tracing_callbacks_creates_langsmith_and_langfuse(monkeypatch):
-    class FakeLangSmithTracer:
-        def __init__(self, *, project_name: str):
-            self.project_name = project_name
+def test_build_langfuse_handler_returns_none_when_only_langsmith_enabled(monkeypatch):
+    monkeypatch.setattr(tracing_factory, "validate_enabled_tracing_providers", lambda: None)
+    monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: ["langsmith"])
 
+    assert tracing_factory.build_langfuse_handler() is None
+
+
+def test_build_langfuse_handler_creates_handler_when_enabled(monkeypatch):
     class FakeLangfuseHandler:
         def __init__(self, *, public_key: str):
             self.public_key = public_key
 
-    monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: ["langsmith", "langfuse"])
     monkeypatch.setattr(tracing_factory, "validate_enabled_tracing_providers", lambda: None)
+    monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: ["langfuse"])
     monkeypatch.setattr(
         tracing_factory,
         "get_tracing_config",
@@ -62,7 +63,6 @@ def test_build_tracing_callbacks_creates_langsmith_and_langfuse(monkeypatch):
             "Cfg",
             (),
             {
-                "langsmith": type("LangSmithCfg", (), {"project": "smith-project"})(),
                 "langfuse": type(
                     "LangfuseCfg",
                     (),
@@ -75,23 +75,21 @@ def test_build_tracing_callbacks_creates_langsmith_and_langfuse(monkeypatch):
             },
         )(),
     )
-    monkeypatch.setattr(tracing_factory, "_create_langsmith_tracer", lambda cfg: FakeLangSmithTracer(project_name=cfg.project))
     monkeypatch.setattr(
         tracing_factory,
         "_create_langfuse_handler",
         lambda cfg: FakeLangfuseHandler(public_key=cfg.public_key),
     )
 
-    callbacks = tracing_factory.build_tracing_callbacks()
+    handler = tracing_factory.build_langfuse_handler()
 
-    assert len(callbacks) == 2
-    assert callbacks[0].project_name == "smith-project"
-    assert callbacks[1].public_key == "pk-lf-test"
+    assert handler is not None
+    assert handler.public_key == "pk-lf-test"
 
 
-def test_build_tracing_callbacks_raises_when_enabled_provider_fails(monkeypatch):
-    monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: ["langfuse"])
+def test_build_langfuse_handler_raises_when_init_fails(monkeypatch):
     monkeypatch.setattr(tracing_factory, "validate_enabled_tracing_providers", lambda: None)
+    monkeypatch.setattr(tracing_factory, "get_enabled_tracing_providers", lambda: ["langfuse"])
     monkeypatch.setattr(
         tracing_factory,
         "get_tracing_config",
@@ -110,10 +108,10 @@ def test_build_tracing_callbacks_raises_when_enabled_provider_fails(monkeypatch)
     monkeypatch.setattr(tracing_factory, "_create_langfuse_handler", lambda cfg: (_ for _ in ()).throw(RuntimeError("boom")))
 
     with pytest.raises(RuntimeError, match="Langfuse tracing initialization failed"):
-        tracing_factory.build_tracing_callbacks()
+        tracing_factory.build_langfuse_handler()
 
 
-def test_build_tracing_callbacks_raises_for_explicitly_enabled_misconfigured_provider(monkeypatch):
+def test_build_langfuse_handler_raises_for_explicitly_enabled_misconfigured_provider(monkeypatch):
     from deerflow.config import tracing_config as tracing_module
 
     monkeypatch.setenv("LANGFUSE_TRACING", "true")
@@ -122,7 +120,7 @@ def test_build_tracing_callbacks_raises_for_explicitly_enabled_misconfigured_pro
     tracing_module._tracing_config = None
 
     with pytest.raises(ValueError, match="LANGFUSE_PUBLIC_KEY"):
-        tracing_factory.build_tracing_callbacks()
+        tracing_factory.build_langfuse_handler()
 
 
 def test_create_langfuse_handler_initializes_client_before_handler(monkeypatch):

--- a/docs/plans/2026-04-08-langfuse-trace-grouping-design.md
+++ b/docs/plans/2026-04-08-langfuse-trace-grouping-design.md
@@ -1,0 +1,81 @@
+# Langfuse Trace Grouping — Design
+
+**Date:** 2026-04-08
+**Branch:** `fix/langfuse-trace-grouping`
+**Scope:** Bug fix. Group all model / tool / node calls of one agent run into a single Langfuse trace, instead of producing one root trace per LLM call.
+
+---
+
+## Problem
+
+`packages/harness/deerflow/models/factory.py:114-118` attaches the Langfuse `CallbackHandler` to `model_instance.callbacks`. In LangChain, callbacks set on a model instance are *local* — they create their own callback manager that does not inherit the parent run_id from the surrounding graph invocation. Result: every LLM call becomes its own root trace in Langfuse, with no link to the agent run that produced it.
+
+LangSmith does not show this symptom because LangSmith's `LangChainTracer` is auto-injected by `langchain_core.callbacks.manager._configure()` whenever `LANGSMITH_TRACING=true` (or `LANGCHAIN_TRACING_V2=true`) is set. That auto-injection happens at the root callback manager of every run, independent of the model-level attachment in `factory.py`. The model-level LangSmith attachment is therefore redundant dead code.
+
+## Fix
+
+Attach the Langfuse handler at the **graph runnable** level, not the model level. The handler then participates in the root callback manager of every `agent.astream()` / `agent.ainvoke()` call, and all child runs (nodes, LLM calls, tool calls) are recorded as spans of one trace.
+
+Concretely, in `make_lead_agent()`, after `create_agent(...)` returns the compiled graph, wrap it with `compiled.with_config({"callbacks": [langfuse_handler]})` when Langfuse is enabled. This works for both runtime modes:
+
+- **Standard mode**: LangGraph Server invokes the returned runnable; `with_config` defaults are merged into the runtime config by langchain-core.
+- **Gateway mode**: `runtime/runs/worker.py:145` invokes via `agent.astream(graph_input, config=runnable_config, ...)`. Same merge applies.
+
+Single injection point covers both modes.
+
+## Changes
+
+### 1. `packages/harness/deerflow/tracing/factory.py`
+
+- Add `build_langfuse_handler() -> Any | None`. Returns a Langfuse `CallbackHandler` when the provider is enabled and configured; returns `None` when disabled; raises `RuntimeError` with provider name when explicitly enabled but initialization fails.
+- Delete `_create_langsmith_tracer()` and the LangSmith branch in `build_tracing_callbacks()`. LangSmith is fully handled by the `LANGSMITH_TRACING` env-var path inside langchain-core; the model-level attachment is redundant.
+- Delete `build_tracing_callbacks()` entirely (no remaining callers after the model-factory cleanup below). `validate_enabled_tracing_providers()` is still called from `build_langfuse_handler()` so the explicit-enabled-but-misconfigured failure mode is preserved for both providers.
+
+### 2. `packages/harness/deerflow/models/factory.py`
+
+- Remove the `build_tracing_callbacks()` import and the block at lines 114-118 that appends callbacks to `model_instance.callbacks`. Models no longer carry tracing callbacks.
+
+### 3. `packages/harness/deerflow/agents/lead_agent/agent.py`
+
+- In `make_lead_agent()`, after both `create_agent(...)` return points (bootstrap branch and default branch), apply:
+  ```python
+  langfuse_handler = build_langfuse_handler()
+  if langfuse_handler is not None:
+      compiled = compiled.with_config({"callbacks": [langfuse_handler]})
+  return compiled
+  ```
+- Build the handler **once per `make_lead_agent` call** (not module-level), so config reload picks it up on subsequent invocations.
+
+### 4. Tests
+
+- **`tests/test_tracing_factory.py`**: Replace existing tests. Cover `build_langfuse_handler()` for: provider disabled (returns `None`), provider enabled and configured (returns handler instance), provider explicitly enabled but init throws (raises `RuntimeError` mentioning "Langfuse"), explicitly enabled but missing keys (raises through `validate_enabled_tracing_providers`).
+- **`tests/test_model_factory.py`**: Drop the `build_tracing_callbacks` monkeypatch and the assertion that callbacks were attached to the model instance. Models should no longer have tracing callbacks attached by `create_chat_model`.
+- **New: `tests/test_lead_agent_tracing.py`**: Monkeypatch `build_langfuse_handler` to return a sentinel object. Call `make_lead_agent(config)`. Assert the returned runnable's bound config callbacks contain the sentinel. Also assert: when the handler is `None`, the returned runnable is not wrapped with extra callbacks.
+- **`tests/test_tracing_config.py`**: Unchanged. LangSmith config detection, Langfuse config detection, and validation behaviors are not modified.
+
+### 5. Docs
+
+- `backend/CLAUDE.md`: Add a short note under "Model Factory" / new "Tracing" subsection: tracing callbacks are attached at the graph level in `make_lead_agent`, not at the model level. LangSmith continues to work via the `LANGSMITH_TRACING` env var (langchain-core auto-injection).
+- `README.md` / `backend/README.md`: No change to env-var docs. Optionally add one sentence: "All model and tool calls within one agent run are grouped under a single Langfuse trace."
+
+## Out of Scope (separate PR)
+
+- Tagging Langfuse traces with `session_id = thread_id` / `user_id` for cross-turn grouping in the Langfuse UI.
+- Linking subagent LLM calls to the parent trace. `SubagentExecutor` runs subagents in a separate thread pool, which breaks asyncio contextvar propagation; the parent run_id has to be passed explicitly. This is a follow-up.
+
+## Risk: LangSmith Regression
+
+The fix removes the model-level LangSmith tracer attachment. LangSmith continues to work because:
+
+1. `tracing_config.py` still reads `LANGSMITH_TRACING` / `LANGCHAIN_TRACING_V2` and exposes the LangSmith config block — unchanged.
+2. When the env var is set, `langchain_core.callbacks.manager._configure()` auto-injects `LangChainTracer` at the root callback manager of every run. This path is independent of `factory.py` and has been the canonical LangSmith integration in langchain-core for years.
+3. `validate_enabled_tracing_providers()` still raises if `LANGSMITH_TRACING=true` but no API key is set — unchanged.
+
+Manual smoke test (left to the contributor before merge): start the app with `LANGSMITH_TRACING=true` and a valid API key, run one agent turn, confirm a trace appears in LangSmith with nested LLM / tool spans.
+
+## Acceptance
+
+- Unit tests: `cd backend && uv run pytest tests/test_tracing_config.py tests/test_tracing_factory.py tests/test_model_factory.py tests/test_lead_agent_tracing.py -q` passes.
+- Lint: `cd backend && uv run ruff check packages/harness/deerflow/tracing packages/harness/deerflow/models/factory.py packages/harness/deerflow/agents/lead_agent/agent.py` clean.
+- Manual: with Langfuse enabled, one agent turn produces exactly one Langfuse trace containing the model and tool calls as spans.
+- Manual: with LangSmith enabled, one agent turn still produces a properly nested LangSmith trace.

--- a/docs/plans/2026-04-08-langfuse-trace-grouping-design.md
+++ b/docs/plans/2026-04-08-langfuse-trace-grouping-design.md
@@ -14,12 +14,14 @@ LangSmith does not show this symptom because LangSmith's `LangChainTracer` is au
 
 ## Fix
 
-Attach the Langfuse handler at the **graph runnable** level, not the model level. The handler then participates in the root callback manager of every `agent.astream()` / `agent.ainvoke()` call, and all child runs (nodes, LLM calls, tool calls) are recorded as spans of one trace.
+Attach the Langfuse handler at the **invocation config root**, not the model level. The handler then participates in the root callback manager of every `agent.astream()` / `agent.ainvoke()` call, and all child runs (nodes, LLM calls, tool calls) are recorded as spans of one trace.
 
-Concretely, in `make_lead_agent()`, after `create_agent(...)` returns the compiled graph, wrap it with `compiled.with_config({"callbacks": [langfuse_handler]})` when Langfuse is enabled. This works for both runtime modes:
+Concretely, in `make_lead_agent(config)`, append the handler to `config["callbacks"]` before returning the compiled graph. Both runtime modes pass the very same `RunnableConfig` dict into graph execution afterward:
 
-- **Standard mode**: LangGraph Server invokes the returned runnable; `with_config` defaults are merged into the runtime config by langchain-core.
-- **Gateway mode**: `runtime/runs/worker.py:145` invokes via `agent.astream(graph_input, config=runnable_config, ...)`. Same merge applies.
+- **Standard mode**: LangGraph Server calls `make_lead_agent(config)` per invocation with the request's RunnableConfig, then invokes the returned graph with the same config.
+- **Gateway mode**: `runtime/runs/worker.py` calls `agent_factory(config=runnable_config)` and then `agent.astream(graph_input, config=runnable_config, ...)` using the same dict.
+
+This mutation pattern is consistent with how `make_lead_agent` already populates `config["metadata"]` for trace tagging (a few lines above). An alternative — wrapping the compiled graph with `compiled.with_config({"callbacks": [handler]})` — was considered but rejected because it would return a `RunnableBinding` instead of a `CompiledStateGraph`, which breaks LangGraph Server's subsequent attribute writes (e.g. `agent.checkpointer = ...`).
 
 Single injection point covers both modes.
 
@@ -37,14 +39,17 @@ Single injection point covers both modes.
 
 ### 3. `packages/harness/deerflow/agents/lead_agent/agent.py`
 
-- In `make_lead_agent()`, after both `create_agent(...)` return points (bootstrap branch and default branch), apply:
+- In `make_lead_agent(config)`, after the existing `config["metadata"].update(...)` block and before the `create_agent(...)` calls, append the Langfuse handler to `config["callbacks"]`:
   ```python
   langfuse_handler = build_langfuse_handler()
   if langfuse_handler is not None:
-      compiled = compiled.with_config({"callbacks": [langfuse_handler]})
-  return compiled
+      existing = config.get("callbacks") or []
+      if not isinstance(existing, list):
+          existing = list(existing)
+      config["callbacks"] = [*existing, langfuse_handler]
   ```
 - Build the handler **once per `make_lead_agent` call** (not module-level), so config reload picks it up on subsequent invocations.
+- `create_agent(...)` return value is unchanged — both bootstrap and default branches return the compiled graph directly, as before.
 
 ### 4. Tests
 


### PR DESCRIPTION
Langfuse CallbackHandler was attached to model_instance.callbacks, which forms a local root callback manager for every LLM call. As a result, each model call appeared as its own root trace in Langfuse instead of nesting under the agent run that produced it.

Move Langfuse handler injection into make_lead_agent, where it is appended to the invocation RunnableConfig's callbacks list before the graph is returned. The whole LangGraph invocation then becomes one trace and node / LLM / tool calls become its child spans. Works for both standard (LangGraph Server) and Gateway runtime modes since both pass the same RunnableConfig through to graph execution.

LangSmith is unaffected: it is auto-injected by langchain_core at the root callback manager whenever LANGSMITH_TRACING / LANGCHAIN_TRACING_V2 is set, so the previous model-level attachment was redundant and has been removed along with the now-unused build_tracing_callbacks helper.

Subagent trace linking (cross-thread contextvar propagation) and session_id tagging remain out of scope for this PR.