### PR TITLE
fix(sandbox): Prevent path traversal and symlink escape in LocalSandbox

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -6,6 +6,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from deerflow.sandbox.exceptions import SandboxPermissionError
 from deerflow.sandbox.local.list_dir import list_dir
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.search import GrepMatch, find_glob_matches, find_grep_matches
@@ -101,16 +102,35 @@ class LocalSandbox(Sandbox):
         Returns:
             Resolved local path
         """
-        path_str = str(path)
+        # Normalize the path to use forward slashes consistently
+        path_str = str(path).replace("\\", "/")
+        if not path_str.startswith("/"):
+            path_str = "/" + path_str
 
         # Try each mapping (longest prefix first for more specific matches)
         for mapping in sorted(self.path_mappings, key=lambda m: len(m.container_path), reverse=True):
-            container_path = mapping.container_path
-            local_path = mapping.local_path
+            container_path = mapping.container_path.rstrip("/")
+
             if path_str == container_path or path_str.startswith(container_path + "/"):
                 # Replace the container path prefix with local path
                 relative = path_str[len(container_path) :].lstrip("/")
-                resolved = str(Path(local_path) / relative) if relative else local_path
+
+                # Crucial: Use realpath to resolve all symlinks and relative path segments (..)
+                local_base = os.path.realpath(mapping.local_path).replace("\\", "/")
+                if relative:
+                    resolved = os.path.realpath(os.path.join(local_base, relative)).replace("\\", "/")
+                else:
+                    resolved = local_base
+
+                # Security Check: Ensure the resolved path does not escape the local_base directory
+                # We append "/" to both to prevent partial name matches (e.g. /workspace-hack bypassing /workspace)
+                if not (resolved + "/").startswith(local_base + "/"):
+                    raise SandboxPermissionError(
+                        f"Path '{path}' escapes sandbox boundary",
+                        path=path,
+                        operation="_resolve_path",
+                    )
+
                 return resolved
 
         # No mapping found, return original path

--- a/backend/tests/test_local_sandbox_provider_mounts.py
+++ b/backend/tests/test_local_sandbox_provider_mounts.py
@@ -1,9 +1,11 @@
 import errno
+import os
 from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
+from deerflow.sandbox.exceptions import SandboxPermissionError
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 from deerflow.sandbox.local.local_sandbox_provider import LocalSandboxProvider
 
@@ -29,7 +31,7 @@ class TestLocalSandboxPathResolution:
             ],
         )
         resolved = sandbox._resolve_path("/mnt/skills")
-        assert resolved == "/home/user/skills"
+        assert resolved.replace("\\", "/") == os.path.realpath("/home/user/skills").replace("\\", "/")
 
     def test_resolve_path_nested_path(self):
         sandbox = LocalSandbox(
@@ -39,7 +41,7 @@ class TestLocalSandboxPathResolution:
             ],
         )
         resolved = sandbox._resolve_path("/mnt/skills/agent/prompt.py")
-        assert resolved == "/home/user/skills/agent/prompt.py"
+        assert resolved.replace("\\", "/") == os.path.realpath("/home/user/skills/agent/prompt.py").replace("\\", "/")
 
     def test_resolve_path_no_mapping(self):
         sandbox = LocalSandbox(
@@ -61,7 +63,91 @@ class TestLocalSandboxPathResolution:
         )
         resolved = sandbox._resolve_path("/mnt/skills/file.py")
         # Should match /mnt/skills first (longer prefix)
-        assert resolved == "/home/user/skills/file.py"
+        assert resolved.replace("\\", "/") == os.path.realpath("/home/user/skills/file.py").replace("\\", "/")
+
+    def test_resolve_path_traversal_dot_dot(self):
+        sandbox = LocalSandbox(
+            "test",
+            [
+                PathMapping(container_path="/mnt/workspace", local_path="/tmp/sandbox/123"),
+            ],
+        )
+        # Attempt to escape via ../
+        with pytest.raises(SandboxPermissionError, match="escapes sandbox boundary"):
+            sandbox._resolve_path("/mnt/workspace/../../../etc/passwd")
+
+    def test_resolve_path_traversal_to_similar_name(self):
+        sandbox = LocalSandbox(
+            "test",
+            [
+                PathMapping(container_path="/mnt/workspace", local_path="/tmp/sandbox/workspace"),
+            ],
+        )
+        # Attempting to escape the sandbox directory (/tmp/sandbox/workspace)
+        # to a directory with a similar prefix (/tmp/sandbox/workspace-hack)
+        # using a path traversal sequence.
+        with pytest.raises(SandboxPermissionError, match="escapes sandbox boundary"):
+            sandbox._resolve_path("/mnt/workspace/../workspace-hack/file")
+
+    def test_resolve_path_symlink_escape(self, tmp_path):
+        # Setup a mock environment with a symlink
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+
+        secret_dir = tmp_path / "secrets"
+        secret_dir.mkdir()
+        (secret_dir / "passwd").write_text("secret")
+
+        # Create a symlink inside the workspace pointing outside
+        symlink_path = workspace_dir / "mylink"
+        try:
+            os.symlink(str(secret_dir), str(symlink_path))
+        except OSError:
+            pytest.skip("Symlinks not supported on this OS/filesystem")
+
+        sandbox = LocalSandbox(
+            "test",
+            [
+                PathMapping(container_path="/mnt/workspace", local_path=str(workspace_dir)),
+            ],
+        )
+
+        # Accessing the symlink should fail because its realpath escapes the workspace
+        with pytest.raises(SandboxPermissionError, match="escapes sandbox boundary"):
+            sandbox._resolve_path("/mnt/workspace/mylink/passwd")
+
+    def test_resolve_path_returns_realpath_result(self, tmp_path):
+        """Test that _resolve_path returns the same result as os.path.realpath."""
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+
+        sandbox = LocalSandbox(
+            "test",
+            [
+                PathMapping(container_path="/mnt/workspace", local_path=str(workspace_dir)),
+            ],
+        )
+
+        # Resolve a file inside the workspace
+        resolved = sandbox._resolve_path("/mnt/workspace/test.txt")
+
+        # The resolved path should match os.path.realpath behavior
+        expected_path = os.path.realpath(str(workspace_dir / "test.txt")).replace("\\", "/")
+        assert resolved == expected_path
+
+    def test_resolve_path_traversal_includes_context_in_exception(self):
+        """Test that SandboxPermissionError includes path and operation context."""
+        sandbox = LocalSandbox(
+            "test",
+            [PathMapping(container_path="/mnt/workspace", local_path="/tmp/workspace")],
+        )
+
+        with pytest.raises(SandboxPermissionError) as exc_info:
+            sandbox._resolve_path("/mnt/workspace/../etc/passwd")
+
+        assert exc_info.value.path == "/mnt/workspace/../etc/passwd"
+        assert exc_info.value.operation == "_resolve_path"
+        assert "escapes sandbox boundary" in str(exc_info.value)
 
     def test_reverse_resolve_path_exact_match(self, tmp_path):
         skills_dir = tmp_path / "skills"


### PR DESCRIPTION
## Description
This PR addresses a critical path traversal vulnerability in `LocalSandbox._resolve_path`.
Previously, path resolution relied solely on naive string prefix replacement. This allowed malicious or hallucinated LLM agents to escape the sandbox boundaries using relative traversal sequences (e.g., `../../../etc/passwd`) or symlink attacks.

## Changes
- **Path Normalization**: Introduced `os.path.realpath` to aggressively resolve all relative segments (`..`) and symbolic links to their absolute physical paths on the host.
- **Strict Boundary Assertion**: Added a robust suffix-aware check (`(resolved + "/").startswith(local_base + "/")`) to mathematically guarantee the resolved path remains within the isolated local directory. This also prevents partial-name match bypasses (e.g., preventing access to `/workspace-hack` when only `/workspace` is mounted).
- **Cross-Platform Consistency**: Enforced `/` as the universal path separator during resolution to prevent security check failures on Windows machines.
- **Contract Adherence**: Standardized the error handling by raising the domain-specific `SandboxPermissionError`, preserving the original container path in the exception context to prevent physical path disclosure to the LLM.

## Testing
Added 5 rigorous security test cases in `test_local_sandbox_provider_mounts.py` to prove the fix:
1. `test_resolve_path_returns_realpath_result`: Ensures standard resolution aligns with OS realpath behavior.
2. `test_resolve_path_traversal_dot_dot`: Blocks standard `../` traversal attempts.
3. `test_resolve_path_traversal_to_similar_name`: Blocks traversal to sibling directories with similar prefix names.
4. `test_resolve_path_symlink_escape`: Blocks attempts to escape via malicious symlinks created inside the workspace (with cross-platform skip logic).
5. `test_resolve_path_traversal_includes_context_in_exception`: Verifies that boundary escape exceptions properly populate the structured `path` and `operation` details.