### PR TITLE
fix(frontend): use thread metadata for agent chat routes

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -452,6 +452,7 @@ export function useThreadStream({
             status: "uploaded" as const,
           }),
         );
+        const agentName = extraContext?.agent_name ?? context.agent_name;
 
         await thread.submit(
           {
@@ -477,6 +478,7 @@ export function useThreadStream({
             threadId: threadId,
             streamSubgraphs: true,
             streamResumable: true,
+            metadata: agentName ? { agent_name: agentName } : undefined,
             config: {
               recursion_limit: 1000,
             },
@@ -528,7 +530,7 @@ export function useThreads(
     limit: 50,
     sortBy: "updated_at",
     sortOrder: "desc",
-    select: ["thread_id", "updated_at", "values", "context"],
+    select: ["thread_id", "updated_at", "values", "metadata"],
   },
 ) {
   const apiClient = getAPIClient();

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -1,4 +1,4 @@
-import type { Message, Thread } from "@langchain/langgraph-sdk";
+import type { Message, Metadata, Thread } from "@langchain/langgraph-sdk";
 
 import type { Todo } from "../todos";
 
@@ -19,6 +19,11 @@ export interface AgentThreadContext extends Record<string, unknown> {
   agent_name?: string;
 }
 
-export interface AgentThread extends Thread<AgentThreadState> {
+export interface AgentThreadMetadata extends NonNullable<Metadata> {
+  agent_name?: string;
+}
+
+export interface AgentThread extends Omit<Thread<AgentThreadState>, "metadata"> {
+  metadata: AgentThreadMetadata | null | undefined;
   context?: AgentThreadContext;
 }

--- a/frontend/src/core/threads/utils.test.ts
+++ b/frontend/src/core/threads/utils.test.ts
@@ -15,6 +15,16 @@ void test("uses standard chat route when thread has no agent context", () => {
   );
 });
 
+void test("uses agent chat route when thread metadata has agent_name", () => {
+  assert.equal(
+    pathOfThread({
+      thread_id: "thread-123",
+      metadata: { agent_name: "researcher" },
+    }),
+    "/workspace/agents/researcher/chats/thread-123",
+  );
+});
+
 void test("uses agent chat route when thread context has agent_name", () => {
   assert.equal(
     pathOfThread({

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -1,13 +1,18 @@
 import type { Message } from "@langchain/langgraph-sdk";
 
-import type { AgentThread, AgentThreadContext } from "./types";
+import type {
+  AgentThread,
+  AgentThreadContext,
+  AgentThreadMetadata,
+} from "./types";
 
 type ThreadRouteTarget =
   | string
-  | Pick<AgentThread, "thread_id" | "context">
+  | Pick<AgentThread, "thread_id" | "context" | "metadata">
   | {
       thread_id: string;
       context?: Pick<AgentThreadContext, "agent_name"> | null;
+      metadata?: Pick<AgentThreadMetadata, "agent_name"> | null;
     };
 
 export function pathOfThread(
@@ -18,7 +23,7 @@ export function pathOfThread(
   const agentName =
     typeof thread === "string"
       ? context?.agent_name
-      : thread.context?.agent_name;
+      : thread.metadata?.agent_name ?? thread.context?.agent_name;
 
   return agentName
     ? `/workspace/agents/${encodeURIComponent(agentName)}/chats/${threadId}`


### PR DESCRIPTION
## Summary
- stop requesting `context` from `threads.search`, which returns `422` on current LangGraph API versions
- persist `agent_name` in thread metadata when creating agent chat threads
- derive chat routes from thread metadata, while keeping `context` as a fallback for compatibility
- add route tests for metadata-backed agent threads

## Why
`useThreads()` currently requests:

```ts
select: ["thread_id", "updated_at", "values", "context"]
```

On the currently locked backend API, `threads.search` rejects `context` in `select`, which makes the recent chat list fail to load and appear empty.

Thread metadata is already supported by both the frontend SDK and the backend search schema, so using metadata avoids the schema mismatch and keeps agent chat routing information searchable.

## Validation
- `cd frontend && pnpm check`
- open `http://localhost:2026/workspace/chats/new`
- verify the recent chat list loads again instead of failing with `422` from `POST /api/langgraph/threads/search`
