### PR TITLE
feat(provisioner): support secret-based sandbox env injection

### DIFF
--- a/backend/tests/test_provisioner_pod_spec.py
+++ b/backend/tests/test_provisioner_pod_spec.py
@@ -39,4 +39,3 @@ def test_build_pod_adds_secret_env_from_when_configured():
     assert len(container.env_from) == 1
     assert container.env_from[0].secret_ref is not None
     assert container.env_from[0].secret_ref.name == "sandbox-env"
-

--- a/backend/tests/test_provisioner_pod_spec.py
+++ b/backend/tests/test_provisioner_pod_spec.py
@@ -1,0 +1,42 @@
+"""Regression tests for provisioner sandbox pod spec generation."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_provisioner_module():
+    """Load docker/provisioner/app.py as an importable test module."""
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "docker" / "provisioner" / "app.py"
+    spec = importlib.util.spec_from_file_location("provisioner_app_pod_spec_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_build_pod_omits_env_from_when_sandbox_secret_is_unset():
+    provisioner_module = _load_provisioner_module()
+    provisioner_module.SANDBOX_ENV_SECRET = ""
+
+    pod = provisioner_module._build_pod("sandbox-1", "thread-1")
+    container = pod.spec.containers[0]
+
+    assert container.env_from is None
+
+
+def test_build_pod_adds_secret_env_from_when_configured():
+    provisioner_module = _load_provisioner_module()
+    provisioner_module.SANDBOX_ENV_SECRET = "sandbox-env"
+
+    pod = provisioner_module._build_pod("sandbox-1", "thread-1")
+    container = pod.spec.containers[0]
+
+    assert container.env_from is not None
+    assert len(container.env_from) == 1
+    assert container.env_from[0].secret_ref is not None
+    assert container.env_from[0].secret_ref.name == "sandbox-env"
+

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -70,6 +70,7 @@ KUBECONFIG_PATH = os.environ.get("KUBECONFIG_PATH", "/root/.kube/config")
 # services on the host Kubernetes node.  On Docker Desktop for macOS this
 # is ``host.docker.internal``; on Linux it may be the host's LAN IP.
 NODE_HOST = os.environ.get("NODE_HOST", "host.docker.internal")
+SANDBOX_ENV_SECRET = os.environ.get("SANDBOX_ENV_SECRET", "").strip()
 
 
 def join_host_path(base: str, *parts: str) -> str:
@@ -243,6 +244,18 @@ def _sandbox_url(node_port: int) -> str:
     return f"http://{NODE_HOST}:{node_port}"
 
 
+def _build_env_from_sources() -> list[k8s_client.V1EnvFromSource] | None:
+    """Return optional env_from sources for sandbox pods."""
+    if not SANDBOX_ENV_SECRET:
+        return None
+
+    return [
+        k8s_client.V1EnvFromSource(
+            secret_ref=k8s_client.V1SecretEnvSource(name=SANDBOX_ENV_SECRET),
+        )
+    ]
+
+
 def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
     """Construct a Pod manifest for a single sandbox."""
     thread_id = _validate_thread_id(thread_id)
@@ -263,6 +276,7 @@ def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
                     name="sandbox",
                     image=SANDBOX_IMAGE,
                     image_pull_policy="IfNotPresent",
+                    env_from=_build_env_from_sources(),
                     ports=[
                         k8s_client.V1ContainerPort(
                             name="http",


### PR DESCRIPTION
## Summary
- add optional `SANDBOX_ENV_SECRET` support to the provisioner pod spec
- inject sandbox pod environment variables via `env_from.secret_ref` only when configured
- add pod-spec regression tests for both configured and unset cases

## Why
This addresses the Volcano/K8s pod deployment gap reported in #1993 without changing the default hostPath-based behavior. When `SANDBOX_ENV_SECRET` is unset, the generated pod spec remains unchanged.

## Testing
- `cd backend && uv run ruff check tests/test_provisioner_kubeconfig.py tests/test_provisioner_pod_spec.py ../docker/provisioner/app.py`
- `cd backend && PYTHONPATH=. uv run pytest tests/test_provisioner_kubeconfig.py tests/test_provisioner_pod_spec.py -q`

Closes #1993