### PR TITLE
fix(check): windows pnpm version detection in check script

### DIFF
--- a/backend/tests/test_check_script.py
+++ b/backend/tests/test_check_script.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECK_SCRIPT_PATH = REPO_ROOT / "scripts" / "check.py"
+
+
+spec = importlib.util.spec_from_file_location("deerflow_check_script", CHECK_SCRIPT_PATH)
+assert spec is not None
+assert spec.loader is not None
+check_script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(check_script)
+
+
+def test_find_pnpm_command_prefers_resolved_executable(monkeypatch):
+    def fake_which(name: str) -> str | None:
+        if name == "pnpm":
+            return r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"
+        if name == "pnpm.cmd":
+            return r"C:\Users\tester\AppData\Roaming\npm\pnpm.cmd"
+        return None
+
+    monkeypatch.setattr(check_script.shutil, "which", fake_which)
+
+    assert check_script.find_pnpm_command() == [
+        r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"
+    ]
+
+
+def test_find_pnpm_command_falls_back_to_corepack(monkeypatch):
+    def fake_which(name: str) -> str | None:
+        if name == "corepack":
+            return r"C:\Program Files\nodejs\corepack.exe"
+        return None
+
+    monkeypatch.setattr(check_script.shutil, "which", fake_which)
+
+    assert check_script.find_pnpm_command() == ["corepack", "pnpm"]

--- a/backend/tests/test_check_script.py
+++ b/backend/tests/test_check_script.py
@@ -35,4 +35,23 @@ def test_find_pnpm_command_falls_back_to_corepack(monkeypatch):
 
     monkeypatch.setattr(check_script.shutil, "which", fake_which)
 
-    assert check_script.find_pnpm_command() == ["corepack", "pnpm"]
+    assert check_script.find_pnpm_command() == [
+        r"C:\Program Files\nodejs\corepack.exe",
+        "pnpm",
+    ]
+
+
+def test_find_pnpm_command_falls_back_to_corepack_cmd(monkeypatch):
+    def fake_which(name: str) -> str | None:
+        if name == "corepack":
+            return None
+        if name == "corepack.cmd":
+            return r"C:\Program Files\nodejs\corepack.cmd"
+        return None
+
+    monkeypatch.setattr(check_script.shutil, "which", fake_which)
+
+    assert check_script.find_pnpm_command() == [
+        r"C:\Program Files\nodejs\corepack.cmd",
+        "pnpm",
+    ]

--- a/backend/tests/test_check_script.py
+++ b/backend/tests/test_check_script.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECK_SCRIPT_PATH = REPO_ROOT / "scripts" / "check.py"
 
@@ -25,9 +24,7 @@ def test_find_pnpm_command_prefers_resolved_executable(monkeypatch):
 
     monkeypatch.setattr(check_script.shutil, "which", fake_which)
 
-    assert check_script.find_pnpm_command() == [
-        r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"
-    ]
+    assert check_script.find_pnpm_command() == [r"C:\Users\tester\AppData\Roaming\npm\pnpm.CMD"]
 
 
 def test_find_pnpm_command_falls_back_to_corepack(monkeypatch):

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 
 def configure_stdio() -> None:
@@ -30,13 +31,16 @@ def run_command(command: list[str]) -> str | None:
 
 def find_pnpm_command() -> list[str] | None:
     """Return a pnpm-compatible command that exists on this machine."""
-    candidates = [["pnpm"], ["pnpm.cmd"]]
-    if shutil.which("corepack"):
-        candidates.append(["corepack", "pnpm"])
+    pnpm_path = shutil.which("pnpm")
+    if pnpm_path:
+        return [str(Path(pnpm_path))]
 
-    for command in candidates:
-        if shutil.which(command[0]):
-            return command
+    pnpm_cmd_path = shutil.which("pnpm.cmd")
+    if pnpm_cmd_path:
+        return [str(Path(pnpm_cmd_path))]
+
+    if shutil.which("corepack"):
+        return ["corepack", "pnpm"]
     return None
 
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -39,8 +39,11 @@ def find_pnpm_command() -> list[str] | None:
     if pnpm_cmd_path:
         return [str(Path(pnpm_cmd_path))]
 
-    if shutil.which("corepack"):
-        return ["corepack", "pnpm"]
+    corepack_path = shutil.which("corepack")
+    if not corepack_path:
+        corepack_path = shutil.which("corepack.cmd")
+    if corepack_path:
+        return [str(Path(corepack_path)), "pnpm"]
     return None
 
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -95,7 +95,7 @@ def main() -> int:
     if pnpm_command:
         pnpm_version = run_command([*pnpm_command, "-v"])
         if pnpm_version:
-            if pnpm_command[0] == "corepack":
+            if Path(pnpm_command[0]).stem.lower() == "corepack":
                 print(f"  OK pnpm {pnpm_version} (via Corepack)")
             else:
                 print(f"  OK pnpm {pnpm_version}")


### PR DESCRIPTION
## Summary
- fix Windows `pnpm` version detection by using the resolved executable path instead of invoking the shim name directly
- keep the safer `shell=False` path intact
- add a regression test covering direct `pnpm` resolution and Corepack fallback

## Why this fixes the issue
The issue is not that `run_command()` must always use `shell=True`; the Windows-specific problem is that invoking the `pnpm` shim name directly can fail under `shell=False`. This PR fixes that by resolving the real executable path first, so `subprocess.run(..., shell=False)` continues to work correctly on Windows.

## Verification
- `uv run pytest tests/test_check_script.py -q`
- `python scripts/check.py` on Windows now reports `OK pnpm 10.33.0`

## Screenshot
Local verification after the fix:

![Windows pnpm verification](https://i.img402.dev/s0ectwa5wl.png)

Closes #2172
