### PR TITLE
Clarify Docker custom skills sandbox paths

### DIFF
--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -277,6 +277,14 @@ skills:
 - Each skill has a `SKILL.md` file with metadata
 - Skills are automatically discovered and loaded
 - Available in both local and Docker sandbox via path mapping
+- For Docker Compose, `skills.path` is resolved inside the DeerFlow service containers
+  such as gateway and langgraph. The agent reads the same skills through
+  `skills.container_path`, which defaults to `/mnt/skills`.
+- Do not instruct the agent to read `/app/skills/...` directly. Use the path shown in
+  the skill prompt, for example `/mnt/skills/custom/my-skill/SKILL.md`.
+- To add an offline custom skill, place it at
+  `skills/custom/<skill-name>/SKILL.md`, keep `container_path: /mnt/skills`, and
+  restart DeerFlow so the services reload the skills directory.
 
 **Per-Agent Skill Filtering**:
 Custom agents can restrict which skills they load by defining a `skills` field in their `config.yaml` (located at `workspace/agents/<agent_name>/config.yaml`):

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -565,6 +565,10 @@ You have access to skills that provide optimized workflows for specific tasks. E
 5. Follow the skill's instructions precisely
 
 **Skills are located at:** {container_base_path}
+Use the `<location>` path shown for each skill when reading it. In Docker deployments,
+paths such as `/app/skills` belong to DeerFlow service containers and are not readable
+from the agent sandbox; the sandbox-facing skills path is the configured container path
+above, normally `/mnt/skills`.
 {skill_evolution_section}
 {skills_list}
 

--- a/backend/tests/test_lead_agent_skills.py
+++ b/backend/tests/test_lead_agent_skills.py
@@ -6,15 +6,16 @@ from deerflow.config.agents_config import AgentConfig
 from deerflow.skills.types import Skill
 
 
-def _make_skill(name: str) -> Skill:
+def _make_skill(name: str, *, category: str = "public", relative_path: Path | None = None) -> Skill:
+    relative_path = relative_path or Path(name)
     return Skill(
         name=name,
         description=f"Description for {name}",
         license="MIT",
-        skill_dir=Path(f"/tmp/{name}"),
-        skill_file=Path(f"/tmp/{name}/SKILL.md"),
-        relative_path=Path(name),
-        category="public",
+        skill_dir=Path(f"/tmp/{category}") / relative_path,
+        skill_file=Path(f"/tmp/{category}") / relative_path / "SKILL.md",
+        relative_path=relative_path,
+        category=category,
         enabled=True,
     )
 
@@ -43,6 +44,28 @@ def test_get_skills_prompt_section_returns_skills(monkeypatch):
     assert "skill1" in result
     assert "skill2" not in result
     assert "[built-in]" in result
+
+
+def test_get_skills_prompt_section_uses_sandbox_path_for_custom_skills(monkeypatch):
+    skill = _make_skill(
+        "scenic-spot-analytics",
+        category="custom",
+        relative_path=Path("scenic-spot-analytics"),
+    )
+    monkeypatch.setattr("deerflow.agents.lead_agent.prompt._get_enabled_skills", lambda: [skill])
+    monkeypatch.setattr(
+        "deerflow.config.get_app_config",
+        lambda: SimpleNamespace(
+            skills=SimpleNamespace(container_path="/mnt/skills"),
+            skill_evolution=SimpleNamespace(enabled=False),
+        ),
+    )
+
+    result = get_skills_prompt_section(available_skills=None)
+
+    assert "[custom, editable]" in result
+    assert "<location>/mnt/skills/custom/scenic-spot-analytics/SKILL.md</location>" in result
+    assert "<location>/app/skills/custom/scenic-spot-analytics/SKILL.md</location>" not in result
 
 
 def test_get_skills_prompt_section_returns_all_when_available_skills_is_none(monkeypatch):

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -617,6 +617,13 @@ skills:
   # Default: ../skills (relative to backend directory)
   # Uncomment to customize:
   # path: /absolute/path/to/custom/skills
+  #
+  # Docker Compose note:
+  # - Service containers mount the repo skills directory at /app/skills.
+  # - The agent sandbox reads skills through container_path, normally /mnt/skills.
+  # - For offline custom skills, add:
+  #   skills/custom/<skill-name>/SKILL.md
+  #   and ask the agent to read /mnt/skills/custom/<skill-name>/SKILL.md.
 
   # Path where skills are mounted in the sandbox container
   # This is used by the agent to access skills in both local and Docker sandbox


### PR DESCRIPTION
## Summary

This clarifies how custom skills are exposed to agents in Docker deployments.

The reported confusion in #2125 comes from two different container paths:

- `/app/skills` is the DeerFlow service container mount used by gateway/langgraph to discover skills.
- `/mnt/skills` is the sandbox-facing path that agents can read from prompts and tools.

Changes:

- Add prompt guidance telling agents to read the per-skill `<location>` path and not service-container paths such as `/app/skills`.
- Document the Docker Compose path mapping for offline custom skills in `config.example.yaml` and the backend configuration docs.
- Add a regression test proving custom skills are injected into the prompt with `/mnt/skills/custom/.../SKILL.md`.

Fixes #2125

## Validation

- `python -m pytest backend/tests/test_lead_agent_skills.py -q`
- `python -m ruff check backend/packages/harness/deerflow/agents/lead_agent/prompt.py backend/tests/test_lead_agent_skills.py`
- `git diff --check`
- Parsed `config.example.yaml` with PyYAML
