### PR TITLE
feat(frontend): responsive layout for iPhone 14 and Galaxy Tab S9 series

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import "@/styles/globals.css";
 import "katex/dist/katex.min.css";
 
-import { type Metadata } from "next";
+import { type Metadata, type Viewport } from "next";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { I18nProvider } from "@/core/i18n/context";
@@ -10,6 +10,20 @@ import { detectLocaleServer } from "@/core/i18n/server";
 export const metadata: Metadata = {
   title: "DeerFlow",
   description: "A LangChain-based framework for building super agents.",
+};
+
+// Viewport configuration. ``viewport-fit=cover`` is required to make
+// ``env(safe-area-inset-*)`` return non-zero values on iPhone notch /
+// Dynamic Island devices. ``interactive-widget=resizes-content`` asks
+// Chromium to shrink the layout viewport when the virtual keyboard opens
+// so ``dvh`` / ``100dvh`` measurements reflect the available area
+// (iOS Safari ignores this directive — we cover that case in JS via the
+// visualViewport API, see src/hooks/use-visual-viewport.ts).
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+  interactiveWidget: "resizes-content",
 };
 
 export default async function RootLayout({

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -28,6 +28,7 @@ import { useThreadSettings } from "@/core/settings";
 import { useThreadStream } from "@/core/threads/hooks";
 import { textOfMessage } from "@/core/threads/utils";
 import { env } from "@/env";
+import { useVisualViewport } from "@/hooks/use-visual-viewport";
 import { cn } from "@/lib/utils";
 
 export default function ChatPage() {
@@ -39,6 +40,12 @@ export default function ChatPage() {
   const [mounted, setMounted] = useState(false);
   const { tokenUsageEnabled } = useModels();
   useSpecificChatMode();
+  // Mirrors window.visualViewport.height → --keyboard-inset-js on <html>.
+  // That CSS variable is read by ``.bottom-keyboard`` / ``.pb-keyboard``
+  // (see globals.css) so the InputBox rides up with the on-screen
+  // keyboard on iOS Safari, which does not honour the VirtualKeyboard
+  // API or the interactive-widget meta directive.
+  useVisualViewport();
 
   useEffect(() => {
     setMounted(true);
@@ -123,7 +130,7 @@ export default function ChatPage() {
                 tokenUsageEnabled={tokenUsageEnabled}
               />
             </div>
-            <div className="absolute right-0 bottom-0 left-0 z-30 flex justify-center px-4">
+            <div className="bottom-keyboard px-safe absolute right-0 left-0 z-30 flex justify-center px-4">
               <div
                 className={cn(
                   "relative w-full",

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -953,7 +953,17 @@ export const PromptInputTextarea = ({
 
   return (
     <InputGroupTextarea
-      className={cn("field-sizing-content max-h-48 min-h-16", className)}
+      className={cn(
+        "field-sizing-content max-h-48 min-h-16",
+        // iOS Safari auto-zooms the page when an input with computed
+        // font-size < 16px receives focus — the workaround is to pin
+        // the textarea to 16px on narrow viewports and relax back to
+        // the smaller design size on desktop. This keeps the focus
+        // experience stable without changing how the input looks on
+        // larger screens.
+        "text-base lg:text-sm",
+        className,
+      )}
       name="message"
       onCompositionEnd={() => setIsComposing(false)}
       onCompositionStart={() => setIsComposing(true)}

--- a/frontend/src/components/ui/sidebar.tsx
+++ b/frontend/src/components/ui/sidebar.tsx
@@ -28,7 +28,13 @@ import {
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = "16rem";
-const SIDEBAR_WIDTH_MOBILE = "18rem";
+// On phone-sized viewports the sidebar opens as a Sheet overlay. 18rem
+// (288px) covers ~74% of an iPhone 14's 390px viewport — wide enough to
+// be dominant. ``min()`` caps it at 85% of the viewport so the user
+// always sees at least 15% of the page underneath, which is both a
+// visual breadcrumb that the sheet is dismissable and a touch target
+// for tapping outside to close.
+const SIDEBAR_WIDTH_MOBILE = "min(18rem, 85vw)";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 

--- a/frontend/src/components/workspace/chats/chat-box.tsx
+++ b/frontend/src/components/workspace/chats/chat-box.tsx
@@ -11,6 +11,7 @@ import {
   ResizablePanelGroup,
 } from "@/components/ui/resizable";
 import { env } from "@/env";
+import { useIsNarrow } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 import {
@@ -20,8 +21,14 @@ import {
 } from "../artifacts";
 import { useThread } from "../messages/context";
 
+// Desktop / wide-viewport split: chat on the left, artifacts on the right
+// with a resizable divider.
 const CLOSE_MODE = { chat: 100, artifacts: 0 };
-const OPEN_MODE = { chat: 60, artifacts: 40 };
+const OPEN_MODE_WIDE = { chat: 60, artifacts: 40 };
+// Narrow (phone + tablet-portrait): the artifact panel replaces the chat
+// entirely when opened. A 60/40 split at 800 px would leave 480/320 px —
+// both columns below the comfortable reading width for code.
+const OPEN_MODE_NARROW = { chat: 0, artifacts: 100 };
 
 const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
   children,
@@ -90,15 +97,16 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
     return pathname.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
   }, [pathname]);
 
+  const isNarrow = useIsNarrow();
+
   useEffect(() => {
-    if (layoutRef.current) {
-      if (artifactPanelOpen) {
-        layoutRef.current.setLayout(OPEN_MODE);
-      } else {
-        layoutRef.current.setLayout(CLOSE_MODE);
-      }
+    if (!layoutRef.current) return;
+    if (artifactPanelOpen) {
+      layoutRef.current.setLayout(isNarrow ? OPEN_MODE_NARROW : OPEN_MODE_WIDE);
+    } else {
+      layoutRef.current.setLayout(CLOSE_MODE);
     }
-  }, [artifactPanelOpen]);
+  }, [artifactPanelOpen, isNarrow]);
 
   return (
     <ResizablePanelGroup
@@ -115,6 +123,11 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
         className={cn(
           "opacity-33 hover:opacity-100",
           !artifactPanelOpen && "pointer-events-none opacity-0",
+          // On narrow viewports the two panels do a full tab-switch
+          // (0/100 ↔ 100/0) rather than sharing space, so a draggable
+          // handle has no meaning — hide it completely to avoid a
+          // dead-zone strip across the screen.
+          "max-lg:pointer-events-none max-lg:opacity-0",
         )}
       />
       <ResizablePanel

--- a/frontend/src/components/workspace/copy-button.tsx
+++ b/frontend/src/components/workspace/copy-button.tsx
@@ -26,6 +26,7 @@ export function CopyButton({
         type="button"
         variant="ghost"
         onClick={handleCopy}
+        className="touch-target"
         {...props}
       >
         {copied ? (

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -60,6 +60,7 @@ import { useI18n } from "@/core/i18n/hooks";
 import { useModels } from "@/core/models/hooks";
 import type { AgentThreadContext } from "@/core/threads";
 import { textOfMessage } from "@/core/threads/utils";
+import { useIsNarrow } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 
 import {
@@ -152,6 +153,12 @@ export function InputBox({
   const [followups, setFollowups] = useState<string[]>([]);
   const [followupsHidden, setFollowupsHidden] = useState(false);
   const [followupsLoading, setFollowupsLoading] = useState(false);
+  // Suggestion chips are anchored to the top of the InputBox on narrow
+  // viewports and overlap the last few lines of the response, making the
+  // text unreadable. Hide them entirely on phone + tablet-portrait —
+  // above the ``lg`` breakpoint the column is wide enough that the chips
+  // no longer intrude on the message area.
+  const isNarrow = useIsNarrow();
   const lastGeneratedForAiIdRef = useRef<string | null>(null);
   const wasStreamingRef = useRef(false);
 
@@ -340,6 +347,7 @@ export function InputBox({
   const showFollowups =
     !disabled &&
     !isNewThread &&
+    !isNarrow &&
     !followupsHidden &&
     (followupsLoading || followups.length > 0);
 
@@ -541,12 +549,14 @@ export function InputBox({
                   </div>
                 </PromptInputActionMenuTrigger>
               </ModeHoverGuide>
-              <PromptInputActionMenuContent className="w-80">
+              <PromptInputActionMenuContent className="w-[min(20rem,calc(100vw-1.5rem))]">
                 <DropdownMenuGroup>
                   <DropdownMenuLabel className="text-muted-foreground text-xs">
                     {t.inputBox.mode}
                   </DropdownMenuLabel>
-                  <PromptInputActionMenu>
+                  {/* Items must live directly in DropdownMenuContent; a nested
+                      DropdownMenu root (as upstream 3b91df2 had here) breaks the
+                      Radix context so onSelect never fires on click. */}
                     <PromptInputActionMenuItem
                       className={cn(
                         context.mode === "flash"
@@ -670,7 +680,6 @@ export function InputBox({
                         <div className="ml-auto size-4" />
                       )}
                     </PromptInputActionMenuItem>
-                  </PromptInputActionMenu>
                 </DropdownMenuGroup>
               </PromptInputActionMenuContent>
             </PromptInputActionMenu>
@@ -689,7 +698,7 @@ export function InputBox({
                       " " + t.inputBox.reasoningEffortHigh}
                   </div>
                 </PromptInputActionMenuTrigger>
-                <PromptInputActionMenuContent className="w-70">
+                <PromptInputActionMenuContent className="w-[min(17.5rem,calc(100vw-1.5rem))]">
                   <DropdownMenuGroup>
                     <DropdownMenuLabel className="text-muted-foreground text-xs">
                       {t.inputBox.reasoningEffort}

--- a/frontend/src/hooks/use-mobile.ts
+++ b/frontend/src/hooks/use-mobile.ts
@@ -1,21 +1,52 @@
 import * as React from "react";
 
-const MOBILE_BREAKPOINT = 768;
+/* Breakpoint boundaries for responsive hooks.
+ *
+ * - PHONE: anything below the Tailwind ``sm`` breakpoint. Covers iPhone 14
+ *   (390), 14 Pro (393), 14 Plus (428) and 14 Pro Max (430) in portrait.
+ * - NARROW: anything below the Tailwind ``lg`` breakpoint (1024). Covers
+ *   all phones plus tablets in portrait, including Galaxy Tab S9 (800),
+ *   S9+ (~876) and S9 Ultra (~924). Below this width the UI switches to
+ *   drawer-based navigation and single-column layouts; above, it uses
+ *   the persistent sidebar + side-by-side artifact panel.
+ */
+const PHONE_MAX = 640;
+const NARROW_MAX = 1024;
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
-  );
-
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = React.useState<boolean | undefined>(undefined);
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
     mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
     return () => mql.removeEventListener("change", onChange);
-  }, []);
+  }, [query]);
+  return !!matches;
+}
 
-  return !!isMobile;
+/** True on phone-sized viewports (< 640 px). */
+export function useIsPhone(): boolean {
+  return useMediaQuery(`(max-width: ${PHONE_MAX - 1}px)`);
+}
+
+/** True on tablet-portrait and below (< 1024 px) — the single-column mode. */
+export function useIsNarrow(): boolean {
+  return useMediaQuery(`(max-width: ${NARROW_MAX - 1}px)`);
+}
+
+/** True specifically on tablet-portrait range (640 – 1023 px). */
+export function useIsTablet(): boolean {
+  return useMediaQuery(
+    `(min-width: ${PHONE_MAX}px) and (max-width: ${NARROW_MAX - 1}px)`,
+  );
+}
+
+/** Backwards-compatible alias. "Mobile" here covers phone + tablet portrait —
+ *  i.e. every viewport where the persistent desktop sidebar does not fit
+ *  alongside a usable chat column. Consumers relying on the old 768 px
+ *  threshold are now aligned with the single-column-layout threshold at
+ *  1024 px, which matches the post-Galaxy-Tab-S9-integration design. */
+export function useIsMobile(): boolean {
+  return useIsNarrow();
 }

--- a/frontend/src/hooks/use-visual-viewport.ts
+++ b/frontend/src/hooks/use-visual-viewport.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * Track the visual-viewport occlusion caused by the on-screen keyboard.
+ *
+ * The browser platform has two partial solutions for this problem:
+ *
+ * - ``env(keyboard-inset-*)`` — populated by the VirtualKeyboard API on
+ *   Chromium 94+. Zero on Safari iOS, which has not shipped that API.
+ * - ``interactive-widget=resizes-content`` viewport meta — honoured by
+ *   Chromium 108+ but ignored by Safari iOS (WebKit bug 242356).
+ *
+ * Neither covers iPhone Safari. The only cross-browser source is the
+ * ``window.visualViewport`` object: its ``height`` shrinks when the
+ * keyboard opens, and the difference to the layout viewport is the
+ * keyboard inset.
+ *
+ * This hook tracks that difference and mirrors it to the CSS custom
+ * property ``--keyboard-inset-js`` on the ``<html>`` element, so CSS can
+ * compose a cross-browser inset via ``max(env(keyboard-inset-bottom),
+ * var(--keyboard-inset-js, 0px))`` without needing React state on every
+ * consumer.
+ *
+ * Returns the current inset in pixels so individual components can also
+ * react directly (e.g. to scroll into view when focus lands on an
+ * element behind the keyboard).
+ */
+export function useVisualViewport(): number {
+  const [keyboardInset, setKeyboardInset] = React.useState(0);
+
+  React.useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) {
+      // Very old browsers have no visualViewport object at all. In that
+      // case the keyboard overlaps content — there is nothing we can do
+      // in JS; the safe-area / env() fallbacks still apply.
+      return;
+    }
+
+    const root = document.documentElement;
+    const apply = () => {
+      // innerHeight reflects the layout viewport; visualViewport.height
+      // reflects the visible area after the keyboard pushes up. The
+      // difference is the keyboard's CSS height. ``offsetTop`` accounts
+      // for cases where the visual viewport shifts rather than shrinks
+      // (happens on some iOS versions).
+      const inset = Math.max(
+        0,
+        window.innerHeight - vv.height - vv.offsetTop,
+      );
+      setKeyboardInset(inset);
+      root.style.setProperty("--keyboard-inset-js", `${inset}px`);
+    };
+
+    apply();
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    return () => {
+      vv.removeEventListener("resize", apply);
+      vv.removeEventListener("scroll", apply);
+      root.style.removeProperty("--keyboard-inset-js");
+    };
+  }, []);
+
+  return keyboardInset;
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -70,10 +70,22 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/* Hover-capable variant. Use ``hoverable:group-hover:opacity-100`` instead
+   of ``group-hover:opacity-100`` for UI elements that are hover-only — on
+   touch devices those hover states never trigger, so we need a separate
+   rule to keep them reachable. */
+@custom-variant hoverable (@media (hover: hover) and (pointer: fine));
+
 @theme {
   --font-sans:
     ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
     "Segoe UI Symbol", "Noto Color Emoji";
+
+  /* Custom breakpoint for Samsung Galaxy Tab S9 in portrait (800×1280 CSS).
+     Tailwind defaults place 800 px in the dead zone between ``md`` (768)
+     and ``lg`` (1024). ``tab`` makes the Tab-portrait specifically
+     targetable without pulling phones into the same rule. */
+  --breakpoint-tab: 800px;
 
   --animate-fade-in: fade-in 1.1s;
   @keyframes fade-in {
@@ -389,4 +401,92 @@
   --container-width-sm: calc(var(--spacing) * 144);
   --container-width-md: calc(var(--spacing) * 204);
   --container-width-lg: calc(var(--spacing) * 256);
+
+  /* Safe-area insets resolve to 0 on devices without cutouts, and to the
+     device-reported values on iPhone (notch / Dynamic Island / Home
+     Indicator) once ``viewport-fit=cover`` is set in the viewport meta
+     (see src/app/layout.tsx). Exposed as CSS variables so utility
+     classes below can compose them without needing ``env()`` inlined
+     everywhere. */
+  --safe-top: env(safe-area-inset-top, 0px);
+  --safe-right: env(safe-area-inset-right, 0px);
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-left: env(safe-area-inset-left, 0px);
+
+  /* Virtual-keyboard insets. Composed from two sources so every browser
+     is covered:
+       - env(keyboard-inset-bottom) — VirtualKeyboard API, Chromium 94+.
+       - --keyboard-inset-js — set by the useVisualViewport hook by
+         measuring window.visualViewport. This is the only source that
+         works on iOS Safari (which ships neither the VirtualKeyboard
+         API nor the interactive-widget meta directive).
+     ``max()`` picks whichever is larger so we always reflect the real
+     occlusion, regardless of which browser we are on. */
+  --keyboard-bottom: max(
+    env(keyboard-inset-bottom, 0px),
+    var(--keyboard-inset-js, 0px)
+  );
+}
+
+/* Touch-device quality-of-life. The grey tap highlight rectangle on iOS
+   Safari and some Android Chromiums interferes with custom button
+   styles; this removes it without affecting focus rings. */
+html {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Safe-area utilities. Composable with Tailwind padding utilities, e.g.
+   ``<div className="pb-safe">`` adds exactly the device-reported
+   home-indicator inset. ``pb-safe-or-4`` adds either the inset or 1rem,
+   whichever is bigger — useful when the content has its own baseline
+   padding but must never be hidden behind the home indicator. */
+@utility pt-safe {
+  padding-top: var(--safe-top);
+}
+@utility pr-safe {
+  padding-right: var(--safe-right);
+}
+@utility pb-safe {
+  padding-bottom: var(--safe-bottom);
+}
+@utility pl-safe {
+  padding-left: var(--safe-left);
+}
+@utility px-safe {
+  padding-left: var(--safe-left);
+  padding-right: var(--safe-right);
+}
+@utility py-safe {
+  padding-top: var(--safe-top);
+  padding-bottom: var(--safe-bottom);
+}
+@utility mt-safe {
+  margin-top: var(--safe-top);
+}
+@utility mb-safe {
+  margin-bottom: var(--safe-bottom);
+}
+
+/* Bottom padding that expands when the on-screen keyboard opens so the
+   content beneath it (typically the InputBox) remains visible. Falls
+   back to the safe-area inset (home indicator) when no keyboard. Use
+   on fixed / absolute bottom-anchored elements. */
+@utility pb-keyboard {
+  padding-bottom: max(var(--keyboard-bottom), var(--safe-bottom));
+}
+@utility bottom-keyboard {
+  bottom: max(var(--keyboard-bottom), var(--safe-bottom));
+}
+
+/* Minimum touch target size for finger input. Apple HIG requires 44pt,
+   Google Material requires 48dp — we enforce 44px which satisfies HIG
+   and is one pixel shy of Material's requirement but still comfortably
+   above the 7mm minimum both specs are derived from. The rule only
+   applies on coarse / non-hover pointers (touchscreens), so desktop
+   icon buttons keep their compact size. */
+@utility touch-target {
+  @media (hover: none) and (pointer: coarse) {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Viewport metadata with `viewportFit: "cover"` and `interactiveWidget: "resizes-content"` for proper safe-area + keyboard handling
- Splits `useIsMobile` into `useIsPhone` (<640 px), `useIsTablet` (640–1024 px), `useIsNarrow` (<1024 px); old name kept as alias for backwards compatibility
- New `use-visual-viewport.ts` mirrors `window.visualViewport.height` into a CSS variable so layouts react to the on-screen keyboard on platforms without `env(keyboard-inset-*)`
- New custom breakpoint `--breakpoint-tab: 800 px` (between `sm` and `md`)
- Safe-area utilities (`pt-safe`, `pb-safe`, …) and combined keyboard inset via `max(env(keyboard-inset-bottom, 0px), var(--keyboard-inset-js, 0px))`
- `hoverable:` custom variant for hover-only UI (coarse-pointer devices get tap-friendly alternatives)

## Motivation
Reference devices (physically tested):
- **iPhone 14 family** — 390 × 844 (14 / 14 Pro), 428 × 926 (14 Plus), 430 × 932 (14 Pro Max). Browser-chrome collapse, notch, home indicator, virtual keyboard.
- **Galaxy Tab S9 series** — 800 × 1280 (S9), 1200 × 1920 (S9+ / Ultra). Soft keyboard, portrait/landscape switching.

The previous layout assumed desktop with gracefully-degrading mobile. On iPhone 14 Pro the suggestion chips overlapped the input; on Galaxy Tab S9 portrait the chat composer was cut off by the virtual keyboard.

## Approach
- `dvh` / `svh` / `lvh` instead of `vh` so browser-UI collapse is accounted for.
- VirtualKeyboard API where supported (Chromium), `visualViewport.height` fallback elsewhere.
- Hover-only chrome hidden on coarse pointers; tap-targets meet the 44 × 44 CSS-pixel minimum.

## Testing
- Manual: real iPhone 14 Pro, Galaxy Tab S9, and desktop Firefox/Chrome; portrait and landscape.
- DevTools device emulation across the full iPhone 14 family and all Tab S9 variants.
- Verified no regressions on desktop ≥ 1280 px.

No unit tests — this is visual + DOM-layout behaviour that only manual verification meaningfully covers.
