### PR TITLE
feat(mcp): support custom tool interceptors via extensions_config.json

### DIFF
--- a/backend/docs/MCP_SERVER.md
+++ b/backend/docs/MCP_SERVER.md
@@ -45,6 +45,41 @@ Example:
 }
 ```
 
+## Custom Tool Interceptors
+
+You can register custom interceptors that run before every MCP tool call. This is useful for injecting per-request headers (e.g., user auth tokens from the LangGraph execution context), logging, or metrics.
+
+Declare interceptors in `extensions_config.json` using the `mcpInterceptors` field:
+
+```json
+{
+  "mcpInterceptors": [
+    "my_package.mcp.auth:build_auth_interceptor"
+  ],
+  "mcpServers": { ... }
+}
+```
+
+Each entry is a Python import path in `module:variable` format (resolved via `resolve_variable`). The variable must be a **no-arg builder function** that returns an async interceptor compatible with `MultiServerMCPClient`’s `tool_interceptors` interface, or `None` to skip.
+
+Example interceptor that injects auth headers from LangGraph metadata:
+
+```python
+def build_auth_interceptor():
+    async def interceptor(request, handler):
+        from langgraph.config import get_config
+        metadata = get_config().get("metadata", {})
+        headers = dict(request.headers or {})
+        if token := metadata.get("auth_token"):
+            headers["X-Auth-Token"] = token
+        return await handler(request.override(headers=headers))
+    return interceptor
+```
+
+- A single string value is accepted and normalized to a one-element list.
+- Invalid paths or builder failures are logged as warnings without blocking other interceptors.
+- The builder return value must be `callable`; non-callable values are skipped with a warning.
+
 ## How It Works
 
 MCP servers expose tools that are automatically discovered and integrated into DeerFlow’s agent system at runtime. Once enabled, these tools become available to agents without additional code changes.

--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -95,6 +95,21 @@ async def get_mcp_tools() -> list[BaseTool]:
         if oauth_interceptor is not None:
             tool_interceptors.append(oauth_interceptor)
 
+        # Load custom interceptors declared in extensions_config.json
+        # Format: "mcpInterceptors": ["pkg.module:builder_func", ...]
+        mcp_interceptor_paths = (extensions_config.model_extra or {}).get("mcpInterceptors", [])
+        for interceptor_path in mcp_interceptor_paths:
+            try:
+                from deerflow.reflection import resolve_variable
+
+                builder = resolve_variable(interceptor_path)
+                interceptor = builder()
+                if interceptor is not None:
+                    tool_interceptors.append(interceptor)
+                    logger.info(f"Loaded MCP interceptor: {interceptor_path}")
+            except Exception as e:
+                logger.warning(f"Failed to load MCP interceptor {interceptor_path}: {e}")
+
         client = MultiServerMCPClient(servers_config, tool_interceptors=tool_interceptors, tool_name_prefix=True)
 
         # Get all tools from all servers

--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -108,7 +108,7 @@ async def get_mcp_tools() -> list[BaseTool]:
                     tool_interceptors.append(interceptor)
                     logger.info(f"Loaded MCP interceptor: {interceptor_path}")
             except Exception as e:
-                logger.warning(f"Failed to load MCP interceptor {interceptor_path}: {e}")
+                logger.warning(f"Failed to load MCP interceptor {interceptor_path}: {e}", exc_info=True)
 
         client = MultiServerMCPClient(servers_config, tool_interceptors=tool_interceptors, tool_name_prefix=True)
 

--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -12,6 +12,7 @@ from langchain_core.tools import BaseTool
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.mcp.client import build_servers_config
 from deerflow.mcp.oauth import build_oauth_tool_interceptor, get_initial_oauth_headers
+from deerflow.reflection import resolve_variable
 
 logger = logging.getLogger(__name__)
 
@@ -106,13 +107,13 @@ async def get_mcp_tools() -> list[BaseTool]:
             raw_interceptor_paths = []
         for interceptor_path in raw_interceptor_paths:
             try:
-                from deerflow.reflection import resolve_variable
-
                 builder = resolve_variable(interceptor_path)
                 interceptor = builder()
-                if interceptor is not None:
+                if callable(interceptor):
                     tool_interceptors.append(interceptor)
                     logger.info(f"Loaded MCP interceptor: {interceptor_path}")
+                elif interceptor is not None:
+                    logger.warning(f"Builder {interceptor_path} returned non-callable {type(interceptor).__name__}; skipping")
             except Exception as e:
                 logger.warning(f"Failed to load MCP interceptor {interceptor_path}: {e}", exc_info=True)
 

--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -97,8 +97,14 @@ async def get_mcp_tools() -> list[BaseTool]:
 
         # Load custom interceptors declared in extensions_config.json
         # Format: "mcpInterceptors": ["pkg.module:builder_func", ...]
-        mcp_interceptor_paths = (extensions_config.model_extra or {}).get("mcpInterceptors", [])
-        for interceptor_path in mcp_interceptor_paths:
+        raw_interceptor_paths = (extensions_config.model_extra or {}).get("mcpInterceptors")
+        if isinstance(raw_interceptor_paths, str):
+            raw_interceptor_paths = [raw_interceptor_paths]
+        elif not isinstance(raw_interceptor_paths, list):
+            if raw_interceptor_paths is not None:
+                logger.warning(f"mcpInterceptors must be a list of strings, got {type(raw_interceptor_paths).__name__}; skipping")
+            raw_interceptor_paths = []
+        for interceptor_path in raw_interceptor_paths:
             try:
                 from deerflow.reflection import resolve_variable
 

--- a/backend/tests/test_mcp_custom_interceptors.py
+++ b/backend/tests/test_mcp_custom_interceptors.py
@@ -6,10 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from deerflow.mcp.tools import get_mcp_tools
 
 
-def _make_mock_env(*, interceptor_paths=None):
+def _make_patches(*, interceptor_paths=None):
     """Set up mocks for get_mcp_tools() with optional custom interceptors.
 
-    Returns a dict of patch contexts and captured state.
+    Returns a dict of patch context managers.
     """
     mock_client = MagicMock()
     mock_client.get_tools = AsyncMock(return_value=[])
@@ -18,7 +18,7 @@ def _make_mock_env(*, interceptor_paths=None):
     if interceptor_paths is not None:
         extra["mcpInterceptors"] = interceptor_paths
 
-    patches = {
+    return {
         "client_cls": patch(
             "langchain_mcp_adapters.client.MultiServerMCPClient",
             return_value=mock_client,
@@ -44,7 +44,12 @@ def _make_mock_env(*, interceptor_paths=None):
             return_value=None,
         ),
     }
-    return patches, mock_client
+
+
+def _get_interceptors(mock_cls):
+    """Extract the tool_interceptors list passed to MultiServerMCPClient."""
+    kw = mock_cls.call_args
+    return kw.kwargs.get("tool_interceptors") or kw[1].get("tool_interceptors", [])
 
 
 def test_custom_interceptor_loaded_and_appended():
@@ -56,23 +61,19 @@ def test_custom_interceptor_loaded_and_appended():
     def fake_builder():
         return fake_interceptor
 
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["my_package.auth:build_interceptor"],
-    )
+    p = _make_patches(interceptor_paths=["my_package.auth:build_interceptor"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
         patch("deerflow.reflection.resolve_variable", return_value=fake_builder),
     ):
         asyncio.run(get_mcp_tools())
 
-        # Verify MultiServerMCPClient received the interceptor
-        call_kwargs = mock_cls.call_args
-        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        interceptors = _get_interceptors(mock_cls)
         assert len(interceptors) == 1
         assert interceptors[0] is fake_interceptor
 
@@ -91,22 +92,19 @@ def test_multiple_custom_interceptors():
         "pkg.b:build_b": lambda: interceptor_b,
     }
 
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["pkg.a:build_a", "pkg.b:build_b"],
-    )
+    p = _make_patches(interceptor_paths=["pkg.a:build_a", "pkg.b:build_b"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
         patch("deerflow.reflection.resolve_variable", side_effect=lambda path: builders[path]),
     ):
         asyncio.run(get_mcp_tools())
 
-        call_kwargs = mock_cls.call_args
-        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        interceptors = _get_interceptors(mock_cls)
         assert len(interceptors) == 2
         assert interceptors[0] is interceptor_a
         assert interceptors[1] is interceptor_b
@@ -114,47 +112,37 @@ def test_multiple_custom_interceptors():
 
 def test_custom_interceptor_builder_returning_none_is_skipped():
     """If a builder returns None, it is not appended to the interceptor list."""
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["pkg.noop:build_noop"],
-    )
+    p = _make_patches(interceptor_paths=["pkg.noop:build_noop"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
         patch("deerflow.reflection.resolve_variable", return_value=lambda: None),
     ):
         asyncio.run(get_mcp_tools())
 
-        call_kwargs = mock_cls.call_args
-        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
-        assert len(interceptors) == 0
+        assert len(_get_interceptors(mock_cls)) == 0
 
 
 def test_custom_interceptor_resolve_error_logs_warning_and_continues():
     """A broken interceptor path logs a warning and does not block tool loading."""
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["broken.path:does_not_exist"],
-    )
+    p = _make_patches(interceptor_paths=["broken.path:does_not_exist"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"],
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
         patch("deerflow.reflection.resolve_variable", side_effect=ImportError("no such module")),
         patch("deerflow.mcp.tools.logger.warning") as mock_warn,
     ):
-        # Should not raise
         tools = asyncio.run(get_mcp_tools())
 
-        # Tools still loaded successfully (empty in this mock)
         assert tools == []
-
-        # Warning logged with the broken path
         mock_warn.assert_called_once()
         assert "broken.path:does_not_exist" in mock_warn.call_args[0][0]
 
@@ -165,16 +153,14 @@ def test_custom_interceptor_builder_exception_logs_warning_and_continues():
     def exploding_builder():
         raise RuntimeError("builder exploded")
 
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["pkg.bad:exploding_builder"],
-    )
+    p = _make_patches(interceptor_paths=["pkg.bad:exploding_builder"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"],
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
         patch("deerflow.reflection.resolve_variable", return_value=exploding_builder),
         patch("deerflow.mcp.tools.logger.warning") as mock_warn,
     ):
@@ -187,20 +173,18 @@ def test_custom_interceptor_builder_exception_logs_warning_and_continues():
 
 def test_no_mcp_interceptors_field_is_safe():
     """When mcpInterceptors is absent from config, no interceptors are added."""
-    patches, mock_client = _make_mock_env(interceptor_paths=None)
+    p = _make_patches(interceptor_paths=None)
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
-        patches["oauth_interceptor"],
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
     ):
         asyncio.run(get_mcp_tools())
 
-        call_kwargs = mock_cls.call_args
-        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
-        assert len(interceptors) == 0
+        assert len(_get_interceptors(mock_cls)) == 0
 
 
 def test_custom_interceptor_coexists_with_oauth_interceptor():
@@ -212,22 +196,59 @@ def test_custom_interceptor_coexists_with_oauth_interceptor():
     async def custom_fn(request, handler):
         return await handler(request)
 
-    patches, mock_client = _make_mock_env(
-        interceptor_paths=["pkg.custom:build_custom"],
-    )
+    p = _make_patches(interceptor_paths=["pkg.custom:build_custom"])
 
     with (
-        patches["client_cls"] as mock_cls,
-        patches["from_file"],
-        patches["build_servers"],
-        patches["oauth_headers"],
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
         patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=oauth_fn),
         patch("deerflow.reflection.resolve_variable", return_value=lambda: custom_fn),
     ):
         asyncio.run(get_mcp_tools())
 
-        call_kwargs = mock_cls.call_args
-        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        interceptors = _get_interceptors(mock_cls)
         assert len(interceptors) == 2
         assert interceptors[0] is oauth_fn
         assert interceptors[1] is custom_fn
+
+
+def test_mcp_interceptors_single_string_is_normalized():
+    """A single string value for mcpInterceptors is normalized to a list."""
+
+    async def fake_interceptor(request, handler):
+        return await handler(request)
+
+    p = _make_patches(interceptor_paths="pkg.single:build_it")
+
+    with (
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", return_value=lambda: fake_interceptor),
+    ):
+        asyncio.run(get_mcp_tools())
+
+        assert len(_get_interceptors(mock_cls)) == 1
+
+
+def test_mcp_interceptors_invalid_type_logs_warning():
+    """A non-list, non-string value for mcpInterceptors logs a warning and is skipped."""
+    p = _make_patches(interceptor_paths=42)
+
+    with (
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
+        patch("deerflow.mcp.tools.logger.warning") as mock_warn,
+    ):
+        asyncio.run(get_mcp_tools())
+
+        assert len(_get_interceptors(mock_cls)) == 0
+        mock_warn.assert_called_once()
+        assert "must be a list" in mock_warn.call_args[0][0]

--- a/backend/tests/test_mcp_custom_interceptors.py
+++ b/backend/tests/test_mcp_custom_interceptors.py
@@ -69,7 +69,7 @@ def test_custom_interceptor_loaded_and_appended():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", return_value=fake_builder),
+        patch("deerflow.mcp.tools.resolve_variable", return_value=fake_builder),
     ):
         asyncio.run(get_mcp_tools())
 
@@ -100,7 +100,7 @@ def test_multiple_custom_interceptors():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", side_effect=lambda path: builders[path]),
+        patch("deerflow.mcp.tools.resolve_variable", side_effect=lambda path: builders[path]),
     ):
         asyncio.run(get_mcp_tools())
 
@@ -120,7 +120,7 @@ def test_custom_interceptor_builder_returning_none_is_skipped():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", return_value=lambda: None),
+        patch("deerflow.mcp.tools.resolve_variable", return_value=lambda: None),
     ):
         asyncio.run(get_mcp_tools())
 
@@ -137,7 +137,7 @@ def test_custom_interceptor_resolve_error_logs_warning_and_continues():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", side_effect=ImportError("no such module")),
+        patch("deerflow.mcp.tools.resolve_variable", side_effect=ImportError("no such module")),
         patch("deerflow.mcp.tools.logger.warning") as mock_warn,
     ):
         tools = asyncio.run(get_mcp_tools())
@@ -161,7 +161,7 @@ def test_custom_interceptor_builder_exception_logs_warning_and_continues():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", return_value=exploding_builder),
+        patch("deerflow.mcp.tools.resolve_variable", return_value=exploding_builder),
         patch("deerflow.mcp.tools.logger.warning") as mock_warn,
     ):
         tools = asyncio.run(get_mcp_tools())
@@ -204,7 +204,7 @@ def test_custom_interceptor_coexists_with_oauth_interceptor():
         p["build_servers"],
         p["oauth_headers"],
         patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=oauth_fn),
-        patch("deerflow.reflection.resolve_variable", return_value=lambda: custom_fn),
+        patch("deerflow.mcp.tools.resolve_variable", return_value=lambda: custom_fn),
     ):
         asyncio.run(get_mcp_tools())
 
@@ -228,7 +228,7 @@ def test_mcp_interceptors_single_string_is_normalized():
         p["build_servers"],
         p["oauth_headers"],
         p["oauth_interceptor"],
-        patch("deerflow.reflection.resolve_variable", return_value=lambda: fake_interceptor),
+        patch("deerflow.mcp.tools.resolve_variable", return_value=lambda: fake_interceptor),
     ):
         asyncio.run(get_mcp_tools())
 
@@ -252,3 +252,23 @@ def test_mcp_interceptors_invalid_type_logs_warning():
         assert len(_get_interceptors(mock_cls)) == 0
         mock_warn.assert_called_once()
         assert "must be a list" in mock_warn.call_args[0][0]
+
+
+def test_custom_interceptor_non_callable_return_logs_warning():
+    """If a builder returns a non-callable value, it is skipped with a warning."""
+    p = _make_patches(interceptor_paths=["pkg.bad:returns_string"])
+
+    with (
+        p["client_cls"] as mock_cls,
+        p["from_file"],
+        p["build_servers"],
+        p["oauth_headers"],
+        p["oauth_interceptor"],
+        patch("deerflow.mcp.tools.resolve_variable", return_value=lambda: "not_a_callable"),
+        patch("deerflow.mcp.tools.logger.warning") as mock_warn,
+    ):
+        asyncio.run(get_mcp_tools())
+
+        assert len(_get_interceptors(mock_cls)) == 0
+        mock_warn.assert_called_once()
+        assert "non-callable" in mock_warn.call_args[0][0]

--- a/backend/tests/test_mcp_custom_interceptors.py
+++ b/backend/tests/test_mcp_custom_interceptors.py
@@ -1,0 +1,233 @@
+"""Tests for custom MCP tool interceptors loaded via extensions_config.json."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from deerflow.mcp.tools import get_mcp_tools
+
+
+def _make_mock_env(*, interceptor_paths=None):
+    """Set up mocks for get_mcp_tools() with optional custom interceptors.
+
+    Returns a dict of patch contexts and captured state.
+    """
+    mock_client = MagicMock()
+    mock_client.get_tools = AsyncMock(return_value=[])
+
+    extra = {}
+    if interceptor_paths is not None:
+        extra["mcpInterceptors"] = interceptor_paths
+
+    patches = {
+        "client_cls": patch(
+            "langchain_mcp_adapters.client.MultiServerMCPClient",
+            return_value=mock_client,
+        ),
+        "from_file": patch(
+            "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+            return_value=MagicMock(
+                model_extra=extra,
+                get_enabled_mcp_servers=MagicMock(return_value={}),
+            ),
+        ),
+        "build_servers": patch(
+            "deerflow.mcp.tools.build_servers_config",
+            return_value={"test-server": {}},
+        ),
+        "oauth_headers": patch(
+            "deerflow.mcp.tools.get_initial_oauth_headers",
+            new_callable=AsyncMock,
+            return_value={},
+        ),
+        "oauth_interceptor": patch(
+            "deerflow.mcp.tools.build_oauth_tool_interceptor",
+            return_value=None,
+        ),
+    }
+    return patches, mock_client
+
+
+def test_custom_interceptor_loaded_and_appended():
+    """A valid interceptor builder path is resolved, called, and appended to tool_interceptors."""
+
+    async def fake_interceptor(request, handler):
+        return await handler(request)
+
+    def fake_builder():
+        return fake_interceptor
+
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["my_package.auth:build_interceptor"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", return_value=fake_builder),
+    ):
+        asyncio.run(get_mcp_tools())
+
+        # Verify MultiServerMCPClient received the interceptor
+        call_kwargs = mock_cls.call_args
+        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        assert len(interceptors) == 1
+        assert interceptors[0] is fake_interceptor
+
+
+def test_multiple_custom_interceptors():
+    """Multiple interceptor paths are all loaded in order."""
+
+    async def interceptor_a(request, handler):
+        return await handler(request)
+
+    async def interceptor_b(request, handler):
+        return await handler(request)
+
+    builders = {
+        "pkg.a:build_a": lambda: interceptor_a,
+        "pkg.b:build_b": lambda: interceptor_b,
+    }
+
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["pkg.a:build_a", "pkg.b:build_b"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", side_effect=lambda path: builders[path]),
+    ):
+        asyncio.run(get_mcp_tools())
+
+        call_kwargs = mock_cls.call_args
+        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        assert len(interceptors) == 2
+        assert interceptors[0] is interceptor_a
+        assert interceptors[1] is interceptor_b
+
+
+def test_custom_interceptor_builder_returning_none_is_skipped():
+    """If a builder returns None, it is not appended to the interceptor list."""
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["pkg.noop:build_noop"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", return_value=lambda: None),
+    ):
+        asyncio.run(get_mcp_tools())
+
+        call_kwargs = mock_cls.call_args
+        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        assert len(interceptors) == 0
+
+
+def test_custom_interceptor_resolve_error_logs_warning_and_continues():
+    """A broken interceptor path logs a warning and does not block tool loading."""
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["broken.path:does_not_exist"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", side_effect=ImportError("no such module")),
+        patch("deerflow.mcp.tools.logger.warning") as mock_warn,
+    ):
+        # Should not raise
+        tools = asyncio.run(get_mcp_tools())
+
+        # Tools still loaded successfully (empty in this mock)
+        assert tools == []
+
+        # Warning logged with the broken path
+        mock_warn.assert_called_once()
+        assert "broken.path:does_not_exist" in mock_warn.call_args[0][0]
+
+
+def test_custom_interceptor_builder_exception_logs_warning_and_continues():
+    """If the builder function itself raises, the error is caught and logged."""
+
+    def exploding_builder():
+        raise RuntimeError("builder exploded")
+
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["pkg.bad:exploding_builder"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+        patch("deerflow.reflection.resolve_variable", return_value=exploding_builder),
+        patch("deerflow.mcp.tools.logger.warning") as mock_warn,
+    ):
+        tools = asyncio.run(get_mcp_tools())
+
+        assert tools == []
+        mock_warn.assert_called_once()
+        assert "pkg.bad:exploding_builder" in mock_warn.call_args[0][0]
+
+
+def test_no_mcp_interceptors_field_is_safe():
+    """When mcpInterceptors is absent from config, no interceptors are added."""
+    patches, mock_client = _make_mock_env(interceptor_paths=None)
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patches["oauth_interceptor"],
+    ):
+        asyncio.run(get_mcp_tools())
+
+        call_kwargs = mock_cls.call_args
+        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        assert len(interceptors) == 0
+
+
+def test_custom_interceptor_coexists_with_oauth_interceptor():
+    """Custom interceptors are appended after the OAuth interceptor."""
+
+    async def oauth_fn(request, handler):
+        return await handler(request)
+
+    async def custom_fn(request, handler):
+        return await handler(request)
+
+    patches, mock_client = _make_mock_env(
+        interceptor_paths=["pkg.custom:build_custom"],
+    )
+
+    with (
+        patches["client_cls"] as mock_cls,
+        patches["from_file"],
+        patches["build_servers"],
+        patches["oauth_headers"],
+        patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=oauth_fn),
+        patch("deerflow.reflection.resolve_variable", return_value=lambda: custom_fn),
+    ):
+        asyncio.run(get_mcp_tools())
+
+        call_kwargs = mock_cls.call_args
+        interceptors = call_kwargs.kwargs.get("tool_interceptors") or call_kwargs[1].get("tool_interceptors", [])
+        assert len(interceptors) == 2
+        assert interceptors[0] is oauth_fn
+        assert interceptors[1] is custom_fn

--- a/extensions_config.example.json
+++ b/extensions_config.example.json
@@ -1,4 +1,7 @@
 {
+  "mcpInterceptors": [
+    "my_package.mcp.auth:build_auth_interceptor"
+  ],
   "mcpServers": {
     "filesystem": {
       "enabled": false,


### PR DESCRIPTION
## Summary

Add a generic extension point for registering custom MCP tool interceptors through `extensions_config.json`, enabling downstream projects to inject per-request behavior (auth headers, logging, metrics, etc.) **without modifying DeerFlow source code**.

## Motivation

When integrating DeerFlow with external platforms, MCP tool calls often need per-user, per-session dynamic headers (e.g., auth tokens from the current chat user). The existing OAuth interceptor handles service-level `Authorization` headers but cannot inject arbitrary headers derived from the LangGraph execution context.

Currently, the only way to add a custom interceptor is to modify `tools.py` directly — which creates merge conflicts on every DeerFlow upgrade for downstream consumers.

## Solution

A new optional `mcpInterceptors` field in `extensions_config.json`:

```json
{
  "mcpInterceptors": [
    "my_package.mcp.auth:build_auth_interceptor"
  ],
  "mcpServers": { ... }
}
```

Each entry is a Python callable path resolved via DeerFlow's existing `resolve_variable` reflection mechanism (same pattern used for tools and models in `config.yaml`). The builder function is called with no arguments and must return an async interceptor compatible with `MultiServerMCPClient`'s `tool_interceptors` interface, or `None` to skip.

### Example interceptor

```python
def build_auth_interceptor():
    async def interceptor(request, handler):
        from langgraph.config import get_config
        metadata = get_config().get("metadata", {})
        headers = dict(request.headers or {})
        if token := metadata.get("auth_token"):
            headers["Authorization"] = f"Bearer {token}"
        return await handler(request.override(headers=headers))
    return interceptor
```

## Changes

- `backend/packages/harness/deerflow/mcp/tools.py` — 15 lines added after the existing OAuth interceptor registration:
  - Read `mcpInterceptors` from `extensions_config.model_extra` (leveraging Pydantic's `extra="allow"`)
  - Load each builder via `resolve_variable`, call it, append to `tool_interceptors`
  - Failures are logged as warnings and do not block MCP initialization

## Design Decisions

- **Zero schema change**: Uses Pydantic `model_extra` so `ExtensionsConfig` does not need a new field definition
- **Consistent pattern**: Reuses `resolve_variable` — the same reflection mechanism for tools, models, and sandbox providers
- **Graceful degradation**: Each interceptor loads independently; a broken one logs a warning and doesn't affect others
- **No new dependencies**: Only uses existing `deerflow.reflection` utilities

## Test plan

- [ ] Verify MCP tools load normally when `mcpInterceptors` is absent or empty
- [ ] Verify a valid interceptor builder path is loaded and invoked per tool call
- [ ] Verify an invalid path logs a warning and does not break tool loading
- [ ] Verify the interceptor can access `langgraph.config.get_config()` during tool execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)