### PR TITLE
fix: rename present_file to present_files in docs and prompts

### DIFF
--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -199,7 +199,7 @@ class ThreadState(AgentState):
 │   Built-in Tools    │  │  Configured Tools   │  │     MCP Tools       │
 │  (packages/harness/deerflow/tools/)       │  │  (config.yaml)      │  │  (extensions.json)  │
 ├─────────────────────┤  ├─────────────────────┤  ├─────────────────────┤
-│ - present_file      │  │ - web_search        │  │ - github            │
+│ - present_files     │  │ - web_search        │  │ - github            │
 │ - ask_clarification │  │ - web_fetch         │  │ - filesystem        │
 │ - view_image        │  │ - bash              │  │ - postgres          │
 │                     │  │ - read_file         │  │ - brave-search      │

--- a/backend/docs/GUARDRAILS.md
+++ b/backend/docs/GUARDRAILS.md
@@ -296,7 +296,7 @@ These are the tool names your provider will see in `request.tool_name`:
 | `web_search` | Web search query |
 | `web_fetch` | Fetch URL content |
 | `image_search` | Image search |
-| `present_file` | Present file to user |
+| `present_files` | Present file to user |
 | `view_image` | Display image |
 | `ask_clarification` | Ask user a question |
 | `task` | Delegate to subagent |

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -420,7 +420,7 @@ You: "Deploying to staging..." [proceed]
 - Treat `/mnt/user-data/workspace` as your default current working directory for coding and file-editing tasks
 - When writing scripts or commands that create/read files from the workspace, prefer relative paths such as `hello.txt`, `../uploads/data.csv`, and `../outputs/report.md`
 - Avoid hardcoding `/mnt/user-data/...` inside generated scripts when a relative path from the workspace is enough
-- Final deliverables must be copied to `/mnt/user-data/outputs` and presented using `present_file` tool
+- Final deliverables must be copied to `/mnt/user-data/outputs` and presented using `present_files` tool
 {acp_section}
 </working_directory>
 
@@ -648,7 +648,7 @@ def _build_acp_section() -> str:
         "- ACP agents (e.g. codex, claude_code) run in their own independent workspace — NOT in `/mnt/user-data/`\n"
         "- When writing prompts for ACP agents, describe the task only — do NOT reference `/mnt/user-data` paths\n"
         "- ACP agent results are accessible at `/mnt/acp-workspace/` (read-only) — use `ls`, `read_file`, or `bash cp` to retrieve output files\n"
-        "- To deliver ACP output to the user: copy from `/mnt/acp-workspace/<file>` to `/mnt/user-data/outputs/<file>`, then use `present_file`"
+        "- To deliver ACP output to the user: copy from `/mnt/acp-workspace/<file>` to `/mnt/user-data/outputs/<file>`, then use `present_files`"
     )
 
 


### PR DESCRIPTION
## Summary

The tool is registered as `present_files` (plural) in `present_file_tool.py` (line 80: `@tool("present_files", ...)`), but four references in documentation and prompt strings incorrectly used the singular form `present_file`. This mismatch could cause confusion and potentially lead to incorrect tool invocations by the LLM agent.

## Changes

| File | Description |
|------|-------------|
| `backend/docs/GUARDRAILS.md` | Fixed tool name in the guardrails tool table |
| `backend/docs/ARCHITECTURE.md` | Fixed tool name in the architecture diagram |
| `backend/packages/harness/deerflow/agents/lead_agent/prompt.py` | Fixed 2 occurrences in prompt templates (working directory section and ACP section) |

## Verification

- `present_files` has **97 occurrences** across the codebase (the correct form)
- `present_file` previously had **5 occurrences** — 4 were typos (now fixed), 1 is the Python module filename `present_file_tool.py` (correct as-is)
- All **1975 backend unit tests pass** with no failures
- No new test cases needed — this is a docs/prompt-only text fix with no behavior change