### PR TITLE
fix(middleware): fix present_files thread id fallback

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 from langchain.tools import InjectedToolCallId, ToolRuntime, tool
 from langchain_core.messages import ToolMessage
+from langgraph.config import get_config
 from langgraph.types import Command
 from langgraph.typing import ContextT
 
@@ -10,6 +11,18 @@ from deerflow.agents.thread_state import ThreadState
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX, get_paths
 
 OUTPUTS_VIRTUAL_PREFIX = f"{VIRTUAL_PATH_PREFIX}/outputs"
+
+
+def _get_thread_id(runtime: ToolRuntime[ContextT, ThreadState]) -> str | None:
+    """Resolve the current thread id from runtime context or RunnableConfig."""
+    thread_id = runtime.context.get("thread_id") if runtime.context else None
+    if thread_id:
+        return thread_id
+
+    try:
+        return get_config().get("configurable", {}).get("thread_id")
+    except RuntimeError:
+        return None
 
 
 def _normalize_presented_filepath(
@@ -33,7 +46,7 @@ def _normalize_presented_filepath(
     if runtime.state is None:
         raise ValueError("Thread runtime state is not available")
 
-    thread_id = runtime.context.get("thread_id") if runtime.context else None
+    thread_id = _get_thread_id(runtime)
     if not thread_id:
         raise ValueError("Thread ID is not available in runtime context")
 

--- a/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
@@ -19,6 +19,11 @@ def _get_thread_id(runtime: ToolRuntime[ContextT, ThreadState]) -> str | None:
     if thread_id:
         return thread_id
 
+    runtime_config = getattr(runtime, "config", None) or {}
+    thread_id = runtime_config.get("configurable", {}).get("thread_id")
+    if thread_id:
+        return thread_id
+
     try:
         return get_config().get("configurable", {}).get("thread_id")
     except RuntimeError:
@@ -48,7 +53,7 @@ def _normalize_presented_filepath(
 
     thread_id = _get_thread_id(runtime)
     if not thread_id:
-        raise ValueError("Thread ID is not available in runtime context")
+        raise ValueError("Thread ID is not available in runtime context or runtime config")
 
     thread_data = runtime.state.get("thread_data") or {}
     outputs_path = thread_data.get("outputs_path")

--- a/backend/tests/test_present_file_tool_core_logic.py
+++ b/backend/tests/test_present_file_tool_core_logic.py
@@ -50,6 +50,38 @@ def test_present_files_keeps_virtual_outputs_path(tmp_path, monkeypatch):
     assert result.update["artifacts"] == ["/mnt/user-data/outputs/summary.json"]
 
 
+def test_present_files_uses_config_thread_id_when_context_missing(tmp_path, monkeypatch):
+    outputs_dir = tmp_path / "threads" / "thread-from-config" / "user-data" / "outputs"
+    outputs_dir.mkdir(parents=True)
+    artifact_path = outputs_dir / "summary.json"
+    artifact_path.write_text("{}")
+
+    monkeypatch.setattr(
+        present_file_tool_module,
+        "get_config",
+        lambda: {"configurable": {"thread_id": "thread-from-config"}},
+    )
+    monkeypatch.setattr(
+        present_file_tool_module,
+        "get_paths",
+        lambda: SimpleNamespace(resolve_virtual_path=lambda thread_id, path: artifact_path),
+    )
+
+    runtime = SimpleNamespace(
+        state={"thread_data": {"outputs_path": str(outputs_dir)}},
+        context={},
+    )
+
+    result = present_file_tool_module.present_file_tool.func(
+        runtime=runtime,
+        filepaths=["/mnt/user-data/outputs/summary.json"],
+        tool_call_id="tc-config",
+    )
+
+    assert result.update["artifacts"] == ["/mnt/user-data/outputs/summary.json"]
+    assert result.update["messages"][0].content == "Successfully presented files"
+
+
 def test_present_files_rejects_paths_outside_outputs(tmp_path):
     outputs_dir = tmp_path / "threads" / "thread-1" / "user-data" / "outputs"
     workspace_dir = tmp_path / "threads" / "thread-1" / "user-data" / "workspace"

--- a/backend/tests/test_present_file_tool_core_logic.py
+++ b/backend/tests/test_present_file_tool_core_logic.py
@@ -10,6 +10,7 @@ def _make_runtime(outputs_path: str) -> SimpleNamespace:
     return SimpleNamespace(
         state={"thread_data": {"outputs_path": outputs_path}},
         context={"thread_id": "thread-1"},
+        config={},
     )
 
 
@@ -58,11 +59,6 @@ def test_present_files_uses_config_thread_id_when_context_missing(tmp_path, monk
 
     monkeypatch.setattr(
         present_file_tool_module,
-        "get_config",
-        lambda: {"configurable": {"thread_id": "thread-from-config"}},
-    )
-    monkeypatch.setattr(
-        present_file_tool_module,
         "get_paths",
         lambda: SimpleNamespace(resolve_virtual_path=lambda thread_id, path: artifact_path),
     )
@@ -70,6 +66,7 @@ def test_present_files_uses_config_thread_id_when_context_missing(tmp_path, monk
     runtime = SimpleNamespace(
         state={"thread_data": {"outputs_path": str(outputs_dir)}},
         context={},
+        config={"configurable": {"thread_id": "thread-from-config"}},
     )
 
     result = present_file_tool_module.present_file_tool.func(


### PR DESCRIPTION
## Summary

- Fix `present_files` so it can resolve `thread_id` from LangGraph runnable config when `ToolRuntime.context` is empty
- Match the fallback behavior already used by `ThreadDataMiddleware`
- Add regression coverage for the LangGraph Server / LangSmith execution path

Fixes #2180

## Why

When running DeerFlow with `backend/make dev` and sending a request from LangSmith, `thread_id` may be available as `configurable.thread_id` but not in `ToolRuntime.context`.

Before this change, `present_files` only checked `runtime.context["thread_id"]`, so it could fail with:

```text
Error: Thread ID is not available in runtime context
```

This could happen even after the requested file had already been written to `/mnt/user-data/outputs/...`.

## Testing

```shell
uv run pytest tests/test_present_file_tool_core_logic.py -q
uv run ruff check packages/harness/deerflow/tools/builtins/present_file_tool.py tests/test_present_file_tool_core_logic.py
```
