### PR TITLE
fix attachment upload flow and add file progress UI

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -149,8 +149,9 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         """Extract file info from message additional_kwargs.files.
 
         The frontend sends uploaded file metadata in additional_kwargs.files
-        after a successful upload. Each entry has: filename, size (bytes),
-        path (virtual path), status.
+        after a successful upload. Each entry has: filename (display name),
+        size (bytes), path (virtual path), status, and optionally
+        stored_filename (actual basename on disk) and markdown_file.
 
         Args:
             message: The human message to inspect.
@@ -169,19 +170,45 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
             if not isinstance(f, dict):
                 continue
             filename = f.get("filename") or ""
+            stored_filename = f.get("stored_filename") or filename
+            markdown_file = f.get("markdown_file")
             if not filename or Path(filename).name != filename:
                 continue
-            if uploads_dir is not None and not (uploads_dir / filename).is_file():
+            if not stored_filename or Path(stored_filename).name != stored_filename:
+                continue
+            if markdown_file and Path(markdown_file).name != markdown_file:
+                markdown_file = None
+            if uploads_dir is not None and not (uploads_dir / stored_filename).is_file():
                 continue
             files.append(
                 {
                     "filename": filename,
+                    "stored_filename": stored_filename,
+                    "markdown_file": markdown_file,
                     "size": int(f.get("size") or 0),
-                    "path": f"/mnt/user-data/uploads/{filename}",
+                    "path": f"/mnt/user-data/uploads/{stored_filename}",
                     "extension": Path(filename).suffix,
                 }
             )
         return files if files else None
+
+    def _collect_uploaded_file_metadata(self, messages: list) -> tuple[dict[str, str], set[str]]:
+        """Collect display-name mappings and generated markdown sidecars from messages."""
+        stored_name_to_display_name: dict[str, str] = {}
+        generated_markdown_files: set[str] = set()
+
+        for message in messages:
+            if not isinstance(message, HumanMessage):
+                continue
+            known_files = self._files_from_kwargs(message, uploads_dir=None) or []
+            for file in known_files:
+                stored_filename = file["stored_filename"]
+                stored_name_to_display_name.setdefault(stored_filename, file["filename"])
+                markdown_file = file.get("markdown_file")
+                if markdown_file:
+                    generated_markdown_files.add(markdown_file)
+
+        return stored_name_to_display_name, generated_markdown_files
 
     @override
     def before_agent(self, state: UploadsMiddlewareState, runtime: Runtime) -> dict | None:
@@ -223,23 +250,29 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
                 pass  # get_config() raises outside a runnable context (e.g. unit tests)
         uploads_dir = self._paths.sandbox_uploads_dir(thread_id) if thread_id else None
 
+        stored_name_to_display_name, historical_markdown_files = self._collect_uploaded_file_metadata(messages)
+
         # Get newly uploaded files from the current message's additional_kwargs.files
         new_files = self._files_from_kwargs(last_message, uploads_dir) or []
 
         # Collect historical files from the uploads directory (all except the new ones)
-        new_filenames = {f["filename"] for f in new_files}
+        new_stored_filenames = {f["stored_filename"] for f in new_files}
+        current_markdown_files = {f["markdown_file"] for f in new_files if f.get("markdown_file")}
+        skipped_historical_filenames = new_stored_filenames | historical_markdown_files | current_markdown_files
         historical_files: list[dict] = []
         if uploads_dir and uploads_dir.exists():
             for file_path in sorted(uploads_dir.iterdir()):
-                if file_path.is_file() and file_path.name not in new_filenames:
+                if file_path.is_file() and file_path.name not in skipped_historical_filenames:
                     stat = file_path.stat()
                     outline, preview = _extract_outline_for_file(file_path)
+                    display_name = stored_name_to_display_name.get(file_path.name, file_path.name)
                     historical_files.append(
                         {
-                            "filename": file_path.name,
+                            "filename": display_name,
+                            "stored_filename": file_path.name,
                             "size": stat.st_size,
                             "path": f"/mnt/user-data/uploads/{file_path.name}",
-                            "extension": file_path.suffix,
+                            "extension": Path(display_name).suffix or file_path.suffix,
                             "outline": outline,
                             "outline_preview": preview,
                         }
@@ -248,7 +281,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         # Attach outlines to new files as well
         if uploads_dir:
             for file in new_files:
-                phys_path = uploads_dir / file["filename"]
+                phys_path = uploads_dir / file["stored_filename"]
                 outline, preview = _extract_outline_for_file(phys_path)
                 file["outline"] = outline
                 file["outline_preview"] = preview

--- a/backend/tests/test_uploads_middleware_core_logic.py
+++ b/backend/tests/test_uploads_middleware_core_logic.py
@@ -341,9 +341,7 @@ class TestBeforeAgent:
             }
         ]
 
-    def test_stored_filename_does_not_reappear_as_historical_and_still_loads_outline(
-        self, tmp_path
-    ):
+    def test_stored_filename_does_not_reappear_as_historical_and_still_loads_outline(self, tmp_path):
         mw = _middleware(tmp_path)
         uploads_dir = _uploads_dir(tmp_path)
         (uploads_dir / "draft_abc123.pdf").write_bytes(b"%PDF fake")
@@ -374,9 +372,7 @@ class TestBeforeAgent:
         assert "previous messages" not in content
         assert "Executive Summary" in content
 
-    def test_historical_files_keep_display_name_and_hide_generated_markdown_sidecars(
-        self, tmp_path
-    ):
+    def test_historical_files_keep_display_name_and_hide_generated_markdown_sidecars(self, tmp_path):
         mw = _middleware(tmp_path)
         uploads_dir = _uploads_dir(tmp_path)
         (uploads_dir / "draft_abc123.pdf").write_bytes(b"%PDF fake")

--- a/backend/tests/test_uploads_middleware_core_logic.py
+++ b/backend/tests/test_uploads_middleware_core_logic.py
@@ -104,7 +104,50 @@ class TestFilesFromKwargs:
         assert result is not None
         assert len(result) == 1
         assert result[0]["filename"] == "data.csv"
+        assert result[0]["stored_filename"] == "data.csv"
         assert result[0]["path"] == "/mnt/user-data/uploads/data.csv"
+
+    def test_prefers_stored_filename_for_disk_lookup_and_path(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "draft_abc123.pdf").write_text("pdf")
+        msg = _human(
+            "hi",
+            files=[
+                {
+                    "filename": "Quarterly Report.pdf",
+                    "stored_filename": "draft_abc123.pdf",
+                    "size": 3,
+                    "path": "/mnt/user-data/uploads/draft_abc123.pdf",
+                }
+            ],
+        )
+        result = mw._files_from_kwargs(msg, uploads_dir)
+        assert result is not None
+        assert result[0]["filename"] == "Quarterly Report.pdf"
+        assert result[0]["stored_filename"] == "draft_abc123.pdf"
+        assert result[0]["markdown_file"] is None
+        assert result[0]["path"] == "/mnt/user-data/uploads/draft_abc123.pdf"
+
+    def test_keeps_markdown_file_metadata_when_present(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "draft_abc123.pdf").write_text("pdf")
+        msg = _human(
+            "hi",
+            files=[
+                {
+                    "filename": "Quarterly Report.pdf",
+                    "stored_filename": "draft_abc123.pdf",
+                    "markdown_file": "draft_abc123.md",
+                    "size": 3,
+                    "path": "/mnt/user-data/uploads/draft_abc123.pdf",
+                }
+            ],
+        )
+        result = mw._files_from_kwargs(msg, uploads_dir)
+        assert result is not None
+        assert result[0]["markdown_file"] == "draft_abc123.md"
 
     def test_skips_nonexistent_but_accepts_existing_in_mixed_list(self, tmp_path):
         mw = _middleware(tmp_path)
@@ -288,6 +331,8 @@ class TestBeforeAgent:
         assert result["uploaded_files"] == [
             {
                 "filename": "notes.txt",
+                "stored_filename": "notes.txt",
+                "markdown_file": None,
                 "size": 5,
                 "path": "/mnt/user-data/uploads/notes.txt",
                 "extension": ".txt",
@@ -295,6 +340,74 @@ class TestBeforeAgent:
                 "outline_preview": [],
             }
         ]
+
+    def test_stored_filename_does_not_reappear_as_historical_and_still_loads_outline(
+        self, tmp_path
+    ):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "draft_abc123.pdf").write_bytes(b"%PDF fake")
+        (uploads_dir / "draft_abc123.md").write_text(
+            "# Executive Summary\n\nBody text.\n",
+            encoding="utf-8",
+        )
+
+        msg = _human(
+            "summarise",
+            files=[
+                {
+                    "filename": "Quarterly Report.pdf",
+                    "stored_filename": "draft_abc123.pdf",
+                    "markdown_file": "draft_abc123.md",
+                    "size": 9,
+                    "path": "/mnt/user-data/uploads/draft_abc123.pdf",
+                }
+            ],
+        )
+        result = mw.before_agent(self._state(msg), _runtime())
+
+        assert result is not None
+        content = result["messages"][-1].content
+        assert "Quarterly Report.pdf" in content
+        assert "draft_abc123.md" not in content
+        assert "/mnt/user-data/uploads/draft_abc123.pdf" in content
+        assert "previous messages" not in content
+        assert "Executive Summary" in content
+
+    def test_historical_files_keep_display_name_and_hide_generated_markdown_sidecars(
+        self, tmp_path
+    ):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "draft_abc123.pdf").write_bytes(b"%PDF fake")
+        (uploads_dir / "draft_abc123.md").write_text(
+            "# Executive Summary\n\nBody text.\n",
+            encoding="utf-8",
+        )
+
+        first = _human(
+            "summarise",
+            files=[
+                {
+                    "filename": "Quarterly Report.pdf",
+                    "stored_filename": "draft_abc123.pdf",
+                    "markdown_file": "draft_abc123.md",
+                    "size": 9,
+                    "path": "/mnt/user-data/uploads/draft_abc123.pdf",
+                }
+            ],
+        )
+        second = _human("follow-up question")
+
+        result = mw.before_agent(self._state(first, second), _runtime())
+
+        assert result is not None
+        content = result["messages"][-1].content
+        assert "previous messages" in content
+        assert "Quarterly Report.pdf" in content
+        assert "- draft_abc123.pdf (" not in content
+        assert "draft_abc123.md" not in content
+        assert "/mnt/user-data/uploads/draft_abc123.pdf" in content
 
     def test_historical_files_from_uploads_dir_excluding_new(self, tmp_path):
         mw = _middleware(tmp_path)

--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -48,7 +48,7 @@ export default function AgentChatPage() {
   const { tokenUsageEnabled } = useModels();
 
   const { showNotification } = useNotification();
-  const [thread, sendMessage] = useThreadStream({
+  const [thread, sendMessage, isUploading] = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
     context: { ...settings.context, agent_name: agent_name },
     onStart: (createdThreadId) => {
@@ -81,7 +81,7 @@ export default function AgentChatPage() {
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
-      void sendMessage(threadId, message, { agent_name });
+      return sendMessage(threadId, message, { agent_name });
     },
     [sendMessage, threadId, agent_name],
   );
@@ -175,6 +175,7 @@ export default function AgentChatPage() {
                 <InputBox
                   className={cn("bg-background/5 w-full -translate-y-4")}
                   isNewThread={isNewThread}
+                  isUploading={isUploading}
                   threadId={threadId}
                   autoFocus={isNewThread}
                   status={
@@ -190,7 +191,10 @@ export default function AgentChatPage() {
                       <AgentWelcome agent={agent} agentName={agent_name} />
                     )
                   }
-                  disabled={env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true"}
+                  disabled={
+                    env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
+                    isUploading
+                  }
                   onContextChange={(context) => setSettings("context", context)}
                   onFollowupsVisibilityChange={setShowFollowups}
                   onSubmit={handleSubmit}

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -76,7 +76,7 @@ export default function ChatPage() {
 
   const handleSubmit = useCallback(
     (message: PromptInputMessage) => {
-      void sendMessage(threadId, message);
+      return sendMessage(threadId, message);
     },
     [sendMessage, threadId],
   );
@@ -161,6 +161,7 @@ export default function ChatPage() {
                     extraHeader={
                       isNewThread && <Welcome mode={settings.context.mode} />
                     }
+                    isUploading={isUploading}
                     disabled={
                       env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
                       isUploading

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { useI18n } from "@/core/i18n/hooks";
 import {
   Command,
   CommandEmpty,
@@ -40,12 +41,15 @@ import { isIMEComposing } from "@/lib/ime";
 import { cn } from "@/lib/utils";
 import type { ChatStatus } from "ai";
 import {
+  AlertCircleIcon,
   ArrowUpIcon,
+  CheckIcon,
   ImageIcon,
   Loader2Icon,
   MicIcon,
   PaperclipIcon,
   PlusIcon,
+  RotateCcwIcon,
   SquareIcon,
   UploadIcon,
   XIcon,
@@ -79,11 +83,18 @@ import { toast } from "sonner";
 // Provider Context & Types
 // ============================================================================
 
+type PromptInputAttachmentItem = PromptInputFilePart & { id: string };
+
 export type AttachmentsContext = {
-  files: (PromptInputFilePart & { id: string })[];
+  files: PromptInputAttachmentItem[];
   add: (files: File[] | FileList) => void;
   remove: (id: string) => void;
   clear: () => void;
+  update: (
+    id: string,
+    updater: (file: PromptInputAttachmentItem) => PromptInputAttachmentItem,
+  ) => void;
+  retry: (id: string) => void;
   openFileDialog: () => void;
   fileInputRef: RefObject<HTMLInputElement | null>;
 };
@@ -160,7 +171,7 @@ export function PromptInputProvider({
 
   // ----- attachments state (global when wrapped)
   const [attachmentFiles, setAttachmentFiles] = useState<
-    (PromptInputFilePart & { id: string })[]
+    PromptInputAttachmentItem[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const openRef = useRef<() => void>(() => {});
@@ -180,6 +191,10 @@ export function PromptInputProvider({
           mediaType: file.type,
           filename: file.name,
           file,
+          upload: {
+            status: "pending",
+            progress: 0,
+          },
         })),
       ),
     );
@@ -204,6 +219,35 @@ export function PromptInputProvider({
       }
       return [];
     });
+  }, []);
+
+  const update = useCallback(
+    (
+      id: string,
+      updater: (file: PromptInputAttachmentItem) => PromptInputAttachmentItem,
+    ) => {
+      setAttachmentFiles((prev) =>
+        prev.map((file) => (file.id === id ? updater(file) : file)),
+      );
+    },
+    [],
+  );
+
+  const retry = useCallback((id: string) => {
+    setAttachmentFiles((prev) =>
+      prev.map((file) =>
+        file.id === id
+          ? {
+              ...file,
+              upload: {
+                status: "pending",
+                progress: 0,
+                storedFilename: file.upload?.storedFilename,
+              },
+            }
+          : file,
+      ),
+    );
   }, []);
 
   // Keep a ref to attachments for cleanup on unmount (avoids stale closure)
@@ -231,10 +275,12 @@ export function PromptInputProvider({
       add,
       remove,
       clear,
+      update,
+      retry,
       openFileDialog,
       fileInputRef,
     }),
-    [attachmentFiles, add, remove, clear, openFileDialog],
+    [attachmentFiles, add, remove, clear, update, retry, openFileDialog],
   );
 
   const __registerFileInput = useCallback(
@@ -287,7 +333,7 @@ export const usePromptInputAttachments = () => {
 };
 
 export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
-  data: PromptInputFilePart & { id: string };
+  data: PromptInputAttachmentItem;
   className?: string;
 };
 
@@ -296,6 +342,7 @@ export function PromptInputAttachment({
   className,
   ...props
 }: PromptInputAttachmentProps) {
+  const { t } = useI18n();
   const attachments = usePromptInputAttachments();
 
   const filename = data.filename || "";
@@ -303,39 +350,67 @@ export function PromptInputAttachment({
   const mediaType =
     data.mediaType?.startsWith("image/") && data.url ? "image" : "file";
   const isImage = mediaType === "image";
+  const upload = data.upload;
+  const uploadStatus = upload?.status;
+  const progress = Math.min(100, Math.max(0, upload?.progress ?? 0));
+  const isUploading =
+    uploadStatus === "pending" || uploadStatus === "uploading";
+  const isUploaded = uploadStatus === "uploaded";
+  const isError = uploadStatus === "error";
 
   const attachmentLabel = filename || (isImage ? "Image" : "Attachment");
+  const uploadStatusLabel = isError
+    ? upload?.error || t.uploads.uploadFailed
+    : isUploading
+      ? `${t.uploads.uploading} ${progress}%`
+      : data.mediaType || "";
 
   return (
     <PromptInputHoverCard>
       <HoverCardTrigger asChild>
         <div
           className={cn(
-            "group border-border hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 relative flex h-8 cursor-pointer items-center gap-1.5 rounded-md border px-1.5 text-sm font-medium transition-all select-none",
+            "group border-border hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 relative flex min-h-10 cursor-pointer items-center gap-2 rounded-md border px-2 py-1.5 text-sm font-medium transition-all select-none",
+            isError && "border-destructive/50 bg-destructive/5",
             className,
           )}
           key={data.id}
           {...props}
         >
-          <div className="relative size-5 shrink-0">
-            <div className="bg-background absolute inset-0 flex size-5 items-center justify-center overflow-hidden rounded transition-opacity group-hover:opacity-0">
+          <div className="relative size-8 shrink-0">
+            <div className="bg-background absolute inset-0 flex size-8 items-center justify-center overflow-hidden rounded-md transition-opacity group-hover:opacity-0">
               {isImage ? (
                 <img
                   alt={filename || "attachment"}
-                  className="size-5 object-cover"
-                  height={20}
+                  className="size-8 object-cover"
+                  height={32}
                   src={data.url}
-                  width={20}
+                  width={32}
                 />
               ) : (
-                <div className="text-muted-foreground flex size-5 items-center justify-center">
-                  <PaperclipIcon className="size-3" />
+                <div className="text-muted-foreground flex size-8 items-center justify-center rounded-md border">
+                  <PaperclipIcon className="size-4" />
                 </div>
               )}
             </div>
+            {isUploading && (
+              <div className="bg-background/55 absolute inset-0 flex items-center justify-center rounded-md backdrop-blur-[1px]">
+                <AttachmentUploadRing progress={progress} />
+              </div>
+            )}
+            {isUploaded && (
+              <div className="bg-background absolute -right-1 -bottom-1 rounded-full p-0.5">
+                <CheckIcon className="size-3 text-emerald-500" />
+              </div>
+            )}
+            {isError && (
+              <div className="bg-background absolute -right-1 -bottom-1 rounded-full p-0.5">
+                <AlertCircleIcon className="size-3 text-red-500" />
+              </div>
+            )}
             <Button
               aria-label="Remove attachment"
-              className="absolute inset-0 size-5 cursor-pointer rounded p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 [&>svg]:size-2.5"
+              className="absolute inset-0 size-8 cursor-pointer rounded-md p-0 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 [&>svg]:size-3"
               onClick={(e) => {
                 e.stopPropagation();
                 attachments.remove(data.id);
@@ -348,7 +423,34 @@ export function PromptInputAttachment({
             </Button>
           </div>
 
-          <span className="flex-1 truncate">{attachmentLabel}</span>
+          <div className="min-w-0 flex-1">
+            <div className="truncate">{attachmentLabel}</div>
+            {uploadStatusLabel ? (
+              <div
+                className={cn(
+                  "truncate text-[10px] font-normal",
+                  isError ? "text-red-500" : "text-muted-foreground",
+                )}
+              >
+                {uploadStatusLabel}
+              </div>
+            ) : null}
+          </div>
+          {isError && (
+            <Button
+              className="h-7 shrink-0 rounded-full px-2 text-[10px]"
+              onClick={(e) => {
+                e.stopPropagation();
+                attachments.retry(data.id);
+              }}
+              size="sm"
+              type="button"
+              variant="outline"
+            >
+              <RotateCcwIcon className="size-3" />
+              {t.common.retry}
+            </Button>
+          )}
         </div>
       </HoverCardTrigger>
       <PromptInputHoverCardContent className="w-auto p-2">
@@ -386,7 +488,7 @@ export type PromptInputAttachmentsProps = Omit<
   HTMLAttributes<HTMLDivElement>,
   "children"
 > & {
-  children: (attachment: PromptInputFilePart & { id: string }) => ReactNode;
+  children: (attachment: PromptInputAttachmentItem) => ReactNode;
 };
 
 export function PromptInputAttachments({
@@ -491,9 +593,7 @@ export const PromptInput = ({
   const formRef = useRef<HTMLFormElement | null>(null);
 
   // ----- Local attachments (only used when no provider)
-  const [items, setItems] = useState<(PromptInputFilePart & { id: string })[]>(
-    [],
-  );
+  const [items, setItems] = useState<PromptInputAttachmentItem[]>([]);
   const files = usingProvider ? controller.attachments.files : items;
 
   // Keep a ref to files for cleanup on unmount (avoids stale closure)
@@ -561,7 +661,7 @@ export const PromptInput = ({
             message: "Too many files. Some were not added.",
           });
         }
-        const next: (PromptInputFilePart & { id: string })[] = [];
+        const next: PromptInputAttachmentItem[] = [];
         for (const file of capped) {
           next.push({
             id: nanoid(),
@@ -570,6 +670,10 @@ export const PromptInput = ({
             mediaType: file.type,
             filename: file.name,
             file,
+            upload: {
+              status: "pending",
+              progress: 0,
+            },
           });
         }
         return prev.concat(next);
@@ -603,9 +707,41 @@ export const PromptInput = ({
     [],
   );
 
+  const updateLocal = useCallback(
+    (
+      id: string,
+      updater: (file: PromptInputAttachmentItem) => PromptInputAttachmentItem,
+    ) =>
+      setItems((prev) =>
+        prev.map((file) => (file.id === id ? updater(file) : file)),
+      ),
+    [],
+  );
+
+  const retryLocal = useCallback(
+    (id: string) =>
+      setItems((prev) =>
+        prev.map((file) =>
+          file.id === id
+            ? {
+                ...file,
+                upload: {
+                  status: "pending",
+                  progress: 0,
+                  storedFilename: file.upload?.storedFilename,
+                },
+              }
+            : file,
+        ),
+      ),
+    [],
+  );
+
   const add = usingProvider ? controller.attachments.add : addLocal;
   const remove = usingProvider ? controller.attachments.remove : removeLocal;
   const clear = usingProvider ? controller.attachments.clear : clearLocal;
+  const update = usingProvider ? controller.attachments.update : updateLocal;
+  const retry = usingProvider ? controller.attachments.retry : retryLocal;
   const openFileDialog = usingProvider
     ? controller.attachments.openFileDialog
     : openFileDialogLocal;
@@ -744,10 +880,12 @@ export const PromptInput = ({
       add,
       remove,
       clear,
+      update,
+      retry,
       openFileDialog,
       fileInputRef: inputRef,
     }),
-    [files, add, remove, clear, openFileDialog],
+    [files, add, remove, clear, update, retry, openFileDialog],
   );
 
   const handleSubmit: FormEventHandler<HTMLFormElement> = (event) => {
@@ -1103,6 +1241,46 @@ export const PromptInputSubmit = ({
     </InputGroupButton>
   );
 };
+
+function AttachmentUploadRing({ progress }: { progress: number }) {
+  const size = 22;
+  const strokeWidth = 2.5;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - progress / 100);
+
+  return (
+    <div className="relative flex size-6 items-center justify-center">
+      <svg
+        className="-rotate-90"
+        height={size}
+        width={size}
+        viewBox={`0 0 ${size} ${size}`}
+      >
+        <circle
+          className="stroke-black/10 dark:stroke-white/15"
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={radius}
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          className="stroke-foreground"
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={radius}
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+        />
+      </svg>
+      <span className="text-[7px] font-semibold tabular-nums">{progress}</span>
+    </div>
+  );
+}
 
 interface SpeechRecognition extends EventTarget {
   continuous: boolean;

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -360,7 +360,10 @@ export function InputBox({
   const uploadAttachment = useCallback(
     async (attachmentId: string, file: File) => {
       const abortController = new AbortController();
-      const storageFilename = createDraftUploadFilename(attachmentId, file.name);
+      const storageFilename = createDraftUploadFilename(
+        attachmentId,
+        file.name,
+      );
       const uploadFile =
         file.name === storageFilename
           ? file
@@ -426,8 +429,7 @@ export function InputBox({
             progress: 0,
             error:
               error instanceof Error ? error.message : t.uploads.uploadFailed,
-            storedFilename:
-              current.upload?.storedFilename ?? storageFilename,
+            storedFilename: current.upload?.storedFilename ?? storageFilename,
           },
         }));
       } finally {
@@ -444,7 +446,9 @@ export function InputBox({
     const previousAttachmentFiles = previousAttachmentFilesRef.current;
     previousAttachmentFilesRef.current = attachmentFiles;
 
-    const currentAttachmentIds = new Set(attachmentFiles.map((file) => file.id));
+    const currentAttachmentIds = new Set(
+      attachmentFiles.map((file) => file.id),
+    );
     for (const previousAttachment of previousAttachmentFiles) {
       if (currentAttachmentIds.has(previousAttachment.id)) {
         continue;
@@ -705,7 +709,8 @@ export function InputBox({
     return () => controller.abort();
   }, [context.model_name, disabled, isMock, status, thread.messages, threadId]);
 
-  const showUploadingHint = isUploading || (!isMock && hasPendingAttachmentUploads);
+  const showUploadingHint =
+    isUploading || (!isMock && hasPendingAttachmentUploads);
   const submitDisabled = (disabled ?? false) || hasBlockingAttachmentUploads;
 
   return (
@@ -1234,7 +1239,9 @@ function AddAttachmentsButton({ className }: { className?: string }) {
   const attachments = usePromptInputAttachments();
   return (
     <Tooltip
-      content={isMock ? t.common.notAvailableInDemoMode : t.inputBox.addAttachments}
+      content={
+        isMock ? t.common.notAvailableInDemoMode : t.inputBox.addAttachments
+      }
     >
       <PromptInputButton
         className={cn("px-2!", className)}

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -21,6 +21,7 @@ import {
   useState,
   type ComponentProps,
 } from "react";
+import { toast } from "sonner";
 
 import {
   PromptInput,
@@ -60,6 +61,12 @@ import { useI18n } from "@/core/i18n/hooks";
 import { useModels } from "@/core/models/hooks";
 import type { AgentThreadContext } from "@/core/threads";
 import { textOfMessage } from "@/core/threads/utils";
+import {
+  createDraftUploadFilename,
+  deleteUploadedFile,
+  UploadedFileNotFoundError,
+  uploadFiles,
+} from "@/core/uploads";
 import { cn } from "@/lib/utils";
 
 import {
@@ -106,6 +113,7 @@ export function InputBox({
   context,
   extraHeader,
   isNewThread,
+  isUploading = false,
   threadId,
   initialValue,
   onContextChange,
@@ -126,6 +134,7 @@ export function InputBox({
   };
   extraHeader?: React.ReactNode;
   isNewThread?: boolean;
+  isUploading?: boolean;
   threadId: string;
   initialValue?: string;
   onContextChange?: (
@@ -138,7 +147,7 @@ export function InputBox({
     },
   ) => void;
   onFollowupsVisibilityChange?: (visible: boolean) => void;
-  onSubmit?: (message: PromptInputMessage) => void;
+  onSubmit?: (message: PromptInputMessage) => void | Promise<void>;
   onStop?: () => void;
 }) {
   const { t } = useI18n();
@@ -146,8 +155,14 @@ export function InputBox({
   const [modelDialogOpen, setModelDialogOpen] = useState(false);
   const { models } = useModels();
   const { thread, isMock } = useThread();
+  const attachments = usePromptInputAttachments();
   const { textInput } = usePromptInputController();
   const promptRootRef = useRef<HTMLDivElement | null>(null);
+  const activeUploadIdsRef = useRef(new Set<string>());
+  const uploadAbortControllersRef = useRef(new Map<string, AbortController>());
+  const discardedAttachmentIdsRef = useRef(new Set<string>());
+  const committedAttachmentIdsRef = useRef(new Set<string>());
+  const attachmentFilesRef = useRef(attachments.files);
 
   const [followups, setFollowups] = useState<string[]>([]);
   const [followupsHidden, setFollowupsHidden] = useState(false);
@@ -245,10 +260,244 @@ export function InputBox({
     [onContextChange, context],
   );
 
+  const attachmentFiles = attachments.files;
+  attachmentFilesRef.current = attachmentFiles;
+  const hasPendingAttachmentUploads = attachmentFiles.some((file) => {
+    const uploadStatus = file.upload?.status;
+    return uploadStatus === "pending" || uploadStatus === "uploading";
+  });
+  const hasFailedAttachmentUploads = attachmentFiles.some(
+    (file) => file.upload?.status === "error",
+  );
+  const hasBlockingAttachmentUploads =
+    !isMock && (hasPendingAttachmentUploads || hasFailedAttachmentUploads);
+
+  useEffect(() => {
+    if (!isMock || attachmentFiles.length === 0) {
+      return;
+    }
+
+    attachments.clear();
+    toast.error(t.common.notAvailableInDemoMode);
+  }, [
+    attachmentFiles.length,
+    attachments,
+    isMock,
+    t.common.notAvailableInDemoMode,
+  ]);
+
+  const cleanupUploadedAttachment = useCallback(
+    async (filename: string) => {
+      let lastError: unknown = null;
+      const retryDelaysMs = [0, 100, 250, 500, 1000];
+
+      for (const delayMs of retryDelaysMs) {
+        if (delayMs > 0) {
+          await new Promise((resolve) => window.setTimeout(resolve, delayMs));
+        }
+
+        try {
+          await deleteUploadedFile(threadId, filename);
+          return;
+        } catch (error) {
+          if (error instanceof UploadedFileNotFoundError) {
+            return;
+          }
+          lastError = error;
+        }
+      }
+
+      console.warn("Failed to clean up preuploaded attachment", {
+        error: lastError,
+        filename,
+        threadId,
+      });
+    },
+    [threadId],
+  );
+
+  const getAttachmentStorageFilename = useCallback(
+    (attachment: (typeof attachmentFiles)[number]) => {
+      if (attachment.upload?.storedFilename) {
+        return attachment.upload.storedFilename;
+      }
+      if (attachment.upload?.info?.filename) {
+        return attachment.upload.info.filename;
+      }
+      const originalFilename =
+        (attachment.file instanceof File && attachment.file.name) ||
+        attachment.filename;
+      if (!originalFilename) {
+        return null;
+      }
+      return createDraftUploadFilename(attachment.id, originalFilename);
+    },
+    [],
+  );
+
+  const cleanupDraftAttachment = useCallback(
+    (attachment: (typeof attachmentFiles)[number]) => {
+      if (committedAttachmentIdsRef.current.delete(attachment.id)) {
+        return;
+      }
+
+      discardedAttachmentIdsRef.current.add(attachment.id);
+
+      const controller = uploadAbortControllersRef.current.get(attachment.id);
+      if (controller) {
+        controller.abort();
+        uploadAbortControllersRef.current.delete(attachment.id);
+      }
+
+      const uploadedFilename = getAttachmentStorageFilename(attachment);
+      if (uploadedFilename) {
+        void cleanupUploadedAttachment(uploadedFilename);
+      }
+    },
+    [cleanupUploadedAttachment, getAttachmentStorageFilename],
+  );
+
+  const uploadAttachment = useCallback(
+    async (attachmentId: string, file: File) => {
+      const abortController = new AbortController();
+      const storageFilename = createDraftUploadFilename(attachmentId, file.name);
+      const uploadFile =
+        file.name === storageFilename
+          ? file
+          : new File([file], storageFilename, {
+              type: file.type,
+              lastModified: file.lastModified,
+            });
+      uploadAbortControllersRef.current.set(attachmentId, abortController);
+      attachments.update(attachmentId, (current) => ({
+        ...current,
+        upload: {
+          status: "uploading",
+          progress: 0,
+          storedFilename: storageFilename,
+        },
+      }));
+
+      try {
+        const response = await uploadFiles(threadId, [uploadFile], {
+          signal: abortController.signal,
+          onProgress: (progress) => {
+            attachments.update(attachmentId, (current) => ({
+              ...current,
+              upload: {
+                status: "uploading",
+                progress,
+                storedFilename:
+                  current.upload?.storedFilename ?? storageFilename,
+              },
+            }));
+          },
+        });
+
+        const uploadedFile = response.files[0];
+        if (!uploadedFile) {
+          throw new Error("Upload failed");
+        }
+
+        if (discardedAttachmentIdsRef.current.has(attachmentId)) {
+          void cleanupUploadedAttachment(uploadedFile.filename);
+          return;
+        }
+
+        attachments.update(attachmentId, (current) => ({
+          ...current,
+          upload: {
+            status: "uploaded",
+            progress: 100,
+            info: uploadedFile,
+            storedFilename:
+              current.upload?.storedFilename ?? uploadedFile.filename,
+          },
+        }));
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return;
+        }
+
+        attachments.update(attachmentId, (current) => ({
+          ...current,
+          upload: {
+            status: "error",
+            progress: 0,
+            error:
+              error instanceof Error ? error.message : t.uploads.uploadFailed,
+            storedFilename:
+              current.upload?.storedFilename ?? storageFilename,
+          },
+        }));
+      } finally {
+        uploadAbortControllersRef.current.delete(attachmentId);
+        activeUploadIdsRef.current.delete(attachmentId);
+      }
+    },
+    [attachments, cleanupUploadedAttachment, t.uploads.uploadFailed, threadId],
+  );
+
+  const previousAttachmentFilesRef = useRef(attachmentFiles);
+
+  useEffect(() => {
+    const previousAttachmentFiles = previousAttachmentFilesRef.current;
+    previousAttachmentFilesRef.current = attachmentFiles;
+
+    const currentAttachmentIds = new Set(attachmentFiles.map((file) => file.id));
+    for (const previousAttachment of previousAttachmentFiles) {
+      if (currentAttachmentIds.has(previousAttachment.id)) {
+        continue;
+      }
+      cleanupDraftAttachment(previousAttachment);
+    }
+  }, [attachmentFiles, cleanupDraftAttachment]);
+
+  useEffect(() => {
+    const uploadAbortControllers = uploadAbortControllersRef.current;
+    return () => {
+      for (const controller of uploadAbortControllers.values()) {
+        controller.abort();
+      }
+      uploadAbortControllers.clear();
+
+      for (const attachment of attachmentFilesRef.current) {
+        cleanupDraftAttachment(attachment);
+      }
+    };
+  }, [cleanupDraftAttachment]);
+
+  useEffect(() => {
+    if (!threadId || isMock) {
+      return;
+    }
+
+    for (const attachment of attachmentFiles) {
+      if (!(attachment.file instanceof File)) {
+        continue;
+      }
+
+      const uploadStatus = attachment.upload?.status ?? "pending";
+      if (uploadStatus !== "pending") {
+        continue;
+      }
+
+      if (activeUploadIdsRef.current.has(attachment.id)) {
+        continue;
+      }
+
+      activeUploadIdsRef.current.add(attachment.id);
+      void uploadAttachment(attachment.id, attachment.file);
+    }
+  }, [attachmentFiles, isMock, threadId, uploadAttachment]);
+
   const handleSubmit = useCallback(
     async (message: PromptInputMessage) => {
       if (status === "streaming") {
         onStop?.();
+        return;
+      }
+      if (hasBlockingAttachmentUploads) {
         return;
       }
       if (!message.text) {
@@ -257,6 +506,24 @@ export function InputBox({
       setFollowups([]);
       setFollowupsHidden(false);
       setFollowupsLoading(false);
+
+      const submitPreparedMessage = async (nextMessage: PromptInputMessage) => {
+        const messageForSubmit =
+          isMock && nextMessage.files.length > 0
+            ? { ...nextMessage, files: [] }
+            : nextMessage;
+        for (const attachment of attachmentFiles) {
+          committedAttachmentIdsRef.current.add(attachment.id);
+        }
+        try {
+          await onSubmit?.(messageForSubmit);
+        } catch (error) {
+          for (const attachment of attachmentFiles) {
+            committedAttachmentIdsRef.current.delete(attachment.id);
+          }
+          throw error;
+        }
+      };
 
       // Guard against submitting before the initial model auto-selection
       // effect has flushed thread settings to storage/state.
@@ -269,14 +536,21 @@ export function InputBox({
             selectedModel?.supports_thinking ?? false,
           ),
         });
-        setTimeout(() => onSubmit?.(message), 0);
+        await new Promise<void>((resolve, reject) => {
+          setTimeout(() => {
+            void submitPreparedMessage(message).then(resolve, reject);
+          }, 0);
+        });
         return;
       }
 
-      onSubmit?.(message);
+      await submitPreparedMessage(message);
     },
     [
+      attachmentFiles,
       context,
+      hasBlockingAttachmentUploads,
+      isMock,
       onContextChange,
       onSubmit,
       onStop,
@@ -287,9 +561,12 @@ export function InputBox({
   );
 
   const requestFormSubmit = useCallback(() => {
+    if (hasBlockingAttachmentUploads) {
+      return;
+    }
     const form = promptRootRef.current?.querySelector("form");
     form?.requestSubmit();
-  }, []);
+  }, [hasBlockingAttachmentUploads]);
 
   const handleFollowupClick = useCallback(
     (suggestion: string) => {
@@ -427,6 +704,9 @@ export function InputBox({
 
     return () => controller.abort();
   }, [context.model_name, disabled, isMock, status, thread.messages, threadId]);
+
+  const showUploadingHint = isUploading || (!isMock && hasPendingAttachmentUploads);
+  const submitDisabled = (disabled ?? false) || hasBlockingAttachmentUploads;
 
   return (
     <div ref={promptRootRef} className="relative flex flex-col gap-4">
@@ -830,11 +1110,16 @@ export function InputBox({
                 </ModelSelectorList>
               </ModelSelectorContent>
             </ModelSelector>
+            {showUploadingHint && (
+              <span className="text-muted-foreground px-1 text-[10px]">
+                {t.uploads.uploadingFiles}
+              </span>
+            )}
             <PromptInputSubmit
               className="rounded-full"
-              disabled={disabled}
+              disabled={submitDisabled}
               variant="outline"
-              status={status}
+              status={showUploadingHint ? "submitted" : status}
             />
           </PromptInputTools>
         </PromptInputFooter>
@@ -945,11 +1230,15 @@ function SuggestionList() {
 
 function AddAttachmentsButton({ className }: { className?: string }) {
   const { t } = useI18n();
+  const { isMock } = useThread();
   const attachments = usePromptInputAttachments();
   return (
-    <Tooltip content={t.inputBox.addAttachments}>
+    <Tooltip
+      content={isMock ? t.common.notAvailableInDemoMode : t.inputBox.addAttachments}
+    >
       <PromptInputButton
         className={cn("px-2!", className)}
+        disabled={isMock}
         onClick={() => attachments.openFileDialog()}
       >
         <PaperclipIcon className="size-3" />

--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -1,5 +1,5 @@
 import type { Message } from "@langchain/langgraph-sdk";
-import { FileIcon, Loader2Icon } from "lucide-react";
+import { FileIcon } from "lucide-react";
 import {
   memo,
   useMemo,
@@ -348,29 +348,40 @@ function RichFileCard({
   const { t } = useI18n();
   const isUploading = file.status === "uploading";
   const isImage = isImageFile(file.filename);
+  const progress = Math.min(100, Math.max(0, file.progress ?? 0));
 
   if (isUploading) {
     return (
-      <div className="bg-background border-border/40 flex max-w-50 min-w-30 flex-col gap-1 rounded-lg border p-3 opacity-60 shadow-sm">
-        <div className="flex items-start gap-2">
-          <Loader2Icon className="text-muted-foreground mt-0.5 size-4 shrink-0 animate-spin" />
-          <span
-            className="text-foreground truncate text-sm font-medium"
-            title={file.filename}
-          >
-            {file.filename}
-          </span>
-        </div>
-        <div className="flex items-center justify-between gap-2">
-          <Badge
-            variant="secondary"
-            className="rounded px-1.5 py-0.5 text-[10px] font-normal"
-          >
-            {getFileTypeLabel(file.filename)}
-          </Badge>
-          <span className="text-muted-foreground text-[10px]">
-            {t.uploads.uploading}
-          </span>
+      <div className="bg-background border-border/40 flex max-w-50 min-w-30 flex-col gap-2 rounded-lg border p-3 shadow-sm">
+        <div className="flex items-start gap-3">
+          <div className="bg-muted/40 border-border/50 relative flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-md border">
+            <FileIcon className="text-muted-foreground size-4" />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/12 backdrop-blur-[1px]">
+              <UploadProgressRing progress={progress} />
+            </div>
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <span
+              className="text-foreground block truncate text-sm font-medium"
+              title={file.filename}
+            >
+              {file.filename}
+            </span>
+            <div className="flex items-center justify-between gap-2">
+              <Badge
+                variant="secondary"
+                className="rounded px-1.5 py-0.5 text-[10px] font-normal"
+              >
+                {getFileTypeLabel(file.filename)}
+              </Badge>
+              <span className="text-muted-foreground font-mono text-[10px]">
+                {progress}%
+              </span>
+            </div>
+            <div className="text-muted-foreground text-[10px]">
+              {t.uploads.uploading}
+            </div>
+          </div>
         </div>
       </div>
     );
@@ -419,6 +430,48 @@ function RichFileCard({
           {formatBytes(file.size)}
         </span>
       </div>
+    </div>
+  );
+}
+
+function UploadProgressRing({ progress }: { progress: number }) {
+  const size = 28;
+  const strokeWidth = 2.5;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - progress / 100);
+
+  return (
+    <div className="relative flex size-8 items-center justify-center">
+      <svg
+        className="-rotate-90"
+        height={size}
+        width={size}
+        viewBox={`0 0 ${size} ${size}`}
+      >
+        <circle
+          className="stroke-white/25"
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={radius}
+          strokeWidth={strokeWidth}
+        />
+        <circle
+          className="stroke-white"
+          cx={size / 2}
+          cy={size / 2}
+          fill="none"
+          r={radius}
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          strokeLinecap="round"
+          strokeWidth={strokeWidth}
+        />
+      </svg>
+      <span className="text-[8px] font-semibold text-white tabular-nums">
+        {progress}
+      </span>
     </div>
   );
 }

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -42,6 +42,7 @@ export const enUS: Translations = {
     preview: "Preview",
     cancel: "Cancel",
     save: "Save",
+    retry: "Retry",
     install: "Install",
     create: "Create",
     import: "Import",
@@ -284,6 +285,7 @@ export const enUS: Translations = {
   uploads: {
     uploading: "Uploading...",
     uploadingFiles: "Uploading files, please wait...",
+    uploadFailed: "Upload failed",
   },
 
   subtasks: {

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -31,6 +31,7 @@ export interface Translations {
     preview: string;
     cancel: string;
     save: string;
+    retry: string;
     install: string;
     create: string;
     import: string;
@@ -215,6 +216,7 @@ export interface Translations {
   uploads: {
     uploading: string;
     uploadingFiles: string;
+    uploadFailed: string;
   };
 
   // Subtasks

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -42,6 +42,7 @@ export const zhCN: Translations = {
     preview: "预览",
     cancel: "取消",
     save: "保存",
+    retry: "重试",
     install: "安装",
     create: "创建",
     import: "导入",
@@ -270,6 +271,7 @@ export const zhCN: Translations = {
   uploads: {
     uploading: "上传中...",
     uploadingFiles: "文件上传中，请稍候...",
+    uploadFailed: "上传失败",
   },
 
   subtasks: {

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -339,7 +339,10 @@ export interface FileInMessage {
   filename: string;
   size: number; // bytes
   path?: string; // virtual path, may not be set during upload
+  stored_filename?: string; // actual stored basename used for backend resolution
+  markdown_file?: string; // generated markdown sidecar for convertible uploads
   status?: "uploading" | "uploaded";
+  progress?: number; // 0-100, only used for optimistic upload UI
 }
 
 /**

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -13,7 +13,6 @@ import { useI18n } from "../i18n/hooks";
 import type { FileInMessage } from "../messages/utils";
 import type { LocalSettings } from "../settings";
 import { useUpdateSubtask } from "../tasks/context";
-import type { UploadedFileInfo } from "../uploads";
 import { promptInputFilePartToFile, uploadFiles } from "../uploads";
 
 import type { AgentThread, AgentThreadState } from "./types";
@@ -336,17 +335,43 @@ export function useThreadStream({
       sendInFlightRef.current = true;
 
       const text = message.text.trim();
+      const messageFiles = message.files ?? [];
+      const uploadedFileInfoByIndex = messageFiles.map((file) =>
+        file.upload?.status === "uploaded" && file.upload.info
+          ? file.upload.info
+          : undefined,
+      );
+      const pendingFilePartsWithIndex = messageFiles
+        .map((file, index) => ({ file, index }))
+        .filter(({ file }) => !file.upload?.info);
 
       // Capture current count before showing optimistic messages
       prevMsgCountRef.current = thread.messages.length;
 
       // Build optimistic files list with uploading status
-      const optimisticFiles: FileInMessage[] = (message.files ?? []).map(
-        (f) => ({
-          filename: f.filename ?? "",
-          size: 0,
-          status: "uploading" as const,
-        }),
+      const optimisticFiles: FileInMessage[] = messageFiles.map(
+        (file, index) => {
+          const uploadedInfo = uploadedFileInfoByIndex[index];
+          if (uploadedInfo) {
+            return {
+              filename: file.filename ?? uploadedInfo.filename,
+              size: uploadedInfo.size,
+              path: uploadedInfo.virtual_path,
+              stored_filename: uploadedInfo.filename,
+              markdown_file: uploadedInfo.markdown_file,
+              status: "uploaded" as const,
+              progress: 100,
+            };
+          }
+
+          return {
+            filename: file.filename ?? "",
+            size: 0,
+            status: "uploading" as const,
+            progress: file.upload?.progress ?? 0,
+            stored_filename: file.upload?.storedFilename,
+          };
+        },
       );
 
       const hideFromUI = options?.additionalKwargs?.hide_from_ui === true;
@@ -365,7 +390,7 @@ export function useThreadStream({
         });
       }
 
-      if (optimisticFiles.length > 0 && !hideFromUI) {
+      if (pendingFilePartsWithIndex.length > 0 && !hideFromUI) {
         // Mock AI message while files are being uploaded
         newOptimistic.push({
           type: "ai",
@@ -383,15 +408,13 @@ export function useThreadStream({
         _handleOnStart(threadId);
       }
 
-      let uploadedFileInfo: UploadedFileInfo[] = [];
-
       try {
         // Upload files first if any
-        if (message.files && message.files.length > 0) {
+        if (pendingFilePartsWithIndex.length > 0) {
           setIsUploading(true);
           try {
-            const filePromises = message.files.map((fileUIPart) =>
-              promptInputFilePartToFile(fileUIPart),
+            const filePromises = pendingFilePartsWithIndex.map(({ file }) =>
+              promptInputFilePartToFile(file),
             );
 
             const conversionResults = await Promise.all(filePromises);
@@ -411,25 +434,132 @@ export function useThreadStream({
             }
 
             if (files.length > 0) {
-              const uploadResponse = await uploadFiles(threadId, files);
-              uploadedFileInfo = uploadResponse.files;
+              const totalFileBytes = files.reduce(
+                (sum, file) => sum + Math.max(file.size, 0),
+                0,
+              );
+              const fileByteOffsets = files.reduce<number[]>(
+                (offsets, file, index) => {
+                  if (index === 0) {
+                    offsets.push(0);
+                    return offsets;
+                  }
+
+                  const previousOffset = offsets[index - 1] ?? 0;
+                  const previousSize = Math.max(files[index - 1]?.size ?? 0, 0);
+                  offsets.push(previousOffset + previousSize);
+                  return offsets;
+                },
+                [],
+              );
+
+              const uploadResponse = await uploadFiles(threadId, files, {
+                onProgress: (progress) => {
+                  if (hideFromUI) {
+                    return;
+                  }
+
+                  const fileProgresses =
+                    totalFileBytes > 0
+                      ? files.map((file, index) => {
+                          const approximateLoadedBytes = Math.round(
+                            (progress / 100) * totalFileBytes,
+                          );
+                          const fileOffset = fileByteOffsets[index] ?? 0;
+                          const fileSize = Math.max(file.size, 0);
+
+                          if (fileSize === 0) {
+                            return progress > 0 ? 100 : 0;
+                          }
+
+                          const loadedForFile = Math.min(
+                            fileSize,
+                            Math.max(0, approximateLoadedBytes - fileOffset),
+                          );
+
+                          return Math.min(
+                            100,
+                            Math.max(
+                              0,
+                              Math.round((loadedForFile / fileSize) * 100),
+                            ),
+                          );
+                        })
+                      : files.map(() => progress);
+
+                  setOptimisticMessages((messages) => {
+                    const humanMessage = messages[0];
+                    if (!humanMessage || humanMessage.type !== "human") {
+                      return messages;
+                    }
+
+                    const existingFiles =
+                      (humanMessage.additional_kwargs?.files as
+                        | FileInMessage[]
+                        | undefined) ?? [];
+
+                    return [
+                      {
+                        ...humanMessage,
+                        additional_kwargs: {
+                          ...humanMessage.additional_kwargs,
+                          files: existingFiles.map((file, index) => {
+                            if (file.status === "uploaded") {
+                              return {
+                                ...file,
+                                status: "uploaded" as const,
+                                progress: 100,
+                              };
+                            }
+
+                            return {
+                              ...file,
+                              status: "uploading" as const,
+                              progress: fileProgresses[index] ?? progress,
+                            };
+                          }),
+                        },
+                      },
+                      ...messages.slice(1),
+                    ];
+                  });
+                },
+              });
+              uploadResponse.files.forEach((info, uploadIndex) => {
+                const originalIndex =
+                  pendingFilePartsWithIndex[uploadIndex]?.index ?? uploadIndex;
+                uploadedFileInfoByIndex[originalIndex] = info;
+              });
 
               // Update optimistic human message with uploaded status + paths
-              const uploadedFiles: FileInMessage[] = uploadedFileInfo.map(
-                (info) => ({
-                  filename: info.filename,
+              const uploadedFiles: FileInMessage[] = messageFiles.reduce<
+                FileInMessage[]
+              >((acc, file, index) => {
+                const info = uploadedFileInfoByIndex[index];
+                if (!info) {
+                  return acc;
+                }
+                acc.push({
+                  filename: file.filename ?? info.filename,
                   size: info.size,
                   path: info.virtual_path,
+                  stored_filename: info.filename,
+                  markdown_file: info.markdown_file,
                   status: "uploaded" as const,
-                }),
-              );
+                  progress: 100,
+                });
+                return acc;
+              }, []);
               setOptimisticMessages((messages) => {
                 if (messages.length > 1 && messages[0]) {
                   const humanMessage: Message = messages[0];
                   return [
                     {
                       ...humanMessage,
-                      additional_kwargs: { files: uploadedFiles },
+                      additional_kwargs: {
+                        ...humanMessage.additional_kwargs,
+                        files: uploadedFiles,
+                      },
                     },
                     ...messages.slice(1),
                   ];
@@ -451,14 +581,23 @@ export function useThreadStream({
         }
 
         // Build files metadata for submission (included in additional_kwargs)
-        const filesForSubmit: FileInMessage[] = uploadedFileInfo.map(
-          (info) => ({
-            filename: info.filename,
+        const filesForSubmit: FileInMessage[] = messageFiles.reduce<
+          FileInMessage[]
+        >((acc, file, index) => {
+          const info = uploadedFileInfoByIndex[index];
+          if (!info) {
+            return acc;
+          }
+          acc.push({
+            filename: file.filename ?? info.filename,
             size: info.size,
             path: info.virtual_path,
+            stored_filename: info.filename,
+            markdown_file: info.markdown_file,
             status: "uploaded" as const,
-          }),
-        );
+          });
+          return acc;
+        }, []);
 
         await thread.submit(
           {

--- a/frontend/src/core/uploads/api.ts
+++ b/frontend/src/core/uploads/api.ts
@@ -29,6 +29,18 @@ export interface ListFilesResponse {
   count: number;
 }
 
+export interface UploadFilesOptions {
+  onProgress?: (progress: number) => void;
+  signal?: AbortSignal;
+}
+
+export class UploadedFileNotFoundError extends Error {
+  constructor(message = "Uploaded file already removed") {
+    super(message);
+    this.name = "UploadedFileNotFoundError";
+  }
+}
+
 async function readErrorDetail(
   response: Response,
   fallback: string,
@@ -43,6 +55,7 @@ async function readErrorDetail(
 export async function uploadFiles(
   threadId: string,
   files: File[],
+  options?: UploadFilesOptions,
 ): Promise<UploadResponse> {
   const formData = new FormData();
 
@@ -50,19 +63,92 @@ export async function uploadFiles(
     formData.append("files", file);
   });
 
-  const response = await fetch(
-    `${getBackendBaseURL()}/api/threads/${threadId}/uploads`,
-    {
-      method: "POST",
-      body: formData,
-    },
-  );
+  return new Promise<UploadResponse>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let settled = false;
+    const abortError = new DOMException("Upload aborted", "AbortError");
 
-  if (!response.ok) {
-    throw new Error(await readErrorDetail(response, "Upload failed"));
-  }
+    const finalize = () => {
+      settled = true;
+      options?.signal?.removeEventListener("abort", handleAbort);
+    };
 
-  return response.json();
+    const rejectOnce = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      finalize();
+      reject(error);
+    };
+
+    const resolveOnce = (payload: UploadResponse) => {
+      if (settled) {
+        return;
+      }
+      finalize();
+      resolve(payload);
+    };
+
+    const handleAbort = () => {
+      try {
+        xhr.abort();
+      } catch {
+        // Best-effort: XHR may already be complete.
+      }
+      rejectOnce(abortError);
+    };
+
+    if (options?.signal?.aborted) {
+      rejectOnce(abortError);
+      return;
+    }
+
+    xhr.open("POST", `${getBackendBaseURL()}/api/threads/${threadId}/uploads`);
+
+    xhr.upload.onprogress = (event) => {
+      if (!event.lengthComputable) {
+        return;
+      }
+      const progress = Math.min(
+        100,
+        Math.max(0, Math.round((event.loaded / event.total) * 100)),
+      );
+      options?.onProgress?.(progress);
+    };
+
+    xhr.onerror = () => {
+      rejectOnce(new Error("Upload failed"));
+    };
+
+    xhr.onabort = () => {
+      rejectOnce(abortError);
+    };
+
+    xhr.onload = () => {
+      const responseText = xhr.responseText || "";
+      let payload: UploadResponse | { detail?: string } | undefined;
+      try {
+        payload = responseText
+          ? (JSON.parse(responseText) as UploadResponse | { detail?: string })
+          : undefined;
+      } catch {
+        payload = undefined;
+      }
+
+      if (xhr.status < 200 || xhr.status >= 300) {
+        const detail =
+          payload && "detail" in payload ? payload.detail : undefined;
+        rejectOnce(new Error(detail ?? "Upload failed"));
+        return;
+      }
+
+      options?.onProgress?.(100);
+      resolveOnce(payload as UploadResponse);
+    };
+
+    options?.signal?.addEventListener("abort", handleAbort, { once: true });
+    xhr.send(formData);
+  });
 }
 
 /**
@@ -92,13 +178,16 @@ export async function deleteUploadedFile(
   filename: string,
 ): Promise<{ success: boolean; message: string }> {
   const response = await fetch(
-    `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${filename}`,
+    `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${encodeURIComponent(filename)}`,
     {
       method: "DELETE",
     },
   );
 
   if (!response.ok) {
+    if (response.status === 404) {
+      throw new UploadedFileNotFoundError();
+    }
     throw new Error(await readErrorDetail(response, "Failed to delete file"));
   }
 

--- a/frontend/src/core/uploads/prompt-input-files.ts
+++ b/frontend/src/core/uploads/prompt-input-files.ts
@@ -1,9 +1,36 @@
 import type { FileUIPart } from "ai";
 
+import type { UploadedFileInfo } from "./api";
+
+export type PromptInputFileUploadStatus =
+  | "pending"
+  | "uploading"
+  | "uploaded"
+  | "error";
+
+export interface PromptInputFileUploadState {
+  status: PromptInputFileUploadStatus;
+  progress: number;
+  error?: string;
+  info?: UploadedFileInfo;
+  storedFilename?: string;
+}
+
 export type PromptInputFilePart = FileUIPart & {
   // Transient submit-time handle to the original browser File; not serializable.
   file?: File;
+  upload?: PromptInputFileUploadState;
 };
+
+export function createDraftUploadFilename(
+  attachmentId: string,
+  originalFilename: string,
+): string {
+  const dotIndex = originalFilename.lastIndexOf(".");
+  const extension =
+    dotIndex > 0 ? originalFilename.slice(dotIndex).toLowerCase() : "";
+  return `draft_${attachmentId}${extension}`;
+}
 
 export async function promptInputFilePartToFile(
   filePart: PromptInputFilePart,


### PR DESCRIPTION
## Summary

- preupload attachments immediately after selection using the draft thread id without creating a thread record up front
- assign deterministic draft storage filenames so discarded preuploads can be cleaned up reliably even when the browser aborts before the upload success response arrives
- clean up discarded draft uploads on remove/unmount, abort in-flight uploads, and encode cleanup deletes so rollback also works for special filenames
- show per-file upload progress, keep submit blocked while real attachments are pending, and surface inline retry/remove controls on failed uploads
- disable attachment interactions in mock/demo chats so unsupported uploads do not trap the composer in a blocked state
- submit chat messages using already-uploaded file metadata instead of re-uploading the same files during send
- preserve user-facing attachment names across follow-up turns and hide generated markdown sidecars from historical upload lists

Supersedes #2089.

Fixes #1630

Related issue:
- #1966
