### PR TITLE
fix(ui): add mobile header with sidebar trigger in workspace layout

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "sonner";
 import { QueryClientProvider } from "@/components/query-client-provider";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { CommandPalette } from "@/components/workspace/command-palette";
+import { WorkspaceMobileHeader } from "@/components/workspace/workspace-mobile-header";
 import { WorkspaceSidebar } from "@/components/workspace/workspace-sidebar";
 
 function parseSidebarOpenCookie(
@@ -26,7 +27,10 @@ export default async function WorkspaceLayout({
     <QueryClientProvider>
       <SidebarProvider className="h-screen" defaultOpen={initialSidebarOpen}>
         <WorkspaceSidebar />
-        <SidebarInset className="min-w-0">{children}</SidebarInset>
+        <div className="flex flex-1 flex-col min-w-0">
+          <WorkspaceMobileHeader />
+          <SidebarInset className="min-w-0 flex-1">{children}</SidebarInset>
+        </div>
       </SidebarProvider>
       <CommandPalette />
       <Toaster position="top-center" />

--- a/frontend/src/components/workspace/workspace-mobile-header.tsx
+++ b/frontend/src/components/workspace/workspace-mobile-header.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+import { Menu, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useSidebar } from "@/components/ui/sidebar";
+import { env } from "@/env";
+
+export function WorkspaceMobileHeader() {
+  const { openMobile, setOpenMobile } = useSidebar();
+
+  return (
+    <div className="sticky top-0 z-50 flex md:hidden h-12 shrink-0 items-center gap-2 border-b bg-background px-4">
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7 opacity-50 hover:opacity-100"
+        onClick={() => setOpenMobile(!openMobile)}
+        aria-label={openMobile ? "Close sidebar" : "Open sidebar"}
+      >
+        {openMobile ? (
+          <X className="size-4" />
+        ) : (
+          <Menu className="size-4" />
+        )}
+      </Button>
+      {env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ? (
+        <Link href="/" className="font-serif text-primary">
+          DeerFlow
+        </Link>
+      ) : (
+        <span className="font-serif text-primary">DeerFlow</span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
On narrow viewports the sidebar (and its trigger) is hidden inside a Sheet component, leaving users no way to open the menu. This PR adds a dedicated mobile header to the workspace layout so the hamburger button is always visible on phones and tablets.