### PR TITLE
fix(sandbox): prevent memory leak in file operation locks using WeakValueDictionary

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/file_operation_lock.py
+++ b/backend/packages/harness/deerflow/sandbox/file_operation_lock.py
@@ -1,8 +1,14 @@
 import threading
+import weakref
 
 from deerflow.sandbox.sandbox import Sandbox
 
-_FILE_OPERATION_LOCKS: dict[tuple[str, str], threading.Lock] = {}
+# Use WeakValueDictionary to prevent memory leak in long-running processes.
+# Locks are automatically removed when no longer referenced by any thread.
+_LockKey = tuple[str, str]
+_FILE_OPERATION_LOCKS: weakref.WeakValueDictionary[_LockKey, threading.Lock] = (
+    weakref.WeakValueDictionary()
+)
 _FILE_OPERATION_LOCKS_GUARD = threading.Lock()
 
 

--- a/backend/packages/harness/deerflow/sandbox/file_operation_lock.py
+++ b/backend/packages/harness/deerflow/sandbox/file_operation_lock.py
@@ -6,9 +6,7 @@ from deerflow.sandbox.sandbox import Sandbox
 # Use WeakValueDictionary to prevent memory leak in long-running processes.
 # Locks are automatically removed when no longer referenced by any thread.
 _LockKey = tuple[str, str]
-_FILE_OPERATION_LOCKS: weakref.WeakValueDictionary[_LockKey, threading.Lock] = (
-    weakref.WeakValueDictionary()
-)
+_FILE_OPERATION_LOCKS: weakref.WeakValueDictionary[_LockKey, threading.Lock] = weakref.WeakValueDictionary()
 _FILE_OPERATION_LOCKS_GUARD = threading.Lock()
 
 

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1018,3 +1018,33 @@ def test_str_replace_and_append_on_same_path_should_preserve_both_updates(monkey
 
     assert failures == []
     assert sandbox.content == "ALPHA\ntail\n"
+
+def test_file_operation_lock_memory_cleanup() -> None:
+    """Verify that released locks are eventually cleaned up by WeakValueDictionary.
+
+    This ensures that the sandbox component doesn't leak memory over time when
+    operating on many unique file paths.
+    """
+    import gc
+    from deerflow.sandbox.file_operation_lock import _FILE_OPERATION_LOCKS, get_file_operation_lock
+
+    class MockSandbox:
+        id = "test_cleanup_sandbox"
+
+    initial_count = len(_FILE_OPERATION_LOCKS)
+
+    def _use_lock_and_release() -> None:
+        # Create and acquire the lock within this scope
+        lock = get_file_operation_lock(MockSandbox(), "/tmp/deer-flow/memory_leak_test_file.txt")
+        with lock:
+            pass
+        # As soon as this function returns, the local 'lock' variable is destroyed.
+        # Its reference count goes to zero, triggering WeakValueDictionary cleanup.
+
+    _use_lock_and_release()
+
+    # Force a garbage collection to be absolutely sure
+    gc.collect()
+
+    # The dictionary should be back to its initial size (i.e. our test lock was evicted)
+    assert len(_FILE_OPERATION_LOCKS) == initial_count

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1019,6 +1019,7 @@ def test_str_replace_and_append_on_same_path_should_preserve_both_updates(monkey
     assert failures == []
     assert sandbox.content == "ALPHA\ntail\n"
 
+
 def test_file_operation_lock_memory_cleanup() -> None:
     """Verify that released locks are eventually cleaned up by WeakValueDictionary.
 
@@ -1026,16 +1027,21 @@ def test_file_operation_lock_memory_cleanup() -> None:
     operating on many unique file paths.
     """
     import gc
+
     from deerflow.sandbox.file_operation_lock import _FILE_OPERATION_LOCKS, get_file_operation_lock
 
     class MockSandbox:
         id = "test_cleanup_sandbox"
 
-    initial_count = len(_FILE_OPERATION_LOCKS)
+    test_path = "/tmp/deer-flow/memory_leak_test_file.txt"
+    lock_key = (MockSandbox.id, test_path)
+
+    # 确保测试开始前 key 不存在
+    assert lock_key not in _FILE_OPERATION_LOCKS
 
     def _use_lock_and_release() -> None:
         # Create and acquire the lock within this scope
-        lock = get_file_operation_lock(MockSandbox(), "/tmp/deer-flow/memory_leak_test_file.txt")
+        lock = get_file_operation_lock(MockSandbox(), test_path)
         with lock:
             pass
         # As soon as this function returns, the local 'lock' variable is destroyed.
@@ -1046,5 +1052,5 @@ def test_file_operation_lock_memory_cleanup() -> None:
     # Force a garbage collection to be absolutely sure
     gc.collect()
 
-    # The dictionary should be back to its initial size (i.e. our test lock was evicted)
-    assert len(_FILE_OPERATION_LOCKS) == initial_count
+    # 检查特定 key 是否被清理（而不是检查总长度）
+    assert lock_key not in _FILE_OPERATION_LOCKS


### PR DESCRIPTION
### Problem
  In `sandbox/file_operation_lock.py`, file locks are stored in a global dictionary `_FILE_OPERATION_LOCKS`. With the original `dict` implementation, once a lock is created for a
  specific `(sandbox_id, path)` key, it is never removed.

  For long-running processes (e.g., Gateway mode) that handle a large volume of unique file paths across different threads, this dictionary grows unboundedly over time, causing a
  memory leak.

  ### Solution
  Replace `dict` with `weakref.WeakValueDictionary`.

  **Why this works:**
  - `WeakValueDictionary` holds weak references to its values, not strong references
  - When a lock is no longer held by any thread (the `with` block exits), the lock object becomes eligible for garbage collection
  - Upon garbage collection, the weak reference automatically becomes invalid and the entry is transparently removed from the dictionary

  ### Trade-offs
  - **Pros**: Zero manual cleanup required; bounded memory footprint; thread-safe
  - **Cons**: Entry cleanup is tied to GC timing (not immediate); iteration over the dictionary is not safe if GC occurs during iteration (not a concern in current usage)

  ### Testing
  - [x] Verified `threading.Lock` supports weak references
  - [x] Tested in local sandbox mode with concurrent file operations
  - [ ] Load test with high volume of unique paths (optional)

  ### References
  - PEP 205: Weak References (Python 2.1+)
  - https://docs.python.org/3/library/weakref.html#weakref.WeakValueDictionary