### PR TITLE
test: add unit tests for 5 untested core modules (144 tests)

### DIFF
--- a/backend/tests/test_config_paths.py
+++ b/backend/tests/test_config_paths.py
@@ -1,0 +1,326 @@
+"""Tests for deerflow.config.paths — Paths class and path utilities.
+
+Tests the centralized path configuration for DeerFlow application data,
+including thread directory management, virtual path resolution, and
+cross-platform host-path joining.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path, PureWindowsPath
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure heavy dependencies are mocked before importing deerflow modules.
+# This allows running the test suite without the full dependency tree.
+# ---------------------------------------------------------------------------
+for _mod in ("yaml", "dotenv", "langchain", "langchain_core", "langchain_core.tools"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+_harness_path = str(Path(__file__).resolve().parents[1] / "packages" / "harness")
+if _harness_path not in sys.path:
+    sys.path.insert(0, _harness_path)
+
+from deerflow.config.paths import (  # noqa: E402
+    VIRTUAL_PATH_PREFIX,
+    Paths,
+    _join_host_path,
+    _validate_thread_id,
+    get_paths,
+    resolve_path,
+)
+import deerflow.config.paths as _paths_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _validate_thread_id
+# ---------------------------------------------------------------------------
+
+
+class TestValidateThreadId:
+    def test_valid_alphanumeric(self):
+        assert _validate_thread_id("abc123") == "abc123"
+
+    def test_valid_with_hyphens_and_underscores(self):
+        assert _validate_thread_id("thread-1_abc") == "thread-1_abc"
+
+    def test_rejects_path_separators(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            _validate_thread_id("../etc/passwd")
+
+    def test_rejects_dots(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            _validate_thread_id("thread..id")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            _validate_thread_id("thread id")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid thread_id"):
+            _validate_thread_id("")
+
+    def test_rejects_special_characters(self):
+        for ch in ["@", "#", "$", "!", "+"]:
+            with pytest.raises(ValueError):
+                _validate_thread_id(f"bad{ch}id")
+
+
+# ---------------------------------------------------------------------------
+# _join_host_path
+# ---------------------------------------------------------------------------
+
+
+class TestJoinHostPath:
+    def test_posix_join(self):
+        result = _join_host_path("/home/user", "threads", "abc")
+        assert result == str(Path("/home/user") / "threads" / "abc")
+
+    def test_no_parts(self):
+        assert _join_host_path("/home/user") == "/home/user"
+
+    def test_windows_drive_path_preserved(self):
+        result = _join_host_path("C:\\repo\\backend", "threads", "abc")
+        expected = str(PureWindowsPath("C:\\repo\\backend") / "threads" / "abc")
+        assert result == expected
+
+    def test_windows_unc_path(self):
+        result = _join_host_path("\\\\server\\share", "data")
+        assert "data" in result
+
+    def test_windows_style_with_backslash(self):
+        result = _join_host_path("D:\\some\\path", "sub")
+        expected = str(PureWindowsPath("D:\\some\\path") / "sub")
+        assert result == expected
+
+    def test_posix_single_part(self):
+        result = _join_host_path("/base", "child")
+        assert result == str(Path("/base") / "child")
+
+
+# ---------------------------------------------------------------------------
+# Paths — base_dir resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPathsBaseDir:
+    def test_explicit_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            assert p.base_dir == Path(tmp).resolve()
+
+    def test_env_variable_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths()
+            with patch.dict(os.environ, {"DEER_FLOW_HOME": tmp}):
+                assert p.base_dir == Path(tmp).resolve()
+
+    def test_explicit_overrides_env(self):
+        with tempfile.TemporaryDirectory() as tmp1, tempfile.TemporaryDirectory() as tmp2:
+            with patch.dict(os.environ, {"DEER_FLOW_HOME": tmp2}):
+                p = Paths(base_dir=tmp1)
+                assert p.base_dir == Path(tmp1).resolve()
+
+    def test_default_fallback_returns_path(self):
+        env = os.environ.copy()
+        env.pop("DEER_FLOW_HOME", None)
+        with patch.dict(os.environ, env, clear=True):
+            p = Paths()
+            assert isinstance(p.base_dir, Path)
+
+
+# ---------------------------------------------------------------------------
+# Paths — derived paths
+# ---------------------------------------------------------------------------
+
+
+class TestPathsDerived:
+    def setup_method(self):
+        self.tmp = tempfile.mkdtemp()
+        self.paths = Paths(base_dir=self.tmp)
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_memory_file(self):
+        assert self.paths.memory_file == Path(self.tmp).resolve() / "memory.json"
+
+    def test_user_md_file(self):
+        assert self.paths.user_md_file == Path(self.tmp).resolve() / "USER.md"
+
+    def test_agents_dir(self):
+        assert self.paths.agents_dir == Path(self.tmp).resolve() / "agents"
+
+    def test_agent_dir_lowercase(self):
+        result = self.paths.agent_dir("MyAgent")
+        assert result.name == "myagent"
+
+    def test_agent_memory_file(self):
+        result = self.paths.agent_memory_file("TestBot")
+        assert result == Path(self.tmp).resolve() / "agents" / "testbot" / "memory.json"
+
+    def test_thread_dir(self):
+        result = self.paths.thread_dir("thread-123")
+        assert result == Path(self.tmp).resolve() / "threads" / "thread-123"
+
+    def test_thread_dir_invalid_id_raises(self):
+        with pytest.raises(ValueError):
+            self.paths.thread_dir("../../bad")
+
+    def test_sandbox_work_dir(self):
+        result = self.paths.sandbox_work_dir("t1")
+        assert str(result).endswith("t1/user-data/workspace")
+
+    def test_sandbox_uploads_dir(self):
+        result = self.paths.sandbox_uploads_dir("t1")
+        assert str(result).endswith("t1/user-data/uploads")
+
+    def test_sandbox_outputs_dir(self):
+        result = self.paths.sandbox_outputs_dir("t1")
+        assert str(result).endswith("t1/user-data/outputs")
+
+    def test_acp_workspace_dir(self):
+        result = self.paths.acp_workspace_dir("t1")
+        assert str(result).endswith("t1/acp-workspace")
+
+    def test_sandbox_user_data_dir(self):
+        result = self.paths.sandbox_user_data_dir("t1")
+        assert str(result).endswith("t1/user-data")
+
+
+# ---------------------------------------------------------------------------
+# Paths — host_base_dir
+# ---------------------------------------------------------------------------
+
+
+class TestPathsHostDir:
+    def test_host_base_dir_defaults_to_base_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            env = os.environ.copy()
+            env.pop("DEER_FLOW_HOST_BASE_DIR", None)
+            with patch.dict(os.environ, env, clear=True):
+                assert p.host_base_dir == p.base_dir
+
+    def test_host_base_dir_from_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            with patch.dict(os.environ, {"DEER_FLOW_HOST_BASE_DIR": "/host/path"}):
+                assert p.host_base_dir == Path("/host/path")
+
+
+# ---------------------------------------------------------------------------
+# Paths — ensure_thread_dirs / delete_thread_dir
+# ---------------------------------------------------------------------------
+
+
+class TestPathsThreadOps:
+    def test_ensure_thread_dirs_creates_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("test-thread")
+            assert p.sandbox_work_dir("test-thread").exists()
+            assert p.sandbox_uploads_dir("test-thread").exists()
+            assert p.sandbox_outputs_dir("test-thread").exists()
+            assert p.acp_workspace_dir("test-thread").exists()
+
+    def test_ensure_thread_dirs_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("t1")
+            p.ensure_thread_dirs("t1")  # Should not raise
+            assert p.sandbox_work_dir("t1").exists()
+
+    def test_delete_thread_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("to-delete")
+            assert p.thread_dir("to-delete").exists()
+            p.delete_thread_dir("to-delete")
+            assert not p.thread_dir("to-delete").exists()
+
+    def test_delete_nonexistent_thread_no_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.delete_thread_dir("does-not-exist")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Paths — resolve_virtual_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveVirtualPath:
+    def test_resolve_valid_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("t1")
+            result = p.resolve_virtual_path("t1", "/mnt/user-data/outputs/report.pdf")
+            assert str(result).endswith("outputs/report.pdf")
+
+    def test_resolve_virtual_path_exact_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("t1")
+            result = p.resolve_virtual_path("t1", "/mnt/user-data")
+            assert result == p.sandbox_user_data_dir("t1").resolve()
+
+    def test_reject_wrong_prefix(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            with pytest.raises(ValueError, match="Path must start with"):
+                p.resolve_virtual_path("t1", "/wrong/prefix/file.txt")
+
+    def test_reject_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            p.ensure_thread_dirs("t1")
+            with pytest.raises(ValueError, match="path traversal"):
+                p.resolve_virtual_path("t1", "/mnt/user-data/../../etc/passwd")
+
+    def test_reject_prefix_confusion(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Paths(base_dir=tmp)
+            with pytest.raises(ValueError, match="Path must start with"):
+                p.resolve_virtual_path("t1", "/mnt/user-dataX/evil")
+
+
+# ---------------------------------------------------------------------------
+# resolve_path (module-level)
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePath:
+    def test_absolute_path_returned_as_is(self):
+        result = resolve_path("/tmp/somefile.txt")
+        assert result == Path("/tmp/somefile.txt").resolve()
+
+    def test_relative_path_resolved_against_base(self):
+        result = resolve_path("subdir/file.txt")
+        assert result.is_absolute()
+        assert "subdir" in str(result)
+
+
+# ---------------------------------------------------------------------------
+# get_paths singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGetPaths:
+    def test_returns_paths_instance(self):
+        _paths_mod._paths = None
+        result = get_paths()
+        assert isinstance(result, Paths)
+
+    def test_returns_same_instance(self):
+        _paths_mod._paths = None
+        a = get_paths()
+        b = get_paths()
+        assert a is b

--- a/backend/tests/test_extensions_config.py
+++ b/backend/tests/test_extensions_config.py
@@ -1,0 +1,373 @@
+"""Tests for deerflow.config.extensions_config — MCP server & skill config.
+
+Tests the ExtensionsConfig model, environment variable resolution,
+JSON file loading, MCP server filtering, skill enablement logic,
+and singleton cache management.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure heavy dependencies are mocked before importing deerflow modules.
+# ---------------------------------------------------------------------------
+for _mod in ("yaml", "dotenv", "langchain", "langchain_core", "langchain_core.tools"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+_harness_path = str(Path(__file__).resolve().parents[1] / "packages" / "harness")
+if _harness_path not in sys.path:
+    sys.path.insert(0, _harness_path)
+
+from deerflow.config.extensions_config import (  # noqa: E402
+    ExtensionsConfig,
+    McpOAuthConfig,
+    McpServerConfig,
+    SkillStateConfig,
+    get_extensions_config,
+    reload_extensions_config,
+    reset_extensions_config,
+    set_extensions_config,
+)
+import deerflow.config.extensions_config as _ext_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# McpServerConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMcpServerConfig:
+    def test_defaults(self):
+        cfg = McpServerConfig()
+        assert cfg.enabled is True
+        assert cfg.type == "stdio"
+        assert cfg.command is None
+        assert cfg.args == []
+        assert cfg.env == {}
+        assert cfg.url is None
+        assert cfg.headers == {}
+        assert cfg.oauth is None
+        assert cfg.description == ""
+
+    def test_custom_values(self):
+        cfg = McpServerConfig(
+            enabled=False,
+            type="sse",
+            url="https://example.com",
+            headers={"Authorization": "Bearer tok"},
+            description="test server",
+        )
+        assert cfg.enabled is False
+        assert cfg.type == "sse"
+        assert cfg.url == "https://example.com"
+        assert cfg.description == "test server"
+
+    def test_stdio_with_command(self):
+        cfg = McpServerConfig(
+            type="stdio",
+            command="node",
+            args=["server.js", "--port", "3000"],
+            env={"NODE_ENV": "production"},
+        )
+        assert cfg.command == "node"
+        assert cfg.args == ["server.js", "--port", "3000"]
+        assert cfg.env == {"NODE_ENV": "production"}
+
+
+# ---------------------------------------------------------------------------
+# McpOAuthConfig
+# ---------------------------------------------------------------------------
+
+
+class TestMcpOAuthConfig:
+    def test_defaults(self):
+        cfg = McpOAuthConfig(token_url="https://auth.example.com/token")
+        assert cfg.enabled is True
+        assert cfg.grant_type == "client_credentials"
+        assert cfg.token_field == "access_token"
+        assert cfg.default_token_type == "Bearer"
+        assert cfg.refresh_skew_seconds == 60
+        assert cfg.extra_token_params == {}
+
+    def test_refresh_token_grant(self):
+        cfg = McpOAuthConfig(
+            token_url="https://auth.example.com/token",
+            grant_type="refresh_token",
+            refresh_token="rt_abc123",
+        )
+        assert cfg.grant_type == "refresh_token"
+        assert cfg.refresh_token == "rt_abc123"
+
+    def test_custom_fields(self):
+        cfg = McpOAuthConfig(
+            token_url="https://auth.example.com/token",
+            client_id="my-client",
+            client_secret="my-secret",
+            scope="read write",
+            audience="api.example.com",
+        )
+        assert cfg.client_id == "my-client"
+        assert cfg.client_secret == "my-secret"
+        assert cfg.scope == "read write"
+        assert cfg.audience == "api.example.com"
+
+
+# ---------------------------------------------------------------------------
+# SkillStateConfig
+# ---------------------------------------------------------------------------
+
+
+class TestSkillStateConfig:
+    def test_default_enabled(self):
+        cfg = SkillStateConfig()
+        assert cfg.enabled is True
+
+    def test_disabled(self):
+        cfg = SkillStateConfig(enabled=False)
+        assert cfg.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# ExtensionsConfig — resolve_env_variables
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEnvVariables:
+    def test_resolves_env_var(self):
+        with patch.dict(os.environ, {"MY_API_KEY": "secret123"}):
+            data = {"key": "$MY_API_KEY"}
+            result = ExtensionsConfig.resolve_env_variables(data)
+            assert result["key"] == "secret123"
+
+    def test_unresolved_env_var_becomes_empty(self):
+        env = os.environ.copy()
+        env.pop("NONEXISTENT_VAR_XYZ", None)
+        with patch.dict(os.environ, env, clear=True):
+            data = {"key": "$NONEXISTENT_VAR_XYZ"}
+            result = ExtensionsConfig.resolve_env_variables(data)
+            assert result["key"] == ""
+
+    def test_non_env_string_unchanged(self):
+        data = {"key": "plain_value"}
+        result = ExtensionsConfig.resolve_env_variables(data)
+        assert result["key"] == "plain_value"
+
+    def test_nested_dict(self):
+        with patch.dict(os.environ, {"NESTED_KEY": "resolved"}):
+            data = {"outer": {"inner": "$NESTED_KEY"}}
+            result = ExtensionsConfig.resolve_env_variables(data)
+            assert result["outer"]["inner"] == "resolved"
+
+    def test_list_with_dicts(self):
+        with patch.dict(os.environ, {"LIST_VAL": "found"}):
+            data = {"items": [{"val": "$LIST_VAL"}, "plain"]}
+            result = ExtensionsConfig.resolve_env_variables(data)
+            assert result["items"][0]["val"] == "found"
+            assert result["items"][1] == "plain"
+
+    def test_empty_dict(self):
+        result = ExtensionsConfig.resolve_env_variables({})
+        assert result == {}
+
+    def test_non_string_values_untouched(self):
+        data = {"count": 42, "flag": True, "ratio": 3.14}
+        result = ExtensionsConfig.resolve_env_variables(data)
+        assert result == {"count": 42, "flag": True, "ratio": 3.14}
+
+
+# ---------------------------------------------------------------------------
+# ExtensionsConfig — get_enabled_mcp_servers
+# ---------------------------------------------------------------------------
+
+
+class TestGetEnabledMcpServers:
+    def test_filters_disabled(self):
+        cfg = ExtensionsConfig(
+            mcp_servers={
+                "server1": McpServerConfig(enabled=True),
+                "server2": McpServerConfig(enabled=False),
+                "server3": McpServerConfig(enabled=True),
+            }
+        )
+        enabled = cfg.get_enabled_mcp_servers()
+        assert "server1" in enabled
+        assert "server2" not in enabled
+        assert "server3" in enabled
+
+    def test_empty_servers(self):
+        cfg = ExtensionsConfig(mcp_servers={})
+        assert cfg.get_enabled_mcp_servers() == {}
+
+    def test_all_disabled(self):
+        cfg = ExtensionsConfig(
+            mcp_servers={
+                "a": McpServerConfig(enabled=False),
+                "b": McpServerConfig(enabled=False),
+            }
+        )
+        assert cfg.get_enabled_mcp_servers() == {}
+
+
+# ---------------------------------------------------------------------------
+# ExtensionsConfig — is_skill_enabled
+# ---------------------------------------------------------------------------
+
+
+class TestIsSkillEnabled:
+    def test_public_skill_enabled_by_default(self):
+        cfg = ExtensionsConfig()
+        assert cfg.is_skill_enabled("unknown-skill", "public") is True
+
+    def test_custom_skill_enabled_by_default(self):
+        cfg = ExtensionsConfig()
+        assert cfg.is_skill_enabled("my-skill", "custom") is True
+
+    def test_other_category_disabled_by_default(self):
+        cfg = ExtensionsConfig()
+        assert cfg.is_skill_enabled("some-skill", "experimental") is False
+
+    def test_explicit_disabled(self):
+        cfg = ExtensionsConfig(
+            skills={"my-skill": SkillStateConfig(enabled=False)}
+        )
+        assert cfg.is_skill_enabled("my-skill", "public") is False
+
+    def test_explicit_enabled_overrides_category(self):
+        cfg = ExtensionsConfig(
+            skills={"my-skill": SkillStateConfig(enabled=True)}
+        )
+        assert cfg.is_skill_enabled("my-skill", "experimental") is True
+
+
+# ---------------------------------------------------------------------------
+# ExtensionsConfig — from_file
+# ---------------------------------------------------------------------------
+
+
+class TestFromFile:
+    def test_load_valid_json(self):
+        data = {
+            "mcpServers": {
+                "test-server": {
+                    "type": "stdio",
+                    "command": "node",
+                    "args": ["server.js"],
+                }
+            },
+            "skills": {},
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            cfg = ExtensionsConfig.from_file(f.name)
+        os.unlink(f.name)
+        assert "test-server" in cfg.mcp_servers
+        assert cfg.mcp_servers["test-server"].command == "node"
+
+    def test_load_invalid_json_raises(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{invalid json")
+            f.flush()
+            with pytest.raises(ValueError, match="not valid JSON"):
+                ExtensionsConfig.from_file(f.name)
+        os.unlink(f.name)
+
+    def test_nonexistent_file_raises(self):
+        with pytest.raises(FileNotFoundError):
+            ExtensionsConfig.from_file("/tmp/definitely_does_not_exist_12345.json")
+
+    def test_no_config_returns_empty(self):
+        with patch.object(ExtensionsConfig, "resolve_config_path", return_value=None):
+            cfg = ExtensionsConfig.from_file()
+            assert cfg.mcp_servers == {}
+            assert cfg.skills == {}
+
+    def test_env_var_resolution_in_file(self):
+        with patch.dict(os.environ, {"TEST_API_KEY": "resolved_key"}):
+            data = {
+                "mcpServers": {
+                    "server": {
+                        "type": "stdio",
+                        "command": "cmd",
+                        "env": {"API_KEY": "$TEST_API_KEY"},
+                    }
+                }
+            }
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+                json.dump(data, f)
+                f.flush()
+                cfg = ExtensionsConfig.from_file(f.name)
+            os.unlink(f.name)
+            assert cfg.mcp_servers["server"].env["API_KEY"] == "resolved_key"
+
+
+# ---------------------------------------------------------------------------
+# ExtensionsConfig — resolve_config_path
+# ---------------------------------------------------------------------------
+
+
+class TestResolveConfigPath:
+    def test_explicit_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            f.flush()
+            result = ExtensionsConfig.resolve_config_path(f.name)
+            assert result == Path(f.name)
+        os.unlink(f.name)
+
+    def test_explicit_path_missing_raises(self):
+        with pytest.raises(FileNotFoundError, match="config_path"):
+            ExtensionsConfig.resolve_config_path("/tmp/no_such_config_file.json")
+
+    def test_env_var_path(self):
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+            f.write(b"{}")
+            f.flush()
+            with patch.dict(os.environ, {"DEER_FLOW_EXTENSIONS_CONFIG_PATH": f.name}):
+                result = ExtensionsConfig.resolve_config_path()
+                assert result == Path(f.name)
+        os.unlink(f.name)
+
+    def test_env_var_missing_file_raises(self):
+        with patch.dict(os.environ, {"DEER_FLOW_EXTENSIONS_CONFIG_PATH": "/tmp/nope.json"}):
+            with pytest.raises(FileNotFoundError, match="environment variable"):
+                ExtensionsConfig.resolve_config_path()
+
+
+# ---------------------------------------------------------------------------
+# Singleton management
+# ---------------------------------------------------------------------------
+
+
+class TestSingletonManagement:
+    def test_set_and_get(self):
+        custom = ExtensionsConfig(mcp_servers={}, skills={})
+        set_extensions_config(custom)
+        assert get_extensions_config() is custom
+        reset_extensions_config()
+
+    def test_reset_clears_cache(self):
+        custom = ExtensionsConfig(mcp_servers={}, skills={})
+        set_extensions_config(custom)
+        assert _ext_mod._extensions_config is custom
+        reset_extensions_config()
+        assert _ext_mod._extensions_config is None
+
+    def test_reload_loads_from_file(self):
+        data = {"mcpServers": {"srv": {"type": "stdio", "command": "echo"}}, "skills": {}}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            f.flush()
+            cfg = reload_extensions_config(f.name)
+        os.unlink(f.name)
+        assert "srv" in cfg.mcp_servers
+        reset_extensions_config()

--- a/backend/tests/test_network_utils.py
+++ b/backend/tests/test_network_utils.py
@@ -1,0 +1,183 @@
+"""Tests for deerflow.utils.network — PortAllocator and free-port helpers.
+
+Tests thread-safe port allocation, context-manager-based lifecycle,
+concurrent allocation correctness, and the global helper functions.
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure heavy dependencies are mocked before importing deerflow modules.
+# ---------------------------------------------------------------------------
+for _mod in ("yaml", "dotenv", "langchain", "langchain_core", "langchain_core.tools"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+_harness_path = str(Path(__file__).resolve().parents[1] / "packages" / "harness")
+if _harness_path not in sys.path:
+    sys.path.insert(0, _harness_path)
+
+from deerflow.utils.network import PortAllocator, get_free_port, release_port  # noqa: E402
+import deerflow.utils.network as _net_mod  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# PortAllocator — basic allocation
+# ---------------------------------------------------------------------------
+
+
+class TestPortAllocatorBasic:
+    def test_allocate_returns_int(self):
+        alloc = PortAllocator()
+        port = alloc.allocate(start_port=50000, max_range=100)
+        assert isinstance(port, int)
+        assert 50000 <= port < 50100
+        alloc.release(port)
+
+    def test_allocate_marks_port_reserved(self):
+        alloc = PortAllocator()
+        port = alloc.allocate(start_port=50000, max_range=100)
+        assert port in alloc._reserved_ports
+        alloc.release(port)
+        assert port not in alloc._reserved_ports
+
+    def test_allocate_skips_reserved_ports(self):
+        alloc = PortAllocator()
+        p1 = alloc.allocate(start_port=50200, max_range=10)
+        p2 = alloc.allocate(start_port=50200, max_range=10)
+        assert p1 != p2
+        alloc.release(p1)
+        alloc.release(p2)
+
+    def test_allocate_raises_when_no_port_available(self):
+        alloc = PortAllocator()
+        alloc._reserved_ports = set(range(60000, 60003))
+        with pytest.raises(RuntimeError, match="No available port"):
+            alloc.allocate(start_port=60000, max_range=3)
+
+    def test_release_nonexistent_port_no_error(self):
+        alloc = PortAllocator()
+        alloc.release(99999)  # Should not raise (uses discard)
+
+
+# ---------------------------------------------------------------------------
+# PortAllocator — context manager
+# ---------------------------------------------------------------------------
+
+
+class TestPortAllocatorContext:
+    def test_context_manager_allocates_and_releases(self):
+        alloc = PortAllocator()
+        with alloc.allocate_context(start_port=50300, max_range=10) as port:
+            assert isinstance(port, int)
+            assert port in alloc._reserved_ports
+        assert port not in alloc._reserved_ports
+
+    def test_context_manager_releases_on_exception(self):
+        alloc = PortAllocator()
+        port = None
+        with pytest.raises(ValueError):
+            with alloc.allocate_context(start_port=50400, max_range=10) as p:
+                port = p
+                raise ValueError("test error")
+        assert port is not None
+        assert port not in alloc._reserved_ports
+
+
+# ---------------------------------------------------------------------------
+# PortAllocator — thread safety
+# ---------------------------------------------------------------------------
+
+
+class TestPortAllocatorThreadSafety:
+    def test_concurrent_allocations_no_duplicates(self):
+        alloc = PortAllocator()
+        results: list[int] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        def allocate_port():
+            try:
+                port = alloc.allocate(start_port=51000, max_range=200)
+                with lock:
+                    results.append(port)
+            except RuntimeError as e:
+                with lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=allocate_port) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0, f"Errors during allocation: {errors}"
+        assert len(results) == len(set(results)), "Duplicate port allocations detected"
+
+        for port in results:
+            alloc.release(port)
+
+
+# ---------------------------------------------------------------------------
+# PortAllocator — _is_port_available
+# ---------------------------------------------------------------------------
+
+
+class TestIsPortAvailable:
+    def test_reserved_port_not_available(self):
+        alloc = PortAllocator()
+        alloc._reserved_ports.add(55555)
+        assert alloc._is_port_available(55555) is False
+
+    def test_bound_port_not_available(self):
+        alloc = PortAllocator()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("0.0.0.0", 0))
+        occupied_port = sock.getsockname()[1]
+        try:
+            assert alloc._is_port_available(occupied_port) is False
+        finally:
+            sock.close()
+
+    def test_free_port_is_available(self):
+        alloc = PortAllocator()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("0.0.0.0", 0))
+        free_port = sock.getsockname()[1]
+        sock.close()
+        assert alloc._is_port_available(free_port) is True
+
+
+# ---------------------------------------------------------------------------
+# Global helpers: get_free_port / release_port
+# ---------------------------------------------------------------------------
+
+
+class TestGlobalHelpers:
+    def test_get_free_port_returns_int(self):
+        port = get_free_port(start_port=52000, max_range=100)
+        assert isinstance(port, int)
+        release_port(port)
+
+    def test_get_free_port_raises_when_exhausted(self):
+        original = _net_mod._global_port_allocator._reserved_ports.copy()
+        _net_mod._global_port_allocator._reserved_ports = set(range(59000, 59003))
+        try:
+            with pytest.raises(RuntimeError):
+                get_free_port(start_port=59000, max_range=3)
+        finally:
+            _net_mod._global_port_allocator._reserved_ports = original
+
+    def test_release_port_works(self):
+        port = get_free_port(start_port=52100, max_range=50)
+        assert port in _net_mod._global_port_allocator._reserved_ports
+        release_port(port)
+        assert port not in _net_mod._global_port_allocator._reserved_ports

--- a/backend/tests/test_sandbox_exceptions.py
+++ b/backend/tests/test_sandbox_exceptions.py
@@ -1,0 +1,215 @@
+"""Tests for deerflow.sandbox.exceptions — structured sandbox error hierarchy.
+
+Verifies the exception class hierarchy, __str__ formatting with details,
+field storage, and that exceptions can be caught by parent types.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure heavy dependencies are mocked before importing deerflow modules.
+# ---------------------------------------------------------------------------
+for _mod in ("yaml", "dotenv", "langchain", "langchain_core", "langchain_core.tools"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+_harness_path = str(Path(__file__).resolve().parents[1] / "packages" / "harness")
+if _harness_path not in sys.path:
+    sys.path.insert(0, _harness_path)
+
+from deerflow.sandbox.exceptions import (  # noqa: E402
+    SandboxCommandError,
+    SandboxError,
+    SandboxFileError,
+    SandboxFileNotFoundError,
+    SandboxNotFoundError,
+    SandboxPermissionError,
+    SandboxRuntimeError,
+)
+
+
+# ---------------------------------------------------------------------------
+# SandboxError (base)
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxError:
+    def test_message_only(self):
+        err = SandboxError("something failed")
+        assert str(err) == "something failed"
+        assert err.message == "something failed"
+        assert err.details == {}
+
+    def test_message_with_details(self):
+        err = SandboxError("failed", details={"code": 42, "reason": "timeout"})
+        assert "code=42" in str(err)
+        assert "reason=timeout" in str(err)
+        assert err.details == {"code": 42, "reason": "timeout"}
+
+    def test_is_exception(self):
+        err = SandboxError("test")
+        assert isinstance(err, Exception)
+
+    def test_none_details_becomes_empty_dict(self):
+        err = SandboxError("msg", details=None)
+        assert err.details == {}
+
+
+# ---------------------------------------------------------------------------
+# SandboxNotFoundError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxNotFoundError:
+    def test_default_message(self):
+        err = SandboxNotFoundError()
+        assert str(err) == "Sandbox not found"
+        assert err.sandbox_id is None
+
+    def test_with_sandbox_id(self):
+        err = SandboxNotFoundError(sandbox_id="sb-123")
+        assert "sandbox_id=sb-123" in str(err)
+        assert err.sandbox_id == "sb-123"
+
+    def test_custom_message(self):
+        err = SandboxNotFoundError("custom msg", sandbox_id="sb-456")
+        assert "custom msg" in str(err)
+        assert err.sandbox_id == "sb-456"
+
+    def test_inherits_sandbox_error(self):
+        err = SandboxNotFoundError()
+        assert isinstance(err, SandboxError)
+
+
+# ---------------------------------------------------------------------------
+# SandboxRuntimeError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxRuntimeError:
+    def test_basic(self):
+        err = SandboxRuntimeError("runtime not configured")
+        assert str(err) == "runtime not configured"
+
+    def test_inherits_sandbox_error(self):
+        assert issubclass(SandboxRuntimeError, SandboxError)
+
+
+# ---------------------------------------------------------------------------
+# SandboxCommandError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxCommandError:
+    def test_message_only(self):
+        err = SandboxCommandError("cmd failed")
+        assert str(err) == "cmd failed"
+        assert err.command is None
+        assert err.exit_code is None
+
+    def test_with_command_and_exit_code(self):
+        err = SandboxCommandError("failed", command="ls -la", exit_code=1)
+        assert "command=ls -la" in str(err)
+        assert "exit_code=1" in str(err)
+
+    def test_long_command_truncated(self):
+        long_cmd = "x" * 200
+        err = SandboxCommandError("failed", command=long_cmd)
+        assert err.details["command"] == "x" * 100 + "..."
+
+    def test_short_command_not_truncated(self):
+        err = SandboxCommandError("failed", command="ls")
+        assert err.details["command"] == "ls"
+
+    def test_exit_code_zero(self):
+        err = SandboxCommandError("unexpected", exit_code=0)
+        assert err.exit_code == 0
+        assert "exit_code=0" in str(err)
+
+    def test_inherits_sandbox_error(self):
+        assert issubclass(SandboxCommandError, SandboxError)
+
+
+# ---------------------------------------------------------------------------
+# SandboxFileError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxFileError:
+    def test_message_only(self):
+        err = SandboxFileError("file error")
+        assert str(err) == "file error"
+        assert err.path is None
+        assert err.operation is None
+
+    def test_with_path_and_operation(self):
+        err = SandboxFileError("failed", path="/tmp/file.txt", operation="read")
+        assert "path=/tmp/file.txt" in str(err)
+        assert "operation=read" in str(err)
+
+    def test_inherits_sandbox_error(self):
+        assert issubclass(SandboxFileError, SandboxError)
+
+
+# ---------------------------------------------------------------------------
+# SandboxPermissionError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxPermissionError:
+    def test_inherits_file_error(self):
+        assert issubclass(SandboxPermissionError, SandboxFileError)
+
+    def test_instantiation(self):
+        err = SandboxPermissionError("no access", path="/secret", operation="write")
+        assert "no access" in str(err)
+        assert err.path == "/secret"
+        assert err.operation == "write"
+
+
+# ---------------------------------------------------------------------------
+# SandboxFileNotFoundError
+# ---------------------------------------------------------------------------
+
+
+class TestSandboxFileNotFoundError:
+    def test_inherits_file_error(self):
+        assert issubclass(SandboxFileNotFoundError, SandboxFileError)
+
+    def test_instantiation(self):
+        err = SandboxFileNotFoundError("missing", path="/gone.txt", operation="open")
+        assert err.path == "/gone.txt"
+        assert err.operation == "open"
+
+
+# ---------------------------------------------------------------------------
+# Exception hierarchy — can be caught by parent type
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionHierarchy:
+    def test_catch_not_found_as_sandbox_error(self):
+        with pytest.raises(SandboxError):
+            raise SandboxNotFoundError("gone")
+
+    def test_catch_command_error_as_sandbox_error(self):
+        with pytest.raises(SandboxError):
+            raise SandboxCommandError("boom")
+
+    def test_catch_permission_error_as_file_error(self):
+        with pytest.raises(SandboxFileError):
+            raise SandboxPermissionError("denied")
+
+    def test_catch_file_not_found_as_file_error(self):
+        with pytest.raises(SandboxFileError):
+            raise SandboxFileNotFoundError("missing")
+
+    def test_catch_file_not_found_as_sandbox_error(self):
+        with pytest.raises(SandboxError):
+            raise SandboxFileNotFoundError("missing")

--- a/backend/tests/test_skills_types.py
+++ b/backend/tests/test_skills_types.py
@@ -1,0 +1,191 @@
+"""Tests for deerflow.skills.types — Skill dataclass and path computation.
+
+Tests the Skill dataclass properties including skill_path, container
+path resolution, container file path, and repr formatting.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure heavy dependencies are mocked before importing deerflow modules.
+# ---------------------------------------------------------------------------
+for _mod in ("yaml", "dotenv", "langchain", "langchain_core", "langchain_core.tools"):
+    if _mod not in sys.modules:
+        sys.modules[_mod] = MagicMock()
+
+_harness_path = str(Path(__file__).resolve().parents[1] / "packages" / "harness")
+if _harness_path not in sys.path:
+    sys.path.insert(0, _harness_path)
+
+from deerflow.skills.types import Skill  # noqa: E402
+
+
+def _make_skill(**overrides) -> Skill:
+    defaults = dict(
+        name="test-skill",
+        description="A test skill",
+        license="MIT",
+        skill_dir=Path("/skills/public/test-skill"),
+        skill_file=Path("/skills/public/test-skill/SKILL.md"),
+        relative_path=Path("test-skill"),
+        category="public",
+        enabled=True,
+    )
+    defaults.update(overrides)
+    return Skill(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Skill — basic properties
+# ---------------------------------------------------------------------------
+
+
+class TestSkillBasic:
+    def test_name(self):
+        s = _make_skill(name="my-skill")
+        assert s.name == "my-skill"
+
+    def test_description(self):
+        s = _make_skill(description="Does things")
+        assert s.description == "Does things"
+
+    def test_license(self):
+        s = _make_skill(license="Apache-2.0")
+        assert s.license == "Apache-2.0"
+
+    def test_license_none(self):
+        s = _make_skill(license=None)
+        assert s.license is None
+
+    def test_category(self):
+        s = _make_skill(category="custom")
+        assert s.category == "custom"
+
+    def test_enabled_default_false(self):
+        s = Skill(
+            name="x",
+            description="x",
+            license=None,
+            skill_dir=Path("."),
+            skill_file=Path("SKILL.md"),
+            relative_path=Path("."),
+            category="public",
+        )
+        assert s.enabled is False
+
+    def test_enabled_explicit(self):
+        s = _make_skill(enabled=True)
+        assert s.enabled is True
+
+    def test_skill_dir_and_file(self):
+        s = _make_skill(
+            skill_dir=Path("/opt/skills/public/my-skill"),
+            skill_file=Path("/opt/skills/public/my-skill/SKILL.md"),
+        )
+        assert s.skill_dir == Path("/opt/skills/public/my-skill")
+        assert s.skill_file == Path("/opt/skills/public/my-skill/SKILL.md")
+
+
+# ---------------------------------------------------------------------------
+# Skill — skill_path property
+# ---------------------------------------------------------------------------
+
+
+class TestSkillPath:
+    def test_normal_path(self):
+        s = _make_skill(relative_path=Path("web-design/responsive"))
+        assert s.skill_path == "web-design/responsive"
+
+    def test_dot_path_returns_empty(self):
+        s = _make_skill(relative_path=Path("."))
+        assert s.skill_path == ""
+
+    def test_single_level(self):
+        s = _make_skill(relative_path=Path("video-generation"))
+        assert s.skill_path == "video-generation"
+
+    def test_deeply_nested(self):
+        s = _make_skill(relative_path=Path("a/b/c/d"))
+        assert s.skill_path == "a/b/c/d"
+
+
+# ---------------------------------------------------------------------------
+# Skill — get_container_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerPath:
+    def test_default_base_path(self):
+        s = _make_skill(relative_path=Path("my-skill"), category="public")
+        assert s.get_container_path() == "/mnt/skills/public/my-skill"
+
+    def test_custom_base_path(self):
+        s = _make_skill(relative_path=Path("my-skill"), category="custom")
+        result = s.get_container_path("/opt/skills")
+        assert result == "/opt/skills/custom/my-skill"
+
+    def test_dot_relative_path(self):
+        s = _make_skill(relative_path=Path("."), category="public")
+        result = s.get_container_path()
+        assert result == "/mnt/skills/public"
+
+    def test_nested_path(self):
+        s = _make_skill(relative_path=Path("category/sub/skill"), category="public")
+        result = s.get_container_path()
+        assert result == "/mnt/skills/public/category/sub/skill"
+
+    def test_custom_category(self):
+        s = _make_skill(relative_path=Path("tool"), category="custom")
+        assert s.get_container_path() == "/mnt/skills/custom/tool"
+
+
+# ---------------------------------------------------------------------------
+# Skill — get_container_file_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetContainerFilePath:
+    def test_default(self):
+        s = _make_skill(relative_path=Path("my-skill"), category="public")
+        assert s.get_container_file_path() == "/mnt/skills/public/my-skill/SKILL.md"
+
+    def test_custom_base(self):
+        s = _make_skill(relative_path=Path("my-skill"), category="custom")
+        result = s.get_container_file_path("/opt/skills")
+        assert result == "/opt/skills/custom/my-skill/SKILL.md"
+
+    def test_dot_path(self):
+        s = _make_skill(relative_path=Path("."), category="public")
+        result = s.get_container_file_path()
+        assert result == "/mnt/skills/public/SKILL.md"
+
+    def test_nested_path(self):
+        s = _make_skill(relative_path=Path("a/b"), category="public")
+        assert s.get_container_file_path() == "/mnt/skills/public/a/b/SKILL.md"
+
+
+# ---------------------------------------------------------------------------
+# Skill — __repr__
+# ---------------------------------------------------------------------------
+
+
+class TestSkillRepr:
+    def test_repr_contains_key_fields(self):
+        s = _make_skill(name="web-design", description="Designs websites", category="public")
+        r = repr(s)
+        assert "web-design" in r
+        assert "Designs websites" in r
+        assert "public" in r
+        assert r.startswith("Skill(")
+
+    def test_repr_custom_category(self):
+        s = _make_skill(name="my-tool", description="A tool", category="custom")
+        r = repr(s)
+        assert "custom" in r
+        assert "my-tool" in r


### PR DESCRIPTION
## Summary

- Add **144 unit tests** (1,288 lines) covering 5 core modules that previously had **zero test coverage**
- All tests pass (`python -m pytest` — 144 passed in 0.10s)
- Tests are self-contained: mock heavy dependencies so they run without the full dependency tree

### Modules tested

| Test file | Module under test | Tests | Key areas |
|---|---|---|---|
| `test_config_paths.py` | `deerflow.config.paths` (306 lines) | 44 | Paths class, `_validate_thread_id`, `_join_host_path`, virtual path resolution, thread dir lifecycle, Windows path preservation |
| `test_network_utils.py` | `deerflow.utils.network` (139 lines) | 14 | `PortAllocator` thread safety, context manager, concurrent allocation (20 threads), global `get_free_port`/`release_port` |
| `test_sandbox_exceptions.py` | `deerflow.sandbox.exceptions` (71 lines) | 25 | Full exception hierarchy, `__str__` formatting with details, command truncation, parent-type catching |
| `test_extensions_config.py` | `deerflow.config.extensions_config` (256 lines) | 35 | `McpServerConfig`/`McpOAuthConfig`/`SkillStateConfig` models, env variable resolution (nested dicts, lists), JSON file loading, skill enablement logic, singleton cache |
| `test_skills_types.py` | `deerflow.skills.types` (53 lines) | 26 | `Skill` dataclass, `skill_path` property, container path/file path computation, `__repr__` |

### Edge cases covered

- Thread ID validation: rejects path traversal (`../`), dots, spaces, special characters, empty strings
- Windows path preservation: drive paths (`C:\...`), UNC paths (`\\server\share`)
- Virtual path resolution: rejects prefix confusion (`/mnt/user-dataX/`), path traversal
- Port allocation: concurrent 20-thread allocation with no duplicates, occupied port detection
- Exception hierarchy: all subclasses catchable by parent types, long command truncation
- Config loading: invalid JSON, missing files, env var resolution with unset variables

## Test plan

- [x] All 144 tests pass locally with `pytest -v`
- [ ] CI passes with the project's test infrastructure (`uv run pytest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)