### PR TITLE
fix(frontend): use mock artifact URLs in messages

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 
 import { CopyButton } from "../copy-button";
 
+import { useThread } from "./context";
 import { MarkdownContent } from "./markdown-content";
 
 export function MessageListItem({
@@ -92,6 +93,7 @@ function MessageImage({
   threadId: string;
   maxWidth?: string;
 }) {
+  const { isMock } = useThread();
   if (!src) return null;
 
   const imgClassName = cn("overflow-hidden rounded-lg", `max-w-[${maxWidth}]`);
@@ -100,7 +102,9 @@ function MessageImage({
     return <img className={imgClassName} src={src} alt={alt} {...props} />;
   }
 
-  const url = src.startsWith("/mnt/") ? resolveArtifactURL(src, threadId) : src;
+  const url = src.startsWith("/mnt/")
+    ? resolveArtifactURL(src, threadId, isMock)
+    : src;
 
   return (
     <a href={url} target="_blank" rel="noopener noreferrer">
@@ -311,6 +315,7 @@ function RichFileCard({
   threadId: string;
 }) {
   const { t } = useI18n();
+  const { isMock } = useThread();
   const isUploading = file.status === "uploading";
   const isImage = isImageFile(file.filename);
 
@@ -343,7 +348,7 @@ function RichFileCard({
 
   if (!file.path) return null;
 
-  const fileUrl = resolveArtifactURL(file.path, threadId);
+  const fileUrl = resolveArtifactURL(file.path, threadId, isMock);
 
   if (isImage) {
     return (

--- a/frontend/src/core/artifacts/utils.ts
+++ b/frontend/src/core/artifacts/utils.ts
@@ -22,6 +22,10 @@ export function extractArtifactsFromThread(thread: AgentThread) {
   return thread.values.artifacts ?? [];
 }
 
-export function resolveArtifactURL(absolutePath: string, threadId: string) {
-  return `${getBackendBaseURL()}/api/threads/${threadId}/artifacts${absolutePath}`;
+export function resolveArtifactURL(
+  absolutePath: string,
+  threadId: string,
+  isMock = false,
+) {
+  return urlOfArtifact({ filepath: absolutePath, threadId, isMock });
 }


### PR DESCRIPTION
## Summary
- let `resolveArtifactURL` forward the mock flag through the shared artifact URL builder
- use the thread mock context for inline artifact images in messages
- use the same mock-aware URL path for uploaded file cards rendered inside messages

## Verification
- pnpm check