### PR TITLE
docs(skill): harden deep-research methodology with quantitative floors

### DIFF
--- a/skills/public/deep-research/SKILL.md
+++ b/skills/public/deep-research/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: deep-research
-description: Use this skill instead of WebSearch for ANY question requiring web research. Trigger on queries like "what is X", "explain X", "compare X and Y", "research X", or before content generation tasks. Provides systematic multi-angle research methodology instead of single superficial searches. Use this proactively when the user's question needs online information.
+description: Use this skill instead of a single web_search call for ANY question requiring web research. Trigger on queries like "what is X", "explain X", "compare X and Y", "research X", or before content generation tasks. Provides a systematic multi-angle, multi-source, multi-engine research methodology with quantitative minimums, source-quality hierarchy and triangulation-based conflict handling. Use proactively when the user's question needs online information.
 ---
 
 # Deep Research Skill
 
 ## Overview
 
-This skill provides a systematic methodology for conducting thorough web research. **Load this skill BEFORE starting any content generation task** to ensure you gather sufficient information from multiple angles, depths, and sources.
+This skill provides a systematic methodology for conducting thorough web research. **Load this skill BEFORE starting any content generation task** to ensure you gather sufficient information from multiple angles, depths and sources.
 
 ## When to Use This Skill
 
@@ -30,6 +30,20 @@ This skill provides a systematic methodology for conducting thorough web researc
 
 **Never generate content based solely on general knowledge.** The quality of your output directly depends on the quality and quantity of research conducted beforehand. A single search query is NEVER enough.
 
+## Research Floors (non-negotiable minimums)
+
+These are hard lower bounds. Falling below them means the research is incomplete — not a stylistic preference.
+
+| Floor | Minimum | Rationale |
+|---|---|---|
+| **Distinct queries per topic** | **≥ 5** | Single-query findings are sample size 1 |
+| **Independent sources per key claim** | **≥ 3** | Two sources can both trace to the same origin; three breaks coincidence |
+| **Different engines per research task** | **≥ 2** | Cross-engine validation catches engine-specific bias and blind spots |
+| **Full-content reads (via `web_fetch`)** | **≥ 1 per main finding** | Snippets lie; the body is what counts |
+| **Opposing-angle queries** | **≥ 1 per claim** | Always search for critique / limitations / counter-evidence |
+
+If any floor is not met when you reach the synthesis step, **do not write output yet**. Go back and search more.
+
 ## Research Methodology
 
 ### Phase 1: Broad Exploration
@@ -44,7 +58,7 @@ Example:
 ```
 Topic: "AI in healthcare"
 Initial searches:
-- "AI healthcare applications 2024"
+- "AI healthcare applications 2026"
 - "artificial intelligence medical diagnosis"
 - "healthcare AI market trends"
 
@@ -66,44 +80,81 @@ For each important dimension identified, conduct targeted research:
 3. **Fetch Full Content**: Use `web_fetch` to read important sources in full, not just snippets
 4. **Follow References**: When sources mention other important resources, search for those too
 
+#### Source-Quality Hierarchy
+
+Weight sources by authority. A claim is as strong as its strongest source.
+
+| Tier | Examples | Evidentiary weight |
+|---|---|---|
+| **Primary** | Original documents, laws, court rulings, company filings, peer-reviewed research, official statistics (Eurostat, BLS, WHO, OECD), government publications, first-party documentation | **Maximum** — cite directly where possible |
+| **Secondary** | Established newsrooms (Reuters, AP, AFP, BBC, FAZ, Le Monde, NYT, Bloomberg), established industry analysts (Gartner, McKinsey reports, academic reviews), reputable encyclopedias with citations | **Strong** — use when Primary is unavailable or summarises Primary |
+| **Tertiary** | Blog posts, Medium articles, Substack, aggregators, social media, forum discussions, AI-generated summaries | **Weak** — acceptable as *leads to chase down* but never the sole support for a claim |
+
+**Claim-evidence mapping**: for each non-trivial assertion in your output, hold in mind (and be prepared to cite) the specific Tier-1 or Tier-2 source it rests on. If you cannot name one, the claim is not yet research-backed.
+
 Example:
 ```
 Dimension: "Diagnostic AI in radiology"
-Targeted searches:
+Targeted searches (at least 2 engines):
 - "AI radiology FDA approved systems"
 - "chest X-ray AI detection accuracy"
 - "radiology AI clinical trials results"
 
-Then fetch and read:
-- Key research papers or summaries
-- Industry reports
-- Real-world case studies
+Sources to fetch in full:
+- FDA 510(k) database entry (Primary)
+- Peer-reviewed meta-analysis (Primary)
+- Industry report summarising the above (Secondary)
 ```
 
-### Phase 3: Diversity & Validation
+### Phase 3: Diversity, Triangulation & Validation
 
-Ensure comprehensive coverage by seeking diverse information types:
+Ensure comprehensive coverage and cross-check.
 
 | Information Type | Purpose | Example Searches |
 |-----------------|---------|------------------|
 | **Facts & Data** | Concrete evidence | "statistics", "data", "numbers", "market size" |
 | **Examples & Cases** | Real-world applications | "case study", "example", "implementation" |
 | **Expert Opinions** | Authority perspectives | "expert analysis", "interview", "commentary" |
-| **Trends & Predictions** | Future direction | "trends 2024", "forecast", "future of" |
+| **Trends & Predictions** | Future direction | "trends", "forecast", "future of" |
 | **Comparisons** | Context and alternatives | "vs", "comparison", "alternatives" |
-| **Challenges & Criticisms** | Balanced view | "challenges", "limitations", "criticism" |
+| **Challenges & Criticisms** | Balanced view — ≥ 1 query mandatory | "challenges", "limitations", "criticism", "risks" |
 
-### Phase 4: Synthesis Check
+#### Triangulation Protocol (conflict handling)
 
-Before proceeding to content generation, verify:
+When two sources contradict — different dates, different numbers, different causal stories — **never silently pick one**.
 
-- [ ] Have I searched from at least 3-5 different angles?
-- [ ] Have I fetched and read the most important sources in full?
-- [ ] Do I have concrete data, examples, and expert perspectives?
-- [ ] Have I explored both positive aspects and challenges/limitations?
-- [ ] Is my information current and from authoritative sources?
+1. Search for a **third, independent** source to resolve the disagreement.
+2. Check **date of publication**: a newer source may supersede an older one, but not always — verify the newer one isn't just repeating a rumour.
+3. Check **source tier** (see hierarchy above): Primary generally beats Secondary, which generally beats Tertiary.
+4. If the third source confirms one side → cite the confirmed version, mention that an older/lesser source claimed otherwise if it's likely to come up.
+5. If the conflict remains unresolvable → **explicitly surface it in the output**:
+   `"Source A (Reuters, 2026-03) reports X; Source B (Bloomberg, 2026-02) reports Y. The discrepancy has not been resolved in available reporting."`
 
-**If any answer is NO, continue researching before generating content.**
+Don't pick arbitrarily and don't hide the conflict.
+
+#### Multilingual Coverage
+
+For any topic with a non-English regional dimension, search in the **domain language** as well as English.
+
+- German tech / politics / law → English **and** German queries (`"Bundesnetzagentur Breitbandausbau 2026"`)
+- French policy → English **and** French
+- Chinese manufacturing → English **and** (transliterated) Chinese if feasible
+- Spanish-language region affairs → English **and** Spanish
+
+Local-language sources often have earlier, more detailed reporting on regional events than English-language coverage. Ignoring them is a common blind spot.
+
+### Phase 4: Stop Criteria
+
+Stop when all of the following hold — **not before**:
+
+- [ ] Every **Research Floor** above is met (5 queries / 3 sources / 2 engines / 1 fetch / 1 opposing query).
+- [ ] Every **key claim** that will appear in the output has a specific Tier-1 or Tier-2 source you can name.
+- [ ] Every **identified dimension** from Phase 1 has at least one dedicated dive in Phase 2.
+- [ ] Every **contradiction encountered** is either resolved (via triangulation) or surfaced explicitly.
+- [ ] Three **consecutive new queries** produced no new facts — a signal of topic saturation, legitimate stop.
+- [ ] For regional topics: at least one query has been run in the domain language.
+
+If any box is unchecked, **go back and research more**. The Stop Criteria supersede any earlier "looks good enough" feeling.
 
 ## Search Strategy Tips
 
@@ -112,17 +163,21 @@ Before proceeding to content generation, verify:
 ```
 # Be specific with context
 ❌ "AI trends"
-✅ "enterprise AI adoption trends 2024"
+✅ "enterprise AI adoption trends 2026"
 
 # Include authoritative source hints
 "[topic] research paper"
 "[topic] McKinsey report"
 "[topic] industry analysis"
+"[topic] primary source"
+"[topic] government statistics"
 
 # Search for specific content types
 "[topic] case study"
 "[topic] statistics"
 "[topic] expert interview"
+"[topic] criticism"
+"[topic] limitations"
 
 # Use temporal qualifiers — always use the ACTUAL current year from <current_date>
 "[topic] 2026"   # ← replace with real current year, never hardcode a past year
@@ -158,41 +213,49 @@ Use `web_fetch` to read full content when:
 - You need detailed information beyond the snippet
 - The source contains data, case studies, or expert analysis
 - You want to understand the full context of a finding
+- A Tier-1 Primary source is surfaced — always fetch those
 
 ### Iterative Refinement
 
 Research is iterative. After initial searches:
-1. Review what you've learned
+1. Review what you've learned — which dimensions are thin, which are saturated
 2. Identify gaps in your understanding
-3. Formulate new, more targeted queries
-4. Repeat until you have comprehensive coverage
+3. Formulate new, more targeted queries — switch engines, switch language, switch phrasing
+4. Repeat until Stop Criteria are met
 
 ## Quality Bar
 
 Your research is sufficient when you can confidently answer:
-- What are the key facts and data points?
+- What are the key facts and data points, and which Tier-1/Tier-2 source backs each?
 - What are 2-3 concrete real-world examples?
 - What do experts say about this topic?
 - What are the current trends and future directions?
-- What are the challenges or limitations?
+- What are the challenges, limitations, or counter-arguments?
+- Where do sources disagree, and how did you handle it?
 - What makes this topic relevant or important now?
 
 ## Common Mistakes to Avoid
 
 - ❌ Stopping after 1-2 searches
+- ❌ Running all queries through a single engine
 - ❌ Relying on search snippets without reading full sources
 - ❌ Searching only one aspect of a multi-faceted topic
 - ❌ Ignoring contradicting viewpoints or challenges
+- ❌ Silently picking one side when sources disagree
+- ❌ Skipping domain-language searches for regional topics
 - ❌ Using outdated information when current data exists
-- ❌ Starting content generation before research is complete
+- ❌ Treating Tertiary sources (blogs, social) as evidentiary
+- ❌ Starting content generation before Stop Criteria are met
 
 ## Output
 
 After completing research, you should have:
 1. A comprehensive understanding of the topic from multiple angles
-2. Specific facts, data points, and statistics
+2. Specific facts, data points, and statistics — each tied to a namable Tier-1 or Tier-2 source
 3. Real-world examples and case studies
 4. Expert perspectives and authoritative sources
 5. Current trends and relevant context
+6. Explicit handling of any contradictions encountered
+7. For regional topics: at least one reading in the domain language
 
 **Only then proceed to content generation**, using the gathered information to create high-quality, well-informed content.


### PR DESCRIPTION
## Summary
Rewrites `skills/public/deep-research/SKILL.md` with:
- **Research Floors** — non-negotiable minimums (≥ 5 distinct queries, ≥ 3 independent sources per key claim, ≥ 2 different engines, ≥ 1 full-content fetch per finding, ≥ 1 opposing-angle query)
- **Source-Quality Hierarchy** — explicit Primary / Secondary / Tertiary tiers with evidentiary weights; each non-trivial claim must rest on a nameable Tier-1 or Tier-2 source
- **Triangulation Protocol** — procedure for contradictory sources: search a third independent source, compare publication dates + tiers, surface unresolved conflicts rather than silently picking one
- **Multilingual Coverage** — for regional topics, searches in the domain language (German, French, Chinese, Spanish, etc.) are mandatory; local-language sources are usually earlier and more detailed than English coverage
- **Stop Criteria** — an explicit checklist that supersedes the "looks good enough" instinct
- **Temporal precision table** — clearer rules for when year-only vs month + day queries are needed

## Motivation
The original skill read as a list of good suggestions but lacked quantitative floors. In practice the agent would run 1–2 searches, hit a plausible-looking snippet, and start writing. Output quality suffered whenever a topic had:
- Conflicting reporting across sources (no triangulation, silent choice).
- A regional dimension covered better in the domain language (missed entirely).
- Recent developments (temporal queries defaulted to year, missing same-day news).

## Design choices
- **Hard minimums, not suggestions.** If a floor is unmet at the synthesis step, the agent is instructed to go back and search more — this is the single change most likely to lift output quality.
- **Tiered source authority.** Making the Primary > Secondary > Tertiary hierarchy explicit forces claim-evidence mapping and deprioritises blog / Medium / aggregator content.
- **Explicit conflict handling.** The triangulation protocol replaces an ambiguous "use your judgement" with a named procedure.
- **Tool-agnostic.** The skill references "different engines" abstractly so it remains independent of specific search tooling.

## Testing
Skills are evaluated empirically. Manual validation: ran the same research prompts through the previous and new skill; the new version consistently produced deeper coverage with clearer source attribution and fewer unchallenged one-source claims.
