### PR TITLE
fix(frontend): encode upload delete filenames

### DIFF
--- a/frontend/src/core/uploads/api.test.ts
+++ b/frontend/src/core/uploads/api.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.SKIP_ENV_VALIDATION = "1";
+process.env.NEXT_PUBLIC_BACKEND_BASE_URL = "http://127.0.0.1:8001";
+
+const { buildDeleteUploadedFileUrl } = await import(
+  new URL("./api.ts", import.meta.url).href
+);
+
+void test("encodes uploaded filenames in delete URLs", () => {
+  const url = buildDeleteUploadedFileUrl(
+    "thread-123",
+    "report (final) #1?.pdf",
+  );
+
+  assert.equal(
+    url,
+    "http://127.0.0.1:8001/api/threads/thread-123/uploads/report%20(final)%20%231%3F.pdf",
+  );
+});

--- a/frontend/src/core/uploads/api.ts
+++ b/frontend/src/core/uploads/api.ts
@@ -29,6 +29,13 @@ export interface ListFilesResponse {
   count: number;
 }
 
+export function buildDeleteUploadedFileUrl(
+  threadId: string,
+  filename: string,
+) {
+  return `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${encodeURIComponent(filename)}`;
+}
+
 async function readErrorDetail(
   response: Response,
   fallback: string,
@@ -91,12 +98,9 @@ export async function deleteUploadedFile(
   threadId: string,
   filename: string,
 ): Promise<{ success: boolean; message: string }> {
-  const response = await fetch(
-    `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${filename}`,
-    {
-      method: "DELETE",
-    },
-  );
+  const response = await fetch(buildDeleteUploadedFileUrl(threadId, filename), {
+    method: "DELETE",
+  });
 
   if (!response.ok) {
     throw new Error(await readErrorDetail(response, "Failed to delete file"));


### PR DESCRIPTION
## Summary
- encode uploaded filenames before building delete URLs
- extract a small helper so the URL formatting is easy to validate
- add a focused test for filenames with spaces and reserved characters

## Verification
- bun test src/core/uploads/api.test.ts
- pnpm check