### PR TITLE
fix: remove mismatched context param in debug.py to suppress Pydantic warning

### DIFF
--- a/backend/debug.py
+++ b/backend/debug.py
@@ -20,6 +20,7 @@ import logging
 
 from dotenv import load_dotenv
 from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
 
 from deerflow.agents import make_lead_agent
 
@@ -52,6 +53,9 @@ async def main():
         }
     }
 
+    runtime = Runtime(context={"thread_id": "debug-thread-001"})
+    config["configurable"]["__pregel_runtime"] = runtime
+
     agent = make_lead_agent(config)
 
     print("=" * 50)
@@ -70,7 +74,7 @@ async def main():
 
             # Invoke the agent
             state = {"messages": [HumanMessage(content=user_input)]}
-            result = await agent.ainvoke(state, config=config, context={"thread_id": "debug-thread-001"})
+            result = await agent.ainvoke(state, config=config)
 
             # Print the response
             if result.get("messages"):

--- a/backend/debug.py
+++ b/backend/debug.py
@@ -53,7 +53,7 @@ async def main():
         }
     }
 
-    runtime = Runtime(context={"thread_id": "debug-thread-001"})
+    runtime = Runtime(context={"thread_id": config["configurable"]["thread_id"]})
     config["configurable"]["__pregel_runtime"] = runtime
 
     agent = make_lead_agent(config)


### PR DESCRIPTION
## Summary

- Remove the `context` kwarg from `agent.ainvoke()` in `debug.py`, which caused a `PydanticSerializationUnexpectedValue` warning on every invocation because the agent graph has no `context_schema` (`ContextT` defaults to `None`).
- Inject runtime context via `Runtime` object into `config["configurable"]["__pregel_runtime"]` instead, aligning with the production `run_agent` code path.

## Test plan

- [x] Run `debug.py` and verify the Pydantic serialization warning no longer appears
- [x] Verify agent responds normally after the change

Closes #2445

Made with [Cursor](https://cursor.com)