### PR TITLE
fix(reasoning): prevent LLM-hallucinated HTML tags from rendering as DOM elements

### DIFF
--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -11,6 +11,7 @@ import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
 import { Streamdown } from "streamdown";
+import { reasoningPlugins } from "@/core/streamdown/plugins";
 import { Shimmer } from "./shimmer";
 
 type ReasoningContextValue = {
@@ -177,7 +178,7 @@ export const ReasoningContent = memo(
       )}
       {...props}
     >
-      <Streamdown {...props}>{children}</Streamdown>
+      <Streamdown {...reasoningPlugins}>{children}</Streamdown>
     </CollapsibleContent>
   ),
 );

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -28,6 +28,18 @@ export const streamdownPluginsWithWordAnimation = {
   ] as StreamdownProps["rehypePlugins"],
 };
 
+// Plugins for reasoning/thinking content — same as streamdownPlugins but without rehypeRaw,
+// to prevent LLM-hallucinated HTML tags (e.g. <simd>) from being rendered as DOM elements.
+export const reasoningPlugins = {
+  remarkPlugins: [
+    remarkGfm,
+    [remarkMath, { singleDollarTextMath: true }],
+  ] as StreamdownProps["remarkPlugins"],
+  rehypePlugins: [
+    [rehypeKatex, { output: "html" }],
+  ] as StreamdownProps["rehypePlugins"],
+};
+
 // Plugins for human messages - no autolink to prevent URL bleeding into adjacent text
 export const humanMessagePlugins = {
   remarkPlugins: [

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -28,16 +28,13 @@ export const streamdownPluginsWithWordAnimation = {
   ] as StreamdownProps["rehypePlugins"],
 };
 
-// Plugins for reasoning/thinking content — same as streamdownPlugins but without rehypeRaw,
+// Plugins for reasoning/thinking content — derived from streamdownPlugins but without rehypeRaw,
 // to prevent LLM-hallucinated HTML tags (e.g. <simd>) from being rendered as DOM elements.
 export const reasoningPlugins = {
-  remarkPlugins: [
-    remarkGfm,
-    [remarkMath, { singleDollarTextMath: true }],
-  ] as StreamdownProps["remarkPlugins"],
-  rehypePlugins: [
-    [rehypeKatex, { output: "html" }],
-  ] as StreamdownProps["rehypePlugins"],
+  remarkPlugins: streamdownPlugins.remarkPlugins,
+  rehypePlugins: streamdownPlugins.rehypePlugins?.filter(
+    (p) => p !== rehypeRaw,
+  ) as StreamdownProps["rehypePlugins"],
 };
 
 // Plugins for human messages - no autolink to prevent URL bleeding into adjacent text

--- a/frontend/tests/unit/core/streamdown/plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown/plugins.test.ts
@@ -1,0 +1,13 @@
+import rehypeRaw from "rehype-raw";
+import { expect, test } from "vitest";
+
+import { reasoningPlugins, streamdownPlugins } from "@/core/streamdown/plugins";
+
+test("streamdownPlugins includes rehypeRaw", () => {
+  expect(streamdownPlugins.rehypePlugins).toContain(rehypeRaw);
+});
+
+test("reasoningPlugins does not include rehypeRaw", () => {
+  const flat = reasoningPlugins.rehypePlugins?.flat();
+  expect(flat).not.toContain(rehypeRaw);
+});


### PR DESCRIPTION
#2320 


## Pull request overview

This PR prevents LLM-hallucinated HTML tags inside reasoning/thinking Markdown (e.g. <simd>...</simd>) from being parsed into real DOM elements by ensuring reasoning content uses a Streamdown plugin set that does not include rehype-raw.

## Changes:

Added a dedicated reasoningPlugins preset (mirrors existing Streamdown plugins but omits rehypeRaw).
Updated ReasoningContent to pass reasoningPlugins to <Streamdown> instead of forwarding CollapsibleContent props.
Added unit tests asserting rehypeRaw is present in streamdownPlugins but absent from reasoningPlugins.

ReasoningContent 渲染 <Streamdown {...props}> 时，props 是从 CollapsibleContent 透传来的布局属性（className、data-state 等），没有包含任何 rehypePlugins。

Streamdown 在没有收到 rehypePlugins 时，使用它自己的内置默认值，其中包含了 rehype-raw：

```
// streamdown 内部 defaults
const defaultRehypePlugins = {
  harden: [rehypeHarden, ...],
  raw: rehypeRaw,       // ← 这个！
  katex: [rehypeKatex, ...],
};
```

rehype-raw 的作用是把 markdown AST 中的原始 HTML 字符串原封不动地解析成真实 DOM 节点。当 LLM 在思考内容（reasoning）里输出了 <simd> 这样的自创 HTML 标签时，它就被当作合法 HTML 渲染给了 React，React 看到未知小写标签 <simd> 就报 warning。

问题链路总结：

```
LLM 输出 "<simd>..." 文本
  → Streamdown 使用默认 rehypeRaw
  → rehype-raw 把 <simd> 解析为 DOM element
  → React 渲染 <simd>，报 "unrecognized tag" warning
  → 页面崩溃（因为 <simd> 是无效 JSX 元素）
```


修复方式：给 ReasoningContent 传入不含 rehype-raw 的插件集合（reasoningPlugins），让未知 HTML 标签在 AST 阶段就被过滤掉，而不是透传给 DOM。