### PR TITLE
feat(subagents): allow model override per subagent in config.yaml

### DIFF
--- a/backend/packages/harness/deerflow/config/subagents_config.py
+++ b/backend/packages/harness/deerflow/config/subagents_config.py
@@ -22,6 +22,7 @@ class SubagentOverrideConfig(BaseModel):
     )
     model: str | None = Field(
         default=None,
+        min_length=1,
         description="Model name for this subagent (None = inherit from parent agent)",
     )
 

--- a/backend/packages/harness/deerflow/config/subagents_config.py
+++ b/backend/packages/harness/deerflow/config/subagents_config.py
@@ -20,6 +20,10 @@ class SubagentOverrideConfig(BaseModel):
         ge=1,
         description="Maximum turns for this subagent (None = use global or builtin default)",
     )
+    model: str | None = Field(
+        default=None,
+        description="Model name for this subagent (None = inherit from parent agent)",
+    )
 
 
 class SubagentsAppConfig(BaseModel):
@@ -54,6 +58,20 @@ class SubagentsAppConfig(BaseModel):
             return override.timeout_seconds
         return self.timeout_seconds
 
+    def get_model_for(self, agent_name: str) -> str | None:
+        """Get the model override for a specific agent.
+
+        Args:
+            agent_name: The name of the subagent.
+
+        Returns:
+            Model name if overridden, None otherwise (subagent will inherit parent model).
+        """
+        override = self.agents.get(agent_name)
+        if override is not None and override.model is not None:
+            return override.model
+        return None
+
     def get_max_turns_for(self, agent_name: str, builtin_default: int) -> int:
         """Get the effective max_turns for a specific agent."""
         override = self.agents.get(agent_name)
@@ -84,6 +102,8 @@ def load_subagents_config_from_dict(config_dict: dict) -> None:
             parts.append(f"timeout={override.timeout_seconds}s")
         if override.max_turns is not None:
             parts.append(f"max_turns={override.max_turns}")
+        if override.model is not None:
+            parts.append(f"model={override.model}")
         if parts:
             overrides_summary[name] = ", ".join(parts)
 

--- a/backend/packages/harness/deerflow/subagents/registry.py
+++ b/backend/packages/harness/deerflow/subagents/registry.py
@@ -23,7 +23,8 @@ def get_subagent_config(name: str) -> SubagentConfig | None:
     if config is None:
         return None
 
-    # Apply timeout override from config.yaml (lazy import to avoid circular deps)
+    # Apply runtime overrides (timeout, max_turns, model) from config.yaml
+    # Lazy import to avoid circular deps.
     from deerflow.config.subagents_config import get_subagents_app_config
 
     app_config = get_subagents_app_config()

--- a/backend/packages/harness/deerflow/subagents/registry.py
+++ b/backend/packages/harness/deerflow/subagents/registry.py
@@ -47,6 +47,15 @@ def get_subagent_config(name: str) -> SubagentConfig | None:
             effective_max_turns,
         )
         overrides["max_turns"] = effective_max_turns
+    effective_model = app_config.get_model_for(name)
+    if effective_model is not None and effective_model != config.model:
+        logger.debug(
+            "Subagent '%s': model overridden by config.yaml (%s -> %s)",
+            name,
+            config.model,
+            effective_model,
+        )
+        overrides["model"] = effective_model
     if overrides:
         config = replace(config, **overrides)
 

--- a/backend/tests/test_subagent_timeout_config.py
+++ b/backend/tests/test_subagent_timeout_config.py
@@ -50,11 +50,18 @@ class TestSubagentOverrideConfig:
         override = SubagentOverrideConfig()
         assert override.timeout_seconds is None
         assert override.max_turns is None
+        assert override.model is None
 
     def test_explicit_value(self):
-        override = SubagentOverrideConfig(timeout_seconds=300, max_turns=42)
+        override = SubagentOverrideConfig(timeout_seconds=300, max_turns=42, model="gpt-5.4")
         assert override.timeout_seconds == 300
         assert override.max_turns == 42
+        assert override.model == "gpt-5.4"
+
+    def test_model_accepts_any_string(self):
+        """Model name is a free-form string; validation happens at registry lookup time."""
+        override = SubagentOverrideConfig(model="any-arbitrary-model-name")
+        assert override.model == "any-arbitrary-model-name"
 
     def test_rejects_zero(self):
         with pytest.raises(ValueError):
@@ -165,6 +172,42 @@ class TestRuntimeResolution:
         assert config.get_max_turns_for("general-purpose", 100) == 200
         assert config.get_max_turns_for("bash", 60) == 80
 
+    def test_get_model_for_returns_none_when_no_override(self):
+        """No per-agent model override -> returns None so callers fall back to builtin/parent."""
+        config = SubagentsAppConfig(timeout_seconds=900)
+        assert config.get_model_for("general-purpose") is None
+        assert config.get_model_for("bash") is None
+        assert config.get_model_for("unknown-agent") is None
+
+    def test_get_model_for_returns_override_when_set(self):
+        config = SubagentsAppConfig(
+            timeout_seconds=900,
+            agents={
+                "general-purpose": SubagentOverrideConfig(model="qwen3.5-35b-a3b"),
+                "bash": SubagentOverrideConfig(model="gpt-5.4"),
+            },
+        )
+        assert config.get_model_for("general-purpose") == "qwen3.5-35b-a3b"
+        assert config.get_model_for("bash") == "gpt-5.4"
+
+    def test_get_model_for_returns_none_for_omitted_agent(self):
+        """An agent not listed in overrides returns None even when other agents have model overrides."""
+        config = SubagentsAppConfig(
+            timeout_seconds=900,
+            agents={"bash": SubagentOverrideConfig(model="gpt-5.4")},
+        )
+        assert config.get_model_for("general-purpose") is None
+
+    def test_get_model_for_handles_explicit_none(self):
+        """Explicit model=None in the override is equivalent to no override."""
+        config = SubagentsAppConfig(
+            timeout_seconds=900,
+            agents={"bash": SubagentOverrideConfig(timeout_seconds=300, model=None)},
+        )
+        assert config.get_model_for("bash") is None
+        # Timeout override is still applied even when model is None.
+        assert config.get_timeout_for("bash") == 300
+
 
 # ---------------------------------------------------------------------------
 # load_subagents_config_from_dict / get_subagents_app_config singleton
@@ -210,6 +253,22 @@ class TestLoadSubagentsConfig:
         assert cfg.get_timeout_for("bash") == 120
         assert cfg.get_max_turns_for("general-purpose", 100) == 100
         assert cfg.get_max_turns_for("bash", 60) == 70
+
+    def test_load_with_model_overrides(self):
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {
+                    "general-purpose": {"model": "qwen3.5-35b-a3b"},
+                    "bash": {"model": "gpt-5.4", "timeout_seconds": 300},
+                },
+            }
+        )
+        cfg = get_subagents_app_config()
+        assert cfg.get_model_for("general-purpose") == "qwen3.5-35b-a3b"
+        assert cfg.get_model_for("bash") == "gpt-5.4"
+        # Other override fields on the same agent must still load correctly.
+        assert cfg.get_timeout_for("bash") == 300
 
     def test_load_empty_dict_uses_defaults(self):
         load_subagents_config_from_dict({})
@@ -295,6 +354,97 @@ class TestRegistryGetSubagentConfig:
         gp_config = get_subagent_config("general-purpose")
         assert gp_config.timeout_seconds == 900
         assert gp_config.max_turns == 120
+
+    def test_per_agent_model_override_applied(self):
+        from deerflow.subagents.registry import get_subagent_config
+
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"model": "gpt-5.4-mini"}},
+            }
+        )
+        bash_config = get_subagent_config("bash")
+        assert bash_config.model == "gpt-5.4-mini"
+
+    def test_omitted_model_keeps_builtin_value(self):
+        """When config.yaml has no `model` field for an agent, the builtin default must be preserved."""
+        from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
+        from deerflow.subagents.registry import get_subagent_config
+
+        builtin_bash_model = BUILTIN_SUBAGENTS["bash"].model
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"timeout_seconds": 300}},
+            }
+        )
+        bash_config = get_subagent_config("bash")
+        assert bash_config.model == builtin_bash_model
+
+    def test_explicit_null_model_keeps_builtin_value(self):
+        """An explicit `model: null` in config.yaml is equivalent to omission — builtin wins."""
+        from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
+        from deerflow.subagents.registry import get_subagent_config
+
+        builtin_bash_model = BUILTIN_SUBAGENTS["bash"].model
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"model": None}},
+            }
+        )
+        bash_config = get_subagent_config("bash")
+        assert bash_config.model == builtin_bash_model
+
+    def test_model_override_does_not_affect_other_agents(self):
+        from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
+        from deerflow.subagents.registry import get_subagent_config
+
+        builtin_gp_model = BUILTIN_SUBAGENTS["general-purpose"].model
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"model": "gpt-5.4"}},
+            }
+        )
+        gp_config = get_subagent_config("general-purpose")
+        assert gp_config.model == builtin_gp_model
+
+    def test_model_override_preserves_other_fields(self):
+        """Applying a model override must leave timeout_seconds / max_turns / name intact."""
+        from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
+        from deerflow.subagents.registry import get_subagent_config
+
+        original = BUILTIN_SUBAGENTS["bash"]
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"model": "gpt-5.4-mini"}},
+            }
+        )
+        overridden = get_subagent_config("bash")
+        assert overridden.model == "gpt-5.4-mini"
+        assert overridden.name == original.name
+        assert overridden.description == original.description
+        # No timeout / max_turns override was set, so they use global default / builtin.
+        assert overridden.timeout_seconds == 900
+        assert overridden.max_turns == original.max_turns
+
+    def test_model_override_does_not_mutate_builtin(self):
+        """Registry must return a new object, leaving the builtin default intact."""
+        from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
+        from deerflow.subagents.registry import get_subagent_config
+
+        original_bash_model = BUILTIN_SUBAGENTS["bash"].model
+        load_subagents_config_from_dict(
+            {
+                "timeout_seconds": 900,
+                "agents": {"bash": {"model": "gpt-5.4-mini"}},
+            }
+        )
+        _ = get_subagent_config("bash")
+        assert BUILTIN_SUBAGENTS["bash"].model == original_bash_model
 
     def test_builtin_config_object_is_not_mutated(self):
         """Registry must return a new object, leaving the builtin default intact."""

--- a/backend/tests/test_subagent_timeout_config.py
+++ b/backend/tests/test_subagent_timeout_config.py
@@ -58,8 +58,9 @@ class TestSubagentOverrideConfig:
         assert override.max_turns == 42
         assert override.model == "gpt-5.4"
 
-    def test_model_accepts_any_string(self):
-        """Model name is a free-form string; validation happens at registry lookup time."""
+    def test_model_accepts_any_non_empty_string(self):
+        """Model name is a free-form non-empty string; cross-reference validation
+        against the `models:` section happens at registry lookup time."""
         override = SubagentOverrideConfig(model="any-arbitrary-model-name")
         assert override.model == "any-arbitrary-model-name"
 
@@ -74,6 +75,13 @@ class TestSubagentOverrideConfig:
             SubagentOverrideConfig(timeout_seconds=-1)
         with pytest.raises(ValueError):
             SubagentOverrideConfig(max_turns=-1)
+
+    def test_rejects_empty_model(self):
+        """Empty-string model would silently bypass the `is not None` check and
+        reach `create_chat_model(name="")` as a runtime error. Reject at load time
+        instead, symmetric with the `ge=1` guard on timeout_seconds / max_turns."""
+        with pytest.raises(ValueError):
+            SubagentOverrideConfig(model="")
 
     def test_minimum_valid_value(self):
         override = SubagentOverrideConfig(timeout_seconds=1, max_turns=1)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -562,9 +562,14 @@ sandbox:
 #     general-purpose:
 #       timeout_seconds: 1800  # 30 minutes for complex multi-step tasks
 #       max_turns: 160
+#       # model: qwen3:32b     # Use a specific model (default: inherit from lead agent)
 #     bash:
 #       timeout_seconds: 300   # 5 minutes for quick command execution
 #       max_turns: 80
+#
+#   # Model override: by default, subagents inherit the lead agent's model.
+#   # Set `model` to use a different model (e.g., a local Ollama model for cost savings).
+#   # The model name must match a name defined in the `models:` section above.
 
 # ============================================================================
 # ACP Agents Configuration


### PR DESCRIPTION
## Problem

`SubagentConfig` (dataclass) already has a `model` field with full support for per-subagent model selection — `executor.py`'s `_get_model_name()` implements inherit vs. explicit model logic. However, `SubagentOverrideConfig` (Pydantic model for `config.yaml`) does not expose a `model` field, so:

- The `model` key in `config.yaml`'s `subagents.agents` entries is **silently dropped** by Pydantic
- All subagents always inherit the lead agent's model
- Users cannot assign cost-effective local models to subagent workloads via configuration

This is particularly valuable for deployments with local models (e.g., Ollama) where subagent tasks (research, bash) can use a lighter/cheaper model while the lead agent uses a more capable cloud model.

## Root Cause

The code path has a gap:

```
config.yaml  →  SubagentOverrideConfig (Pydantic)  →  registry.py  →  SubagentConfig (dataclass)
                     ❌ no model field                  ❌ no model     ✅ has model field
                                                         passthrough     (default: "inherit")
```

## Solution

Three minimal changes to wire the existing capability to `config.yaml`:

1. **`subagents_config.py`**: Add `model: str | None` field to `SubagentOverrideConfig` + `get_model_for()` method to `SubagentsAppConfig` + include model in startup log
2. **`registry.py`**: Pass model override from `config.yaml` into `SubagentConfig` via `dataclasses.replace()`
3. **`config.example.yaml`**: Document model override option in the subagents section

```yaml
# config.yaml usage:
subagents:
  agents:
    general-purpose:
      model: qwen3.5-local    # Use local Ollama model instead of inheriting lead agent
      timeout_seconds: 1800
    bash:
      model: gpt-5.4          # Keep cloud model for bash tasks
      timeout_seconds: 300
```

When `model` is omitted or `null`, the existing `inherit` behavior is preserved — no breaking change.

## Real-World Verification

Tested on a production DeerFlow 2.0 deployment (docker prod, Mac Studio M4 Max 64GB) with:
- **Lead agent**: Claude Opus 4.6 (cloud)
- **general-purpose subagent**: Qwen 3.5 35B MoE via local Ollama (`langchain_ollama:ChatOllama`)

Ultra mode task ("Compare GDP of Japan and Germany"): lead agent dispatched 2 parallel subagents. Logs confirmed subagents called Ollama native API (`host.docker.internal:11434/api/chat`) while lead agent called Anthropic API. Task completed successfully with correct results.

Startup log with the patch:
```
Subagents config loaded: default timeout=900s, default max_turns=None,
  per-agent overrides={'general-purpose': 'timeout=1800s, max_turns=160, model=qwen3.5-35b-a3b',
                        'bash': 'timeout=300s, max_turns=80, model=gpt-5.4'}
```

## Changes

| File | Change |
|------|--------|
| `backend/.../config/subagents_config.py` | Add `model` field to `SubagentOverrideConfig`, `get_model_for()` to `SubagentsAppConfig`, model in log output |
| `backend/.../subagents/registry.py` | Pass `model` override from config into `SubagentConfig` |
| `config.example.yaml` | Document `model` option in subagents section |

## Compatibility

- **No breaking change**: `model` defaults to `None`, preserving the existing `inherit` behavior
- **No new dependencies**: uses existing `SubagentConfig.model` field and `_get_model_name()` logic
- Works with any model defined in the `models:` section — cloud or local