### PR TITLE
fix(frontend): wait for async prompt submits before clearing

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -78,9 +78,8 @@ export default function AgentChatPage() {
   });
 
   const handleSubmit = useCallback(
-    (message: PromptInputMessage) => {
-      void sendMessage(threadId, message, { agent_name });
-    },
+    (message: PromptInputMessage) =>
+      sendMessage(threadId, message, { agent_name }),
     [sendMessage, threadId, agent_name],
   );
 

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -73,9 +73,7 @@ export default function ChatPage() {
   });
 
   const handleSubmit = useCallback(
-    (message: PromptInputMessage) => {
-      void sendMessage(threadId, message);
-    },
+    (message: PromptInputMessage) => sendMessage(threadId, message),
     [sendMessage, threadId],
   );
   const handleStop = useCallback(async () => {

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -138,7 +138,7 @@ export function InputBox({
     },
   ) => void;
   onFollowupsVisibilityChange?: (visible: boolean) => void;
-  onSubmit?: (message: PromptInputMessage) => void;
+  onSubmit?: (message: PromptInputMessage) => void | Promise<void>;
   onStop?: () => void;
 }) {
   const { t } = useI18n();
@@ -269,11 +269,14 @@ export function InputBox({
             selectedModel?.supports_thinking ?? false,
           ),
         });
-        setTimeout(() => onSubmit?.(message), 0);
-        return;
+        return new Promise<void>((resolve, reject) => {
+          setTimeout(() => {
+            Promise.resolve(onSubmit?.(message)).then(resolve).catch(reject);
+          }, 0);
+        });
       }
 
-      onSubmit?.(message);
+      return onSubmit?.(message);
     },
     [
       context,


### PR DESCRIPTION
## Summary
- return the async send promise from chat page submit handlers instead of fire-and-forget
- let `InputBox` propagate async submit completion, including the delayed auto-submit path used after model auto-selection
- keep prompt attachments/text from being cleared until the submit promise actually resolves

## Testing
- pnpm typecheck
- pnpm exec eslint 'src/components/workspace/input-box.tsx' 'src/app/workspace/chats/[thread_id]/page.tsx' 'src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx'
- pnpm test

Closes #2208