### PR TITLE
feat(frontend): add missing API rewrites for gateway endpoints

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -60,6 +60,38 @@ const config = {
         source: "/api/skills/:path*",
         destination: `${gatewayURL}/api/skills/:path*`,
       });
+      rewrites.push({
+        source: "/api/models/:path*",
+        destination: `${gatewayURL}/api/models/:path*`,
+      });
+      rewrites.push({
+        source: "/api/threads/:threadId/suggestions",
+        destination: `${gatewayURL}/api/threads/:threadId/suggestions`,
+      });
+      rewrites.push({
+        source: "/api/threads/:threadId/:path*",
+        destination: `${gatewayURL}/api/threads/:threadId/:path*`,
+      });
+      rewrites.push({
+        source: "/api/memory",
+        destination: `${gatewayURL}/api/memory`,
+      });
+      rewrites.push({
+        source: "/api/memory/:path*",
+        destination: `${gatewayURL}/api/memory/:path*`,
+      });
+      rewrites.push({
+        source: "/api/uploads/:path*",
+        destination: `${gatewayURL}/api/uploads/:path*`,
+      });
+      rewrites.push({
+        source: "/api/mcp/:path*",
+        destination: `${gatewayURL}/api/mcp/:path*`,
+      });
+      rewrites.push({
+        source: "/api/:path*",
+        destination: `${gatewayURL}/api/:path*`,
+      });
     }
 
     return rewrites;


### PR DESCRIPTION
## Summary

This PR addresses issue #2327 by adding missing API rewrites in the Next.js configuration. Previously, several API endpoints were returning 404 errors when accessed through the frontend proxy because the rewrites were not configured properly.

Changes include:
- Added rewrite for `/api/models` endpoint
- Added rewrite for `/api/threads/:threadId/suggestions` endpoint
- Added rewrites for other missing API endpoints like memory, uploads, mcp, etc.
- Added catch-all `/api/:path*` rewrite to ensure all API requests are properly proxied

Fixes #2327

## Test Plan

- [ ] Start the frontend server: `cd frontend && pnpm run dev`
- [ ] Verify that `http://localhost:3000/api/models` returns 200 with models list
- [ ] Verify that `http://localhost:3000/api/threads/{threadId}/suggestions` returns 200
- [ ] Test other API endpoints to ensure they are properly proxied to the gateway
- [ ] Confirm existing functionality is not broken

<img width="562" height="290" alt="image" src="https://github.com/user-attachments/assets/41cdb62b-7148-4506-8ead-891f20d1fc76" />

<img width="668" height="409" alt="image" src="https://github.com/user-attachments/assets/de6f3411-1bbf-4466-8c36-fa831ea86816" />

