### PR TITLE
Fix Windows pnpm detection and settings API proxy

### DIFF
--- a/backend/tests/test_check_script.py
+++ b/backend/tests/test_check_script.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_SCRIPT_PATH = REPO_ROOT / "scripts" / "check.py"
+
+
+spec = importlib.util.spec_from_file_location("deerflow_check_script", CHECK_SCRIPT_PATH)
+assert spec is not None
+assert spec.loader is not None
+check_script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_script)
+
+
+def test_find_pnpm_command_prefers_resolved_executable(monkeypatch):
+    def fake_which(name: str) -> str | None:
+        if name == "pnpm":
+            return r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"
+        if name == "pnpm.cmd":
+            return r"C:\Users\tester\AppData\Roaming\npm\pnpm.cmd"
+        return None
+
+    monkeypatch.setattr(check_script.shutil, "which", fake_which)
+
+    assert check_script.find_pnpm_command() == [
+        r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"
+    ]
+
+
+def test_find_pnpm_command_falls_back_to_corepack(monkeypatch):
+    def fake_which(name: str) -> str | None:
+        if name == "corepack":
+            return r"C:\Program Files\nodejs\corepack.exe"
+        return None
+
+    monkeypatch.setattr(check_script.shutil, "which", fake_which)
+
+    assert check_script.find_pnpm_command() == ["corepack", "pnpm"]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -14,6 +14,17 @@ import nextra from "nextra";
 
 const withNextra = nextra({});
 
+const gatewayRoutePrefixes = [
+  "agents",
+  "assistants",
+  "channels",
+  "mcp",
+  "models",
+  "runs",
+  "skills",
+  "threads",
+];
+
 /** @type {import("next").NextConfig} */
 const config = {
   i18n: {
@@ -44,14 +55,16 @@ const config = {
     }
 
     if (!process.env.NEXT_PUBLIC_BACKEND_BASE_URL) {
-      rewrites.push({
-        source: "/api/agents",
-        destination: `${gatewayURL}/api/agents`,
-      });
-      rewrites.push({
-        source: "/api/agents/:path*",
-        destination: `${gatewayURL}/api/agents/:path*`,
-      });
+      for (const prefix of gatewayRoutePrefixes) {
+        rewrites.push({
+          source: `/api/${prefix}`,
+          destination: `${gatewayURL}/api/${prefix}`,
+        });
+        rewrites.push({
+          source: `/api/${prefix}/:path*`,
+          destination: `${gatewayURL}/api/${prefix}/:path*`,
+        });
+      }
     }
 
     return rewrites;

--- a/frontend/src/app/api/mcp/[...path]/route.ts
+++ b/frontend/src/app/api/mcp/[...path]/route.ts
@@ -1,0 +1,21 @@
+import type { NextRequest } from "next/server";
+
+import { proxyRequest } from "../../proxy";
+
+function resolvePath(path: string[]) {
+  return `/api/mcp/${path.join("/")}`;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}

--- a/frontend/src/app/api/proxy.ts
+++ b/frontend/src/app/api/proxy.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from "next/server";
+
+const BACKEND_BASE_URL =
+  process.env.NEXT_PUBLIC_BACKEND_BASE_URL ?? "http://127.0.0.1:8001";
+
+function buildBackendUrl(pathname: string) {
+  return new URL(pathname, BACKEND_BASE_URL);
+}
+
+export async function proxyRequest(request: NextRequest, pathname: string) {
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.delete("connection");
+  headers.delete("content-length");
+
+  const hasBody = !["GET", "HEAD"].includes(request.method);
+  const response = await fetch(buildBackendUrl(pathname), {
+    method: request.method,
+    headers,
+    body: hasBody ? await request.arrayBuffer() : undefined,
+  });
+
+  return new Response(await response.arrayBuffer(), {
+    status: response.status,
+    headers: response.headers,
+  });
+}

--- a/frontend/src/app/api/skills/[...path]/route.ts
+++ b/frontend/src/app/api/skills/[...path]/route.ts
@@ -1,0 +1,35 @@
+import type { NextRequest } from "next/server";
+
+import { proxyRequest } from "../../proxy";
+
+function resolvePath(path: string[]) {
+  return `/api/skills/${path.join("/")}`;
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  return proxyRequest(request, resolvePath((await params).path));
+}

--- a/frontend/src/app/api/skills/route.ts
+++ b/frontend/src/app/api/skills/route.ts
@@ -1,0 +1,11 @@
+import type { NextRequest } from "next/server";
+
+import { proxyRequest } from "../proxy";
+
+export async function GET(request: NextRequest) {
+  return proxyRequest(request, "/api/skills");
+}
+
+export async function POST(request: NextRequest) {
+  return proxyRequest(request, "/api/skills");
+}

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
-from typing import Optional
+from pathlib import Path
 
 
 def configure_stdio() -> None:
@@ -20,7 +20,7 @@ def configure_stdio() -> None:
                 continue
 
 
-def run_command(command: list[str]) -> Optional[str]:
+def run_command(command: list[str]) -> str | None:
     """Run a command and return trimmed stdout, or None on failure."""
     try:
         result = subprocess.run(command, capture_output=True, text=True, check=True, shell=False)
@@ -29,19 +29,22 @@ def run_command(command: list[str]) -> Optional[str]:
     return result.stdout.strip() or result.stderr.strip()
 
 
-def find_pnpm_command() -> Optional[list[str]]:
+def find_pnpm_command() -> list[str] | None:
     """Return a pnpm-compatible command that exists on this machine."""
-    candidates = [["pnpm"], ["pnpm.cmd"]]
-    if shutil.which("corepack"):
-        candidates.append(["corepack", "pnpm"])
+    pnpm_path = shutil.which("pnpm")
+    if pnpm_path:
+        return [str(Path(pnpm_path))]
 
-    for command in candidates:
-        if shutil.which(command[0]):
-            return command
+    pnpm_cmd_path = shutil.which("pnpm.cmd")
+    if pnpm_cmd_path:
+        return [str(Path(pnpm_cmd_path))]
+
+    if shutil.which("corepack"):
+        return ["corepack", "pnpm"]
     return None
 
 
-def parse_node_major(version_text: str) -> Optional[int]:
+def parse_node_major(version_text: str) -> int | None:
     version = version_text.strip()
     if version.startswith("v"):
         version = version[1:]
@@ -145,7 +148,9 @@ def main() -> int:
         print()
         print("You can now run:")
         print("  make install  - Install project dependencies")
-        print("  make config   - Generate local config files")
+        print("  make setup    - Create a minimal working config (recommended)")
+        print("  make config   - Copy the full config template (manual setup)")
+        print("  make doctor   - Verify config and dependency health")
         print("  make dev      - Start development server")
         print("  make start    - Start production server")
         return 0


### PR DESCRIPTION
## Summary
- resolve Windows pnpm version detection by using the resolved executable path instead of invoking the shim name directly
- add local Next.js API proxy routes for skills and MCP settings so the Settings dialog no longer parses HTML 404 pages as JSON
- keep a regression test around the pnpm command resolution behavior

## Verification
- uv run pytest tests/test_check_script.py -q
- python scripts/check.py on Windows now reports OK pnpm 10.33.0
- started DeerFlow locally and verified in-browser that etch('/api/skills') and etch('/api/mcp/config') both return 200
- confirmed the Settings dialog Skills and Tools pages no longer show Unexpected token '<'

Closes #2172
Closes #2173