### PR TITLE
fix(sandbox): add missing path masking in ls_tool output

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1047,6 +1047,7 @@ def ls_tool(runtime: ToolRuntime[ContextT, ThreadState], description: str, path:
         sandbox = ensure_sandbox_initialized(runtime)
         ensure_thread_directories_exist(runtime)
         requested_path = path
+        thread_data = None
         if is_local_sandbox(runtime):
             thread_data = get_thread_data(runtime)
             validate_local_tool_path(path, thread_data, read_only=True)
@@ -1061,6 +1062,8 @@ def ls_tool(runtime: ToolRuntime[ContextT, ThreadState], description: str, path:
         if not children:
             return "(empty)"
         output = "\n".join(children)
+        if thread_data is not None:
+            output = mask_local_paths_in_output(output, thread_data)
         try:
             from deerflow.config.app_config import get_app_config
 

--- a/backend/tests/test_sandbox_search_tools.py
+++ b/backend/tests/test_sandbox_search_tools.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from deerflow.community.aio_sandbox.aio_sandbox import AioSandbox
 from deerflow.sandbox.local.local_sandbox import LocalSandbox
 from deerflow.sandbox.search import GrepMatch, find_glob_matches, find_grep_matches
-from deerflow.sandbox.tools import glob_tool, grep_tool
+from deerflow.sandbox.tools import glob_tool, grep_tool, ls_tool
 
 
 def _make_runtime(tmp_path):
@@ -391,3 +391,71 @@ def test_aio_sandbox_grep_skips_mismatched_line_number_payloads(monkeypatch) -> 
 
     assert matches == [GrepMatch(path="/mnt/user-data/workspace/app.py", line_number=7, line="TODO = True")]
     assert truncated is False
+
+
+# ---------------------------------------------------------------------------
+# ls_tool — path masking
+# ---------------------------------------------------------------------------
+
+
+def test_ls_tool_masks_user_data_host_paths(tmp_path, monkeypatch) -> None:
+    """ls_tool output must not leak host user-data paths; they should be virtual."""
+    runtime = _make_runtime(tmp_path)
+    workspace = tmp_path / "workspace"
+    (workspace / "report.txt").write_text("hello\n", encoding="utf-8")
+    (workspace / "subdir").mkdir()
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox(id="local"))
+
+    result = ls_tool.func(
+        runtime=runtime,
+        description="list workspace",
+        path="/mnt/user-data/workspace",
+    )
+
+    # Virtual paths must be present
+    assert "/mnt/user-data/workspace" in result
+    # Host paths must NOT leak
+    assert str(workspace) not in result
+    assert str(tmp_path) not in result
+
+
+def test_ls_tool_masks_skills_host_paths(tmp_path, monkeypatch) -> None:
+    """ls_tool output must not leak host skills paths; they should be virtual."""
+    runtime = _make_runtime(tmp_path)
+    skills_dir = tmp_path / "skills"
+    (skills_dir / "public").mkdir(parents=True)
+    (skills_dir / "public" / "SKILL.md").write_text("# Skill\n", encoding="utf-8")
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox(id="local"))
+
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_path", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_host_path", return_value=str(skills_dir)),
+    ):
+        result = ls_tool.func(
+            runtime=runtime,
+            description="list skills",
+            path="/mnt/skills",
+        )
+
+    # Virtual paths must be present
+    assert "/mnt/skills" in result
+    # Host paths must NOT leak
+    assert str(skills_dir) not in result
+    assert str(tmp_path) not in result
+
+
+def test_ls_tool_returns_empty_for_empty_directory(tmp_path, monkeypatch) -> None:
+    """ls_tool should return '(empty)' for an empty directory."""
+    runtime = _make_runtime(tmp_path)
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox(id="local"))
+
+    result = ls_tool.func(
+        runtime=runtime,
+        description="list empty dir",
+        path="/mnt/user-data/workspace",
+    )
+
+    assert result == "(empty)"


### PR DESCRIPTION
## Problem

`ls_tool` is the **only** file-system sandbox tool that does not call `mask_local_paths_in_output()` before returning its result to the LLM. This causes host absolute paths (e.g. `/Users/.../backend/.deer-flow/knowledge-base/...`) to leak instead of the expected virtual paths (`/mnt/knowledge-base/...`, `/mnt/user-data/...`, etc.).

### Evidence

| Tool | Calls `mask_local_paths_in_output` | Location |
|---|---|---|
| `bash_tool` | ✅ Yes | line ~1020 |
| `glob_tool` | ✅ Yes | line ~1117 |
| `grep_tool` | ✅ Yes | line ~1179 |
| **`ls_tool`** | **❌ No** | — |

### Impact

1. **Security**: Host filesystem structure is exposed to the LLM (information leak in SaaS/multi-tenant scenarios).
2. **Functional**: The LLM may use leaked host paths in subsequent tool calls (`read_file`, `bash`, etc.), which will be rejected by `validate_local_tool_path`, breaking the agent workflow.
3. **UX**: The LLM may display raw host paths to end users.

## Solution

- Add `mask_local_paths_in_output()` call to `ls_tool`, consistent with `bash_tool`, `glob_tool`, and `grep_tool`.
- Initialize `thread_data = None` before the `is_local_sandbox` branch (same pattern as `glob_tool`) so the variable is always in scope.

### Changes

- **`backend/packages/harness/deerflow/sandbox/tools.py`**: 3-line fix adding path masking to `ls_tool`.
- **`backend/tests/test_sandbox_search_tools.py`**: 3 new test cases:
  - `test_ls_tool_masks_user_data_host_paths` — verifies user-data paths are masked
  - `test_ls_tool_masks_skills_host_paths` — verifies skills paths are masked
  - `test_ls_tool_returns_empty_for_empty_directory` — verifies empty directory edge case

### Testing

All 117 related tests pass (including 3 new ones):

```
tests/test_sandbox_search_tools.py       — 21 passed
tests/test_sandbox_tools_security.py     — 86 passed
tests/test_tool_output_truncation.py     — 24 passed
tests/test_local_bash_tool_loading.py    —  7 passed
```
