### PR TITLE
Add TypeScript SDK path to code-workspace settings

### DIFF
--- a/deer-flow.code-workspace
+++ b/deer-flow.code-workspace
@@ -5,7 +5,7 @@
     }
   ],
   "settings": {
-    "js/ts.tsdk.path": "frontend/node_modules/typescript/lib",
+    "typescript.tsdk": "frontend/node_modules/typescript/lib",
     "python-envs.pythonProjects": [
       {
         "path": "backend",

--- a/deer-flow.code-workspace
+++ b/deer-flow.code-workspace
@@ -5,6 +5,7 @@
     }
   ],
   "settings": {
+    "js/ts.tsdk.path": "frontend/node_modules/typescript/lib",
     "python-envs.pythonProjects": [
       {
         "path": "backend",


### PR DESCRIPTION
This pull request makes a small configuration update to the `deer-flow.code-workspace` file, specifying the TypeScript SDK path for JavaScript and TypeScript development in the workspace.