### PR TITLE
feat(middleware): model-agnostic tool-args normalization for schema drift

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -225,6 +225,23 @@ def _build_middlewares(config: RunnableConfig, model_name: str | None, agent_nam
     """
     middlewares = build_lead_runtime_middlewares(lazy_init=True)
 
+    # Middlewares that behave differently per model family must be gated —
+    # applying them to unrelated models would actively degrade quality.
+    # Currently only the Gemma 4 thought-channel cleanup falls into this
+    # category: the ``<|channel>…<channel|>`` block format is Gemma-specific,
+    # and stripping it from another model's history would mangle output.
+    # Registration order matters here: this must run before
+    # Summarization/Memory/Title so they see the pruned history.
+    app_config = get_app_config()
+    model_config_for_gating = app_config.get_model_config(model_name) if model_name else None
+    if model_config_for_gating is not None:
+        from deerflow.models.factory import is_gemma4
+
+        if is_gemma4(model_config_for_gating):
+            from deerflow.agents.middlewares.gemma_thought_cleanup_middleware import GemmaThoughtCleanupMiddleware
+
+            middlewares.append(GemmaThoughtCleanupMiddleware())
+
     # Add summarization middleware if enabled
     summarization_middleware = _create_summarization_middleware()
     if summarization_middleware is not None:
@@ -342,7 +359,12 @@ def make_lead_agent(config: RunnableConfig):
             model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
             tools=get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled) + [setup_agent],
             middleware=_build_middlewares(config, model_name=model_name),
-            system_prompt=apply_prompt_template(subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, available_skills=set(["bootstrap"])),
+            system_prompt=apply_prompt_template(
+                subagent_enabled=subagent_enabled,
+                max_concurrent_subagents=max_concurrent_subagents,
+                available_skills=set(["bootstrap"]),
+                model_name=model_name,
+            ),
             state_schema=ThreadState,
         )
 
@@ -352,7 +374,11 @@ def make_lead_agent(config: RunnableConfig):
         tools=get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled),
         middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name),
         system_prompt=apply_prompt_template(
-            subagent_enabled=subagent_enabled, max_concurrent_subagents=max_concurrent_subagents, agent_name=agent_name, available_skills=set(agent_config.skills) if agent_config and agent_config.skills is not None else None
+            subagent_enabled=subagent_enabled,
+            max_concurrent_subagents=max_concurrent_subagents,
+            agent_name=agent_name,
+            available_skills=set(agent_config.skills) if agent_config and agent_config.skills is not None else None,
+            model_name=model_name,
         ),
         state_schema=ThreadState,
     )

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -242,6 +242,19 @@ def _build_middlewares(config: RunnableConfig, model_name: str | None, agent_nam
 
             middlewares.append(GemmaThoughtCleanupMiddleware())
 
+    # Tool-args normalization is registered unconditionally because it is a
+    # model-agnostic safety net. It only mutates tool calls that ship with
+    # known quirks (``file_path`` alias for ``path``, missing ``description``);
+    # for correctly-formed tool calls it is a no-op. Observed originally on
+    # Magistral and Gemma 4 27B, but the pattern — training conventions from
+    # other schemas leaking into tool arguments — can surface on any local
+    # or third-party model, so gating it per-family would just delay the
+    # fix for the next model that ships with the same quirk. Every actual
+    # mutation is logged at INFO level for discovery.
+    from deerflow.agents.middlewares.tool_args_normalization_middleware import ToolArgsNormalizationMiddleware
+
+    middlewares.append(ToolArgsNormalizationMiddleware())
+
     # Add summarization middleware if enabled
     summarization_middleware = _create_summarization_middleware()
     if summarization_middleware is not None:

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -8,8 +8,35 @@ from deerflow.config.agents_config import load_agent_soul
 from deerflow.skills import load_skills
 from deerflow.skills.types import Skill
 from deerflow.subagents import get_available_subagent_names
+from deerflow.utils.text_sanitize import strip_symbols_and_invisibles
 
 logger = logging.getLogger(__name__)
+
+
+UI_STYLE_RULES_SECTION = """
+
+<gemma_output_rules>
+This rule overrides any general output-style guidance above.
+
+NO EMOJI — EVER.
+- Do NOT emit any emoji, pictograph, or decorative symbol in your output.
+  This applies to ALL output: chat replies, summaries, reports, code, UI
+  deliverables, thread titles, explanations, headings, bullets, everything.
+- Forbidden character ranges include (not exhaustive):
+  U+1F300-U+1FAFF (emoji & pictographs), U+2600-U+27BF (misc symbols /
+  dingbats), U+2B00-U+2BFF (arrows / misc symbols), U+1F1E6-U+1F1FF
+  (regional-indicator flags), U+E000-U+F8FF (Nerdfont / FontAwesome /
+  Material Icon Private-Use Area).
+- Also avoid ASCII substitutes that carry the same decorative intent:
+  no leading "►", "✓", "✦", "★", "◆", "→", etc. as bullet or heading
+  ornaments. Use plain text and standard Markdown syntax only.
+- For icons in frontend/UI deliverables: emit inline SVG only
+  (Heroicons, Lucide, Tabler, Phosphor). Never icon fonts, never PUA
+  characters. Prefer stroke="currentColor" with explicit width/height.
+- If a literal emoji appears inside content you are quoting or citing
+  (e.g. a forum post), paraphrase it in words — do not pass it through.
+</gemma_output_rules>
+"""
 
 _ENABLED_SKILLS_REFRESH_WAIT_TIMEOUT_SECONDS = 5.0
 _enabled_skills_lock = threading.Lock()
@@ -653,7 +680,13 @@ def _build_acp_section() -> str:
 
 
 def _build_custom_mounts_section() -> str:
-    """Build a prompt section for explicitly configured sandbox mounts."""
+    """Build a prompt section for explicitly configured sandbox mounts.
+
+    Detects a full-host mount (``host_path: /``) and, if present, adds an
+    explicit capability statement so the model knows it can roam the host
+    freely. Individual mounts are still listed so the model sees which
+    container paths map to what.
+    """
     try:
         from deerflow.config import get_app_config
 
@@ -666,15 +699,48 @@ def _build_custom_mounts_section() -> str:
         return ""
 
     lines = []
+    full_host_mount = None
     for mount in mounts:
         access = "read-only" if mount.read_only else "read-write"
         lines.append(f"- Custom mount: `{mount.container_path}` - Host directory mapped into the sandbox ({access})")
+        if getattr(mount, "host_path", None) == "/" and not mount.read_only and full_host_mount is None:
+            full_host_mount = mount
 
     mounts_list = "\n".join(lines)
-    return f"\n**Custom Mounted Directories:**\n{mounts_list}\n- If the user needs files outside `/mnt/user-data`, use these absolute container paths directly when they match the requested directory"
+    section = f"\n**Custom Mounted Directories:**\n{mounts_list}\n- If the user needs files outside `/mnt/user-data`, use these absolute container paths directly when they match the requested directory"
+
+    if full_host_mount is not None:
+        prefix = full_host_mount.container_path.rstrip("/")
+        section += (
+            "\n\n**Full Host Access (enabled):**"
+            f"\n- The entire host filesystem is mounted read-write at `{prefix}`. "
+            f"Any real path `/foo/bar` on the host is reachable at `{prefix}/foo/bar`."
+            "\n- You also have `bash` with host execution enabled; absolute host paths"
+            " (e.g. `/home/atlas/...`, `/etc/...`, `/var/log/...`) can be used directly"
+            " inside `bash` commands without any prefix."
+            "\n- There are no directory whitelists or path restrictions — you can roam,"
+            " inspect, edit, create, or delete anything the operating-system user has"
+            " permission for. Use this responsibly:"
+            "\n  - Read the user's real intent before touching system files."
+            "\n  - Prefer least-invasive actions: dry-run, `ls`, `cat` before mutation."
+            "\n  - Destructive commands (`rm -rf`, overwrite configs, kill processes,"
+            " package removal) require clear user intent — ask via `ask_clarification`"
+            " when in doubt."
+            "\n  - Never exfiltrate credentials, SSH keys, tokens, or browser profiles"
+            " to external services or tool results."
+        )
+
+    return section
 
 
-def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagents: int = 3, *, agent_name: str | None = None, available_skills: set[str] | None = None) -> str:
+def apply_prompt_template(
+    subagent_enabled: bool = False,
+    max_concurrent_subagents: int = 3,
+    *,
+    agent_name: str | None = None,
+    available_skills: set[str] | None = None,
+    model_name: str | None = None,
+) -> str:
     # Get memory context
     memory_context = _get_memory_context(agent_name)
 
@@ -723,5 +789,15 @@ def apply_prompt_template(subagent_enabled: bool = False, max_concurrent_subagen
         subagent_thinking=subagent_thinking,
         acp_section=acp_and_mounts_section,
     )
+
+    # Gemma 4: keep all DeerFlow instructions verbatim, but strip decorative
+    # emoji/pictograph characters (they cost tokens and bias Gemma toward
+    # emoji-laden UI output) and append the stricter UI style contract.
+    if model_name:
+        from deerflow.models.factory import is_gemma4_by_name
+
+        if is_gemma4_by_name(model_name):
+            prompt = strip_symbols_and_invisibles(prompt)
+            prompt += UI_STYLE_RULES_SECTION
 
     return prompt + f"\n<current_date>{datetime.now().strftime('%Y-%m-%d, %A')}</current_date>"

--- a/backend/packages/harness/deerflow/agents/middlewares/gemma_thought_cleanup_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/gemma_thought_cleanup_middleware.py
@@ -1,0 +1,134 @@
+"""Middleware that removes Gemma 4 thought blocks from historical model turns.
+
+Google's Gemma 4 prompt-formatting guide requires that ``<|channel>...<channel|>``
+reasoning blocks from previous model turns be stripped before the next user
+turn is submitted — except while a tool-call sequence is still in flight. Left
+in place they inflate the input token budget and can destabilize the 26B/31B
+variants, which may then hallucinate further reasoning channels.
+
+Design mirrors :class:`DanglingToolCallMiddleware` — we intercept the request
+via ``wrap_model_call`` so only the payload sent to the model is cleaned;
+persistent thread state keeps the original AIMessages intact for tracing,
+LangSmith, and UI inspection.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, ToolMessage
+
+from deerflow.utils.text_sanitize import strip_gemma_channel_blocks
+
+logger = logging.getLogger(__name__)
+
+
+class GemmaThoughtCleanupMiddleware(AgentMiddleware[AgentState]):
+    """Strips Gemma 4 channel blocks from historical AIMessages before model invocation."""
+
+    @staticmethod
+    def _has_outstanding_tool_calls(messages: list, index: int) -> bool:
+        """Return True if messages[index] is part of an in-flight tool-call sequence."""
+        msg = messages[index]
+        tool_calls = getattr(msg, "tool_calls", None) or []
+        if not tool_calls:
+            return False
+        outstanding = {tc.get("id") for tc in tool_calls if tc.get("id")}
+        if not outstanding:
+            return False
+        for subsequent in messages[index + 1 :]:
+            if isinstance(subsequent, ToolMessage) and subsequent.tool_call_id in outstanding:
+                outstanding.discard(subsequent.tool_call_id)
+            if not outstanding:
+                return False
+        return bool(outstanding)
+
+    @staticmethod
+    def _clean_text(text: str) -> str:
+        return strip_gemma_channel_blocks(text)
+
+    def _clean_content(self, content):
+        """Clean AIMessage.content, which can be a plain string or a list of content blocks."""
+        if isinstance(content, str):
+            return self._clean_text(content)
+        if isinstance(content, list):
+            new_parts: list = []
+            for part in content:
+                if isinstance(part, str):
+                    new_parts.append(self._clean_text(part))
+                elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                    new_part = dict(part)
+                    new_part["text"] = self._clean_text(part["text"])
+                    new_parts.append(new_part)
+                else:
+                    new_parts.append(part)
+            return new_parts
+        return content
+
+    def _build_cleaned_messages(self, messages: list) -> list | None:
+        """Return a new message list with channel blocks removed, or None if no change."""
+        if not messages:
+            return None
+
+        cleaned: list = []
+        mutated = False
+        for index, msg in enumerate(messages):
+            if not isinstance(msg, AIMessage):
+                cleaned.append(msg)
+                continue
+
+            if self._has_outstanding_tool_calls(messages, index):
+                # In-flight tool-call sequence — Gemma 4 expects its own thoughts
+                # echoed back in this window. Leave untouched.
+                cleaned.append(msg)
+                continue
+
+            new_content = self._clean_content(msg.content)
+            if new_content == msg.content:
+                cleaned.append(msg)
+                continue
+
+            mutated = True
+            cleaned.append(
+                AIMessage(
+                    id=msg.id,
+                    content=new_content,
+                    name=msg.name,
+                    tool_calls=msg.tool_calls,
+                    invalid_tool_calls=getattr(msg, "invalid_tool_calls", []),
+                    additional_kwargs=msg.additional_kwargs,
+                    response_metadata=msg.response_metadata,
+                    usage_metadata=msg.usage_metadata,
+                )
+            )
+
+        if not mutated:
+            return None
+        return cleaned
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        cleaned = self._build_cleaned_messages(request.messages)
+        if cleaned is not None:
+            request = request.override(messages=cleaned)
+        return handler(request)
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        cleaned = self._build_cleaned_messages(request.messages)
+        if cleaned is not None:
+            request = request.override(messages=cleaned)
+        return await handler(request)

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -88,8 +88,15 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         return prompt, user_msg
 
     def _strip_think_tags(self, text: str) -> str:
-        """Remove <think>...</think> blocks emitted by reasoning models (e.g. minimax, DeepSeek-R1)."""
-        return re.sub(r"<think>[\s\S]*?</think>", "", text, flags=re.IGNORECASE).strip()
+        """Remove reasoning-model scratchpad blocks before scoring a title.
+
+        Covers ``<think>...</think>`` (minimax, DeepSeek-R1) and the Gemma 4
+        channel form ``<|channel>...<channel|>``. Non-matching models pass
+        through unchanged.
+        """
+        text = re.sub(r"<think>[\s\S]*?</think>", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"<\|?channel\|?>[\s\S]*?<\|?channel\|?>", "", text)
+        return text.strip()
 
     def _parse_title(self, content: object) -> str:
         """Normalize model output into a clean title string."""

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_args_normalization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_args_normalization_middleware.py
@@ -1,0 +1,193 @@
+"""Middleware that normalizes tool-call arguments for models with schema drift.
+
+Local and third-party models occasionally emit tool calls using parameter
+names from their own training data rather than the schema DeerFlow's
+sandbox tools actually expose. Two patterns have been observed in real
+threads and are fixed here:
+
+* ``file_path`` (or ``filepath``) where the schema wants ``path`` — the
+  alias is Mistral's generic file-tool convention and surfaces on every
+  file-oriented tool the model tries to call.
+* Missing ``description`` — DeerFlow's sandbox tools declare this as a
+  required first argument for audit-logging purposes; models that were
+  trained on schemas without it simply omit the field.
+
+The middleware is registered **unconditionally** (see
+``lead_agent/agent.py``) because the pattern is model-agnostic: the same
+training quirk can appear on any model that arrives with its own tool-use
+convention. For correctly-formed tool calls the middleware is a no-op —
+it returns the original response object by identity, so ``wrap_model_call``
+adds no measurable overhead on the happy path.
+
+The hook point is :meth:`wrap_model_call`: we intercept the ModelResponse
+and mutate the ``tool_calls`` list on each AIMessage before it is
+dispatched to the tool executor. The rewritten calls are what ends up
+persisted in the thread state, so UI, LangSmith and replay all agree on
+what was actually executed. Every mutation is logged at INFO level so
+newly-emerging quirks are discoverable via log search rather than having
+to register a model in a gate list.
+
+The alias map is intentionally narrow. Only aliases observed on real
+responses are translated, so genuine schema violations surface as
+ToolErrorHandlingMiddleware errors instead of being silently masked. To
+add a new alias, extend ``_FILE_PATH_ALIASES`` (or add a new alias set
+with the same pattern) and include a regression test.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage
+
+logger = logging.getLogger(__name__)
+
+
+AUTO_DESCRIPTION_MARKER = "(auto-filled: model did not provide description)"
+
+_FILE_PATH_ALIASES = {"file_path", "filepath"}
+
+
+class ToolArgsNormalizationMiddleware(AgentMiddleware[AgentState]):
+    """Rewrites tool-call arguments to match DeerFlow's sandbox schema."""
+
+    @staticmethod
+    def _normalize_args(tool_name: str, args: dict) -> tuple[dict, bool]:
+        """Return (normalized_args, mutated). Pure function, ``args`` is not mutated."""
+        if not isinstance(args, dict):
+            return args, False
+
+        new_args = dict(args)
+        mutated = False
+
+        # Alias: file_path / filepath → path. Only applied if ``path`` isn't
+        # already set (schema-correct calls win, conflicts favour the schema).
+        for alias in _FILE_PATH_ALIASES:
+            if alias in new_args:
+                if "path" not in new_args:
+                    new_args["path"] = new_args.pop(alias)
+                    mutated = True
+                else:
+                    new_args.pop(alias)
+                    mutated = True
+
+        # Missing description — all sandbox tools declare it as required.
+        # Only auto-fill for tools that have it in their signature; we
+        # conservatively key on tool_name since the schema is stable.
+        if tool_name in _TOOLS_REQUIRING_DESCRIPTION and "description" not in new_args:
+            new_args["description"] = AUTO_DESCRIPTION_MARKER
+            mutated = True
+
+        return new_args, mutated
+
+    @classmethod
+    def _normalize_tool_calls(cls, tool_calls: list) -> tuple[list, bool]:
+        if not tool_calls:
+            return tool_calls, False
+
+        new_calls: list = []
+        any_mutated = False
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                new_calls.append(tc)
+                continue
+            tool_name = tc.get("name") or ""
+            args = tc.get("args") or {}
+            new_args, mutated = cls._normalize_args(tool_name, args)
+            if mutated:
+                any_mutated = True
+                rebuilt = dict(tc)
+                rebuilt["args"] = new_args
+                new_calls.append(rebuilt)
+                logger.info(
+                    "tool-args normalized for %s (original keys=%s, final keys=%s)",
+                    tool_name,
+                    sorted(args.keys()) if isinstance(args, dict) else "n/a",
+                    sorted(new_args.keys()),
+                )
+            else:
+                new_calls.append(tc)
+        return new_calls, any_mutated
+
+    @classmethod
+    def _normalize_messages(cls, messages: list) -> list | None:
+        """Return a new list of messages with tool_calls normalized, or None if nothing changed."""
+        if not messages:
+            return None
+
+        result: list = []
+        mutated_any = False
+        for msg in messages:
+            if not isinstance(msg, AIMessage):
+                result.append(msg)
+                continue
+            tool_calls = getattr(msg, "tool_calls", None) or []
+            new_calls, mutated = cls._normalize_tool_calls(tool_calls)
+            if not mutated:
+                result.append(msg)
+                continue
+            mutated_any = True
+            result.append(
+                AIMessage(
+                    id=msg.id,
+                    content=msg.content,
+                    name=msg.name,
+                    tool_calls=new_calls,
+                    invalid_tool_calls=getattr(msg, "invalid_tool_calls", []),
+                    additional_kwargs=msg.additional_kwargs,
+                    response_metadata=msg.response_metadata,
+                    usage_metadata=msg.usage_metadata,
+                )
+            )
+        return result if mutated_any else None
+
+    @classmethod
+    def _normalize_response(cls, response):
+        """Normalize a ModelResponse (or bare AIMessage) returned by ``handler(request)``."""
+        if isinstance(response, AIMessage):
+            normalized = cls._normalize_messages([response])
+            if normalized is None:
+                return response
+            return normalized[0]
+        result = getattr(response, "result", None)
+        if not isinstance(result, list):
+            return response
+        normalized = cls._normalize_messages(result)
+        if normalized is None:
+            return response
+        response.result = normalized
+        return response
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        response = handler(request)
+        return self._normalize_response(response)
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        response = await handler(request)
+        return self._normalize_response(response)
+
+
+_TOOLS_REQUIRING_DESCRIPTION = {
+    "bash",
+    "ls",
+    "glob",
+    "grep",
+    "read_file",
+    "write_file",
+    "str_replace",
+}

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -235,6 +235,7 @@ class DeerFlowClient:
                 max_concurrent_subagents=max_concurrent_subagents,
                 agent_name=self._agent_name,
                 available_skills=self._available_skills,
+                model_name=model_name,
             ),
             "state_schema": ThreadState,
         }

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -20,6 +20,38 @@ def _deep_merge_dicts(base: dict | None, override: dict) -> dict:
     return merged
 
 
+def is_gemma4(model_config) -> bool:
+    """Return True when the given ModelConfig represents a Gemma 4 family model.
+
+    Detection is dual: an explicit ``family: gemma4`` field in the config takes
+    precedence, otherwise the model name prefix ``gemma4-`` is matched. Keeping
+    both paths lets users rename models freely while still opting in via the
+    explicit flag.
+    """
+    if model_config is None:
+        return False
+    extra = getattr(model_config, "model_extra", None) or {}
+    if extra.get("family") == "gemma4":
+        return True
+    name = getattr(model_config, "name", None) or ""
+    return name.lower().startswith("gemma4")
+
+
+def is_gemma4_by_name(name: str | None) -> bool:
+    """Resolve a model name through the app config and check the Gemma 4 gate."""
+    if not name:
+        return False
+    try:
+        from deerflow.config import get_app_config
+
+        model_config = get_app_config().get_model_config(name)
+    except Exception:
+        model_config = None
+    if model_config is not None:
+        return is_gemma4(model_config)
+    return name.lower().startswith("gemma4")
+
+
 def _vllm_disable_chat_template_kwargs(chat_template_kwargs: dict) -> dict:
     """Build the disable payload for vLLM/Qwen chat template kwargs."""
     disable_kwargs: dict[str, bool] = {}
@@ -75,6 +107,7 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
             "when_thinking_disabled",
             "thinking",
             "supports_vision",
+            "family",
         },
     )
     # Compute effective when_thinking_enabled by merging in the `thinking` shortcut field.
@@ -113,7 +146,21 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
         kwargs.pop("reasoning_effort", None)
         model_settings_from_config.pop("reasoning_effort", None)
 
+    # Upstream (c99865f, 2026-04): enable stream_usage by default for
+    # OpenAI-compatible providers so token-usage deltas arrive with streaming
+    # chunks. Applied before the Gemma override so a potential
+    # ``stream_usage`` knob set by this call is still visible to later
+    # model-family overrides if they ever need to touch it.
     _enable_stream_usage_by_default(model_config.use, model_settings_from_config)
+
+    # Gemma 4 family: apply Google's recommended sampling envelope. Temperature
+    # is hard-overridden to 0.9 (user choice, between Google's 1.0 default and
+    # the previous project default of 0.7). top_p / top_k use setdefault so
+    # explicit per-model values in config.yaml still win.
+    if is_gemma4(model_config):
+        model_settings_from_config["temperature"] = 0.9
+        model_settings_from_config.setdefault("top_p", 0.95)
+        model_settings_from_config.setdefault("top_k", 64)
 
     # For Codex Responses API models: map thinking mode to reasoning_effort
     from deerflow.models.openai_codex_provider import CodexChatModel

--- a/backend/packages/harness/deerflow/utils/text_sanitize.py
+++ b/backend/packages/harness/deerflow/utils/text_sanitize.py
@@ -1,0 +1,93 @@
+"""Shared text sanitization helpers.
+
+Provides reusable sanitizers for two concerns:
+
+1. ``strip_symbols_and_invisibles`` — removes emoji/pictograph blocks, icon-font
+   private-use-area characters, BiDi/invisible control characters, variation
+   selectors, and related Unicode ranges. Used both by the SearXNG web-search
+   tool (to defang injection payloads hidden in third-party content) and by the
+   Gemma 4 prompt pipeline (to strip decorative emojis that would otherwise
+   cost tokens and bias deliverables toward emoji-heavy UI output).
+
+2. ``strip_gemma_channel_blocks`` — removes Gemma 4 internal reasoning markers
+   (``<|channel>thought\\n...<channel|>``) that must be dropped from historical
+   model turns per Google's Gemma 4 prompt-formatting documentation.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Unicode ranges covering emoji, pictographs, icon-font private-use characters,
+# and invisible/BiDi control characters that can be abused for prompt injection
+# or bloat deliverables.
+_UNSAFE_CHAR_RE = re.compile(
+    "["
+    # Invisible & BiDi control
+    "\u00ad"  # soft hyphen
+    "\u061c"  # Arabic letter mark
+    "\u180e"  # Mongolian vowel separator
+    "\u200b-\u200f"  # ZWSP/ZWNJ/ZWJ/LRM/RLM
+    "\u202a-\u202e"  # LRE/RLE/PDF/LRO/RLO (BiDi override)
+    "\u2060-\u206f"  # WJ, invisible times/separator, etc.
+    "\ufe00-\ufe0f"  # variation selectors
+    "\ufeff"  # BOM / zero-width no-break space
+    "\ufff9-\ufffb"  # interlinear annotation
+    "\U000e0000-\U000e007f"  # tag characters (invisible)
+    "\U000e0100-\U000e01ef"  # variation selectors supplement
+    # Symbol & pictograph blocks (emoji families)
+    "\u2300-\u23ff"  # misc technical
+    "\u2460-\u24ff"  # enclosed alphanumerics
+    "\u2500-\u257f"  # box drawing
+    "\u2580-\u259f"  # block elements
+    "\u25a0-\u25ff"  # geometric shapes
+    "\u2600-\u26ff"  # misc symbols
+    "\u2700-\u27bf"  # dingbats
+    "\u2b00-\u2bff"  # misc symbols and arrows
+    "\u2934-\u2935"  # curved arrows commonly used as icons
+    "\U0001f000-\U0001ffff"  # SMP symbol/emoji planes
+    # Private use areas — used by Nerdfonts / FontAwesome / material icons
+    "\ue000-\uf8ff"  # BMP PUA
+    "\U000f0000-\U000ffffd"  # SPUA-A
+    "\U00100000-\U0010fffd"  # SPUA-B
+    "]"
+)
+
+# Matches Gemma 4 reasoning blocks emitted between `<|channel>` and `<channel|>`.
+# Accepts both the tokenizer-literal form and variants that sometimes leak with
+# extra pipe characters (`<|channel|>foo<|channel|>` etc.).
+_GEMMA_CHANNEL_RE = re.compile(
+    r"<\|?channel\|?>[\s\S]*?<\|?channel\|?>",
+    flags=re.IGNORECASE,
+)
+
+
+def strip_symbols_and_invisibles(text: str) -> str:
+    """Remove emojis, pictographs, icon-font PUA characters, and invisible controls.
+
+    Preserves ordinary ASCII, CJK text, punctuation, and whitespace structure.
+    Whitespace is intentionally left untouched so Markdown/code blocks and
+    indentation stay intact; callers that need whitespace normalization should
+    handle it after this pass.
+    """
+    if not text:
+        return ""
+    return _UNSAFE_CHAR_RE.sub("", text)
+
+
+def strip_gemma_channel_blocks(text: str) -> str:
+    """Remove Gemma 4 ``<|channel>...<channel|>`` reasoning blocks.
+
+    Non-destructive for any input that does not contain channel markers, which
+    makes it safe to apply unconditionally when Gemma 4 is the active model
+    (other Gemma-family outputs simply pass through).
+    """
+    if not text:
+        return ""
+    return _GEMMA_CHANNEL_RE.sub("", text)
+
+
+__all__ = [
+    "strip_symbols_and_invisibles",
+    "strip_gemma_channel_blocks",
+]

--- a/backend/tests/test_gemma4_gating.py
+++ b/backend/tests/test_gemma4_gating.py
@@ -1,0 +1,324 @@
+"""Tests for Gemma 4 detection, factory gating, sanitization, and cleanup middleware."""
+
+from __future__ import annotations
+
+from langchain.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from deerflow.agents.lead_agent import prompt as prompt_module
+from deerflow.agents.middlewares.gemma_thought_cleanup_middleware import (
+    GemmaThoughtCleanupMiddleware,
+)
+from deerflow.agents.middlewares.title_middleware import TitleMiddleware
+from deerflow.config.app_config import AppConfig
+from deerflow.config.model_config import ModelConfig
+from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.models import factory as factory_module
+from deerflow.utils.text_sanitize import strip_gemma_channel_blocks, strip_symbols_and_invisibles
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_model_factory.py patterns)
+# ---------------------------------------------------------------------------
+
+
+def _make_app_config(models: list[ModelConfig]) -> AppConfig:
+    return AppConfig(
+        models=models,
+        sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"),
+    )
+
+
+def _make_model(name: str = "gemma4-4b", *, family: str | None = None, **extras) -> ModelConfig:
+    kwargs = dict(
+        name=name,
+        display_name=name,
+        description=None,
+        use="langchain_ollama:ChatOllama",
+        model=name,
+    )
+    if family is not None:
+        kwargs["family"] = family
+    kwargs.update(extras)
+    return ModelConfig(**kwargs)
+
+
+class FakeChatModel(BaseChatModel):
+    captured_kwargs: dict = {}
+
+    def __init__(self, **kwargs):
+        FakeChatModel.captured_kwargs = dict(kwargs)
+        super().__init__(**kwargs)
+
+    @property
+    def _llm_type(self) -> str:
+        return "fake"
+
+    def _generate(self, *args, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+    def _stream(self, *args, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _patch_factory(monkeypatch, app_config: AppConfig, model_class=FakeChatModel):
+    monkeypatch.setattr(factory_module, "get_app_config", lambda: app_config)
+    monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: model_class)
+    monkeypatch.setattr(factory_module, "build_tracing_callbacks", lambda: [])
+
+
+# ---------------------------------------------------------------------------
+# 1. Detection: is_gemma4
+# ---------------------------------------------------------------------------
+
+
+def test_is_gemma4_matches_name_prefix():
+    assert factory_module.is_gemma4(_make_model("gemma4-4b")) is True
+    assert factory_module.is_gemma4(_make_model("gemma4-27b")) is True
+
+
+def test_is_gemma4_matches_explicit_family():
+    assert factory_module.is_gemma4(_make_model("custom-name", family="gemma4")) is True
+
+
+def test_is_gemma4_false_for_non_gemma_models():
+    assert factory_module.is_gemma4(_make_model("claude-opus-4-7")) is False
+    assert factory_module.is_gemma4(_make_model("gpt-4o")) is False
+    assert factory_module.is_gemma4(None) is False
+
+
+# ---------------------------------------------------------------------------
+# 2-4. Factory gating — temperature override and top-p/k setdefault
+# ---------------------------------------------------------------------------
+
+
+def test_gemma4_hard_overrides_temperature(monkeypatch):
+    """Even when config explicitly sets 0.7, Gemma 4 must end up at 0.9."""
+    cfg = _make_app_config([_make_model("gemma4-4b", temperature=0.7)])
+    _patch_factory(monkeypatch, cfg)
+
+    FakeChatModel.captured_kwargs = {}
+    factory_module.create_chat_model(name="gemma4-4b")
+
+    assert FakeChatModel.captured_kwargs["temperature"] == 0.9
+
+
+def test_gemma4_sets_top_p_and_top_k_defaults(monkeypatch):
+    cfg = _make_app_config([_make_model("gemma4-4b")])
+    _patch_factory(monkeypatch, cfg)
+
+    FakeChatModel.captured_kwargs = {}
+    factory_module.create_chat_model(name="gemma4-4b")
+
+    assert FakeChatModel.captured_kwargs["top_p"] == 0.95
+    assert FakeChatModel.captured_kwargs["top_k"] == 64
+
+
+def test_gemma4_respects_explicit_top_p_override(monkeypatch):
+    cfg = _make_app_config([_make_model("gemma4-4b", top_p=0.8)])
+    _patch_factory(monkeypatch, cfg)
+
+    FakeChatModel.captured_kwargs = {}
+    factory_module.create_chat_model(name="gemma4-4b")
+
+    assert FakeChatModel.captured_kwargs["top_p"] == 0.8
+    assert FakeChatModel.captured_kwargs["top_k"] == 64
+
+
+def test_non_gemma_temperature_untouched(monkeypatch):
+    cfg = _make_app_config([_make_model("claude-opus", temperature=0.7)])
+    _patch_factory(monkeypatch, cfg)
+
+    FakeChatModel.captured_kwargs = {}
+    factory_module.create_chat_model(name="claude-opus")
+
+    assert FakeChatModel.captured_kwargs["temperature"] == 0.7
+    assert "top_p" not in FakeChatModel.captured_kwargs
+    assert "top_k" not in FakeChatModel.captured_kwargs
+
+
+def test_family_field_is_excluded_from_kwargs(monkeypatch):
+    """`family` is an internal marker and must not reach the provider constructor."""
+    cfg = _make_app_config([_make_model("gemma-custom", family="gemma4")])
+    _patch_factory(monkeypatch, cfg)
+
+    FakeChatModel.captured_kwargs = {}
+    factory_module.create_chat_model(name="gemma-custom")
+
+    assert "family" not in FakeChatModel.captured_kwargs
+
+
+# ---------------------------------------------------------------------------
+# 5-6. Sanitizer utilities
+# ---------------------------------------------------------------------------
+
+
+def test_strip_symbols_removes_emoji_and_pictographs():
+    assert strip_symbols_and_invisibles("Hello 🔥 World") == "Hello  World"
+    assert strip_symbols_and_invisibles("Flag 🇩🇪 here") == "Flag  here"
+
+
+def test_strip_symbols_removes_invisibles_and_bidi():
+    # ZWSP, BiDi override, BOM, soft hyphen
+    assert strip_symbols_and_invisibles("zero\u200bwidth") == "zerowidth"
+    assert strip_symbols_and_invisibles("Normal\u202etext") == "Normaltext"
+
+
+def test_strip_symbols_removes_private_use_nerdfont():
+    # U+F000 is in the BMP PUA range (typical Nerdfont glyph)
+    assert strip_symbols_and_invisibles("Nerd\uf000icon") == "Nerdicon"
+
+
+def test_strip_symbols_preserves_common_text():
+    assert strip_symbols_and_invisibles("a < b and c > d") == "a < b and c > d"
+    assert strip_symbols_and_invisibles('JSON {"x": 1}') == 'JSON {"x": 1}'
+
+
+def test_strip_gemma_channel_removes_block():
+    text = "before <|channel>thought\ninternal<channel|> after"
+    assert strip_gemma_channel_blocks(text) == "before  after"
+
+
+def test_strip_gemma_channel_leaves_plain_text():
+    assert strip_gemma_channel_blocks("ordinary text") == "ordinary text"
+
+
+# ---------------------------------------------------------------------------
+# 7-8. GemmaThoughtCleanupMiddleware
+# ---------------------------------------------------------------------------
+
+
+class _FakeModelRequest:
+    """Stand-in for langchain.agents.middleware.types.ModelRequest."""
+
+    def __init__(self, messages: list):
+        self.messages = messages
+
+    def override(self, *, messages):
+        return _FakeModelRequest(messages)
+
+
+def _run_wrap(messages: list) -> list:
+    """Drive the middleware once and capture the messages it passes downstream."""
+    mw = GemmaThoughtCleanupMiddleware()
+    captured: list = []
+
+    def handler(request):
+        captured.append(request.messages)
+        return "result"
+
+    mw.wrap_model_call(_FakeModelRequest(messages), handler)
+    return captured[0]
+
+
+def test_cleanup_strips_channel_blocks_from_ai_messages():
+    ai = AIMessage(id="m1", content="Hi <|channel>thought\nsecret<channel|> ok")
+    result = _run_wrap([HumanMessage(content="hello"), ai])
+
+    ai_out = result[1]
+    assert isinstance(ai_out, AIMessage)
+    assert "channel" not in ai_out.content
+    assert ai_out.id == "m1"  # same ID → LangGraph reducer replaces original
+
+
+def test_cleanup_noop_when_no_channel_blocks():
+    ai = AIMessage(id="m1", content="Just a normal answer")
+    captured = _run_wrap([ai])
+    # No change → middleware returns the same list (handler still runs)
+    assert captured[0].content == "Just a normal answer"
+
+
+def test_cleanup_leaves_other_message_types_untouched():
+    ai = AIMessage(id="m1", content="Reply <|channel>t\nx<channel|> done")
+    tool_msg = ToolMessage(content="tool-result", tool_call_id="call-1")
+    result = _run_wrap([HumanMessage(content="q"), ai, tool_msg])
+
+    assert isinstance(result[0], HumanMessage)
+    assert result[0].content == "q"
+    assert isinstance(result[2], ToolMessage)
+    assert result[2].content == "tool-result"
+
+
+def test_cleanup_skips_in_flight_tool_sequence():
+    """AIMessages with unresolved tool_calls must retain their thoughts."""
+    ai = AIMessage(
+        id="m1",
+        content="deciding <|channel>t\nreason<channel|>",
+        tool_calls=[{"name": "bash", "args": {"cmd": "ls"}, "id": "tc-1"}],
+    )
+    result = _run_wrap([HumanMessage(content="run ls"), ai])
+
+    # No ToolMessage for tc-1 yet → sequence still in flight → skip
+    assert "channel" in result[1].content
+
+
+def test_cleanup_cleans_resolved_tool_sequence():
+    ai = AIMessage(
+        id="m1",
+        content="decided <|channel>t\nreason<channel|>",
+        tool_calls=[{"name": "bash", "args": {"cmd": "ls"}, "id": "tc-1"}],
+    )
+    tool = ToolMessage(content="ok", tool_call_id="tc-1")
+    result = _run_wrap([HumanMessage(content="run ls"), ai, tool])
+
+    # Tool call now resolved → the earlier AIMessage can be cleaned
+    assert "channel" not in result[1].content
+
+
+# ---------------------------------------------------------------------------
+# 9-10. apply_prompt_template — Gemma 4 vs. default
+# ---------------------------------------------------------------------------
+
+
+def test_apply_prompt_template_without_model_name_keeps_emojis(monkeypatch):
+    # Patch slow/skill-dependent functions to return empty strings
+    monkeypatch.setattr(prompt_module, "get_skills_prompt_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "get_deferred_tools_prompt_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_get_memory_context", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "get_agent_soul", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_build_acp_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_build_custom_mounts_section", lambda *a, **k: "")
+
+    out = prompt_module.apply_prompt_template(subagent_enabled=True, model_name=None)
+    # Original template contains the rocket emoji in the subagent banner
+    assert "🚀" in out
+    assert "<ui_style_rules>" not in out
+
+
+def test_apply_prompt_template_with_gemma4_strips_emojis_and_adds_ui_rules(monkeypatch):
+    monkeypatch.setattr(prompt_module, "get_skills_prompt_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "get_deferred_tools_prompt_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_get_memory_context", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "get_agent_soul", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_build_acp_section", lambda *a, **k: "")
+    monkeypatch.setattr(prompt_module, "_build_custom_mounts_section", lambda *a, **k: "")
+
+    # Ensure the factory helper reports Gemma 4 for our test name
+    monkeypatch.setattr(factory_module, "is_gemma4_by_name", lambda name: True)
+
+    out = prompt_module.apply_prompt_template(subagent_enabled=True, model_name="gemma4-4b")
+    assert "🚀" not in out
+    assert "⛔" not in out
+    assert "<gemma_output_rules>" in out
+    assert "NO EMOJI" in out  # hard rule clearly stated
+    assert "SUBAGENT MODE ACTIVE" in out  # core DeerFlow instructions preserved
+    assert "<clarification_system>" in out  # other sections intact
+
+
+# ---------------------------------------------------------------------------
+# 11. TitleMiddleware — channel blocks are stripped alongside <think>
+# ---------------------------------------------------------------------------
+
+
+def test_title_middleware_strips_both_tag_styles():
+    mw = TitleMiddleware()
+    text = "<think>inner</think>Title core <|channel>thought\nx<channel|> tail"
+    out = mw._strip_think_tags(text)
+    assert "think" not in out
+    assert "channel" not in out
+    assert "Title core" in out
+    assert "tail" in out
+
+
+def test_title_middleware_untouched_when_no_tags():
+    mw = TitleMiddleware()
+    assert mw._strip_think_tags("plain title candidate") == "plain title candidate"

--- a/backend/tests/test_tool_args_normalization.py
+++ b/backend/tests/test_tool_args_normalization.py
@@ -1,0 +1,365 @@
+"""Tests for the model-agnostic tool-call arg normalization middleware."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig
+
+from deerflow.agents.lead_agent.agent import _build_middlewares
+from deerflow.agents.middlewares.tool_args_normalization_middleware import (
+    AUTO_DESCRIPTION_MARKER,
+    ToolArgsNormalizationMiddleware,
+)
+from deerflow.config.app_config import AppConfig
+from deerflow.config.model_config import ModelConfig
+from deerflow.config.sandbox_config import SandboxConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_model(name: str = "example-model", **extras) -> ModelConfig:
+    kwargs = dict(
+        name=name,
+        display_name=name,
+        description=None,
+        use="langchain_ollama:ChatOllama",
+        model=name,
+    )
+    kwargs.update(extras)
+    return ModelConfig(**kwargs)
+
+
+@dataclass
+class _FakeModelRequest:
+    messages: list
+
+    def override(self, *, messages):
+        return _FakeModelRequest(messages=messages)
+
+
+@dataclass
+class _FakeModelResponse:
+    result: list
+    structured_response: Any = None
+
+
+def _tc(name: str, args: dict, tool_call_id: str = "tc-1") -> dict:
+    return {"name": name, "args": args, "id": tool_call_id, "type": "tool_call"}
+
+
+def _run_with_response(response: Any) -> Any:
+    """Drive the middleware once; return whatever it sends downstream."""
+    mw = ToolArgsNormalizationMiddleware()
+
+    def handler(_request):
+        return response
+
+    return mw.wrap_model_call(_FakeModelRequest(messages=[]), handler)
+
+
+# ---------------------------------------------------------------------------
+# 1. file_path → path alias
+# ---------------------------------------------------------------------------
+
+
+def test_aliases_file_path_to_path_for_write_file():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[
+            _tc(
+                "write_file",
+                {"content": "hi", "file_path": "/mnt/user-data/workspace/x.txt", "description": "d"},
+            )
+        ],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args["path"] == "/mnt/user-data/workspace/x.txt"
+    assert "file_path" not in out_args
+
+
+def test_aliases_filepath_variant():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("read_file", {"filepath": "/mnt/host/etc/hosts", "description": "d"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args["path"] == "/mnt/host/etc/hosts"
+    assert "filepath" not in out_args
+
+
+def test_path_wins_over_file_path_when_both_present():
+    """If model sends both, the schema-correct key takes precedence; alias is dropped."""
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[
+            _tc(
+                "write_file",
+                {
+                    "path": "/correct",
+                    "file_path": "/ignored",
+                    "content": "c",
+                    "description": "d",
+                },
+            )
+        ],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args["path"] == "/correct"
+    assert "file_path" not in out_args
+
+
+# ---------------------------------------------------------------------------
+# 3. Auto-fill missing description
+# ---------------------------------------------------------------------------
+
+
+def test_auto_fills_missing_description():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"path": "/x", "content": "c"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args["description"] == AUTO_DESCRIPTION_MARKER
+
+
+def test_description_unchanged_when_provided():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"path": "/x", "content": "c", "description": "real reason"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    assert result.result[0].tool_calls[0]["args"]["description"] == "real reason"
+
+
+def test_auto_fill_and_alias_rewrite_combined():
+    """The exact failure from the observed Magistral thread: file_path + missing description."""
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[
+            _tc(
+                "write_file",
+                {"content": "<html/>", "file_path": "/mnt/user-data/workspace/app.html"},
+            )
+        ],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args == {
+        "content": "<html/>",
+        "path": "/mnt/user-data/workspace/app.html",
+        "description": AUTO_DESCRIPTION_MARKER,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. No-op paths
+# ---------------------------------------------------------------------------
+
+
+def test_no_op_when_no_tool_calls():
+    ai = AIMessage(id="m1", content="plain text")
+    original = _FakeModelResponse(result=[ai])
+    result = _run_with_response(original)
+    assert result is original  # identity preserved, no pointless rebuild
+
+
+def test_no_op_when_args_already_valid():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"path": "/x", "content": "c", "description": "d"})],
+    )
+    original = _FakeModelResponse(result=[ai])
+    result = _run_with_response(original)
+    assert result is original
+
+
+def test_non_ai_messages_pass_through_untouched():
+    human = HumanMessage(content="hi")
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"file_path": "/x", "content": "c"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[human, ai]))
+    assert result.result[0] is human
+    assert result.result[1].tool_calls[0]["args"]["path"] == "/x"
+
+
+def test_unknown_tool_does_not_get_auto_description():
+    """For tools we don't recognize, we don't invent a description — surface the real error."""
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("some_mcp_tool", {"query": "foo"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    # No description injected for unknown tools
+    assert "description" not in result.result[0].tool_calls[0]["args"]
+
+
+def test_unknown_tool_still_gets_path_alias_rewrite():
+    """file_path is a generic Mistral convention; alias normalization is safe even for unknown tools."""
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("future_tool", {"file_path": "/p"})],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_args = result.result[0].tool_calls[0]["args"]
+    assert out_args == {"path": "/p"}
+
+
+# ---------------------------------------------------------------------------
+# 5. Response shape compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_handles_bare_ai_message_response():
+    """Middleware handlers may return an AIMessage directly instead of a ModelResponse."""
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"file_path": "/x", "content": "c"})],
+    )
+    result = _run_with_response(ai)
+    assert isinstance(result, AIMessage)
+    assert result.tool_calls[0]["args"]["path"] == "/x"
+    assert result.tool_calls[0]["args"]["description"] == AUTO_DESCRIPTION_MARKER
+
+
+def test_preserves_tool_call_id_and_type():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[_tc("write_file", {"file_path": "/x", "content": "c"}, tool_call_id="abc-123")],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    out_tc = result.result[0].tool_calls[0]
+    assert out_tc["id"] == "abc-123"
+    assert out_tc["type"] == "tool_call"
+
+
+def test_mixed_tool_calls_only_mutate_the_broken_one():
+    ai = AIMessage(
+        id="m1",
+        content="",
+        tool_calls=[
+            _tc("bash", {"command": "ls", "description": "list"}, tool_call_id="ok"),
+            _tc("write_file", {"file_path": "/x", "content": "c"}, tool_call_id="broken"),
+        ],
+    )
+    result = _run_with_response(_FakeModelResponse(result=[ai]))
+    calls = result.result[0].tool_calls
+    assert calls[0]["args"] == {"command": "ls", "description": "list"}
+    assert calls[1]["args"] == {
+        "path": "/x",
+        "content": "c",
+        "description": AUTO_DESCRIPTION_MARKER,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 6. Middleware is registered unconditionally in _build_middlewares
+# ---------------------------------------------------------------------------
+#
+# The middleware is a model-agnostic safety net (see its module docstring)
+# so _build_middlewares must register it for every model configuration.
+# This parameter list is the regression guard: it covers the main vendor
+# families and their common packaging formats (Ollama tags, HuggingFace
+# repo paths, direct API names, AWS Bedrock ARNs). The assertion is the
+# same for every entry — extending the list costs one line and documents
+# an additional class/provider that DeerFlow should keep covered.
+#
+# Grouped by vendor-family with the relevant reason annotated:
+
+
+def _app_config_with(model: ModelConfig) -> AppConfig:
+    return AppConfig(
+        models=[model],
+        sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"),
+    )
+
+
+def _middleware_names(middlewares: list[AgentMiddleware]) -> list[str]:
+    return [type(m).__name__ for m in middlewares]
+
+
+def _run_build(model_name: str, model: ModelConfig) -> list[AgentMiddleware]:
+    app_config = _app_config_with(model)
+    with patch("deerflow.agents.lead_agent.agent.get_app_config", return_value=app_config):
+        return _build_middlewares(RunnableConfig(configurable={}), model_name=model_name)
+
+
+# Each row is (human-readable id, model name as it would appear in
+# ``config.yaml``). Model names are verbatim so provider naming
+# conventions stay visible in the test catalogue.
+_REGISTRATION_MATRIX: list[tuple[str, str]] = [
+    # --- Mistral AI — historic trigger of the file_path alias + missing description
+    ("mistral-magistral-ollama", "magistral:24b"),
+    ("mistral-devstral-small-2-ollama", "devstral-small-2:24b"),
+    ("mistral-devstral-2-ollama", "devstral-2:24b"),
+    ("mistral-mixtral-ollama", "mixtral:8x7b"),
+    ("mistral-codestral-ollama", "codestral:22b"),
+    ("mistral-ministral-ollama", "ministral:8b"),
+    ("mistral-api-direct", "mistral-large-2407"),
+    ("mistral-huggingface", "mistralai/Mixtral-8x7B-Instruct-v0.1"),
+    ("mistral-bedrock", "mistral.mistral-large-2402-v1:0"),
+    # --- Google Gemma 4 — intermittent description-drop on tool calls.
+    #     Earlier Gemma generations (Gemma 3, CodeGemma) don't ship with
+    #     function-calling support, so they never produce the tool calls
+    #     the middleware would operate on — they stay out of the matrix.
+    ("gemma4-ollama-default", "gemma4-2b"),
+    ("gemma4-ollama-xl", "gemma4-27b"),
+    # Major model families without a tracked tool-args quirk are
+    # deliberately kept out of this matrix:
+    #   - Anthropic Claude, OpenAI GPT: reliably emit tool arguments in
+    #     the exact schema DeerFlow's sandbox tools expect — the
+    #     middleware is a no-op on them.
+    #   - Qwen, Llama, DeepSeek and other open-source families: not
+    #     (or not extensively) tested against the quirk, so we have
+    #     neither evidence of a problem nor a guarantee of cleanliness;
+    #     adding them would be speculative rather than informative.
+    # The ``neutral-placeholder`` entry below already guards the
+    # gate-removal invariant for any untested family.
+    # --- Neutrally-named placeholder: proves the gate really was removed
+    #     (would fail if anyone re-introduces a family-whitelist check)
+    ("neutral-placeholder", "example-clean-model"),
+]
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [pytest.param(name, id=case_id) for case_id, name in _REGISTRATION_MATRIX],
+)
+def test_normalization_middleware_registered_for_every_model(model_name: str):
+    """Registration is model-agnostic. Regression guard against re-introducing
+    a family-gate in _build_middlewares."""
+    mws = _run_build(model_name, _make_model(model_name))
+    assert "ToolArgsNormalizationMiddleware" in _middleware_names(mws)
+
+
+def test_auto_description_marker_is_model_agnostic():
+    """Marker copy reads naturally for any model family."""
+    assert "magistral" not in AUTO_DESCRIPTION_MARKER.lower()
+    assert "gemma" not in AUTO_DESCRIPTION_MARKER.lower()
+    assert "model" in AUTO_DESCRIPTION_MARKER.lower()


### PR DESCRIPTION
## Summary
- New `ToolArgsNormalizationMiddleware` registered unconditionally in the lead agent
- Rewrites `file_path` / `filepath` → `path` for sandbox tools
- Auto-fills missing `description` on tools that require it (`bash`, `ls`, `glob`, `grep`, `read_file`, `write_file`, `str_replace`)
- Every mutation logged at INFO level for observability
- Regression matrix in `tests/test_tool_args_normalization.py` covering Mistral (Devstral, Magistral, Mixtral, Codestral, Ministral, mistral-large-2407) and Gemma 4 variants

## Motivation
Locally-hosted models from several providers emit tool calls using the parameter conventions they were trained on, not the schema DeerFlow's sandbox tools actually expose. Two observed patterns:

1. **`file_path` / `filepath` where the schema wants `path`** — Mistral's generic file-tool convention; surfaces on every file-oriented tool the model tries to call.
2. **Missing `description`** — DeerFlow declares this as a required first argument for audit logging; models trained on schemas without it simply omit the field.

Without normalization these calls fail at `ToolErrorHandlingMiddleware` and the user sees a cryptic "invalid arguments" error, even though the model's intent is obvious.

## Design choices
- **Model-agnostic**: the pattern isn't specific to one family — any model trained on its own tool-use convention can hit it. Registering unconditionally keeps the middleware schema-driven rather than family-driven.
- **No-op on happy path**: correctly-formed tool calls return the original response by identity — `wrap_model_call` adds no measurable overhead.
- **Narrow alias map**: only aliases observed on real responses are translated, so genuine schema violations still surface as errors rather than being silently masked.

## Relationship to #feat/gemma4-family-support
This branch is stacked on top of the Gemma 4 PR because both register middlewares in `lead_agent/agent.py`. Once that PR merges, GitHub will automatically narrow the diff here to the tool-args changes only.

## Testing
```
cd backend && PYTHONPATH=. uv run pytest tests/test_tool_args_normalization.py -v
```
All 14 functional tests plus the parametrized registration matrix pass.
