### PR TITLE
fix: improve sandbox security and preserve multimodal content

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -262,21 +262,27 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         files_message = self._create_files_message(new_files, historical_files)
 
         # Extract original content - handle both string and list formats
-        original_content = ""
-        if isinstance(last_message.content, str):
-            original_content = last_message.content
-        elif isinstance(last_message.content, list):
-            text_parts = []
-            for block in last_message.content:
-                if isinstance(block, dict) and block.get("type") == "text":
-                    text_parts.append(block.get("text", ""))
-            original_content = "\n".join(text_parts)
+        original_content = last_message.content
+        if isinstance(original_content, str):
+            # Simple case: string content, just prepend files message
+            updated_content = f"{files_message}\n\n{original_content}"
+        elif isinstance(original_content, list):
+            # Complex case: list content (multimodal), preserve all blocks
+            # Prepend files message as the first text block
+            files_block = {"type": "text", "text": files_message}
+            # Add a separator block
+            separator_block = {"type": "text", "text": "\n\n"}
+            # Keep all original blocks (including images)
+            updated_content = [files_block, separator_block, *original_content]
+        else:
+            # Other types, preserve as-is
+            updated_content = original_content
 
         # Create new message with combined content.
         # Preserve additional_kwargs (including files metadata) so the frontend
         # can read structured file info from the streamed message.
         updated_message = HumanMessage(
-            content=f"{files_message}\n\n{original_content}",
+            content=updated_content,
             id=last_message.id,
             additional_kwargs=last_message.additional_kwargs,
         )

--- a/backend/packages/harness/deerflow/sandbox/security.py
+++ b/backend/packages/harness/deerflow/sandbox/security.py
@@ -39,7 +39,7 @@ def is_host_bash_allowed(config=None) -> bool:
 
     sandbox_cfg = getattr(config, "sandbox", None)
     if sandbox_cfg is None:
-        return True
+        return False
     if not uses_local_sandbox_provider(config):
         return True
     return bool(getattr(sandbox_cfg, "allow_host_bash", False))


### PR DESCRIPTION
This PR fixes two important issues:

### 1. Sandbox Security Improvement
Problem : Previously, when the sandbox configuration was missing, is_host_bash_allowed() would return True by default, allowing host bash execution even when not explicitly configured.

Fix : Changed the default behavior to return False when sandbox config is missing, making the system more secure by default.

### 2. Multimodal Content Preservation in Uploads Middleware
Problem : When processing messages with multimodal content (images, etc.), the uploads middleware was extracting only text parts and discarding other content blocks.

Fix : Now properly preserves all original content blocks when prepending uploaded files information. For list-format multimodal messages, it adds the files message as the first block while keeping all original content intact.

Files modified :

- backend/packages/harness/deerflow/sandbox/security.py
- backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py