### PR TITLE
fix: remove invalid "context" from thread search select parameter

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -528,7 +528,7 @@ export function useThreads(
     limit: 50,
     sortBy: "updated_at",
     sortOrder: "desc",
-    select: ["thread_id", "updated_at", "values", "context"],
+    select: ["thread_id", "updated_at", "values"],
   },
 ) {
   const apiClient = getAPIClient();


### PR DESCRIPTION
## Summary

- Remove `"context"` from the `select` array in `useThreads` hook, as it is not a valid field for the LangGraph Platform API's `/threads/search` endpoint
- This was causing **422 Unprocessable Entity** errors when loading the `/workspace/chats` page

## Root Cause

The LangGraph Platform API's `select` parameter only accepts: `thread_id`, `created_at`, `updated_at`, `state_updated_at`, `metadata`, `config`, `status`, `values`, `interrupts`. The `"context"` field is a frontend extension (`AgentThreadContext`) whose data is already available within `"values"`, which remains in the select list.

## Test Plan

- [ ] Navigate to `/workspace/chats` and verify the thread list loads without 422 errors
- [ ] Verify thread context (agent_name, model settings) is still correctly displayed in thread list items
- [ ] Verify thread sorting and pagination still work correctly