### PR TITLE
feat(client): add patch_thread parity for embedded client

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -21,6 +21,7 @@ import logging
 import mimetypes
 import shutil
 import tempfile
+import time
 import uuid
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
@@ -40,6 +41,7 @@ from deerflow.config.app_config import get_app_config, reload_app_config
 from deerflow.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
 from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
+from deerflow.runtime.store.provider import get_store
 from deerflow.skills.installer import install_skill_from_archive
 from deerflow.uploads.manager import (
     claim_unique_filename,
@@ -53,6 +55,7 @@ from deerflow.uploads.manager import (
 )
 
 logger = logging.getLogger(__name__)
+THREADS_NS: tuple[str, ...] = ("threads",)
 
 
 @dataclass
@@ -416,6 +419,41 @@ class DeerFlowClient:
         checkpoints.sort(key=lambda x: x["ts"] if x["ts"] else "")
 
         return {"thread_id": thread_id, "checkpoints": checkpoints}
+
+    def patch_thread(self, thread_id: str, metadata: dict[str, Any]) -> dict:
+        """Merge metadata into an existing thread record.
+
+        Args:
+            thread_id: Thread ID.
+            metadata: Metadata keys to merge into the thread record.
+
+        Returns:
+            Dict matching the Gateway ``ThreadResponse`` shape.
+        """
+        store = get_store()
+        if store is None:
+            raise RuntimeError("Store not available")
+
+        item = store.get(THREADS_NS, thread_id)
+        record = item.value if item is not None else None
+        if record is None:
+            raise FileNotFoundError(f"Thread {thread_id} not found")
+
+        now = time.time()
+        updated = dict(record)
+        updated.setdefault("metadata", {}).update(metadata)
+        updated["updated_at"] = now
+        store.put(THREADS_NS, thread_id, updated)
+
+        return {
+            "thread_id": thread_id,
+            "status": updated.get("status", "idle"),
+            "created_at": str(updated.get("created_at", "")),
+            "updated_at": str(now),
+            "metadata": updated.get("metadata", {}),
+            "values": {},
+            "interrupts": {},
+        }
 
     # ------------------------------------------------------------------
     # Public API — conversation

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -571,7 +571,7 @@ class TestGetModel:
 
 
 # ---------------------------------------------------------------------------
-# Thread Queries (list_threads / get_thread)
+# Thread Queries (list_threads / get_thread / patch_thread)
 # ---------------------------------------------------------------------------
 
 
@@ -709,6 +709,63 @@ class TestThreadQueries:
         assert result["thread_id"] == "t99"
         assert result["checkpoints"] == []
         mock_checkpointer.list.assert_called_once_with({"configurable": {"thread_id": "t99"}})
+
+    def test_patch_thread(self, client):
+        store = MagicMock()
+        item = MagicMock()
+        item.value = {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": 1710000000.0,
+            "updated_at": 1710000001.0,
+            "metadata": {"source": "old", "keep": "yes"},
+            "values": {"title": "Existing"},
+        }
+        store.get.return_value = item
+
+        with (
+            patch("deerflow.client.get_store", return_value=store),
+            patch("deerflow.client.time.time", return_value=1710001234.5),
+        ):
+            result = client.patch_thread("t1", {"source": "new", "added": "ok"})
+
+        store.get.assert_called_once_with(("threads",), "t1")
+        store.put.assert_called_once_with(
+            ("threads",),
+            "t1",
+            {
+                "thread_id": "t1",
+                "status": "idle",
+                "created_at": 1710000000.0,
+                "updated_at": 1710001234.5,
+                "metadata": {"source": "new", "keep": "yes", "added": "ok"},
+                "values": {"title": "Existing"},
+            },
+        )
+        assert result == {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": "1710000000.0",
+            "updated_at": "1710001234.5",
+            "metadata": {"source": "new", "keep": "yes", "added": "ok"},
+            "values": {},
+            "interrupts": {},
+        }
+
+    def test_patch_thread_not_found(self, client):
+        store = MagicMock()
+        store.get.return_value = None
+
+        with patch("deerflow.client.get_store", return_value=store):
+            with pytest.raises(FileNotFoundError, match="Thread t-missing not found"):
+                client.patch_thread("t-missing", {"status": "new"})
+
+        store.get.assert_called_once_with(("threads",), "t-missing")
+
+    def test_patch_thread_store_unavailable(self, client):
+        with patch("deerflow.client.get_store", return_value=None):
+            with pytest.raises(RuntimeError, match="Store not available"):
+                client.patch_thread("t1", {"status": "new"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `DeerFlowClient.patch_thread()` to mirror the Gateway thread metadata patch endpoint
- merge metadata through the embedded sync store and return a Gateway-shaped thread response
- cover success, missing thread, and store-unavailable paths in client tests

## Testing
- cd backend && uv run ruff check packages/harness/deerflow/client.py tests/test_client.py
- cd backend && PYTHONPATH=. uv run pytest tests/test_client.py -q