### PR TITLE
fix: validate bootstrap agent names before filesystem writes

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -17,7 +17,7 @@ from deerflow.agents.middlewares.token_usage_middleware import TokenUsageMiddlew
 from deerflow.agents.middlewares.tool_error_handling_middleware import build_lead_runtime_middlewares
 from deerflow.agents.middlewares.view_image_middleware import ViewImageMiddleware
 from deerflow.agents.thread_state import ThreadState
-from deerflow.config.agents_config import load_agent_config
+from deerflow.config.agents_config import load_agent_config, validate_agent_name
 from deerflow.config.app_config import get_app_config
 from deerflow.config.memory_config import get_memory_config
 from deerflow.config.summarization_config import get_summarization_config
@@ -291,7 +291,7 @@ def make_lead_agent(config: RunnableConfig):
     subagent_enabled = cfg.get("subagent_enabled", False)
     max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
     is_bootstrap = cfg.get("is_bootstrap", False)
-    agent_name = cfg.get("agent_name")
+    agent_name = validate_agent_name(cfg.get("agent_name"))
 
     agent_config = load_agent_config(agent_name) if not is_bootstrap else None
     # Custom agent model from agent config (if any), or None to let _resolve_model_name pick the default

--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -15,6 +15,15 @@ SOUL_FILENAME = "SOUL.md"
 AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
 
 
+def validate_agent_name(name: str | None) -> str | None:
+    """Validate a custom agent name before using it in filesystem paths."""
+    if name is None:
+        return None
+    if not AGENT_NAME_PATTERN.match(name):
+        raise ValueError(f"Invalid agent name '{name}'. Must match pattern: {AGENT_NAME_PATTERN.pattern}")
+    return name
+
+
 class AgentConfig(BaseModel):
     """Configuration for a custom agent."""
 
@@ -46,8 +55,7 @@ def load_agent_config(name: str | None) -> AgentConfig | None:
     if name is None:
         return None
 
-    if not AGENT_NAME_PATTERN.match(name):
-        raise ValueError(f"Invalid agent name '{name}'. Must match pattern: {AGENT_NAME_PATTERN.pattern}")
+    name = validate_agent_name(name)
     agent_dir = get_paths().agent_dir(name)
     config_file = agent_dir / "config.yaml"
 

--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -19,7 +19,9 @@ def validate_agent_name(name: str | None) -> str | None:
     """Validate a custom agent name before using it in filesystem paths."""
     if name is None:
         return None
-    if not AGENT_NAME_PATTERN.match(name):
+    if not isinstance(name, str):
+        raise ValueError("Invalid agent name. Expected a string or None.")
+    if not AGENT_NAME_PATTERN.fullmatch(name):
         raise ValueError(f"Invalid agent name '{name}'. Must match pattern: {AGENT_NAME_PATTERN.pattern}")
     return name
 

--- a/backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py
@@ -6,6 +6,7 @@ from langchain_core.tools import tool
 from langgraph.prebuilt import ToolRuntime
 from langgraph.types import Command
 
+from deerflow.config.agents_config import validate_agent_name
 from deerflow.config.paths import get_paths
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,10 @@ def setup_agent(
     """
 
     agent_name: str | None = runtime.context.get("agent_name") if runtime.context else None
+    agent_dir = None
 
     try:
+        agent_name = validate_agent_name(agent_name)
         paths = get_paths()
         agent_dir = paths.agent_dir(agent_name) if agent_name else paths.base_dir
         agent_dir.mkdir(parents=True, exist_ok=True)
@@ -55,7 +58,7 @@ def setup_agent(
     except Exception as e:
         import shutil
 
-        if agent_name and agent_dir.exists():
+        if agent_name and agent_dir is not None and agent_dir.exists():
             # Cleanup the custom agent directory only if it was created but an error occurred during setup
             shutil.rmtree(agent_dir)
         logger.error(f"[agent_creator] Failed to create agent '{agent_name}': {e}", exc_info=True)

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -113,6 +113,26 @@ def test_make_lead_agent_disables_thinking_when_model_does_not_support_it(monkey
     assert result["model"] is not None
 
 
+def test_make_lead_agent_rejects_invalid_bootstrap_agent_name(monkeypatch):
+    app_config = _make_app_config([_make_model("safe-model", supports_thinking=False)])
+
+    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: app_config)
+
+    with pytest.raises(ValueError, match="Invalid agent name"):
+        lead_agent_module.make_lead_agent(
+            {
+                "configurable": {
+                    "model_name": "safe-model",
+                    "thinking_enabled": False,
+                    "is_plan_mode": False,
+                    "subagent_enabled": False,
+                    "is_bootstrap": True,
+                    "agent_name": "../../../tmp/evil",
+                }
+            }
+        )
+
+
 def test_build_middlewares_uses_resolved_model_name_for_vision(monkeypatch):
     app_config = _make_app_config(
         [

--- a/backend/tests/test_setup_agent_tool.py
+++ b/backend/tests/test_setup_agent_tool.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from deerflow.tools.builtins.setup_agent_tool import setup_agent
+
+
+class _DummyRuntime(SimpleNamespace):
+    context: dict
+    tool_call_id: str
+
+
+def test_setup_agent_rejects_invalid_agent_name_before_writing(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    runtime = _DummyRuntime(context={"agent_name": "../../../tmp/evil"}, tool_call_id="tool-1")
+
+    result = setup_agent.func(soul="test soul", description="desc", runtime=runtime)
+
+    messages = result.update["messages"]
+    assert len(messages) == 1
+    assert "Invalid agent name" in messages[0].content
+    assert not (tmp_path / "agents").exists()
+    assert not (Path("/tmp/evil") / "SOUL.md").exists()
+
+
+def test_setup_agent_rejects_absolute_agent_name_before_writing(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    absolute_agent = str(tmp_path / "outside-agent")
+    runtime = _DummyRuntime(context={"agent_name": absolute_agent}, tool_call_id="tool-2")
+
+    result = setup_agent.func(soul="test soul", description="desc", runtime=runtime)
+
+    messages = result.update["messages"]
+    assert len(messages) == 1
+    assert "Invalid agent name" in messages[0].content
+    assert not (tmp_path / "agents").exists()
+    assert not (Path(absolute_agent) / "SOUL.md").exists()

--- a/backend/tests/test_setup_agent_tool.py
+++ b/backend/tests/test_setup_agent_tool.py
@@ -13,7 +13,9 @@ class _DummyRuntime(SimpleNamespace):
 
 def test_setup_agent_rejects_invalid_agent_name_before_writing(tmp_path, monkeypatch):
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
-    runtime = _DummyRuntime(context={"agent_name": "../../../tmp/evil"}, tool_call_id="tool-1")
+    outside_dir = tmp_path.parent / "outside-target"
+    traversal_agent = f"../../../{outside_dir.name}/evil"
+    runtime = _DummyRuntime(context={"agent_name": traversal_agent}, tool_call_id="tool-1")
 
     result = setup_agent.func(soul="test soul", description="desc", runtime=runtime)
 
@@ -21,7 +23,7 @@ def test_setup_agent_rejects_invalid_agent_name_before_writing(tmp_path, monkeyp
     assert len(messages) == 1
     assert "Invalid agent name" in messages[0].content
     assert not (tmp_path / "agents").exists()
-    assert not (Path("/tmp/evil") / "SOUL.md").exists()
+    assert not (outside_dir / "evil" / "SOUL.md").exists()
 
 
 def test_setup_agent_rejects_absolute_agent_name_before_writing(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
This PR hardens bootstrap-mode custom-agent creation by enforcing the existing backend agent-name validation before any filesystem path construction occurs.
- bootstrap-mode `make_lead_agent()` now validates `configurable["agent_name"]` instead of bypassing validation when `is_bootstrap=true`
- `setup_agent()` now validates `runtime.context["agent_name"]` before building `agent_dir` or writing `config.yaml` / `SOUL.md`
- the cleanup path in `setup_agent()` is hardened so invalid-name failures do not dereference an uninitialized `agent_dir`
- regression tests now cover traversal and absolute-path agent names in both the bootstrap entry path and the filesystem-writing tool path

## Security issues covered
| Issue | Impact | Severity |
|-------|--------|----------|
| Bootstrap-mode agent-name validation bypass | attacker-controlled invalid `agent_name` values can reach custom-agent filesystem paths during bootstrap flows | High |
| Unvalidated `setup_agent` filesystem writes | traversal or absolute-path `agent_name` values can redirect `config.yaml` / `SOUL.md` writes outside the intended agents directory, subject to runtime filesystem permissions | High |

## Before this PR
- bootstrap mode skipped `load_agent_config()`, which was the only backend path enforcing the `^[A-Za-z0-9-]+$` custom-agent name pattern
- `setup_agent()` trusted `runtime.context["agent_name"]` and used it directly in `paths.agent_dir(agent_name)` before writing files
- absolute-path and traversal-style agent names were not rejected before filesystem path construction
- regression tests did not cover invalid bootstrap-mode agent names or invalid `setup_agent()` runtime agent names

## After this PR
- bootstrap-mode lead-agent creation rejects invalid custom agent names before any bootstrap agent is created
- `setup_agent()` rejects invalid runtime agent names before directory creation or file writes
- cleanup logic no longer assumes an initialized `agent_dir` after early validation failures
- regression tests lock in both the bootstrap entry validation and the tool-level path-safety validation

## Why this matters
- the broken boundary was: request/runtime-controlled `agent_name` -> filesystem path construction -> file writes
- if a bootstrap flow could be reached with an attacker-controlled invalid agent name, the pre-patch path could redirect writes outside the intended `agents/` directory
- even when constrained by runtime write permissions, this is the wrong trust boundary for custom-agent creation and should fail before any path is built

## Attack flow
```text
attacker-controlled bootstrap agent_name
    -> bootstrap-mode make_lead_agent() skips load_agent_config() validation
        -> setup_agent() uses runtime.context.agent_name in paths.agent_dir()
            -> config.yaml / SOUL.md write outside intended agents directory
```

## Affected code
| Issue | Files |
|-------|-------|
| Bootstrap-mode validation bypass | `backend/packages/harness/deerflow/agents/lead_agent/agent.py`, `backend/packages/harness/deerflow/config/agents_config.py` |
| Unvalidated `setup_agent` writes | `backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py`, `backend/packages/harness/deerflow/config/agents_config.py`, `backend/packages/harness/deerflow/config/paths.py` |

## Root cause
Issue 1: bootstrap-mode validation bypass
- `make_lead_agent()` only called `load_agent_config(agent_name)` when `is_bootstrap` was false
- the existing name-validation rule lived inside `load_agent_config()`, so bootstrap mode accidentally bypassed the only backend validation gate

Issue 2: unvalidated filesystem writes in `setup_agent`
- `setup_agent()` read `runtime.context["agent_name"]` and passed it directly into `paths.agent_dir(agent_name)` before writing files
- this allowed request/runtime-controlled path components to influence filesystem writes without prior validation

## CVSS assessment
| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Bootstrap-mode agent-name validation bypass | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H` |
| Unvalidated `setup_agent` filesystem writes | 8.1 High | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H` |

Rationale:
- the validated primitive is attacker-influenced file write outside the intended custom-agent directory boundary
- confidentiality impact is not the primary claim here, but integrity and availability can be materially affected if writable target paths are reachable in deployment

## Safe reproduction steps
### 1. Bootstrap-mode validation bypass
1. Prepare a bootstrap-mode `RunnableConfig` with `is_bootstrap=true` and an invalid `agent_name` such as `../../../tmp/evil`.
2. Call `make_lead_agent()` with that configuration.
3. Observe that the pre-patch code accepted the invalid name into the bootstrap path instead of rejecting it early.

### 2. Unvalidated `setup_agent` writes
1. Invoke `setup_agent()` with a runtime context containing an invalid `agent_name` such as `../../../tmp/evil` or an absolute path.
2. Let `setup_agent()` derive `agent_dir = paths.agent_dir(agent_name)`.
3. Observe that the pre-patch code proceeded toward directory creation and `config.yaml` / `SOUL.md` writes using the invalid path-derived location.

Prefer safe local test harnesses; no destructive payload is required.

## Expected vulnerable behavior
- bootstrap flows should never accept traversal or absolute-path custom agent names
- `setup_agent()` should never build filesystem paths from unvalidated runtime agent names
- pre-patch behavior allowed invalid names to reach filesystem path construction instead of failing immediately

## Changes in this PR
- add shared `validate_agent_name()` helper in `agents_config.py`
- reuse that helper inside `load_agent_config()` so validation remains centralized
- validate `configurable["agent_name"]` in `make_lead_agent()` even when `is_bootstrap=true`
- validate `runtime.context["agent_name"]` in `setup_agent()` before any filesystem path use
- guard cleanup so invalid-name failures do not access an uninitialized `agent_dir`
- add regression tests for invalid bootstrap agent names and invalid `setup_agent()` runtime agent names

## Files changed
| Category | Files | What changed |
|----------|-------|--------------|
| Shared validation | `backend/packages/harness/deerflow/config/agents_config.py` | added `validate_agent_name()` helper and reused it from `load_agent_config()` |
| Bootstrap hardening | `backend/packages/harness/deerflow/agents/lead_agent/agent.py` | validate `agent_name` before bootstrap-mode lead-agent creation |
| Tool hardening | `backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py` | validate runtime `agent_name` before path construction and harden cleanup |
| Regression tests | `backend/tests/test_lead_agent_model_resolution.py`, `backend/tests/test_setup_agent_tool.py` | add traversal and absolute-path regression coverage |

## Maintainer impact
- this is a narrow backend hardening patch
- normal valid custom-agent creation flows remain unchanged
- frontend and unrelated runtime systems are untouched
- centralizing validation into a shared helper reduces the chance of future bootstrap-vs-non-bootstrap drift

## Suggested fix rationale
- the right boundary is to reject invalid custom agent names before any filesystem path is constructed
- applying the same validation rule in both bootstrap entry and tool-level write paths makes the behavior consistent and durable
- the regression tests are sufficient to prevent the exact bootstrap/path-safety drift that allowed this gap

## Type of change
- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan
- [x] validate bootstrap-mode invalid agent names are rejected
- [x] validate `setup_agent()` rejects traversal-style runtime agent names before writing
- [x] validate `setup_agent()` rejects absolute-path runtime agent names before writing
- [ ] full backend test suite

Executed with:
- `cd backend && uv sync`
- `cd backend && PYTHONPATH=. uv run pytest tests/test_lead_agent_model_resolution.py tests/test_setup_agent_tool.py -q`

If something was not run:
- the full backend test suite was not run for this PR body update; only the targeted regression tests above were executed for this patch

## Disclosure notes
- claims here are intentionally bounded to the validated bootstrap/path-construction and filesystem-write code paths
- this PR does not claim arbitrary write success to every path, only that invalid names reached filesystem path construction and write attempts outside the intended agents directory boundary subject to runtime permissions
- no unrelated files were changed outside the minimal validation and regression-test scope
