### PR TITLE
fix(middleware): complete skipped tool calls on loop warnings

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
@@ -21,7 +21,7 @@ from typing import override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, ToolMessage
 from langgraph.runtime import Runtime
 
 logger = logging.getLogger(__name__)
@@ -126,6 +126,7 @@ def _hash_tool_calls(tool_calls: list[dict]) -> str:
 _WARNING_MSG = "[LOOP DETECTED] You are repeating the same tool calls. Stop calling tools and produce your final answer now. If you cannot complete the task, summarize what you accomplished so far."
 
 _HARD_STOP_MSG = "[FORCED STOP] Repeated tool calls exceeded the safety limit. Producing final answer with results collected so far."
+_INTERRUPTED_TOOL_MSG = "[Tool call was interrupted due to loop detection and did not return a result.]"
 
 
 class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
@@ -261,12 +262,46 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         # Fallback: coerce unexpected types to str to avoid TypeError
         return str(content) + f"\n\n{text}"
 
+    @staticmethod
+    def _build_interrupted_tool_messages(tool_calls: list[dict] | None) -> list[ToolMessage]:
+        """Build placeholder ToolMessages for tool calls we intentionally skipped.
+
+        Loop warnings ask the model to stop calling tools and wrap up. When we
+        short-circuit a repeated tool-call turn, the original assistant message
+        still contains ``tool_calls`` that will never be executed. Emit
+        synthetic error ToolMessages immediately so the next model turn sees a
+        valid assistant-tool history without relying on later repair passes.
+        """
+        if not tool_calls:
+            return []
+
+        placeholders: list[ToolMessage] = []
+        seen_ids: set[str] = set()
+        for tool_call in tool_calls:
+            tool_call_id = tool_call.get("id")
+            if not tool_call_id or tool_call_id in seen_ids:
+                continue
+
+            placeholders.append(
+                ToolMessage(
+                    content=_INTERRUPTED_TOOL_MSG,
+                    tool_call_id=tool_call_id,
+                    name=tool_call.get("name", "unknown"),
+                    status="error",
+                )
+            )
+            seen_ids.add(tool_call_id)
+
+        return placeholders
+
     def _apply(self, state: AgentState, runtime: Runtime) -> dict | None:
         warning, hard_stop = self._track_and_check(state, runtime)
+        messages = state.get("messages", [])
+        last_msg = messages[-1] if messages else None
+        pending_tool_msgs = self._build_interrupted_tool_messages(getattr(last_msg, "tool_calls", None))
 
         if hard_stop:
             # Strip tool_calls from the last AIMessage to force text output
-            messages = state.get("messages", [])
             last_msg = messages[-1]
             stripped_msg = last_msg.model_copy(
                 update={
@@ -283,7 +318,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             # the conversation; injecting one mid-conversation crashes
             # langchain_anthropic's _format_messages(). HumanMessage works
             # with all providers. See #1299.
-            return {"messages": [HumanMessage(content=warning)]}
+            return {"messages": [*pending_tool_msgs, HumanMessage(content=warning)]}
 
         return None
 

--- a/backend/tests/test_loop_detection_middleware.py
+++ b/backend/tests/test_loop_detection_middleware.py
@@ -3,10 +3,11 @@
 import copy
 from unittest.mock import MagicMock
 
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from deerflow.agents.middlewares.loop_detection_middleware import (
     _HARD_STOP_MSG,
+    _INTERRUPTED_TOOL_MSG,
     LoopDetectionMiddleware,
     _hash_tool_calls,
 )
@@ -150,9 +151,11 @@ class TestLoopDetection:
         result = mw._apply(_make_state(tool_calls=call), runtime)
         assert result is not None
         msgs = result["messages"]
-        assert len(msgs) == 1
-        assert isinstance(msgs[0], HumanMessage)
-        assert "LOOP DETECTED" in msgs[0].content
+        assert len(msgs) == 2
+        assert isinstance(msgs[0], ToolMessage)
+        assert msgs[0].tool_call_id == call[0]["id"]
+        assert isinstance(msgs[1], HumanMessage)
+        assert "LOOP DETECTED" in msgs[1].content
 
     def test_warn_only_injected_once(self):
         """Warning for the same hash should only be injected once per thread."""
@@ -167,11 +170,32 @@ class TestLoopDetection:
         # Third — warning injected
         result = mw._apply(_make_state(tool_calls=call), runtime)
         assert result is not None
-        assert "LOOP DETECTED" in result["messages"][0].content
+        assert isinstance(result["messages"][0], ToolMessage)
+        assert "LOOP DETECTED" in result["messages"][1].content
 
         # Fourth — warning already injected, should return None
         result = mw._apply(_make_state(tool_calls=call), runtime)
         assert result is None
+
+    def test_warn_adds_placeholder_tool_messages_before_warning(self):
+        """Loop warning should complete the pending tool-call turn before re-prompting."""
+        mw = LoopDetectionMiddleware(warn_threshold=2, hard_limit=5)
+        runtime = _make_runtime()
+        call = [_bash_call("ls")]
+
+        mw._apply(_make_state(tool_calls=call), runtime)
+        result = mw._apply(_make_state(tool_calls=call), runtime)
+
+        assert result is not None
+        msgs = result["messages"]
+        assert len(msgs) == 2
+        assert isinstance(msgs[0], ToolMessage)
+        assert msgs[0].tool_call_id == call[0]["id"]
+        assert msgs[0].name == call[0]["name"]
+        assert msgs[0].status == "error"
+        assert msgs[0].content == _INTERRUPTED_TOOL_MSG
+        assert isinstance(msgs[1], HumanMessage)
+        assert "LOOP DETECTED" in msgs[1].content
 
     def test_hard_stop_at_limit(self):
         mw = LoopDetectionMiddleware(warn_threshold=2, hard_limit=4)
@@ -258,12 +282,14 @@ class TestLoopDetection:
         # Second call on thread A — triggers warning (2 >= warn_threshold)
         result = mw._apply(_make_state(tool_calls=call), runtime_a)
         assert result is not None
-        assert "LOOP DETECTED" in result["messages"][0].content
+        assert isinstance(result["messages"][0], ToolMessage)
+        assert "LOOP DETECTED" in result["messages"][1].content
 
         # Second call on thread B — also triggers (independent tracking)
         result = mw._apply(_make_state(tool_calls=call), runtime_b)
         assert result is not None
-        assert "LOOP DETECTED" in result["messages"][0].content
+        assert isinstance(result["messages"][0], ToolMessage)
+        assert "LOOP DETECTED" in result["messages"][1].content
 
     def test_lru_eviction(self):
         """Old threads should be evicted when max_tracked_threads is exceeded."""


### PR DESCRIPTION
## Problem

When loop detection warns the agent to stop repeating the same tool calls, the repeated assistant turn can still contain pending `tool_calls` that will never be executed. That leaves the conversation in an invalid assistant-tool state and can trigger provider errors about insufficient tool messages on the next model turn.

Closes #2029.

## Root cause

`LoopDetectionMiddleware` injected only a follow-up `HumanMessage` warning. It did not complete the skipped tool-call turn itself, so the conversation had to rely on later repair passes to become valid.

## Fix

- add placeholder error `ToolMessage`s for skipped tool calls when a loop warning is emitted
- keep the warning as a `HumanMessage` so the next turn still asks the model to wrap up
- add a regression test covering the assistant-tool-warning message sequence
- update existing loop warning tests to reflect the now-valid message ordering

## Verification

- `cd backend && uv run pytest tests/test_loop_detection_middleware.py -q`
- `cd backend && uv run ruff check packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py tests/test_loop_detection_middleware.py`

## Non-goals

- changing hard-stop behavior
- broad loop-detection refactors
- provider-specific formatting changes outside the loop-warning path