### PR TITLE
feat(client): add get_thread_state parity for embedded client

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -40,6 +40,7 @@ from deerflow.config.app_config import get_app_config, reload_app_config
 from deerflow.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
 from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
+from deerflow.runtime import serialize_channel_values
 from deerflow.skills.installer import install_skill_from_archive
 from deerflow.uploads.manager import (
     claim_unique_filename,
@@ -416,6 +417,64 @@ class DeerFlowClient:
         checkpoints.sort(key=lambda x: x["ts"] if x["ts"] else "")
 
         return {"thread_id": thread_id, "checkpoints": checkpoints}
+
+    def get_thread_state(self, thread_id: str) -> dict:
+        """Get the latest state snapshot for a thread.
+
+        Args:
+            thread_id: Thread ID.
+
+        Returns:
+            Dict matching the Gateway ``ThreadStateResponse`` shape.
+
+        Raises:
+            ValueError: If the thread does not exist.
+            AttributeError: If the configured checkpointer cannot read thread state snapshots.
+        """
+        checkpointer = self._checkpointer
+        if checkpointer is None:
+            from deerflow.agents.checkpointer.provider import get_checkpointer
+
+            checkpointer = get_checkpointer()
+
+        get_tuple = getattr(checkpointer, "get_tuple", None)
+        if get_tuple is None:
+            raise AttributeError("Configured checkpointer does not support get_tuple()")
+
+        config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+        checkpoint_tuple = get_tuple(config)
+        if checkpoint_tuple is None:
+            raise ValueError(f"Thread {thread_id} not found")
+
+        checkpoint = getattr(checkpoint_tuple, "checkpoint", {}) or {}
+        metadata = getattr(checkpoint_tuple, "metadata", {}) or {}
+        checkpoint_id = None
+        ckpt_config = getattr(checkpoint_tuple, "config", {}) or {}
+        if ckpt_config:
+            checkpoint_id = ckpt_config.get("configurable", {}).get("checkpoint_id")
+
+        channel_values = checkpoint.get("channel_values", {})
+
+        parent_config = getattr(checkpoint_tuple, "parent_config", None)
+        parent_checkpoint_id = None
+        if parent_config:
+            parent_checkpoint_id = parent_config.get("configurable", {}).get("checkpoint_id")
+
+        tasks_raw = getattr(checkpoint_tuple, "tasks", []) or []
+        next_tasks = [task.name for task in tasks_raw if hasattr(task, "name")]
+        tasks = [{"id": getattr(task, "id", ""), "name": getattr(task, "name", "")} for task in tasks_raw]
+
+        created_at = str(metadata.get("created_at", ""))
+        return {
+            "values": serialize_channel_values(channel_values),
+            "next": next_tasks,
+            "metadata": metadata,
+            "checkpoint": {"id": checkpoint_id, "ts": created_at},
+            "checkpoint_id": checkpoint_id,
+            "parent_checkpoint_id": parent_checkpoint_id,
+            "created_at": created_at,
+            "tasks": tasks,
+        }
 
     # ------------------------------------------------------------------
     # Public API — conversation

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -606,6 +606,31 @@ class TestThreadQueries:
         cp.pending_writes = pending_writes or []
         return cp
 
+    def _make_mock_state_checkpoint_tuple(
+        self,
+        thread_id: str,
+        checkpoint_id: str,
+        *,
+        created_at: str,
+        parent_id: str | None = None,
+        channel_values: dict | None = None,
+        tasks: list | None = None,
+    ):
+        cp = MagicMock()
+        cp.config = {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+        cp.checkpoint = {
+            "channel_values": channel_values or {},
+        }
+        cp.metadata = {"created_at": created_at, "source": "test"}
+        cp.parent_config = {"configurable": {"thread_id": thread_id, "checkpoint_id": parent_id}} if parent_id else None
+        cp.tasks = tasks or []
+        return cp
+
     def test_list_threads_empty(self, client):
         mock_checkpointer = MagicMock()
         mock_checkpointer.list.return_value = []
@@ -709,6 +734,62 @@ class TestThreadQueries:
         assert result["thread_id"] == "t99"
         assert result["checkpoints"] == []
         mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t99"}})
+
+    def test_get_thread_state(self, client):
+        mock_checkpointer = MagicMock()
+        client._checkpointer = mock_checkpointer
+
+        msg1 = HumanMessage(content="Hello", id="m1")
+        msg2 = AIMessage(content="Hi there", id="m2")
+        task = MagicMock()
+        task.id = "task-1"
+        task.name = "resume_node"
+        cp = self._make_mock_state_checkpoint_tuple(
+            "t1",
+            "c2",
+            created_at="2023-01-01T10:01:00Z",
+            parent_id="c1",
+            channel_values={"title": "Thread 1", "messages": [msg1, msg2]},
+            tasks=[task],
+        )
+        mock_checkpointer.get_tuple.return_value = cp
+
+        result = client.get_thread_state("t1")
+
+        mock_checkpointer.get_tuple.assert_called_once_with({"configurable": {"thread_id": "t1", "checkpoint_ns": ""}})
+        assert result["checkpoint"] == {"id": "c2", "ts": "2023-01-01T10:01:00Z"}
+        assert result["checkpoint_id"] == "c2"
+        assert result["parent_checkpoint_id"] == "c1"
+        assert result["created_at"] == "2023-01-01T10:01:00Z"
+        assert result["metadata"]["source"] == "test"
+        assert result["next"] == ["resume_node"]
+        assert result["tasks"] == [{"id": "task-1", "name": "resume_node"}]
+        assert result["values"]["title"] == "Thread 1"
+        assert result["values"]["messages"][0]["content"] == "Hello"
+        assert result["values"]["messages"][1]["content"] == "Hi there"
+
+    def test_get_thread_state_not_found(self, client):
+        mock_checkpointer = MagicMock()
+        mock_checkpointer.get_tuple.return_value = None
+        client._checkpointer = mock_checkpointer
+
+        with pytest.raises(ValueError, match="Thread missing not found"):
+            client.get_thread_state("missing")
+
+    def test_get_thread_state_fallback_checkpointer(self, client):
+        mock_checkpointer = MagicMock()
+        cp = self._make_mock_state_checkpoint_tuple(
+            "t99",
+            "c99",
+            created_at="2023-01-01T00:00:00Z",
+        )
+        mock_checkpointer.get_tuple.return_value = cp
+
+        with patch("deerflow.agents.checkpointer.provider.get_checkpointer", return_value=mock_checkpointer):
+            result = client.get_thread_state("t99")
+
+        assert result["checkpoint_id"] == "c99"
+        mock_checkpointer.get_tuple.assert_called_once_with({"configurable": {"thread_id": "t99", "checkpoint_ns": ""}})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add DeerFlowClient.get_thread_state(thread_id) for embedded mode
- mirror the Gateway ThreadStateResponse shape for latest checkpoint snapshots
- add regression coverage for direct usage, fallback checkpointer resolution, and missing threads

## Testing
- cd backend && uv run ruff check packages/harness/deerflow/client.py tests/test_client.py
- cd backend && PYTHONPATH=. uv run pytest tests/test_client.py -q
