### PR TITLE
refactor(config): add system_models config for centralized system task model resolution

### DIFF
--- a/backend/app/gateway/routers/suggestions.py
+++ b/backend/app/gateway/routers/suggestions.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
-from deerflow.models import create_chat_model
+from deerflow.models import create_chat_model, get_system_model_name
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class SuggestionMessage(BaseModel):
 class SuggestionsRequest(BaseModel):
     messages: list[SuggestionMessage] = Field(..., description="Recent conversation messages")
     n: int = Field(default=3, ge=1, le=5, description="Number of suggestions to generate")
-    model_name: str | None = Field(default=None, description="Optional model override")
+    model_name: str | None = Field(default=None, deprecated="Ignored. Suggestions always use system_models.default.")
 
 
 class SuggestionsResponse(BaseModel):
@@ -120,7 +120,8 @@ async def generate_suggestions(thread_id: str, request: SuggestionsRequest) -> S
     user_content = f"Conversation Context:\n{conversation}\n\nGenerate {n} follow-up questions"
 
     try:
-        model = create_chat_model(name=request.model_name, thinking_enabled=False)
+        model_name = get_system_model_name(task_override=None)
+        model = create_chat_model(name=model_name, thinking_enabled=False)
         response = await model.ainvoke([SystemMessage(content=system_instruction), HumanMessage(content=user_content)])
         raw = _extract_response_text(response.content)
         suggestions = _parse_json_string_list(raw) or []

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -21,7 +21,7 @@ from deerflow.config.agents_config import load_agent_config
 from deerflow.config.app_config import get_app_config
 from deerflow.config.memory_config import get_memory_config
 from deerflow.config.summarization_config import get_summarization_config
-from deerflow.models import create_chat_model
+from deerflow.models import create_chat_model, get_system_model_name
 
 logger = logging.getLogger(__name__)
 
@@ -60,12 +60,8 @@ def _create_summarization_middleware() -> DeerFlowSummarizationMiddleware | None
     keep = config.keep.to_tuple()
 
     # Prepare model parameter
-    if config.model_name:
-        model = create_chat_model(name=config.model_name, thinking_enabled=False)
-    else:
-        # Use a lightweight model for summarization to save costs
-        # Falls back to default model if not explicitly specified
-        model = create_chat_model(thinking_enabled=False)
+    model_name = get_system_model_name(config.model_name)
+    model = create_chat_model(name=model_name, thinking_enabled=False)
 
     # Prepare kwargs
     kwargs = {

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -21,7 +21,7 @@ from deerflow.agents.memory.storage import (
     utc_now_iso_z,
 )
 from deerflow.config.memory_config import get_memory_config
-from deerflow.models import create_chat_model
+from deerflow.models import create_chat_model, get_system_model_name
 
 logger = logging.getLogger(__name__)
 
@@ -309,7 +309,7 @@ class MemoryUpdater:
     def _get_model(self):
         """Get the model for memory updates."""
         config = get_memory_config()
-        model_name = self._model_name or config.model_name
+        model_name = get_system_model_name(self._model_name or config.model_name)
         return create_chat_model(name=model_name, thinking_enabled=False)
 
     def _build_correction_hint(

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -9,7 +9,7 @@ from langchain.agents.middleware import AgentMiddleware
 from langgraph.runtime import Runtime
 
 from deerflow.config.title_config import get_title_config
-from deerflow.models import create_chat_model
+from deerflow.models import create_chat_model, get_system_model_name
 
 logger = logging.getLogger(__name__)
 
@@ -123,10 +123,8 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         prompt, user_msg = self._build_title_prompt(state)
 
         try:
-            if config.model_name:
-                model = create_chat_model(name=config.model_name, thinking_enabled=False)
-            else:
-                model = create_chat_model(thinking_enabled=False)
+            model_name = get_system_model_name(config.model_name)
+            model = create_chat_model(name=model_name, thinking_enabled=False)
             response = await model.ainvoke(prompt)
             title = self._parse_title(response.content)
             if title:

--- a/backend/packages/harness/deerflow/config/__init__.py
+++ b/backend/packages/harness/deerflow/config/__init__.py
@@ -4,6 +4,7 @@ from .memory_config import MemoryConfig, get_memory_config
 from .paths import Paths, get_paths
 from .skill_evolution_config import SkillEvolutionConfig
 from .skills_config import SkillsConfig
+from .system_models_config import SystemModelsConfig, get_system_models_config
 from .tracing_config import (
     get_enabled_tracing_providers,
     get_explicitly_enabled_tracing_providers,
@@ -22,6 +23,8 @@ __all__ = [
     "get_extensions_config",
     "MemoryConfig",
     "get_memory_config",
+    "SystemModelsConfig",
+    "get_system_models_config",
     "get_tracing_config",
     "get_explicitly_enabled_tracing_providers",
     "get_enabled_tracing_providers",

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -66,7 +66,7 @@ class AppConfig(BaseModel):
     subagents: SubagentsAppConfig = Field(default_factory=SubagentsAppConfig, description="Subagent runtime configuration")
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig, description="Guardrail middleware configuration")
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig, description="LLM circuit breaker configuration")
-    system_models: SystemModelsConfig | None = Field(default=None, description="Default model configuration for system-level LLM tasks")
+    system_models: SystemModelsConfig = Field(default_factory=SystemModelsConfig, description="Default model configuration for system-level LLM tasks")
     model_config = ConfigDict(extra="allow", frozen=False)
     checkpointer: CheckpointerConfig | None = Field(default=None, description="Checkpointer configuration")
     stream_bridge: StreamBridgeConfig | None = Field(default=None, description="Stream bridge configuration")
@@ -163,6 +163,7 @@ class AppConfig(BaseModel):
         # Load system_models config; always call to reset singleton on reload.
         system_models_val = config_data.get("system_models")
         load_system_models_config_from_dict(system_models_val if isinstance(system_models_val, dict) else {})
+        config_data.setdefault("system_models", {})
 
         # Load extensions config separately (it's in a different file)
         extensions_config = ExtensionsConfig.from_file()

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -163,7 +163,8 @@ class AppConfig(BaseModel):
         # Load system_models config; always call to reset singleton on reload.
         system_models_val = config_data.get("system_models")
         load_system_models_config_from_dict(system_models_val if isinstance(system_models_val, dict) else {})
-        config_data.setdefault("system_models", {})
+        if not isinstance(config_data.get("system_models"), dict):
+            config_data["system_models"] = {}
 
         # Load extensions config separately (it's in a different file)
         extensions_config = ExtensionsConfig.from_file()

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -21,6 +21,7 @@ from deerflow.config.skills_config import SkillsConfig
 from deerflow.config.stream_bridge_config import StreamBridgeConfig, load_stream_bridge_config_from_dict
 from deerflow.config.subagents_config import SubagentsAppConfig, load_subagents_config_from_dict
 from deerflow.config.summarization_config import SummarizationConfig, load_summarization_config_from_dict
+from deerflow.config.system_models_config import SystemModelsConfig, load_system_models_config_from_dict
 from deerflow.config.title_config import TitleConfig, load_title_config_from_dict
 from deerflow.config.token_usage_config import TokenUsageConfig
 from deerflow.config.tool_config import ToolConfig, ToolGroupConfig
@@ -65,6 +66,7 @@ class AppConfig(BaseModel):
     subagents: SubagentsAppConfig = Field(default_factory=SubagentsAppConfig, description="Subagent runtime configuration")
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig, description="Guardrail middleware configuration")
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig, description="LLM circuit breaker configuration")
+    system_models: SystemModelsConfig | None = Field(default=None, description="Default model configuration for system-level LLM tasks")
     model_config = ConfigDict(extra="allow", frozen=False)
     checkpointer: CheckpointerConfig | None = Field(default=None, description="Checkpointer configuration")
     stream_bridge: StreamBridgeConfig | None = Field(default=None, description="Stream bridge configuration")
@@ -157,6 +159,10 @@ class AppConfig(BaseModel):
 
         # Always refresh ACP agent config so removed entries do not linger across reloads.
         load_acp_config_from_dict(config_data.get("acp_agents", {}))
+
+        # Load system_models config; always call to reset singleton on reload.
+        system_models_val = config_data.get("system_models")
+        load_system_models_config_from_dict(system_models_val if isinstance(system_models_val, dict) else {})
 
         # Load extensions config separately (it's in a different file)
         extensions_config = ExtensionsConfig.from_file()

--- a/backend/packages/harness/deerflow/config/system_models_config.py
+++ b/backend/packages/harness/deerflow/config/system_models_config.py
@@ -1,0 +1,39 @@
+"""Configuration for system-level model defaults."""
+
+from pydantic import BaseModel, Field
+
+
+class SystemModelsConfig(BaseModel):
+    """Default model configuration for system-level LLM tasks.
+
+    When a system task (title generation, memory, summarization, suggestions,
+    skill security scanning) has no explicit model_name override, it falls back
+    to the 'default' model specified here. If this section is absent or default
+    is null, the first model in the models[] list is used (backward compatible).
+    """
+
+    default: str | None = Field(
+        default=None,
+        description=("Default model name for system-level LLM tasks (title, memory, summarization, suggestions, security scanning). null = use the first model in the models list."),
+    )
+
+
+# Global configuration instance
+_system_models_config: SystemModelsConfig = SystemModelsConfig()
+
+
+def get_system_models_config() -> SystemModelsConfig:
+    """Get the current system models configuration."""
+    return _system_models_config
+
+
+def set_system_models_config(config: SystemModelsConfig) -> None:
+    """Set the system models configuration."""
+    global _system_models_config
+    _system_models_config = config
+
+
+def load_system_models_config_from_dict(config_dict: dict) -> None:
+    """Load system models configuration from a dictionary."""
+    global _system_models_config
+    _system_models_config = SystemModelsConfig(**config_dict)

--- a/backend/packages/harness/deerflow/models/__init__.py
+++ b/backend/packages/harness/deerflow/models/__init__.py
@@ -1,3 +1,3 @@
-from .factory import create_chat_model
+from .factory import create_chat_model, get_system_model_name
 
-__all__ = ["create_chat_model"]
+__all__ = ["create_chat_model", "get_system_model_name"]

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -30,7 +30,7 @@ def get_system_model_name(task_override: str | None = None) -> str | None:
     from deerflow.config.system_models_config import get_system_models_config
 
     system_config = get_system_models_config()
-    if system_config.default is not None:
+    if system_config.default and system_config.default.strip():
         return system_config.default
 
     return None

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -9,6 +9,33 @@ from deerflow.tracing import build_tracing_callbacks
 logger = logging.getLogger(__name__)
 
 
+def get_system_model_name(task_override: str | None = None) -> str | None:
+    """Resolve the model name for a system-level LLM task.
+
+    Priority:
+    1. task_override -- per-task model_name from config (e.g., title.model_name)
+    2. system_models.default -- global system default
+    3. None -- caller should fall back to create_chat_model(name=None)
+       which uses the first model in models[].
+
+    Args:
+        task_override: The model_name from the task-specific config, or None.
+
+    Returns:
+        A model name string, or None to signal "use default model".
+    """
+    if task_override:
+        return task_override
+
+    from deerflow.config.system_models_config import get_system_models_config
+
+    system_config = get_system_models_config()
+    if system_config.default is not None:
+        return system_config.default
+
+    return None
+
+
 def _deep_merge_dicts(base: dict | None, override: dict) -> dict:
     """Recursively merge two dictionaries without mutating the inputs."""
     merged = dict(base or {})

--- a/backend/packages/harness/deerflow/skills/security_scanner.py
+++ b/backend/packages/harness/deerflow/skills/security_scanner.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 
 from deerflow.config import get_app_config
-from deerflow.models import create_chat_model
+from deerflow.models import create_chat_model, get_system_model_name
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,8 @@ async def scan_skill_content(content: str, *, executable: bool = False, location
 
     try:
         config = get_app_config()
-        model_name = config.skill_evolution.moderation_model_name
-        model = create_chat_model(name=model_name, thinking_enabled=False) if model_name else create_chat_model(thinking_enabled=False)
+        model_name = get_system_model_name(config.skill_evolution.moderation_model_name)
+        model = create_chat_model(name=model_name, thinking_enabled=False)
         response = await model.ainvoke(
             [
                 {"role": "system", "content": rubric},

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -187,3 +187,58 @@ def test_create_summarization_middleware_registers_memory_flush_hook_when_memory
     lead_agent_module._create_summarization_middleware()
 
     assert captured["before_summarization"] == [lead_agent_module.memory_flush_hook]
+
+
+def test_create_summarization_middleware_resolves_model_via_get_system_model_name(monkeypatch):
+    """_create_summarization_middleware passes config.model_name through get_system_model_name."""
+    monkeypatch.setattr(
+        lead_agent_module,
+        "get_summarization_config",
+        lambda: SummarizationConfig(enabled=True, model_name=None),
+    )
+    monkeypatch.setattr(lead_agent_module, "get_memory_config", lambda: MemoryConfig(enabled=False))
+
+    captured_system_name = {}
+
+    def _fake_get_system_model_name(task_override=None):
+        captured_system_name["task_override"] = task_override
+        return "resolved-system-model"
+
+    captured_create = {}
+
+    def _fake_create_chat_model(*, name=None, thinking_enabled, reasoning_effort=None):
+        captured_create["name"] = name
+        return object()
+
+    monkeypatch.setattr(lead_agent_module, "get_system_model_name", _fake_get_system_model_name)
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
+    monkeypatch.setattr(lead_agent_module, "DeerFlowSummarizationMiddleware", lambda **kwargs: kwargs)
+
+    lead_agent_module._create_summarization_middleware()
+
+    assert captured_system_name["task_override"] is None
+    assert captured_create["name"] == "resolved-system-model"
+
+
+def test_create_summarization_middleware_passes_task_override_to_resolver(monkeypatch):
+    """When config.model_name is set, it's passed as task_override to get_system_model_name."""
+    monkeypatch.setattr(
+        lead_agent_module,
+        "get_summarization_config",
+        lambda: SummarizationConfig(enabled=True, model_name="my-summarizer"),
+    )
+    monkeypatch.setattr(lead_agent_module, "get_memory_config", lambda: MemoryConfig(enabled=False))
+
+    captured_system_name = {}
+
+    def _fake_get_system_model_name(task_override=None):
+        captured_system_name["task_override"] = task_override
+        return task_override
+
+    monkeypatch.setattr(lead_agent_module, "get_system_model_name", _fake_get_system_model_name)
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: object())
+    monkeypatch.setattr(lead_agent_module, "DeerFlowSummarizationMiddleware", lambda **kwargs: kwargs)
+
+    lead_agent_module._create_summarization_middleware()
+
+    assert captured_system_name["task_override"] == "my-summarizer"

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -881,3 +881,97 @@ class TestReinforcementHint:
         prompt = model.ainvoke.await_args.args[0]
         assert "Explicit correction signals were detected" in prompt
         assert "Positive reinforcement signals were detected" in prompt
+
+
+class TestMemoryUpdaterGetModel:
+    """Tests for MemoryUpdater._get_model model resolution via get_system_model_name."""
+
+    def setup_method(self):
+        from deerflow.config.memory_config import get_memory_config
+        from deerflow.config.system_models_config import get_system_models_config
+
+        self._original_system_models = get_system_models_config()
+        self._original_memory = get_memory_config()
+
+    def teardown_method(self):
+        from deerflow.config.memory_config import set_memory_config
+        from deerflow.config.system_models_config import set_system_models_config
+
+        set_system_models_config(self._original_system_models)
+        set_memory_config(self._original_memory)
+
+    def test_get_model_with_instance_model_name(self, monkeypatch):
+        """Instance model_name takes priority when set."""
+        from deerflow.config.memory_config import MemoryConfig, set_memory_config
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_memory_config(MemoryConfig(model_name=None))
+        set_system_models_config(SystemModelsConfig(default="sys-default"))
+
+        captured = {}
+
+        def _fake_get_system_model_name(task_override=None):
+            return task_override or "unexpected"
+
+        def _fake_create_chat_model(**kwargs):
+            captured["name"] = kwargs.get("name")
+            return MagicMock()
+
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_system_model_name", _fake_get_system_model_name)
+        monkeypatch.setattr("deerflow.agents.memory.updater.create_chat_model", _fake_create_chat_model)
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_memory_config", lambda: MemoryConfig(model_name=None))
+
+        updater = MemoryUpdater(model_name="instance-model")
+        updater._get_model()
+
+        assert captured["name"] == "instance-model"
+
+    def test_get_model_falls_back_to_config_model_name(self, monkeypatch):
+        """When no instance model_name, uses config.model_name via get_system_model_name."""
+        from deerflow.config.memory_config import MemoryConfig
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="sys-default"))
+
+        captured = {}
+
+        def _fake_get_system_model_name(task_override=None):
+            return task_override or "sys-default"
+
+        def _fake_create_chat_model(**kwargs):
+            captured["name"] = kwargs.get("name")
+            return MagicMock()
+
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_system_model_name", _fake_get_system_model_name)
+        monkeypatch.setattr("deerflow.agents.memory.updater.create_chat_model", _fake_create_chat_model)
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_memory_config", lambda: MemoryConfig(model_name="config-model"))
+
+        updater = MemoryUpdater(model_name=None)
+        updater._get_model()
+
+        assert captured["name"] == "config-model"
+
+    def test_get_model_falls_back_to_system_default(self, monkeypatch):
+        """When neither instance nor config model_name, falls back to system_models.default."""
+        from deerflow.config.memory_config import MemoryConfig
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="gpt-4o-mini"))
+
+        captured = {}
+
+        def _fake_get_system_model_name(task_override=None):
+            return task_override or "gpt-4o-mini"
+
+        def _fake_create_chat_model(**kwargs):
+            captured["name"] = kwargs.get("name")
+            return MagicMock()
+
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_system_model_name", _fake_get_system_model_name)
+        monkeypatch.setattr("deerflow.agents.memory.updater.create_chat_model", _fake_create_chat_model)
+        monkeypatch.setattr("deerflow.agents.memory.updater.get_memory_config", lambda: MemoryConfig(model_name=None))
+
+        updater = MemoryUpdater(model_name=None)
+        updater._get_model()
+
+        assert captured["name"] == "gpt-4o-mini"

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -1,4 +1,4 @@
-"""Tests for deerflow.models.factory.create_chat_model."""
+"""Tests for deerflow.models.factory.create_chat_model and get_system_model_name."""
 
 from __future__ import annotations
 
@@ -863,3 +863,62 @@ def test_no_duplicate_kwarg_when_reasoning_effort_in_config_and_thinking_disable
 
     # kwargs (runtime) takes precedence: thinking-disabled path sets reasoning_effort=minimal
     assert captured.get("reasoning_effort") == "minimal"
+
+
+# ---------------------------------------------------------------------------
+# get_system_model_name
+# ---------------------------------------------------------------------------
+
+
+class TestGetSystemModelName:
+    """Tests for the three-tier model name resolution used by system tasks."""
+
+    def setup_method(self):
+        from deerflow.config.system_models_config import get_system_models_config
+
+        self._original = get_system_models_config()
+
+    def teardown_method(self):
+        from deerflow.config.system_models_config import set_system_models_config
+
+        set_system_models_config(self._original)
+
+    def test_returns_task_override_when_truthy(self, monkeypatch):
+        """Priority 1: task_override is returned directly, no config lookup."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="global-default"))
+        result = factory_module.get_system_model_name(task_override="my-task-model")
+        assert result == "my-task-model"
+
+    def test_returns_system_models_default_when_no_override(self, monkeypatch):
+        """Priority 2: Falls back to system_models.default when no override."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="gpt-4o-mini"))
+        result = factory_module.get_system_model_name(task_override=None)
+        assert result == "gpt-4o-mini"
+
+    def test_returns_none_when_no_override_and_no_default(self, monkeypatch):
+        """Priority 3: Returns None when neither override nor system_models.default is set."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default=None))
+        result = factory_module.get_system_model_name(task_override=None)
+        assert result is None
+
+    def test_empty_string_override_falls_through_to_system_default(self):
+        """Empty string is falsy, so it should fall through to system_models.default."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="fallback-model"))
+        result = factory_module.get_system_model_name(task_override="")
+        assert result == "fallback-model"
+
+    def test_empty_string_override_and_no_default_returns_none(self):
+        """Empty string override with no system default returns None."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default=None))
+        result = factory_module.get_system_model_name(task_override="")
+        assert result is None

--- a/backend/tests/test_security_scanner.py
+++ b/backend/tests/test_security_scanner.py
@@ -9,9 +9,56 @@ from deerflow.skills.security_scanner import scan_skill_content
 async def test_scan_skill_content_blocks_when_model_unavailable(monkeypatch):
     config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=None))
     monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_system_model_name", lambda task_override=None: None)
     monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
 
     result = await scan_skill_content("---\nname: demo-skill\ndescription: demo\n---\n", executable=False)
 
     assert result.decision == "block"
     assert "manual review required" in result.reason
+
+
+@pytest.mark.anyio
+async def test_scan_skill_content_uses_system_model_name(monkeypatch):
+    """Verify scan_skill_content passes the resolved system model name to create_chat_model."""
+    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name="task-model"))
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
+
+    captured = {}
+
+    def _fake_get_system_model_name(task_override=None):
+        return task_override or "fallback"
+
+    def _fake_create_chat_model(**kwargs):
+        captured["name"] = kwargs.get("name")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_system_model_name", _fake_get_system_model_name)
+    monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", _fake_create_chat_model)
+
+    await scan_skill_content("---\nname: demo-skill\ndescription: demo\n---\n", executable=False)
+
+    assert captured["name"] == "task-model"
+
+
+@pytest.mark.anyio
+async def test_scan_skill_content_falls_back_when_no_task_override(monkeypatch):
+    """When task_override is None, get_system_model_name returns the system default."""
+    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=None))
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
+
+    captured = {}
+
+    def _fake_get_system_model_name(task_override=None):
+        return "system-default"
+
+    def _fake_create_chat_model(**kwargs):
+        captured["name"] = kwargs.get("name")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_system_model_name", _fake_get_system_model_name)
+    monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", _fake_create_chat_model)
+
+    await scan_skill_content("---\nname: demo-skill\ndescription: demo\n---\n", executable=False)
+
+    assert captured["name"] == "system-default"

--- a/backend/tests/test_suggestions_router.py
+++ b/backend/tests/test_suggestions_router.py
@@ -44,6 +44,7 @@ def test_generate_suggestions_parses_and_limits(monkeypatch):
     )
     fake_model = MagicMock()
     fake_model.ainvoke = AsyncMock(return_value=MagicMock(content='```json\n["Q1", "Q2", "Q3", "Q4"]\n```'))
+    monkeypatch.setattr(suggestions, "get_system_model_name", lambda task_override=None: "sys-default")
     monkeypatch.setattr(suggestions, "create_chat_model", lambda **kwargs: fake_model)
 
     result = asyncio.run(suggestions.generate_suggestions("t1", req))
@@ -62,6 +63,7 @@ def test_generate_suggestions_parses_list_block_content(monkeypatch):
     )
     fake_model = MagicMock()
     fake_model.ainvoke = AsyncMock(return_value=MagicMock(content=[{"type": "text", "text": '```json\n["Q1", "Q2"]\n```'}]))
+    monkeypatch.setattr(suggestions, "get_system_model_name", lambda task_override=None: None)
     monkeypatch.setattr(suggestions, "create_chat_model", lambda **kwargs: fake_model)
 
     result = asyncio.run(suggestions.generate_suggestions("t1", req))
@@ -80,6 +82,7 @@ def test_generate_suggestions_parses_output_text_block_content(monkeypatch):
     )
     fake_model = MagicMock()
     fake_model.ainvoke = AsyncMock(return_value=MagicMock(content=[{"type": "output_text", "text": '```json\n["Q1", "Q2"]\n```'}]))
+    monkeypatch.setattr(suggestions, "get_system_model_name", lambda task_override=None: None)
     monkeypatch.setattr(suggestions, "create_chat_model", lambda **kwargs: fake_model)
 
     result = asyncio.run(suggestions.generate_suggestions("t1", req))
@@ -95,8 +98,40 @@ def test_generate_suggestions_returns_empty_on_model_error(monkeypatch):
     )
     fake_model = MagicMock()
     fake_model.ainvoke = AsyncMock(side_effect=RuntimeError("boom"))
+    monkeypatch.setattr(suggestions, "get_system_model_name", lambda task_override=None: None)
     monkeypatch.setattr(suggestions, "create_chat_model", lambda **kwargs: fake_model)
 
     result = asyncio.run(suggestions.generate_suggestions("t1", req))
 
     assert result.suggestions == []
+
+
+def test_generate_suggestions_uses_system_model_name(monkeypatch):
+    """Verify that generate_suggestions passes the resolved system model name to create_chat_model."""
+    req = suggestions.SuggestionsRequest(
+        messages=[
+            suggestions.SuggestionMessage(role="user", content="Hi"),
+            suggestions.SuggestionMessage(role="assistant", content="Hello"),
+        ],
+        n=2,
+        model_name=None,
+    )
+    fake_model = MagicMock()
+    fake_model.ainvoke = AsyncMock(return_value=MagicMock(content='```json\n["Q1", "Q2"]\n```'))
+
+    captured_name = {}
+
+    def _fake_get_system_model_name(task_override=None):
+        return "gpt-4o-mini"
+
+    def _fake_create_chat_model(**kwargs):
+        captured_name["name"] = kwargs.get("name")
+        return fake_model
+
+    monkeypatch.setattr(suggestions, "get_system_model_name", _fake_get_system_model_name)
+    monkeypatch.setattr(suggestions, "create_chat_model", _fake_create_chat_model)
+
+    result = asyncio.run(suggestions.generate_suggestions("t1", req))
+
+    assert result.suggestions == ["Q1", "Q2"]
+    assert captured_name["name"] == "gpt-4o-mini"

--- a/backend/tests/test_system_models_config.py
+++ b/backend/tests/test_system_models_config.py
@@ -1,0 +1,62 @@
+"""Tests for deerflow.config.system_models_config."""
+
+from deerflow.config.system_models_config import (
+    SystemModelsConfig,
+    get_system_models_config,
+    load_system_models_config_from_dict,
+    set_system_models_config,
+)
+
+
+class TestSystemModelsConfig:
+    def test_default_is_none(self):
+        config = SystemModelsConfig()
+        assert config.default is None
+
+    def test_accepts_model_name(self):
+        config = SystemModelsConfig(default="gpt-4o-mini")
+        assert config.default == "gpt-4o-mini"
+
+
+class TestGetSetSystemModelsConfig:
+    def setup_method(self):
+        self._original = get_system_models_config()
+
+    def teardown_method(self):
+        set_system_models_config(self._original)
+
+    def test_get_returns_current_config(self):
+        config = get_system_models_config()
+        assert isinstance(config, SystemModelsConfig)
+
+    def test_set_updates_global(self):
+        new_config = SystemModelsConfig(default="test-model")
+        set_system_models_config(new_config)
+        assert get_system_models_config().default == "test-model"
+
+    def test_set_then_reset(self):
+        set_system_models_config(SystemModelsConfig(default="first"))
+        assert get_system_models_config().default == "first"
+        set_system_models_config(SystemModelsConfig(default=None))
+        assert get_system_models_config().default is None
+
+
+class TestLoadSystemModelsConfigFromDict:
+    def setup_method(self):
+        self._original = get_system_models_config()
+
+    def teardown_method(self):
+        set_system_models_config(self._original)
+
+    def test_loads_from_dict_with_default(self):
+        load_system_models_config_from_dict({"default": "loaded-model"})
+        assert get_system_models_config().default == "loaded-model"
+
+    def test_loads_from_empty_dict(self):
+        load_system_models_config_from_dict({})
+        assert get_system_models_config().default is None
+
+    def test_loads_overwrites_previous(self):
+        load_system_models_config_from_dict({"default": "first"})
+        load_system_models_config_from_dict({"default": "second"})
+        assert get_system_models_config().default == "second"

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -25,11 +25,17 @@ def _set_test_title_config(**overrides) -> TitleConfig:
 
 class TestTitleMiddlewareCoreLogic:
     def setup_method(self):
-        # Title config is a global singleton; snapshot and restore for test isolation.
+        # Title config and system_models_config are global singletons; snapshot and restore for test isolation.
         self._original = _clone_title_config(get_title_config())
+        from deerflow.config.system_models_config import get_system_models_config
+
+        self._original_system_models = get_system_models_config()
 
     def teardown_method(self):
         set_title_config(self._original)
+        from deerflow.config.system_models_config import set_system_models_config
+
+        set_system_models_config(self._original_system_models)
 
     def test_should_generate_title_for_first_complete_exchange(self):
         _set_test_title_config(enabled=True)
@@ -91,7 +97,9 @@ class TestTitleMiddlewareCoreLogic:
         title = result["title"]
 
         assert title == "短标题"
-        title_middleware_module.create_chat_model.assert_called_once_with(thinking_enabled=False)
+        create_call_kwargs = title_middleware_module.create_chat_model.call_args
+        assert create_call_kwargs.kwargs.get("thinking_enabled") is False
+        assert "name" in create_call_kwargs.kwargs
         model.ainvoke.assert_awaited_once()
 
     def test_generate_title_normalizes_structured_message_content(self, monkeypatch):
@@ -228,3 +236,59 @@ class TestTitleMiddlewareCoreLogic:
         assert result is not None
         assert "<think>" not in result["title"]
         assert result["title"] == "贵阳发展研究"
+
+    def test_generate_title_uses_system_model_default(self, monkeypatch):
+        """TitleMiddleware passes get_system_model_name result to create_chat_model."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="gpt-4o-mini"))
+        _set_test_title_config(max_chars=50)
+        middleware = TitleMiddleware()
+        model = MagicMock()
+        model.ainvoke = AsyncMock(return_value=AIMessage(content="测试标题"))
+
+        captured_name = {}
+
+        def _fake_create_chat_model(**kwargs):
+            captured_name["name"] = kwargs.get("name")
+            return model
+
+        monkeypatch.setattr(title_middleware_module, "create_chat_model", MagicMock(side_effect=_fake_create_chat_model))
+
+        state = {
+            "messages": [
+                HumanMessage(content="你好"),
+                AIMessage(content="你好！"),
+            ]
+        }
+        result = asyncio.run(middleware._agenerate_title_result(state))
+        assert result["title"] == "测试标题"
+        assert captured_name["name"] == "gpt-4o-mini"
+
+    def test_generate_title_task_override_takes_priority(self, monkeypatch):
+        """When title config has model_name set, it takes priority over system_models.default."""
+        from deerflow.config.system_models_config import SystemModelsConfig, set_system_models_config
+
+        set_system_models_config(SystemModelsConfig(default="gpt-4o-mini"))
+        _set_test_title_config(max_chars=50, model_name="title-specific-model")
+        middleware = TitleMiddleware()
+        model = MagicMock()
+        model.ainvoke = AsyncMock(return_value=AIMessage(content="特定标题"))
+
+        captured_name = {}
+
+        def _fake_create_chat_model(**kwargs):
+            captured_name["name"] = kwargs.get("name")
+            return model
+
+        monkeypatch.setattr(title_middleware_module, "create_chat_model", MagicMock(side_effect=_fake_create_chat_model))
+
+        state = {
+            "messages": [
+                HumanMessage(content="你好"),
+                AIMessage(content="你好！"),
+            ]
+        }
+        result = asyncio.run(middleware._agenerate_title_result(state))
+        assert result["title"] == "特定标题"
+        assert captured_name["name"] == "title-specific-model"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -326,6 +326,22 @@ models:
   #         enable_thinking: true
 
 # ============================================================================
+# System Models Configuration
+# ============================================================================
+# Default model for system-level LLM tasks (title generation, memory updates,
+# summarization, suggestions, skill security scanning).
+# Each system task follows a three-tier fallback:
+#   1. Task-specific model_name override (e.g., title.model_name)
+#   2. system_models.default (this setting)
+#   3. First model in the models[] list (backward compatible)
+#
+# Recommended: Use a lightweight, cost-effective model for system tasks
+# to reduce costs on operations that don't require heavy reasoning.
+#
+# system_models:
+#   default: gpt-4o-mini  # or any model name from your models list
+
+# ============================================================================
 # Tool Groups Configuration
 # ============================================================================
 # Define groups of tools for organization and access control


### PR DESCRIPTION
## Background

System-level LLM tasks (title generation, memory updates, summarization, suggestions, skill security scanning) each had their own scattered if/else logic for picking a model. There was no way to set a single lightweight default model for all of them — you had to configure each one individually or fall back to the heavy first model in `models[]`.

## Solution

Introduce `system_models.default` in `config.yaml` — a single knob that sets the default model for all system tasks. Each task can still override it via its own `model_name` config.

Three-tier resolution: **task override** → **`system_models.default`** → **`models[0]`** (backward compatible).

  Affected system tasks:                                                                                                                     
  - **Lead Agent** — summarization middleware (`summarization.model_name`)                                                                   
  - **Memory Updater** — memory consolidation model (`memory.model_name` + instance `model_name`)                                            
  - **Title Middleware** — conversation title generation (`title.model_name`)                                                                
  - **Security Scanner** — skill content moderation (`skill_evolution.moderation_model_name`)                                                
  - **Suggestions Router** — follow-up suggestion generation (no task-level override, always uses system default)  

## Test Plan                                                                                                                               
                                                                                                                                             
  - [x] Full suite: **1946 passed**, 0 failures                                                                                              
  - [x] `SystemModelsConfig` CRUD + `load_from_dict` overwrite/reset behavior correct                                                        
  - [x] `get_system_model_name` three-tier priority: task_override > system_models.default > None                                            
  - [x] All consumers (lead_agent / memory_updater / title_middleware / security_scanner / suggestions_router) verified via monkeypatch that 
  resolved model name is passed correctly                                                                                                    
  - [x] All tests use `setup_method`/`teardown_method` to manually save/restore global singletons — no autouse fixtures                      
  - [x] Manual: add `system_models: { default: gpt-4o-mini }` to config.yaml, verify title/memory/summarization tasks use it                 
  - [x] Manual: omit `system_models` section entirely, confirm system tasks behave identically to before the change    

Closes #2229 