### PR TITLE
fix: keep debug.py interactive terminal free from background log noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ coverage/
 skills/custom/*
 logs/
 log/
+debug.log
 
 # Local git hooks (keep only on this machine, do not push)
 .githooks/

--- a/backend/debug.py
+++ b/backend/debug.py
@@ -55,19 +55,32 @@ def _setup_logging(log_level: str) -> None:
     root.setLevel(level)
 
     file_handler = logging.FileHandler("debug.log", mode="a", encoding="utf-8")
+    file_handler.setLevel(level)
     file_handler.setFormatter(logging.Formatter(_LOG_FMT, datefmt=_LOG_DATEFMT))
     root.addHandler(file_handler)
 
 
+def _update_logging_level(log_level: str) -> None:
+    """Update the root logger and existing handlers to *log_level*."""
+    level = _logging_level_from_config(log_level)
+    root = logging.root
+    root.setLevel(level)
+    for handler in root.handlers:
+        handler.setLevel(level)
+
+
 async def main():
-    # Imported first so we can read ``log_level`` before installing handlers.
+    # Install file logging first so warnings emitted while loading config do not
+    # leak onto the interactive terminal via Python's lastResort handler.
+    _setup_logging("info")
+
     from deerflow.config import get_app_config
 
     app_config = get_app_config()
-    _setup_logging(app_config.log_level)
+    _update_logging_level(app_config.log_level)
 
-    # Delay the rest of the deerflow imports until *after* _setup_logging() so
-    # that any import-time side effects (e.g. deerflow.agents starts a
+    # Delay the rest of the deerflow imports until *after* logging is installed
+    # so that any import-time side effects (e.g. deerflow.agents starts a
     # background skill-loader thread on import) emit logs to debug.log instead
     # of leaking onto the interactive terminal via Python's lastResort handler.
     from langchain_core.messages import HumanMessage

--- a/backend/debug.py
+++ b/backend/debug.py
@@ -19,10 +19,6 @@ import asyncio
 import logging
 
 from dotenv import load_dotenv
-from langchain_core.messages import HumanMessage
-from langgraph.runtime import Runtime
-
-from deerflow.agents import make_lead_agent
 
 try:
     from prompt_toolkit import PromptSession
@@ -34,18 +30,54 @@ except ImportError:
 
 load_dotenv()
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
+_LOG_FMT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+_LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def _logging_level_from_config(name: str) -> int:
+    """Map ``config.yaml`` ``log_level`` string to a ``logging`` level constant."""
+    mapping = logging.getLevelNamesMapping()
+    return mapping.get((name or "info").strip().upper(), logging.INFO)
+
+
+def _setup_logging(log_level: str) -> None:
+    """Send application logs to ``debug.log`` at *log_level*; do not print them on the console.
+
+    Idempotent: any pre-existing handlers on the root logger (e.g. installed by
+    ``logging.basicConfig`` in transitively imported modules) are removed so the
+    debug session output only lands in ``debug.log``.
+    """
+    level = _logging_level_from_config(log_level)
+    root = logging.root
+    for h in list(root.handlers):
+        root.removeHandler(h)
+        h.close()
+    root.setLevel(level)
+
+    file_handler = logging.FileHandler("debug.log", mode="a", encoding="utf-8")
+    file_handler.setFormatter(logging.Formatter(_LOG_FMT, datefmt=_LOG_DATEFMT))
+    root.addHandler(file_handler)
 
 
 async def main():
+    # Imported first so we can read ``log_level`` before installing handlers.
+    from deerflow.config import get_app_config
+
+    app_config = get_app_config()
+    _setup_logging(app_config.log_level)
+
+    # Delay the rest of the deerflow imports until *after* _setup_logging() so
+    # that any import-time side effects (e.g. deerflow.agents starts a
+    # background skill-loader thread on import) emit logs to debug.log instead
+    # of leaking onto the interactive terminal via Python's lastResort handler.
+    from langchain_core.messages import HumanMessage
+    from langgraph.runtime import Runtime
+
+    from deerflow.agents import make_lead_agent
+    from deerflow.mcp import initialize_mcp_tools
+
     # Initialize MCP tools at startup
     try:
-        from deerflow.mcp import initialize_mcp_tools
-
         await initialize_mcp_tools()
     except Exception as e:
         print(f"Warning: Failed to initialize MCP tools: {e}")
@@ -71,6 +103,7 @@ async def main():
     print("=" * 50)
     print("Lead Agent Debug Mode")
     print("Type 'quit' or 'exit' to stop")
+    print(f"Logs: debug.log (log_level={app_config.log_level})")
     if not _HAS_PROMPT_TOOLKIT:
         print("Tip: `uv sync --group dev` to enable arrow-key & history support")
     print("=" * 50)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -686,6 +686,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "prompt-toolkit" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -708,6 +709,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.14.11" },
 ]
@@ -2708,6 +2710,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3958,6 +3972,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Redirect all `debug.py` logs to a file (`debug.log`) so the interactive terminal only shows user input and agent responses
- Honor `AppConfig.log_level` so the log verbosity follows `config.yaml` instead of being hard-coded to `INFO`
- Defer all deerflow/langchain/langgraph imports until after the file handler is attached, preventing import-time side-effects (e.g. background skill-loader thread) from leaking onto the terminal

Closes #2465