### PR TITLE
fix(mcp): prevent RuntimeError from escaping except block in get_cach…

### DIFF
--- a/backend/packages/harness/deerflow/mcp/cache.py
+++ b/backend/packages/harness/deerflow/mcp/cache.py
@@ -120,11 +120,11 @@ def get_cached_mcp_tools() -> list[BaseTool]:
             # No event loop exists, create one
             try:
                 asyncio.run(initialize_mcp_tools())
-            except Exception as e:
-                logger.error(f"Failed to lazy-initialize MCP tools: {e}")
+            except Exception:
+                logger.exception("Failed to lazy-initialize MCP tools")
                 return []
-        except Exception as e:
-            logger.error(f"Failed to lazy-initialize MCP tools: {e}")
+        except Exception:
+            logger.exception("Failed to lazy-initialize MCP tools")
             return []
 
     return _mcp_tools_cache or []

--- a/backend/packages/harness/deerflow/mcp/cache.py
+++ b/backend/packages/harness/deerflow/mcp/cache.py
@@ -118,7 +118,11 @@ def get_cached_mcp_tools() -> list[BaseTool]:
                 loop.run_until_complete(initialize_mcp_tools())
         except RuntimeError:
             # No event loop exists, create one
-            asyncio.run(initialize_mcp_tools())
+            try:
+                asyncio.run(initialize_mcp_tools())
+            except Exception as e:
+                logger.error(f"Failed to lazy-initialize MCP tools: {e}")
+                return []
         except Exception as e:
             logger.error(f"Failed to lazy-initialize MCP tools: {e}")
             return []


### PR DESCRIPTION
## Problem

When get_cached_mcp_tools() catches a RuntimeError from asyncio.get_event_loop() and falls back to asyncio.run(), any exception raised by that fallback escapes unhandled. Python does not route exceptions raised inside an except block to sibling except clauses, so the outer except Exception never fires.

Symptoms included:

 - get_cached_mcp_tools() crashes instead of returning [] when no event loop exists and MCP initialization fails
 - Unhandled RuntimeError propagates to caller, potentially crashing the agent startup
 - MCP tool loading failure becomes fatal instead of gracefully degraded

## Fix

Wrap the fallback asyncio.run() inside except RuntimeError with its own try/except, so failures are logged and the function returns [] as intended.

## Changes

- Update cache.py to wrap the fallback asyncio.run() in a nested try/except Exception inside the except RuntimeError block
- Log the error and return [] on failure, matching the behavior of the outer except Exception

## Tests

- `uv run pytest tests/ -k "mcp" -q`
