### PR TITLE
fix: disable custom-agent management API by default

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -8,6 +8,7 @@ import yaml
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from deerflow.config.agents_api_config import get_agents_api_config
 from deerflow.config.agents_config import AgentConfig, list_custom_agents, load_agent_config, load_agent_soul
 from deerflow.config.paths import get_paths
 
@@ -73,6 +74,18 @@ def _normalize_agent_name(name: str) -> str:
     return name.lower()
 
 
+def _require_agents_api_enabled() -> None:
+    """Reject access unless the custom-agent management API is explicitly enabled."""
+    if not get_agents_api_config().enabled:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Custom-agent management API is disabled. "
+                "Set agents_api.enabled=true to expose agent and user-profile routes over HTTP."
+            ),
+        )
+
+
 def _agent_config_to_response(agent_cfg: AgentConfig, include_soul: bool = False) -> AgentResponse:
     """Convert AgentConfig to AgentResponse."""
     soul: str | None = None
@@ -100,6 +113,8 @@ async def list_agents() -> AgentsListResponse:
     Returns:
         List of all custom agents with their metadata and soul content.
     """
+    _require_agents_api_enabled()
+
     try:
         agents = list_custom_agents()
         return AgentsListResponse(agents=[_agent_config_to_response(a, include_soul=True) for a in agents])
@@ -125,6 +140,7 @@ async def check_agent_name(name: str) -> dict:
     Raises:
         HTTPException: 422 if the name is invalid.
     """
+    _require_agents_api_enabled()
     _validate_agent_name(name)
     normalized = _normalize_agent_name(name)
     available = not get_paths().agent_dir(normalized).exists()
@@ -149,6 +165,7 @@ async def get_agent(name: str) -> AgentResponse:
     Raises:
         HTTPException: 404 if agent not found.
     """
+    _require_agents_api_enabled()
     _validate_agent_name(name)
     name = _normalize_agent_name(name)
 
@@ -181,6 +198,7 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
     Raises:
         HTTPException: 409 if agent already exists, 422 if name is invalid.
     """
+    _require_agents_api_enabled()
     _validate_agent_name(request.name)
     normalized_name = _normalize_agent_name(request.name)
 
@@ -243,6 +261,7 @@ async def update_agent(name: str, request: AgentUpdateRequest) -> AgentResponse:
     Raises:
         HTTPException: 404 if agent not found.
     """
+    _require_agents_api_enabled()
     _validate_agent_name(name)
     name = _normalize_agent_name(name)
 
@@ -315,6 +334,8 @@ async def get_user_profile() -> UserProfileResponse:
     Returns:
         UserProfileResponse with content=None if USER.md does not exist yet.
     """
+    _require_agents_api_enabled()
+
     try:
         user_md_path = get_paths().user_md_file
         if not user_md_path.exists():
@@ -341,6 +362,8 @@ async def update_user_profile(request: UserProfileUpdateRequest) -> UserProfileR
     Returns:
         UserProfileResponse with the saved content.
     """
+    _require_agents_api_enabled()
+
     try:
         paths = get_paths()
         paths.base_dir.mkdir(parents=True, exist_ok=True)
@@ -367,6 +390,7 @@ async def delete_agent(name: str) -> None:
     Raises:
         HTTPException: 404 if agent not found.
     """
+    _require_agents_api_enabled()
     _validate_agent_name(name)
     name = _normalize_agent_name(name)
 

--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -79,10 +79,7 @@ def _require_agents_api_enabled() -> None:
     if not get_agents_api_config().enabled:
         raise HTTPException(
             status_code=403,
-            detail=(
-                "Custom-agent management API is disabled. "
-                "Set agents_api.enabled=true to expose agent and user-profile routes over HTTP."
-            ),
+            detail=("Custom-agent management API is disabled. Set agents_api.enabled=true to expose agent and user-profile routes over HTTP."),
         )
 
 

--- a/backend/packages/harness/deerflow/config/agents_api_config.py
+++ b/backend/packages/harness/deerflow/config/agents_api_config.py
@@ -8,11 +8,7 @@ class AgentsApiConfig(BaseModel):
 
     enabled: bool = Field(
         default=False,
-        description=(
-            "Whether to expose the custom-agent management API over HTTP. "
-            "When disabled, the gateway rejects read/write access to custom agent "
-            "SOUL.md, config, and USER.md prompt-management routes."
-        ),
+        description=("Whether to expose the custom-agent management API over HTTP. When disabled, the gateway rejects read/write access to custom agent SOUL.md, config, and USER.md prompt-management routes."),
     )
 
 

--- a/backend/packages/harness/deerflow/config/agents_api_config.py
+++ b/backend/packages/harness/deerflow/config/agents_api_config.py
@@ -1,0 +1,36 @@
+"""Configuration for the custom agents management API."""
+
+from pydantic import BaseModel, Field
+
+
+class AgentsApiConfig(BaseModel):
+    """Configuration for custom-agent and user-profile management routes."""
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to expose the custom-agent management API over HTTP. "
+            "When disabled, the gateway rejects read/write access to custom agent "
+            "SOUL.md, config, and USER.md prompt-management routes."
+        ),
+    )
+
+
+_agents_api_config: AgentsApiConfig = AgentsApiConfig()
+
+
+def get_agents_api_config() -> AgentsApiConfig:
+    """Get the current agents API configuration."""
+    return _agents_api_config
+
+
+def set_agents_api_config(config: AgentsApiConfig) -> None:
+    """Set the agents API configuration."""
+    global _agents_api_config
+    _agents_api_config = config
+
+
+def load_agents_api_config_from_dict(config_dict: dict) -> None:
+    """Load agents API configuration from a dictionary."""
+    global _agents_api_config
+    _agents_api_config = AgentsApiConfig(**config_dict)

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, ConfigDict, Field
 
 from deerflow.config.acp_config import load_acp_config_from_dict
+from deerflow.config.agents_api_config import AgentsApiConfig, load_agents_api_config_from_dict
 from deerflow.config.checkpointer_config import CheckpointerConfig, load_checkpointer_config_from_dict
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_config_from_dict
@@ -60,6 +61,7 @@ class AppConfig(BaseModel):
     title: TitleConfig = Field(default_factory=TitleConfig, description="Automatic title generation configuration")
     summarization: SummarizationConfig = Field(default_factory=SummarizationConfig, description="Conversation summarization configuration")
     memory: MemoryConfig = Field(default_factory=MemoryConfig, description="Memory subsystem configuration")
+    agents_api: AgentsApiConfig = Field(default_factory=AgentsApiConfig, description="Custom-agent management API configuration")
     subagents: SubagentsAppConfig = Field(default_factory=SubagentsAppConfig, description="Subagent runtime configuration")
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig, description="Guardrail middleware configuration")
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig, description="LLM circuit breaker configuration")
@@ -124,6 +126,10 @@ class AppConfig(BaseModel):
         # Load memory config if present
         if "memory" in config_data:
             load_memory_config_from_dict(config_data["memory"])
+
+        # Load agents API config if present
+        if "agents_api" in config_data:
+            load_agents_api_config_from_dict(config_data["agents_api"])
 
         # Load subagents config if present
         if "subagents" in config_data:

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -127,9 +127,9 @@ class AppConfig(BaseModel):
         if "memory" in config_data:
             load_memory_config_from_dict(config_data["memory"])
 
-        # Load agents API config if present
-        if "agents_api" in config_data:
-            load_agents_api_config_from_dict(config_data["agents_api"])
+        # Always refresh agents API config so removed config sections reset
+        # singleton-backed state to its default/disabled values on reload.
+        load_agents_api_config_from_dict(config_data.get("agents_api") or {})
 
         # Load subagents config if present
         if "subagents" in config_data:

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import yaml
 
+from deerflow.config.agents_api_config import get_agents_api_config
 from deerflow.config.app_config import get_app_config, reset_app_config
 
 
@@ -26,6 +27,30 @@ def _write_config(path: Path, *, model_name: str, supports_thinking: bool) -> No
         ),
         encoding="utf-8",
     )
+
+
+def _write_config_with_agents_api(
+    path: Path,
+    *,
+    model_name: str,
+    supports_thinking: bool,
+    agents_api: dict | None = None,
+) -> None:
+    config = {
+        "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+        "models": [
+            {
+                "name": model_name,
+                "use": "langchain_openai:ChatOpenAI",
+                "model": "gpt-test",
+                "supports_thinking": supports_thinking,
+            }
+        ],
+    }
+    if agents_api is not None:
+        config["agents_api"] = agents_api
+
+    path.write_text(yaml.safe_dump(config), encoding="utf-8")
 
 
 def _write_extensions_config(path: Path) -> None:
@@ -77,5 +102,40 @@ def test_get_app_config_reloads_when_config_path_changes(tmp_path, monkeypatch):
         second = get_app_config()
         assert second.models[0].name == "model-b"
         assert second is not first
+    finally:
+        reset_app_config()
+
+
+def test_get_app_config_resets_agents_api_config_when_section_removed(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    _write_config_with_agents_api(
+        config_path,
+        model_name="first-model",
+        supports_thinking=False,
+        agents_api={"enabled": True},
+    )
+
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+    reset_app_config()
+
+    try:
+        initial = get_app_config()
+        assert initial.models[0].name == "first-model"
+        assert get_agents_api_config().enabled is True
+
+        _write_config_with_agents_api(
+            config_path,
+            model_name="first-model",
+            supports_thinking=False,
+        )
+        next_mtime = config_path.stat().st_mtime + 5
+        os.utime(config_path, (next_mtime, next_mtime))
+
+        reloaded = get_app_config()
+        assert reloaded is not initial
+        assert get_agents_api_config().enabled is False
     finally:
         reset_app_config()

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -598,8 +598,20 @@ class TestAgentsApiDisabled:
         response = disabled_agent_client.get("/api/agents/example-agent")
         assert response.status_code == 403
 
+    def test_agent_name_check_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.get("/api/agents/check", params={"name": "example-agent"})
+        assert response.status_code == 403
+
     def test_agent_create_returns_403(self, disabled_agent_client):
         response = disabled_agent_client.post("/api/agents", json={"name": "example-agent", "soul": "blocked"})
+        assert response.status_code == 403
+
+    def test_agent_update_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.put("/api/agents/example-agent", json={"description": "blocked"})
+        assert response.status_code == 403
+
+    def test_agent_delete_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.delete("/api/agents/example-agent")
         assert response.status_code == 403
 
     def test_user_profile_routes_return_403(self, disabled_agent_client):

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -396,12 +396,13 @@ def agent_client(tmp_path):
 
     with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch.object(agents_router, "get_paths", return_value=paths_instance):
         set_agents_api_config(AgentsApiConfig(enabled=True))
-        app = _make_test_app(tmp_path)
-        with TestClient(app) as client:
-            client._tmp_path = tmp_path  # type: ignore[attr-defined]
-            yield client
-
-    set_agents_api_config(previous_config)
+        try:
+            app = _make_test_app(tmp_path)
+            with TestClient(app) as client:
+                client._tmp_path = tmp_path  # type: ignore[attr-defined]
+                yield client
+        finally:
+            set_agents_api_config(previous_config)
 
 
 @pytest.fixture()
@@ -414,11 +415,12 @@ def disabled_agent_client(tmp_path):
 
     with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch.object(agents_router, "get_paths", return_value=paths_instance):
         set_agents_api_config(AgentsApiConfig(enabled=False))
-        app = _make_test_app(tmp_path)
-        with TestClient(app) as client:
-            yield client
-
-    set_agents_api_config(previous_config)
+        try:
+            app = _make_test_app(tmp_path)
+            with TestClient(app) as client:
+                yield client
+        finally:
+            set_agents_api_config(previous_config)
 
 
 class TestAgentsAPI:

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -9,6 +9,8 @@ import pytest
 import yaml
 from fastapi.testclient import TestClient
 
+from deerflow.config.agents_api_config import AgentsApiConfig, get_agents_api_config, set_agents_api_config
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -387,13 +389,36 @@ def _make_test_app(tmp_path: Path):
 @pytest.fixture()
 def agent_client(tmp_path):
     """TestClient with agents router, using tmp_path as base_dir."""
-    paths_instance = _make_paths(tmp_path)
+    import app.gateway.routers.agents as agents_router
 
-    with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch("app.gateway.routers.agents.get_paths", return_value=paths_instance):
+    paths_instance = _make_paths(tmp_path)
+    previous_config = AgentsApiConfig(**get_agents_api_config().model_dump())
+
+    with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch.object(agents_router, "get_paths", return_value=paths_instance):
+        set_agents_api_config(AgentsApiConfig(enabled=True))
         app = _make_test_app(tmp_path)
         with TestClient(app) as client:
             client._tmp_path = tmp_path  # type: ignore[attr-defined]
             yield client
+
+    set_agents_api_config(previous_config)
+
+
+@pytest.fixture()
+def disabled_agent_client(tmp_path):
+    """TestClient with agents router while the management API is disabled."""
+    import app.gateway.routers.agents as agents_router
+
+    paths_instance = _make_paths(tmp_path)
+    previous_config = AgentsApiConfig(**get_agents_api_config().model_dump())
+
+    with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch.object(agents_router, "get_paths", return_value=paths_instance):
+        set_agents_api_config(AgentsApiConfig(enabled=False))
+        app = _make_test_app(tmp_path)
+        with TestClient(app) as client:
+            yield client
+
+    set_agents_api_config(previous_config)
 
 
 class TestAgentsAPI:
@@ -559,3 +584,25 @@ class TestUserProfileAPI:
         response = agent_client.put("/api/user-profile", json={"content": ""})
         assert response.status_code == 200
         assert response.json()["content"] is None
+
+
+class TestAgentsApiDisabled:
+    def test_agents_list_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.get("/api/agents")
+        assert response.status_code == 403
+        assert "agents_api.enabled=true" in response.json()["detail"]
+
+    def test_agent_get_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.get("/api/agents/example-agent")
+        assert response.status_code == 403
+
+    def test_agent_create_returns_403(self, disabled_agent_client):
+        response = disabled_agent_client.post("/api/agents", json={"name": "example-agent", "soul": "blocked"})
+        assert response.status_code == 403
+
+    def test_user_profile_routes_return_403(self, disabled_agent_client):
+        get_response = disabled_agent_client.get("/api/user-profile")
+        put_response = disabled_agent_client.put("/api/user-profile", json={"content": "blocked"})
+
+        assert get_response.status_code == 403
+        assert put_response.status_code == 403

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 6
+config_version: 7
 
 # ============================================================================
 # Logging
@@ -707,6 +707,14 @@ memory:
   fact_confidence_threshold: 0.7 # Minimum confidence for storing facts
   injection_enabled: true # Whether to inject memory into system prompt
   max_injection_tokens: 2000 # Maximum tokens for memory injection
+
+# ============================================================================
+# Custom Agent Management API
+# ============================================================================
+# Controls whether the HTTP gateway exposes custom-agent SOUL/USER.md management.
+# Keep this disabled unless the gateway is behind a trusted authenticated admin boundary.
+agents_api:
+  enabled: false
 
 # ============================================================================
 # Skill Self-Evolution Configuration


### PR DESCRIPTION
## Summary
This PR hardens DeerFlow's custom-agent management surface by making remote agent-management an explicit opt-in instead of an exposed default.

- adds a new `agents_api.enabled` config gate that defaults to `false`
- blocks unauthenticated access to `/api/agents/*` and `/api/user-profile` unless an operator explicitly opts in
- preserves existing custom-agent and USER.md management behavior for trusted deployments that intentionally enable the route family
- adds regression coverage for both the enabled and disabled states

## Security issues covered

| issue | impact | severity |
| --- | --- | --- |
| Unauthenticated custom-agent disclosure through `/api/agents` and `/api/agents/{name}` | Exposes full `SOUL.md` content and agent metadata over HTTP | High |
| Unauthenticated custom-agent overwrite through `/api/agents` and `/api/agents/{name}` | Allows persistent prompt poisoning of future custom-agent runs | Critical |
| Unauthenticated global `USER.md` disclosure/overwrite through `/api/user-profile` | Exposes and rewrites prompt context injected into all custom agents | High |

## Before this PR

- the gateway mounted `/api/agents` and `/api/user-profile` with no authenticated admin boundary
- `GET /api/agents` and `GET /api/agents/{name}` returned full `SOUL.md` content
- `POST`, `PUT`, and `DELETE` on `/api/agents` modified agent config and `SOUL.md` on disk over HTTP
- `GET` and `PUT` on `/api/user-profile` exposed and rewrote global `USER.md` prompt context over HTTP

## After this PR

- the custom-agent management API is disabled by default via `agents_api.enabled: false`
- `/api/agents/*` and `/api/user-profile` return `403` unless the operator explicitly enables the route family
- trusted/self-managed deployments can still opt in to the existing behavior when they intentionally want remote agent management
- regression tests cover both the enabled and disabled states

## Explicit operator choice

This PR is intentionally opt-in.

Default secure setting:

```yaml
agents_api:
  enabled: false
```

If a trusted operator explicitly wants remote custom-agent management, they can enable it:

```yaml
agents_api:
  enabled: true
```

Behavior summary:

- `enabled: false`
  - `/api/agents/*` returns `403`
  - `/api/user-profile` returns `403`
  - remote SOUL/USER prompt management is disabled by default
- `enabled: true`
  - existing remote management behavior is restored
  - operators can manage custom agents and USER.md over HTTP in deployments where that is intentional and protected by other controls

## Why this matters

`SOUL.md` and `USER.md` are not cosmetic files. DeerFlow loads them as prompt context for future custom-agent runs, so unauthenticated read/write access creates both a confidentiality problem and a persistent integrity problem.

A remote client that can overwrite these files can silently change how custom agents behave in future conversations.

## Attack flow

```text
unauthenticated HTTP request
    -> /api/agents or /api/user-profile
        -> read/write SOUL.md, config.yaml, or USER.md on disk
            -> secret disclosure or persistent prompt poisoning of future custom-agent runs
```

## Affected code

| area | files |
| --- | --- |
| unauthenticated custom-agent HTTP management | `backend/app/gateway/routers/agents.py` |
| prompt-loading of custom agent SOUL content | `backend/packages/harness/deerflow/config/agents_config.py` |
| global config wiring for secure default | `backend/packages/harness/deerflow/config/app_config.py`, `backend/packages/harness/deerflow/config/agents_api_config.py`, `config.example.yaml` |
| regression coverage | `backend/tests/test_custom_agent.py` |

## Root cause

- the gateway exposed custom-agent management routes without an authenticated admin boundary
- those routes directly loaded and rewrote `SOUL.md`, `config.yaml`, and `USER.md` on disk
- DeerFlow later consumed that disk state as prompt context for future agent runs
- the management surface therefore acted as a remote prompt-disclosure and prompt-poisoning primitive rather than a local-only configuration convenience

## CVSS assessment

| issue | CVSS v3.1 | vector |
| --- | --- | --- |
| unauthenticated SOUL/USER prompt disclosure and overwrite | 9.1 Critical | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N` |

Rationale:
- `AV:N`: reachable over HTTP where the gateway is exposed
- `AC:L`: no race or special precondition beyond reachability
- `PR:N`: no authentication required on the vulnerable default path before this PR
- `UI:N`: no victim interaction required
- `C:H`: `SOUL.md` and `USER.md` can contain sensitive instructions, secrets, or operating context
- `I:H`: attackers can persistently modify prompt context that is later consumed by custom-agent runs
- `A:N`: this score stays conservative and does not rely on service disruption

## Safe reproduction steps

1. Start DeerFlow on a build before this patch.
2. Create a benign custom agent whose `SOUL.md` contains a visible marker.
3. Call `GET /api/agents` or `GET /api/agents/{name}` and observe that the marker is returned over HTTP.
4. Call `PUT /api/agents/{name}` with a benign replacement `soul` value.
5. Observe that `SOUL.md` on disk changes and that subsequent reads return the attacker-controlled replacement.
6. Call `GET /api/user-profile` and `PUT /api/user-profile` to observe equivalent disclosure/overwrite of global `USER.md` prompt context.

## Expected vulnerable behavior

- agent SOUL content is returned over unauthenticated HTTP
- agent SOUL content can be overwritten over unauthenticated HTTP
- global `USER.md` prompt context is returned and rewritten over unauthenticated HTTP
- future custom-agent runs consume the modified disk-backed prompt context

## Changes in this PR

- add `AgentsApiConfig` with secure default `enabled = false`
- load `agents_api` from app config
- gate `/api/agents/*` and `/api/user-profile` behind `agents_api.enabled`
- return a stable `403` response with an explicit operator message when the API is disabled
- document the new config in `config.example.yaml`
- add regression tests proving both the enabled path and the secure-default disabled path

## Files changed

| category | files | change |
| --- | --- | --- |
| route hardening | `backend/app/gateway/routers/agents.py` | add secure-default gate for all custom-agent and user-profile HTTP routes |
| config schema | `backend/packages/harness/deerflow/config/agents_api_config.py` | new config model for route exposure |
| config loading | `backend/packages/harness/deerflow/config/app_config.py` | wire `agents_api` into app config loading |
| operator docs | `config.example.yaml` | document `agents_api.enabled: false` and bump config version |
| tests | `backend/tests/test_custom_agent.py` | add disabled-state regression coverage |

## Maintainer impact

- narrow patch: only the custom-agent and user-profile management HTTP surface changes
- no change to prompt-loading semantics for trusted deployments that explicitly enable the API
- operators who truly need remote agent management can opt in explicitly instead of inheriting an exposed default
- the new config gate makes the security boundary easier to audit and harder to regress accidentally

## Fix rationale

The secure default should be to keep prompt-management routes closed unless an operator intentionally exposes them behind a trusted admin boundary. This patch preserves existing functionality for trusted/self-hosted environments while removing the risky default exposure.

## Reference patterns / best practice

This follows the same general secure-by-default pattern used in other systems that separate dangerous management capabilities from ordinary runtime behavior:

- GitHub Actions fork workflow protections
  - privileged workflow execution is not granted by default for untrusted fork input
- GitLab protected variables / protected runners
  - sensitive execution paths are restricted unless explicitly allowed
- Kubernetes RBAC
  - administrative capabilities should be explicitly granted, not implicitly available
- Keycloak fine-grained admin permissions
  - management actions are modeled as explicit privileged operations

The principle here is the same:
- prompt-management endpoints are privileged control-plane actions
- they should be disabled by default or placed behind an explicit authorization boundary
- trusted operators can opt in deliberately when their deployment model requires it

## Type of change

- [x] Security fix
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update only

## Test plan

- [x] Run targeted regression tests for custom-agent and user-profile routes
- [x] Verify disabled-state regressions return `403`

Executed:

```bash
cd backend
source .venv/bin/activate
PYTHONPATH=.:packages/harness python -m pytest tests/test_custom_agent.py -q
```

Result:

`51 passed`

## Disclosure notes

- I did not find a public DeerFlow issue/PR specifically covering unauthenticated `/api/agents` plus `/api/user-profile` disclosure/overwrite of `SOUL.md` and `USER.md`
- related public work exists for other unauthenticated management surfaces, including MCP and memory routes, but this patch addresses a distinct prompt-management surface
- claims in this PR are bounded to reviewed code paths and reproduced route behavior
