### PR TITLE
Add deerflow-kernel export and push automation

### DIFF
--- a/Install.md
+++ b/Install.md
@@ -82,6 +82,31 @@ Return a short status report with:
 4. Remaining user action: model config, env var values, auth files, or nothing
 5. Exact next command to start DeerFlow
 
+## Optional Maintenance Task: Export deerflow-kernel
+
+Use this only when the user explicitly asks to export/publish a standalone kernel repository.
+
+1. Export kernel files from this monorepo:
+
+```bash
+./scripts/export-deerflow-kernel.sh --output /tmp/deerflow-kernel --force
+```
+
+2. Push to internal Git with SSH (supports passphrase-protected keys):
+
+```bash
+DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE=1 \
+./scripts/push-deerflow-kernel.sh \
+  --output /tmp/deerflow-kernel \
+  --skip-export \
+  --merge-remote-history \
+  --remote-url git@code.tiancloud.com:xiaosi/deerflow-kernel.git
+```
+
+Notes:
+- `--merge-remote-history` handles non-fast-forward rejections when remote `main` already has commits.
+- For HTTP remotes, set `DEERFLOW_KERNEL_GIT_USERNAME` and `DEERFLOW_KERNEL_GIT_PASSWORD` (or `DEERFLOW_KERNEL_GIT_TOKEN`).
+
 ## EXECUTE NOW
 
 Complete the steps above. When finished, stop after the setup boundary and report status instead of continuing into unrelated project work.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ DeerFlow has newly integrated the intelligent search and crawling toolset indepe
     - [Long-Term Memory](#long-term-memory)
   - [Recommended Models](#recommended-models)
   - [Embedded Python Client](#embedded-python-client)
+  - [Kernel Export and Push](#kernel-export-and-push)
   - [Documentation](#documentation)
   - [⚠️ Security Notice](#️-security-notice)
     - [Improper Deployment May Introduce Security Risks](#improper-deployment-may-introduce-security-risks)
@@ -696,6 +697,31 @@ client.upload_files("thread-1", ["./report.pdf"])  # {"success": True, "files": 
 ```
 
 All dict-returning methods are validated against Gateway Pydantic response models in CI (`TestGatewayConformance`), ensuring the embedded client stays in sync with the HTTP API schemas. See `backend/packages/harness/deerflow/client.py` for full API documentation.
+
+## Kernel Export and Push
+
+For maintainers who need to export a standalone `deerflow-kernel` repository and push it to an internal Git server:
+
+1. Export kernel sources from this monorepo.
+
+  ```bash
+  ./scripts/export-deerflow-kernel.sh --output /tmp/deerflow-kernel --force
+  ```
+
+2. Push with SSH.
+
+  ```bash
+  DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE=1 \
+  ./scripts/push-deerflow-kernel.sh \
+    --output /tmp/deerflow-kernel \
+    --skip-export \
+    --merge-remote-history \
+    --remote-url git@code.tiancloud.com:xiaosi/deerflow-kernel.git
+  ```
+
+Notes:
+- `--merge-remote-history` auto-handles non-fast-forward rejects when remote `main` already has commits.
+- For HTTP remotes, set `DEERFLOW_KERNEL_GIT_USERNAME` and `DEERFLOW_KERNEL_GIT_PASSWORD` (or `DEERFLOW_KERNEL_GIT_TOKEN`).
 
 ## Documentation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -58,6 +58,7 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
     - [长期记忆](#长期记忆)
   - [推荐模型](#推荐模型)
   - [内嵌 Python Client](#内嵌-python-client)
+  - [内核导出与推送](#内核导出与推送)
   - [文档](#文档)
   - [⚠️ 安全使用](#️-安全使用)
   - [参与贡献](#参与贡献)
@@ -526,6 +527,31 @@ client.upload_files("thread-1", ["./report.pdf"])  # {"success": True, "files": 
 ```
 
 所有返回 dict 的方法都会在 CI 中通过 Gateway 的 Pydantic 响应模型校验（`TestGatewayConformance`），以确保内嵌 client 始终和 HTTP API schema 保持同步。完整 API 说明见 `backend/packages/harness/deerflow/client.py`。
+
+## 内核导出与推送
+
+如果你需要把当前仓库导出为独立的 `deerflow-kernel` 仓库并推送到内部 Git：
+
+1. 从当前 monorepo 导出内核代码。
+
+  ```bash
+  ./scripts/export-deerflow-kernel.sh --output /tmp/deerflow-kernel --force
+  ```
+
+2. 使用 SSH 推送。
+
+  ```bash
+  DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE=1 \
+  ./scripts/push-deerflow-kernel.sh \
+    --output /tmp/deerflow-kernel \
+    --skip-export \
+    --merge-remote-history \
+    --remote-url git@code.tiancloud.com:xiaosi/deerflow-kernel.git
+  ```
+
+说明：
+- `--merge-remote-history` 会在远端 `main` 已有提交导致非快进拒绝时，自动拉取并合并后重试推送。
+- 如果使用 HTTP 远端，请设置 `DEERFLOW_KERNEL_GIT_USERNAME` 和 `DEERFLOW_KERNEL_GIT_PASSWORD`（或 `DEERFLOW_KERNEL_GIT_TOKEN`）。
 
 ## 文档
 

--- a/scripts/export-deerflow-kernel.sh
+++ b/scripts/export-deerflow-kernel.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SOURCE_REPO="$REPO_ROOT"
+OUTPUT_DIR="${TMPDIR:-/tmp}/deerflow-kernel"
+FORCE=0
+
+usage() {
+    cat <<'EOF'
+Usage: export-deerflow-kernel.sh [options]
+
+Export the standalone deerflow-kernel repository skeleton from the current
+DeerFlow monorepo checkout.
+
+Options:
+  --source-dir DIR   Source deer-flow repository. Default: current repo root
+  --output DIR       Export destination. Default: ${TMPDIR:-/tmp}/deerflow-kernel
+  --force            Remove the output directory before export
+  -h, --help         Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-dir)
+            SOURCE_REPO="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+HARNESS_PKG_DIR="$SOURCE_REPO/backend/packages/harness/deerflow"
+HARNESS_PYPROJECT="$SOURCE_REPO/backend/packages/harness/pyproject.toml"
+LANGGRAPH_JSON="$SOURCE_REPO/backend/langgraph.json"
+
+for required in "$HARNESS_PKG_DIR" "$HARNESS_PYPROJECT" "$LANGGRAPH_JSON"; do
+    if [[ ! -e "$required" ]]; then
+        echo "Required source path not found: $required" >&2
+        exit 1
+    fi
+done
+
+if [[ -e "$OUTPUT_DIR" ]]; then
+    if [[ "$FORCE" != "1" ]]; then
+        echo "Output directory already exists: $OUTPUT_DIR" >&2
+        echo "Re-run with --force to replace it." >&2
+        exit 1
+    fi
+    rm -rf "$OUTPUT_DIR"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+cp -a "$HARNESS_PKG_DIR" "$OUTPUT_DIR/deerflow"
+cp "$SOURCE_REPO/LICENSE" "$OUTPUT_DIR/LICENSE"
+
+find "$OUTPUT_DIR/deerflow" \
+    \( -type d -name '__pycache__' -o -type f \( -name '*.pyc' -o -name '*.pyo' \) \) \
+    -print0 | xargs -0 -r rm -rf
+
+SOURCE_COMMIT="unknown"
+if git -C "$SOURCE_REPO" rev-parse HEAD >/dev/null 2>&1; then
+    SOURCE_COMMIT="$(git -C "$SOURCE_REPO" rev-parse HEAD)"
+fi
+
+python_requires="$(sed -n 's/^requires-python[[:space:]]*=[[:space:]]*"\([^"]*\)"/\1/p' "$HARNESS_PYPROJECT" | head -n 1)"
+if [[ -z "$python_requires" ]]; then
+    python_requires=">=3.12"
+fi
+
+cat > "$OUTPUT_DIR/pyproject.toml" <<EOF
+[project]
+name = "deerflow-kernel"
+version = "0.1.0"
+description = "Standalone DeerFlow harness kernel package"
+readme = "README.md"
+requires-python = "$python_requires"
+dependencies = [
+    "agent-client-protocol>=0.4.0",
+    "agent-sandbox>=0.0.19",
+    "dotenv>=0.9.9",
+    "exa-py>=1.0.0",
+    "httpx>=0.28.0",
+    "kubernetes>=30.0.0",
+    "langchain>=1.2.3",
+    "langchain-anthropic>=1.3.4",
+    "langchain-deepseek>=1.0.1",
+    "langchain-mcp-adapters>=0.1.0",
+    "langchain-openai>=1.1.7",
+    "langfuse>=3.4.1",
+    "langgraph>=1.0.6,<1.0.10",
+    "langgraph-api>=0.7.0,<0.8.0",
+    "langgraph-cli>=0.4.14",
+    "langgraph-runtime-inmem>=0.22.1",
+    "markdownify>=1.2.2",
+    "markitdown[all,xlsx]>=0.0.1a2",
+    "pydantic>=2.12.5",
+    "pyyaml>=6.0.3",
+    "readabilipy>=0.3.0",
+    "tavily-python>=0.7.17",
+    "firecrawl-py>=1.15.0",
+    "tiktoken>=0.8.0",
+    "ddgs>=9.10.0",
+    "duckdb>=1.4.4",
+    "langchain-google-genai>=4.2.1",
+    "langgraph-checkpoint-sqlite>=3.0.3",
+    "langgraph-sdk>=0.1.51",
+]
+
+[project.optional-dependencies]
+ollama = ["langchain-ollama>=0.3.0"]
+pymupdf = ["pymupdf4llm>=0.0.17"]
+
+[project.scripts]
+deerflow-kernel = "deerflow.kernel_cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["deerflow"]
+
+[tool.hatch.build]
+include = [
+    "langgraph.json",
+    "README.md",
+    "LICENSE",
+]
+EOF
+
+cat > "$OUTPUT_DIR/deerflow/kernel_cli.py" <<'EOF'
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+
+def _repo_root() -> pathlib.Path:
+    return pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load_langgraph_config() -> dict:
+    config_path = _repo_root() / "langgraph.json"
+    with config_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _cmd_version() -> int:
+    try:
+        from importlib.metadata import version
+
+        print(version("deerflow-kernel"))
+        return 0
+    except Exception as exc:
+        print(f"failed to resolve installed package version: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_check() -> int:
+    try:
+        import deerflow  # noqa: F401
+        from deerflow.agents import make_lead_agent  # noqa: F401
+
+        config = _load_langgraph_config()
+        print("kernel import check passed")
+        print(f"graph entry: {config['graphs']['lead_agent']}")
+        return 0
+    except Exception as exc:
+        print(f"kernel check failed: {exc}", file=sys.stderr)
+        return 1
+
+
+def _cmd_show_langgraph_json() -> int:
+    config = _load_langgraph_config()
+    print(json.dumps(config, ensure_ascii=False, indent=2))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="deerflow-kernel")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("version")
+    subparsers.add_parser("check")
+    subparsers.add_parser("show-langgraph-json")
+
+    args = parser.parse_args()
+    if args.command == "version":
+        return _cmd_version()
+    if args.command == "check":
+        return _cmd_check()
+    if args.command == "show-langgraph-json":
+        return _cmd_show_langgraph_json()
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+EOF
+
+cat > "$OUTPUT_DIR/langgraph.json" <<'EOF'
+{
+  "$schema": "https://langgra.ph/schema.json",
+  "python_version": "3.12",
+  "dependencies": [
+    "."
+  ],
+  "graphs": {
+    "lead_agent": "deerflow.agents:make_lead_agent"
+  },
+  "checkpointer": {
+    "path": "./deerflow/agents/checkpointer/async_provider.py:make_checkpointer"
+  }
+}
+EOF
+
+cat > "$OUTPUT_DIR/README.md" <<'EOF'
+# deerflow-kernel
+
+This repository is an extracted standalone kernel package generated from the
+open-source DeerFlow repository.
+
+- Source repository: __SOURCE_REPO__
+- Source commit: __SOURCE_COMMIT__
+
+## Contents
+
+- deerflow/: harness runtime, agents, tools, sandbox, memory, MCP, skills
+- langgraph.json: LangGraph graph and checkpointer entrypoints
+- pyproject.toml: standalone package metadata for deerflow-kernel
+
+## Local build
+
+```bash
+uv build
+```
+
+## Quick validation
+
+```bash
+uv run deerflow-kernel check
+```
+
+## Regenerating this repository
+
+This repository is intended to be regenerated from the main DeerFlow monorepo
+using scripts/export-deerflow-kernel.sh in the source repository.
+EOF
+
+sed -i \
+    -e "s|__SOURCE_REPO__|$SOURCE_REPO|g" \
+    -e "s|__SOURCE_COMMIT__|$SOURCE_COMMIT|g" \
+    "$OUTPUT_DIR/README.md"
+
+cat > "$OUTPUT_DIR/.gitignore" <<'EOF'
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+dist/
+build/
+*.egg-info/
+.DS_Store
+EOF
+
+echo "Export completed: $OUTPUT_DIR"
+echo "Source commit: $SOURCE_COMMIT"

--- a/scripts/push-deerflow-kernel.sh
+++ b/scripts/push-deerflow-kernel.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+EXPORT_SCRIPT="$SCRIPT_DIR/export-deerflow-kernel.sh"
+REMOTE_URL="${DEERFLOW_KERNEL_REMOTE_URL:-http://code.tiancloud.com:9002/xiaosi/deerflow-kernel}"
+OUTPUT_DIR="${TMPDIR:-/tmp}/deerflow-kernel"
+BRANCH="main"
+COMMIT_MESSAGE="chore: export deerflow kernel"
+SKIP_EXPORT=0
+FORCE_EXPORT=0
+MERGE_REMOTE_HISTORY=0
+
+normalize_remote_url() {
+    local url="$1"
+
+    if [[ "$url" =~ ^https?:// ]] && [[ ! "$url" =~ \.git$ ]]; then
+        url="${url}.git"
+    fi
+
+    printf '%s\n' "$url"
+}
+
+is_ssh_remote_url() {
+    local url="$1"
+    [[ "$url" =~ ^git@ ]] || [[ "$url" =~ ^ssh:// ]]
+}
+
+build_authenticated_remote_url() {
+    local url="$1"
+    local username="${DEERFLOW_KERNEL_GIT_USERNAME:-}"
+    local password="${DEERFLOW_KERNEL_GIT_PASSWORD:-${DEERFLOW_KERNEL_GIT_TOKEN:-}}"
+
+    if [[ -z "$username" || -z "$password" ]]; then
+        printf '%s\n' "$url"
+        return 0
+    fi
+
+    if [[ ! "$url" =~ ^https?:// ]]; then
+        printf '%s\n' "$url"
+        return 0
+    fi
+
+    local encoded_username encoded_password
+    encoded_username="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$username")"
+    encoded_password="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$password")"
+    printf '%s\n' "${url/\/\//\/\/$encoded_username:$encoded_password@}"
+}
+
+usage() {
+    cat <<'EOF'
+Usage: push-deerflow-kernel.sh [options]
+
+Export the standalone deerflow-kernel repository and push it to a remote Git
+repository in non-interactive mode.
+
+Options:
+  --output DIR         Export destination. Default: ${TMPDIR:-/tmp}/deerflow-kernel
+  --remote-url URL     Git remote URL. Default: http://code.tiancloud.com:9002/xiaosi/deerflow-kernel
+  --branch NAME        Branch to push. Default: main
+  --message TEXT       Commit message. Default: chore: export deerflow kernel
+  --skip-export        Do not re-run the export step
+  --force-export       Recreate the export directory before push
+    --merge-remote-history
+                                            If push is rejected (non-fast-forward), fetch and merge
+                                            remote branch history, then retry push.
+  -h, --help           Show this help message
+
+Environment:
+  GIT_AUTHOR_NAME / GIT_AUTHOR_EMAIL can be set to control the commit identity.
+  DEERFLOW_KERNEL_REMOTE_URL can override the default remote URL.
+    DEERFLOW_KERNEL_GIT_USERNAME and DEERFLOW_KERNEL_GIT_PASSWORD (or
+    DEERFLOW_KERNEL_GIT_TOKEN) can be set for non-interactive HTTP Basic Auth.
+    DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE=1 can be set to allow interactive
+    SSH auth (for passphrase-protected private keys).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --remote-url)
+            REMOTE_URL="$2"
+            shift 2
+            ;;
+        --branch)
+            BRANCH="$2"
+            shift 2
+            ;;
+        --message)
+            COMMIT_MESSAGE="$2"
+            shift 2
+            ;;
+        --skip-export)
+            SKIP_EXPORT=1
+            shift
+            ;;
+        --force-export)
+            FORCE_EXPORT=1
+            shift
+            ;;
+        --merge-remote-history)
+            MERGE_REMOTE_HISTORY=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$SKIP_EXPORT" != "1" ]]; then
+    export_args=(--output "$OUTPUT_DIR")
+    if [[ "$FORCE_EXPORT" == "1" ]]; then
+        export_args+=(--force)
+    fi
+    "$EXPORT_SCRIPT" "${export_args[@]}"
+fi
+
+if [[ ! -d "$OUTPUT_DIR" ]]; then
+    echo "Export directory not found: $OUTPUT_DIR" >&2
+    exit 1
+fi
+
+if [[ ! -f "$OUTPUT_DIR/pyproject.toml" ]]; then
+    echo "Export directory is missing pyproject.toml: $OUTPUT_DIR" >&2
+    exit 1
+fi
+
+REMOTE_URL="$(normalize_remote_url "$REMOTE_URL")"
+AUTH_REMOTE_URL="$(build_authenticated_remote_url "$REMOTE_URL")"
+
+GIT_AUTHOR_NAME="${GIT_AUTHOR_NAME:-$(git -C "$REPO_ROOT" config user.name || true)}"
+GIT_AUTHOR_EMAIL="${GIT_AUTHOR_EMAIL:-$(git -C "$REPO_ROOT" config user.email || true)}"
+
+if [[ -z "$GIT_AUTHOR_NAME" || -z "$GIT_AUTHOR_EMAIL" ]]; then
+    echo "Git author identity is not configured." >&2
+    echo "Set GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL before running this script." >&2
+    exit 1
+fi
+
+export GIT_AUTHOR_NAME
+export GIT_AUTHOR_EMAIL
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+
+if [[ ! -d "$OUTPUT_DIR/.git" ]]; then
+    git -C "$OUTPUT_DIR" init -b "$BRANCH"
+fi
+
+git -C "$OUTPUT_DIR" remote remove origin >/dev/null 2>&1 || true
+git -C "$OUTPUT_DIR" remote add origin "$AUTH_REMOTE_URL"
+
+git -C "$OUTPUT_DIR" add .
+
+if git -C "$OUTPUT_DIR" diff --cached --quiet; then
+    echo "No changes to commit in $OUTPUT_DIR"
+else
+    git -C "$OUTPUT_DIR" commit -m "$COMMIT_MESSAGE"
+fi
+
+git_remote_probe_cmd=(git -C "$OUTPUT_DIR" ls-remote "$AUTH_REMOTE_URL")
+git_push_cmd=(git -C "$OUTPUT_DIR" push --set-upstream origin "$BRANCH")
+
+if is_ssh_remote_url "$AUTH_REMOTE_URL"; then
+    ssh_allow_interactive="${DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE:-0}"
+    if [[ "$ssh_allow_interactive" == "1" ]]; then
+        ssh_opts='ssh -o StrictHostKeyChecking=accept-new'
+        git_remote_probe_cmd=(env GIT_SSH_COMMAND="$ssh_opts" "${git_remote_probe_cmd[@]}")
+        git_push_cmd=(env GIT_SSH_COMMAND="$ssh_opts" "${git_push_cmd[@]}")
+    else
+        ssh_non_interactive_opts='ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new'
+        git_remote_probe_cmd=(env GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="$ssh_non_interactive_opts" "${git_remote_probe_cmd[@]}")
+        git_push_cmd=(env GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND="$ssh_non_interactive_opts" "${git_push_cmd[@]}")
+    fi
+else
+    git_remote_probe_cmd=(env GIT_TERMINAL_PROMPT=0 "${git_remote_probe_cmd[@]}")
+    git_push_cmd=(env GIT_TERMINAL_PROMPT=0 "${git_push_cmd[@]}")
+fi
+
+resolve_merge_conflicts_if_safe() {
+    local conflict_files
+    conflict_files="$(git -C "$OUTPUT_DIR" diff --name-only --diff-filter=U)"
+
+    if [[ "$conflict_files" == "README.md" ]]; then
+        git -C "$OUTPUT_DIR" checkout --ours README.md
+        git -C "$OUTPUT_DIR" add README.md
+        git -C "$OUTPUT_DIR" commit -m "chore: merge remote $BRANCH before kernel export push"
+        return 0
+    fi
+
+    if [[ -n "$conflict_files" ]]; then
+        echo "Merge conflicts require manual resolution:" >&2
+        echo "$conflict_files" >&2
+    else
+        echo "Merge failed without tracked conflict files. Resolve manually in $OUTPUT_DIR." >&2
+    fi
+    return 1
+}
+
+merge_remote_history_and_retry_push() {
+    echo "Push was rejected. Attempting to merge remote history from origin/$BRANCH..."
+    git -C "$OUTPUT_DIR" fetch origin "$BRANCH"
+
+    if ! git -C "$OUTPUT_DIR" merge --allow-unrelated-histories --no-edit "origin/$BRANCH"; then
+        if ! resolve_merge_conflicts_if_safe; then
+            return 1
+        fi
+    fi
+
+    "${git_push_cmd[@]}"
+}
+
+if ! "${git_remote_probe_cmd[@]}" >/dev/null 2>&1; then
+    echo "Remote is not reachable in non-interactive mode: $REMOTE_URL" >&2
+    if is_ssh_remote_url "$AUTH_REMOTE_URL"; then
+        echo "Check SSH key auth: ssh -T git@code.tiancloud.com" >&2
+        echo "If your key is passphrase-protected, re-run with DEERFLOW_KERNEL_SSH_ALLOW_INTERACTIVE=1." >&2
+    else
+        echo "Check network connectivity or provide DEERFLOW_KERNEL_GIT_USERNAME plus DEERFLOW_KERNEL_GIT_PASSWORD/DEERFLOW_KERNEL_GIT_TOKEN." >&2
+    fi
+    exit 1
+fi
+
+if ! "${git_push_cmd[@]}"; then
+    if [[ "$MERGE_REMOTE_HISTORY" == "1" ]]; then
+        merge_remote_history_and_retry_push
+    else
+        echo "Push failed. Re-run with --merge-remote-history to auto-merge remote history and retry." >&2
+        exit 1
+    fi
+fi
+
+echo "Push completed: $REMOTE_URL ($BRANCH)"


### PR DESCRIPTION
## Summary
Add reusable scripts and docs for exporting DeerFlow kernel from the monorepo and publishing it to an internal Git repository.

## Changes
- add `scripts/export-deerflow-kernel.sh` to generate a standalone `deerflow-kernel` repo under `/tmp/deerflow-kernel`
- add `scripts/push-deerflow-kernel.sh` with:
  - SSH and HTTP remote support
  - optional interactive SSH mode for passphrase-protected keys
  - optional remote-history merge and retry for non-fast-forward push rejection
- document the workflow in:
  - `README.md`
  - `README_zh.md`
  - `Install.md`

## Validation
- shell syntax checks for both scripts passed
- exported kernel repo builds successfully (`uv build` and `pip wheel`)
- push workflow verified against internal SSH remote
