### PR TITLE
fix(sandbox): stale sandbox URL recovery before tool execution

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -19,6 +19,8 @@ import threading
 import time
 import uuid
 
+import requests
+
 try:
     import fcntl
 except ImportError:  # pragma: no cover - Windows fallback
@@ -603,9 +605,50 @@ class AioSandboxProvider(SandboxProvider):
         """
         with self._lock:
             sandbox = self._sandboxes.get(sandbox_id)
+        if sandbox is None:
+            return None
+
+        # Cached AIO sandboxes can outlive the underlying container/URL.
+        # Probe before returning so callers do not execute against a dead endpoint.
+        if isinstance(sandbox, AioSandbox) and not self._sandbox_url_is_healthy(sandbox.base_url):
+            logger.warning(f"Sandbox {sandbox_id} at {sandbox.base_url} is unreachable, attempting rediscovery")
+            return self._recover_stale_sandbox(sandbox_id)
+
+        with self._lock:
+            sandbox = self._sandboxes.get(sandbox_id)
             if sandbox is not None:
                 self._last_activity[sandbox_id] = time.time()
             return sandbox
+
+    @staticmethod
+    def _sandbox_url_is_healthy(sandbox_url: str) -> bool:
+        """Return whether the sandbox HTTP endpoint is reachable."""
+        try:
+            response = requests.get(f"{sandbox_url}/v1/sandbox", timeout=2)
+            return response.status_code == 200
+        except requests.exceptions.RequestException:
+            return False
+
+    def _recover_stale_sandbox(self, sandbox_id: str) -> Sandbox | None:
+        """Drop a stale cached sandbox and rediscover the current live endpoint."""
+        discovered = self._backend.discover(sandbox_id)
+
+        with self._lock:
+            self._sandboxes.pop(sandbox_id, None)
+            self._sandbox_infos.pop(sandbox_id, None)
+            self._last_activity.pop(sandbox_id, None)
+
+            if discovered is None:
+                logger.warning(f"Sandbox {sandbox_id} could not be rediscovered after health-check failure")
+                return None
+
+            sandbox = AioSandbox(id=discovered.sandbox_id, base_url=discovered.sandbox_url)
+            self._sandboxes[discovered.sandbox_id] = sandbox
+            self._sandbox_infos[discovered.sandbox_id] = discovered
+            self._last_activity[discovered.sandbox_id] = time.time()
+
+        logger.info(f"Recovered sandbox {sandbox_id} at {discovered.sandbox_url}")
+        return sandbox
 
     def release(self, sandbox_id: str) -> None:
         """Release a sandbox from active use into the warm pool.

--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -668,6 +668,8 @@ class AioSandboxProvider(SandboxProvider):
             self._sandbox_infos[discovered.sandbox_id] = discovered
             self._last_activity[discovered.sandbox_id] = time.time()
             self._health_check_cache[discovered.sandbox_id] = (time.time(), True, discovered.sandbox_url)
+            for tid in thread_ids_to_remove:
+                self._thread_sandboxes[tid] = discovered.sandbox_id
 
         logger.info(f"Recovered sandbox {sandbox_id} at {discovered.sandbox_url}")
         return sandbox

--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -46,6 +46,7 @@ DEFAULT_PORT = 8080
 DEFAULT_CONTAINER_PREFIX = "deer-flow-sandbox"
 DEFAULT_IDLE_TIMEOUT = 600  # 10 minutes in seconds
 DEFAULT_REPLICAS = 3  # Maximum concurrent sandbox containers
+DEFAULT_HEALTH_CHECK_INTERVAL = 1.0  # Throttle cached health probes on hot paths
 IDLE_CHECK_INTERVAL = 60  # Check every 60 seconds
 
 
@@ -98,6 +99,7 @@ class AioSandboxProvider(SandboxProvider):
         self._thread_sandboxes: dict[str, str] = {}  # thread_id -> sandbox_id
         self._thread_locks: dict[str, threading.Lock] = {}  # thread_id -> in-process lock
         self._last_activity: dict[str, float] = {}  # sandbox_id -> last activity timestamp
+        self._health_check_cache: dict[str, tuple[float, bool, str]] = {}  # sandbox_id -> (checked_at, healthy, sandbox_url)
         # Warm pool: released sandboxes whose containers are still running.
         # Maps sandbox_id -> (SandboxInfo, release_timestamp).
         # Containers here can be reclaimed quickly (no cold-start) or destroyed
@@ -610,7 +612,7 @@ class AioSandboxProvider(SandboxProvider):
 
         # Cached AIO sandboxes can outlive the underlying container/URL.
         # Probe before returning so callers do not execute against a dead endpoint.
-        if isinstance(sandbox, AioSandbox) and not self._sandbox_url_is_healthy(sandbox.base_url):
+        if isinstance(sandbox, AioSandbox) and not self._sandbox_url_is_healthy(sandbox_id, sandbox.base_url):
             logger.warning(f"Sandbox {sandbox_id} at {sandbox.base_url} is unreachable, attempting rediscovery")
             return self._recover_stale_sandbox(sandbox_id)
 
@@ -620,14 +622,29 @@ class AioSandboxProvider(SandboxProvider):
                 self._last_activity[sandbox_id] = time.time()
             return sandbox
 
-    @staticmethod
-    def _sandbox_url_is_healthy(sandbox_url: str) -> bool:
-        """Return whether the sandbox HTTP endpoint is reachable."""
+    def _sandbox_url_is_healthy(self, sandbox_id: str, sandbox_url: str) -> bool:
+        """Return whether the sandbox HTTP endpoint is reachable.
+
+        Successful checks are briefly cached to avoid probing the same sandbox
+        on every hot-path ``get()`` call.
+        """
+        now = time.time()
+        with self._lock:
+            cached = self._health_check_cache.get(sandbox_id)
+            if cached is not None:
+                checked_at, healthy, cached_url = cached
+                if cached_url == sandbox_url and (now - checked_at) < DEFAULT_HEALTH_CHECK_INTERVAL:
+                    return healthy
+
         try:
             response = requests.get(f"{sandbox_url}/v1/sandbox", timeout=2)
-            return response.status_code == 200
+            healthy = response.status_code == 200
         except requests.exceptions.RequestException:
-            return False
+            healthy = False
+
+        with self._lock:
+            self._health_check_cache[sandbox_id] = (now, healthy, sandbox_url)
+        return healthy
 
     def _recover_stale_sandbox(self, sandbox_id: str) -> Sandbox | None:
         """Drop a stale cached sandbox and rediscover the current live endpoint."""
@@ -637,6 +654,10 @@ class AioSandboxProvider(SandboxProvider):
             self._sandboxes.pop(sandbox_id, None)
             self._sandbox_infos.pop(sandbox_id, None)
             self._last_activity.pop(sandbox_id, None)
+            self._health_check_cache.pop(sandbox_id, None)
+            thread_ids_to_remove = [tid for tid, sid in self._thread_sandboxes.items() if sid == sandbox_id]
+            for tid in thread_ids_to_remove:
+                del self._thread_sandboxes[tid]
 
             if discovered is None:
                 logger.warning(f"Sandbox {sandbox_id} could not be rediscovered after health-check failure")
@@ -646,6 +667,7 @@ class AioSandboxProvider(SandboxProvider):
             self._sandboxes[discovered.sandbox_id] = sandbox
             self._sandbox_infos[discovered.sandbox_id] = discovered
             self._last_activity[discovered.sandbox_id] = time.time()
+            self._health_check_cache[discovered.sandbox_id] = (time.time(), True, discovered.sandbox_url)
 
         logger.info(f"Recovered sandbox {sandbox_id} at {discovered.sandbox_url}")
         return sandbox
@@ -670,6 +692,7 @@ class AioSandboxProvider(SandboxProvider):
             for tid in thread_ids_to_remove:
                 del self._thread_sandboxes[tid]
             self._last_activity.pop(sandbox_id, None)
+            self._health_check_cache.pop(sandbox_id, None)
             # Park in warm pool — container keeps running
             if info and sandbox_id not in self._warm_pool:
                 self._warm_pool[sandbox_id] = (info, time.time())
@@ -695,6 +718,7 @@ class AioSandboxProvider(SandboxProvider):
             for tid in thread_ids_to_remove:
                 del self._thread_sandboxes[tid]
             self._last_activity.pop(sandbox_id, None)
+            self._health_check_cache.pop(sandbox_id, None)
             # Also pull from warm pool if it was parked there
             if info is None and sandbox_id in self._warm_pool:
                 info, _ = self._warm_pool.pop(sandbox_id)

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -1,10 +1,13 @@
-"""Tests for AioSandboxProvider mount helpers."""
+"""Tests for AioSandboxProvider helpers and recovery paths."""
 
 import importlib
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
+from deerflow.community.aio_sandbox.sandbox_info import SandboxInfo
 from deerflow.config.paths import Paths, join_host_path
 
 # ── ensure_thread_dirs ───────────────────────────────────────────────────────
@@ -48,8 +51,15 @@ def _make_provider(tmp_path):
         provider = aio_mod.AioSandboxProvider.__new__(aio_mod.AioSandboxProvider)
         provider._config = {}
         provider._sandboxes = {}
-        provider._lock = MagicMock()
+        provider._sandbox_infos = {}
+        provider._thread_sandboxes = {}
+        provider._thread_locks = {}
+        provider._last_activity = {}
+        provider._warm_pool = {}
+        provider._lock = threading.Lock()
+        provider._backend = MagicMock()
         provider._idle_checker_stop = MagicMock()
+        provider._idle_checker_thread = None
     return provider
 
 
@@ -134,3 +144,70 @@ def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatc
             provider._discover_or_create_with_lock("thread-5", "sandbox-5")
 
     assert unlock_calls == []
+
+
+def test_get_rediscovers_stale_cached_sandbox(tmp_path, monkeypatch):
+    """If the cached sandbox URL is dead, get() should rediscover and refresh it."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+
+    with patch("deerflow.community.aio_sandbox.aio_sandbox.AioSandboxClient"):
+        stale = aio_mod.AioSandbox(id="sandbox-1", base_url="http://stale-host:8080")
+
+    provider._sandboxes["sandbox-1"] = stale
+    provider._sandbox_infos["sandbox-1"] = SandboxInfo(
+        sandbox_id="sandbox-1",
+        sandbox_url="http://stale-host:8080",
+        container_name="deer-flow-sandbox-sandbox-1",
+    )
+    provider._thread_sandboxes["thread-1"] = "sandbox-1"
+    provider._last_activity["sandbox-1"] = 1.0
+
+    provider._backend.discover.return_value = SandboxInfo(
+        sandbox_id="sandbox-1",
+        sandbox_url="http://fresh-host:9090",
+        container_name="deer-flow-sandbox-sandbox-1",
+    )
+
+    def _raise_connection_error(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("Connection refused")
+
+    monkeypatch.setattr(requests, "get", _raise_connection_error)
+
+    refreshed = provider.get("sandbox-1")
+
+    assert refreshed is not None
+    assert refreshed is not stale
+    assert refreshed.base_url == "http://fresh-host:9090"
+    assert provider._sandbox_infos["sandbox-1"].sandbox_url == "http://fresh-host:9090"
+
+
+def test_get_returns_none_when_cached_sandbox_cannot_be_rediscovered(tmp_path, monkeypatch):
+    """If the cached sandbox URL is dead and discover() fails, get() should return None."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+
+    with patch("deerflow.community.aio_sandbox.aio_sandbox.AioSandboxClient"):
+        stale = aio_mod.AioSandbox(id="sandbox-2", base_url="http://dead-host:8080")
+
+    provider._sandboxes["sandbox-2"] = stale
+    provider._sandbox_infos["sandbox-2"] = SandboxInfo(
+        sandbox_id="sandbox-2",
+        sandbox_url="http://dead-host:8080",
+        container_name="deer-flow-sandbox-sandbox-2",
+    )
+    provider._thread_sandboxes["thread-2"] = "sandbox-2"
+    provider._last_activity["sandbox-2"] = 1.0
+    provider._backend.discover.return_value = None
+
+    def _raise_connection_error(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("Connection refused")
+
+    monkeypatch.setattr(requests, "get", _raise_connection_error)
+
+    result = provider.get("sandbox-2")
+
+    assert result is None
+    assert "sandbox-2" not in provider._sandboxes
+    assert "sandbox-2" not in provider._sandbox_infos
+    assert "sandbox-2" not in provider._last_activity

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -55,6 +55,7 @@ def _make_provider(tmp_path):
         provider._thread_sandboxes = {}
         provider._thread_locks = {}
         provider._last_activity = {}
+        provider._health_check_cache = {}
         provider._warm_pool = {}
         provider._lock = threading.Lock()
         provider._backend = MagicMock()
@@ -182,6 +183,40 @@ def test_get_rediscovers_stale_cached_sandbox(tmp_path, monkeypatch):
     assert provider._sandbox_infos["sandbox-1"].sandbox_url == "http://fresh-host:9090"
 
 
+def test_get_throttles_repeated_health_checks_for_healthy_sandbox(tmp_path, monkeypatch):
+    """Repeated get() calls within the throttle window should reuse the cached health result."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+
+    with patch("deerflow.community.aio_sandbox.aio_sandbox.AioSandboxClient"):
+        sandbox = aio_mod.AioSandbox(id="sandbox-healthy", base_url="http://healthy-host:8080")
+
+    provider._sandboxes["sandbox-healthy"] = sandbox
+    provider._sandbox_infos["sandbox-healthy"] = SandboxInfo(
+        sandbox_id="sandbox-healthy",
+        sandbox_url="http://healthy-host:8080",
+        container_name="deer-flow-sandbox-sandbox-healthy",
+    )
+
+    timestamps = iter([100.0, 100.0, 100.2, 100.2])
+    monkeypatch.setattr(aio_mod.time, "time", lambda: next(timestamps))
+
+    request_calls = {"count": 0}
+
+    class _Response:
+        status_code = 200
+
+    def _healthy_response(*args, **kwargs):
+        request_calls["count"] += 1
+        return _Response()
+
+    monkeypatch.setattr(requests, "get", _healthy_response)
+
+    assert provider.get("sandbox-healthy") is sandbox
+    assert provider.get("sandbox-healthy") is sandbox
+    assert request_calls["count"] == 1
+
+
 def test_get_returns_none_when_cached_sandbox_cannot_be_rediscovered(tmp_path, monkeypatch):
     """If the cached sandbox URL is dead and discover() fails, get() should return None."""
     aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
@@ -211,3 +246,4 @@ def test_get_returns_none_when_cached_sandbox_cannot_be_rediscovered(tmp_path, m
     assert "sandbox-2" not in provider._sandboxes
     assert "sandbox-2" not in provider._sandbox_infos
     assert "sandbox-2" not in provider._last_activity
+    assert "thread-2" not in provider._thread_sandboxes

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -181,6 +181,7 @@ def test_get_rediscovers_stale_cached_sandbox(tmp_path, monkeypatch):
     assert refreshed is not stale
     assert refreshed.base_url == "http://fresh-host:9090"
     assert provider._sandbox_infos["sandbox-1"].sandbox_url == "http://fresh-host:9090"
+    assert provider._thread_sandboxes["thread-1"] == "sandbox-1"
 
 
 def test_get_throttles_repeated_health_checks_for_healthy_sandbox(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary
Automatically recover from stale sandbox URLs before tool execution by probing cached AIO sandboxes in `AioSandboxProvider.get()` and rediscovering or recreating the live endpoint when the old URL is no longer reachable.

Problem
A thread could keep a cached `sandbox_id` after its original sandbox URL had already become invalid. In that state, later tool calls such as `bash` failed with `Error: [Errno 111] Connection refused` instead of self-healing and continuing.

Root Cause
The sandbox recovery path stopped too early:

- `ensure_sandbox_initialized()` trusted `provider.get(sandbox_id)` as long as it returned an object
- `AioSandboxProvider.get()` only returned the in-memory sandbox instance and refreshed activity timestamps
- no health check was performed on the cached sandbox URL before reuse
- when the underlying sandbox had already been reclaimed, the stale cached object was still returned and the failure only surfaced later during HTTP command execution

That left the system unable to recover from the common case where the sandbox URL had already gone stale before the next tool call started.

Changes
- add a lightweight health probe in `AioSandboxProvider.get()` for cached `AioSandbox` instances
- if the cached sandbox URL is unreachable, attempt rediscovery via the backend before returning it
- if rediscovery succeeds, replace the stale cached sandbox with a fresh in-memory instance bound to the live URL
- if rediscovery fails, clear the stale cached state and return `None` so the existing upper-layer initialization path can reacquire a sandbox
- add regression tests covering both:
  - stale cached sandbox successfully rediscovered
  - stale cached sandbox not rediscoverable and therefore dropped

Testing
- `deer-flow/backend/.venv/bin/pytest backend/tests/test_aio_sandbox_provider.py -q`
- `deer-flow/backend/.venv/bin/pytest backend/tests/test_aio_sandbox.py backend/tests/test_sandbox_tools_security.py -q`

These runs confirm the new stale-URL recovery behavior and verify that adjacent sandbox and tool behavior still passes unchanged.
