### PR TITLE
fix(subagent): inherit parent agent's tool_groups in task_tool

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -332,6 +332,7 @@ def make_lead_agent(config: RunnableConfig):
             "reasoning_effort": reasoning_effort,
             "is_plan_mode": is_plan_mode,
             "subagent_enabled": subagent_enabled,
+            "tool_groups": agent_config.tool_groups if agent_config else None,
         }
     )
 

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -88,6 +88,7 @@ async def task_tool(
     thread_id = None
     parent_model = None
     trace_id = None
+    metadata: dict = {}
 
     if runtime is not None:
         sandbox_state = runtime.state.get("sandbox")
@@ -108,7 +109,7 @@ async def task_tool(
     from deerflow.tools import get_available_tools
 
     # Inherit parent agent's tool_groups so subagents respect the same restrictions
-    parent_tool_groups = metadata.get("tool_groups") if runtime is not None else None
+    parent_tool_groups = metadata.get("tool_groups")
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
     tools = get_available_tools(model_name=parent_model, groups=parent_tool_groups, subagent_enabled=False)

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -107,8 +107,11 @@ async def task_tool(
     # Lazy import to avoid circular dependency
     from deerflow.tools import get_available_tools
 
+    # Inherit parent agent's tool_groups so subagents respect the same restrictions
+    parent_tool_groups = metadata.get("tool_groups") if runtime is not None else None
+
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
-    tools = get_available_tools(model_name=parent_model, subagent_enabled=False)
+    tools = get_available_tools(model_name=parent_model, groups=parent_tool_groups, subagent_enabled=False)
 
     # Create executor
     executor = SubagentExecutor(

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -167,14 +167,140 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     assert captured["executor_kwargs"]["config"].max_turns == 7
     assert "Skills Appendix" in captured["executor_kwargs"]["config"].system_prompt
 
-    get_available_tools.assert_called_once_with(model_name="ark-model", subagent_enabled=False)
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False)
 
     event_types = [e["type"] for e in events]
     assert event_types == ["task_started", "task_running", "task_running", "task_completed"]
     assert events[-1]["result"] == "all done"
 
 
-def test_task_tool_returns_failed_message(monkeypatch):
+def test_task_tool_propagates_tool_groups_to_subagent(monkeypatch):
+    """Verify tool_groups from parent metadata are passed to get_available_tools(groups=...)."""
+    config = _make_subagent_config()
+    parent_tool_groups = ["file:read", "file:write", "bash"]
+    runtime = SimpleNamespace(
+        state={
+            "sandbox": {"sandbox_id": "local"},
+            "thread_data": {"workspace_path": "/tmp/workspace"},
+        },
+        context={"thread_id": "thread-1"},
+        config={"metadata": {"model_name": "ark-model", "trace_id": "trace-1", "tool_groups": parent_tool_groups}},
+    )
+    events = []
+    get_available_tools = MagicMock(return_value=["tool-a"])
+
+    class DummyExecutor:
+        def __init__(self, **kwargs):
+            pass
+
+        def execute_async(self, prompt, task_id=None):
+            return task_id or "generated-task-id"
+
+    monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
+    monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(
+        task_tool_module,
+        "get_background_task_result",
+        lambda _: _make_result(FakeSubagentStatus.COMPLETED, result="done"),
+    )
+    monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
+    monkeypatch.setattr(task_tool_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr("deerflow.tools.get_available_tools", get_available_tools)
+
+    output = _run_task_tool(
+        runtime=runtime,
+        description="执行任务",
+        prompt="file work only",
+        subagent_type="general-purpose",
+        tool_call_id="tc-groups",
+    )
+
+    assert output == "Task Succeeded. Result: done"
+    # The key assertion: groups should be propagated from parent metadata
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=parent_tool_groups, subagent_enabled=False)
+
+
+def test_task_tool_no_tool_groups_passes_none(monkeypatch):
+    """Verify that when metadata has no tool_groups, groups=None is passed (backward compat)."""
+    config = _make_subagent_config()
+    # Default _make_runtime() has no tool_groups in metadata
+    runtime = _make_runtime()
+    events = []
+    get_available_tools = MagicMock(return_value=[])
+
+    class DummyExecutor:
+        def __init__(self, **kwargs):
+            pass
+
+        def execute_async(self, prompt, task_id=None):
+            return task_id or "generated-task-id"
+
+    monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
+    monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(
+        task_tool_module,
+        "get_background_task_result",
+        lambda _: _make_result(FakeSubagentStatus.COMPLETED, result="ok"),
+    )
+    monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
+    monkeypatch.setattr(task_tool_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr("deerflow.tools.get_available_tools", get_available_tools)
+
+    output = _run_task_tool(
+        runtime=runtime,
+        description="执行任务",
+        prompt="normal work",
+        subagent_type="general-purpose",
+        tool_call_id="tc-no-groups",
+    )
+
+    assert output == "Task Succeeded. Result: ok"
+    # No tool_groups in metadata → groups=None (default behavior preserved)
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False)
+
+
+def test_task_tool_runtime_none_passes_groups_none(monkeypatch):
+    """Verify that when runtime is None, groups=None is passed (e.g., unknown subagent path exits early, but tools still load correctly)."""
+    config = _make_subagent_config()
+    events = []
+    get_available_tools = MagicMock(return_value=[])
+
+    class DummyExecutor:
+        def __init__(self, **kwargs):
+            pass
+
+        def execute_async(self, prompt, task_id=None):
+            return task_id or "generated-task-id"
+
+    monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
+    monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
+    monkeypatch.setattr(
+        task_tool_module,
+        "get_background_task_result",
+        lambda _: _make_result(FakeSubagentStatus.COMPLETED, result="ok"),
+    )
+    monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
+    monkeypatch.setattr(task_tool_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr("deerflow.tools.get_available_tools", get_available_tools)
+
+    output = _run_task_tool(
+        runtime=None,
+        description="执行任务",
+        prompt="no runtime",
+        subagent_type="general-purpose",
+        tool_call_id="tc-no-runtime",
+    )
+
+    assert output == "Task Succeeded. Result: ok"
+    # runtime is None → metadata is empty dict → groups=None
+    get_available_tools.assert_called_once_with(model_name=None, groups=None, subagent_enabled=False)
+
     config = _make_subagent_config()
     events = []
 


### PR DESCRIPTION
## Summary

When a custom agent defines `tool_groups` in its `config.yaml` (e.g., `[file:read, file:write, bash]`), the restriction is correctly applied to the lead agent. However, when the lead agent delegates work to a subagent via the `task` tool, `get_available_tools()` is called **without** the `groups` parameter, causing the subagent to receive **all** tools (including `web_search`, `web_fetch`, `image_search`, etc.) regardless of the parent agent's configuration.

## Problem

```
Lead Agent (tool_groups=[file:read, file:write, bash])  ✅ tools filtered
  └→ task_tool
       └→ get_available_tools(groups=None)              ❌ loads ALL tools
            └→ SubagentExecutor receives all tools
                 └→ general-purpose subagent gets web_search, web_fetch, image_search, etc.
```

**Root cause:** `task_tool.py:111` calls `get_available_tools(model_name=parent_model, subagent_enabled=False)` without passing `groups`, so the tool group filter is lost.

## Fix

Propagate `tool_groups` through run metadata so that `task_tool` applies the same group filter when building the subagent's tool set.

### Changes

1. **`agent.py`** (+1 line): Include `tool_groups` in run metadata alongside existing fields like `model_name`, `agent_name`, etc.
2. **`task_tool.py`** (+4/-1 lines): Read `tool_groups` from metadata and pass it to `get_available_tools(groups=...)`.

### After fix

```
Lead Agent (tool_groups=[file:read, file:write, bash])  ✅ tools filtered
  └→ metadata.tool_groups = [file:read, file:write, bash]
       └→ task_tool
            └→ get_available_tools(groups=[file:read, file:write, bash])  ✅
                 └→ SubagentExecutor receives only matching tools
                      └→ general-purpose subagent: no web_search, web_fetch, image_search  ✅
```

**Note:** When `tool_groups` is `None` (default agent, no custom config), the behavior is unchanged — `groups=None` means no filtering, preserving full backward compatibility.

## How to reproduce

1. Create a custom agent with restricted `tool_groups`:
   ```yaml
   # .deer-flow/agents/my-agent/config.yaml
   name: my-agent
   description: A file-only agent
   tool_groups:
     - file:read
     - file:write
     - bash
   ```
2. Send a task that triggers subagent delegation (via the `task` tool).
3. Observe that the subagent receives `web_search`, `web_fetch`, `image_search` tools despite the parent agent not having them.