### PR TITLE
fix(gateway): preserve non-user input message types

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -15,7 +15,7 @@ import time
 from typing import Any
 
 from fastapi import HTTPException, Request
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from app.gateway.deps import get_checkpointer, get_run_manager, get_store, get_stream_bridge
 from deerflow.runtime import (
@@ -85,8 +85,31 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
                 content = msg.get("content", "")
                 if role in ("user", "human"):
                     converted.append(HumanMessage(content=content))
+                elif role in ("assistant", "ai"):
+                    converted.append(
+                        AIMessage(
+                            content=content,
+                            tool_calls=msg.get("tool_calls", []),
+                            id=msg.get("id"),
+                        )
+                    )
+                elif role == "system":
+                    converted.append(SystemMessage(content=content, id=msg.get("id")))
+                elif role == "tool":
+                    tool_call_id = msg.get("tool_call_id")
+                    if tool_call_id:
+                        converted.append(
+                            ToolMessage(
+                                content=content,
+                                tool_call_id=tool_call_id,
+                                name=msg.get("name"),
+                                id=msg.get("id"),
+                            )
+                        )
+                    else:
+                        logger.warning("normalize_input: tool message missing tool_call_id; falling back to HumanMessage")
+                        converted.append(HumanMessage(content=content))
                 else:
-                    # TODO: handle other message types (system, ai, tool)
                     converted.append(HumanMessage(content=content))
             else:
                 converted.append(msg)

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -105,9 +105,7 @@ def test_normalize_input_preserves_non_user_message_types():
     assert result["messages"][0].id == "sys-1"
     assert isinstance(result["messages"][1], AIMessage)
     assert result["messages"][1].id == "ai-1"
-    assert result["messages"][1].tool_calls == [
-        {"name": "web_search", "id": "tc-1", "args": {"query": "deerflow"}, "type": "tool_call"}
-    ]
+    assert result["messages"][1].tool_calls == [{"name": "web_search", "id": "tc-1", "args": {"query": "deerflow"}, "type": "tool_call"}]
     assert isinstance(result["messages"][2], ToolMessage)
     assert result["messages"][2].tool_call_id == "tc-1"
     assert result["messages"][2].name == "web_search"

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
 
 def test_format_sse_basic():
     from app.gateway.services import format_sse
@@ -71,7 +73,44 @@ def test_normalize_input_with_messages():
 
     result = normalize_input({"messages": [{"role": "user", "content": "hi"}]})
     assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], HumanMessage)
     assert result["messages"][0].content == "hi"
+
+
+def test_normalize_input_preserves_non_user_message_types():
+    from app.gateway.services import normalize_input
+
+    result = normalize_input(
+        {
+            "messages": [
+                {"role": "system", "content": "You are helpful.", "id": "sys-1"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "id": "ai-1",
+                    "tool_calls": [{"name": "web_search", "id": "tc-1", "args": {"query": "deerflow"}}],
+                },
+                {
+                    "role": "tool",
+                    "content": "search results",
+                    "name": "web_search",
+                    "tool_call_id": "tc-1",
+                    "id": "tool-1",
+                },
+            ]
+        }
+    )
+
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert result["messages"][0].id == "sys-1"
+    assert isinstance(result["messages"][1], AIMessage)
+    assert result["messages"][1].id == "ai-1"
+    assert result["messages"][1].tool_calls == [
+        {"name": "web_search", "id": "tc-1", "args": {"query": "deerflow"}, "type": "tool_call"}
+    ]
+    assert isinstance(result["messages"][2], ToolMessage)
+    assert result["messages"][2].tool_call_id == "tc-1"
+    assert result["messages"][2].name == "web_search"
 
 
 def test_normalize_input_passthrough():


### PR DESCRIPTION
## Summary
- preserve `system`, `assistant`, and `tool` message roles when normalizing run input
- keep assistant tool calls and tool message metadata instead of downgrading everything to `HumanMessage`
- add regression coverage for mixed message histories

## Why
`normalize_input()` currently converts every non-user dict message into `HumanMessage`, which corrupts replayed histories passed to the LangGraph-compatible run endpoints.

## Testing
- `cd backend && uv run ruff check app/gateway/services.py tests/test_gateway_services.py`
- `cd backend && PYTHONPATH=. uv run pytest tests/test_gateway_services.py -q`