### PR TITLE
docs: add Zhipu Claude/OpenAI-compatible model templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,67 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
 
    To route OpenAI models through `/v1/responses`, keep using `langchain_openai:ChatOpenAI` and set `use_responses_api: true` with `output_version: responses/v1`.
 
+   Zhipu also provides a Claude-compatible endpoint. You can configure multiple Zhipu models with `langchain_anthropic:ChatAnthropic` plus `base_url: https://open.bigmodel.cn/api/anthropic`:
+
+   ```yaml
+   models:
+     - name: zhipu-glm-5-1
+       display_name: Zhipu GLM-5.1
+       use: langchain_anthropic:ChatAnthropic
+       model: glm-5.1
+       api_key: $ANTHROPIC_API_KEY
+       base_url: https://open.bigmodel.cn/api/anthropic
+
+     - name: zhipu-glm-5-turbo
+       display_name: Zhipu GLM-5-Turbo
+       use: langchain_anthropic:ChatAnthropic
+       model: glm-5-turbo
+       api_key: $ANTHROPIC_API_KEY
+       base_url: https://open.bigmodel.cn/api/anthropic
+
+     - name: zhipu-glm-4-7
+       display_name: Zhipu GLM-4.7
+       use: langchain_anthropic:ChatAnthropic
+       model: glm-4.7
+       api_key: $ANTHROPIC_API_KEY
+       base_url: https://open.bigmodel.cn/api/anthropic
+
+     - name: zhipu-glm-4-5-air
+       display_name: Zhipu GLM-4.5-Air
+       use: langchain_anthropic:ChatAnthropic
+       model: glm-4.5-air
+       api_key: $ANTHROPIC_API_KEY
+       base_url: https://open.bigmodel.cn/api/anthropic
+   ```
+
+   Available models depend on your Zhipu plan.
+
+   Zhipu also provides an OpenAI-compatible endpoint (`https://open.bigmodel.cn/api/paas/v4`):
+
+   ```yaml
+   models:
+     - name: zhipu-openai-glm-5-1
+       display_name: Zhipu GLM-5.1 (OpenAI API)
+       use: langchain_openai:ChatOpenAI
+       model: glm-5.1
+       api_key: $ZHIPU_API_KEY
+       base_url: https://open.bigmodel.cn/api/paas/v4
+
+     - name: zhipu-openai-glm-5-turbo
+       display_name: Zhipu GLM-5-Turbo (OpenAI API)
+       use: langchain_openai:ChatOpenAI
+       model: glm-5-turbo
+       api_key: $ZHIPU_API_KEY
+       base_url: https://open.bigmodel.cn/api/paas/v4
+
+     - name: zhipu-openai-glm-4-7
+       display_name: Zhipu GLM-4.7 (OpenAI API)
+       use: langchain_openai:ChatOpenAI
+       model: glm-4.7
+       api_key: $ZHIPU_API_KEY
+       base_url: https://open.bigmodel.cn/api/paas/v4
+   ```
+
    For vLLM 0.19.0, use `deerflow.models.vllm_provider:VllmChatModel`. For Qwen-style reasoning models, DeerFlow toggles reasoning with `extra_body.chat_template_kwargs.enable_thinking` and preserves vLLM's non-standard `reasoning` field across multi-turn tool-call conversations. Legacy `thinking` configs are normalized automatically for backward compatibility. Reasoning models may also require the server to be started with `--reasoning-parser ...`. If your local vLLM deployment accepts any non-empty API key, you can still set `VLLM_API_KEY` to a placeholder value.
 
    CLI-backed provider examples:

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -123,6 +123,67 @@ models:
 
 If your OpenRouter key lives in a different environment variable name, point `api_key` at that variable explicitly (for example `api_key: $OPENROUTER_API_KEY`).
 
+For Zhipu's Claude-compatible endpoint, keep using `langchain_anthropic:ChatAnthropic` and set `base_url`:
+
+```yaml
+models:
+  - name: zhipu-glm-5-1
+    display_name: Zhipu GLM-5.1
+    use: langchain_anthropic:ChatAnthropic
+    model: glm-5.1
+    api_key: $ANTHROPIC_API_KEY
+    base_url: https://open.bigmodel.cn/api/anthropic
+
+  - name: zhipu-glm-5-turbo
+    display_name: Zhipu GLM-5-Turbo
+    use: langchain_anthropic:ChatAnthropic
+    model: glm-5-turbo
+    api_key: $ANTHROPIC_API_KEY
+    base_url: https://open.bigmodel.cn/api/anthropic
+
+  - name: zhipu-glm-4-7
+    display_name: Zhipu GLM-4.7
+    use: langchain_anthropic:ChatAnthropic
+    model: glm-4.7
+    api_key: $ANTHROPIC_API_KEY
+    base_url: https://open.bigmodel.cn/api/anthropic
+
+  - name: zhipu-glm-4-5-air
+    display_name: Zhipu GLM-4.5-Air
+    use: langchain_anthropic:ChatAnthropic
+    model: glm-4.5-air
+    api_key: $ANTHROPIC_API_KEY
+    base_url: https://open.bigmodel.cn/api/anthropic
+```
+
+Available models depend on your Zhipu plan.
+
+For Zhipu's OpenAI-compatible endpoint, use `langchain_openai:ChatOpenAI` with `base_url`:
+
+```yaml
+models:
+  - name: zhipu-openai-glm-5-1
+    display_name: Zhipu GLM-5.1 (OpenAI API)
+    use: langchain_openai:ChatOpenAI
+    model: glm-5.1
+    api_key: $ZHIPU_API_KEY
+    base_url: https://open.bigmodel.cn/api/paas/v4
+
+  - name: zhipu-openai-glm-5-turbo
+    display_name: Zhipu GLM-5-Turbo (OpenAI API)
+    use: langchain_openai:ChatOpenAI
+    model: glm-5-turbo
+    api_key: $ZHIPU_API_KEY
+    base_url: https://open.bigmodel.cn/api/paas/v4
+
+  - name: zhipu-openai-glm-4-7
+    display_name: Zhipu GLM-4.7 (OpenAI API)
+    use: langchain_openai:ChatOpenAI
+    model: glm-4.7
+    api_key: $ZHIPU_API_KEY
+    base_url: https://open.bigmodel.cn/api/paas/v4
+```
+
 **Thinking Models**:
 Some models support "thinking" mode for complex reasoning:
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -132,6 +132,81 @@ models:
   #     thinking:
   #       type: disabled
 
+  # Example: Zhipu Claude-compatible models (Anthropic SDK compatible)
+  # Model availability depends on your Zhipu plan. Common options include:
+  # glm-5.1, glm-5-turbo, glm-4.7, glm-4.5-air
+  # - name: zhipu-glm-5-1
+  #   display_name: Zhipu GLM-5.1
+  #   use: langchain_anthropic:ChatAnthropic
+  #   model: glm-5.1
+  #   api_key: $ANTHROPIC_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/anthropic
+  #   default_request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #
+  # - name: zhipu-glm-5-turbo
+  #   display_name: Zhipu GLM-5-Turbo
+  #   use: langchain_anthropic:ChatAnthropic
+  #   model: glm-5-turbo
+  #   api_key: $ANTHROPIC_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/anthropic
+  #   default_request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #
+  # - name: zhipu-glm-4-7
+  #   display_name: Zhipu GLM-4.7
+  #   use: langchain_anthropic:ChatAnthropic
+  #   model: glm-4.7
+  #   api_key: $ANTHROPIC_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/anthropic
+  #   default_request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #
+  # - name: zhipu-glm-4-5-air
+  #   display_name: Zhipu GLM-4.5-Air
+  #   use: langchain_anthropic:ChatAnthropic
+  #   model: glm-4.5-air
+  #   api_key: $ANTHROPIC_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/anthropic
+  #   default_request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+
+  # Example: Zhipu OpenAI-compatible models
+  # Endpoint: https://open.bigmodel.cn/api/paas/v4
+  # - name: zhipu-openai-glm-5-1
+  #   display_name: Zhipu GLM-5.1 (OpenAI API)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-5.1
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #
+  # - name: zhipu-openai-glm-5-turbo
+  #   display_name: Zhipu GLM-5-Turbo (OpenAI API)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-5-turbo
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #
+  # - name: zhipu-openai-glm-4-7
+  #   display_name: Zhipu GLM-4.7 (OpenAI API)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-4.7
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+
   # Example: Google Gemini model (native SDK, no thinking support)
   # - name: gemini-2.5-pro
   #   display_name: Gemini 2.5 Pro


### PR DESCRIPTION
## Summary
- add Zhipu Claude-compatible multi-model templates (`glm-5.1`, `glm-5-turbo`, `glm-4.7`, `glm-4.5-air`) to `config.example.yaml`
- add matching manual configuration examples in `README.md`
- add matching configuration guide examples in `backend/docs/CONFIGURATION.md`
- add OpenAI-compatible Zhipu templates (`/api/paas/v4`) in all three docs

## Rationale
Zhipu is commonly used in the community. This PR adds copy-paste-ready templates while keeping runtime behavior unchanged.

## Verification
- `cd backend && uv run pytest tests/test_setup_wizard.py -q`
- `cd backend && uv run pytest tests/test_model_config.py -q`
