### PR TITLE
fix(reasoning): prevent LLM-hallucinated HTML tags from rendering as DOM elements

### DIFF
--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -11,6 +11,8 @@ import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
 import { Streamdown } from "streamdown";
+
+import { reasoningPlugins } from "@/core/streamdown/plugins";
 import { Shimmer } from "./shimmer";
 
 type ReasoningContextValue = {
@@ -177,7 +179,7 @@ export const ReasoningContent = memo(
       )}
       {...props}
     >
-      <Streamdown {...props}>{children}</Streamdown>
+      <Streamdown {...reasoningPlugins}>{children}</Streamdown>
     </CollapsibleContent>
   ),
 );

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -28,6 +28,20 @@ export const streamdownPluginsWithWordAnimation = {
   ] as StreamdownProps["rehypePlugins"],
 };
 
+// Plugins for reasoning content - like streamdownPlugins but without rehype-raw
+// so that LLM-hallucinated HTML tags (e.g. <simd>some text</simd>) are left as
+// escaped text instead of being parsed into unknown DOM elements, which
+// triggers React warnings and can break rendering of the reasoning block.
+export const reasoningPlugins = {
+  remarkPlugins: [
+    remarkGfm,
+    [remarkMath, { singleDollarTextMath: true }],
+  ] as StreamdownProps["remarkPlugins"],
+  rehypePlugins: [
+    [rehypeKatex, { output: "html" }],
+  ] as StreamdownProps["rehypePlugins"],
+};
+
 // Plugins for human messages - no autolink to prevent URL bleeding into adjacent text
 export const humanMessagePlugins = {
   remarkPlugins: [


### PR DESCRIPTION
Closes #2320

## Problem

`ReasoningContent` passed `{...props}` directly to `<Streamdown>`. Two consequences:

1. Streamdown fell back to its default rehype plugin set, which includes `rehype-raw`. `rehype-raw` parses raw HTML strings in the Markdown AST into real DOM nodes, so when an LLM emits an invented tag inside its thinking output (e.g. `<simd>some text</simd>`), it gets rendered as an unknown HTML element. React warns about the unrecognized tag, and the element can break the surrounding reasoning block.
2. The same spread forwarded `CollapsibleContent` layout props (`asChild`, `forceMount`, and friends) onto `<Streamdown>`, which does not accept them.

## Fix

- Add a `reasoningPlugins` preset in `src/core/streamdown/plugins.ts`. It mirrors `streamdownPlugins` but drops `rehype-raw`, so unknown HTML tags in reasoning output render as escaped text instead of being parsed into DOM nodes.
- In `ReasoningContent` (`frontend/src/components/ai-elements/reasoning.tsx`), spread `reasoningPlugins` onto `<Streamdown>` instead of forwarding arbitrary `CollapsibleContent` props. `CollapsibleContent` still receives `{...props}` as before.

## Testing

```
pnpm typecheck   # passes
pnpm lint        # passes
pnpm test        # 19/19 passing
```

Manual reasoning-block behaviour:
- Before: LLM-emitted `<simd>text</simd>` rendered as a DOM `<simd>` element, triggering React's "unrecognized tag" warning.
- After: the literal markup is escaped and displayed as text. Markdown, GFM, and KaTeX still render as expected because `remarkGfm`, `remarkMath`, and `rehypeKatex` are preserved in `reasoningPlugins`.

## Scope notes

- `streamdownPlugins`, `streamdownPluginsWithWordAnimation`, and `humanMessagePlugins` are untouched, so nothing outside reasoning blocks changes behaviour.
- The existing `ReasoningContent` export signature is unchanged.

