### PR TITLE
fix(frontend): add skills API rewrite rule to prevent HTML fallback

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -52,6 +52,14 @@ const config = {
         source: "/api/agents/:path*",
         destination: `${gatewayURL}/api/agents/:path*`,
       });
+      rewrites.push({
+        source: "/api/skills",
+        destination: `${gatewayURL}/api/skills`,
+      });
+      rewrites.push({
+        source: "/api/skills/:path*",
+        destination: `${gatewayURL}/api/skills/:path*`,
+      });
     }
 
     return rewrites;


### PR DESCRIPTION
Fixes #2203

## Problem
When `NEXT_PUBLIC_BACKEND_BASE_URL` is not set, the skill settings page shows:
```
Error: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

## Root Cause
`next.config.js` rewrites proxy `/api/agents` and `/api/langgraph` to the gateway, but `/api/skills` routes are missing. When the frontend fetches `/api/skills`, Next.js has no matching rewrite and falls through to the SPA HTML fallback.

## Fix
Add rewrite rules for `/api/skills` and `/api/skills/:path*` to proxy to the gateway, consistent with the existing `/api/agents` pattern.

## Testing
1. Start DeerFlow with `make dev` (no `NEXT_PUBLIC_BACKEND_BASE_URL` set)
2. Navigate to Settings → Skills
3. Verify skill list loads without JSON parse error