### PR TITLE
fix(frontend): add catch-all API rewrite for gateway routes

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -60,6 +60,18 @@ const config = {
         source: "/api/skills/:path*",
         destination: `${gatewayURL}/api/skills/:path*`,
       });
+
+      // Catch-all for remaining gateway API routes (models, threads, memory,
+      // mcp, artifacts, uploads, suggestions, runs, etc.) that don't have
+      // their own NEXT_PUBLIC_* env var toggle.
+      //
+      // NOTE: this must come AFTER the /api/langgraph rewrite above so that
+      // LangGraph routes are matched first when NEXT_PUBLIC_LANGGRAPH_BASE_URL
+      // is unset.
+      rewrites.push({
+        source: "/api/:path*",
+        destination: `${gatewayURL}/api/:path*`,
+      });
     }
 
     return rewrites;


### PR DESCRIPTION
## Summary

Fixes #2327

When `NEXT_PUBLIC_BACKEND_BASE_URL` is unset (default local dev), the frontend proxies API requests to the gateway. Only `/api/agents` and `/api/skills` had rewrite rules, causing 404 errors for:

- `/api/models` — model list endpoint (the one reported in #2327)
- `/api/threads/*` — thread CRUD, artifacts, uploads, suggestions
- `/api/memory/*` — memory management
- `/api/mcp/*` — MCP configuration
- `/api/runs/*` — run management

## Fix

Add a catch-all `/api/:path*` rewrite that proxies all remaining gateway API routes. The existing specific rewrites (`/api/agents`, `/api/skills`) are kept as documentation and take priority since they appear earlier in the array.

The `/api/langgraph` rewrite is unaffected because it is pushed to the array **before** the catch-all, and Next.js processes rewrites in order.

## Comparison with #2328

#2328 by @gs8040 addresses the same issue but adds 7 granular rewrite rules plus a catch-all — making the granular rules redundant. This PR uses only the catch-all, which is simpler and self-maintaining (new gateway routes are automatically covered).

## Test Plan

1. `cd frontend && pnpm dev`
2. Without `NEXT_PUBLIC_BACKEND_BASE_URL` set, verify `http://localhost:3000/api/models` returns 200 with models list
3. Verify `/api/langgraph/*` still routes to the LangGraph server, not the gateway
4. Verify existing `/api/agents` and `/api/skills` routes continue working