### PR TITLE
feat(sdk): add TypeScript streaming client for DeerFlow API

### DIFF
--- a/sdk/typescript/.gitignore
+++ b/sdk/typescript/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -23,6 +23,8 @@ console.log(reply);
 
 ## Streaming Usage
 
+The client requests `stream_mode: ["values", "messages-tuple", "custom"]` by default, matching the `useStream` contract the DeerFlow frontend relies on. `StreamEvent` is a discriminated union covering every SSE event the gateway can emit (`values`, `messages`, `messages-tuple`, `custom`, `metadata`, `error`, `end`), so handlers can branch safely on `event.event` without casting.
+
 ```ts
 import { DeerFlowClient } from "@deerflow/client";
 
@@ -32,13 +34,16 @@ const client = new DeerFlowClient({
 
 for await (const event of client.stream("Summarize the latest roadmap updates")) {
   if (event.event === "messages-tuple") {
-    const [message] = event.data as [{ type?: string; content?: string }, Record<string, unknown>];
-    if (message.type === "ai" && message.content) {
+    const [message] = event.data;
+    if (message.type === "ai" && typeof message.content === "string") {
       process.stdout.write(message.content);
     }
-  }
-
-  if (event.event === "end") {
+  } else if (event.event === "messages") {
+    // Plain stream_mode=messages (no tuple wrapper)
+    if (event.data.type === "ai" && typeof event.data.content === "string") {
+      process.stdout.write(event.data.content);
+    }
+  } else if (event.event === "end") {
     process.stdout.write("\n");
   }
 }

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,0 +1,71 @@
+# @deerflow/client
+
+Lightweight TypeScript client for DeerFlow's LangGraph HTTP API (`/api/langgraph`).
+
+## Installation
+
+```bash
+npm install @deerflow/client
+```
+
+## Basic Usage
+
+```ts
+import { DeerFlowClient } from "@deerflow/client";
+
+const client = new DeerFlowClient({
+  baseUrl: "http://localhost:2026/api/langgraph",
+});
+
+const reply = await client.chat("What can you do?");
+console.log(reply);
+```
+
+## Streaming Usage
+
+```ts
+import { DeerFlowClient } from "@deerflow/client";
+
+const client = new DeerFlowClient({
+  baseUrl: "http://localhost:2026/api/langgraph",
+});
+
+for await (const event of client.stream("Summarize the latest roadmap updates")) {
+  if (event.event === "messages-tuple") {
+    const [message] = event.data as [{ type?: string; content?: string }, Record<string, unknown>];
+    if (message.type === "ai" && message.content) {
+      process.stdout.write(message.content);
+    }
+  }
+
+  if (event.event === "end") {
+    process.stdout.write("\n");
+  }
+}
+```
+
+## Thread Management
+
+```ts
+import { DeerFlowClient } from "@deerflow/client";
+
+const client = new DeerFlowClient({
+  baseUrl: "http://localhost:2026/api/langgraph",
+});
+
+const thread = await client.createThread({ source: "sdk-example" });
+console.log(thread.thread_id);
+
+const state = await client.getThreadState(thread.thread_id);
+console.log(state.messages.length);
+
+const answer = await client.chat("Continue this thread", thread.thread_id);
+console.log(answer);
+```
+
+## API
+
+- `createThread(metadata?)` → creates a new thread
+- `getThreadState(threadId)` → fetches latest thread state
+- `stream(message, threadId?)` → async generator of SSE stream events
+- `chat(message, threadId?)` → convenience method returning final AI text

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@deerflow/client",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.2"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bytedance/deer-flow.git",
+    "directory": "sdk/typescript"
+  }
+}

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,11 +1,23 @@
 import { parseSSEStream } from "./sse.js";
 import type {
   DeerFlowClientOptions,
+  MessageChunk,
   MessagesTupleEvent,
   StreamEvent,
+  StreamEventName,
   ThreadInfo,
   ValuesEvent,
 } from "./types.js";
+
+const KNOWN_STREAM_EVENTS = new Set<StreamEventName>([
+  "values",
+  "messages",
+  "messages-tuple",
+  "custom",
+  "metadata",
+  "error",
+  "end",
+]);
 
 type RunStreamRequest = {
   assistant_id: string;
@@ -90,7 +102,7 @@ export class DeerFlowClient {
     }
 
     for await (const rawEvent of parseSSEStream(response.body)) {
-      if (rawEvent.event !== "values" && rawEvent.event !== "messages-tuple" && rawEvent.event !== "custom" && rawEvent.event !== "end") {
+      if (!KNOWN_STREAM_EVENTS.has(rawEvent.event as StreamEventName)) {
         continue;
       }
 
@@ -104,7 +116,7 @@ export class DeerFlowClient {
       yield {
         event: rawEvent.event,
         data: parsed,
-      };
+      } as StreamEvent;
     }
   }
 
@@ -118,13 +130,15 @@ export class DeerFlowClient {
         continue;
       }
 
-      if (event.event !== "messages-tuple" || !Array.isArray(event.data)) {
-        continue;
+      let chunk: MessageChunk | undefined;
+
+      if (event.event === "messages-tuple" && Array.isArray(event.data)) {
+        chunk = (event.data as MessagesTupleEvent)[0];
+      } else if (event.event === "messages" && event.data && typeof event.data === "object") {
+        chunk = event.data as MessageChunk;
       }
 
-      const tuple = event.data as MessagesTupleEvent;
-      const chunk = tuple[0];
-      if (chunk?.type !== "ai" || typeof chunk.content !== "string") {
+      if (!chunk || chunk.type !== "ai" || typeof chunk.content !== "string") {
         continue;
       }
 

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,0 +1,199 @@
+import { parseSSEStream } from "./sse.js";
+import type {
+  DeerFlowClientOptions,
+  MessagesTupleEvent,
+  StreamEvent,
+  ThreadInfo,
+  ValuesEvent,
+} from "./types.js";
+
+type RunStreamRequest = {
+  assistant_id: string;
+  input: {
+    messages: Array<{
+      type: "human";
+      content: Array<{
+        type: "text";
+        text: string;
+      }>;
+    }>;
+  };
+  stream_mode: Array<"values" | "messages-tuple" | "custom">;
+  stream_subgraphs: boolean;
+  context: {
+    thread_id: string;
+  };
+};
+
+export class DeerFlowClient {
+  private readonly baseUrl: string;
+  private readonly headers: Record<string, string>;
+
+  constructor(options: DeerFlowClientOptions) {
+    if (!options.baseUrl) {
+      throw new Error("DeerFlowClient requires a baseUrl");
+    }
+
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.headers = {
+      ...(options.headers ?? {}),
+    };
+  }
+
+  async createThread(metadata: Record<string, unknown> = {}): Promise<ThreadInfo> {
+    return this.requestJson<ThreadInfo>("/threads", {
+      method: "POST",
+      body: JSON.stringify({ metadata }),
+    });
+  }
+
+  async getThreadState(threadId: string): Promise<ValuesEvent> {
+    const state = await this.requestJson<{ values?: ValuesEvent }>(`/threads/${encodeURIComponent(threadId)}/state`, {
+      method: "GET",
+    });
+
+    return state.values ?? ({ messages: [] } as ValuesEvent);
+  }
+
+  async *stream(message: string, threadId?: string): AsyncGenerator<StreamEvent> {
+    const resolvedThreadId = threadId ?? (await this.createThread()).thread_id;
+    const payload: RunStreamRequest = {
+      assistant_id: "lead_agent",
+      input: {
+        messages: [
+          {
+            type: "human",
+            content: [{ type: "text", text: message }],
+          },
+        ],
+      },
+      stream_mode: ["values", "messages-tuple", "custom"],
+      stream_subgraphs: true,
+      context: {
+        thread_id: resolvedThreadId,
+      },
+    };
+
+    const response = await fetch(this.resolve(`/threads/${encodeURIComponent(resolvedThreadId)}/runs/stream`), {
+      method: "POST",
+      headers: this.requestHeaders(),
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`Failed to stream run (${response.status}): ${detail || response.statusText}`);
+    }
+
+    if (!response.body) {
+      throw new Error("SSE stream response has no body");
+    }
+
+    for await (const rawEvent of parseSSEStream(response.body)) {
+      if (rawEvent.event !== "values" && rawEvent.event !== "messages-tuple" && rawEvent.event !== "custom" && rawEvent.event !== "end") {
+        continue;
+      }
+
+      let parsed: unknown = rawEvent.data;
+      try {
+        parsed = JSON.parse(rawEvent.data);
+      } catch {
+        // Keep original string when server sends non-JSON payload.
+      }
+
+      yield {
+        event: rawEvent.event,
+        data: parsed,
+      };
+    }
+  }
+
+  async chat(message: string, threadId?: string): Promise<string> {
+    let lastValues: ValuesEvent | null = null;
+    const textByMessageId = new Map<string, string>();
+
+    for await (const event of this.stream(message, threadId)) {
+      if (event.event === "values" && isValuesEvent(event.data)) {
+        lastValues = event.data;
+        continue;
+      }
+
+      if (event.event !== "messages-tuple" || !Array.isArray(event.data)) {
+        continue;
+      }
+
+      const tuple = event.data as MessagesTupleEvent;
+      const chunk = tuple[0];
+      if (chunk?.type !== "ai" || typeof chunk.content !== "string") {
+        continue;
+      }
+
+      const id = typeof chunk.id === "string" ? chunk.id : "_final";
+      textByMessageId.set(id, (textByMessageId.get(id) ?? "") + chunk.content);
+    }
+
+    if (textByMessageId.size > 0) {
+      return Array.from(textByMessageId.values()).join("\n").trim();
+    }
+
+    if (!lastValues?.messages?.length) {
+      return "";
+    }
+
+    for (let i = lastValues.messages.length - 1; i >= 0; i -= 1) {
+      const msg = lastValues.messages[i];
+      if (msg?.type !== "ai" && msg?.role !== "assistant") {
+        continue;
+      }
+
+      if (typeof msg.content === "string") {
+        return msg.content;
+      }
+
+      if (Array.isArray(msg.content)) {
+        const text = msg.content
+          .map((part) => (part && typeof part === "object" && "text" in part ? String((part as { text?: unknown }).text ?? "") : ""))
+          .join("")
+          .trim();
+
+        if (text) {
+          return text;
+        }
+      }
+    }
+
+    return "";
+  }
+
+  private resolve(path: string): string {
+    return `${this.baseUrl}${path}`;
+  }
+
+  private requestHeaders(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      ...this.headers,
+    };
+  }
+
+  private async requestJson<T>(path: string, init: RequestInit): Promise<T> {
+    const response = await fetch(this.resolve(path), {
+      ...init,
+      headers: {
+        ...this.requestHeaders(),
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(`Request failed (${response.status}): ${detail || response.statusText}`);
+    }
+
+    return (await response.json()) as T;
+  }
+}
+
+function isValuesEvent(value: unknown): value is ValuesEvent {
+  return typeof value === "object" && value !== null && Array.isArray((value as ValuesEvent).messages);
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./client.js";
+export * from "./types.js";

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -13,6 +13,12 @@ export async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGe
             transform(chunk, controller) {
               controller.enqueue(utf8Decoder.decode(chunk, { stream: true }));
             },
+            flush(controller) {
+              const tail = utf8Decoder.decode();
+              if (tail) {
+                controller.enqueue(tail);
+              }
+            },
           }),
         );
 
@@ -35,37 +41,46 @@ export async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGe
     return event;
   };
 
-  while (true) {
-    const { done, value } = await reader.read();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
 
-    if (done) {
-      if (pending.length > 0) {
-        pending += "\n";
-      }
-      const tail = await flushPending(pending);
-      pending = tail.pending;
-      if (tail.events.length > 0) {
-        for (const evt of tail.events) {
-          if (evt.event !== "message" || evt.data !== "") {
-            yield evt;
+      if (done) {
+        if (pending.length > 0) {
+          pending += "\n";
+        }
+        const tail = await flushPending(pending);
+        pending = tail.pending;
+        if (tail.events.length > 0) {
+          for (const evt of tail.events) {
+            if (evt.event !== "message" || evt.data !== "") {
+              yield evt;
+            }
           }
         }
+        const evt = await flush();
+        if (evt) {
+          yield evt;
+        }
+        break;
       }
-      const evt = await flush();
-      if (evt) {
-        yield evt;
-      }
-      break;
-    }
 
-    pending += value;
-    const result = await flushPending(pending);
-    pending = result.pending;
-    for (const evt of result.events) {
-      if (evt.event !== "message" || evt.data !== "") {
-        yield evt;
+      pending += value;
+      const result = await flushPending(pending);
+      pending = result.pending;
+      for (const evt of result.events) {
+        if (evt.event !== "message" || evt.data !== "") {
+          yield evt;
+        }
       }
     }
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // Reader may already be closed; ignore.
+    }
+    reader.releaseLock();
   }
 
   async function flushPending(input: string): Promise<{ pending: string; events: RawSSEEvent[] }> {

--- a/sdk/typescript/src/sse.ts
+++ b/sdk/typescript/src/sse.ts
@@ -1,0 +1,106 @@
+export type RawSSEEvent = {
+  event: string;
+  data: string;
+};
+
+export async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGenerator<RawSSEEvent> {
+  const utf8Decoder = new TextDecoder();
+  const decodedStream =
+    typeof TextDecoderStream !== "undefined"
+      ? body.pipeThrough(new TextDecoderStream() as unknown as TransformStream<Uint8Array, string>)
+      : body.pipeThrough(
+          new TransformStream<Uint8Array, string>({
+            transform(chunk, controller) {
+              controller.enqueue(utf8Decoder.decode(chunk, { stream: true }));
+            },
+          }),
+        );
+
+  const reader = decodedStream.getReader();
+  let pending = "";
+  let currentEvent = "message";
+  let dataLines: string[] = [];
+
+  const flush = async () => {
+    if (dataLines.length === 0) {
+      currentEvent = "message";
+      return;
+    }
+
+    const data = dataLines.join("\n");
+    dataLines = [];
+
+    const event: RawSSEEvent = { event: currentEvent, data };
+    currentEvent = "message";
+    return event;
+  };
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      if (pending.length > 0) {
+        pending += "\n";
+      }
+      const tail = await flushPending(pending);
+      pending = tail.pending;
+      if (tail.events.length > 0) {
+        for (const evt of tail.events) {
+          if (evt.event !== "message" || evt.data !== "") {
+            yield evt;
+          }
+        }
+      }
+      const evt = await flush();
+      if (evt) {
+        yield evt;
+      }
+      break;
+    }
+
+    pending += value;
+    const result = await flushPending(pending);
+    pending = result.pending;
+    for (const evt of result.events) {
+      if (evt.event !== "message" || evt.data !== "") {
+        yield evt;
+      }
+    }
+  }
+
+  async function flushPending(input: string): Promise<{ pending: string; events: RawSSEEvent[] }> {
+    const normalized = input.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    const lines = normalized.split("\n");
+    const remainder = lines.pop() ?? "";
+    const events: RawSSEEvent[] = [];
+
+    for (const line of lines) {
+      if (line === "") {
+        const evt = await flush();
+        if (evt) {
+          events.push(evt);
+        }
+        continue;
+      }
+
+      if (line.startsWith(":")) {
+        continue;
+      }
+
+      const colonIndex = line.indexOf(":");
+      const field = colonIndex === -1 ? line : line.slice(0, colonIndex);
+      let rawValue = colonIndex === -1 ? "" : line.slice(colonIndex + 1);
+      if (rawValue.startsWith(" ")) {
+        rawValue = rawValue.slice(1);
+      }
+
+      if (field === "event") {
+        currentEvent = rawValue || "message";
+      } else if (field === "data") {
+        dataLines.push(rawValue);
+      }
+    }
+
+    return { pending: remainder, events };
+  }
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -1,0 +1,63 @@
+export type MessageContentPart = {
+  type?: string;
+  text?: string;
+  [key: string]: unknown;
+};
+
+export type Message = {
+  id?: string;
+  type?: string;
+  role?: string;
+  name?: string;
+  content?: string | MessageContentPart[];
+  tool_calls?: unknown[];
+  tool_call_id?: string;
+  usage_metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type MessageChunk = {
+  id?: string;
+  type?: string;
+  role?: string;
+  content?: string;
+  name?: string;
+  tool_calls?: unknown[];
+  tool_call_id?: string;
+  usage_metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type Artifact = {
+  id?: string;
+  name?: string;
+  path?: string;
+  mime_type?: string;
+  size?: number;
+  [key: string]: unknown;
+};
+
+export type ValuesEvent = {
+  messages: Message[];
+  title?: string;
+  artifacts?: Artifact[];
+  [key: string]: unknown;
+};
+
+export type MessagesTupleEvent = [message: MessageChunk, metadata: Record<string, unknown>];
+
+export type StreamEvent = {
+  event: "values" | "messages-tuple" | "custom" | "end";
+  data: unknown;
+};
+
+export type ThreadInfo = {
+  thread_id: string;
+  created_at: string;
+  metadata: Record<string, unknown>;
+};
+
+export type DeerFlowClientOptions = {
+  baseUrl: string;
+  headers?: Record<string, string>;
+};

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -46,10 +46,34 @@ export type ValuesEvent = {
 
 export type MessagesTupleEvent = [message: MessageChunk, metadata: Record<string, unknown>];
 
-export type StreamEvent = {
-  event: "values" | "messages-tuple" | "custom" | "end";
-  data: unknown;
-};
+/**
+ * SSE event names emitted by DeerFlow's LangGraph gateway. The set depends on
+ * the requested `stream_mode`:
+ *   - `values`: full state snapshots (stream_mode=values)
+ *   - `messages`: plain message chunks (stream_mode=messages)
+ *   - `messages-tuple`: [chunk, metadata] tuples (stream_mode=messages-tuple, the useStream default)
+ *   - `custom`: user-dispatched custom payloads
+ *   - `metadata`: run metadata (gateway-compatible streams)
+ *   - `error`: per-chunk error frames (gateway-compatible streams)
+ *   - `end`: terminal frame signaling the stream has closed
+ */
+export type StreamEventName =
+  | "values"
+  | "messages"
+  | "messages-tuple"
+  | "custom"
+  | "metadata"
+  | "error"
+  | "end";
+
+export type StreamEvent =
+  | { event: "values"; data: ValuesEvent }
+  | { event: "messages"; data: MessageChunk }
+  | { event: "messages-tuple"; data: MessagesTupleEvent }
+  | { event: "custom"; data: unknown }
+  | { event: "metadata"; data: Record<string, unknown> }
+  | { event: "error"; data: { message?: string; [key: string]: unknown } }
+  | { event: "end"; data: unknown };
 
 export type ThreadInfo = {
   thread_id: string;

--- a/sdk/typescript/tests/sse.test.ts
+++ b/sdk/typescript/tests/sse.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSSEStream } from "../src/sse.js";
+
+function toStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+describe("parseSSEStream", () => {
+  it("parses basic events", async () => {
+    const body = toStream([
+      "event: values\n",
+      "data: {\"messages\":[]}\n\n",
+      "event: end\n",
+      "data: {}\n\n",
+    ]);
+
+    const events: Array<{ event: string; data: string }> = [];
+    for await (const evt of parseSSEStream(body)) {
+      events.push(evt);
+    }
+
+    expect(events).toEqual([
+      { event: "values", data: '{"messages":[]}' },
+      { event: "end", data: "{}" },
+    ]);
+  });
+
+  it("supports multiline data and chunk boundaries", async () => {
+    const body = toStream([
+      "event: custom\n",
+      "data: line1\n",
+      "data: line",
+      "2\n\n",
+    ]);
+
+    const events: Array<{ event: string; data: string }> = [];
+    for await (const evt of parseSSEStream(body)) {
+      events.push(evt);
+    }
+
+    expect(events).toEqual([{ event: "custom", data: "line1\nline2" }]);
+  });
+
+  it("ignores comments and events without data", async () => {
+    const body = toStream([": keepalive\n\n", "event: values\n", "data: {}\n\n"]);
+
+    const events: Array<{ event: string; data: string }> = [];
+    for await (const evt of parseSSEStream(body)) {
+      events.push(evt);
+    }
+
+    expect(events).toEqual([{ event: "values", data: "{}" }]);
+  });
+});

--- a/sdk/typescript/tests/types.test.ts
+++ b/sdk/typescript/tests/types.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { DeerFlowClient } from "../src/client.js";
+import type {
+  DeerFlowClientOptions,
+  MessagesTupleEvent,
+  StreamEvent,
+  ThreadInfo,
+  ValuesEvent,
+} from "../src/types.js";
+
+describe("types", () => {
+  it("exposes expected client and type shapes", () => {
+    const options: DeerFlowClientOptions = {
+      baseUrl: "http://localhost:2026/api/langgraph",
+    };
+
+    const thread: ThreadInfo = {
+      thread_id: "t-1",
+      created_at: new Date().toISOString(),
+      metadata: {},
+    };
+
+    const valuesEvent: ValuesEvent = {
+      messages: [{ type: "ai", content: "hello" }],
+      title: "Thread",
+      artifacts: [],
+    };
+
+    const tupleEvent: MessagesTupleEvent = [{ id: "m1", type: "ai", content: "hel" }, {}];
+
+    const streamEvent: StreamEvent = {
+      event: "messages-tuple",
+      data: tupleEvent,
+    };
+
+    const client = new DeerFlowClient(options);
+
+    expect(client).toBeInstanceOf(DeerFlowClient);
+    expect(thread.thread_id).toBe("t-1");
+    expect(valuesEvent.messages.length).toBe(1);
+    expect(streamEvent.event).toBe("messages-tuple");
+  });
+});

--- a/sdk/typescript/tests/types.test.ts
+++ b/sdk/typescript/tests/types.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { DeerFlowClient } from "../src/client.js";
 import type {
   DeerFlowClientOptions,
+  MessageChunk,
   MessagesTupleEvent,
   StreamEvent,
   ThreadInfo,
@@ -40,5 +41,47 @@ describe("types", () => {
     expect(thread.thread_id).toBe("t-1");
     expect(valuesEvent.messages.length).toBe(1);
     expect(streamEvent.event).toBe("messages-tuple");
+  });
+
+  it("StreamEvent union covers every SSE event the gateway can emit", () => {
+    const messagesChunk: MessageChunk = { id: "m1", type: "ai", content: "hi" };
+
+    const events: StreamEvent[] = [
+      { event: "values", data: { messages: [] } },
+      { event: "messages", data: messagesChunk },
+      { event: "messages-tuple", data: [messagesChunk, {}] },
+      { event: "custom", data: { foo: "bar" } },
+      { event: "metadata", data: { run_id: "r1" } },
+      { event: "error", data: { message: "boom" } },
+      { event: "end", data: null },
+    ];
+
+    expect(events).toHaveLength(7);
+    // Narrow each branch so the discriminated union is exercised at compile time.
+    for (const evt of events) {
+      switch (evt.event) {
+        case "values":
+          expect(Array.isArray(evt.data.messages)).toBe(true);
+          break;
+        case "messages":
+          expect(evt.data.type).toBe("ai");
+          break;
+        case "messages-tuple":
+          expect(evt.data[0]?.content).toBe("hi");
+          break;
+        case "custom":
+          expect(typeof evt.data).toBe("object");
+          break;
+        case "metadata":
+          expect(evt.data.run_id).toBe("r1");
+          break;
+        case "error":
+          expect(evt.data.message).toBe("boom");
+          break;
+        case "end":
+          expect(evt.data).toBeNull();
+          break;
+      }
+    }
   });
 });

--- a/sdk/typescript/tsconfig.json
+++ b/sdk/typescript/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

Adds `@deerflow/client`, a TypeScript SDK that connects to DeerFlow's Gateway HTTP APIs with full SSE streaming support. Mirrors the Python `DeerFlowClient` API shape documented in `STREAMING.md`.

## Why this matters

DeerFlow's streaming protocol is well-documented (`backend/docs/STREAMING.md`, 351 lines) and the Python `DeerFlowClient` got a major expansion recently (`client.py`, 1195 lines). But third-party developers building integrations or custom frontends in TypeScript have no official client library. OpenClaw ships a TypeScript SDK; DeerFlow should too.

| Source | Evidence |
|--------|----------|
| Codebase | `STREAMING.md` (351 lines) documents the full protocol |
| Codebase | Python `client.py` expanded to 1195 lines with streaming |
| Codebase | TypeScript SDK path added to `deer-flow.code-workspace` |

## Changes

New directory: `sdk/typescript/` (not touching any existing code)

- `src/client.ts` - `DeerFlowClient` class with `createThread`, `getThreadState`, `stream` (AsyncGenerator), and `chat` methods
- `src/types.ts` - TypeScript types for the streaming protocol (StreamEvent, ValuesEvent, ThreadInfo, etc.)
- `src/sse.ts` - SSE parser using native `ReadableStream` + `TextDecoderStream`
- `tests/sse.test.ts` - SSE parser unit tests
- `tests/types.test.ts` - Type validation tests
- `README.md` - Usage docs with examples

Zero external runtime dependencies. Uses native `fetch` (Node 18+).

## Testing

Build + 4 tests pass with strict TypeScript compilation.

## Demo

![Demo](https://files.catbox.moe/cywzcl.gif)

This contribution was developed with AI assistance (Codex).