### PR TITLE
fix(frontend): replace invalid "context" select field with "metadata" in threads.search

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -213,8 +213,8 @@ export function useThreadStream({
       handleStreamStart(meta.thread_id);
       setOnStreamThreadId(meta.thread_id);
       if (context.agent_name && !isMock) {
-        void getAPIClient().threads
-          .update(meta.thread_id, {
+        void getAPIClient()
+          .threads.update(meta.thread_id, {
             metadata: { agent_name: context.agent_name },
           })
           .catch(() => ({}));

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -212,10 +212,12 @@ export function useThreadStream({
     onCreated(meta) {
       handleStreamStart(meta.thread_id);
       setOnStreamThreadId(meta.thread_id);
-      if (context.agent_name) {
-        void getAPIClient(isMock).threads.update(meta.thread_id, {
-          metadata: { agent_name: context.agent_name },
-        });
+      if (context.agent_name && !isMock) {
+        void getAPIClient().threads
+          .update(meta.thread_id, {
+            metadata: { agent_name: context.agent_name },
+          })
+          .catch(() => ({}));
       }
     },
     onLangChainEvent(event) {

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -212,6 +212,11 @@ export function useThreadStream({
     onCreated(meta) {
       handleStreamStart(meta.thread_id);
       setOnStreamThreadId(meta.thread_id);
+      if (context.agent_name) {
+        void getAPIClient(isMock).threads.update(meta.thread_id, {
+          metadata: { agent_name: context.agent_name },
+        });
+      }
     },
     onLangChainEvent(event) {
       if (event.event === "on_tool_end") {
@@ -528,7 +533,7 @@ export function useThreads(
     limit: 50,
     sortBy: "updated_at",
     sortOrder: "desc",
-    select: ["thread_id", "updated_at", "values", "context"],
+    select: ["thread_id", "updated_at", "values", "metadata"],
   },
 ) {
   const apiClient = getAPIClient();

--- a/frontend/src/core/threads/utils.test.ts
+++ b/frontend/src/core/threads/utils.test.ts
@@ -31,3 +31,24 @@ void test("uses provided context when pathOfThread is called with a thread id", 
     "/workspace/agents/ops%20agent/chats/thread-123",
   );
 });
+
+void test("uses agent chat route when thread metadata has agent_name", () => {
+  assert.equal(
+    pathOfThread({
+      thread_id: "thread-456",
+      metadata: { agent_name: "coder" },
+    }),
+    "/workspace/agents/coder/chats/thread-456",
+  );
+});
+
+void test("prefers context.agent_name over metadata.agent_name", () => {
+  assert.equal(
+    pathOfThread({
+      thread_id: "thread-789",
+      context: { agent_name: "from-context" },
+      metadata: { agent_name: "from-metadata" },
+    }),
+    "/workspace/agents/from-context/chats/thread-789",
+  );
+});

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -4,10 +4,10 @@ import type { AgentThread, AgentThreadContext } from "./types";
 
 type ThreadRouteTarget =
   | string
-  | Pick<AgentThread, "thread_id" | "context">
   | {
       thread_id: string;
       context?: Pick<AgentThreadContext, "agent_name"> | null;
+      metadata?: Record<string, unknown> | null;
     };
 
 export function pathOfThread(
@@ -18,7 +18,10 @@ export function pathOfThread(
   const agentName =
     typeof thread === "string"
       ? context?.agent_name
-      : thread.context?.agent_name;
+      : (thread.context?.agent_name ??
+        (typeof thread.metadata?.agent_name === "string"
+          ? thread.metadata.agent_name
+          : undefined));
 
   return agentName
     ? `/workspace/agents/${encodeURIComponent(agentName)}/chats/${threadId}`

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -15,13 +15,18 @@ export function pathOfThread(
   context?: Pick<AgentThreadContext, "agent_name"> | null,
 ) {
   const threadId = typeof thread === "string" ? thread : thread.thread_id;
-  const agentName =
-    typeof thread === "string"
-      ? context?.agent_name
-      : (thread.context?.agent_name ??
-        (typeof thread.metadata?.agent_name === "string"
-          ? thread.metadata.agent_name
-          : undefined));
+  let agentName: string | undefined;
+  if (typeof thread === "string") {
+    agentName = context?.agent_name;
+  } else {
+    agentName = thread.context?.agent_name;
+    if (!agentName) {
+      const metaAgent = thread.metadata?.agent_name;
+      if (typeof metaAgent === "string") {
+        agentName = metaAgent;
+      }
+    }
+  }
 
   return agentName
     ? `/workspace/agents/${encodeURIComponent(agentName)}/chats/${threadId}`


### PR DESCRIPTION
fixes #2037, #2059

## Summary

The LangGraph API server does not support "context" as a select field for threads/search, causing a 422 Unprocessable Entity error introduced by commit 60e0abf (#1771).

- Replace "context" with "metadata" in the default select list
- Persist agent_name into thread metadata on creation so search results carry the agent identity
- Update pathOfThread() to fall back to metadata.agent_name when context is unavailable from search results
- Add regression tests for metadata-based agent routing

## Screenshots

### After

<img width="1436" height="770" alt="pr-2053" src="https://github.com/user-attachments/assets/e5fc663e-c6ea-4179-8b42-a53a1241ae6a" />

