### PR TITLE
fix(makefile): route Windows shell-script targets through Git Bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,11 @@ BASH ?= bash
 ifeq ($(OS),Windows_NT)
     SHELL := cmd.exe
     PYTHON ?= python
+    # Run repo shell scripts through Git Bash when Make is launched from cmd.exe / PowerShell.
+    RUN_WITH_GIT_BASH = call scripts\run-with-git-bash.cmd
 else
     PYTHON ?= python3
+    RUN_WITH_GIT_BASH =
 endif
 
 help:
@@ -48,7 +51,7 @@ config:
 	@$(PYTHON) ./scripts/configure.py
 
 config-upgrade:
-	@./scripts/config-upgrade.sh
+	@$(RUN_WITH_GIT_BASH) ./scripts/config-upgrade.sh
 
 # Check required tools
 check:
@@ -106,78 +109,46 @@ setup-sandbox:
 # Start all services in development mode (with hot-reloading)
 dev:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --dev
-else
-	@./scripts/serve.sh --dev
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --dev
 
 # Start all services in dev + Gateway mode (experimental: agent runtime embedded in Gateway)
 dev-pro:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --dev --gateway
-else
-	@./scripts/serve.sh --dev --gateway
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --dev --gateway
 
 # Start all services in production mode (with optimizations)
 start:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --prod
-else
-	@./scripts/serve.sh --prod
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --prod
 
 # Start all services in prod + Gateway mode (experimental)
 start-pro:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --prod --gateway
-else
-	@./scripts/serve.sh --prod --gateway
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --prod --gateway
 
 # Start all services in daemon mode (background)
 dev-daemon:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --dev --daemon
-else
-	@./scripts/serve.sh --dev --daemon
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --dev --daemon
 
 # Start daemon + Gateway mode (experimental)
 dev-daemon-pro:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --dev --gateway --daemon
-else
-	@./scripts/serve.sh --dev --gateway --daemon
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --dev --gateway --daemon
 
 # Start prod services in daemon mode (background)
 start-daemon:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --prod --daemon
-else
-	@./scripts/serve.sh --prod --daemon
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --prod --daemon
 
 # Start prod daemon + Gateway mode (experimental)
 start-daemon-pro:
 	@$(PYTHON) ./scripts/check.py
-ifeq ($(OS),Windows_NT)
-	@call scripts\run-with-git-bash.cmd ./scripts/serve.sh --prod --gateway --daemon
-else
-	@./scripts/serve.sh --prod --gateway --daemon
-endif
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --prod --gateway --daemon
 
 # Stop all services
 stop:
-	@./scripts/serve.sh --stop
+	@$(RUN_WITH_GIT_BASH) ./scripts/serve.sh --stop
 
 # Clean up
 clean: stop
@@ -193,29 +164,29 @@ clean: stop
 
 # Initialize Docker containers and install dependencies
 docker-init:
-	@./scripts/docker.sh init
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh init
 
 # Start Docker development environment
 docker-start:
-	@./scripts/docker.sh start
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh start
 
 # Start Docker in Gateway mode (experimental)
 docker-start-pro:
-	@./scripts/docker.sh start --gateway
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh start --gateway
 
 # Stop Docker development environment
 docker-stop:
-	@./scripts/docker.sh stop
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh stop
 
 # View Docker development logs
 docker-logs:
-	@./scripts/docker.sh logs
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh logs
 
 # View Docker development logs
 docker-logs-frontend:
-	@./scripts/docker.sh logs --frontend
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh logs --frontend
 docker-logs-gateway:
-	@./scripts/docker.sh logs --gateway
+	@$(RUN_WITH_GIT_BASH) ./scripts/docker.sh logs --gateway
 
 # ==========================================
 # Production Docker Commands
@@ -223,12 +194,12 @@ docker-logs-gateway:
 
 # Build and start production services
 up:
-	@./scripts/deploy.sh
+	@$(RUN_WITH_GIT_BASH) ./scripts/deploy.sh
 
 # Build and start production services in Gateway mode
 up-pro:
-	@./scripts/deploy.sh --gateway
+	@$(RUN_WITH_GIT_BASH) ./scripts/deploy.sh --gateway
 
 # Stop and remove production containers
 down:
-	@./scripts/deploy.sh down
+	@$(RUN_WITH_GIT_BASH) ./scripts/deploy.sh down


### PR DESCRIPTION
Fixes #1278

## Summary

Route the root `Makefile` shell-script targets through the existing `scripts/run-with-git-bash.cmd` wrapper on Windows.

## Problem

`make docker-init` on Windows fails before `scripts/docker.sh` ever runs because GNU Make under `cmd.exe` / PowerShell cannot execute `./scripts/*.sh` recipes directly. `make dev` / `make start` had already been patched for Windows, but Docker, deploy, config-upgrade, and stop targets still used direct `.sh` execution and remained broken.

## Root Cause

The root `Makefile` mixed two execution patterns:

- `serve.sh` entrypoints already used `scripts/run-with-git-bash.cmd` on Windows
- `docker.sh`, `deploy.sh`, `config-upgrade.sh`, and `serve.sh --stop` still invoked shell scripts directly

That left Windows support only partially fixed and produced the same `CreateProcess` launcher failure on the remaining targets.

## Changes

- add a `RUN_WITH_GIT_BASH` helper alongside OS detection
- reuse that helper for every root `Makefile` target that launches a repo shell script
- preserve Unix behavior by expanding to the original `./scripts/...` commands outside Windows
- cover `config-upgrade`, all `serve.sh` targets, Docker dev targets, and production deploy targets

## Testing

- `make -n docker-init docker-start-pro up down`
- `make -n start dev-daemon-pro docker-logs-frontend`
- `make -n OS=Windows_NT docker-init docker-start up down config-upgrade stop`
- `make -n OS=Windows_NT start dev-daemon-pro docker-logs-frontend`

These dry runs confirm that Unix recipes still expand to `./scripts/...`, while the Windows branch now expands through `call scripts\run-with-git-bash.cmd ...`.
