### PR TITLE
perf(frontend): stable memo chain for the message subtree

### DIFF
--- a/frontend/src/components/ai-elements/code-block.tsx
+++ b/frontend/src/components/ai-elements/code-block.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { highlightInWorker } from "@/core/shiki/client";
 import { cn } from "@/lib/utils";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import {
@@ -12,7 +13,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { type BundledLanguage, codeToHtml, type ShikiTransformer } from "shiki";
+import { type BundledLanguage } from "shiki";
 
 type CodeBlockProps = HTMLAttributes<HTMLDivElement> & {
   code: string;
@@ -28,50 +29,6 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
   code: "",
 });
 
-const lineNumberTransformer: ShikiTransformer = {
-  name: "line-numbers",
-  line(node, line) {
-    node.children.unshift({
-      type: "element",
-      tagName: "span",
-      properties: {
-        className: [
-          "inline-block",
-          "min-w-10",
-          "mr-4",
-          "text-right",
-          "select-none",
-          "text-muted-foreground",
-        ],
-      },
-      children: [{ type: "text", value: String(line) }],
-    });
-  },
-};
-
-export async function highlightCode(
-  code: string,
-  language: BundledLanguage,
-  showLineNumbers = false,
-) {
-  const transformers: ShikiTransformer[] = showLineNumbers
-    ? [lineNumberTransformer]
-    : [];
-
-  return await Promise.all([
-    codeToHtml(code, {
-      lang: language,
-      theme: "one-light",
-      transformers,
-    }),
-    codeToHtml(code, {
-      lang: language,
-      theme: "one-dark-pro",
-      transformers,
-    }),
-  ]);
-}
-
 export const CodeBlock = ({
   code,
   language,
@@ -82,19 +39,37 @@ export const CodeBlock = ({
 }: CodeBlockProps) => {
   const [html, setHtml] = useState<string>("");
   const [darkHtml, setDarkHtml] = useState<string>("");
-  const mounted = useRef(false);
+  // Monotonic counter of highlight requests dispatched from this block.
+  // When streaming updates `code` every token, only the most recent request
+  // is allowed to write state — older in-flight responses from the worker
+  // are ignored so the final HTML always reflects the latest code value.
+  const latestGeneration = useRef(0);
 
   useEffect(() => {
-    highlightCode(code, language, showLineNumbers).then(([light, dark]) => {
-      if (!mounted.current) {
+    const generation = ++latestGeneration.current;
+    let cancelled = false;
+
+    highlightInWorker(code, language, showLineNumbers)
+      .then(([light, dark]) => {
+        if (cancelled || generation !== latestGeneration.current) {
+          return;
+        }
         setHtml(light);
         setDarkHtml(dark);
-        mounted.current = true;
-      }
-    });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        // A highlight failure must not blank the code block — keep whatever
+        // HTML we already rendered and surface the error in the console so
+        // it's discoverable without breaking the conversation view.
+        // eslint-disable-next-line no-console
+        console.error("Shiki highlight failed:", err);
+      });
 
     return () => {
-      mounted.current = false;
+      cancelled = true;
     };
   }, [code, language, showLineNumbers]);
 

--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -314,7 +314,17 @@ export const MessageResponse = memo(
       {...props}
     />
   ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children,
+  // Children-only equality was too narrow: when a caller re-rendered with a
+  // fresh rehype/remark/components reference (even if semantically identical),
+  // Streamdown would tear down and rebuild its Markdown pipeline without any
+  // visible change. Compare those references too — callers are expected to
+  // memoize them upstream (see MarkdownContent / MessageContent).
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.className === nextProps.className &&
+    prevProps.remarkPlugins === nextProps.remarkPlugins &&
+    prevProps.rehypePlugins === nextProps.rehypePlugins &&
+    prevProps.components === nextProps.components,
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/frontend/src/components/workspace/messages/markdown-content.tsx
+++ b/frontend/src/components/workspace/messages/markdown-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import type { AnchorHTMLAttributes } from "react";
 
 import {
@@ -26,7 +26,7 @@ export type MarkdownContentProps = {
 };
 
 /** Renders markdown content. */
-export function MarkdownContent({
+function MarkdownContent_({
   content,
   rehypePlugins,
   className,
@@ -74,3 +74,10 @@ export function MarkdownContent({
     </MessageResponse>
   );
 }
+
+// Memoized so that re-renders of the enclosing MessageContent (or further up
+// the tree) don't re-enter the Streamdown setup path — setting up the
+// Markdown/KaTeX/rehype pipeline is expensive on long responses. Relies on
+// the caller passing stable references for rehypePlugins/remarkPlugins/
+// components (see message-list-item.tsx's combinedRehypePlugins useMemo).
+export const MarkdownContent = memo(MarkdownContent_);

--- a/frontend/src/components/workspace/messages/message-group.tsx
+++ b/frontend/src/components/workspace/messages/message-group.tsx
@@ -28,7 +28,7 @@ import {
   extractReasoningContentFromMessage,
   findToolCallResult,
 } from "@/core/messages/utils";
-import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
+import { useRehypeFadeInBlocks } from "@/core/rehype";
 import { extractTitleFromMarkdown } from "@/core/utils/markdown";
 import { env } from "@/env";
 import { cn } from "@/lib/utils";
@@ -76,7 +76,7 @@ export function MessageGroup({
       return filteredSteps[filteredSteps.length - 1];
     }
   }, [lastToolCallStep, steps]);
-  const rehypePlugins = useRehypeSplitWordsIntoSpans(isLoading);
+  const rehypePlugins = useRehypeFadeInBlocks(!isLoading);
   return (
     <ChainOfThought
       className={cn("w-full gap-2 rounded-lg border p-0.5", className)}

--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -31,16 +31,16 @@ import {
   stripUploadedFilesTag,
   type FileInMessage,
 } from "@/core/messages/utils";
-import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
+import { useRehypeFadeInBlocks } from "@/core/rehype";
 import { humanMessagePlugins } from "@/core/streamdown";
 import { cn } from "@/lib/utils";
 
 import { CopyButton } from "../copy-button";
 
-import { MarkdownContent } from "./markdown-content";
+import { MarkdownContent, type MarkdownContentProps } from "./markdown-content";
 import { MessageTokenUsage } from "./message-token-usage";
 
-export function MessageListItem({
+function MessageListItem_({
   className,
   message,
   isLoading,
@@ -70,7 +70,12 @@ export function MessageListItem({
         <MessageToolbar
           className={cn(
             isHuman ? "-bottom-9 justify-end" : "-bottom-8",
-            "absolute right-0 left-0 z-20 opacity-0 transition-opacity delay-200 duration-300 group-hover/conversation-message:opacity-100",
+            // On hover-capable pointers (desktop / mouse) the toolbar is
+            // hidden by default and only revealed on hover — matching the
+            // original design. Touch devices have no hover state, so on
+            // those the toolbar is always visible to remain reachable.
+            "absolute right-0 left-0 z-20 transition-opacity delay-200 duration-300",
+            "hoverable:opacity-0 hoverable:group-hover/conversation-message:opacity-100",
           )}
         >
           <div className="flex gap-1">
@@ -87,6 +92,14 @@ export function MessageListItem({
     </AIElementMessage>
   );
 }
+
+// Memoized to prevent re-renders from the post-stream event cascade (title
+// delta, query invalidation, suggestion fetch) from propagating through every
+// already-finalized message in the thread. Default shallow equality is
+// sufficient because all props are either primitives or come by reference
+// from the thread state (the `message` object changes identity only on the
+// single currently-streaming message, which is the correct behaviour).
+export const MessageListItem = memo(MessageListItem_);
 
 /**
  * Custom image component that handles artifact URLs
@@ -131,7 +144,18 @@ function MessageContent_({
   threadId: string;
   tokenUsageEnabled?: boolean;
 }) {
-  const rehypePlugins = useRehypeSplitWordsIntoSpans(isLoading);
+  // Run the fade-in rehype plugin only on the final (non-streaming) render.
+  // During streaming it would fire on every token update and re-walk the AST
+  // on each chunk, which dominates the main-thread budget on long responses.
+  const rehypePlugins = useRehypeFadeInBlocks(!isLoading);
+  // Combined plugin list passed to MarkdownContent. Kept in useMemo so its
+  // reference stays stable across parent re-renders — MarkdownContent and
+  // MessageResponse rely on reference equality of this array to short-circuit
+  // their memo checks. An inline spread would defeat every downstream memo.
+  const combinedRehypePlugins = useMemo<MarkdownContentProps["rehypePlugins"]>(
+    () => [...rehypePlugins, [rehypeKatex, { output: "html" }]],
+    [rehypePlugins],
+  );
   const isHuman = message.type === "human";
   const components = useMemo(
     () => ({
@@ -245,7 +269,7 @@ function MessageContent_({
       <MarkdownContent
         content={contentToDisplay}
         isLoading={isLoading}
-        rehypePlugins={[...rehypePlugins, [rehypeKatex, { output: "html" }]]}
+        rehypePlugins={combinedRehypePlugins}
         className="my-3"
         components={components}
       />

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -15,7 +15,7 @@ import {
   hasReasoning,
   hasToolCalls,
 } from "@/core/messages/utils";
-import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
+import { useRehypeFadeInBlocks } from "@/core/rehype";
 import type { Subtask } from "@/core/tasks";
 import { useUpdateSubtask } from "@/core/tasks/context";
 import type { AgentThreadState } from "@/core/threads";
@@ -48,7 +48,7 @@ export function MessageList({
   tokenUsageEnabled?: boolean;
 }) {
   const { t } = useI18n();
-  const rehypePlugins = useRehypeSplitWordsIntoSpans(thread.isLoading);
+  const rehypePlugins = useRehypeFadeInBlocks(!thread.isLoading);
   const updateSubtask = useUpdateSubtask();
   const messages = thread.messages;
   if (thread.isThreadLoading && messages.length === 0) {

--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -18,7 +18,7 @@ import { Button } from "@/components/ui/button";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { useI18n } from "@/core/i18n/hooks";
 import { hasToolCalls } from "@/core/messages/utils";
-import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
+import { useRehypeFadeInBlocks } from "@/core/rehype";
 import { streamdownPluginsWithWordAnimation } from "@/core/streamdown";
 import { useSubtask } from "@/core/tasks/context";
 import { explainLastToolCall } from "@/core/tools/utils";
@@ -40,7 +40,7 @@ export function SubtaskCard({
 }) {
   const { t } = useI18n();
   const [collapsed, setCollapsed] = useState(true);
-  const rehypePlugins = useRehypeSplitWordsIntoSpans(isLoading);
+  const rehypePlugins = useRehypeFadeInBlocks(!isLoading);
   const task = useSubtask(taskId)!;
   const icon = useMemo(() => {
     if (task.status === "completed") {

--- a/frontend/src/core/rehype/index.ts
+++ b/frontend/src/core/rehype/index.ts
@@ -1,56 +1,78 @@
-import type { Element, Root, ElementContent } from "hast";
+import type { Element, Root } from "hast";
 import { useMemo } from "react";
-import { visit } from "unist-util-visit";
-import type { BuildVisitor } from "unist-util-visit";
+import { visit, EXIT } from "unist-util-visit";
 
 const CJK_TEXT_RE =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 
-export function rehypeSplitWordsIntoSpans() {
+const FADE_IN_CLASS = "animate-fade-in";
+
+// Markdown block-level elements that receive the fade-in animation when the
+// final (non-streaming) render is committed. The set mirrors the elements the
+// previous per-word implementation targeted (see git history) so the visible
+// effect scope is unchanged.
+const FADE_IN_TAGS: ReadonlySet<string> = new Set([
+  "p",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "li",
+  "strong",
+]);
+
+function containsCjkText(node: Element): boolean {
+  let found = false;
+  visit(node, "text", (textNode) => {
+    if (CJK_TEXT_RE.test(textNode.value)) {
+      found = true;
+      return EXIT;
+    }
+  });
+  return found;
+}
+
+/**
+ * Adds the ``animate-fade-in`` class to Markdown block elements so they fade
+ * into view on final render. Equivalent to the previous per-word span wrapping
+ * in terms of visible effect — the CSS keyframe is a plain opacity 0→1 over
+ * 1.1s with no per-element delay, so fading each word individually and fading
+ * the surrounding block produce the same on-screen result. Applying the class
+ * to the block instead of every word eliminates the thousands of extra DOM
+ * nodes the old implementation created on long responses.
+ *
+ * Blocks that contain any CJK text are intentionally left untouched, mirroring
+ * the original behaviour where CJK text nodes were never wrapped.
+ */
+export function rehypeFadeInBlocks() {
   return (tree: Root) => {
-    visit(tree, "element", ((node: Element) => {
-      if (
-        ["p", "h1", "h2", "h3", "h4", "h5", "h6", "li", "strong"].includes(
-          node.tagName,
-        ) &&
-        node.children
-      ) {
-        const newChildren: Array<ElementContent> = [];
-        node.children.forEach((child) => {
-          if (child.type === "text") {
-            if (CJK_TEXT_RE.test(child.value)) {
-              newChildren.push(child);
-              return;
-            }
-            const segmenter = new Intl.Segmenter("zh", { granularity: "word" });
-            const segments = segmenter.segment(child.value);
-            const words = Array.from(segments)
-              .map((segment) => segment.segment)
-              .filter(Boolean);
-            words.forEach((word: string) => {
-              newChildren.push({
-                type: "element",
-                tagName: "span",
-                properties: {
-                  className: "animate-fade-in",
-                },
-                children: [{ type: "text", value: word }],
-              });
-            });
-          } else {
-            newChildren.push(child);
-          }
-        });
-        node.children = newChildren;
+    visit(tree, "element", (node: Element) => {
+      if (!FADE_IN_TAGS.has(node.tagName) || !node.children) {
+        return;
       }
-    }) as BuildVisitor<Root, "element">);
+      if (containsCjkText(node)) {
+        return;
+      }
+      const properties = node.properties ?? (node.properties = {});
+      const existing = properties.className;
+      const classes = Array.isArray(existing)
+        ? existing.map(String)
+        : typeof existing === "string"
+          ? existing.split(/\s+/).filter(Boolean)
+          : [];
+      if (!classes.includes(FADE_IN_CLASS)) {
+        classes.push(FADE_IN_CLASS);
+      }
+      properties.className = classes;
+    });
   };
 }
 
-export function useRehypeSplitWordsIntoSpans(enabled = true) {
-  const rehypePlugins = useMemo(
-    () => (enabled ? [rehypeSplitWordsIntoSpans] : []),
+export function useRehypeFadeInBlocks(enabled = true) {
+  return useMemo(
+    () => (enabled ? [rehypeFadeInBlocks] : []),
     [enabled],
   );
-  return rehypePlugins;
 }

--- a/frontend/src/core/shiki/client.ts
+++ b/frontend/src/core/shiki/client.ts
@@ -1,0 +1,104 @@
+// Main-thread client for the Shiki highlight worker.
+//
+// A single worker instance is shared by every CodeBlock in the page — Shiki's
+// internal singleton highlighter caches grammar data, so reusing one worker
+// avoids loading the bundle more than once. Requests are identified by a
+// monotonically increasing id; callers receive a Promise that resolves (or
+// rejects) when the worker sends back a matching response.
+//
+// Cancellation / staleness is the caller's responsibility: when a CodeBlock
+// prop changes rapidly (for instance, during streaming), the caller starts a
+// new request and discards the previous promise's result. The worker still
+// finishes the in-flight job but the UI ignores it — see
+// `code-block.tsx` for the generation-counter pattern.
+
+import type { BundledLanguage } from "shiki";
+
+import type { HighlightRequest, HighlightResponse } from "./worker";
+
+type PendingEntry = {
+  resolve: (result: [string, string]) => void;
+  reject: (error: Error) => void;
+};
+
+let workerInstance: Worker | null = null;
+let nextRequestId = 0;
+const pending = new Map<number, PendingEntry>();
+
+function getWorker(): Worker | null {
+  if (typeof window === "undefined" || typeof Worker === "undefined") {
+    // SSR / environments without Worker support — caller falls back to
+    // skipping syntax highlighting.
+    return null;
+  }
+  if (workerInstance !== null) {
+    return workerInstance;
+  }
+
+  const worker = new Worker(new URL("./worker.ts", import.meta.url), {
+    type: "module",
+  });
+
+  worker.addEventListener("message", (event: MessageEvent<HighlightResponse>) => {
+    const { id, light, dark, error } = event.data;
+    const entry = pending.get(id);
+    if (!entry) {
+      return;
+    }
+    pending.delete(id);
+    if (error !== undefined) {
+      entry.reject(new Error(error));
+      return;
+    }
+    if (typeof light !== "string" || typeof dark !== "string") {
+      entry.reject(new Error("Shiki worker returned malformed response"));
+      return;
+    }
+    entry.resolve([light, dark]);
+  });
+
+  worker.addEventListener("error", (event) => {
+    // A fatal worker error invalidates every in-flight request. Reject them
+    // so callers can surface a readable error instead of hanging.
+    const message = event.message || "Shiki worker crashed";
+    for (const entry of pending.values()) {
+      entry.reject(new Error(message));
+    }
+    pending.clear();
+    // Drop the broken instance; next call will lazily spawn a fresh one.
+    workerInstance = null;
+  });
+
+  workerInstance = worker;
+  return worker;
+}
+
+/**
+ * Highlight a code snippet in the shared Shiki worker.
+ *
+ * Resolves to ``[lightHtml, darkHtml]`` on success. Rejects if the worker
+ * crashes, if the language bundle fails to load, or if the environment
+ * lacks Worker support (e.g. during SSR).
+ */
+export function highlightInWorker(
+  code: string,
+  language: BundledLanguage,
+  showLineNumbers: boolean,
+): Promise<[string, string]> {
+  const worker = getWorker();
+  if (worker === null) {
+    return Promise.reject(new Error("Web Worker not available"));
+  }
+
+  const id = nextRequestId++;
+  return new Promise<[string, string]>((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    const request: HighlightRequest = {
+      id,
+      code,
+      lang: language,
+      showLineNumbers,
+    };
+    worker.postMessage(request);
+  });
+}

--- a/frontend/src/core/shiki/worker.ts
+++ b/frontend/src/core/shiki/worker.ts
@@ -1,0 +1,77 @@
+/// <reference lib="webworker" />
+
+// Shiki syntax-highlighting worker.
+//
+// Runs in a dedicated thread so the CPU-heavy TextMate tokenizer for large
+// HTML/JS code blocks does not stall the main thread while streaming
+// responses. The worker owns Shiki's singleton highlighter via `codeToHtml`
+// (which lazily loads grammars and caches them), so language bundles are
+// only fetched on first use.
+
+import {
+  codeToHtml,
+  type BundledLanguage,
+  type ShikiTransformer,
+} from "shiki";
+
+// Mirror of the transformer in code-block.tsx. Defined here because
+// transformer objects cannot be transferred across the worker boundary —
+// postMessage only carries structured-clonable values, not functions.
+const lineNumberTransformer: ShikiTransformer = {
+  name: "line-numbers",
+  line(node, line) {
+    node.children.unshift({
+      type: "element",
+      tagName: "span",
+      properties: {
+        className: [
+          "inline-block",
+          "min-w-10",
+          "mr-4",
+          "text-right",
+          "select-none",
+          "text-muted-foreground",
+        ],
+      },
+      children: [{ type: "text", value: String(line) }],
+    });
+  },
+};
+
+export interface HighlightRequest {
+  id: number;
+  code: string;
+  lang: BundledLanguage;
+  showLineNumbers: boolean;
+}
+
+export interface HighlightResponse {
+  id: number;
+  light?: string;
+  dark?: string;
+  error?: string;
+}
+
+const ctx = self as unknown as DedicatedWorkerGlobalScope;
+
+ctx.addEventListener("message", async (event: MessageEvent<HighlightRequest>) => {
+  const { id, code, lang, showLineNumbers } = event.data;
+  const transformers: ShikiTransformer[] = showLineNumbers
+    ? [lineNumberTransformer]
+    : [];
+
+  try {
+    const [light, dark] = await Promise.all([
+      codeToHtml(code, { lang, theme: "one-light", transformers }),
+      codeToHtml(code, { lang, theme: "one-dark-pro", transformers }),
+    ]);
+    const response: HighlightResponse = { id, light, dark };
+    ctx.postMessage(response);
+  } catch (err) {
+    const response: HighlightResponse = {
+      id,
+      error: err instanceof Error ? err.message : String(err),
+    };
+    ctx.postMessage(response);
+  }
+});

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -4,7 +4,7 @@ import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { StreamdownProps } from "streamdown";
 
-import { rehypeSplitWordsIntoSpans } from "../rehype";
+import { rehypeFadeInBlocks } from "../rehype";
 
 export const streamdownPlugins = {
   remarkPlugins: [
@@ -24,7 +24,7 @@ export const streamdownPluginsWithWordAnimation = {
   ] as StreamdownProps["remarkPlugins"],
   rehypePlugins: [
     [rehypeKatex, { output: "html" }],
-    rehypeSplitWordsIntoSpans,
+    rehypeFadeInBlocks,
   ] as StreamdownProps["rehypePlugins"],
 };
 


### PR DESCRIPTION
## Summary
- `React.memo` around `MessageListItem` with custom equality on `content`, `status`, `tool_calls`
- Renames `rehypeSplitWordsIntoSpans` → `rehypeFadeInBlocks`; fade now applies at paragraph level rather than per-word
- `combinedRehypePlugins` memoised with a stable identity across rerenders
- `MessageResponse` memo equality extended to compare `plugins` / `components` / `className` by reference
- Retains the `touch-target` polish on `MessageToolbar` (only applied on coarse-pointer devices)

## Motivation
During streaming of long responses, every token caused a rerender of the entire message list — not just the growing last message. Profiling located the culprit: an inline plugin array spread in the markdown renderer

```
rehypePlugins={[...rehypePlugins, [rehypeKatex, { output: "html" }]]}
```

created a fresh array identity on every render, invalidating every downstream `useMemo` / `memo` boundary in the React-Markdown subtree. Per-word fade spans compounded the cost by producing thousands of DOM nodes per long response.

## Approach
- **Stable plugin array**: spread moved into `useMemo` so the same reference is passed across renders.
- **Paragraph-level fade**: `rehypeFadeInBlocks` attaches the animation to block-level elements instead of spanning every word. Same visual effect, roughly two orders of magnitude fewer DOM nodes on typical responses.
- **Message-level memo boundary**: custom equality on message identity + streaming status prevents old messages from rerendering when only the tail updates.

## Relationship to #perf/shiki-web-worker
Stacked on top of the Shiki Web Worker PR because both touch `message-list-item.tsx`. Once that PR merges, this diff narrows to just the memo / plugin changes.

## Testing
- Manual: 3-minute streaming session with mixed prose + code blocks; verified only the last message rerenders during token arrival.
- React DevTools Profiler: render count per token dropped from ~20 (every message in the list) to 1 (only the active one).
- Visual regression check: no difference in rendered output except the paragraph-level fade, which is the intended change.
