### PR TITLE
fix: correct YAML front-matter parsing error in bootstrap skill

### DIFF
--- a/skills/public/bootstrap/SKILL.md
+++ b/skills/public/bootstrap/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bootstrap
-description: Generate a personalized SOUL.md through a warm, adaptive onboarding conversation. Trigger when the user wants to create, set up, or initialize their AI partner's identity — e.g., "create my SOUL.md", "bootstrap my agent", "set up my AI partner", "define who you are", "let's do onboarding", "personalize this AI", "make you mine", or when a SOUL.md is missing. Also trigger for updates: "update my SOUL.md", "change my AI's personality", "tweak the soul".
+description: Generate a personalized SOUL.md through a warm, adaptive onboarding conversation. Trigger when the user wants to create, set up, or initialize their AI partner's identity — e.g., "create my SOUL.md", "bootstrap my agent", "set up my AI partner", "define who you are", "let's do onboarding", "personalize this AI", "make you mine", or when a SOUL.md is missing. Also trigger for updates - "update my SOUL.md", "change my AI's personality", "tweak the soul".
 ---
 
 # Bootstrap Soul


### PR DESCRIPTION
Fixed YAML syntax error in skills/public/bootstrap/SKILL.md where a colon in the description field was causing parsing failures. Replaced colon with hyphen to avoid YAML mapping issues.