### PR TITLE
fix(frontend): parse uploaded file fallback metadata

### DIFF
--- a/frontend/src/core/messages/utils.test.ts
+++ b/frontend/src/core/messages/utils.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const { parseUploadedFiles } = await import(new URL("./utils.ts", import.meta.url).href);
+
+void test("parses uploaded files blocks with type lines and human-readable sizes", () => {
+  const files = parseUploadedFiles(`<uploaded_files>
+The following files were uploaded in this message:
+
+- titanic.csv (58.9 KB)
+  Type: file
+  Path: /mnt/user-data/uploads/titanic.csv
+
+</uploaded_files>`);
+
+  assert.deepEqual(files, [
+    {
+      filename: "titanic.csv",
+      size: 60314,
+      path: "/mnt/user-data/uploads/titanic.csv",
+    },
+  ]);
+});
+
+void test("parses filenames that contain parentheses", () => {
+  const files = parseUploadedFiles(`<uploaded_files>
+The following files were uploaded in this message:
+
+- report (final).pdf (2.0 KB)
+  Path: /mnt/user-data/uploads/report (final).pdf
+
+</uploaded_files>`);
+
+  assert.deepEqual(files, [
+    {
+      filename: "report (final).pdf",
+      size: 2048,
+      path: "/mnt/user-data/uploads/report (final).pdf",
+    },
+  ]);
+});
+
+void test("parses byte-sized uploaded files", () => {
+  const files = parseUploadedFiles(`<uploaded_files>
+The following files were uploaded in this message:
+
+- note.txt (42 bytes)
+  Path: /mnt/user-data/uploads/note.txt
+
+</uploaded_files>`);
+
+  assert.deepEqual(files, [
+    {
+      filename: "note.txt",
+      size: 42,
+      path: "/mnt/user-data/uploads/note.txt",
+    },
+  ]);
+});

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -352,6 +352,36 @@ export function stripUploadedFilesTag(content: string): string {
     .trim();
 }
 
+function parseUploadedFileSize(sizeText: string): number {
+  const normalized = sizeText.trim().toLowerCase();
+  const sizeRegex = /^(\d+(?:\.\d+)?)\s*(bytes?|kb|mb|gb)?$/;
+  const match = sizeRegex.exec(normalized);
+  if (!match) {
+    return 0;
+  }
+
+  const value = Number.parseFloat(match[1] ?? "0");
+  const unit = match[2] ?? "bytes";
+
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  switch (unit) {
+    case "byte":
+    case "bytes":
+      return Math.round(value);
+    case "kb":
+      return Math.round(value * 1024);
+    case "mb":
+      return Math.round(value * 1024 * 1024);
+    case "gb":
+      return Math.round(value * 1024 * 1024 * 1024);
+    default:
+      return 0;
+  }
+}
+
 export function parseUploadedFiles(content: string): FileInMessage[] {
   // Match <uploaded_files>...</uploaded_files> tag
   const uploadedFilesRegex = /<uploaded_files>([\s\S]*?)<\/uploaded_files>/;
@@ -375,15 +405,16 @@ export function parseUploadedFiles(content: string): FileInMessage[] {
   }
 
   // Parse file list
-  // Format: - filename (size)\n  Path: /path/to/file
-  const fileRegex = /- ([^\n(]+)\s*\(([^)]+)\)\s*\n\s*Path:\s*([^\n]+)/g;
+  // Format: - filename (size)\n  [Type: image|file]\n  Path: /path/to/file
+  const fileRegex =
+    /- (.+?)\s+\(([^)]+)\)\s*\n(?:\s*Type:\s*[^\n]+\n)?\s*Path:\s*([^\n]+)/g;
   const files: FileInMessage[] = [];
   let fileMatch;
 
   while ((fileMatch = fileRegex.exec(uploadedFilesContent ?? "")) !== null) {
     files.push({
       filename: fileMatch[1].trim(),
-      size: parseInt(fileMatch[2].trim(), 10) ?? 0,
+      size: parseUploadedFileSize(fileMatch[2] ?? ""),
       path: fileMatch[3].trim(),
     });
   }


### PR DESCRIPTION
## Summary
- make the fallback uploaded-files parser accept the current `Type:` line emitted by the backend
- parse human-readable size strings like `KB`, `MB`, and `bytes` into byte counts
- keep filenames with parentheses intact when reconstructing file metadata

## Verification
- bun test src/core/messages/utils.test.ts
- pnpm check