### PR TITLE
fix(script): use Apple Container image pull syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ setup-sandbox:
 	echo ""; \
 	if command -v container >/dev/null 2>&1 && [ "$$(uname)" = "Darwin" ]; then \
 		echo "Detected Apple Container on macOS, pulling image..."; \
-		container pull "$$IMAGE" || echo "⚠ Apple Container pull failed, will try Docker"; \
+		container image pull "$$IMAGE" || echo "⚠ Apple Container pull failed, will try Docker"; \
 	fi; \
 	if command -v docker >/dev/null 2>&1; then \
 		echo "Pulling image using Docker..."; \


### PR DESCRIPTION
## Summary
- replace the deprecated `container pull` command with `container image pull` in `make setup-sandbox`
- fix Apple Container v0.1+ compatibility on macOS

## Root cause
Apple Container v0.1+ removed the top-level `container pull` command. DeerFlow still used the old syntax in `Makefile`, which caused image pre-pull to fail with `Plugin 'container-pull' not found`.

Closes #2364.
