### PR TITLE
fix(frontend): make Suggestion button opaque in dark mode

### DIFF
--- a/frontend/src/components/ai-elements/suggestion.tsx
+++ b/frontend/src/components/ai-elements/suggestion.tsx
@@ -64,7 +64,7 @@ export const Suggestion = ({
   return (
     <Button
       className={cn(
-        "text-muted-foreground h-auto max-w-full cursor-pointer rounded-full px-4 py-2 text-center text-xs font-normal whitespace-normal",
+        "text-muted-foreground h-auto max-w-full cursor-pointer rounded-full px-4 py-2 text-center text-xs font-normal whitespace-normal dark:bg-background",
         className,
       )}
       onClick={handleClick}

--- a/frontend/src/components/ai-elements/suggestion.tsx
+++ b/frontend/src/components/ai-elements/suggestion.tsx
@@ -64,7 +64,7 @@ export const Suggestion = ({
   return (
     <Button
       className={cn(
-        "text-muted-foreground h-auto max-w-full cursor-pointer rounded-full px-4 py-2 text-center text-xs font-normal whitespace-normal dark:bg-background",
+        "text-muted-foreground dark:bg-background h-auto max-w-full cursor-pointer rounded-full px-4 py-2 text-center text-xs font-normal whitespace-normal",
         className,
       )}
       onClick={handleClick}


### PR DESCRIPTION
## Summary

- Override the outline `Button` variant's `dark:bg-input/30` on `Suggestion`, which made followup suggestion pills ~70% transparent in dark mode.
- Scrolled chat content bled through the buttons and rendered the suggestion text unreadable; adding `dark:bg-background` restores the opaque, light-mode-equivalent appearance.

Fixes #2275

## Test plan

- [x] `pnpm check` (lint + typecheck) passes — already validated by the pre-commit hook.
- [x] Manual: open a chat thread in dark mode, scroll the message list while followup suggestions are visible, confirm the buttons stay opaque and readable.
- [x] Manual: confirm light-mode appearance is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)