### PR TITLE
feat(memory): add sqlite single-writer queue for multi-worker durability

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,8 @@ Across sessions, DeerFlow builds a persistent memory of your profile, preference
 
 Memory updates now skip duplicate fact entries at apply time, so repeated preferences and context do not accumulate endlessly across sessions.
 
+For single-process setups, the default file-backed memory storage is usually sufficient. For multi-worker deployments, switch `memory.storage_class` to `deerflow.agents.memory.sqlite_storage.SQLiteMemoryStorage` so updates flow through the shared SQLite single-writer queue instead of risking silent last-writer-wins overwrites.
+
 ## Recommended Models
 
 DeerFlow is model-agnostic — it works with any LLM that implements the OpenAI-compatible API. That said, it performs best with models that support:

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -343,11 +343,14 @@ Bridges external messaging platforms (Feishu, Slack, Telegram) to the DeerFlow a
 ### Memory System (`packages/harness/deerflow/agents/memory/`)
 
 **Components**:
-- `updater.py` - LLM-based memory updates with fact extraction, whitespace-normalized fact deduplication (trims leading/trailing whitespace before comparing), and atomic file I/O
-- `queue.py` - Debounced update queue (per-thread deduplication, configurable wait time)
+- `updater.py` - LLM-based memory updates with fact extraction and whitespace-normalized fact deduplication (trims leading/trailing whitespace before comparing)
+- `queue.py` - Debounced update queue (per-thread deduplication, configurable wait time) that hands batched work to the SQLite writer queue when `SQLiteMemoryStorage` is configured
+- `writer_queue.py` - Shared SQLite single-writer queue + lease/heartbeat logic for multi-worker-safe memory updates
+- `sqlite_storage.py` - SQLite-backed memory storage with monotonic `seq` guard to reject stale overwrites
+- `storage.py` - File-backed fallback storage plus storage factory / safety warnings
 - `prompt.py` - Prompt templates for memory updates
 
-**Data Structure** (stored in `backend/.deer-flow/memory.json`):
+**Data Structure** (stored in either `backend/.deer-flow/memory.json` or `memory.db`, depending on `memory.storage_class`):
 - **User Context**: `workContext`, `personalContext`, `topOfMind` (1-3 sentence summaries)
 - **History**: `recentMonths`, `earlierContext`, `longTermBackground`
 - **Facts**: Discrete facts with `id`, `content`, `category` (preference/knowledge/context/behavior/goal), `confidence` (0-1), `createdAt`, `source`
@@ -355,16 +358,18 @@ Bridges external messaging platforms (Feishu, Slack, Telegram) to the DeerFlow a
 **Workflow**:
 1. `MemoryMiddleware` filters messages (user inputs + final AI responses) and queues conversation
 2. Queue debounces (30s default), batches updates, deduplicates per-thread
-3. Background thread invokes LLM to extract context updates and facts
-4. Applies updates atomically (temp file + rename) with cache invalidation, skipping duplicate fact content before append
+3. With `FileMemoryStorage`, a background thread invokes the LLM and writes the updated memory JSON atomically (temp file + rename)
+4. With `SQLiteMemoryStorage`, all workers enqueue work into `writer_queue.py`; exactly one process holds the writer lease and runs the full `load → LLM → save` cycle, while `sqlite_storage.py` rejects stale writes via the `seq` guard
 5. Next interaction injects top 15 facts + context into `<memory>` tags in system prompt
 
 Focused regression coverage for the updater lives in `backend/tests/test_memory_updater.py`.
 
 **Configuration** (`config.yaml` → `memory`):
 - `enabled` / `injection_enabled` - Master switches
-- `storage_path` - Path to memory.json
+- `storage_path` - Path to the JSON memory file when using `FileMemoryStorage`
+- `storage_class` - Storage backend (`FileMemoryStorage` by default, `SQLiteMemoryStorage` for multi-worker-safe updates)
 - `debounce_seconds` - Wait time before processing (default: 30)
+- `lock_stale_seconds` / `heartbeat_interval_seconds` / `processing_timeout_seconds` - SQLite writer-queue timings
 - `model_name` - LLM for updates (null = default model)
 - `max_facts` / `fact_confidence_threshold` - Fact storage limits (100 / 0.7)
 - `max_injection_tokens` - Token limit for prompt injection (2000)

--- a/backend/README.md
+++ b/backend/README.md
@@ -98,7 +98,7 @@ LLM-powered persistent context retention across conversations:
 - **Structured storage**: User context (work, personal, top-of-mind), history, and confidence-scored facts
 - **Debounced updates**: Batches updates to minimize LLM calls (configurable wait time)
 - **System prompt injection**: Top facts + context injected into agent prompts
-- **Storage**: JSON file with mtime-based cache invalidation
+- **Storage**: Default file-backed storage for single-process setups, plus an optional SQLite single-writer queue + `seq` guard for multi-worker-safe updates
 
 ### Tool Ecosystem
 

--- a/backend/packages/harness/deerflow/agents/memory/__init__.py
+++ b/backend/packages/harness/deerflow/agents/memory/__init__.py
@@ -18,6 +18,7 @@ from deerflow.agents.memory.queue import (
     get_memory_queue,
     reset_memory_queue,
 )
+from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
 from deerflow.agents.memory.storage import (
     FileMemoryStorage,
     MemoryStorage,
@@ -46,6 +47,7 @@ __all__ = [
     # Storage
     "MemoryStorage",
     "FileMemoryStorage",
+    "SQLiteMemoryStorage",
     "get_memory_storage",
     # Updater
     "MemoryUpdater",

--- a/backend/packages/harness/deerflow/agents/memory/queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/queue.py
@@ -146,6 +146,7 @@ class MemoryUpdateQueue:
     def _process_queue(self) -> None:
         """Process all queued conversation contexts."""
         # Import here to avoid circular dependency
+        from deerflow.agents.memory.storage import get_memory_storage
         from deerflow.agents.memory.updater import MemoryUpdater
 
         with self._lock:
@@ -164,7 +165,52 @@ class MemoryUpdateQueue:
 
         logger.info("Processing %d queued memory updates", len(contexts_to_process))
 
+        # If the configured storage is the SQLite backend, hand every context
+        # off to the single-writer queue (RFC #2283).  This is the correctness
+        # fix for last-writer-wins in multi-worker deployments.
         try:
+            storage = get_memory_storage()
+        except Exception:  # pragma: no cover - defensive
+            storage = None
+
+        sqlite_storage = None
+        try:
+            from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+
+            if isinstance(storage, SQLiteMemoryStorage):
+                sqlite_storage = storage
+        except Exception:  # pragma: no cover - defensive
+            sqlite_storage = None
+
+        try:
+            if sqlite_storage is not None:
+                from deerflow.agents.memory.writer_queue import schedule_memory_updates
+
+                # Hand the whole batch to the single-writer queue in one call
+                # so schema bootstrap / stuck-task reset / lease acquisition
+                # each happen once per tick instead of once per context.
+                try:
+                    schedule_memory_updates(
+                        db_path=sqlite_storage.db_path,
+                        contexts=[
+                            {
+                                "agent_name": context.agent_name,
+                                "messages": context.messages,
+                                "thread_id": context.thread_id,
+                                "correction_detected": context.correction_detected,
+                                "reinforcement_detected": context.reinforcement_detected,
+                            }
+                            for context in contexts_to_process
+                        ],
+                    )
+                except Exception as e:
+                    logger.error(
+                        "Failed to schedule batched memory updates (%d contexts): %s",
+                        len(contexts_to_process),
+                        e,
+                    )
+                return
+
             updater = MemoryUpdater()
 
             for context in contexts_to_process:

--- a/backend/packages/harness/deerflow/agents/memory/sqlite_storage.py
+++ b/backend/packages/harness/deerflow/agents/memory/sqlite_storage.py
@@ -1,0 +1,249 @@
+"""SQLite-backed memory storage.
+
+Implements the storage half of RFC #2283 (single-writer memory queue).
+
+The queue machinery (``writer_queue.py``) requires a shared database file that
+every worker process can open, so switching the memory storage backend to SQLite
+is a prerequisite for eliminating the last-writer-wins race described in PR
+#2251.
+
+Design notes
+------------
+
+* WAL mode is enabled so readers never block and concurrent ``enqueue`` from
+  different processes does not contend with the writer loop.
+* Every call opens a fresh, short-lived connection; connections are never
+  shared across threads or functions.  This avoids SQLite's "same thread only"
+  restriction completely and lets the OS-level WAL layer manage concurrency.
+* ``seq`` is both a diagnostic counter and a hard write guard.  The writer
+  calls ``load()`` immediately before ``save()``; if another writer advanced
+  ``seq`` in between, ``save()`` aborts rather than silently overwriting newer
+  state.  This is the correctness backstop in case the single-writer lease is
+  ever bypassed (e.g. a rogue migration script).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+from deerflow.agents.memory.storage import (
+    MemoryStorage,
+    create_empty_memory,
+    utc_now_iso_z,
+)
+from deerflow.config.paths import get_paths
+
+logger = logging.getLogger(__name__)
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS agent_memory (
+    agent_name  TEXT    NOT NULL DEFAULT '__global__',
+    user_id     TEXT    NOT NULL DEFAULT '__default__',
+    data        TEXT    NOT NULL,
+    seq         INTEGER NOT NULL DEFAULT 0,
+    updated_at  TEXT    NOT NULL,
+    PRIMARY KEY (agent_name, user_id)
+);
+"""
+
+
+_GLOBAL_KEY = "__global__"
+_DEFAULT_USER = "__default__"
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    """Open a WAL-mode SQLite connection that is safe to share across threads.
+
+    Public helper — intentionally exported so companion modules (e.g. the
+    single-writer queue in :mod:`deerflow.agents.memory.writer_queue`) can
+    reuse the same connection semantics without depending on private names.
+    """
+    conn = sqlite3.connect(str(db_path), timeout=10, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+# Backwards-compatible private alias; kept so existing imports elsewhere in the
+# module (and any external callers still on the pre-RFC #2283 API) keep working.
+_connect = connect
+
+
+def init_memory_schema(db_path: Path) -> None:
+    """Idempotently create the agent_memory table.
+
+    Exposed as a module-level helper so ``writer_queue.py`` can ensure the
+    schema exists even when storage has not yet been instantiated in this
+    process (e.g. during migrations or tests).
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = _connect(db_path)
+    try:
+        conn.executescript(SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+class SQLiteMemoryStorage(MemoryStorage):
+    """SQLite-backed memory storage with monotonic ``seq`` guard.
+
+    Intended for deployments that run more than one worker process.  The
+    writer queue (``writer_queue.py``) ensures only one process executes the
+    ``load → LLM → save`` cycle at a time, and this storage's ``seq`` check
+    catches any case where that invariant is violated.
+
+    When ``agent_name is None`` the row is stored under ``__global__`` so
+    every backend file has exactly one "global" row.
+    """
+
+    def __init__(self, db_path: str | Path | None = None) -> None:
+        if db_path is None:
+            db_path = get_paths().base_dir / "memory.db"
+        self._db_path = Path(db_path)
+        # Tracks the seq observed at load() time, per agent key, per thread.
+        # A dict keyed by (thread_ident, agent_key) is overkill in practice —
+        # the writer loop runs in a single thread and processes tasks
+        # sequentially — but using the thread ident keeps reload/load/save
+        # sequences in different threads (e.g. the reader side) from
+        # accidentally cross-contaminating the guard.
+        self._last_seen_seq: dict[tuple[int, str], int] = {}
+        self._lock = threading.Lock()
+        init_memory_schema(self._db_path)
+
+    # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+    @property
+    def db_path(self) -> Path:
+        """Absolute path to the backing SQLite file."""
+        return self._db_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _key(agent_name: str | None) -> str:
+        return agent_name if agent_name is not None else _GLOBAL_KEY
+
+    def _guard_key(self, agent_key: str) -> tuple[int, str]:
+        return (threading.get_ident(), agent_key)
+
+    # ------------------------------------------------------------------
+    # MemoryStorage interface
+    # ------------------------------------------------------------------
+    def load(self, agent_name: str | None = None) -> dict[str, Any]:
+        key = self._key(agent_name)
+        try:
+            conn = _connect(self._db_path)
+            try:
+                row = conn.execute(
+                    "SELECT data, seq FROM agent_memory "
+                    "WHERE agent_name = ? AND user_id = ?",
+                    (key, _DEFAULT_USER),
+                ).fetchone()
+            finally:
+                conn.close()
+        except sqlite3.Error as exc:  # pragma: no cover - logged and degraded
+            logger.error("Failed to load memory for agent %s: %s", key, exc)
+            return create_empty_memory()
+
+        if row is None:
+            # Record seq=0 so that a subsequent save() from this thread knows
+            # the row did not yet exist and can proceed unconditionally.
+            with self._lock:
+                self._last_seen_seq[self._guard_key(key)] = 0
+            return create_empty_memory()
+
+        try:
+            data = json.loads(row["data"])
+        except json.JSONDecodeError as exc:
+            logger.error("Corrupt memory JSON for agent %s: %s", key, exc)
+            return create_empty_memory()
+
+        with self._lock:
+            self._last_seen_seq[self._guard_key(key)] = int(row["seq"])
+        return data
+
+    def reload(self, agent_name: str | None = None) -> dict[str, Any]:
+        # SQLite has no in-process cache, so reload is just load.
+        return self.load(agent_name)
+
+    def save(self, memory_data: dict[str, Any], agent_name: str | None = None) -> bool:
+        key = self._key(agent_name)
+        now = utc_now_iso_z()
+        # Shallow copy so the caller's dict is not mutated.
+        payload = {**memory_data, "lastUpdated": now}
+
+        try:
+            conn = _connect(self._db_path)
+        except sqlite3.Error as exc:  # pragma: no cover
+            logger.error("Failed to open memory DB for agent %s: %s", key, exc)
+            return False
+
+        try:
+            conn.execute("BEGIN EXCLUSIVE")
+            row = conn.execute(
+                "SELECT seq FROM agent_memory "
+                "WHERE agent_name = ? AND user_id = ?",
+                (key, _DEFAULT_USER),
+            ).fetchone()
+            current_seq = int(row["seq"]) if row is not None else 0
+
+            with self._lock:
+                last_seen = self._last_seen_seq.get(self._guard_key(key))
+
+            if last_seen is not None and current_seq != last_seen:
+                logger.error(
+                    "Single-writer invariant violated for agent %s: "
+                    "expected seq=%d, found seq=%d. Aborting write.",
+                    key,
+                    last_seen,
+                    current_seq,
+                )
+                conn.rollback()
+                return False
+
+            new_seq = current_seq + 1
+            conn.execute(
+                """
+                INSERT INTO agent_memory (agent_name, user_id, data, seq, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(agent_name, user_id) DO UPDATE SET
+                    data       = excluded.data,
+                    seq        = excluded.seq,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    key,
+                    _DEFAULT_USER,
+                    json.dumps(payload, ensure_ascii=False),
+                    new_seq,
+                    now,
+                ),
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            logger.error("Failed to save memory for agent %s: %s", key, exc)
+            return False
+        finally:
+            conn.close()
+
+        # Keep the last-seen counter consistent with what we just wrote so that
+        # a subsequent save() in the same writer iteration (rare but possible
+        # during multi-stage updates) does not spuriously trip the guard.
+        with self._lock:
+            self._last_seen_seq[self._guard_key(key)] = new_seq
+        logger.info("Memory saved for agent %s (seq=%d)", key, new_seq)
+        return True

--- a/backend/packages/harness/deerflow/agents/memory/sqlite_storage.py
+++ b/backend/packages/harness/deerflow/agents/memory/sqlite_storage.py
@@ -145,8 +145,7 @@ class SQLiteMemoryStorage(MemoryStorage):
             conn = _connect(self._db_path)
             try:
                 row = conn.execute(
-                    "SELECT data, seq FROM agent_memory "
-                    "WHERE agent_name = ? AND user_id = ?",
+                    "SELECT data, seq FROM agent_memory WHERE agent_name = ? AND user_id = ?",
                     (key, _DEFAULT_USER),
                 ).fetchone()
             finally:
@@ -191,8 +190,7 @@ class SQLiteMemoryStorage(MemoryStorage):
         try:
             conn.execute("BEGIN EXCLUSIVE")
             row = conn.execute(
-                "SELECT seq FROM agent_memory "
-                "WHERE agent_name = ? AND user_id = ?",
+                "SELECT seq FROM agent_memory WHERE agent_name = ? AND user_id = ?",
                 (key, _DEFAULT_USER),
             ).fetchone()
             current_seq = int(row["seq"]) if row is not None else 0
@@ -202,8 +200,7 @@ class SQLiteMemoryStorage(MemoryStorage):
 
             if last_seen is not None and current_seq != last_seen:
                 logger.error(
-                    "Single-writer invariant violated for agent %s: "
-                    "expected seq=%d, found seq=%d. Aborting write.",
+                    "Single-writer invariant violated for agent %s: expected seq=%d, found seq=%d. Aborting write.",
                     key,
                     last_seen,
                     current_seq,

--- a/backend/packages/harness/deerflow/agents/memory/storage.py
+++ b/backend/packages/harness/deerflow/agents/memory/storage.py
@@ -60,7 +60,19 @@ class MemoryStorage(abc.ABC):
 
 
 class FileMemoryStorage(MemoryStorage):
-    """File-based memory storage provider."""
+    """File-based memory storage. **Single-writer only.**
+
+    Do not use in deployments running more than one worker process
+    (``uvicorn --workers N`` with ``N > 1``, ``gunicorn``, LangGraph Server
+    multi-worker mode, ``WEB_CONCURRENCY > 1``).  Concurrent saves from
+    different processes result in last-writer-wins with no error signal:
+    earlier LLM updates are silently overwritten.
+
+    For multi-worker deployments, use
+    :class:`deerflow.agents.memory.sqlite_storage.SQLiteMemoryStorage`
+    together with the single-writer queue
+    (``deerflow.agents.memory.writer_queue``).  See RFC #2283 for context.
+    """
 
     def __init__(self):
         """Initialize the file memory storage."""
@@ -178,6 +190,39 @@ _storage_instance: MemoryStorage | None = None
 _storage_lock = threading.Lock()
 
 
+def _warn_if_unsafe_multiworker(storage: MemoryStorage) -> None:
+    """Warn when ``FileMemoryStorage`` is used in a multi-worker deployment.
+
+    Checks the standard ``WEB_CONCURRENCY`` and ``UVICORN_WORKERS`` env vars.
+    This is best-effort advisory logging; the race condition (RFC #2283) is
+    silent and dangerous enough that users deserve a loud warning at startup.
+    """
+    if not isinstance(storage, FileMemoryStorage):
+        return
+    import os as _os
+
+    workers = 1
+    for env_var in ("WEB_CONCURRENCY", "UVICORN_WORKERS"):
+        raw = _os.getenv(env_var)
+        if not raw:
+            continue
+        try:
+            workers = max(workers, int(raw))
+        except ValueError:
+            continue
+
+    if workers > 1:
+        logger.warning(
+            "FileMemoryStorage is configured with %s=%d; this is unsafe and "
+            "will silently lose memory updates under concurrent writes. "
+            "Switch memory.storage_class to "
+            "'deerflow.agents.memory.sqlite_storage.SQLiteMemoryStorage' "
+            "to use the single-writer queue (RFC #2283).",
+            "WEB_CONCURRENCY/UVICORN_WORKERS",
+            workers,
+        )
+
+
 def get_memory_storage() -> MemoryStorage:
     """Get the configured memory storage instance."""
     global _storage_instance
@@ -212,5 +257,7 @@ def get_memory_storage() -> MemoryStorage:
                 e,
             )
             _storage_instance = FileMemoryStorage()
+
+        _warn_if_unsafe_multiworker(_storage_instance)
 
     return _storage_instance

--- a/backend/packages/harness/deerflow/agents/memory/writer_queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/writer_queue.py
@@ -1,0 +1,611 @@
+"""Single-writer SQLite-backed memory update queue (RFC #2283).
+
+Every worker process may ``enqueue`` conversation contexts; exactly one
+process at a time dequeues them and runs the full ``load → LLM → save`` cycle.
+Because only one process executes that cycle, the stale-load race that
+produced last-writer-wins in PR #2251 becomes impossible by construction.
+
+See :mod:`deerflow.agents.memory.sqlite_storage` for the companion storage
+backend and RFC #2283 in the issue tracker for the full design discussion.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import sqlite3
+import threading
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from deerflow.agents.memory.sqlite_storage import connect, init_memory_schema
+from deerflow.agents.memory.storage import utc_now_iso_z
+from deerflow.config.memory_config import get_memory_config
+
+logger = logging.getLogger(__name__)
+
+
+# ── Tunables ────────────────────────────────────────────────────────────────
+# These are module-level defaults; ``MemoryConfig`` overrides them at runtime
+# via :func:`_get_timings`.  Values are in seconds.
+DEFAULT_LOCK_STALE_SECONDS = 90
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 30
+DEFAULT_PROCESSING_TIMEOUT_SECONDS = 300
+
+
+_QUEUE_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS memory_update_queue (
+    id                     INTEGER  PRIMARY KEY AUTOINCREMENT,
+    agent_name             TEXT     NOT NULL DEFAULT '__global__',
+    user_id                TEXT     NOT NULL DEFAULT '__default__',
+    messages               TEXT     NOT NULL,
+    thread_id              TEXT,
+    correction_detected    INTEGER  NOT NULL DEFAULT 0,
+    reinforcement_detected INTEGER  NOT NULL DEFAULT 0,
+    enqueued_at            TEXT     NOT NULL,
+    status                 TEXT     NOT NULL DEFAULT 'pending',
+    started_at             TEXT,
+    completed_at           TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_queue_status_id
+    ON memory_update_queue (status, id);
+
+CREATE TABLE IF NOT EXISTS memory_writer_lock (
+    id           INTEGER  PRIMARY KEY DEFAULT 1,
+    worker_id    TEXT     NOT NULL,
+    acquired_at  TEXT     NOT NULL,
+    heartbeat_at TEXT     NOT NULL
+);
+"""
+
+
+# Process-local guard: prevents two writer threads from starting inside the
+# same process (e.g. when ``flush()`` races the debounce timer).  Acquired in
+# :func:`schedule_memory_update`, released inside :func:`run_writer_loop`.
+_writer_running = threading.Lock()
+
+# Per-path schema-init cache.  ``CREATE TABLE IF NOT EXISTS`` is cheap, but
+# each call still opens/closes a fresh SQLite connection; caching keeps the
+# hot path (``enqueue`` → ``try_acquire_writer``) from paying that cost on
+# every queue event.  The cache key is the resolved absolute path so
+# different DBs used in the same process are tracked independently.
+_SCHEMA_INITIALISED: set[str] = set()
+_SCHEMA_INIT_LOCK = threading.Lock()
+
+
+# ── Internal helpers ────────────────────────────────────────────────────────
+def _worker_id() -> str:
+    return f"{os.getpid()}@{socket.gethostname()}"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _utc_minus_seconds(seconds: int) -> str:
+    return (_utc_now() - timedelta(seconds=seconds)).isoformat().removesuffix("+00:00") + "Z"
+
+
+def _parse_utc_iso(value: str) -> datetime:
+    """Parse a ``utc_now_iso_z`` timestamp back into an aware UTC datetime.
+
+    The storage helper writes values like ``2025-01-01T00:00:00.000000Z``.
+    Python's ``fromisoformat`` handles the trailing ``Z`` natively on 3.11+;
+    we normalise manually to stay compatible with earlier parsers that would
+    otherwise return a naive datetime interpreted as local time — a subtle
+    source of false lease-stale conclusions.
+    """
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _get_timings() -> tuple[int, int, int]:
+    """Return ``(lock_stale, heartbeat_interval, processing_timeout)`` seconds.
+
+    Reads overrides from :class:`MemoryConfig`; falls back to module defaults
+    when a field is absent (older configs that pre-date these knobs).
+    Enforces ``heartbeat_interval < lock_stale / 2`` to preserve the
+    three-missed-heartbeats safety margin from the RFC.
+    """
+    cfg = get_memory_config()
+    lock_stale = int(getattr(cfg, "lock_stale_seconds", DEFAULT_LOCK_STALE_SECONDS))
+    heartbeat = int(
+        getattr(cfg, "heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
+    )
+    processing_timeout = int(
+        getattr(cfg, "processing_timeout_seconds", DEFAULT_PROCESSING_TIMEOUT_SECONDS)
+    )
+
+    if heartbeat <= 0 or lock_stale <= 0 or processing_timeout <= 0:
+        logger.warning(
+            "Non-positive writer-queue timing (%s/%s/%s); falling back to defaults",
+            heartbeat,
+            lock_stale,
+            processing_timeout,
+        )
+        return (
+            DEFAULT_LOCK_STALE_SECONDS,
+            DEFAULT_HEARTBEAT_INTERVAL_SECONDS,
+            DEFAULT_PROCESSING_TIMEOUT_SECONDS,
+        )
+
+    if heartbeat * 2 >= lock_stale:
+        logger.warning(
+            "heartbeat_interval_seconds=%d is not < lock_stale_seconds=%d / 2; "
+            "clamping heartbeat to keep a safety margin",
+            heartbeat,
+            lock_stale,
+        )
+        heartbeat = max(1, lock_stale // 3)
+
+    return lock_stale, heartbeat, processing_timeout
+
+
+def init_queue_schema(db_path: Path) -> None:
+    """Idempotently create the queue + lock tables (and the storage table).
+
+    Exposed so callers that bootstrap the writer queue before ever calling
+    :class:`SQLiteMemoryStorage` still get a usable ``memory.db``.  The
+    companion storage schema is delegated to
+    :func:`deerflow.agents.memory.sqlite_storage.init_memory_schema` so the
+    queue module no longer has to know the ``agent_memory`` DDL.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    init_memory_schema(db_path)
+    conn = connect(db_path)
+    try:
+        conn.executescript(_QUEUE_SCHEMA_SQL)
+        conn.commit()
+    finally:
+        conn.close()
+    with _SCHEMA_INIT_LOCK:
+        _SCHEMA_INITIALISED.add(str(db_path.resolve()))
+
+
+def _ensure_schema(db_path: Path) -> None:
+    """Fast-path wrapper around :func:`init_queue_schema`.
+
+    ``init_queue_schema`` is idempotent but opens two short-lived SQLite
+    connections and runs ``CREATE TABLE IF NOT EXISTS`` scripts, which is
+    measurable overhead on the hot enqueue path.  We track paths already
+    initialised in this process and skip the work on subsequent calls.
+    """
+    key = str(db_path.resolve())
+    with _SCHEMA_INIT_LOCK:
+        if key in _SCHEMA_INITIALISED:
+            return
+    init_queue_schema(db_path)
+
+
+# ── Heartbeat thread ────────────────────────────────────────────────────────
+class _HeartbeatThread(threading.Thread):
+    """Continuously renew the writer lease while the writer loop runs."""
+
+    def __init__(self, db_path: Path, worker_id: str, interval_seconds: int) -> None:
+        super().__init__(daemon=True, name="memory-writer-heartbeat")
+        self._db_path = db_path
+        self._worker_id = worker_id
+        self._interval = interval_seconds
+        # NOTE: must not be named ``_stop`` — that shadows ``threading.Thread._stop``
+        # and breaks ``Thread.join``'s finalization path (raises TypeError at
+        # the end of the thread's life).
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:  # pragma: no cover - exercised indirectly
+        while not self._stop_event.wait(timeout=self._interval):
+            try:
+                conn = connect(self._db_path)
+                try:
+                    conn.execute(
+                        "UPDATE memory_writer_lock "
+                        "SET heartbeat_at = ? WHERE id = 1 AND worker_id = ?",
+                        (utc_now_iso_z(), self._worker_id),
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+            except Exception:
+                logger.warning(
+                    "Heartbeat renewal failed; writer lease may expire",
+                    exc_info=True,
+                )
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        self.join(timeout=self._interval + 5)
+
+
+# ── Queue operations ────────────────────────────────────────────────────────
+def enqueue(
+    db_path: Path,
+    agent_name: str | None,
+    messages: list,
+    thread_id: str | None,
+    correction_detected: bool = False,
+    reinforcement_detected: bool = False,
+) -> None:
+    """Append a conversation context to the pending queue."""
+    from langchain_core.messages import messages_to_dict
+
+    _ensure_schema(db_path)
+    serialised = messages_to_dict(messages) if messages else []
+    name = agent_name if agent_name is not None else "__global__"
+
+    conn = connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO memory_update_queue
+                (agent_name, user_id, messages, thread_id,
+                 correction_detected, reinforcement_detected,
+                 enqueued_at, status)
+            VALUES (?, '__default__', ?, ?, ?, ?, ?, 'pending')
+            """,
+            (
+                name,
+                json.dumps(serialised, ensure_ascii=False),
+                thread_id,
+                int(correction_detected),
+                int(reinforcement_detected),
+                utc_now_iso_z(),
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def reset_stuck_tasks(db_path: Path) -> int:
+    """Move tasks that have been ``'processing'`` too long back to ``'pending'``."""
+    _ensure_schema(db_path)
+    _, _, processing_timeout = _get_timings()
+    cutoff = _utc_minus_seconds(processing_timeout)
+    conn = connect(db_path)
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE memory_update_queue
+            SET status = 'pending', started_at = NULL
+            WHERE status = 'processing' AND started_at IS NOT NULL AND started_at < ?
+            """,
+            (cutoff,),
+        )
+        reset_count = cursor.rowcount or 0
+        conn.commit()
+    finally:
+        conn.close()
+
+    if reset_count > 0:
+        logger.warning("Reset %d stuck memory tasks back to pending", reset_count)
+    return reset_count
+
+
+def try_acquire_writer(db_path: Path, worker_id: str) -> bool:
+    """Attempt to take the single-writer lease.  Returns True on success."""
+    _ensure_schema(db_path)
+    lock_stale, _, _ = _get_timings()
+    now = utc_now_iso_z()
+    conn = connect(db_path)
+    try:
+        conn.execute("BEGIN EXCLUSIVE")
+        row = conn.execute(
+            "SELECT worker_id, heartbeat_at FROM memory_writer_lock WHERE id = 1"
+        ).fetchone()
+
+        if row is not None:
+            held_by = row["worker_id"]
+            try:
+                heartbeat = _parse_utc_iso(row["heartbeat_at"])
+            except ValueError:
+                heartbeat = _utc_now() - timedelta(seconds=lock_stale + 1)
+            age = (_utc_now() - heartbeat).total_seconds()
+            if held_by != worker_id and age < lock_stale:
+                conn.rollback()
+                return False
+
+        conn.execute(
+            """
+            INSERT INTO memory_writer_lock (id, worker_id, acquired_at, heartbeat_at)
+            VALUES (1, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                worker_id    = excluded.worker_id,
+                acquired_at  = excluded.acquired_at,
+                heartbeat_at = excluded.heartbeat_at
+            """,
+            (worker_id, now, now),
+        )
+        conn.commit()
+        return True
+    except sqlite3.Error:
+        try:
+            conn.rollback()
+        except sqlite3.Error:
+            pass
+        logger.exception("Failed to acquire writer lease")
+        return False
+    finally:
+        conn.close()
+
+
+def _release_writer(db_path: Path, worker_id: str) -> None:
+    try:
+        conn = connect(db_path)
+        try:
+            conn.execute(
+                "DELETE FROM memory_writer_lock WHERE id = 1 AND worker_id = ?",
+                (worker_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        logger.exception("Failed to release writer lease for worker %s", worker_id)
+
+
+def run_writer_loop(db_path: Path, worker_id: str) -> None:
+    """Consume every pending queue item, sequentially, until the queue empties.
+
+    Always releases the writer lease and the process-local guard on exit, even
+    on exception.  Designed to be invoked in a daemon thread.
+    """
+    from langchain_core.messages import messages_from_dict
+
+    # Imported lazily to avoid a circular import at module load time (updater
+    # imports from storage, storage imports are resolved via init, etc.).
+    from deerflow.agents.memory.updater import update_memory_from_conversation
+
+    _, heartbeat_interval, _ = _get_timings()
+    heartbeat = _HeartbeatThread(db_path, worker_id, heartbeat_interval)
+    heartbeat.start()
+
+    try:
+        conn = connect(db_path)
+        try:
+            while True:
+                task = None
+                try:
+                    conn.execute("BEGIN EXCLUSIVE")
+                    row = conn.execute(
+                        """
+                        SELECT id, agent_name, messages, thread_id,
+                               correction_detected, reinforcement_detected
+                        FROM memory_update_queue
+                        WHERE status = 'pending'
+                        ORDER BY id ASC LIMIT 1
+                        """
+                    ).fetchone()
+
+                    if row is None:
+                        conn.commit()
+                        break
+
+                    task = {
+                        "id": row["id"],
+                        "agent_name": row["agent_name"],
+                        "messages": row["messages"],
+                        "thread_id": row["thread_id"],
+                        "correction_detected": bool(row["correction_detected"]),
+                        "reinforcement_detected": bool(row["reinforcement_detected"]),
+                    }
+                    conn.execute(
+                        "UPDATE memory_update_queue "
+                        "SET status = 'processing', started_at = ? WHERE id = ?",
+                        (utc_now_iso_z(), task["id"]),
+                    )
+                    conn.commit()
+                except sqlite3.Error:
+                    try:
+                        conn.rollback()
+                    except sqlite3.Error:
+                        pass
+                    logger.exception(
+                        "Failed to claim next queue item; stopping writer loop"
+                    )
+                    break
+
+                # Run the load → LLM → save cycle with NO db lock held.
+                try:
+                    agent_name: str | None
+                    agent_name = (
+                        None if task["agent_name"] == "__global__" else task["agent_name"]
+                    )
+                    messages = messages_from_dict(json.loads(task["messages"]))
+                    success = update_memory_from_conversation(
+                        messages=messages,
+                        thread_id=task["thread_id"],
+                        agent_name=agent_name,
+                        correction_detected=task["correction_detected"],
+                        reinforcement_detected=task["reinforcement_detected"],
+                    )
+                    final_status = "done" if success else "failed"
+                except Exception:
+                    logger.exception(
+                        "Memory update failed for queue item %d", task["id"]
+                    )
+                    final_status = "failed"
+
+                try:
+                    conn.execute(
+                        "UPDATE memory_update_queue "
+                        "SET status = ?, completed_at = ? WHERE id = ?",
+                        (final_status, utc_now_iso_z(), task["id"]),
+                    )
+                    conn.commit()
+                except sqlite3.Error:
+                    logger.exception(
+                        "Failed to record terminal status for queue item %d",
+                        task["id"],
+                    )
+        finally:
+            conn.close()
+    finally:
+        heartbeat.stop()
+        _release_writer(db_path, worker_id)
+        # Only release the process-local guard if we actually hold it.
+        if _writer_running.locked():
+            try:
+                _writer_running.release()
+            except RuntimeError:  # pragma: no cover - defensive
+                pass
+
+
+def schedule_memory_updates(
+    db_path: Path,
+    contexts: list[dict],
+) -> None:
+    """Enqueue a batch of conversation contexts and, if possible, become the writer.
+
+    Each item in *contexts* is a mapping with the keys ``agent_name``,
+    ``messages``, ``thread_id`` and the optional flags
+    ``correction_detected`` / ``reinforcement_detected``.  Missing flags
+    default to ``False``.
+
+    This is the preferred entry point when the debounced in-memory queue
+    drains several conversation contexts in one tick (RFC #2283): the
+    schema bootstrap, stuck-task reset and writer-lease acquisition each
+    run exactly once per batch instead of once per queued item — the
+    per-item form repeatedly opened short-lived SQLite connections for
+    work that is trivially batchable.
+    """
+    if not contexts:
+        return
+
+    _ensure_schema(db_path)
+    reset_stuck_tasks(db_path)
+
+    for ctx in contexts:
+        enqueue(
+            db_path,
+            ctx.get("agent_name"),
+            ctx.get("messages") or [],
+            ctx.get("thread_id"),
+            correction_detected=bool(ctx.get("correction_detected", False)),
+            reinforcement_detected=bool(ctx.get("reinforcement_detected", False)),
+        )
+
+    if not _writer_running.acquire(blocking=False):
+        return  # a writer thread is already active in this process
+
+    worker_id = _worker_id()
+    if try_acquire_writer(db_path, worker_id):
+        threading.Thread(
+            target=run_writer_loop,
+            args=(db_path, worker_id),
+            daemon=True,
+            name="memory-writer",
+        ).start()
+    else:
+        # Did not become the writer; another live process owns the lease and
+        # will process our enqueued tasks.  Release the in-process guard.
+        try:
+            _writer_running.release()
+        except RuntimeError:  # pragma: no cover - defensive
+            pass
+
+
+def schedule_memory_update(
+    db_path: Path,
+    agent_name: str | None,
+    messages: list,
+    thread_id: str | None,
+    correction_detected: bool = False,
+    reinforcement_detected: bool = False,
+) -> None:
+    """Enqueue a single conversation context and, if possible, become the writer.
+
+    Thin wrapper around :func:`schedule_memory_updates`.  Safe to call from
+    ``threading.Timer`` callbacks: no event loop required.
+    """
+    schedule_memory_updates(
+        db_path,
+        [
+            {
+                "agent_name": agent_name,
+                "messages": messages,
+                "thread_id": thread_id,
+                "correction_detected": correction_detected,
+                "reinforcement_detected": reinforcement_detected,
+            }
+        ],
+    )
+
+
+def trim_queue(db_path: Path, keep_days: int = 7) -> int:
+    """Delete ``done`` / ``failed`` tasks older than *keep_days*.
+
+    Returns the number of rows deleted.  Can be called from a periodic
+    maintenance job; never blocks the writer loop because each call uses its
+    own short-lived connection and WAL mode permits concurrent reads.
+    """
+    _ensure_schema(db_path)
+    if keep_days < 0:
+        raise ValueError("keep_days must be non-negative")
+    cutoff = _utc_minus_seconds(keep_days * 86400)
+    conn = connect(db_path)
+    try:
+        cursor = conn.execute(
+            "DELETE FROM memory_update_queue "
+            "WHERE status IN ('done', 'failed') "
+            "AND completed_at IS NOT NULL AND completed_at < ?",
+            (cutoff,),
+        )
+        deleted = cursor.rowcount or 0
+        conn.commit()
+    finally:
+        conn.close()
+    return deleted
+
+
+def migrate_json_to_sqlite(
+    json_path: Path,
+    db_path: Path,
+    agent_name: str | None = None,
+) -> None:
+    """Import an existing ``memory.json`` (or per-agent file) into SQLite.
+
+    Raises :class:`RuntimeError` if the import fails; the original JSON file
+    is never deleted.
+    """
+    from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+
+    _ensure_schema(db_path)
+    with open(json_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    storage = SQLiteMemoryStorage(db_path)
+    if not storage.save(data, agent_name=agent_name):
+        raise RuntimeError(
+            f"Migration failed for {json_path}; original file unchanged"
+        )
+    logger.info(
+        "Migrated %s into %s (agent=%s); original file preserved",
+        json_path,
+        db_path,
+        agent_name if agent_name is not None else "__global__",
+    )
+
+
+# Test hook: ``queue._process_queue`` checks ``hasattr(memory_queue_module,
+# "schedule_memory_update")`` when wiring up the SQLite backend, so any future
+# rename here must keep ``schedule_memory_update`` as the public entry point.
+__all__ = [
+    "DEFAULT_HEARTBEAT_INTERVAL_SECONDS",
+    "DEFAULT_LOCK_STALE_SECONDS",
+    "DEFAULT_PROCESSING_TIMEOUT_SECONDS",
+    "enqueue",
+    "init_queue_schema",
+    "migrate_json_to_sqlite",
+    "reset_stuck_tasks",
+    "run_writer_loop",
+    "schedule_memory_update",
+    "schedule_memory_updates",
+    "trim_queue",
+    "try_acquire_writer",
+]

--- a/backend/packages/harness/deerflow/agents/memory/writer_queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/writer_queue.py
@@ -111,17 +111,13 @@ def _get_timings() -> tuple[int, int, int]:
 
     Reads overrides from :class:`MemoryConfig`; falls back to module defaults
     when a field is absent (older configs that pre-date these knobs).
-    Enforces ``heartbeat_interval < lock_stale / 2`` to preserve the
-    three-missed-heartbeats safety margin from the RFC.
+    Enforces ``heartbeat_interval < lock_stale / 2`` to preserve a
+    stale-lease safety margin.
     """
     cfg = get_memory_config()
     lock_stale = int(getattr(cfg, "lock_stale_seconds", DEFAULT_LOCK_STALE_SECONDS))
-    heartbeat = int(
-        getattr(cfg, "heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS)
-    )
-    processing_timeout = int(
-        getattr(cfg, "processing_timeout_seconds", DEFAULT_PROCESSING_TIMEOUT_SECONDS)
-    )
+    heartbeat = int(getattr(cfg, "heartbeat_interval_seconds", DEFAULT_HEARTBEAT_INTERVAL_SECONDS))
+    processing_timeout = int(getattr(cfg, "processing_timeout_seconds", DEFAULT_PROCESSING_TIMEOUT_SECONDS))
 
     if heartbeat <= 0 or lock_stale <= 0 or processing_timeout <= 0:
         logger.warning(
@@ -138,8 +134,7 @@ def _get_timings() -> tuple[int, int, int]:
 
     if heartbeat * 2 >= lock_stale:
         logger.warning(
-            "heartbeat_interval_seconds=%d is not < lock_stale_seconds=%d / 2; "
-            "clamping heartbeat to keep a safety margin",
+            "heartbeat_interval_seconds=%d is not < lock_stale_seconds=%d / 2; clamping heartbeat to keep a safety margin",
             heartbeat,
             lock_stale,
         )
@@ -204,8 +199,7 @@ class _HeartbeatThread(threading.Thread):
                 conn = connect(self._db_path)
                 try:
                     conn.execute(
-                        "UPDATE memory_writer_lock "
-                        "SET heartbeat_at = ? WHERE id = 1 AND worker_id = ?",
+                        "UPDATE memory_writer_lock SET heartbeat_at = ? WHERE id = 1 AND worker_id = ?",
                         (utc_now_iso_z(), self._worker_id),
                     )
                     conn.commit()
@@ -295,9 +289,7 @@ def try_acquire_writer(db_path: Path, worker_id: str) -> bool:
     conn = connect(db_path)
     try:
         conn.execute("BEGIN EXCLUSIVE")
-        row = conn.execute(
-            "SELECT worker_id, heartbeat_at FROM memory_writer_lock WHERE id = 1"
-        ).fetchone()
+        row = conn.execute("SELECT worker_id, heartbeat_at FROM memory_writer_lock WHERE id = 1").fetchone()
 
         if row is not None:
             held_by = row["worker_id"]
@@ -395,8 +387,7 @@ def run_writer_loop(db_path: Path, worker_id: str) -> None:
                         "reinforcement_detected": bool(row["reinforcement_detected"]),
                     }
                     conn.execute(
-                        "UPDATE memory_update_queue "
-                        "SET status = 'processing', started_at = ? WHERE id = ?",
+                        "UPDATE memory_update_queue SET status = 'processing', started_at = ? WHERE id = ?",
                         (utc_now_iso_z(), task["id"]),
                     )
                     conn.commit()
@@ -405,17 +396,13 @@ def run_writer_loop(db_path: Path, worker_id: str) -> None:
                         conn.rollback()
                     except sqlite3.Error:
                         pass
-                    logger.exception(
-                        "Failed to claim next queue item; stopping writer loop"
-                    )
+                    logger.exception("Failed to claim next queue item; stopping writer loop")
                     break
 
                 # Run the load → LLM → save cycle with NO db lock held.
                 try:
                     agent_name: str | None
-                    agent_name = (
-                        None if task["agent_name"] == "__global__" else task["agent_name"]
-                    )
+                    agent_name = None if task["agent_name"] == "__global__" else task["agent_name"]
                     messages = messages_from_dict(json.loads(task["messages"]))
                     success = update_memory_from_conversation(
                         messages=messages,
@@ -426,15 +413,12 @@ def run_writer_loop(db_path: Path, worker_id: str) -> None:
                     )
                     final_status = "done" if success else "failed"
                 except Exception:
-                    logger.exception(
-                        "Memory update failed for queue item %d", task["id"]
-                    )
+                    logger.exception("Memory update failed for queue item %d", task["id"])
                     final_status = "failed"
 
                 try:
                     conn.execute(
-                        "UPDATE memory_update_queue "
-                        "SET status = ?, completed_at = ? WHERE id = ?",
+                        "UPDATE memory_update_queue SET status = ?, completed_at = ? WHERE id = ?",
                         (final_status, utc_now_iso_z(), task["id"]),
                     )
                     conn.commit()
@@ -551,9 +535,7 @@ def trim_queue(db_path: Path, keep_days: int = 7) -> int:
     conn = connect(db_path)
     try:
         cursor = conn.execute(
-            "DELETE FROM memory_update_queue "
-            "WHERE status IN ('done', 'failed') "
-            "AND completed_at IS NOT NULL AND completed_at < ?",
+            "DELETE FROM memory_update_queue WHERE status IN ('done', 'failed') AND completed_at IS NOT NULL AND completed_at < ?",
             (cutoff,),
         )
         deleted = cursor.rowcount or 0
@@ -581,9 +563,7 @@ def migrate_json_to_sqlite(
 
     storage = SQLiteMemoryStorage(db_path)
     if not storage.save(data, agent_name=agent_name):
-        raise RuntimeError(
-            f"Migration failed for {json_path}; original file unchanged"
-        )
+        raise RuntimeError(f"Migration failed for {json_path}; original file unchanged")
     logger.info(
         "Migrated %s into %s (agent=%s); original file preserved",
         json_path,

--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -1,6 +1,6 @@
 """Configuration for memory mechanism."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class MemoryConfig(BaseModel):
@@ -59,6 +59,61 @@ class MemoryConfig(BaseModel):
         le=8000,
         description="Maximum tokens to use for memory injection",
     )
+    # Single-writer queue (RFC #2283) tunables.  These only apply when the
+    # configured ``storage_class`` is ``SQLiteMemoryStorage``; with file
+    # storage they are ignored.
+    lock_stale_seconds: int = Field(
+        default=90,
+        ge=10,
+        le=3600,
+        description=(
+            "Writer lease is considered dead after this many seconds without "
+            "a heartbeat renewal. Must be strictly greater than "
+            "2 * heartbeat_interval_seconds (enforced by the cross-field "
+            "validator below) so two missed heartbeats are required before "
+            "the lease is considered stale."
+        ),
+    )
+    heartbeat_interval_seconds: int = Field(
+        default=30,
+        ge=1,
+        le=600,
+        description=(
+            "Writer lease heartbeat period. Must be strictly less than "
+            "lock_stale_seconds / 2 (enforced by the cross-field validator "
+            "below) so two missed heartbeats are required before the lease "
+            "is considered stale."
+        ),
+    )
+    processing_timeout_seconds: int = Field(
+        default=300,
+        ge=10,
+        le=86400,
+        description=(
+            "Maximum time a queue task may remain in the 'processing' state "
+            "before reset_stuck_tasks() moves it back to 'pending'."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_writer_queue_timings(self) -> "MemoryConfig":
+        """Enforce ``heartbeat_interval_seconds * 2 < lock_stale_seconds``.
+
+        This is the safety margin described in RFC #2283: the lease is only
+        declared stale after at least two missed heartbeats, so a briefly
+        delayed writer (e.g. GIL contention, a long LLM call) does not lose
+        its lease to a racing process.  Moving the check here means invalid
+        configs fail fast at load time rather than being silently clamped on
+        every writer-queue call.
+        """
+        if self.heartbeat_interval_seconds * 2 >= self.lock_stale_seconds:
+            raise ValueError(
+                "heartbeat_interval_seconds must be strictly less than "
+                "lock_stale_seconds / 2 to preserve the two-missed-heartbeats "
+                f"safety margin (got heartbeat={self.heartbeat_interval_seconds}s, "
+                f"lock_stale={self.lock_stale_seconds}s)."
+            )
+        return self
 
 
 # Global configuration instance

--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -59,9 +59,8 @@ class MemoryConfig(BaseModel):
         le=8000,
         description="Maximum tokens to use for memory injection",
     )
-    # Single-writer queue (RFC #2283) tunables.  These only apply when the
-    # configured ``storage_class`` is ``SQLiteMemoryStorage``; with file
-    # storage they are ignored.
+    # SQLite writer-queue tunables. These only apply when the configured
+    # ``storage_class`` is ``SQLiteMemoryStorage``; file storage ignores them.
     lock_stale_seconds: int = Field(
         default=90,
         ge=10,
@@ -70,48 +69,35 @@ class MemoryConfig(BaseModel):
             "Writer lease is considered dead after this many seconds without "
             "a heartbeat renewal. Must be strictly greater than "
             "2 * heartbeat_interval_seconds (enforced by the cross-field "
-            "validator below) so two missed heartbeats are required before "
-            "the lease is considered stale."
+            "validator below) to preserve a safety margin before the lease "
+            "is considered stale."
         ),
     )
     heartbeat_interval_seconds: int = Field(
         default=30,
         ge=1,
         le=600,
-        description=(
-            "Writer lease heartbeat period. Must be strictly less than "
-            "lock_stale_seconds / 2 (enforced by the cross-field validator "
-            "below) so two missed heartbeats are required before the lease "
-            "is considered stale."
-        ),
+        description=("Writer lease heartbeat period. Must be strictly less than lock_stale_seconds / 2 (enforced by the cross-field validator below) to preserve a safety margin before the lease is considered stale."),
     )
     processing_timeout_seconds: int = Field(
         default=300,
         ge=10,
         le=86400,
-        description=(
-            "Maximum time a queue task may remain in the 'processing' state "
-            "before reset_stuck_tasks() moves it back to 'pending'."
-        ),
+        description=("Maximum time a queue task may remain in the 'processing' state before reset_stuck_tasks() moves it back to 'pending'."),
     )
 
     @model_validator(mode="after")
     def _validate_writer_queue_timings(self) -> "MemoryConfig":
         """Enforce ``heartbeat_interval_seconds * 2 < lock_stale_seconds``.
 
-        This is the safety margin described in RFC #2283: the lease is only
-        declared stale after at least two missed heartbeats, so a briefly
-        delayed writer (e.g. GIL contention, a long LLM call) does not lose
-        its lease to a racing process.  Moving the check here means invalid
-        configs fail fast at load time rather than being silently clamped on
-        every writer-queue call.
+        This keeps the heartbeat interval comfortably below the stale-lease
+        threshold, so a briefly delayed writer (for example, a long LLM call)
+        does not lose its lease to a racing process. Invalid configs fail fast
+        at load time instead of being silently clamped later.
         """
         if self.heartbeat_interval_seconds * 2 >= self.lock_stale_seconds:
             raise ValueError(
-                "heartbeat_interval_seconds must be strictly less than "
-                "lock_stale_seconds / 2 to preserve the two-missed-heartbeats "
-                f"safety margin (got heartbeat={self.heartbeat_interval_seconds}s, "
-                f"lock_stale={self.lock_stale_seconds}s)."
+                f"heartbeat_interval_seconds must be strictly less than lock_stale_seconds / 2 to preserve the stale-lease safety margin (got heartbeat={self.heartbeat_interval_seconds}s, lock_stale={self.lock_stale_seconds}s)."
             )
         return self
 

--- a/backend/tests/test_memory_writer_queue.py
+++ b/backend/tests/test_memory_writer_queue.py
@@ -1,0 +1,335 @@
+"""Tests for the single-writer memory queue (RFC #2283)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from unittest.mock import patch
+
+import pytest
+
+from deerflow.agents.memory import writer_queue
+from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+from deerflow.agents.memory.writer_queue import (
+    _parse_utc_iso,
+    enqueue,
+    init_queue_schema,
+    migrate_json_to_sqlite,
+    reset_stuck_tasks,
+    run_writer_loop,
+    schedule_memory_update,
+    trim_queue,
+    try_acquire_writer,
+)
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    p = tmp_path / "memory.db"
+    init_queue_schema(p)
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _release_process_guard():
+    """Ensure the process-local writer guard is released between tests."""
+    yield
+    if writer_queue._writer_running.locked():
+        try:
+            writer_queue._writer_running.release()
+        except RuntimeError:
+            pass
+
+
+# --------------------------------------------------------------------------- #
+#  Timestamp parser                                                            #
+# --------------------------------------------------------------------------- #
+class TestParseUtcIso:
+    def test_round_trip_with_z_suffix(self):
+        from deerflow.agents.memory.storage import utc_now_iso_z
+
+        ts = utc_now_iso_z()
+        parsed = _parse_utc_iso(ts)
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset().total_seconds() == 0
+
+    def test_naive_iso_string_is_treated_as_utc(self):
+        parsed = _parse_utc_iso("2025-01-01T00:00:00")
+        assert parsed.tzinfo is not None
+        assert parsed.utcoffset().total_seconds() == 0
+
+
+# --------------------------------------------------------------------------- #
+#  Enqueue                                                                    #
+# --------------------------------------------------------------------------- #
+class TestEnqueue:
+    def test_inserts_pending_row(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id="t1")
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT agent_name, status, thread_id FROM memory_update_queue"
+            ).fetchone()
+        assert row["agent_name"] == "__global__"
+        assert row["status"] == "pending"
+        assert row["thread_id"] == "t1"
+
+    def test_agent_name_none_becomes_global_sentinel(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id=None)
+        enqueue(db_path, agent_name="researcher", messages=[], thread_id=None)
+        with sqlite3.connect(str(db_path)) as conn:
+            names = sorted(
+                r[0] for r in conn.execute(
+                    "SELECT agent_name FROM memory_update_queue"
+                ).fetchall()
+            )
+        assert names == ["__global__", "researcher"]
+
+    def test_serialises_messages_via_langchain(self, db_path):
+        from langchain_core.messages import HumanMessage
+
+        enqueue(
+            db_path,
+            agent_name=None,
+            messages=[HumanMessage(content="hello")],
+            thread_id="t",
+        )
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT messages FROM memory_update_queue"
+            ).fetchone()
+        parsed = json.loads(row["messages"])
+        assert parsed[0]["type"] == "human"
+
+
+# --------------------------------------------------------------------------- #
+#  Writer lease                                                               #
+# --------------------------------------------------------------------------- #
+class TestWriterLease:
+    def test_first_caller_acquires(self, db_path):
+        assert try_acquire_writer(db_path, "worker-A") is True
+
+    def test_second_caller_is_rejected_while_lease_fresh(self, db_path):
+        assert try_acquire_writer(db_path, "worker-A") is True
+        assert try_acquire_writer(db_path, "worker-B") is False
+
+    def test_same_worker_can_reacquire_its_own_lease(self, db_path):
+        assert try_acquire_writer(db_path, "worker-A") is True
+        # Same worker acquiring again is a no-op upsert, not a failure.
+        assert try_acquire_writer(db_path, "worker-A") is True
+
+    def test_stale_lease_can_be_taken_over(self, db_path):
+        assert try_acquire_writer(db_path, "worker-A") is True
+        # Age out the heartbeat beyond the default lock_stale window (90s).
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "UPDATE memory_writer_lock SET heartbeat_at='2000-01-01T00:00:00Z'"
+            )
+            conn.commit()
+        assert try_acquire_writer(db_path, "worker-B") is True
+
+
+# --------------------------------------------------------------------------- #
+#  reset_stuck_tasks / trim_queue                                             #
+# --------------------------------------------------------------------------- #
+class TestMaintenance:
+    def test_reset_stuck_tasks(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id="t")
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "UPDATE memory_update_queue "
+                "SET status='processing', started_at='2000-01-01T00:00:00Z'"
+            )
+            conn.commit()
+        assert reset_stuck_tasks(db_path) == 1
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT status, started_at FROM memory_update_queue"
+            ).fetchone()
+        assert row["status"] == "pending"
+        assert row["started_at"] is None
+
+    def test_trim_queue_removes_only_completed(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id="done")
+        enqueue(db_path, agent_name=None, messages=[], thread_id="pending")
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "UPDATE memory_update_queue "
+                "SET status='done', completed_at='2000-01-01T00:00:00Z' "
+                "WHERE thread_id='done'"
+            )
+            conn.commit()
+
+        deleted = trim_queue(db_path, keep_days=1)
+        assert deleted == 1
+        with sqlite3.connect(str(db_path)) as conn:
+            remaining = [
+                r[0] for r in conn.execute(
+                    "SELECT thread_id FROM memory_update_queue"
+                ).fetchall()
+            ]
+        assert remaining == ["pending"]
+
+    def test_trim_queue_rejects_negative_keep_days(self, db_path):
+        with pytest.raises(ValueError):
+            trim_queue(db_path, keep_days=-1)
+
+
+# --------------------------------------------------------------------------- #
+#  run_writer_loop (end-to-end with mocked LLM)                               #
+# --------------------------------------------------------------------------- #
+class TestRunWriterLoop:
+    def test_processes_all_pending_tasks(self, db_path):
+        for i in range(3):
+            enqueue(db_path, agent_name=None, messages=[], thread_id=f"t{i}")
+        try_acquire_writer(db_path, "worker-1")
+
+        # Hold the process-local guard as schedule_memory_update would.
+        writer_queue._writer_running.acquire()
+
+        calls = []
+
+        def fake_update(*, messages, thread_id, agent_name, **kwargs):
+            calls.append(thread_id)
+            return True
+
+        with patch(
+            "deerflow.agents.memory.updater.update_memory_from_conversation",
+            side_effect=fake_update,
+        ):
+            run_writer_loop(db_path, "worker-1")
+
+        assert calls == ["t0", "t1", "t2"]
+        with sqlite3.connect(str(db_path)) as conn:
+            statuses = [
+                r[0] for r in conn.execute(
+                    "SELECT status FROM memory_update_queue ORDER BY id"
+                ).fetchall()
+            ]
+        assert statuses == ["done", "done", "done"]
+
+        # Lease released.
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute("SELECT id FROM memory_writer_lock").fetchone()
+        assert row is None
+
+    def test_failed_llm_marks_task_failed_not_done(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id="t-fail")
+        try_acquire_writer(db_path, "worker-1")
+        writer_queue._writer_running.acquire()
+
+        def fake_update(**kwargs):
+            return False
+
+        with patch(
+            "deerflow.agents.memory.updater.update_memory_from_conversation",
+            side_effect=fake_update,
+        ):
+            run_writer_loop(db_path, "worker-1")
+
+        with sqlite3.connect(str(db_path)) as conn:
+            status = conn.execute(
+                "SELECT status FROM memory_update_queue"
+            ).fetchone()[0]
+        assert status == "failed"
+
+    def test_exception_in_update_is_caught(self, db_path):
+        enqueue(db_path, agent_name=None, messages=[], thread_id="t-boom")
+        try_acquire_writer(db_path, "worker-1")
+        writer_queue._writer_running.acquire()
+
+        def boom(**kwargs):
+            raise RuntimeError("LLM exploded")
+
+        with patch(
+            "deerflow.agents.memory.updater.update_memory_from_conversation",
+            side_effect=boom,
+        ):
+            run_writer_loop(db_path, "worker-1")
+
+        with sqlite3.connect(str(db_path)) as conn:
+            status = conn.execute(
+                "SELECT status FROM memory_update_queue"
+            ).fetchone()[0]
+        assert status == "failed"
+
+    def test_agent_name_sentinel_round_trip(self, db_path):
+        """A global task enqueued as '__global__' must be delivered back as None."""
+        enqueue(db_path, agent_name=None, messages=[], thread_id="t")
+        try_acquire_writer(db_path, "worker-1")
+        writer_queue._writer_running.acquire()
+
+        received: list[str | None] = []
+
+        def fake_update(*, messages, thread_id, agent_name, **kwargs):
+            received.append(agent_name)
+            return True
+
+        with patch(
+            "deerflow.agents.memory.updater.update_memory_from_conversation",
+            side_effect=fake_update,
+        ):
+            run_writer_loop(db_path, "worker-1")
+
+        assert received == [None]
+
+
+# --------------------------------------------------------------------------- #
+#  schedule_memory_update + migrate_json_to_sqlite                            #
+# --------------------------------------------------------------------------- #
+class TestScheduleMemoryUpdate:
+    def test_schedules_and_drains(self, db_path):
+        calls = []
+
+        def fake_update(*, messages, thread_id, agent_name, **kwargs):
+            calls.append(thread_id)
+            return True
+
+        with patch(
+            "deerflow.agents.memory.updater.update_memory_from_conversation",
+            side_effect=fake_update,
+        ):
+            schedule_memory_update(
+                db_path,
+                agent_name=None,
+                messages=[],
+                thread_id="t-1",
+            )
+            # schedule_memory_update spawns a daemon thread; give it a moment.
+            for _ in range(50):
+                with sqlite3.connect(str(db_path)) as conn:
+                    row = conn.execute(
+                        "SELECT status FROM memory_update_queue WHERE thread_id='t-1'"
+                    ).fetchone()
+                if row is not None and row[0] in {"done", "failed"}:
+                    break
+                time.sleep(0.05)
+
+        assert calls == ["t-1"]
+
+
+class TestMigrateJsonToSqlite:
+    def test_imports_global_memory(self, tmp_path):
+        src = tmp_path / "memory.json"
+        src.write_text(json.dumps({"version": "1.0", "facts": [{"content": "x"}]}))
+        db = tmp_path / "memory.db"
+
+        migrate_json_to_sqlite(src, db)
+
+        storage = SQLiteMemoryStorage(db)
+        assert storage.load()["facts"] == [{"content": "x"}]
+
+    def test_imports_per_agent_memory(self, tmp_path):
+        src = tmp_path / "planner.json"
+        src.write_text(json.dumps({"version": "1.0", "facts": [{"content": "p"}]}))
+        db = tmp_path / "memory.db"
+
+        migrate_json_to_sqlite(src, db, agent_name="planner")
+
+        storage = SQLiteMemoryStorage(db)
+        assert storage.load(agent_name="planner")["facts"] == [{"content": "p"}]
+        # Global row is untouched.
+        assert storage.load()["facts"] == []

--- a/backend/tests/test_memory_writer_queue.py
+++ b/backend/tests/test_memory_writer_queue.py
@@ -68,9 +68,7 @@ class TestEnqueue:
         enqueue(db_path, agent_name=None, messages=[], thread_id="t1")
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT agent_name, status, thread_id FROM memory_update_queue"
-            ).fetchone()
+            row = conn.execute("SELECT agent_name, status, thread_id FROM memory_update_queue").fetchone()
         assert row["agent_name"] == "__global__"
         assert row["status"] == "pending"
         assert row["thread_id"] == "t1"
@@ -79,11 +77,7 @@ class TestEnqueue:
         enqueue(db_path, agent_name=None, messages=[], thread_id=None)
         enqueue(db_path, agent_name="researcher", messages=[], thread_id=None)
         with sqlite3.connect(str(db_path)) as conn:
-            names = sorted(
-                r[0] for r in conn.execute(
-                    "SELECT agent_name FROM memory_update_queue"
-                ).fetchall()
-            )
+            names = sorted(r[0] for r in conn.execute("SELECT agent_name FROM memory_update_queue").fetchall())
         assert names == ["__global__", "researcher"]
 
     def test_serialises_messages_via_langchain(self, db_path):
@@ -97,9 +91,7 @@ class TestEnqueue:
         )
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT messages FROM memory_update_queue"
-            ).fetchone()
+            row = conn.execute("SELECT messages FROM memory_update_queue").fetchone()
         parsed = json.loads(row["messages"])
         assert parsed[0]["type"] == "human"
 
@@ -124,9 +116,7 @@ class TestWriterLease:
         assert try_acquire_writer(db_path, "worker-A") is True
         # Age out the heartbeat beyond the default lock_stale window (90s).
         with sqlite3.connect(str(db_path)) as conn:
-            conn.execute(
-                "UPDATE memory_writer_lock SET heartbeat_at='2000-01-01T00:00:00Z'"
-            )
+            conn.execute("UPDATE memory_writer_lock SET heartbeat_at='2000-01-01T00:00:00Z'")
             conn.commit()
         assert try_acquire_writer(db_path, "worker-B") is True
 
@@ -138,17 +128,12 @@ class TestMaintenance:
     def test_reset_stuck_tasks(self, db_path):
         enqueue(db_path, agent_name=None, messages=[], thread_id="t")
         with sqlite3.connect(str(db_path)) as conn:
-            conn.execute(
-                "UPDATE memory_update_queue "
-                "SET status='processing', started_at='2000-01-01T00:00:00Z'"
-            )
+            conn.execute("UPDATE memory_update_queue SET status='processing', started_at='2000-01-01T00:00:00Z'")
             conn.commit()
         assert reset_stuck_tasks(db_path) == 1
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT status, started_at FROM memory_update_queue"
-            ).fetchone()
+            row = conn.execute("SELECT status, started_at FROM memory_update_queue").fetchone()
         assert row["status"] == "pending"
         assert row["started_at"] is None
 
@@ -156,21 +141,13 @@ class TestMaintenance:
         enqueue(db_path, agent_name=None, messages=[], thread_id="done")
         enqueue(db_path, agent_name=None, messages=[], thread_id="pending")
         with sqlite3.connect(str(db_path)) as conn:
-            conn.execute(
-                "UPDATE memory_update_queue "
-                "SET status='done', completed_at='2000-01-01T00:00:00Z' "
-                "WHERE thread_id='done'"
-            )
+            conn.execute("UPDATE memory_update_queue SET status='done', completed_at='2000-01-01T00:00:00Z' WHERE thread_id='done'")
             conn.commit()
 
         deleted = trim_queue(db_path, keep_days=1)
         assert deleted == 1
         with sqlite3.connect(str(db_path)) as conn:
-            remaining = [
-                r[0] for r in conn.execute(
-                    "SELECT thread_id FROM memory_update_queue"
-                ).fetchall()
-            ]
+            remaining = [r[0] for r in conn.execute("SELECT thread_id FROM memory_update_queue").fetchall()]
         assert remaining == ["pending"]
 
     def test_trim_queue_rejects_negative_keep_days(self, db_path):
@@ -204,11 +181,7 @@ class TestRunWriterLoop:
 
         assert calls == ["t0", "t1", "t2"]
         with sqlite3.connect(str(db_path)) as conn:
-            statuses = [
-                r[0] for r in conn.execute(
-                    "SELECT status FROM memory_update_queue ORDER BY id"
-                ).fetchall()
-            ]
+            statuses = [r[0] for r in conn.execute("SELECT status FROM memory_update_queue ORDER BY id").fetchall()]
         assert statuses == ["done", "done", "done"]
 
         # Lease released.
@@ -231,9 +204,7 @@ class TestRunWriterLoop:
             run_writer_loop(db_path, "worker-1")
 
         with sqlite3.connect(str(db_path)) as conn:
-            status = conn.execute(
-                "SELECT status FROM memory_update_queue"
-            ).fetchone()[0]
+            status = conn.execute("SELECT status FROM memory_update_queue").fetchone()[0]
         assert status == "failed"
 
     def test_exception_in_update_is_caught(self, db_path):
@@ -251,9 +222,7 @@ class TestRunWriterLoop:
             run_writer_loop(db_path, "worker-1")
 
         with sqlite3.connect(str(db_path)) as conn:
-            status = conn.execute(
-                "SELECT status FROM memory_update_queue"
-            ).fetchone()[0]
+            status = conn.execute("SELECT status FROM memory_update_queue").fetchone()[0]
         assert status == "failed"
 
     def test_agent_name_sentinel_round_trip(self, db_path):
@@ -301,9 +270,7 @@ class TestScheduleMemoryUpdate:
             # schedule_memory_update spawns a daemon thread; give it a moment.
             for _ in range(50):
                 with sqlite3.connect(str(db_path)) as conn:
-                    row = conn.execute(
-                        "SELECT status FROM memory_update_queue WHERE thread_id='t-1'"
-                    ).fetchone()
+                    row = conn.execute("SELECT status FROM memory_update_queue WHERE thread_id='t-1'").fetchone()
                 if row is not None and row[0] in {"done", "failed"}:
                     break
                 time.sleep(0.05)

--- a/backend/tests/test_memory_writer_queue_multiprocess.py
+++ b/backend/tests/test_memory_writer_queue_multiprocess.py
@@ -1,0 +1,226 @@
+"""Cross-process integration test for the single-writer memory queue.
+
+RFC #2283 is specifically about multi-worker correctness: the per-process
+writer lease must ensure that even when two independent OS processes each
+call ``schedule_memory_update`` concurrently on the same SQLite file, every
+task is executed exactly once and the underlying ``agent_memory.seq``
+counter advances monotonically without any lost updates.
+
+The in-process tests in :mod:`test_memory_writer_queue` exercise the
+lease / queue state machine with mocks, but they cannot detect issues
+that only manifest across process boundaries (for example, schema-init
+races or ``BEGIN EXCLUSIVE`` semantics inside WAL mode).  This test
+closes that gap by spawning real worker processes.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# ``fork`` carries the already-imported deerflow package into children and is
+# significantly faster than ``spawn`` on CI.  We deliberately avoid any
+# SQLite connections in the parent prior to forking so no open handles leak.
+_CTX = mp.get_context("fork") if sys.platform != "win32" else mp.get_context("spawn")
+
+
+def _worker_entry(db_path_str: str, label: str, num_tasks: int) -> None:
+    """Child-process entry point.
+
+    Replaces ``update_memory_from_conversation`` with a real storage write
+    (``load → mutate → save``) so the seq-guard code path is exercised
+    end-to-end, then enqueues *num_tasks* tasks via
+    ``schedule_memory_update``.  Waits briefly for the writer thread (if
+    this process won the lease) to drain the queue before returning.
+    """
+    # Local imports — keep the module importable even without the dev deps.
+    from deerflow.agents.memory import updater as updater_mod
+    from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+    from deerflow.agents.memory.writer_queue import schedule_memory_update
+
+    db_path = Path(db_path_str)
+    storage = SQLiteMemoryStorage(db_path)
+
+    def fake_update(
+        messages,
+        thread_id=None,
+        agent_name=None,
+        correction_detected=False,
+        reinforcement_detected=False,
+    ):
+        # Real load/save so the monotonic ``seq`` guard in SQLiteMemoryStorage
+        # actually runs — that's the invariant this test is verifying.
+        data = storage.load(agent_name=agent_name)
+        facts = list(data.get("facts", []))
+        facts.append({"content": f"{label}:{thread_id}"})
+        data["facts"] = facts
+        return storage.save(data, agent_name=agent_name)
+
+    updater_mod.update_memory_from_conversation = fake_update
+
+    for i in range(num_tasks):
+        schedule_memory_update(
+            db_path,
+            agent_name=None,
+            messages=[],
+            thread_id=f"{label}-{i}",
+        )
+
+    # Give any writer thread spawned in this process time to drain.
+    # run_writer_loop is a daemon thread, so we must wait explicitly before
+    # the process exits.
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        conn = sqlite3.connect(str(db_path), timeout=5)
+        try:
+            pending = conn.execute(
+                "SELECT COUNT(*) FROM memory_update_queue "
+                "WHERE status IN ('pending', 'processing')"
+            ).fetchone()[0]
+            held = conn.execute(
+                "SELECT COUNT(*) FROM memory_writer_lock"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        if pending == 0 and held == 0:
+            return
+        time.sleep(0.1)
+
+
+def _drain_remaining(db_path: Path) -> None:
+    """Parent-side drain: run a writer loop until the queue is empty.
+
+    The test spawns two processes; only one of them can hold the writer
+    lease at any given moment, so the losing process may exit with pending
+    work still in the queue (processed by the winner).  Once both children
+    have joined, we run a final writer loop from the parent to mop up any
+    stragglers — this is exactly how a long-lived deployment behaves when
+    the writer process is restarted.
+    """
+    from deerflow.agents.memory import updater as updater_mod
+    from deerflow.agents.memory import writer_queue
+    from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+
+    storage = SQLiteMemoryStorage(db_path)
+
+    def fake_update(
+        messages,
+        thread_id=None,
+        agent_name=None,
+        correction_detected=False,
+        reinforcement_detected=False,
+    ):
+        data = storage.load(agent_name=agent_name)
+        facts = list(data.get("facts", []))
+        facts.append({"content": f"parent:{thread_id}"})
+        data["facts"] = facts
+        return storage.save(data, agent_name=agent_name)
+
+    updater_mod.update_memory_from_conversation = fake_update
+
+    worker_id = f"parent-drainer-{id(db_path)}"
+    # Force-acquire (children have exited, so any stale lease is safe to take).
+    # Age out whatever lease might remain so try_acquire_writer always wins.
+    conn = sqlite3.connect(str(db_path), timeout=5)
+    try:
+        conn.execute("DELETE FROM memory_writer_lock")
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert writer_queue.try_acquire_writer(db_path, worker_id) is True
+    if not writer_queue._writer_running.acquire(blocking=False):
+        # Another thread inside the parent claims to be running; release it.
+        writer_queue._writer_running.release()
+        writer_queue._writer_running.acquire()
+    try:
+        writer_queue.run_writer_loop(db_path, worker_id)
+    finally:
+        if writer_queue._writer_running.locked():
+            try:
+                writer_queue._writer_running.release()
+            except RuntimeError:
+                pass
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="fork-based multiprocessing is Linux/macOS only; spawn mode is too slow for CI",
+)
+def test_two_processes_do_not_lose_writes(tmp_path: Path) -> None:
+    """Two concurrent processes enqueueing on the same DB must not drop writes."""
+    db_path = tmp_path / "memory.db"
+    # Bootstrap the schema before forking so children don't race on CREATE TABLE.
+    from deerflow.agents.memory.writer_queue import init_queue_schema
+
+    init_queue_schema(db_path)
+
+    tasks_per_worker = 5
+    p1 = _CTX.Process(
+        target=_worker_entry,
+        args=(str(db_path), "w1", tasks_per_worker),
+    )
+    p2 = _CTX.Process(
+        target=_worker_entry,
+        args=(str(db_path), "w2", tasks_per_worker),
+    )
+    p1.start()
+    p2.start()
+    p1.join(timeout=30)
+    p2.join(timeout=30)
+
+    assert p1.exitcode == 0, f"worker 1 failed (exitcode={p1.exitcode})"
+    assert p2.exitcode == 0, f"worker 2 failed (exitcode={p2.exitcode})"
+
+    # Drain any tasks the losing process left behind.
+    _drain_remaining(db_path)
+
+    conn = sqlite3.connect(str(db_path), timeout=5)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT status, COUNT(*) AS n FROM memory_update_queue GROUP BY status"
+        ).fetchall()
+        status_counts = {r["status"]: r["n"] for r in rows}
+        seq_row = conn.execute(
+            "SELECT seq, data FROM agent_memory WHERE agent_name = '__global__'"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    total = 2 * tasks_per_worker
+    # Every enqueued task must be in a terminal state.
+    assert status_counts.get("pending", 0) == 0
+    assert status_counts.get("processing", 0) == 0
+    # Every task must have produced a successful LLM update; any 'failed'
+    # here would indicate a seq-guard violation (concurrent load/save race).
+    assert status_counts.get("done", 0) == total, status_counts
+
+    # The storage seq counter must equal the number of successful writes
+    # exactly — proving no last-writer-wins collision swallowed an update.
+    assert seq_row is not None
+    assert int(seq_row["seq"]) == total
+
+    import json
+
+    data = json.loads(seq_row["data"])
+    assert len(data["facts"]) == total
+    # All worker-labelled thread ids must appear in the final memory.
+    contents = {fact["content"] for fact in data["facts"]}
+    expected = {
+        f"{processor}:{task_label}-{i}"
+        for processor in ("w1", "w2", "parent")
+        for task_label in ("w1", "w2")
+        for i in range(tasks_per_worker)
+    }
+    # Each enqueued task appears exactly once; its content prefix is whichever
+    # worker (w1/w2/parent) ended up processing it.  So each ``label-i`` key
+    # must contribute exactly one of the three possible prefixes.
+    seen_keys = {c.split(":", 1)[1] for c in contents}
+    assert seen_keys == {f"{label}-{i}" for label in ("w1", "w2") for i in range(tasks_per_worker)}
+    assert contents.issubset(expected)

--- a/backend/tests/test_memory_writer_queue_multiprocess.py
+++ b/backend/tests/test_memory_writer_queue_multiprocess.py
@@ -78,13 +78,8 @@ def _worker_entry(db_path_str: str, label: str, num_tasks: int) -> None:
     while time.monotonic() < deadline:
         conn = sqlite3.connect(str(db_path), timeout=5)
         try:
-            pending = conn.execute(
-                "SELECT COUNT(*) FROM memory_update_queue "
-                "WHERE status IN ('pending', 'processing')"
-            ).fetchone()[0]
-            held = conn.execute(
-                "SELECT COUNT(*) FROM memory_writer_lock"
-            ).fetchone()[0]
+            pending = conn.execute("SELECT COUNT(*) FROM memory_update_queue WHERE status IN ('pending', 'processing')").fetchone()[0]
+            held = conn.execute("SELECT COUNT(*) FROM memory_writer_lock").fetchone()[0]
         finally:
             conn.close()
         if pending == 0 and held == 0:
@@ -183,13 +178,9 @@ def test_two_processes_do_not_lose_writes(tmp_path: Path) -> None:
     conn = sqlite3.connect(str(db_path), timeout=5)
     conn.row_factory = sqlite3.Row
     try:
-        rows = conn.execute(
-            "SELECT status, COUNT(*) AS n FROM memory_update_queue GROUP BY status"
-        ).fetchall()
+        rows = conn.execute("SELECT status, COUNT(*) AS n FROM memory_update_queue GROUP BY status").fetchall()
         status_counts = {r["status"]: r["n"] for r in rows}
-        seq_row = conn.execute(
-            "SELECT seq, data FROM agent_memory WHERE agent_name = '__global__'"
-        ).fetchone()
+        seq_row = conn.execute("SELECT seq, data FROM agent_memory WHERE agent_name = '__global__'").fetchone()
     finally:
         conn.close()
 
@@ -212,12 +203,7 @@ def test_two_processes_do_not_lose_writes(tmp_path: Path) -> None:
     assert len(data["facts"]) == total
     # All worker-labelled thread ids must appear in the final memory.
     contents = {fact["content"] for fact in data["facts"]}
-    expected = {
-        f"{processor}:{task_label}-{i}"
-        for processor in ("w1", "w2", "parent")
-        for task_label in ("w1", "w2")
-        for i in range(tasks_per_worker)
-    }
+    expected = {f"{processor}:{task_label}-{i}" for processor in ("w1", "w2", "parent") for task_label in ("w1", "w2") for i in range(tasks_per_worker)}
     # Each enqueued task appears exactly once; its content prefix is whichever
     # worker (w1/w2/parent) ended up processing it.  So each ``label-i`` key
     # must contribute exactly one of the three possible prefixes.

--- a/backend/tests/test_sqlite_memory_storage.py
+++ b/backend/tests/test_sqlite_memory_storage.py
@@ -1,0 +1,162 @@
+"""Tests for SQLiteMemoryStorage (RFC #2283)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+
+import pytest
+
+from deerflow.agents.memory.sqlite_storage import SQLiteMemoryStorage
+
+
+@pytest.fixture()
+def db_path(tmp_path):
+    return tmp_path / "memory.db"
+
+
+class TestSQLiteMemoryStorageBasics:
+    def test_load_empty_returns_empty_memory(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        mem = storage.load()
+        assert mem["version"] == "1.0"
+        assert mem["facts"] == []
+
+    def test_save_then_load_roundtrips(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load()  # register seq=0 for this thread
+        payload = {"version": "1.0", "facts": [{"content": "x"}]}
+        assert storage.save(payload) is True
+
+        # A fresh storage instance sees the persisted data.
+        reader = SQLiteMemoryStorage(db_path)
+        loaded = reader.load()
+        assert loaded["facts"] == [{"content": "x"}]
+        assert "lastUpdated" in loaded
+
+    def test_save_does_not_mutate_caller_dict(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load()
+        original = {"version": "1.0", "facts": []}
+        storage.save(original)
+        assert "lastUpdated" not in original
+
+    def test_per_agent_rows_are_isolated(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load(agent_name="a")
+        storage.load(agent_name="b")
+        storage.save({"version": "1.0", "facts": [{"content": "A"}]}, agent_name="a")
+        storage.save({"version": "1.0", "facts": [{"content": "B"}]}, agent_name="b")
+
+        a = storage.load(agent_name="a")
+        b = storage.load(agent_name="b")
+        assert a["facts"] == [{"content": "A"}]
+        assert b["facts"] == [{"content": "B"}]
+
+    def test_seq_monotonically_increments(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load()
+        assert storage.save({"version": "1.0", "facts": []}) is True
+        storage.load()
+        assert storage.save({"version": "1.0", "facts": [{"content": "x"}]}) is True
+
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT seq FROM agent_memory WHERE agent_name='__global__'"
+            ).fetchone()
+        assert row["seq"] == 2
+
+    def test_seq_guard_blocks_concurrent_overwrite(self, db_path):
+        """A stale-load save() must abort rather than overwrite newer state."""
+        writer_a = SQLiteMemoryStorage(db_path)
+        writer_b = SQLiteMemoryStorage(db_path)
+
+        # Both workers read the initial empty state (seq=0).
+        writer_a.load()
+        writer_b.load()
+
+        # Writer B commits first (seq 0 → 1).
+        assert writer_b.save({"version": "1.0", "facts": [{"content": "B"}]}) is True
+
+        # Writer A still holds last_seen=0; its save must fail closed.
+        result = writer_a.save({"version": "1.0", "facts": [{"content": "A"}]})
+        assert result is False
+
+        # The on-disk state remains B — no silent overwrite.
+        reader = SQLiteMemoryStorage(db_path)
+        assert reader.load()["facts"] == [{"content": "B"}]
+
+    def test_load_handles_corrupt_json(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load()
+        storage.save({"version": "1.0", "facts": []})
+
+        # Tamper directly with the row.
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.execute(
+                "UPDATE agent_memory SET data = ? WHERE agent_name='__global__'",
+                ("not-json",),
+            )
+            conn.commit()
+
+        reloaded = storage.reload()
+        assert reloaded["version"] == "1.0"
+        assert reloaded["facts"] == []
+
+    def test_parallel_load_and_save_does_not_cross_contaminate(self, db_path):
+        """Different threads must not share each other's last-seen seq guards."""
+        storage = SQLiteMemoryStorage(db_path)
+        # Seed a row so seq = 1.
+        storage.load()
+        storage.save({"version": "1.0", "facts": []})
+
+        errors: list[BaseException] = []
+
+        def worker():
+            try:
+                # Each thread independently observes seq=1 and saves,
+                # advancing seq to 2 and then 3.  Without per-thread guards
+                # the second thread's last_seen would be 1 while on-disk is
+                # already 2, incorrectly failing the write.
+                for _ in range(3):
+                    storage.load()
+                    ok = storage.save({"version": "1.0", "facts": []})
+                    if not ok:
+                        # Another thread beat us — that's OK for this test,
+                        # we just want to confirm no exception is raised.
+                        pass
+            except BaseException as e:  # pragma: no cover - diagnostic
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors
+
+    def test_schema_is_idempotent(self, db_path):
+        SQLiteMemoryStorage(db_path)
+        # Second construction must not raise.
+        SQLiteMemoryStorage(db_path)
+
+        with sqlite3.connect(str(db_path)) as conn:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_memory'"
+            ).fetchone()
+        assert row is not None
+
+    def test_payload_written_as_json(self, db_path):
+        storage = SQLiteMemoryStorage(db_path)
+        storage.load()
+        storage.save({"version": "1.0", "facts": [{"content": "中文"}]})
+        with sqlite3.connect(str(db_path)) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT data FROM agent_memory WHERE agent_name='__global__'"
+            ).fetchone()
+        parsed = json.loads(row["data"])
+        assert parsed["facts"] == [{"content": "中文"}]

--- a/backend/tests/test_sqlite_memory_storage.py
+++ b/backend/tests/test_sqlite_memory_storage.py
@@ -63,9 +63,7 @@ class TestSQLiteMemoryStorageBasics:
 
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT seq FROM agent_memory WHERE agent_name='__global__'"
-            ).fetchone()
+            row = conn.execute("SELECT seq FROM agent_memory WHERE agent_name='__global__'").fetchone()
         assert row["seq"] == 2
 
     def test_seq_guard_blocks_concurrent_overwrite(self, db_path):
@@ -144,9 +142,7 @@ class TestSQLiteMemoryStorageBasics:
         SQLiteMemoryStorage(db_path)
 
         with sqlite3.connect(str(db_path)) as conn:
-            row = conn.execute(
-                "SELECT name FROM sqlite_master WHERE type='table' AND name='agent_memory'"
-            ).fetchone()
+            row = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='agent_memory'").fetchone()
         assert row is not None
 
     def test_payload_written_as_json(self, db_path):
@@ -155,8 +151,6 @@ class TestSQLiteMemoryStorageBasics:
         storage.save({"version": "1.0", "facts": [{"content": "中文"}]})
         with sqlite3.connect(str(db_path)) as conn:
             conn.row_factory = sqlite3.Row
-            row = conn.execute(
-                "SELECT data FROM agent_memory WHERE agent_name='__global__'"
-            ).fetchone()
+            row = conn.execute("SELECT data FROM agent_memory WHERE agent_name='__global__'").fetchone()
         parsed = json.loads(row["data"])
         assert parsed["facts"] == [{"content": "中文"}]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -707,8 +707,18 @@ summarization:
 # Stores user context and conversation history for personalized responses
 memory:
   enabled: true
-  storage_path: memory.json # Path relative to backend directory
+  storage_path: memory.json # Path relative to backend directory (used by FileMemoryStorage only)
+  # Storage backend class path. The default file backend is single-writer only
+  # and silently loses updates under multi-worker deployments. For
+  # WEB_CONCURRENCY > 1, switch to the SQLite backend which is backed by the
+  # single-writer queue (RFC #2283):
+  #   storage_class: "deerflow.agents.memory.sqlite_storage.SQLiteMemoryStorage"
+  storage_class: "deerflow.agents.memory.storage.FileMemoryStorage"
   debounce_seconds: 30 # Wait time before processing queued updates
+  # Single-writer queue tunables (SQLite backend only):
+  lock_stale_seconds: 90          # Lease considered dead after this many seconds without a heartbeat
+  heartbeat_interval_seconds: 30  # Must be < lock_stale_seconds / 2
+  processing_timeout_seconds: 300 # Stuck 'processing' tasks are reset to 'pending' after this
   model_name: null # Use default model
   max_facts: 100 # Maximum number of facts to store
   fact_confidence_threshold: 0.7 # Minimum confidence for storing facts


### PR DESCRIPTION
## Summary
Implements [RFC #2283](https://github.com/bytedance/deer-flow/issues/2283) by eliminating the multi-worker last-writer-wins behavior in memory updates with a shared SQLite-backed single-writer queue.

## Problem
In multi-worker deployments, separate workers can load the same memory snapshot, run independent updates, and then overwrite each other on save. Atomic file writes keep the file valid, but they do not prevent silent lost updates.

## What changes in this PR
- add the SQLite-backed writer queue backend that serializes the full `load -> LLM update -> save` flow
- add writer lease, heartbeat, sequence guard, and stuck-task recovery so failures do not fall back to silent overwrites
- wire the queue-backed memory path through memory configuration and example config
- add queue, storage, and multiprocess tests for the multi-worker path
- update `README.md`, `backend/README.md`, and `backend/CLAUDE.md` to describe the new behavior and operator guidance

## Why this matches RFC #2283
- removes the silent last-writer-wins race in multi-worker memory updates
- keeps the deployment model simple by using SQLite instead of introducing a separate queue service
- validates the concurrency behavior with dedicated multiprocess coverage

## Reviewer guide
Primary files:
- `backend/packages/harness/deerflow/agents/memory/writer_queue.py`
- `backend/packages/harness/deerflow/agents/memory/sqlite_storage.py`
- `backend/packages/harness/deerflow/agents/memory/queue.py`
- `backend/packages/harness/deerflow/config/memory_config.py`
- `backend/tests/test_memory_writer_queue_multiprocess.py`

## Validation
- `make lint`
- `make test`