### PR TITLE
fix(threads): Remove incorrect limit positions. 移除错误的limit位置

### DIFF
--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -380,7 +380,7 @@ class DeerFlowClient:
 
         thread_info_map = {}
 
-        for cp in checkpointer.list(config=None, limit=limit):
+        for cp in checkpointer.list(config=None):
             cfg = cp.config.get("configurable", {})
             thread_id = cfg.get("thread_id")
             if not thread_id:


### PR DESCRIPTION
The current limit is passed to the underlying checkpoint traversal, limiting the "number of checkpoints," not the "number of threads." The actual limit is applied at the return statement.
现在的 limit 被传给了底层 checkpoint 遍历，限制的是“checkpoint 数”，不是“thread 数”。真正的limit已经作用在return处