### PR TITLE
fix(frontend): guard markdown paragraphs from block children

### DIFF
--- a/frontend/src/components/workspace/messages/markdown-content-utils.test.ts
+++ b/frontend/src/components/workspace/messages/markdown-content-utils.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { filterPresentChildren, hasBlockLevelChildren } = await import(
+  new URL("./markdown-content-utils.ts", import.meta.url).href
+);
+
+function element(type: string, props: Record<string, unknown> = {}) {
+  return { type, props };
+}
+
+void test("detects block-level markdown children", () => {
+  const children = [
+    element("span", { children: "inline" }),
+    element("div", { children: "block" }),
+  ];
+
+  assert.equal(hasBlockLevelChildren(children), true);
+});
+
+void test("detects streamdown code block containers", () => {
+  const children = element("span", { "data-code-block-container": true });
+
+  assert.equal(hasBlockLevelChildren(children), true);
+});
+
+void test("ignores inline-only children", () => {
+  const children = [
+    element("span", { children: "inline" }),
+    "plain text",
+  ];
+
+  assert.equal(hasBlockLevelChildren(children), false);
+});
+
+void test("filters empty paragraph children when unwrapping", () => {
+  const children = filterPresentChildren([
+    null,
+    undefined,
+    "",
+    "text",
+    element("div", { children: "block" }),
+  ]);
+
+  assert.equal(children.length, 2);
+  assert.equal(children[0], "text");
+  assert.equal((children[1] as { type: string }).type, "div");
+});

--- a/frontend/src/components/workspace/messages/markdown-content-utils.test.ts
+++ b/frontend/src/components/workspace/messages/markdown-content-utils.test.ts
@@ -25,10 +25,7 @@ void test("detects streamdown code block containers", () => {
 });
 
 void test("ignores inline-only children", () => {
-  const children = [
-    element("span", { children: "inline" }),
-    "plain text",
-  ];
+  const children = [element("span", { children: "inline" }), "plain text"];
 
   assert.equal(hasBlockLevelChildren(children), false);
 });

--- a/frontend/src/components/workspace/messages/markdown-content-utils.ts
+++ b/frontend/src/components/workspace/messages/markdown-content-utils.ts
@@ -48,7 +48,9 @@ export function isBlockLevelChild(node: ReactNode): boolean {
   }
 
   const props = element.props;
-  return !!props && typeof props === "object" && "data-code-block-container" in props;
+  return (
+    !!props && typeof props === "object" && "data-code-block-container" in props
+  );
 }
 
 export function hasBlockLevelChildren(children: ReactNode): boolean {
@@ -60,5 +62,7 @@ export function hasBlockLevelChildren(children: ReactNode): boolean {
 
 export function filterPresentChildren(children: ReactNode): ReactNode[] {
   const normalizedChildren = Array.isArray(children) ? children : [children];
-  return normalizedChildren.filter((child) => child !== null && child !== undefined && child !== "");
+  return normalizedChildren.filter(
+    (child) => child !== null && child !== undefined && child !== "",
+  );
 }

--- a/frontend/src/components/workspace/messages/markdown-content-utils.ts
+++ b/frontend/src/components/workspace/messages/markdown-content-utils.ts
@@ -1,0 +1,64 @@
+import type { ReactElement, ReactNode } from "react";
+
+const BLOCK_LEVEL_TAGS = new Set([
+  "div",
+  "section",
+  "article",
+  "header",
+  "footer",
+  "main",
+  "aside",
+  "nav",
+  "figure",
+  "figcaption",
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "ol",
+  "ul",
+  "li",
+  "dl",
+  "dt",
+  "dd",
+  "blockquote",
+  "pre",
+  "hr",
+  "form",
+  "canvas",
+  "video",
+  "audio",
+  "iframe",
+  "object",
+]);
+
+export function isBlockLevelChild(node: ReactNode): boolean {
+  if (!node || typeof node !== "object") {
+    return false;
+  }
+
+  const element = node as ReactElement<Record<string, unknown>>;
+  if (element.type === "div") {
+    return true;
+  }
+
+  if (typeof element.type === "string" && BLOCK_LEVEL_TAGS.has(element.type)) {
+    return true;
+  }
+
+  const props = element.props;
+  return !!props && typeof props === "object" && "data-code-block-container" in props;
+}
+
+export function hasBlockLevelChildren(children: ReactNode): boolean {
+  if (Array.isArray(children)) {
+    return children.some(isBlockLevelChild);
+  }
+  return isBlockLevelChild(children);
+}
+
+export function filterPresentChildren(children: ReactNode): ReactNode[] {
+  const normalizedChildren = Array.isArray(children) ? children : [children];
+  return normalizedChildren.filter((child) => child !== null && child !== undefined && child !== "");
+}

--- a/frontend/src/components/workspace/messages/markdown-content.tsx
+++ b/frontend/src/components/workspace/messages/markdown-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
-import type { AnchorHTMLAttributes } from "react";
+import type { AnchorHTMLAttributes, HTMLAttributes } from "react";
 
 import {
   MessageResponse,
@@ -11,6 +11,10 @@ import { streamdownPlugins } from "@/core/streamdown";
 import { cn } from "@/lib/utils";
 
 import { CitationLink } from "../citations/citation-link";
+import {
+  filterPresentChildren,
+  hasBlockLevelChildren,
+} from "./markdown-content-utils";
 
 function isExternalUrl(href: string | undefined): boolean {
   return !!href && /^https?:\/\//.test(href);
@@ -24,6 +28,17 @@ export type MarkdownContentProps = {
   remarkPlugins?: MessageResponseProps["remarkPlugins"];
   components?: MessageResponseProps["components"];
 };
+
+function Paragraph({
+  children,
+  ...props
+}: HTMLAttributes<HTMLParagraphElement>) {
+  if (hasBlockLevelChildren(children)) {
+    return <>{filterPresentChildren(children)}</>;
+  }
+
+  return <p {...props}>{children}</p>;
+}
 
 /** Renders markdown content. */
 export function MarkdownContent({
@@ -57,6 +72,7 @@ export function MarkdownContent({
           />
         );
       },
+      p: Paragraph,
       ...componentsFromProps,
     };
   }, [componentsFromProps]);


### PR DESCRIPTION
## Summary
- prevent markdown paragraph wrappers from nesting block-level children that trigger hydration errors
- add a small utility to detect block-level and streamdown code-block container nodes before rendering `<p>`
- add a lightweight frontend regression test for the paragraph unwrapping logic

## Testing
- cd frontend && bun test src/components/workspace/messages/markdown-content-utils.test.ts

## Notes
- I did not run full frontend lint/typecheck in this worktree because the full frontend dependency tree is not installed locally here.