### PR TITLE
fix(gateway): bound lifespan shutdown hooks to prevent worker hang under uvicorn reload

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 # Upper bound (seconds) each lifespan shutdown hook is allowed to run.
 # Bounds worker exit time so uvicorn's reload supervisor does not keep
-# firing signals into a stuck worker — see fix/bounded-lifespan-shutdown.
+# firing signals into a worker that is stuck waiting for shutdown cleanup.
 _SHUTDOWN_HOOK_TIMEOUT_SECONDS = 5.0
 
 

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -32,6 +33,11 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+# Upper bound (seconds) each lifespan shutdown hook is allowed to run.
+# Bounds worker exit time so uvicorn's reload supervisor does not keep
+# firing signals into a stuck worker — see fix/bounded-lifespan-shutdown.
+_SHUTDOWN_HOOK_TIMEOUT_SECONDS = 5.0
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -63,11 +69,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         yield
 
-        # Stop channel service on shutdown
+        # Stop channel service on shutdown (bounded to prevent worker hang)
         try:
             from app.channels.service import stop_channel_service
 
-            await stop_channel_service()
+            await asyncio.wait_for(
+                stop_channel_service(),
+                timeout=_SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Channel service shutdown exceeded %.1fs; proceeding with worker exit.",
+                _SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
         except Exception:
             logger.exception("Failed to stop channel service")
 

--- a/backend/tests/test_gateway_lifespan_shutdown.py
+++ b/backend/tests/test_gateway_lifespan_shutdown.py
@@ -52,9 +52,7 @@ async def _run_lifespan_with_hanging_stop() -> float:
             pass
         elapsed = loop.time() - start
 
-    assert _SHUTDOWN_HOOK_TIMEOUT_SECONDS < 30.0, (
-        "Timeout constant must stay modest"
-    )
+    assert _SHUTDOWN_HOOK_TIMEOUT_SECONDS < 30.0, "Timeout constant must stay modest"
     return elapsed
 
 
@@ -65,12 +63,6 @@ def test_shutdown_is_bounded_when_channel_stop_hangs():
     elapsed = asyncio.run(_run_lifespan_with_hanging_stop())
 
     # Generous upper bound: timeout + 2s slack for scheduling overhead.
-    assert elapsed < _SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0, (
-        f"Lifespan shutdown took {elapsed:.2f}s; expected <="
-        f" {_SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0:.1f}s"
-    )
+    assert elapsed < _SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0, f"Lifespan shutdown took {elapsed:.2f}s; expected <= {_SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0:.1f}s"
     # Lower bound: the wait_for should actually have waited.
-    assert elapsed >= _SHUTDOWN_HOOK_TIMEOUT_SECONDS - 0.5, (
-        f"Lifespan exited too quickly ({elapsed:.2f}s); wait_for may not"
-        " have been invoked."
-    )
+    assert elapsed >= _SHUTDOWN_HOOK_TIMEOUT_SECONDS - 0.5, f"Lifespan exited too quickly ({elapsed:.2f}s); wait_for may not have been invoked."

--- a/backend/tests/test_gateway_lifespan_shutdown.py
+++ b/backend/tests/test_gateway_lifespan_shutdown.py
@@ -1,0 +1,76 @@
+"""Regression tests for Gateway lifespan shutdown.
+
+These tests guard the invariant that lifespan shutdown is *bounded*: a
+misbehaving channel whose ``stop()`` blocks forever must not keep the
+uvicorn worker alive. A hung worker is the precondition for the
+signal-reentrancy deadlock described in
+``app.gateway.app._SHUTDOWN_HOOK_TIMEOUT_SECONDS``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+
+
+@asynccontextmanager
+async def _noop_langgraph_runtime(_app):
+    yield
+
+
+async def _run_lifespan_with_hanging_stop() -> float:
+    """Drive the lifespan context with stop_channel_service hanging forever.
+
+    Returns the elapsed wall-clock seconds.
+    """
+    from app.gateway.app import _SHUTDOWN_HOOK_TIMEOUT_SECONDS, lifespan
+
+    async def hang_forever() -> None:
+        await asyncio.sleep(3600)
+
+    app = FastAPI()
+
+    fake_service = MagicMock()
+    fake_service.get_status = MagicMock(return_value={})
+
+    async def fake_start():
+        return fake_service
+
+    with (
+        patch("app.gateway.app.get_app_config"),
+        patch("app.gateway.app.get_gateway_config", return_value=MagicMock(host="x", port=0)),
+        patch("app.gateway.app.langgraph_runtime", _noop_langgraph_runtime),
+        patch("app.channels.service.start_channel_service", side_effect=fake_start),
+        patch("app.channels.service.stop_channel_service", side_effect=hang_forever),
+    ):
+        loop = asyncio.get_event_loop()
+        start = loop.time()
+        async with lifespan(app):
+            pass
+        elapsed = loop.time() - start
+
+    assert _SHUTDOWN_HOOK_TIMEOUT_SECONDS < 30.0, (
+        "Timeout constant must stay modest"
+    )
+    return elapsed
+
+
+def test_shutdown_is_bounded_when_channel_stop_hangs():
+    """Lifespan exit must complete near the configured timeout, not hang."""
+    from app.gateway.app import _SHUTDOWN_HOOK_TIMEOUT_SECONDS
+
+    elapsed = asyncio.run(_run_lifespan_with_hanging_stop())
+
+    # Generous upper bound: timeout + 2s slack for scheduling overhead.
+    assert elapsed < _SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0, (
+        f"Lifespan shutdown took {elapsed:.2f}s; expected <="
+        f" {_SHUTDOWN_HOOK_TIMEOUT_SECONDS + 2.0:.1f}s"
+    )
+    # Lower bound: the wait_for should actually have waited.
+    assert elapsed >= _SHUTDOWN_HOOK_TIMEOUT_SECONDS - 0.5, (
+        f"Lifespan exited too quickly ({elapsed:.2f}s); wait_for may not"
+        " have been invoked."
+    )


### PR DESCRIPTION
## Summary

- Wraps `stop_channel_service()` in the Gateway lifespan with a 5s `asyncio.wait_for` bound so a misbehaving channel cannot keep the worker process alive.
- Adds a regression test that simulates a channel `stop()` hanging forever and asserts the lifespan still exits within the timeout window.

## Problem

I hit an indefinitely-hung Gateway worker in `uvicorn --reload` mode on local dev. The listener socket on `:8001` stayed bound but every `/api/*` request returned 504 through nginx; a direct `curl :8001/health` also timed out. `SIGTERM` had no effect — only `kill -9` recovered the process.

## Root cause

`py-spy dump` on the hung supervisor (pid bound to the socket) showed the main thread stuck with a deeply-stacked trace:

```
Thread 0x… (active): "MainThread"
    __enter__ (threading.py:300)          ← blocks here
    set (threading.py:623)
    signal_handler (uvicorn/supervisors/basereload.py:48)
    __enter__ (threading.py:300)
    set (threading.py:623)
    signal_handler (uvicorn/supervisors/basereload.py:48)
    …  [16+ layers of the same frame]  …
    poll (multiprocessing/popen_fork.py:27)
    wait (multiprocessing/popen_fork.py:43)
    join (multiprocessing/process.py:149)
    shutdown (uvicorn/supervisors/basereload.py:108)
    run (uvicorn/supervisors/basereload.py:61)
    run (uvicorn/main.py:589)
    ...
```

Two problems stacked:

1. **Signal-reentrancy deadlock.** CPython's `threading.Event` is defined as `Condition(Lock())` — the inner `Lock` is **non-reentrant**. uvicorn's `BaseReload.signal_handler` calls `self.should_exit.set()` directly from signal context. Python signals are always delivered to the main thread and can interrupt arbitrary bytecode. If a second signal (SIGTERM/SIGHUP) arrives while the first handler is still inside `Event.set()` holding that Lock, the reentrant call tries to acquire the same Lock → it deadlocks on itself. That's what the stack of `signal_handler → set → __enter__` frames shows.
2. **Slow shutdown widens the danger window.** The supervisor only keeps sending those signals when the worker fails to exit. The longer the lifespan shutdown takes, the more opportunities there are for a reload-supervisor or watchfiles-triggered signal to land inside the critical section.

The first problem is upstream (uvicorn + CPython), and not something DeerFlow can fix. The second problem is within our control: the current shutdown does

```python
await stop_channel_service()   # no timeout
```

If any channel's `stop()` stalls (e.g. Feishu/Slack WebSocket waiting for a close ack that never comes, or an `aiohttp` session cleanup that blocks), the worker cannot exit, the supervisor keeps signaling, and the deadlock becomes reachable.

## Why fix it here

This is a **defense-in-depth** change. It does not fix the Lock reentrancy in `threading.Event`, but it does guarantee the worker exits within a bounded time, which removes the precondition for the signal storm.

## Change

`backend/app/gateway/app.py`:

- Import `asyncio`, add `_SHUTDOWN_HOOK_TIMEOUT_SECONDS = 5.0` module constant.
- Wrap `stop_channel_service()` in `asyncio.wait_for(..., timeout=5.0)`.
- On `TimeoutError`, log a warning and proceed — don't let a stuck channel hold the worker hostage.
- Other exceptions keep the existing `logger.exception(...)` behavior.
- No behavior change on the happy path (channel stop is expected to return in tens of milliseconds).

I intentionally did **not** add a timeout to the startup hooks. Startup failure should raise and abort boot, not be swallowed.

## Test plan

- [x] `uv run pytest backend/tests/test_gateway_lifespan_shutdown.py -v` — new regression test passes (patches `stop_channel_service` with a forever-sleep, asserts lifespan exits within `timeout + 2s`).
- [x] `uv run ruff check backend/app/gateway/app.py backend/tests/test_gateway_lifespan_shutdown.py` — clean.
- [x] Manual: `make gateway` still starts and stops cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)