### PR TITLE
docs(config): update DeepSeek example to V3.2 in config.example.yaml

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -167,9 +167,12 @@ models:
   #       thinking:
   #         type: disabled
 
-  # Example: DeepSeek model (with thinking support)
-  # - name: deepseek-v3
-  #   display_name: DeepSeek V3 (Thinking)
+  # Example: DeepSeek model with thinking support
+  # Note: DeepSeek V3.2 is the recommended version for agent/tool-use scenarios.
+  # It supports thinking mode natively. For older V3 deployments, the same
+  # configuration structure applies.
+  # - name: deepseek-v32
+  #   display_name: DeepSeek V3.2 Thinking
   #   use: deerflow.models.patched_deepseek:PatchedChatDeepSeek
   #   model: deepseek-reasoner
   #   api_key: $DEEPSEEK_API_KEY
@@ -177,7 +180,7 @@ models:
   #   max_retries: 2
   #   max_tokens: 8192
   #   supports_thinking: true
-  #   supports_vision: false  # DeepSeek V3 does not support vision
+  #   supports_vision: false  # DeepSeek V3.2 does not support vision
   #   when_thinking_enabled:
   #     extra_body:
   #       thinking:


### PR DESCRIPTION
## Summary
Update the DeepSeek model example in config.example.yaml to reference V3.2, which is the current recommended version for agent and tool-use scenarios.

## Changes
- Updated model name from deepseek-v3 to deepseek-v32
- Updated displayname to reflect V3.2
- Added clarifying comment about V3.2 being recommended for agent/tool-use
- Preserved backward-compatible configuration structure

## Motivation
DeepSeek V3.2 has been the current production release since late 2025. The existing example still references V3, which may confuse new users setting up DeerFlow for the first time.