### PR TITLE
fix(frontend): preserve memory proxy query strings

### DIFF
--- a/frontend/src/app/api/memory/[...path]/route.ts
+++ b/frontend/src/app/api/memory/[...path]/route.ts
@@ -1,11 +1,6 @@
 import type { NextRequest } from "next/server";
 
-const BACKEND_BASE_URL =
-  process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? "http://127.0.0.1:8001";
-
-function buildBackendUrl(pathname: string) {
-  return new URL(pathname, BACKEND_BASE_URL);
-}
+import { buildBackendUrl } from "../_proxy";
 
 async function proxyRequest(request: NextRequest, pathname: string) {
   const headers = new Headers(request.headers);
@@ -14,7 +9,7 @@ async function proxyRequest(request: NextRequest, pathname: string) {
   headers.delete("content-length");
 
   const hasBody = !["GET", "HEAD"].includes(request.method);
-  const response = await fetch(buildBackendUrl(pathname), {
+  const response = await fetch(buildBackendUrl(pathname, request.url), {
     method: request.method,
     headers,
     body: hasBody ? await request.arrayBuffer() : undefined,

--- a/frontend/src/app/api/memory/_proxy.test.ts
+++ b/frontend/src/app/api/memory/_proxy.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { buildBackendUrl } = await import(new URL("./_proxy.ts", import.meta.url).href);
+
+void test("preserves query strings when proxying to the backend", () => {
+  const url = buildBackendUrl(
+    "/api/memory/facts",
+    "http://localhost:3000/api/memory/facts?limit=1&cursor=next-page",
+    "http://127.0.0.1:8001",
+  );
+
+  assert.equal(url.toString(), "http://127.0.0.1:8001/api/memory/facts?limit=1&cursor=next-page");
+});
+
+void test("leaves query string empty when the incoming request has none", () => {
+  const url = buildBackendUrl(
+    "/api/memory",
+    "http://localhost:3000/api/memory",
+    "http://127.0.0.1:8001",
+  );
+
+  assert.equal(url.toString(), "http://127.0.0.1:8001/api/memory");
+});

--- a/frontend/src/app/api/memory/_proxy.ts
+++ b/frontend/src/app/api/memory/_proxy.ts
@@ -1,0 +1,14 @@
+const BACKEND_BASE_URL =
+  process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? "http://127.0.0.1:8001";
+
+export function buildBackendUrl(
+  pathname: string,
+  requestUrl?: string,
+  backendBaseUrl: string = BACKEND_BASE_URL,
+) {
+  const backendUrl = new URL(pathname, backendBaseUrl);
+  if (requestUrl) {
+    backendUrl.search = new URL(requestUrl).search;
+  }
+  return backendUrl;
+}

--- a/frontend/src/app/api/memory/route.ts
+++ b/frontend/src/app/api/memory/route.ts
@@ -1,11 +1,6 @@
 import type { NextRequest } from "next/server";
 
-const BACKEND_BASE_URL =
-  process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? "http://127.0.0.1:8001";
-
-function buildBackendUrl(pathname: string) {
-  return new URL(pathname, BACKEND_BASE_URL);
-}
+import { buildBackendUrl } from "./_proxy";
 
 async function proxyRequest(request: NextRequest, pathname: string) {
   const headers = new Headers(request.headers);
@@ -14,7 +9,7 @@ async function proxyRequest(request: NextRequest, pathname: string) {
   headers.delete("content-length");
 
   const hasBody = !["GET", "HEAD"].includes(request.method);
-  const response = await fetch(buildBackendUrl(pathname), {
+  const response = await fetch(buildBackendUrl(pathname, request.url), {
     method: request.method,
     headers,
     body: hasBody ? await request.arrayBuffer() : undefined,


### PR DESCRIPTION
## Summary
- extract a shared memory proxy URL builder
- preserve incoming query strings when forwarding memory API requests
- add a focused test covering query propagation

## Verification
- bun test src/app/api/memory/_proxy.test.ts
- pnpm check