### PR TITLE
fix(middleware): ignore think tags in title generation

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -1,6 +1,7 @@
 """Middleware for automatic thread title generation."""
 
 import logging
+import re
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
@@ -11,6 +12,7 @@ from deerflow.config.title_config import get_title_config
 from deerflow.models import create_chat_model
 
 logger = logging.getLogger(__name__)
+THINK_TAG_RE = re.compile(r"<think>\s*([\s\S]*?)\s*</think>", re.IGNORECASE)
 
 
 class TitleMiddlewareState(AgentState):
@@ -23,6 +25,9 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
     """Automatically generate a title for the thread after the first user message."""
 
     state_schema = TitleMiddlewareState
+
+    def _strip_inline_think_tags(self, content: str) -> str:
+        return THINK_TAG_RE.sub("", content).strip()
 
     def _normalize_content(self, content: object) -> str:
         if isinstance(content, str):
@@ -77,7 +82,9 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         assistant_msg_content = next((m.content for m in messages if m.type == "ai"), "")
 
         user_msg = self._normalize_content(user_msg_content)
-        assistant_msg = self._normalize_content(assistant_msg_content)
+        assistant_msg = self._strip_inline_think_tags(
+            self._normalize_content(assistant_msg_content)
+        )
 
         prompt = config.prompt_template.format(
             max_words=config.max_words,
@@ -89,7 +96,9 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
     def _parse_title(self, content: object) -> str:
         """Normalize model output into a clean title string."""
         config = get_title_config()
-        title_content = self._normalize_content(content)
+        title_content = self._strip_inline_think_tags(
+            self._normalize_content(content)
+        )
         title = title_content.strip().strip('"').strip("'")
         return title[: config.max_chars] if len(title) > config.max_chars else title
 

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -113,6 +113,32 @@ class TestTitleMiddlewareCoreLogic:
 
         assert title == "请帮我总结这段代码"
 
+    def test_build_title_prompt_strips_inline_think_tags_from_assistant_messages(self):
+        _set_test_title_config(max_words=6)
+        middleware = TitleMiddleware()
+
+        prompt, user_msg = middleware._build_title_prompt(
+            {
+                "messages": [
+                    HumanMessage(content="帮我总结这个 PR"),
+                    AIMessage(content="<think>\n先分析 diff\n</think>\n\n这是正式回答"),
+                ]
+            }
+        )
+
+        assert user_msg == "帮我总结这个 PR"
+        assert "<think>" not in prompt
+        assert "先分析 diff" not in prompt
+        assert "这是正式回答" in prompt
+
+    def test_parse_title_strips_inline_think_tags_from_model_output(self):
+        _set_test_title_config(max_chars=20)
+        middleware = TitleMiddleware()
+
+        title = middleware._parse_title("<think>internal</think>\n最终标题")
+
+        assert title == "最终标题"
+
     def test_generate_title_fallback_for_long_message(self, monkeypatch):
         _set_test_title_config(max_chars=20)
         middleware = TitleMiddleware()


### PR DESCRIPTION
## Summary
- strip inline `<think>...</think>` blocks before using assistant content in title prompts
- also strip think tags from title model output before normalizing the final title
- add focused middleware tests for both prompt construction and title parsing

## Verification
- uv run pytest tests/test_title_middleware_core_logic.py tests/test_title_generation.py -q
- uv run ruff check packages/harness/deerflow/agents/middlewares/title_middleware.py tests/test_title_middleware_core_logic.py tests/test_title_generation.py