### PR TITLE
chore(frontend):Allow file-only chat uploads

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -46,7 +46,7 @@ export default function AgentChatPage() {
   const [settings, setSettings] = useThreadSettings(threadId);
 
   const { showNotification } = useNotification();
-  const [thread, sendMessage] = useThreadStream({
+  const [thread, sendMessage, isUploading] = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
     context: { ...settings.context, agent_name: agent_name },
     onStart: (createdThreadId) => {
@@ -78,8 +78,8 @@ export default function AgentChatPage() {
   });
 
   const handleSubmit = useCallback(
-    (message: PromptInputMessage) => {
-      void sendMessage(threadId, message, { agent_name });
+    async (message: PromptInputMessage) => {
+      await sendMessage(threadId, message, { agent_name });
     },
     [sendMessage, threadId, agent_name],
   );
@@ -184,7 +184,10 @@ export default function AgentChatPage() {
                       <AgentWelcome agent={agent} agentName={agent_name} />
                     )
                   }
-                  disabled={env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true"}
+                  disabled={
+                    env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
+                    isUploading
+                  }
                   onContextChange={(context) => setSettings("context", context)}
                   onFollowupsVisibilityChange={setShowFollowups}
                   onSubmit={handleSubmit}

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -73,8 +73,8 @@ export default function ChatPage() {
   });
 
   const handleSubmit = useCallback(
-    (message: PromptInputMessage) => {
-      void sendMessage(threadId, message);
+    async (message: PromptInputMessage) => {
+      await sendMessage(threadId, message);
     },
     [sendMessage, threadId],
   );

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -271,9 +271,10 @@ export function InputBox({
             selectedModel?.supports_thinking ?? false,
           ),
         });
-        setTimeout(() => {
-          void onSubmit?.(message);
-        }, 0);
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
+        await onSubmit?.(message);
         return;
       }
 

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -138,7 +138,7 @@ export function InputBox({
     },
   ) => void;
   onFollowupsVisibilityChange?: (visible: boolean) => void;
-  onSubmit?: (message: PromptInputMessage) => void;
+  onSubmit?: (message: PromptInputMessage) => void | Promise<void>;
   onStop?: () => void;
 }) {
   const { t } = useI18n();
@@ -251,7 +251,9 @@ export function InputBox({
         onStop?.();
         return;
       }
-      if (!message.text) {
+      const hasText = message.text.trim().length > 0;
+      const hasFiles = message.files.length > 0;
+      if (!hasText && !hasFiles) {
         return;
       }
       setFollowups([]);
@@ -269,11 +271,13 @@ export function InputBox({
             selectedModel?.supports_thinking ?? false,
           ),
         });
-        setTimeout(() => onSubmit?.(message), 0);
+        setTimeout(() => {
+          void onSubmit?.(message);
+        }, 0);
         return;
       }
 
-      onSubmit?.(message);
+      await onSubmit?.(message);
     },
     [
       context,


### PR DESCRIPTION
## Summary

- Allow workspace chat submissions that contain attachments but no text.
- Await async submit handlers so upload failures leave the composer retryable instead of clearing state too early.
- Apply upload busy-state protection to the agent chat page as well as the main chat page.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint 'src/components/workspace/input-box.tsx' 'src/app/workspace/chats/[thread_id]/page.tsx' 'src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx'`
- `pnpm exec prettier --check 'src/components/workspace/input-box.tsx' 'src/app/workspace/chats/[thread_id]/page.tsx' 'src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx'`
