### PR TITLE
Fix macOS startup failure by using portable locale in LangGraph log pipeline

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -279,7 +279,7 @@ if ! $GATEWAY_MODE; then
         LANGGRAPH_ALLOW_BLOCKING_FLAG="--allow-blocking"
     fi
     run_service "LangGraph" \
-        "cd backend && NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 PY_COLORS=0 TERM=dumb uv run langgraph dev --no-browser $LANGGRAPH_ALLOW_BLOCKING_FLAG --n-jobs-per-worker $LANGGRAPH_JOBS_PER_WORKER --server-log-level $LANGGRAPH_LOG_LEVEL $LANGGRAPH_EXTRA_FLAGS 2>&1 | perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g' > ../logs/langgraph.log" \
+        "cd backend && NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 PY_COLORS=0 TERM=dumb uv run langgraph dev --no-browser $LANGGRAPH_ALLOW_BLOCKING_FLAG --n-jobs-per-worker $LANGGRAPH_JOBS_PER_WORKER --server-log-level $LANGGRAPH_LOG_LEVEL $LANGGRAPH_EXTRA_FLAGS 2>&1 | LC_ALL=C LC_CTYPE=C LANG=C perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g' > ../logs/langgraph.log" \
         2024 60
 else
     echo "⏩ Skipping LangGraph (Gateway mode — runtime embedded in Gateway)"


### PR DESCRIPTION
## What
Replace locale assumptions in scripts/serve.sh for the LangGraph log de-colorization pipeline.

### Change
- Use portable locale env:
  - LC_ALL=C
  - LC_CTYPE=C
  - LANG=C

## Why
On macOS, C.UTF-8 is commonly unavailable. perl then panics during startup log processing, causing make dev to fail waiting for LangGraph.

## Scope
- Affects only log processing pipeline (ANSI color stripping)
- No runtime/business logic changes

## Verification
- Reproduced failure on macOS before change (make dev -> LangGraph timeout)
- After change, make dev starts successfully:
  - LangGraph (2024)
  - Gateway (8001)
  - Frontend (3000)
  - Nginx (2026)
