### PR TITLE
fix: remove unnecessary f-string prefixes and unused import

### DIFF
--- a/skills/public/data-analysis/scripts/analyze.py
+++ b/skills/public/data-analysis/scripts/analyze.py
@@ -215,14 +215,14 @@ def action_inspect(con: duckdb.DuckDBPyConnection, table_map: dict[str, str]) ->
         non_null_sql = f'SELECT {", ".join(non_null_parts)} FROM "{table_name}"'
         try:
             non_null_counts = con.execute(non_null_sql).fetchone()
-            output_parts.append(f"\nNon-null counts:")
+            output_parts.append("\nNon-null counts:")
             for i, c in enumerate(col_names):
                 output_parts.append(f"  {c}: {non_null_counts[i]} / {row_count}")
         except Exception:
             pass
 
         # Sample data (first 5 rows)
-        output_parts.append(f"\nSample data (first 5 rows):")
+        output_parts.append("\nSample data (first 5 rows):")
         try:
             sample = con.execute(f'SELECT * FROM "{table_name}" LIMIT 5').fetchdf()
             output_parts.append(sample.to_string(index=False))
@@ -465,7 +465,7 @@ def action_summary(
                     LIMIT 5
                 """).fetchall()
                 if top_vals:
-                    output_parts.append(f"  top values:")
+                    output_parts.append("  top values:")
                     for val, freq in top_vals:
                         pct = (freq / row_count * 100) if row_count > 0 else 0
                         output_parts.append(f"    {val}: {freq} ({pct:.1f}%)")

--- a/skills/public/skill-creator/eval-viewer/generate_review.py
+++ b/skills/public/skill-creator/eval-viewer/generate_review.py
@@ -447,8 +447,8 @@ def main() -> None:
         port = server.server_address[1]
 
     url = f"http://localhost:{port}"
-    print(f"\n  Eval Viewer")
-    print(f"  ─────────────────────────────────")
+    print("\n  Eval Viewer")
+    print("  ─────────────────────────────────")
     print(f"  URL:       {url}")
     print(f"  Workspace: {workspace}")
     print(f"  Feedback:  {feedback_path}")
@@ -456,7 +456,7 @@ def main() -> None:
         print(f"  Previous:  {args.previous_workspace} ({len(previous)} runs)")
     if benchmark_path:
         print(f"  Benchmark: {benchmark_path}")
-    print(f"\n  Press Ctrl+C to stop.\n")
+    print("\n  Press Ctrl+C to stop.\n")
 
     webbrowser.open(url)
 

--- a/skills/public/skill-creator/scripts/aggregate_benchmark.py
+++ b/skills/public/skill-creator/scripts/aggregate_benchmark.py
@@ -389,7 +389,7 @@ def main():
     configs = [k for k in run_summary if k != "delta"]
     delta = run_summary.get("delta", {})
 
-    print(f"\nSummary:")
+    print("\nSummary:")
     for config in configs:
         pr = run_summary[config]["pass_rate"]["mean"]
         label = config.replace("_", " ").title()

--- a/skills/public/skill-creator/scripts/quick_validate.py
+++ b/skills/public/skill-creator/scripts/quick_validate.py
@@ -4,7 +4,6 @@ Quick validation script for skills - minimal version
 """
 
 import sys
-import os
 import re
 import yaml
 from pathlib import Path

--- a/skills/public/skill-creator/scripts/run_loop.py
+++ b/skills/public/skill-creator/scripts/run_loop.py
@@ -188,7 +188,7 @@ def run_loop(
 
         # Improve the description based on train results
         if verbose:
-            print(f"\nImproving description...", file=sys.stderr)
+            print("\nImproving description...", file=sys.stderr)
 
         t0 = time.time()
         # Strip test scores from history so improvement model can't see them


### PR DESCRIPTION
## Summary

- Remove `f` prefix from 7 strings with no `{...}` placeholders in `skills/public/` scripts (ruff F541)
- Remove unused `os` import in `quick_validate.py` (ruff F401)

5 files, 9 fixes. All in skill scripts — no core code touched. Zero behavior change.

Found by [HUMMBL Arbiter](https://hummbl.io/audit) — deterministic code quality scoring for Python repositories.