### PR TITLE
feat(backend): persist thread agent_name in store

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -17,10 +17,10 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import Response, StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.gateway.deps import get_checkpointer, get_run_manager, get_stream_bridge
-from app.gateway.services import sse_consumer, start_run
+from app.gateway.services import normalize_agent_name, resolve_persisted_agent_name, sse_consumer, start_run
 from deerflow.runtime import RunRecord, serialize_channel_values
 
 logger = logging.getLogger(__name__)
@@ -53,6 +53,16 @@ class RunCreateRequest(BaseModel):
     after_seconds: float | None = Field(default=None, description="Delayed execution")
     if_not_exists: Literal["reject", "create"] = Field(default="create", description="Thread creation policy")
     feedback_keys: list[str] | None = Field(default=None, description="LangSmith feedback keys")
+
+    @model_validator(mode="after")
+    def validate_agent_selection(self) -> "RunCreateRequest":
+        """Normalize and validate agent selection before any run record is created."""
+        resolve_persisted_agent_name(self.assistant_id, self.config)
+        if isinstance(self.config, dict) and isinstance(self.config.get("configurable"), dict):
+            explicit = self.config["configurable"].get("agent_name")
+            if isinstance(explicit, str):
+                self.config["configurable"]["agent_name"] = normalize_agent_name(explicit, source="configurable.agent_name")
+        return self
 
 
 class RunResponse(BaseModel):

--- a/backend/app/gateway/routers/threads.py
+++ b/backend/app/gateway/routers/threads.py
@@ -183,8 +183,8 @@ async def _store_upsert(
     """Create or refresh a thread record in the Store.
 
     On creation the record is written with ``status="idle"``.  On update only
-    ``updated_at`` (and optionally ``metadata`` / ``values``) are changed so
-    that existing fields are preserved.
+    ``updated_at`` and any supplied ``metadata`` / ``values`` / top-level
+    ``agent_name`` are refreshed while preserving other existing fields.
 
     ``values`` carries the agent-state snapshot exposed to the frontend
     (currently just ``{"title": "..."}``).

--- a/backend/app/gateway/routers/threads.py
+++ b/backend/app/gateway/routers/threads.py
@@ -156,7 +156,30 @@ async def _store_put(store, record: dict) -> None:
     await store.aput(THREADS_NS, record["thread_id"], record)
 
 
-async def _store_upsert(store, thread_id: str, *, metadata: dict | None = None, values: dict | None = None) -> None:
+def _resolve_record_agent_name(
+    metadata: dict[str, Any] | None = None,
+    *,
+    agent_name: str | None = None,
+    existing: dict[str, Any] | None = None,
+) -> str | None:
+    """Resolve the persisted top-level ``agent_name`` for a thread record."""
+    if agent_name:
+        return agent_name
+    if metadata and isinstance(metadata.get("agent_name"), str) and metadata["agent_name"]:
+        return metadata["agent_name"]
+    if existing and isinstance(existing.get("agent_name"), str) and existing["agent_name"]:
+        return existing["agent_name"]
+    return None
+
+
+async def _store_upsert(
+    store,
+    thread_id: str,
+    *,
+    metadata: dict | None = None,
+    values: dict | None = None,
+    agent_name: str | None = None,
+) -> None:
     """Create or refresh a thread record in the Store.
 
     On creation the record is written with ``status="idle"``.  On update only
@@ -168,18 +191,19 @@ async def _store_upsert(store, thread_id: str, *, metadata: dict | None = None, 
     """
     now = time.time()
     existing = await _store_get(store, thread_id)
+    persisted_agent_name = _resolve_record_agent_name(metadata, agent_name=agent_name, existing=existing)
     if existing is None:
-        await _store_put(
-            store,
-            {
-                "thread_id": thread_id,
-                "status": "idle",
-                "created_at": now,
-                "updated_at": now,
-                "metadata": metadata or {},
-                "values": values or {},
-            },
-        )
+        record = {
+            "thread_id": thread_id,
+            "status": "idle",
+            "created_at": now,
+            "updated_at": now,
+            "metadata": metadata or {},
+            "values": values or {},
+        }
+        if persisted_agent_name:
+            record["agent_name"] = persisted_agent_name
+        await _store_put(store, record)
     else:
         val = dict(existing)
         val["updated_at"] = now
@@ -187,6 +211,8 @@ async def _store_upsert(store, thread_id: str, *, metadata: dict | None = None, 
             val.setdefault("metadata", {}).update(metadata)
         if values:
             val.setdefault("values", {}).update(values)
+        if persisted_agent_name:
+            val["agent_name"] = persisted_agent_name
         await _store_put(store, val)
 
 

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -8,6 +8,7 @@ frames, and consuming stream bridge events.  Router modules
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 import json
 import logging
 import re
@@ -95,6 +96,29 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
 
 
 _DEFAULT_ASSISTANT_ID = "lead_agent"
+_CUSTOM_AGENT_NAME_PATTERN = re.compile(r"^[a-z0-9-]+$")
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def normalize_agent_name(raw_value: str, *, source: str) -> str:
+    """Normalize and validate a DeerFlow agent name."""
+    normalized = raw_value.strip().lower().replace("_", "-")
+    if not normalized or not _CUSTOM_AGENT_NAME_PATTERN.fullmatch(normalized):
+        raise ValueError(f"Invalid {source} {raw_value!r}: must contain only letters, digits, and hyphens after normalization.")
+    return normalized
+
+
+def _resolve_explicit_agent_name(request_config: dict[str, Any] | None) -> str | None:
+    configurable = _as_dict((request_config or {}).get("configurable"))
+    explicit = configurable.get("agent_name")
+    if explicit is None:
+        return None
+    if not isinstance(explicit, str):
+        raise ValueError("Invalid configurable.agent_name: must be a string.")
+    return normalize_agent_name(explicit, source="configurable.agent_name")
 
 
 def resolve_agent_factory(assistant_id: str | None):
@@ -131,6 +155,8 @@ def build_run_config(
     """
     config: dict[str, Any] = {"recursion_limit": 100}
     if request_config:
+        request_config = _as_dict(request_config)
+        request_configurable = _as_dict(request_config.get("configurable"))
         # LangGraph >= 0.6.0 introduced ``context`` as the preferred way to
         # pass thread-level data and rejects requests that include both
         # ``configurable`` and ``context``.  If the caller already sends
@@ -140,12 +166,12 @@ def build_run_config(
                 logger.warning(
                     "build_run_config: client sent both 'context' and 'configurable'; preferring 'context' (LangGraph >= 0.6.0). thread_id=%s, caller_configurable keys=%s",
                     thread_id,
-                    list(request_config.get("configurable", {}).keys()),
+                    list(request_configurable.keys()),
                 )
             config["context"] = request_config["context"]
         else:
             configurable = {"thread_id": thread_id}
-            configurable.update(request_config.get("configurable", {}))
+            configurable.update(request_configurable)
             config["configurable"] = configurable
         for k, v in request_config.items():
             if k not in ("configurable", "context"):
@@ -157,10 +183,9 @@ def build_run_config(
     # Honour an explicit configurable["agent_name"] in the request if already set.
     if assistant_id and assistant_id != _DEFAULT_ASSISTANT_ID and "configurable" in config:
         if "agent_name" not in config["configurable"]:
-            normalized = assistant_id.strip().lower().replace("_", "-")
-            if not normalized or not re.fullmatch(r"[a-z0-9-]+", normalized):
-                raise ValueError(f"Invalid assistant_id {assistant_id!r}: must contain only letters, digits, and hyphens after normalization.")
-            config["configurable"]["agent_name"] = normalized
+            config["configurable"]["agent_name"] = normalize_agent_name(assistant_id, source="assistant_id")
+    if "configurable" in config and "agent_name" in config["configurable"]:
+        config["configurable"]["agent_name"] = _resolve_explicit_agent_name({"configurable": config["configurable"]})
     if metadata:
         config.setdefault("metadata", {}).update(metadata)
     return config
@@ -171,15 +196,11 @@ def resolve_persisted_agent_name(
     request_config: dict[str, Any] | None,
 ) -> str:
     """Return the agent name that should be persisted alongside a thread."""
-    configurable = (request_config or {}).get("configurable", {})
-    explicit = configurable.get("agent_name")
-    if isinstance(explicit, str) and explicit:
+    explicit = _resolve_explicit_agent_name(request_config)
+    if explicit:
         return explicit
     if assistant_id and assistant_id != _DEFAULT_ASSISTANT_ID:
-        normalized = assistant_id.strip().lower().replace("_", "-")
-        if not normalized or not re.fullmatch(r"[a-z0-9-]+", normalized):
-            raise ValueError(f"Invalid assistant_id {assistant_id!r}: must contain only letters, digits, and hyphens after normalization.")
-        return normalized
+        return normalize_agent_name(assistant_id, source="assistant_id")
     return "default"
 
 
@@ -282,6 +303,8 @@ async def start_run(
     store = get_store(request)
 
     disconnect = DisconnectMode.cancel if body.on_disconnect == "cancel" else DisconnectMode.continue_
+    persisted_agent_name = resolve_persisted_agent_name(body.assistant_id, body.config)
+    config = build_run_config(thread_id, body.config, body.metadata, assistant_id=body.assistant_id)
 
     try:
         record = await run_mgr.create_or_reject(
@@ -300,13 +323,11 @@ async def start_run(
     # Ensure the thread is visible in /threads/search, even for threads that
     # were never explicitly created via POST /threads (e.g. stateless runs).
     store = get_store(request)
-    persisted_agent_name = resolve_persisted_agent_name(body.assistant_id, body.config)
     if store is not None:
         await _upsert_thread_in_store(store, thread_id, body.metadata, agent_name=persisted_agent_name)
 
     agent_factory = resolve_agent_factory(body.assistant_id)
     graph_input = normalize_input(body.input)
-    config = build_run_config(thread_id, body.config, body.metadata, assistant_id=body.assistant_id)
 
     # Merge DeerFlow-specific context overrides into configurable.
     # The ``context`` field is a custom extension for the langgraph-compat layer

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -166,12 +166,35 @@ def build_run_config(
     return config
 
 
+def resolve_persisted_agent_name(
+    assistant_id: str | None,
+    request_config: dict[str, Any] | None,
+) -> str:
+    """Return the agent name that should be persisted alongside a thread."""
+    configurable = (request_config or {}).get("configurable", {})
+    explicit = configurable.get("agent_name")
+    if isinstance(explicit, str) and explicit:
+        return explicit
+    if assistant_id and assistant_id != _DEFAULT_ASSISTANT_ID:
+        normalized = assistant_id.strip().lower().replace("_", "-")
+        if not normalized or not re.fullmatch(r"[a-z0-9-]+", normalized):
+            raise ValueError(f"Invalid assistant_id {assistant_id!r}: must contain only letters, digits, and hyphens after normalization.")
+        return normalized
+    return "default"
+
+
 # ---------------------------------------------------------------------------
 # Run lifecycle
 # ---------------------------------------------------------------------------
 
 
-async def _upsert_thread_in_store(store, thread_id: str, metadata: dict | None) -> None:
+async def _upsert_thread_in_store(
+    store,
+    thread_id: str,
+    metadata: dict | None,
+    *,
+    agent_name: str | None = None,
+) -> None:
     """Create or refresh the thread record in the Store.
 
     Called from :func:`start_run` so that threads created via the stateless
@@ -182,7 +205,7 @@ async def _upsert_thread_in_store(store, thread_id: str, metadata: dict | None) 
     from app.gateway.routers.threads import _store_upsert
 
     try:
-        await _store_upsert(store, thread_id, metadata=metadata)
+        await _store_upsert(store, thread_id, metadata=metadata, agent_name=agent_name)
     except Exception:
         logger.warning("Failed to upsert thread %s in store (non-fatal)", thread_id)
 
@@ -277,8 +300,9 @@ async def start_run(
     # Ensure the thread is visible in /threads/search, even for threads that
     # were never explicitly created via POST /threads (e.g. stateless runs).
     store = get_store(request)
+    persisted_agent_name = resolve_persisted_agent_name(body.assistant_id, body.config)
     if store is not None:
-        await _upsert_thread_in_store(store, thread_id, body.metadata)
+        await _upsert_thread_in_store(store, thread_id, body.metadata, agent_name=persisted_agent_name)
 
     agent_factory = resolve_agent_factory(body.assistant_id)
     graph_input = normalize_input(body.input)

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -145,6 +145,24 @@ def test_build_run_config_explicit_agent_name_not_overwritten():
     assert config["configurable"]["agent_name"] == "explicit-agent"
 
 
+def test_resolve_persisted_agent_name_defaults_to_default():
+    from app.gateway.services import resolve_persisted_agent_name
+
+    assert resolve_persisted_agent_name("lead_agent", None) == "default"
+
+
+def test_resolve_persisted_agent_name_uses_custom_assistant():
+    from app.gateway.services import resolve_persisted_agent_name
+
+    assert resolve_persisted_agent_name("Final_Agent", None) == "final-agent"
+
+
+def test_resolve_persisted_agent_name_prefers_explicit_configurable_agent():
+    from app.gateway.services import resolve_persisted_agent_name
+
+    assert resolve_persisted_agent_name("other-agent", {"configurable": {"agent_name": "explicit-agent"}}) == "explicit-agent"
+
+
 def test_resolve_agent_factory_returns_make_lead_agent():
     """resolve_agent_factory always returns make_lead_agent regardless of assistant_id."""
     from app.gateway.services import resolve_agent_factory

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 
+import pytest
+from pydantic import ValidationError
+
 
 def test_format_sse_basic():
     from app.gateway.services import format_sse
@@ -160,7 +163,37 @@ def test_resolve_persisted_agent_name_uses_custom_assistant():
 def test_resolve_persisted_agent_name_prefers_explicit_configurable_agent():
     from app.gateway.services import resolve_persisted_agent_name
 
-    assert resolve_persisted_agent_name("other-agent", {"configurable": {"agent_name": "explicit-agent"}}) == "explicit-agent"
+    assert resolve_persisted_agent_name("other-agent", {"configurable": {"agent_name": "Explicit_Agent"}}) == "explicit-agent"
+
+
+def test_resolve_persisted_agent_name_ignores_non_dict_configurable():
+    from app.gateway.services import resolve_persisted_agent_name
+
+    assert resolve_persisted_agent_name("Final_Agent", {"configurable": "bad-shape"}) == "final-agent"
+
+
+def test_run_create_request_normalizes_explicit_agent_name():
+    from app.gateway.routers.thread_runs import RunCreateRequest
+
+    body = RunCreateRequest(
+        input={"messages": [{"role": "user", "content": "hi"}]},
+        config={"configurable": {"agent_name": "Explicit_Agent"}, "tags": ["demo"]},
+    )
+
+    assert body.config is not None
+    assert body.config["configurable"]["agent_name"] == "explicit-agent"
+    assert body.config["tags"] == ["demo"]
+
+
+def test_run_create_request_rejects_invalid_agent_selection_before_run_creation():
+    from app.gateway.routers.thread_runs import RunCreateRequest
+
+    with pytest.raises(ValidationError):
+        RunCreateRequest(
+            input={"messages": [{"role": "user", "content": "hi"}]},
+            assistant_id="bad name!",
+            config={"configurable": {"agent_name": "still_bad!"}},
+        )
 
 
 def test_resolve_agent_factory_returns_make_lead_agent():

--- a/backend/tests/test_threads_router.py
+++ b/backend/tests/test_threads_router.py
@@ -1,3 +1,5 @@
+import asyncio
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -107,3 +109,62 @@ def test_delete_thread_data_returns_generic_500_error(tmp_path):
     assert exc_info.value.detail == "Failed to delete local thread data."
     assert "/secret/path" not in exc_info.value.detail
     log_exception.assert_called_once_with("Failed to delete thread data for %s", "thread-cleanup")
+
+
+def test_store_upsert_persists_top_level_agent_name():
+    class FakeStore:
+        def __init__(self):
+            self.records = {}
+
+        async def aget(self, namespace, key):
+            value = self.records.get((namespace, key))
+            if value is None:
+                return None
+            return SimpleNamespace(value=value)
+
+        async def aput(self, namespace, key, value):
+            self.records[(namespace, key)] = value
+
+    store = FakeStore()
+
+    asyncio.run(
+        threads._store_upsert(
+            store,
+            "thread-agent-name",
+            metadata={"agent_name": "lead-agent", "created_by": "system"},
+        )
+    )
+
+    record = store.records[(threads.THREADS_NS, "thread-agent-name")]
+    assert record["agent_name"] == "lead-agent"
+    assert record["metadata"]["agent_name"] == "lead-agent"
+
+
+def test_store_upsert_backfills_agent_name_for_existing_thread():
+    class FakeStore:
+        def __init__(self):
+            self.records = {}
+
+        async def aget(self, namespace, key):
+            value = self.records.get((namespace, key))
+            if value is None:
+                return None
+            return SimpleNamespace(value=value)
+
+        async def aput(self, namespace, key, value):
+            self.records[(namespace, key)] = value
+
+    store = FakeStore()
+    store.records[(threads.THREADS_NS, "thread-existing")] = {
+        "thread_id": "thread-existing",
+        "status": "idle",
+        "created_at": 1.0,
+        "updated_at": 1.0,
+        "metadata": {},
+        "values": {},
+    }
+
+    asyncio.run(threads._store_upsert(store, "thread-existing", agent_name="default"))
+
+    record = store.records[(threads.THREADS_NS, "thread-existing")]
+    assert record["agent_name"] == "default"


### PR DESCRIPTION
## Summary

This fixes issue #2067 by persisting the thread creator agent name into the SQLite-backed thread store.

## What changed

- added a dedicated `resolve_persisted_agent_name()` path in the run service so each run resolves the agent name that should be recorded for the thread
- updated thread store upserts to persist top-level `value.agent_name` and preserve/backfill it for existing thread records
- added regression tests covering default agents, custom agents, and backfilling `agent_name` onto existing store records

## Root cause

The gateway already resolved custom assistants into `agent_name` for runtime execution, but that value was never written into the persistent thread store. As a result, SQLite `store.value` records could not reliably indicate which agent created or owned the thread.

## Impact

After this change, thread records in the persistent store can be audited by `value.agent_name`, including threads first seen through a later run on an existing record.

## Validation

- `C:\Users\18375\Documents\GitHub\deer-flow-main\backend\.venv\Scripts\python.exe -m pytest backend/tests/test_gateway_services.py backend/tests/test_threads_router.py -q`
- `C:\Users\18375\Documents\GitHub\deer-flow-main\backend\.venv\Scripts\python.exe -m py_compile backend/app/gateway/services.py backend/app/gateway/routers/threads.py backend/tests/test_gateway_services.py backend/tests/test_threads_router.py`
