### PR TITLE
[codex] Protect skill management API

### DIFF
--- a/backend/app/gateway/routers/skills.py
+++ b/backend/app/gateway/routers/skills.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 from app.gateway.path_utils import resolve_thread_virtual_path
 from deerflow.agents.lead_agent.prompt import refresh_skills_system_prompt_cache_async
 from deerflow.config.extensions_config import ExtensionsConfig, SkillStateConfig, get_extensions_config, reload_extensions_config
+from deerflow.config.skills_api_config import get_skills_api_config
 from deerflow.skills import Skill, load_skills
 from deerflow.skills.installer import SkillAlreadyExistsError, install_skill_from_archive
 from deerflow.skills.manager import (
@@ -95,6 +96,22 @@ def _skill_to_response(skill: Skill) -> SkillResponse:
     )
 
 
+def _is_skills_api_enabled() -> bool:
+    return get_skills_api_config().enabled
+
+
+def _require_skills_api_enabled() -> None:
+    """Reject access unless the HTTP skill-management API is explicitly enabled."""
+    if not _is_skills_api_enabled():
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Skill management API is disabled. Set skills_api.enabled=true to expose "
+                "skill install, custom-skill management, and skill state mutation routes over HTTP."
+            ),
+        )
+
+
 @router.get(
     "/skills",
     response_model=SkillsListResponse,
@@ -104,6 +121,8 @@ def _skill_to_response(skill: Skill) -> SkillResponse:
 async def list_skills() -> SkillsListResponse:
     try:
         skills = load_skills(enabled_only=False)
+        if not _is_skills_api_enabled():
+            skills = [skill for skill in skills if skill.category != "custom"]
         return SkillsListResponse(skills=[_skill_to_response(skill) for skill in skills])
     except Exception as e:
         logger.error(f"Failed to load skills: {e}", exc_info=True)
@@ -117,6 +136,7 @@ async def list_skills() -> SkillsListResponse:
     description="Install a skill from a .skill file (ZIP archive) located in the thread's user-data directory.",
 )
 async def install_skill(request: SkillInstallRequest) -> SkillInstallResponse:
+    _require_skills_api_enabled()
     try:
         skill_file_path = resolve_thread_virtual_path(request.thread_id, request.path)
         result = install_skill_from_archive(skill_file_path)
@@ -137,6 +157,7 @@ async def install_skill(request: SkillInstallRequest) -> SkillInstallResponse:
 
 @router.get("/skills/custom", response_model=SkillsListResponse, summary="List Custom Skills")
 async def list_custom_skills() -> SkillsListResponse:
+    _require_skills_api_enabled()
     try:
         skills = [skill for skill in load_skills(enabled_only=False) if skill.category == "custom"]
         return SkillsListResponse(skills=[_skill_to_response(skill) for skill in skills])
@@ -147,6 +168,7 @@ async def list_custom_skills() -> SkillsListResponse:
 
 @router.get("/skills/custom/{skill_name}", response_model=CustomSkillContentResponse, summary="Get Custom Skill Content")
 async def get_custom_skill(skill_name: str) -> CustomSkillContentResponse:
+    _require_skills_api_enabled()
     try:
         skills = load_skills(enabled_only=False)
         skill = next((s for s in skills if s.name == skill_name and s.category == "custom"), None)
@@ -162,6 +184,7 @@ async def get_custom_skill(skill_name: str) -> CustomSkillContentResponse:
 
 @router.put("/skills/custom/{skill_name}", response_model=CustomSkillContentResponse, summary="Edit Custom Skill")
 async def update_custom_skill(skill_name: str, request: CustomSkillUpdateRequest) -> CustomSkillContentResponse:
+    _require_skills_api_enabled()
     try:
         ensure_custom_skill_is_editable(skill_name)
         validate_skill_markdown_content(skill_name, request.content)
@@ -198,6 +221,7 @@ async def update_custom_skill(skill_name: str, request: CustomSkillUpdateRequest
 
 @router.delete("/skills/custom/{skill_name}", summary="Delete Custom Skill")
 async def delete_custom_skill(skill_name: str) -> dict[str, bool]:
+    _require_skills_api_enabled()
     try:
         ensure_custom_skill_is_editable(skill_name)
         skill_dir = get_custom_skill_dir(skill_name)
@@ -233,6 +257,7 @@ async def delete_custom_skill(skill_name: str) -> dict[str, bool]:
 
 @router.get("/skills/custom/{skill_name}/history", response_model=CustomSkillHistoryResponse, summary="Get Custom Skill History")
 async def get_custom_skill_history(skill_name: str) -> CustomSkillHistoryResponse:
+    _require_skills_api_enabled()
     try:
         if not custom_skill_exists(skill_name) and not get_skill_history_file(skill_name).exists():
             raise HTTPException(status_code=404, detail=f"Custom skill '{skill_name}' not found")
@@ -246,6 +271,7 @@ async def get_custom_skill_history(skill_name: str) -> CustomSkillHistoryRespons
 
 @router.post("/skills/custom/{skill_name}/rollback", response_model=CustomSkillContentResponse, summary="Rollback Custom Skill")
 async def rollback_custom_skill(skill_name: str, request: SkillRollbackRequest) -> CustomSkillContentResponse:
+    _require_skills_api_enabled()
     try:
         if not custom_skill_exists(skill_name) and not get_skill_history_file(skill_name).exists():
             raise HTTPException(status_code=404, detail=f"Custom skill '{skill_name}' not found")
@@ -304,6 +330,9 @@ async def get_skill(skill_name: str) -> SkillResponse:
         if skill is None:
             raise HTTPException(status_code=404, detail=f"Skill '{skill_name}' not found")
 
+        if skill.category == "custom":
+            _require_skills_api_enabled()
+
         return _skill_to_response(skill)
     except HTTPException:
         raise
@@ -319,6 +348,7 @@ async def get_skill(skill_name: str) -> SkillResponse:
     description="Update a skill's enabled status by modifying the extensions_config.json file.",
 )
 async def update_skill(skill_name: str, request: SkillUpdateRequest) -> SkillResponse:
+    _require_skills_api_enabled()
     try:
         skills = load_skills(enabled_only=False)
         skill = next((s for s in skills if s.name == skill_name), None)

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -278,6 +278,14 @@ skills:
 - Skills are automatically discovered and loaded
 - Available in both local and Docker sandbox via path mapping
 
+**Skill Management API**:
+HTTP routes that install, edit, delete, roll back, or enable/disable skills are disabled by default. Enable them only when the gateway is behind a trusted authenticated admin boundary:
+
+```yaml
+skills_api:
+  enabled: false
+```
+
 **Per-Agent Skill Filtering**:
 Custom agents can restrict which skills they load by defining a `skills` field in their `config.yaml` (located at `workspace/agents/<agent_name>/config.yaml`):
 - **Omitted or `null`**: Loads all globally enabled skills (default fallback).

--- a/backend/packages/harness/deerflow/config/__init__.py
+++ b/backend/packages/harness/deerflow/config/__init__.py
@@ -3,6 +3,7 @@ from .extensions_config import ExtensionsConfig, get_extensions_config
 from .memory_config import MemoryConfig, get_memory_config
 from .paths import Paths, get_paths
 from .skill_evolution_config import SkillEvolutionConfig
+from .skills_api_config import SkillsApiConfig, get_skills_api_config
 from .skills_config import SkillsConfig
 from .tracing_config import (
     get_enabled_tracing_providers,
@@ -18,6 +19,8 @@ __all__ = [
     "Paths",
     "get_paths",
     "SkillsConfig",
+    "SkillsApiConfig",
+    "get_skills_api_config",
     "ExtensionsConfig",
     "get_extensions_config",
     "MemoryConfig",

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -17,6 +17,7 @@ from deerflow.config.memory_config import MemoryConfig, load_memory_config_from_
 from deerflow.config.model_config import ModelConfig
 from deerflow.config.sandbox_config import SandboxConfig
 from deerflow.config.skill_evolution_config import SkillEvolutionConfig
+from deerflow.config.skills_api_config import SkillsApiConfig, load_skills_api_config_from_dict
 from deerflow.config.skills_config import SkillsConfig
 from deerflow.config.stream_bridge_config import StreamBridgeConfig, load_stream_bridge_config_from_dict
 from deerflow.config.subagents_config import SubagentsAppConfig, load_subagents_config_from_dict
@@ -55,6 +56,7 @@ class AppConfig(BaseModel):
     tools: list[ToolConfig] = Field(default_factory=list, description="Available tools")
     tool_groups: list[ToolGroupConfig] = Field(default_factory=list, description="Available tool groups")
     skills: SkillsConfig = Field(default_factory=SkillsConfig, description="Skills configuration")
+    skills_api: SkillsApiConfig = Field(default_factory=SkillsApiConfig, description="HTTP skill-management API configuration")
     skill_evolution: SkillEvolutionConfig = Field(default_factory=SkillEvolutionConfig, description="Agent-managed skill evolution configuration")
     extensions: ExtensionsConfig = Field(default_factory=ExtensionsConfig, description="Extensions configuration (MCP servers and skills state)")
     tool_search: ToolSearchConfig = Field(default_factory=ToolSearchConfig, description="Tool search / deferred loading configuration")
@@ -130,6 +132,10 @@ class AppConfig(BaseModel):
         # Always refresh agents API config so removed config sections reset
         # singleton-backed state to its default/disabled values on reload.
         load_agents_api_config_from_dict(config_data.get("agents_api") or {})
+
+        # Always refresh skills API config so removed config sections reset
+        # singleton-backed state to its default/disabled values on reload.
+        load_skills_api_config_from_dict(config_data.get("skills_api") or {})
 
         # Load subagents config if present
         if "subagents" in config_data:

--- a/backend/packages/harness/deerflow/config/skills_api_config.py
+++ b/backend/packages/harness/deerflow/config/skills_api_config.py
@@ -1,0 +1,36 @@
+"""Configuration for the HTTP skill-management API."""
+
+from pydantic import BaseModel, Field
+
+
+class SkillsApiConfig(BaseModel):
+    """Configuration for skill install and custom-skill management routes."""
+
+    enabled: bool = Field(
+        default=False,
+        description=(
+            "Whether to expose skill install, custom-skill management, and skill state "
+            "mutation routes over HTTP. When disabled, the gateway rejects these "
+            "routes and hides custom-skill metadata from unauthenticated skill listing."
+        ),
+    )
+
+
+_skills_api_config: SkillsApiConfig = SkillsApiConfig()
+
+
+def get_skills_api_config() -> SkillsApiConfig:
+    """Get the current skills API configuration."""
+    return _skills_api_config
+
+
+def set_skills_api_config(config: SkillsApiConfig) -> None:
+    """Set the skills API configuration."""
+    global _skills_api_config
+    _skills_api_config = config
+
+
+def load_skills_api_config_from_dict(config_dict: dict) -> None:
+    """Load skills API configuration from a dictionary."""
+    global _skills_api_config
+    _skills_api_config = SkillsApiConfig(**config_dict)

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -8,6 +8,7 @@ import yaml
 
 from deerflow.config.agents_api_config import get_agents_api_config
 from deerflow.config.app_config import get_app_config, reset_app_config
+from deerflow.config.skills_api_config import get_skills_api_config
 
 
 def _write_config(path: Path, *, model_name: str, supports_thinking: bool) -> None:
@@ -35,6 +36,7 @@ def _write_config_with_agents_api(
     model_name: str,
     supports_thinking: bool,
     agents_api: dict | None = None,
+    skills_api: dict | None = None,
 ) -> None:
     config = {
         "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
@@ -49,6 +51,8 @@ def _write_config_with_agents_api(
     }
     if agents_api is not None:
         config["agents_api"] = agents_api
+    if skills_api is not None:
+        config["skills_api"] = skills_api
 
     path.write_text(yaml.safe_dump(config), encoding="utf-8")
 
@@ -137,5 +141,40 @@ def test_get_app_config_resets_agents_api_config_when_section_removed(tmp_path, 
         reloaded = get_app_config()
         assert reloaded is not initial
         assert get_agents_api_config().enabled is False
+    finally:
+        reset_app_config()
+
+
+def test_get_app_config_resets_skills_api_config_when_section_removed(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    _write_config_with_agents_api(
+        config_path,
+        model_name="first-model",
+        supports_thinking=False,
+        skills_api={"enabled": True},
+    )
+
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+    reset_app_config()
+
+    try:
+        initial = get_app_config()
+        assert initial.models[0].name == "first-model"
+        assert get_skills_api_config().enabled is True
+
+        _write_config_with_agents_api(
+            config_path,
+            model_name="first-model",
+            supports_thinking=False,
+        )
+        next_mtime = config_path.stat().st_mtime + 5
+        os.utime(config_path, (next_mtime, next_mtime))
+
+        reloaded = get_app_config()
+        assert reloaded is not initial
+        assert get_skills_api_config().enabled is False
     finally:
         reset_app_config()

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -3,10 +3,12 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.gateway.routers import skills as skills_router
+from deerflow.config.skills_api_config import SkillsApiConfig, get_skills_api_config, set_skills_api_config
 from deerflow.skills.manager import get_skill_history_file
 from deerflow.skills.types import Skill
 
@@ -35,7 +37,17 @@ def _make_skill(name: str, *, enabled: bool) -> Skill:
     )
 
 
-def test_custom_skills_router_lifecycle(monkeypatch, tmp_path):
+@pytest.fixture()
+def skills_api_enabled():
+    previous_config = SkillsApiConfig(**get_skills_api_config().model_dump())
+    set_skills_api_config(SkillsApiConfig(enabled=True))
+    try:
+        yield
+    finally:
+        set_skills_api_config(previous_config)
+
+
+def test_custom_skills_router_lifecycle(monkeypatch, tmp_path, skills_api_enabled):
     skills_root = tmp_path / "skills"
     custom_dir = skills_root / "custom" / "demo-skill"
     custom_dir.mkdir(parents=True, exist_ok=True)
@@ -83,7 +95,7 @@ def test_custom_skills_router_lifecycle(monkeypatch, tmp_path):
         assert refresh_calls == ["refresh", "refresh"]
 
 
-def test_custom_skill_rollback_blocked_by_scanner(monkeypatch, tmp_path):
+def test_custom_skill_rollback_blocked_by_scanner(monkeypatch, tmp_path, skills_api_enabled):
     skills_root = tmp_path / "skills"
     custom_dir = skills_root / "custom" / "demo-skill"
     custom_dir.mkdir(parents=True, exist_ok=True)
@@ -126,7 +138,7 @@ def test_custom_skill_rollback_blocked_by_scanner(monkeypatch, tmp_path):
         assert history_response.json()["history"][-1]["scanner"]["decision"] == "block"
 
 
-def test_custom_skill_delete_preserves_history_and_allows_restore(monkeypatch, tmp_path):
+def test_custom_skill_delete_preserves_history_and_allows_restore(monkeypatch, tmp_path, skills_api_enabled):
     skills_root = tmp_path / "skills"
     custom_dir = skills_root / "custom" / "demo-skill"
     custom_dir.mkdir(parents=True, exist_ok=True)
@@ -165,7 +177,7 @@ def test_custom_skill_delete_preserves_history_and_allows_restore(monkeypatch, t
         assert refresh_calls == ["refresh", "refresh"]
 
 
-def test_custom_skill_delete_continues_when_history_write_is_readonly(monkeypatch, tmp_path):
+def test_custom_skill_delete_continues_when_history_write_is_readonly(monkeypatch, tmp_path, skills_api_enabled):
     skills_root = tmp_path / "skills"
     custom_dir = skills_root / "custom" / "demo-skill"
     custom_dir.mkdir(parents=True, exist_ok=True)
@@ -199,7 +211,7 @@ def test_custom_skill_delete_continues_when_history_write_is_readonly(monkeypatc
     assert refresh_calls == ["refresh"]
 
 
-def test_custom_skill_delete_fails_when_skill_dir_removal_fails(monkeypatch, tmp_path):
+def test_custom_skill_delete_fails_when_skill_dir_removal_fails(monkeypatch, tmp_path, skills_api_enabled):
     skills_root = tmp_path / "skills"
     custom_dir = skills_root / "custom" / "demo-skill"
     custom_dir.mkdir(parents=True, exist_ok=True)
@@ -233,7 +245,7 @@ def test_custom_skill_delete_fails_when_skill_dir_removal_fails(monkeypatch, tmp
     assert refresh_calls == []
 
 
-def test_update_skill_refreshes_prompt_cache_before_return(monkeypatch, tmp_path):
+def test_update_skill_refreshes_prompt_cache_before_return(monkeypatch, tmp_path, skills_api_enabled):
     config_path = tmp_path / "extensions_config.json"
     enabled_state = {"value": True}
     refresh_calls = []
@@ -264,3 +276,78 @@ def test_update_skill_refreshes_prompt_cache_before_return(monkeypatch, tmp_path
     assert response.json()["enabled"] is False
     assert refresh_calls == ["refresh"]
     assert json.loads(config_path.read_text(encoding="utf-8")) == {"mcpServers": {}, "skills": {"demo-skill": {"enabled": False}}}
+
+
+def test_skill_management_routes_return_403_when_disabled(monkeypatch):
+    previous_config = SkillsApiConfig(**get_skills_api_config().model_dump())
+    set_skills_api_config(SkillsApiConfig(enabled=False))
+    try:
+        monkeypatch.setattr(
+            "app.gateway.routers.skills.load_skills",
+            lambda **_: [
+                Skill(
+                    name="custom-skill",
+                    description="Custom",
+                    license=None,
+                    skill_dir=Path("/tmp/custom-skill"),
+                    skill_file=Path("/tmp/custom-skill/SKILL.md"),
+                    relative_path=Path("custom-skill"),
+                    category="custom",
+                    enabled=True,
+                )
+            ],
+        )
+
+        app = FastAPI()
+        app.include_router(skills_router.router)
+
+        with TestClient(app) as client:
+            responses = [
+                client.post("/api/skills/install", json={"thread_id": "t", "path": "/mnt/user-data/uploads/demo.skill"}),
+                client.get("/api/skills/custom"),
+                client.get("/api/skills/custom/demo-skill"),
+                client.put("/api/skills/custom/demo-skill", json={"content": _skill_content("demo-skill")}),
+                client.delete("/api/skills/custom/demo-skill"),
+                client.get("/api/skills/custom/demo-skill/history"),
+                client.post("/api/skills/custom/demo-skill/rollback", json={"history_index": -1}),
+                client.get("/api/skills/custom-skill"),
+                client.put("/api/skills/demo-skill", json={"enabled": False}),
+            ]
+
+        assert all(response.status_code == 403 for response in responses)
+        assert "skills_api.enabled=true" in responses[0].json()["detail"]
+    finally:
+        set_skills_api_config(previous_config)
+
+
+def test_skill_list_hides_custom_skills_when_management_api_disabled(monkeypatch):
+    previous_config = SkillsApiConfig(**get_skills_api_config().model_dump())
+    set_skills_api_config(SkillsApiConfig(enabled=False))
+    try:
+        monkeypatch.setattr(
+            "app.gateway.routers.skills.load_skills",
+            lambda **_: [
+                _make_skill("public-skill", enabled=True),
+                Skill(
+                    name="custom-skill",
+                    description="Custom",
+                    license=None,
+                    skill_dir=Path("/tmp/custom-skill"),
+                    skill_file=Path("/tmp/custom-skill/SKILL.md"),
+                    relative_path=Path("custom-skill"),
+                    category="custom",
+                    enabled=True,
+                ),
+            ],
+        )
+
+        app = FastAPI()
+        app.include_router(skills_router.router)
+
+        with TestClient(app) as client:
+            response = client.get("/api/skills")
+
+        assert response.status_code == 200
+        assert [skill["name"] for skill in response.json()["skills"]] == ["public-skill"]
+    finally:
+        set_skills_api_config(previous_config)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 7
+config_version: 8
 
 # ============================================================================
 # Logging
@@ -633,6 +633,14 @@ skills:
 # - Omitted or null: load all globally enabled skills (default)
 # - []: disable all skills for this agent
 # - ["skill-name"]: load only specific skills
+
+# ============================================================================
+# Skill Management API
+# ============================================================================
+# Controls whether the HTTP gateway exposes skill install/custom-skill management.
+# Keep this disabled unless the gateway is behind a trusted authenticated admin boundary.
+skills_api:
+  enabled: false
 
 # ============================================================================
 # Title Generation Configuration


### PR DESCRIPTION
## Summary
This PR protects DeerFlow's HTTP skill-management surface by adding a disabled-by-default `skills_api.enabled` gate. When the management API is disabled, HTTP callers cannot install, edit, delete, roll back, or toggle skills, and custom-skill metadata is hidden from the generic skill listing.

## Finding Paths
N/A for this upstream remediation PR. No files under the local `security-findings` archive are changed by this PR.

## Related References
- Security policy: https://github.com/bytedance/deer-flow/security
- Contribution guide: https://github.com/bytedance/deer-flow/blob/main/CONTRIBUTING.md
- PR template: none advertised by the upstream GitHub community profile

## Upstream Org Guidance
- Upstream repo / org: `bytedance/deer-flow`
- Security policy: report vulnerabilities through GitHub Security Advisories
- Contribution guide: `CONTRIBUTING.md`
- PR template: none found upstream
- Docs or style guide: `CONTRIBUTING.md` and existing backend docs patterns
- Key rules captured in this archive update: keep the gateway behind trusted boundaries for management APIs; default new HTTP management surfaces to disabled unless explicitly enabled

## Why
Skill install and custom-skill management routes were reachable through the gateway without a protective management boundary. A caller who could reach those routes could install or mutate custom skills and influence future agent prompt/tool behavior. This PR follows the existing `agents_api.enabled` pattern and makes the skill-management HTTP surface opt-in.

## Scope And Claim Check

- [x] Issue-closing keywords only cover issues fully resolved by this PR.
- [x] Summary, Why, and Changes match the actual diff after the latest edits.
- [x] Any remaining gaps, follow-up work, or superseding branches are called out explicitly.

## Changes
- Add `SkillsApiConfig` and load/reset it through app config reloads.
- Reject `/api/skills/install`, `/api/skills/custom/*`, and skill state mutation routes unless `skills_api.enabled=true`.
- Hide custom skills from `/api/skills` when the management API is disabled.
- Document `skills_api.enabled` and bump `config.example.yaml` to version `8`.
- Add regression coverage for disabled management routes, custom-skill listing redaction, and config reload reset behavior.

## Type of Update

- [x] Upstream security hardening PR
- [ ] New finding writeup
- [ ] Existing finding update
- [ ] Disclosure or CVE draft update
- [ ] Tracker or metadata update
- [ ] Template or repo maintenance

## Validation

- [x] Exact validation steps are listed below.
- [x] Validation was rerun after the latest review-driven edits.
- [x] Links, dates, severity, and status values were spot-checked across touched files.

```console
PYTHONPATH=packages/harness uv run pytest tests/test_skills_custom_router.py tests/test_app_config_reload.py -q
PYTHONPATH=packages/harness uv run ruff check app/gateway/routers/skills.py packages/harness/deerflow/config/__init__.py packages/harness/deerflow/config/app_config.py packages/harness/deerflow/config/skills_api_config.py tests/test_skills_custom_router.py tests/test_app_config_reload.py
```

## Disclosure Status

- [ ] Private archive only
- [ ] Sent to vendor / PSIRT / CNA
- [x] Public remediation PR or advisory linked
- [ ] CVE draft added or updated

## Risks / Notes
This is a management-boundary hardening change, not a full authentication system. Deployments that intentionally expose skill management over HTTP must set `skills_api.enabled=true` and should place the gateway behind an authenticated trusted admin boundary.

## Checklist

- [x] Status values, fix references, and merge state claims do not overstate current public reality.
- [x] Any org-specific security, contribution, or PR-format claims are backed by current upstream docs linked above.
- [x] No secrets, tokens, private credentials, or unintended personal data were added.
- [x] Any required redactions were preserved.
- [ ] `findings/TRACKER.md` was updated if a finding was added or its tracked status changed.
- [ ] New or renamed finding folders follow `<vendor>/<project>/<issue-slug>/`.
- [x] Markdown renders cleanly and relative links resolve.
