### PR TITLE
feat(client): add get_thread_history parity for embedded client

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -40,6 +40,7 @@ from deerflow.config.app_config import get_app_config, reload_app_config
 from deerflow.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
 from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
+from deerflow.runtime import serialize_channel_values
 from deerflow.skills.installer import install_skill_from_archive
 from deerflow.uploads.manager import (
     claim_unique_filename,
@@ -416,6 +417,55 @@ class DeerFlowClient:
         checkpoints.sort(key=lambda x: x["ts"] if x["ts"] else "")
 
         return {"thread_id": thread_id, "checkpoints": checkpoints}
+
+    def get_thread_history(self, thread_id: str, *, limit: int = 10, before: str | None = None) -> list[dict]:
+        """Get checkpoint history entries for a thread.
+
+        Args:
+            thread_id: Thread ID.
+            limit: Maximum number of entries to return. Default is 10.
+            before: Optional checkpoint cursor for pagination.
+
+        Returns:
+            List of dicts matching the Gateway ``HistoryEntry`` shape.
+        """
+        checkpointer = self._checkpointer
+        if checkpointer is None:
+            from deerflow.agents.checkpointer.provider import get_checkpointer
+
+            checkpointer = get_checkpointer()
+
+        config: dict[str, Any] = {"configurable": {"thread_id": thread_id}}
+        if before:
+            config["configurable"]["checkpoint_id"] = before
+
+        entries: list[dict] = []
+        for checkpoint_tuple in checkpointer.list(config, limit=limit):
+            ckpt_config = getattr(checkpoint_tuple, "config", {}) or {}
+            parent_config = getattr(checkpoint_tuple, "parent_config", None)
+            metadata = getattr(checkpoint_tuple, "metadata", {}) or {}
+            checkpoint = getattr(checkpoint_tuple, "checkpoint", {}) or {}
+
+            checkpoint_id = ckpt_config.get("configurable", {}).get("checkpoint_id", "")
+            parent_id = None
+            if parent_config:
+                parent_id = parent_config.get("configurable", {}).get("checkpoint_id")
+
+            tasks_raw = getattr(checkpoint_tuple, "tasks", []) or []
+            next_tasks = [task.name for task in tasks_raw if hasattr(task, "name")]
+
+            entries.append(
+                {
+                    "checkpoint_id": checkpoint_id,
+                    "parent_checkpoint_id": parent_id,
+                    "metadata": metadata,
+                    "values": serialize_channel_values(checkpoint.get("channel_values", {})),
+                    "created_at": str(metadata.get("created_at", "")),
+                    "next": next_tasks,
+                }
+            )
+
+        return entries
 
     # ------------------------------------------------------------------
     # Public API — conversation

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -571,7 +571,7 @@ class TestGetModel:
 
 
 # ---------------------------------------------------------------------------
-# Thread Queries (list_threads / get_thread)
+# Thread Queries (list_threads / get_thread / get_thread_history)
 # ---------------------------------------------------------------------------
 
 
@@ -596,7 +596,7 @@ class TestThreadQueries:
             channel_values["messages"] = messages
 
         cp.checkpoint = {"ts": ts, "channel_values": channel_values}
-        cp.metadata = {"source": "test"}
+        cp.metadata = {"source": "test", "created_at": ts}
 
         if parent_id:
             cp.parent_config = {"configurable": {"thread_id": thread_id, "checkpoint_id": parent_id}}
@@ -709,6 +709,55 @@ class TestThreadQueries:
         assert result["thread_id"] == "t99"
         assert result["checkpoints"] == []
         mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t99"}})
+
+    def test_get_thread_history(self, client):
+        mock_checkpointer = MagicMock()
+        client._checkpointer = mock_checkpointer
+
+        msg1 = HumanMessage(content="Hello", id="m1")
+        msg2 = AIMessage(content="Hi there", id="m2")
+        task = MagicMock()
+        task.name = "resume_node"
+        cp1 = self._make_mock_checkpoint_tuple("t1", "c1", "2023-01-01T10:00:00Z", messages=[msg1])
+        cp1.tasks = []
+        cp2 = self._make_mock_checkpoint_tuple("t1", "c2", "2023-01-01T10:01:00Z", parent_id="c1", messages=[msg1, msg2])
+        cp2.tasks = [task]
+        mock_checkpointer.list.return_value = [cp2, cp1]
+
+        result = client.get_thread_history("t1", limit=2, before="cursor-1")
+
+        mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t1", "checkpoint_id": "cursor-1"}}, limit=2)
+        assert len(result) == 2
+        assert result[0]["checkpoint_id"] == "c2"
+        assert result[0]["parent_checkpoint_id"] == "c1"
+        assert result[0]["created_at"] == "2023-01-01T10:01:00Z"
+        assert result[0]["next"] == ["resume_node"]
+        assert result[0]["values"]["messages"][1]["content"] == "Hi there"
+        assert result[1]["checkpoint_id"] == "c1"
+        assert result[1]["next"] == []
+
+    def test_get_thread_history_empty(self, client):
+        mock_checkpointer = MagicMock()
+        mock_checkpointer.list.return_value = []
+        client._checkpointer = mock_checkpointer
+
+        result = client.get_thread_history("t-empty")
+
+        assert result == []
+        mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t-empty"}}, limit=10)
+
+    def test_get_thread_history_fallback_checkpointer(self, client):
+        mock_checkpointer = MagicMock()
+        cp = self._make_mock_checkpoint_tuple("t99", "c99", "2023-01-01T10:00:00Z")
+        cp.tasks = []
+        mock_checkpointer.list.return_value = [cp]
+
+        with patch("deerflow.agents.checkpointer.provider.get_checkpointer", return_value=mock_checkpointer):
+            result = client.get_thread_history("t99", limit=1)
+
+        assert len(result) == 1
+        assert result[0]["checkpoint_id"] == "c99"
+        mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t99"}}, limit=1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `DeerFlowClient.get_thread_history()` to mirror the Gateway thread history endpoint
- reuse embedded checkpointer access and `serialize_channel_values()` so returned entries match Gateway history payloads
- cover cursor pagination, empty history, and fallback checkpointer lookup in client tests

## Testing
- cd backend && uv run ruff check packages/harness/deerflow/client.py tests/test_client.py
- cd backend && PYTHONPATH=. uv run pytest tests/test_client.py -q