### PR TITLE
feat(client): add create_thread parity for embedded client

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -21,6 +21,7 @@ import logging
 import mimetypes
 import shutil
 import tempfile
+import time
 import uuid
 from collections.abc import Generator, Sequence
 from dataclasses import dataclass, field
@@ -32,6 +33,7 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 
+from deerflow.agents.checkpointer.provider import get_checkpointer
 from deerflow.agents.lead_agent.agent import _build_middlewares
 from deerflow.agents.lead_agent.prompt import apply_prompt_template
 from deerflow.agents.thread_state import ThreadState
@@ -40,6 +42,7 @@ from deerflow.config.app_config import get_app_config, reload_app_config
 from deerflow.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
 from deerflow.config.paths import get_paths
 from deerflow.models import create_chat_model
+from deerflow.runtime.store.provider import get_store
 from deerflow.skills.installer import install_skill_from_archive
 from deerflow.uploads.manager import (
     claim_unique_filename,
@@ -53,6 +56,7 @@ from deerflow.uploads.manager import (
 )
 
 logger = logging.getLogger(__name__)
+THREADS_NS: tuple[str, ...] = ("threads",)
 
 
 @dataclass
@@ -374,6 +378,78 @@ class DeerFlowClient:
         threads.sort(key=lambda x: x.get("created_at") or "", reverse=True)
 
         return {"thread_list": threads[:limit]}
+
+    def create_thread(self, *, thread_id: str | None = None, metadata: dict[str, Any] | None = None) -> dict:
+        """Create a new thread with an empty checkpoint snapshot.
+
+        Args:
+            thread_id: Optional thread ID. Generated when omitted.
+            metadata: Optional metadata to persist on the thread record.
+
+        Returns:
+            Dict matching the Gateway ``ThreadResponse`` shape.
+        """
+        metadata = metadata or {}
+        thread_id = thread_id or str(uuid.uuid4())
+        now = time.time()
+
+        store = get_store()
+        checkpointer = get_checkpointer()
+
+        if store is not None:
+            existing_item = store.get(THREADS_NS, thread_id)
+            existing_record = existing_item.value if existing_item is not None else None
+            if existing_record is not None:
+                return {
+                    "thread_id": thread_id,
+                    "status": existing_record.get("status", "idle"),
+                    "created_at": str(existing_record.get("created_at", "")),
+                    "updated_at": str(existing_record.get("updated_at", "")),
+                    "metadata": existing_record.get("metadata", {}),
+                    "values": {},
+                    "interrupts": {},
+                }
+
+            try:
+                store.put(
+                    THREADS_NS,
+                    thread_id,
+                    {
+                        "thread_id": thread_id,
+                        "status": "idle",
+                        "created_at": now,
+                        "updated_at": now,
+                        "metadata": metadata,
+                    },
+                )
+            except Exception as exc:
+                raise RuntimeError("Failed to create thread") from exc
+
+        try:
+            from langgraph.checkpoint.base import empty_checkpoint
+
+            config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+            ckpt_metadata = {
+                "step": -1,
+                "source": "input",
+                "writes": None,
+                "parents": {},
+                **metadata,
+                "created_at": now,
+            }
+            checkpointer.put(config, empty_checkpoint(), ckpt_metadata, {})
+        except Exception as exc:
+            raise RuntimeError("Failed to create thread") from exc
+
+        return {
+            "thread_id": thread_id,
+            "status": "idle",
+            "created_at": str(now),
+            "updated_at": str(now),
+            "metadata": metadata,
+            "values": {},
+            "interrupts": {},
+        }
 
     def get_thread(self, thread_id: str) -> dict:
         """Get the complete thread record, including all node execution records.

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -571,7 +571,7 @@ class TestGetModel:
 
 
 # ---------------------------------------------------------------------------
-# Thread Queries (list_threads / get_thread)
+# Thread Queries (create_thread / list_threads / get_thread)
 # ---------------------------------------------------------------------------
 
 
@@ -614,6 +614,117 @@ class TestThreadQueries:
         result = client.list_threads()
         assert result == {"thread_list": []}
         mock_checkpointer.list.assert_called_once_with(config=None, limit=10)
+
+    def test_create_thread(self, client):
+        store = MagicMock()
+        store.get.return_value = None
+        checkpointer = MagicMock()
+
+        with (
+            patch("deerflow.client.get_store", return_value=store),
+            patch("deerflow.client.get_checkpointer", return_value=checkpointer),
+            patch("deerflow.client.time.time", return_value=1710001234.5),
+        ):
+            result = client.create_thread(thread_id="t1", metadata={"source": "seed"})
+
+        store.get.assert_called_once_with(("threads",), "t1")
+        store.put.assert_called_once_with(
+            ("threads",),
+            "t1",
+            {
+                "thread_id": "t1",
+                "status": "idle",
+                "created_at": 1710001234.5,
+                "updated_at": 1710001234.5,
+                "metadata": {"source": "seed"},
+            },
+        )
+        checkpointer.put.assert_called_once()
+        put_args = checkpointer.put.call_args.args
+        assert put_args[0] == {"configurable": {"thread_id": "t1", "checkpoint_ns": ""}}
+        assert put_args[2] == {
+            "step": -1,
+            "source": "seed",
+            "writes": None,
+            "parents": {},
+            "created_at": 1710001234.5,
+        }
+        assert result == {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": "1710001234.5",
+            "updated_at": "1710001234.5",
+            "metadata": {"source": "seed"},
+            "values": {},
+            "interrupts": {},
+        }
+
+    def test_create_thread_returns_existing_record(self, client):
+        store = MagicMock()
+        existing = MagicMock()
+        existing.value = {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": 1710001000.0,
+            "updated_at": 1710001001.0,
+            "metadata": {"source": "existing"},
+        }
+        store.get.return_value = existing
+        checkpointer = MagicMock()
+
+        with (
+            patch("deerflow.client.get_store", return_value=store),
+            patch("deerflow.client.get_checkpointer", return_value=checkpointer),
+        ):
+            result = client.create_thread(thread_id="t1", metadata={"source": "ignored"})
+
+        store.put.assert_not_called()
+        checkpointer.put.assert_not_called()
+        assert result == {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": "1710001000.0",
+            "updated_at": "1710001001.0",
+            "metadata": {"source": "existing"},
+            "values": {},
+            "interrupts": {},
+        }
+
+    def test_create_thread_store_write_failure(self, client):
+        store = MagicMock()
+        store.get.return_value = None
+        store.put.side_effect = RuntimeError("boom")
+        checkpointer = MagicMock()
+
+        with (
+            patch("deerflow.client.get_store", return_value=store),
+            patch("deerflow.client.get_checkpointer", return_value=checkpointer),
+        ):
+            with pytest.raises(RuntimeError, match="Failed to create thread"):
+                client.create_thread(thread_id="t1", metadata={"source": "seed"})
+
+        checkpointer.put.assert_not_called()
+
+    def test_create_thread_without_store(self, client):
+        checkpointer = MagicMock()
+
+        with (
+            patch("deerflow.client.get_store", return_value=None),
+            patch("deerflow.client.get_checkpointer", return_value=checkpointer),
+            patch("deerflow.client.time.time", return_value=1710001234.5),
+        ):
+            result = client.create_thread(thread_id="t1")
+
+        checkpointer.put.assert_called_once()
+        assert result == {
+            "thread_id": "t1",
+            "status": "idle",
+            "created_at": "1710001234.5",
+            "updated_at": "1710001234.5",
+            "metadata": {},
+            "values": {},
+            "interrupts": {},
+        }
 
     def test_list_threads_basic(self, client):
         mock_checkpointer = MagicMock()


### PR DESCRIPTION
## Summary
- add `DeerFlowClient.create_thread()` to mirror the Gateway thread creation endpoint
- persist a new thread record through the embedded sync store and write an empty checkpoint snapshot for immediate state reads
- cover creation, idempotent existing-thread behavior, store write failures, and store-less fallback in client tests

## Testing
- cd backend && uv run ruff check packages/harness/deerflow/client.py tests/test_client.py
- cd backend && PYTHONPATH=. uv run pytest tests/test_client.py -q