### PR TITLE
fix(gateway): forward agent_name and is_bootstrap from context to configurable

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -298,6 +298,8 @@ async def start_run(
             "is_plan_mode",
             "subagent_enabled",
             "max_concurrent_subagents",
+            "agent_name",
+            "is_bootstrap",
         }
         configurable = config.setdefault("configurable", {})
         for key in _CONTEXT_CONFIGURABLE_KEYS:


### PR DESCRIPTION
Fixes #2222

The frontend sends `agent_name` and `is_bootstrap` via the `context` field in run requests, but `services.py` only forwards a hardcoded whitelist (`_CONTEXT_CONFIGURABLE_KEYS`) into the agent's `configurable` dict. Both keys were missing.

**Root cause:** Without `agent_name` in configurable, `make_lead_agent` always falls back to the default lead agent — custom agents never load their SOUL.md, per-agent config, or skill set. The user sees a plain lead agent that ignores custom skills.

**Fix:** Add `agent_name` and `is_bootstrap` to `_CONTEXT_CONFIGURABLE_KEYS` so they reach `make_lead_agent`.

**Impact:** 2-line change, no behavioral change for existing default-agent usage.