### PR TITLE
Fix #2308: Timer callback RuntimeError from asyncio.run in executor thread

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -228,7 +228,7 @@ def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
             loop = None
 
         if loop is not None and loop.is_running():
-            future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(asyncio.run, coro)
+            future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(loop.run_until_complete, coro)
             handed_off = True
             return future.result()
 


### PR DESCRIPTION
## Fix #2308: asyncio.run() RuntimeError in executor thread

### Problem
`_run_async_update_sync()` submits async coroutines to a `ThreadPoolExecutor` using `asyncio.run(coro)`. When a `threading.Timer` callback fires in a thread that already has a running event loop (FastAPI/LangGraph worker thread), `asyncio.run()` raises `RuntimeError: asyncio.run() cannot be called from a running event loop`.

This causes memory updates to silently fail — conversation context is lost without any error visible to the user.

### Root Cause
Line 231 of `updater.py`:
```python
future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(asyncio.run, coro)
```

`asyncio.run()` always creates a **new** event loop and closes it when done. In a thread where `loop.is_running() == True`, this conflicts with the existing loop.

### Fix
Since we already hold the running loop reference from `get_running_loop()`, use `loop.run_until_complete(coro)` directly in the executor thread instead:

```python
future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(loop.run_until_complete, coro)
```

`run_until_complete()` runs the coroutine in the already-running loop without attempting to create a new one.

### Files Changed
- `backend/packages/harness/deerflow/agents/memory/updater.py` (1 line)

### Testing
`python -m py_compile` passes. The fix is minimal and targeted — it only changes how the coroutine is dispatched within the executor thread, preserving all existing error handling and fallback logic.