### PR TITLE
fix(memory): use asyncio.to_thread for blocking file I/O in aupdate_memory

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/storage.py
+++ b/backend/packages/harness/deerflow/agents/memory/storage.py
@@ -4,6 +4,7 @@ import abc
 import json
 import logging
 import threading
+import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -144,7 +145,7 @@ class FileMemoryStorage(MemoryStorage):
             file_path.parent.mkdir(parents=True, exist_ok=True)
             memory_data["lastUpdated"] = utc_now_iso_z()
 
-            temp_path = file_path.with_suffix(".tmp")
+            temp_path = file_path.with_suffix(f".{uuid.uuid4().hex}.tmp")
             with open(temp_path, "w", encoding="utf-8") as f:
                 json.dump(memory_data, f, indent=2, ensure_ascii=False)
 

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -406,7 +406,8 @@ class MemoryUpdater:
             current_memory, prompt = prepared
             model = self._get_model()
             response = await model.ainvoke(prompt)
-            return self._finalize_update(
+            return await asyncio.to_thread(
+                self._finalize_update,
                 current_memory=current_memory,
                 response_content=response.content,
                 thread_id=thread_id,

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -394,7 +394,8 @@ class MemoryUpdater:
     ) -> bool:
         """Update memory asynchronously based on conversation messages."""
         try:
-            prepared = self._prepare_update_prompt(
+            prepared = await asyncio.to_thread(
+                self._prepare_update_prompt,
                 messages=messages,
                 agent_name=agent_name,
                 correction_detected=correction_detected,


### PR DESCRIPTION
## Summary

- `_finalize_update` performs synchronous blocking I/O (`os.mkdir`, file open/write/rename/stat) that was called directly from the async `aupdate_memory` method
- This caused `BlockingError: Blocking call to os.mkdir` (via blockbuster) when running under an ASGI server, which blocks the event loop and degrades performance for all concurrent requests
- Wraps the `_finalize_update` call with `asyncio.to_thread` so all blocking file operations run in a thread pool without tying up the event loop

## Test plan

- [x] Run the backend test suite: `cd backend && make test`
- [x] Start the app and trigger a memory update — verify no `BlockingError` appears in logs
- [x] Confirm LangGraph dev server no longer warns about blocking calls from the memory updater

🤖 Generated with [Claude Code](https://claude.com/claude-code)