### PR TITLE
feat: add HTTP mode support for remote OpenCode ACP service

### DIFF
--- a/backend/packages/harness/deerflow/config/acp_config.py
+++ b/backend/packages/harness/deerflow/config/acp_config.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 class ACPAgentConfig(BaseModel):
     """Configuration for a single ACP-compatible agent."""
 
-    command: str = Field(description="Command to launch the ACP agent subprocess")
+    command: str | None = Field(default=None, description="Command to launch the ACP agent subprocess (required for stdio mode)")
     args: list[str] = Field(default_factory=list, description="Additional command arguments")
     env: dict[str, str] = Field(default_factory=dict, description="Environment variables to inject into the agent subprocess. Values starting with $ are resolved from host environment variables.")
     description: str = Field(description="Description of the agent's capabilities (shown in tool description)")
@@ -24,6 +24,7 @@ class ACPAgentConfig(BaseModel):
             "are denied — the agent must be configured to operate without requesting permissions."
         ),
     )
+    url: str | None = Field(default=None, description="Remote ACP service URL (e.g. http://localhost:3020). When set, uses HTTP REST API instead of stdio subprocess.")
 
 
 _acp_agents: dict[str, ACPAgentConfig] = {}

--- a/backend/packages/harness/deerflow/config/acp_config.py
+++ b/backend/packages/harness/deerflow/config/acp_config.py
@@ -3,7 +3,7 @@
 import logging
 from collections.abc import Mapping
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +25,12 @@ class ACPAgentConfig(BaseModel):
         ),
     )
     url: str | None = Field(default=None, description="Remote ACP service URL (e.g. http://localhost:3020). When set, uses HTTP REST API instead of stdio subprocess.")
+
+    @model_validator(mode="after")
+    def _validate_command_or_url(self) -> "ACPAgentConfig":
+        if not self.command and not self.url:
+            raise ValueError("Either 'command' (for stdio mode) or 'url' (for HTTP mode) must be provided")
+        return self
 
 
 _acp_agents: dict[str, ACPAgentConfig] = {}

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -13,23 +13,34 @@ logger = logging.getLogger(__name__)
 
 
 class _OpenCodeHTTPClient:
-    """HTTP client for remote OpenCode ACP service."""
+    """HTTP client for remote OpenCode ACP service with connection pooling."""
 
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url.rstrip("/")
+        self._client: Any = None
+
+    async def _get_client(self) -> Any:
+        if self._client is None:
+            import httpx
+
+            self._client = httpx.AsyncClient(timeout=120.0)
+        return self._client
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
 
     async def _request(self, method: str, path: str, data: dict | None = None) -> dict:
-        import httpx
-
+        client = await self._get_client()
         url = f"{self.base_url}{path}"
         headers = {"Content-Type": "application/json"}
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            if method == "GET":
-                resp = await client.get(url, headers=headers)
-            else:
-                resp = await client.post(url, headers=headers, json=data)
-            resp.raise_for_status()
-            return resp.json()
+        if method == "GET":
+            resp = await client.get(url, headers=headers)
+        else:
+            resp = await client.post(url, headers=headers, json=data)
+        resp.raise_for_status()
+        return resp.json()
 
     async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
         result = await self._request("POST", "/session", {"agent": agent, "directory": directory})
@@ -43,6 +54,12 @@ class _OpenCodeHTTPClient:
         )
         text_parts = [p for p in result.get("parts", []) if p.get("type") == "text"]
         return "".join(p.get("text", "") for p in text_parts) or "(no response)"
+
+    async def delete_session(self, session_id: str) -> None:
+        try:
+            await self._request("DELETE", f"/session/{session_id}")
+        except Exception as e:
+            logger.warning("Failed to delete remote session %s: %s", session_id, e)
 
 
 class _InvokeACPAgentInput(BaseModel):
@@ -234,8 +251,9 @@ async def _invoke_http(agent: str, agent_config: Any, prompt: str, config: Any) 
         remote_agent,
     )
 
+    client = _OpenCodeHTTPClient(url)
+    session_id: str | None = None
     try:
-        client = _OpenCodeHTTPClient(url)
         session_id = await client.create_session(agent=remote_agent, directory=directory)
         logger.info("Created session %s for ACP agent '%s'", session_id, agent)
         result = await client.send_message(session_id, prompt, agent=remote_agent)
@@ -244,6 +262,10 @@ async def _invoke_http(agent: str, agent_config: Any, prompt: str, config: Any) 
     except Exception as e:
         logger.error("HTTP ACP agent '%s' invocation failed: %s", agent, e)
         return f"Error invoking ACP agent '{agent}' via {url}: {e}"
+    finally:
+        if session_id:
+            await client.delete_session(session_id)
+        await client.close()
 
 
 async def _invoke_stdio(agent: str, agent_config: Any, prompt: str, config: Any) -> str:

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -203,12 +203,12 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
         agent_config = _agents[agent]
 
-        # HTTP mode: use remote OpenCode ACP service
-        if agent_config.url:
-            return await _invoke_http(agent, agent_config, prompt)
+        # stdio mode takes precedence when command is set
+        if agent_config.command:
+            return await _invoke_stdio(agent, agent_config, prompt, config)
 
-        # stdio mode: use local subprocess
-        return await _invoke_stdio(agent, agent_config, prompt, config)
+        # HTTP mode: use remote OpenCode ACP service
+        return await _invoke_http(agent, agent_config, prompt, config)
 
     return StructuredTool.from_function(
         name="invoke_acp_agent",
@@ -218,17 +218,27 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
     )
 
 
-async def _invoke_http(agent: str, agent_config: Any, prompt: str) -> str:
+async def _invoke_http(agent: str, agent_config: Any, prompt: str, config: Any) -> str:
     """Invoke ACP agent via remote HTTP REST API."""
     url = agent_config.url
-    logger.info("Invoking ACP agent '%s' via HTTP at %s", agent, url)
+    thread_id: str | None = ((config or {}).get("configurable") or {}).get("thread_id")
+    directory = _get_work_dir(thread_id)
+
+    # Resolve remote agent name: prefer model hint, fall back to agent name
+    remote_agent = agent_config.model or agent
+
+    logger.info(
+        "Invoking ACP agent '%s' via HTTP at %s using remote agent '%s'",
+        agent,
+        url,
+        remote_agent,
+    )
 
     try:
         client = _OpenCodeHTTPClient(url)
-        directory = "/tmp"
-        session_id = await client.create_session(agent="build", directory=directory)
+        session_id = await client.create_session(agent=remote_agent, directory=directory)
         logger.info("Created session %s for ACP agent '%s'", session_id, agent)
-        result = await client.send_message(session_id, prompt, agent="build")
+        result = await client.send_message(session_id, prompt, agent=remote_agent)
         logger.info("ACP agent '%s' returned %d characters", agent, len(result))
         return result
     except Exception as e:

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -12,6 +12,39 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger(__name__)
 
 
+class _OpenCodeHTTPClient:
+    """HTTP client for remote OpenCode ACP service."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    async def _request(self, method: str, path: str, data: dict | None = None) -> dict:
+        import httpx
+
+        url = f"{self.base_url}{path}"
+        headers = {"Content-Type": "application/json"}
+        async with httpx.AsyncClient(timeout=120.0) as client:
+            if method == "GET":
+                resp = await client.get(url, headers=headers)
+            else:
+                resp = await client.post(url, headers=headers, json=data)
+            resp.raise_for_status()
+            return resp.json()
+
+    async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+        result = await self._request("POST", "/session", {"agent": agent, "directory": directory})
+        return result["id"]
+
+    async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
+        result = await self._request(
+            "POST",
+            f"/session/{session_id}/message",
+            {"parts": [{"type": "text", "text": text}], "agent": agent},
+        )
+        text_parts = [p for p in result.get("parts", []) if p.get("type") == "text"]
+        return "".join(p.get("text", "") for p in text_parts) or "(no response)"
+
+
 class _InvokeACPAgentInput(BaseModel):
     agent: str = Field(description="Name of the ACP agent to invoke")
     prompt: str = Field(description="The concise task prompt to send to the agent")
@@ -169,84 +202,13 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
             return f"Error: Unknown agent '{agent}'. Available: {available}"
 
         agent_config = _agents[agent]
-        thread_id: str | None = ((config or {}).get("configurable") or {}).get("thread_id")
 
-        try:
-            from acp import PROTOCOL_VERSION, Client, text_block
-            from acp.schema import ClientCapabilities, Implementation
-        except ImportError:
-            return "Error: agent-client-protocol package is not installed. Run `uv sync` to install project dependencies."
+        # HTTP mode: use remote OpenCode ACP service
+        if agent_config.url:
+            return await _invoke_http(agent, agent_config, prompt)
 
-        class _CollectingClient(Client):
-            """Minimal ACP Client that collects streamed text from session updates."""
-
-            def __init__(self) -> None:
-                self._chunks: list[str] = []
-
-            @property
-            def collected_text(self) -> str:
-                return "".join(self._chunks)
-
-            async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
-                try:
-                    from acp.schema import TextContentBlock
-
-                    if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
-                        self._chunks.append(update.content.text)
-                except Exception:
-                    pass
-
-            async def request_permission(self, options, session_id: str, tool_call, **kwargs):  # type: ignore[override]
-                response = _build_permission_response(options, auto_approve=agent_config.auto_approve_permissions)
-                outcome = response.outcome.outcome
-                if outcome == "selected":
-                    logger.info("ACP permission auto-approved for tool call %s in session %s", tool_call.tool_call_id, session_id)
-                else:
-                    logger.warning("ACP permission denied for tool call %s in session %s (set auto_approve_permissions: true in config.yaml to enable)", tool_call.tool_call_id, session_id)
-                return response
-
-        client = _CollectingClient()
-        cmd = agent_config.command
-        args = agent_config.args or []
-        physical_cwd = _get_work_dir(thread_id)
-        try:
-            mcp_servers = _build_acp_mcp_servers()
-        except ValueError as exc:
-            logger.warning(
-                "Invalid MCP server configuration for ACP agent '%s'; continuing without MCP servers: %s",
-                agent,
-                exc,
-            )
-            mcp_servers = []
-        agent_env: dict[str, str] | None = None
-        if agent_config.env:
-            agent_env = {k: (os.environ.get(v[1:], "") if v.startswith("$") else v) for k, v in agent_config.env.items()}
-
-        try:
-            from acp import spawn_agent_process
-
-            async with spawn_agent_process(client, cmd, *args, env=agent_env, cwd=physical_cwd) as (conn, proc):
-                logger.info("Spawning ACP agent '%s' with command '%s' and args %s in cwd %s", agent, cmd, args, physical_cwd)
-                await conn.initialize(
-                    protocol_version=PROTOCOL_VERSION,
-                    client_capabilities=ClientCapabilities(),
-                    client_info=Implementation(name="deerflow", title="DeerFlow", version="0.1.0"),
-                )
-                session_kwargs: dict[str, Any] = {"cwd": physical_cwd, "mcp_servers": mcp_servers}
-                if agent_config.model:
-                    session_kwargs["model"] = agent_config.model
-                session = await conn.new_session(**session_kwargs)
-                await conn.prompt(
-                    session_id=session.session_id,
-                    prompt=[text_block(prompt)],
-                )
-            result = client.collected_text
-            logger.info("ACP agent '%s' returned %s", agent, result[:1000])
-            logger.info("ACP agent '%s' returned %d characters", agent, len(result))
-            return result or "(no response)"
-        except Exception as e:
-            logger.error("ACP agent '%s' invocation failed: %s", agent, e)
-            return _format_invocation_error(agent, cmd, e)
+        # stdio mode: use local subprocess
+        return await _invoke_stdio(agent, agent_config, prompt, config)
 
     return StructuredTool.from_function(
         name="invoke_acp_agent",
@@ -254,3 +216,106 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         coroutine=_invoke,
         args_schema=_InvokeACPAgentInput,
     )
+
+
+async def _invoke_http(agent: str, agent_config: Any, prompt: str) -> str:
+    """Invoke ACP agent via remote HTTP REST API."""
+    url = agent_config.url
+    logger.info("Invoking ACP agent '%s' via HTTP at %s", agent, url)
+
+    try:
+        client = _OpenCodeHTTPClient(url)
+        directory = "/tmp"
+        session_id = await client.create_session(agent="build", directory=directory)
+        logger.info("Created session %s for ACP agent '%s'", session_id, agent)
+        result = await client.send_message(session_id, prompt, agent="build")
+        logger.info("ACP agent '%s' returned %d characters", agent, len(result))
+        return result
+    except Exception as e:
+        logger.error("HTTP ACP agent '%s' invocation failed: %s", agent, e)
+        return f"Error invoking ACP agent '{agent}' via {url}: {e}"
+
+
+async def _invoke_stdio(agent: str, agent_config: Any, prompt: str, config: Any) -> str:
+    """Invoke ACP agent via local stdio subprocess."""
+    if not agent_config.command:
+        return f"Error: ACP agent '{agent}' requires 'command' field for stdio mode. Set 'url' for HTTP mode instead."
+
+    try:
+        from acp import PROTOCOL_VERSION, Client, text_block
+        from acp.schema import ClientCapabilities, Implementation
+    except ImportError:
+        return "Error: agent-client-protocol package is not installed. Run `uv sync` to install project dependencies."
+
+    thread_id: str | None = ((config or {}).get("configurable") or {}).get("thread_id")
+
+    class _CollectingClient(Client):
+        """Minimal ACP Client that collects streamed text from session updates."""
+
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        @property
+        def collected_text(self) -> str:
+            return "".join(self._chunks)
+
+        async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
+            try:
+                from acp.schema import TextContentBlock
+
+                if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
+                    self._chunks.append(update.content.text)
+            except Exception:
+                pass
+
+        async def request_permission(self, options, session_id: str, tool_call, **kwargs):  # type: ignore[override]
+            response = _build_permission_response(options, auto_approve=agent_config.auto_approve_permissions)
+            outcome = response.outcome.outcome
+            if outcome == "selected":
+                logger.info("ACP permission auto-approved for tool call %s in session %s", tool_call.tool_call_id, session_id)
+            else:
+                logger.warning("ACP permission denied for tool call %s in session %s (set auto_approve_permissions: true in config.yaml to enable)", tool_call.tool_call_id, session_id)
+            return response
+
+    client = _CollectingClient()
+    cmd = agent_config.command
+    args = agent_config.args or []
+    physical_cwd = _get_work_dir(thread_id)
+    try:
+        mcp_servers = _build_acp_mcp_servers()
+    except ValueError as exc:
+        logger.warning(
+            "Invalid MCP server configuration for ACP agent '%s'; continuing without MCP servers: %s",
+            agent,
+            exc,
+        )
+        mcp_servers = []
+    agent_env: dict[str, str] | None = None
+    if agent_config.env:
+        agent_env = {k: (os.environ.get(v[1:], "") if v.startswith("$") else v) for k, v in agent_config.env.items()}
+
+    try:
+        from acp import spawn_agent_process
+
+        async with spawn_agent_process(client, cmd, *args, env=agent_env, cwd=physical_cwd) as (conn, proc):
+            logger.info("Spawning ACP agent '%s' with command '%s' and args %s in cwd %s", agent, cmd, args, physical_cwd)
+            await conn.initialize(
+                protocol_version=PROTOCOL_VERSION,
+                client_capabilities=ClientCapabilities(),
+                client_info=Implementation(name="deerflow", title="DeerFlow", version="0.1.0"),
+            )
+            session_kwargs: dict[str, Any] = {"cwd": physical_cwd, "mcp_servers": mcp_servers}
+            if agent_config.model:
+                session_kwargs["model"] = agent_config.model
+            session = await conn.new_session(**session_kwargs)
+            await conn.prompt(
+                session_id=session.session_id,
+                prompt=[text_block(prompt)],
+            )
+        result = client.collected_text
+        logger.info("ACP agent '%s' returned %s", agent, result[:1000])
+        logger.info("ACP agent '%s' returned %d characters", agent, len(result))
+        return result or "(no response)"
+    except Exception as e:
+        logger.error("ACP agent '%s' invocation failed: %s", agent, e)
+        return _format_invocation_error(agent, cmd, e)

--- a/backend/tests/test_acp_config.py
+++ b/backend/tests/test_acp_config.py
@@ -106,8 +106,23 @@ def test_acp_agent_config_auto_approve_permissions():
 
 
 def test_acp_agent_config_missing_command_raises():
+    """Neither command nor url provided should raise ValidationError."""
     with pytest.raises(ValidationError):
         ACPAgentConfig(description="No command provided")
+
+
+def test_acp_agent_config_url_only_is_valid():
+    """HTTP mode: url without command should be valid."""
+    cfg = ACPAgentConfig(url="http://localhost:3020", description="OpenCode remote ACP")
+    assert cfg.url == "http://localhost:3020"
+    assert cfg.command is None
+
+
+def test_acp_agent_config_command_and_url_both_set():
+    """Both command and url set should be valid (command takes precedence for stdio mode)."""
+    cfg = ACPAgentConfig(command="my-agent", url="http://localhost:3020", description="Hybrid config")
+    assert cfg.command == "my-agent"
+    assert cfg.url == "http://localhost:3020"
 
 
 def test_acp_agent_config_missing_description_raises():

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -693,3 +693,124 @@ def test_get_available_tools_includes_invoke_acp_agent_when_agents_configured(mo
     assert "invoke_acp_agent" in [tool.name for tool in tools]
 
     load_acp_config_from_dict({})
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch):
+    """HTTP mode: agent with url should use HTTP client instead of stdio subprocess."""
+    captured: dict[str, object] = {}
+
+    class DummyHTTPClient:
+        def __init__(self, base_url: str) -> None:
+            captured["url"] = base_url
+
+        async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+            captured["create_session"] = {"agent": agent, "directory": directory}
+            return "http-session-123"
+
+        async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
+            captured["send_message"] = {"session_id": session_id, "text": text, "agent": agent}
+            return "HTTP agent response"
+
+    monkeypatch.setattr(
+        "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
+        DummyHTTPClient,
+    )
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "opencode": ACPAgentConfig(
+                url="http://localhost:3020",
+                description="OpenCode remote ACP agent",
+            )
+        }
+    )
+
+    result = await tool.coroutine(agent="opencode", prompt="Create a hello world script")
+
+    assert result == "HTTP agent response"
+    assert captured["url"] == "http://localhost:3020"
+    assert captured["create_session"] == {"agent": "build", "directory": "/tmp"}
+    assert captured["send_message"] == {
+        "session_id": "http-session-123",
+        "text": "Create a hello world script",
+        "agent": "build",
+    }
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_http_mode_error_handling(monkeypatch):
+    """HTTP mode: connection errors should return user-friendly error message."""
+
+    class DummyHTTPClient:
+        def __init__(self, base_url: str) -> None:
+            pass
+
+        async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+            raise ConnectionError("Connection refused")
+
+    monkeypatch.setattr(
+        "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
+        DummyHTTPClient,
+    )
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "opencode": ACPAgentConfig(
+                url="http://unreachable-host:9999",
+                description="Unreachable ACP agent",
+            )
+        }
+    )
+
+    result = await tool.coroutine(agent="opencode", prompt="Do something")
+
+    assert "Error invoking ACP agent 'opencode'" in result
+    assert "http://unreachable-host:9999" in result
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_http_mode_description_includes_url(monkeypatch):
+    """HTTP mode agent description should be included in tool description."""
+    tool = build_invoke_acp_agent_tool(
+        {
+            "opencode": ACPAgentConfig(
+                url="http://localhost:3020",
+                description="OpenCode remote ACP agent for coding tasks",
+            )
+        }
+    )
+
+    assert "- opencode: OpenCode remote ACP agent for coding tasks" in tool.description
+    assert "invoke_acp_agent" == tool.name
+
+
+def test_get_available_tools_includes_http_acp_agent(monkeypatch):
+    """HTTP mode ACP agents should also be included in available tools."""
+    from deerflow.config.acp_config import load_acp_config_from_dict
+
+    load_acp_config_from_dict(
+        {
+            "opencode": {
+                "url": "http://localhost:3020",
+                "description": "OpenCode remote ACP",
+            }
+        }
+    )
+
+    fake_config = SimpleNamespace(
+        tools=[],
+        models=[],
+        tool_search=SimpleNamespace(enabled=False),
+        get_model_config=lambda name: None,
+    )
+    monkeypatch.setattr("deerflow.tools.tools.get_app_config", lambda: fake_config)
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    tools = get_available_tools(include_mcp=True, subagent_enabled=False)
+    assert "invoke_acp_agent" in [tool.name for tool in tools]
+
+    load_acp_config_from_dict({})

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -696,8 +696,12 @@ def test_get_available_tools_includes_invoke_acp_agent_when_agents_configured(mo
 
 
 @pytest.mark.anyio
-async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch):
+async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch, tmp_path):
     """HTTP mode: agent with url should use HTTP client instead of stdio subprocess."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+
     captured: dict[str, object] = {}
 
     class DummyHTTPClient:
@@ -730,17 +734,222 @@ async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch):
 
     assert result == "HTTP agent response"
     assert captured["url"] == "http://localhost:3020"
-    assert captured["create_session"] == {"agent": "build", "directory": "/tmp"}
+    expected_dir = str(tmp_path / "acp-workspace")
+    assert captured["create_session"] == {"agent": "opencode", "directory": expected_dir}
     assert captured["send_message"] == {
         "session_id": "http-session-123",
         "text": "Create a hello world script",
-        "agent": "build",
+        "agent": "opencode",
     }
 
 
 @pytest.mark.anyio
-async def test_invoke_acp_agent_http_mode_error_handling(monkeypatch):
+async def test_invoke_acp_agent_http_mode_uses_model_as_remote_agent(monkeypatch, tmp_path):
+    """HTTP mode: should use model config as remote agent name when set."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+
+    captured: dict[str, object] = {}
+
+    class DummyHTTPClient:
+        def __init__(self, base_url: str) -> None:
+            pass
+
+        async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+            captured["create_session_agent"] = agent
+            return "s1"
+
+        async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
+            captured["send_message_agent"] = agent
+            return "ok"
+
+    monkeypatch.setattr(
+        "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
+        DummyHTTPClient,
+    )
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "opencode": ACPAgentConfig(
+                url="http://localhost:3020",
+                description="OpenCode remote ACP agent",
+                model="claude-sonnet-4",
+            )
+        }
+    )
+
+    await tool.coroutine(agent="opencode", prompt="Do something")
+
+    assert captured["create_session_agent"] == "claude-sonnet-4"
+    assert captured["send_message_agent"] == "claude-sonnet-4"
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_http_mode_uses_per_thread_workspace(monkeypatch, tmp_path):
+    """HTTP mode: should use per-thread workspace directory when thread_id is available."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+
+    captured: dict[str, object] = {}
+
+    class DummyHTTPClient:
+        def __init__(self, base_url: str) -> None:
+            pass
+
+        async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+            captured["directory"] = directory
+            return "s1"
+
+        async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
+            return "ok"
+
+    monkeypatch.setattr(
+        "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
+        DummyHTTPClient,
+    )
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "opencode": ACPAgentConfig(
+                url="http://localhost:3020",
+                description="OpenCode remote ACP agent",
+            )
+        }
+    )
+
+    await tool.coroutine(
+        agent="opencode",
+        prompt="Do something",
+        config={"configurable": {"thread_id": "thread-abc-123"}},
+    )
+
+    expected_dir = str(tmp_path / "threads" / "thread-abc-123" / "acp-workspace")
+    assert captured["directory"] == expected_dir
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_stdio_mode_takes_precedence_over_http(monkeypatch, tmp_path):
+    """When both command and url are set, stdio mode should take precedence."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    stdio_called = False
+    http_called = False
+
+    class DummyHTTPClient:
+        def __init__(self, base_url: str) -> None:
+            nonlocal http_called
+            http_called = True
+
+        async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
+            return "s1"
+
+        async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
+            return "http response"
+
+    monkeypatch.setattr(
+        "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
+        DummyHTTPClient,
+    )
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        @property
+        def collected_text(self) -> str:
+            return "stdio response"
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s1")
+
+        async def prompt(self, **kwargs):
+            pass
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, cwd):
+            nonlocal stdio_called
+            stdio_called = True
+            # Simulate a response by appending to client's chunks
+            if hasattr(client, "_chunks"):
+                client._chunks.append("stdio response")
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            TextContentBlock=type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)}),
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool(
+        {
+            "hybrid": ACPAgentConfig(
+                command="my-agent",
+                url="http://localhost:3020",
+                description="Hybrid agent",
+            )
+        }
+    )
+
+    try:
+        result = await tool.coroutine(agent="hybrid", prompt="Do something")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert stdio_called is True
+    assert http_called is False
+    assert result == "stdio response"
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_http_mode_error_handling(monkeypatch, tmp_path):
     """HTTP mode: connection errors should return user-friendly error message."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
 
     class DummyHTTPClient:
         def __init__(self, base_url: str) -> None:

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -716,6 +716,12 @@ async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch, tmp_
             captured["send_message"] = {"session_id": session_id, "text": text, "agent": agent}
             return "HTTP agent response"
 
+        async def delete_session(self, session_id: str) -> None:
+            captured["delete_session"] = session_id
+
+        async def close(self) -> None:
+            captured["close_called"] = True
+
     monkeypatch.setattr(
         "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
         DummyHTTPClient,
@@ -741,6 +747,8 @@ async def test_invoke_acp_agent_http_mode_calls_remote_service(monkeypatch, tmp_
         "text": "Create a hello world script",
         "agent": "opencode",
     }
+    assert captured["delete_session"] == "http-session-123"
+    assert captured["close_called"] is True
 
 
 @pytest.mark.anyio
@@ -763,6 +771,12 @@ async def test_invoke_acp_agent_http_mode_uses_model_as_remote_agent(monkeypatch
         async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
             captured["send_message_agent"] = agent
             return "ok"
+
+        async def delete_session(self, session_id: str) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
 
     monkeypatch.setattr(
         "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
@@ -804,6 +818,12 @@ async def test_invoke_acp_agent_http_mode_uses_per_thread_workspace(monkeypatch,
 
         async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
             return "ok"
+
+        async def delete_session(self, session_id: str) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
 
     monkeypatch.setattr(
         "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
@@ -853,6 +873,12 @@ async def test_invoke_acp_agent_stdio_mode_takes_precedence_over_http(monkeypatc
 
         async def send_message(self, session_id: str, text: str, agent: str = "build") -> str:
             return "http response"
+
+        async def delete_session(self, session_id: str) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
 
     monkeypatch.setattr(
         "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",
@@ -957,6 +983,12 @@ async def test_invoke_acp_agent_http_mode_error_handling(monkeypatch, tmp_path):
 
         async def create_session(self, agent: str = "build", directory: str = "/tmp") -> str:
             raise ConnectionError("Connection refused")
+
+        async def delete_session(self, session_id: str) -> None:
+            pass
+
+        async def close(self) -> None:
+            pass
 
     monkeypatch.setattr(
         "deerflow.tools.builtins.invoke_acp_agent_tool._OpenCodeHTTPClient",

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -583,8 +583,12 @@ sandbox:
 # ACP Agents Configuration
 # ============================================================================
 # Configure external ACP-compatible agents for the built-in `invoke_acp_agent` tool.
+# Two modes are supported:
+#   1. stdio mode: Uses 'command' to spawn a local subprocess
+#   2. HTTP mode:  Uses 'url' to connect to a remote OpenCode ACP service
 
 # acp_agents:
+#   # --- stdio mode examples ---
 #   claude_code:
 #     # DeerFlow expects an ACP adapter here. The standard `claude` CLI does not
 #     # speak ACP directly. Install `claude-agent-acp` separately or use:
@@ -606,6 +610,12 @@ sandbox:
 #     # auto_approve_permissions: false  # Set to true to auto-approve ACP permission requests
 #     # env:                             # Optional: inject environment variables into the agent subprocess
 #     #   OPENAI_API_KEY: $OPENAI_API_KEY  # $VAR resolves from host environment
+#
+#   # --- HTTP mode example (remote OpenCode ACP service) ---
+#   opencode:
+#     url: http://localhost:3020
+#     description: OpenCode remote ACP agent for coding tasks
+#     # auto_approve_permissions: false  # Set to true to auto-approve permission requests
 
 # ============================================================================
 # Skills Configuration


### PR DESCRIPTION
- Add 'url' field to ACPAgentConfig for remote HTTP ACP service connection
- Implement _OpenCodeHTTPClient for HTTP REST API communication
- Add _invoke_http() function as alternative to stdio subprocess mode
- Update config.example.yaml with HTTP mode configuration example
- Make 'command' field optional when 'url' is set for HTTP mode