### PR TITLE
fix(frontend): stop artifact panel auto-opening on rehydrated write_file

### DIFF
--- a/frontend/src/components/workspace/messages/message-group.tsx
+++ b/frontend/src/components/workspace/messages/message-group.tsx
@@ -336,7 +336,7 @@ function ToolCall({
       description = t.toolCalls.writeFile;
     }
     const path: string | undefined = (args as { path: string })?.path;
-    if (isLoading && isLast && autoOpen && autoSelect && path) {
+    if (isLoading && isLast && autoOpen && autoSelect && path && !result) {
       setTimeout(() => {
         const url = new URL(
           `write-file:${path}?message_id=${messageId}&tool_call_id=${id}`,


### PR DESCRIPTION
## Summary

- After a page refresh, `autoOpen` / `autoSelect` in the artifact context reset to `true`. Submitting a new question flips `thread.isLoading` to `true`, which `message-list.tsx` passes to every `MessageGroup` — including historical ones. The previous response's last `write_file` step still satisfies `isLast && path`, so the render-time side effect in `message-group.tsx:339` fires and re-opens the stale artifact.
- Gate the auto-open on `!result` so only a `write_file` that is still streaming in the current response can trigger it; rehydrated tool calls always carry a `result` (populated by `convertToSteps` when a matching tool result message exists) and are now skipped.

Fixes #2277

## Test plan

- [x] `pnpm check` (lint + typecheck) passes — validated by the pre-commit hook.
- [x] Manual: ask a question that triggers a markdown `write_file`; confirm the artifact panel still auto-opens for the new artifact.
- [x] Manual: reproduce the bug path — refresh the page, submit a new question, confirm the panel no longer re-pops the previous response's artifact.
- [x] Manual: close the artifact panel mid-stream, confirm it stays closed for the rest of the response (existing `autoOpen=false` behavior preserved).

## Notes

The auto-open is currently a render-time side effect inside `setTimeout`. A proper `useEffect` keyed on the tool-call id would be a cleaner long-term shape, but this one-line gate is the smallest safe fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)