### PR TITLE
fix(skills): avoid blocking custom skill deletion on readonly history writes

### DIFF
--- a/backend/app/gateway/routers/skills.py
+++ b/backend/app/gateway/routers/skills.py
@@ -1,3 +1,4 @@
+import errno
 import json
 import logging
 import shutil
@@ -201,18 +202,23 @@ async def delete_custom_skill(skill_name: str) -> dict[str, bool]:
         ensure_custom_skill_is_editable(skill_name)
         skill_dir = get_custom_skill_dir(skill_name)
         prev_content = read_custom_skill_content(skill_name)
-        append_history(
-            skill_name,
-            {
-                "action": "human_delete",
-                "author": "human",
-                "thread_id": None,
-                "file_path": "SKILL.md",
-                "prev_content": prev_content,
-                "new_content": None,
-                "scanner": {"decision": "allow", "reason": "Deletion requested."},
-            },
-        )
+        try:
+            append_history(
+                skill_name,
+                {
+                    "action": "human_delete",
+                    "author": "human",
+                    "thread_id": None,
+                    "file_path": "SKILL.md",
+                    "prev_content": prev_content,
+                    "new_content": None,
+                    "scanner": {"decision": "allow", "reason": "Deletion requested."},
+                },
+            )
+        except OSError as e:
+            if not isinstance(e, PermissionError) and e.errno not in {errno.EACCES, errno.EPERM, errno.EROFS}:
+                raise
+            logger.warning("Skipping delete history write for custom skill %s due to readonly/permission failure; continuing with skill directory removal: %s", skill_name, e)
         shutil.rmtree(skill_dir)
         await refresh_skills_system_prompt_cache_async()
         return {"success": True}

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -1,3 +1,4 @@
+import errno
 import json
 from pathlib import Path
 from types import SimpleNamespace
@@ -162,6 +163,74 @@ def test_custom_skill_delete_preserves_history_and_allows_restore(monkeypatch, t
         assert rollback_response.json()["description"] == "Demo skill"
         assert (custom_dir / "SKILL.md").read_text(encoding="utf-8") == original_content
         assert refresh_calls == ["refresh", "refresh"]
+
+
+def test_custom_skill_delete_continues_when_history_write_is_readonly(monkeypatch, tmp_path):
+    skills_root = tmp_path / "skills"
+    custom_dir = skills_root / "custom" / "demo-skill"
+    custom_dir.mkdir(parents=True, exist_ok=True)
+    (custom_dir / "SKILL.md").write_text(_skill_content("demo-skill"), encoding="utf-8")
+    config = SimpleNamespace(
+        skills=SimpleNamespace(get_skills_path=lambda: skills_root, container_path="/mnt/skills"),
+        skill_evolution=SimpleNamespace(enabled=True, moderation_model_name=None),
+    )
+    monkeypatch.setattr("deerflow.config.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.skills.manager.get_app_config", lambda: config)
+    refresh_calls = []
+
+    async def _refresh():
+        refresh_calls.append("refresh")
+
+    def _readonly_history(*args, **kwargs):
+        raise OSError(errno.EROFS, "Read-only file system", str(skills_root / "custom" / ".history"))
+
+    monkeypatch.setattr("app.gateway.routers.skills.append_history", _readonly_history)
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_skills_system_prompt_cache_async", _refresh)
+
+    app = FastAPI()
+    app.include_router(skills_router.router)
+
+    with TestClient(app) as client:
+        delete_response = client.delete("/api/skills/custom/demo-skill")
+
+    assert delete_response.status_code == 200
+    assert delete_response.json() == {"success": True}
+    assert not custom_dir.exists()
+    assert refresh_calls == ["refresh"]
+
+
+def test_custom_skill_delete_fails_when_skill_dir_removal_fails(monkeypatch, tmp_path):
+    skills_root = tmp_path / "skills"
+    custom_dir = skills_root / "custom" / "demo-skill"
+    custom_dir.mkdir(parents=True, exist_ok=True)
+    (custom_dir / "SKILL.md").write_text(_skill_content("demo-skill"), encoding="utf-8")
+    config = SimpleNamespace(
+        skills=SimpleNamespace(get_skills_path=lambda: skills_root, container_path="/mnt/skills"),
+        skill_evolution=SimpleNamespace(enabled=True, moderation_model_name=None),
+    )
+    monkeypatch.setattr("deerflow.config.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.skills.manager.get_app_config", lambda: config)
+    refresh_calls = []
+
+    async def _refresh():
+        refresh_calls.append("refresh")
+
+    def _fail_rmtree(*args, **kwargs):
+        raise PermissionError(errno.EACCES, "Permission denied", str(custom_dir))
+
+    monkeypatch.setattr("app.gateway.routers.skills.shutil.rmtree", _fail_rmtree)
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_skills_system_prompt_cache_async", _refresh)
+
+    app = FastAPI()
+    app.include_router(skills_router.router)
+
+    with TestClient(app) as client:
+        delete_response = client.delete("/api/skills/custom/demo-skill")
+
+    assert delete_response.status_code == 500
+    assert "Failed to delete custom skill" in delete_response.json()["detail"]
+    assert custom_dir.exists()
+    assert refresh_calls == []
 
 
 def test_update_skill_refreshes_prompt_cache_before_return(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Treat custom-skill delete history writes as best-effort for readonly/permission failures
- Keep the actual `shutil.rmtree(skill_dir)` deletion strict, so real skill removal failures still surface
- Add regression coverage for readonly `.history` and failed skill directory deletion

## Why

Thanks for the report in #2178. The delete API writes a history record before removing the custom skill directory.

In readonly or permission-restricted environments, that history write can fail first, for example under `skills/custom/.history`, which prevents the actual skill deletion from being attempted.

This PR keeps history capture as a useful best-effort step for this specific delete path, while avoiding blocking deletion when the failure is limited to readonly/permission errors on the history write.

## Scope

This change is intentionally narrow:

- readonly/permission failures from `append_history(...)` are downgraded to a warning and deletion continues
- unrelated history errors are still raised
- actual skill directory deletion remains strict
- this does **not** hide a fully readonly `/app/skills` mount; if `shutil.rmtree(skill_dir)` fails, the API still fails

Fixes #2178

## Tests

- `uv run pytest tests/test_skills_custom_router.py`
- `uv run ruff check app/gateway/routers/skills.py tests/test_skills_custom_router.py`
- `git diff --check`