### PR TITLE
feat: add optional prompt-toolkit support to debug.py

### DIFF
--- a/backend/debug.py
+++ b/backend/debug.py
@@ -24,6 +24,14 @@ from langgraph.runtime import Runtime
 
 from deerflow.agents import make_lead_agent
 
+try:
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import InMemoryHistory
+
+    _HAS_PROMPT_TOOLKIT = True
+except ImportError:
+    _HAS_PROMPT_TOOLKIT = False
+
 load_dotenv()
 
 logging.basicConfig(
@@ -58,14 +66,21 @@ async def main():
 
     agent = make_lead_agent(config)
 
+    session = PromptSession(history=InMemoryHistory()) if _HAS_PROMPT_TOOLKIT else None
+
     print("=" * 50)
     print("Lead Agent Debug Mode")
     print("Type 'quit' or 'exit' to stop")
+    if not _HAS_PROMPT_TOOLKIT:
+        print("Tip: `uv sync --group dev` to enable arrow-key & history support")
     print("=" * 50)
 
     while True:
         try:
-            user_input = input("\nYou: ").strip()
+            if session:
+                user_input = (await session.prompt_async("\nYou: ")).strip()
+            else:
+                user_input = input("\nYou: ").strip()
             if not user_input:
                 continue
             if user_input.lower() in ("quit", "exit"):

--- a/backend/debug.py
+++ b/backend/debug.py
@@ -96,8 +96,8 @@ async def main():
                 last_message = result["messages"][-1]
                 print(f"\nAgent: {last_message.content}")
 
-        except KeyboardInterrupt:
-            print("\nInterrupted. Goodbye!")
+        except (KeyboardInterrupt, EOFError):
+            print("\nGoodbye!")
             break
         except Exception as e:
             print(f"\nError: {e}")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=9.0.3", "ruff>=0.14.11"]
+dev = ["prompt-toolkit>=3.0.0", "pytest>=9.0.3", "ruff>=0.14.11"]
 
 [tool.uv.workspace]
 members = ["packages/harness"]


### PR DESCRIPTION
## Summary

- Add optional `prompt-toolkit` support to `backend/debug.py` for arrow-key navigation, line editing, and input history during interactive debugging sessions
- Gracefully degrade to built-in `input()` when `prompt-toolkit` is not installed, with a tip guiding developers to `uv sync --group dev`
- Add `prompt-toolkit>=3.0.0` to the dev dependency group in `backend/pyproject.toml`

Closes #2460

Made with [Cursor](https://cursor.com)