### PR TITLE
feat(models): Provider for MindIE model engine

### DIFF
--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -133,6 +133,7 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
 
     # For MindIE models: inject extended timeouts to support mock streaming
     import httpx
+
     from deerflow.models.mindie_provider import MindIEChatModel
 
     if issubclass(model_class, MindIEChatModel):
@@ -152,14 +153,8 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
         # Enforce max_retries constraint to prevent cascading timeouts.
         model_settings_from_config["max_retries"] = model_settings_from_config.get("max_retries", 1)
 
-        model_settings_from_config["http_client"] = httpx.Client(
-            timeout=extended_timeout,
-            verify=False,
-        )
-        model_settings_from_config["http_async_client"] = httpx.AsyncClient(
-            timeout=extended_timeout,
-            verify=False,
-        )
+        model_settings_from_config["http_client"] = httpx.Client(timeout=extended_timeout)
+        model_settings_from_config["http_async_client"] = httpx.AsyncClient(timeout=extended_timeout)
 
     model_instance = model_class(**{**model_settings_from_config, **kwargs})
 

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -131,30 +131,11 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
         elif "reasoning_effort" not in model_settings_from_config:
             model_settings_from_config["reasoning_effort"] = "medium"
 
-    # For MindIE models: inject extended timeouts to support mock streaming
-    import httpx
-
-    from deerflow.models.mindie_provider import MindIEChatModel
-
-    if issubclass(model_class, MindIEChatModel):
-        # Extract timeout settings from config with safe defaults for mock streaming
-        connect_timeout = model_settings_from_config.pop("connect_timeout", 30.0)
-        read_timeout = model_settings_from_config.pop("read_timeout", 900.0)
-        write_timeout = model_settings_from_config.pop("write_timeout", 60.0)
-        pool_timeout = model_settings_from_config.pop("pool_timeout", 30.0)
-
-        extended_timeout = httpx.Timeout(
-            connect=connect_timeout,
-            read=read_timeout,
-            write=write_timeout,
-            pool=pool_timeout,
-        )
-
+    # For MindIE models: enforce conservative retry defaults.
+    # Timeout normalization is handled inside MindIEChatModel itself.
+    if getattr(model_class, "__name__", "") == "MindIEChatModel":
         # Enforce max_retries constraint to prevent cascading timeouts.
         model_settings_from_config["max_retries"] = model_settings_from_config.get("max_retries", 1)
-
-        model_settings_from_config["http_client"] = httpx.Client(timeout=extended_timeout)
-        model_settings_from_config["http_async_client"] = httpx.AsyncClient(timeout=extended_timeout)
 
     model_instance = model_class(**{**model_settings_from_config, **kwargs})
 

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -131,6 +131,36 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
         elif "reasoning_effort" not in model_settings_from_config:
             model_settings_from_config["reasoning_effort"] = "medium"
 
+    # For MindIE models: inject extended timeouts to support mock streaming
+    import httpx
+    from deerflow.models.mindie_provider import MindIEChatModel
+
+    if issubclass(model_class, MindIEChatModel):
+        # Extract timeout settings from config with safe defaults for mock streaming
+        connect_timeout = model_settings_from_config.pop("connect_timeout", 30.0)
+        read_timeout = model_settings_from_config.pop("read_timeout", 900.0)
+        write_timeout = model_settings_from_config.pop("write_timeout", 60.0)
+        pool_timeout = model_settings_from_config.pop("pool_timeout", 30.0)
+
+        extended_timeout = httpx.Timeout(
+            connect=connect_timeout,
+            read=read_timeout,
+            write=write_timeout,
+            pool=pool_timeout,
+        )
+
+        # Enforce max_retries constraint to prevent cascading timeouts.
+        model_settings_from_config["max_retries"] = model_settings_from_config.get("max_retries", 1)
+
+        model_settings_from_config["http_client"] = httpx.Client(
+            timeout=extended_timeout,
+            verify=False,
+        )
+        model_settings_from_config["http_async_client"] = httpx.AsyncClient(
+            timeout=extended_timeout,
+            verify=False,
+        )
+
     model_instance = model_class(**{**model_settings_from_config, **kwargs})
 
     callbacks = build_tracing_callbacks()

--- a/backend/packages/harness/deerflow/models/mindie_provider.py
+++ b/backend/packages/harness/deerflow/models/mindie_provider.py
@@ -2,7 +2,9 @@ import ast
 import json
 import re
 import uuid
+from collections.abc import Iterator
 
+import httpx
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_openai import ChatOpenAI
@@ -69,12 +71,11 @@ def _parse_xml_tool_call_to_dict(content: str) -> tuple[str, list[dict]]:
         return content, []
 
     tool_calls = []
-    tool_call_blocks = re.finditer(r"<tool_call>(.*?)</tool_call>", content, re.DOTALL)
-
-    clean_content = content
-    for block_match in tool_call_blocks:
-        full_block = block_match.group(0)
-        inner_content = block_match.group(1)
+    clean_parts: list[str] = []
+    cursor = 0
+    for start, end, inner_content in _iter_tool_call_blocks(content):
+        clean_parts.append(content[cursor:start])
+        cursor = end
 
         func_match = re.search(r"<function=([^>]+)>", inner_content)
         if not func_match:
@@ -102,10 +103,48 @@ def _parse_xml_tool_call_to_dict(content: str) -> tuple[str, list[dict]]:
             args[key] = parsed_value
 
         tool_calls.append({"name": function_name, "args": args, "id": f"call_{uuid.uuid4().hex[:10]}"})
+    clean_parts.append(content[cursor:])
 
-        clean_content = clean_content.replace(full_block, "")
+    return "".join(clean_parts).strip(), tool_calls
 
-    return clean_content.strip(), tool_calls
+
+def _iter_tool_call_blocks(content: str) -> Iterator[tuple[int, int, str]]:
+    """Iterate `<tool_call>...</tool_call>` blocks and tolerate nesting."""
+    token_pattern = re.compile(r"</?tool_call>")
+    depth = 0
+    block_start = -1
+
+    for match in token_pattern.finditer(content):
+        token = match.group(0)
+        if token == "<tool_call>":
+            if depth == 0:
+                block_start = match.start()
+            depth += 1
+            continue
+
+        if depth == 0:
+            continue
+
+        depth -= 1
+        if depth == 0 and block_start != -1:
+            block_end = match.end()
+            inner_start = block_start + len("<tool_call>")
+            inner_end = match.start()
+            yield block_start, block_end, content[inner_start:inner_end]
+            block_start = -1
+
+
+def _decode_escaped_newlines_outside_fences(content: str) -> str:
+    """Decode literal `\\n` outside fenced code blocks."""
+    if "\\n" not in content:
+        return content
+
+    parts = re.split(r"(```[\s\S]*?```)", content)
+    for idx, part in enumerate(parts):
+        if part.startswith("```"):
+            continue
+        parts[idx] = part.replace("\\n", "\n")
+    return "".join(parts)
 
 
 class MindIEChatModel(ChatOpenAI):
@@ -119,14 +158,32 @@ class MindIEChatModel(ChatOpenAI):
     - Fixing over-escaped newline characters from gateway responses.
     """
 
+    def __init__(self, **kwargs):
+        """Normalize timeout kwargs without creating long-lived clients."""
+        connect_timeout = kwargs.pop("connect_timeout", 30.0)
+        read_timeout = kwargs.pop("read_timeout", 900.0)
+        write_timeout = kwargs.pop("write_timeout", 60.0)
+        pool_timeout = kwargs.pop("pool_timeout", 30.0)
+
+        kwargs.setdefault(
+            "timeout",
+            httpx.Timeout(
+                connect=connect_timeout,
+                read=read_timeout,
+                write=write_timeout,
+                pool=pool_timeout,
+            ),
+        )
+        super().__init__(**kwargs)
+
     def _patch_result_with_tools(self, result: ChatResult) -> ChatResult:
         """Apply post-generation fixes to the model result."""
         for gen in result.generations:
             msg = gen.message
 
             if isinstance(msg.content, str):
-                # Fix over-escaped newlines returned by the gateway
-                msg.content = msg.content.replace("\\n", "\n")
+                # Keep escaped newlines inside fenced code blocks untouched.
+                msg.content = _decode_escaped_newlines_outside_fences(msg.content)
 
                 if "<tool_call>" in msg.content:
                     clean_content, extracted_tools = _parse_xml_tool_call_to_dict(msg.content)
@@ -151,7 +208,7 @@ class MindIEChatModel(ChatOpenAI):
         if not kwargs.get("tools"):
             async for chunk in super()._astream(_fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs):
                 if isinstance(chunk.message.content, str):
-                    chunk.message.content = chunk.message.content.replace("\\n", "\n")
+                    chunk.message.content = _decode_escaped_newlines_outside_fences(chunk.message.content)
                 yield chunk
             return
 

--- a/backend/packages/harness/deerflow/models/mindie_provider.py
+++ b/backend/packages/harness/deerflow/models/mindie_provider.py
@@ -1,0 +1,217 @@
+import re
+import uuid
+import json
+import ast
+import asyncio
+
+from langchain_openai import ChatOpenAI
+from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_core.messages import AIMessageChunk, AIMessage, HumanMessage, ToolMessage
+
+
+def _fix_messages(messages: list) -> list:
+    """Sanitize incoming messages for MindIE compatibility.
+
+    MindIE's chat template may fail to parse LangChain's native tool_calls
+    or ToolMessage roles, resulting in 0-token generation errors. This function
+    flattens multi-modal list contents into strings and converts tool-related
+    messages into raw text with XML tags expected by the underlying model.
+    """
+    fixed = []
+    for msg in messages:
+        # Flatten content if it's a list of blocks
+        if isinstance(msg.content, list):
+            text = "".join(
+                block.get("text", "")
+                for block in msg.content
+                if isinstance(block, dict) and block.get("type") == "text"
+            )
+        else:
+            text = msg.content or ""
+
+        # Convert AIMessage with tool_calls to raw XML text format
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", []):
+            xml_parts = []
+            for tool in msg.tool_calls:
+                args_xml = " ".join(
+                    f"<parameter={k}>{v}</parameter>" 
+                    for k, v in tool.get("args", {}).items()
+                )
+                xml_parts.append(
+                    f"<tool_call> <function={tool['name']}> {args_xml} </function> </tool_call>"
+                )
+            full_text = f"{text}\n" + "\n".join(xml_parts) if text else "\n".join(xml_parts)
+            fixed.append(AIMessage(content=full_text.strip() or " "))
+            continue
+
+        # Wrap tool execution results in XML tags and convert to HumanMessage
+        if isinstance(msg, ToolMessage):
+            tool_result_text = f"<tool_response>\n{text}\n</tool_response>"
+            fixed.append(HumanMessage(content=tool_result_text))
+            continue
+        
+        # Fallback to prevent completely empty message content
+        if not text.strip():
+            text = " "
+            
+        fixed.append(msg.copy(update={"content": text}))
+
+    return fixed
+
+
+def _parse_xml_tool_call_to_dict(content: str) -> tuple[str, list[dict]]:
+    """Parse XML-style tool calls from model output into LangChain dicts.
+
+    Args:
+        content: The raw text output from the model.
+
+    Returns:
+        A tuple containing the cleaned text (with XML blocks removed) and
+        a list of tool call dictionaries formatted for LangChain.
+    """
+    if not isinstance(content, str) or "<tool_call>" not in content:
+        return content, []
+
+    tool_calls = []
+    tool_call_blocks = re.finditer(r'<tool_call>(.*?)</tool_call>', content, re.DOTALL)
+    
+    clean_content = content
+    for block_match in tool_call_blocks:
+        full_block = block_match.group(0)
+        inner_content = block_match.group(1)
+        
+        func_match = re.search(r'<function=([^>]+)>', inner_content)
+        if not func_match:
+            continue
+        function_name = func_match.group(1).strip()
+        
+        args = {}
+        param_pattern = re.compile(r'<parameter=([^>]+)>(.*?)</parameter>', re.DOTALL)
+        for param_match in param_pattern.finditer(inner_content):
+            key = param_match.group(1).strip()
+            raw_value = param_match.group(2).strip()
+            
+            # Attempt to deserialize string values into native Python types
+            # to satisfy downstream Pydantic validation.
+            parsed_value = raw_value
+            if raw_value.startswith(("[", "{")) or raw_value in ("true", "false", "null") or raw_value.isdigit():
+                try:
+                    parsed_value = json.loads(raw_value)
+                except json.JSONDecodeError:
+                    try:
+                        parsed_value = ast.literal_eval(raw_value)
+                    except (ValueError, SyntaxError):
+                        pass
+                        
+            args[key] = parsed_value
+        
+        tool_calls.append({
+            "name": function_name,
+            "args": args,
+            "id": f"call_{uuid.uuid4().hex[:10]}"
+        })
+        
+        clean_content = clean_content.replace(full_block, "")
+    
+    return clean_content.strip(), tool_calls
+
+
+class MindIEChatModel(ChatOpenAI):
+    """Chat model adapter for MindIE engine.
+
+    Addresses compatibility issues including:
+    - Flattening multimodal list contents to strings.
+    - Intercepting and parsing hardcoded XML tool calls into LangChain standard.
+    - Handling stream=True dropping choices when tools are present by falling back
+      to non-streaming generation and yielding simulated chunks.
+    - Fixing over-escaped newline characters from gateway responses.
+    """
+    
+    def _patch_result_with_tools(self, result: ChatResult) -> ChatResult:
+        """Apply post-generation fixes to the model result."""
+        for gen in result.generations:
+            msg = gen.message
+            
+            if isinstance(msg.content, str):
+                # Fix over-escaped newlines returned by the gateway
+                msg.content = msg.content.replace("\\n", "\n")
+                
+                if "<tool_call>" in msg.content:
+                    clean_content, extracted_tools = _parse_xml_tool_call_to_dict(msg.content)
+                    
+                    if extracted_tools:
+                        msg.content = clean_content
+                        if getattr(msg, "tool_calls", None) is None:
+                            msg.tool_calls = []
+                        msg.tool_calls.extend(extracted_tools)
+        return result
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        result = super()._generate(
+            _fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs
+        )
+        return self._patch_result_with_tools(result)
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+        result = await super()._agenerate(
+            _fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs
+        )
+        return self._patch_result_with_tools(result)
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        # Route standard queries to native streaming for lower TTFB
+        if not kwargs.get("tools"):
+            async for chunk in super()._astream(_fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs):
+                if isinstance(chunk.message.content, str):
+                    chunk.message.content = chunk.message.content.replace("\\n", "\n")
+                yield chunk
+            return
+
+        # Fallback for tool-enabled requests:
+        # MindIE currently drops choices when stream=True and tools are present.
+        # We await the full generation and yield chunks to simulate streaming.
+        result = await self._agenerate(
+            messages, stop=stop, run_manager=run_manager, **kwargs
+        )
+        
+        for gen in result.generations:
+            msg = gen.message
+            content = msg.content
+            standard_tool_calls = getattr(msg, "tool_calls", [])
+            
+            # Yield text in chunks to allow downstream UI/Markdown parsers to render smoothly
+            if isinstance(content, str) and content:
+                chunk_size = 15 
+                for i in range(0, len(content), chunk_size):
+                    chunk_text = content[i:i+chunk_size]
+                    chunk_msg = AIMessageChunk(
+                        content=chunk_text,
+                        id=msg.id,
+                        response_metadata=msg.response_metadata if i == 0 else {}
+                    )
+                    yield ChatGenerationChunk(
+                        message=chunk_msg,
+                        generation_info=gen.generation_info if i == 0 else None
+                    )
+                    await asyncio.sleep(0.01) 
+                
+                if standard_tool_calls:
+                    yield ChatGenerationChunk(
+                        message=AIMessageChunk(
+                            content="",
+                            id=msg.id,
+                            tool_calls=standard_tool_calls,
+                            invalid_tool_calls=getattr(msg, "invalid_tool_calls", [])
+                        )
+                    )
+            else:
+                chunk_msg = AIMessageChunk(
+                    content=content,
+                    id=msg.id,
+                    tool_calls=standard_tool_calls,
+                    invalid_tool_calls=getattr(msg, "invalid_tool_calls", [])
+                )
+                yield ChatGenerationChunk(
+                    message=chunk_msg,
+                    generation_info=gen.generation_info
+                )

--- a/backend/packages/harness/deerflow/models/mindie_provider.py
+++ b/backend/packages/harness/deerflow/models/mindie_provider.py
@@ -1,12 +1,11 @@
+import ast
+import json
 import re
 import uuid
-import json
-import ast
-import asyncio
 
-from langchain_openai import ChatOpenAI
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
-from langchain_core.messages import AIMessageChunk, AIMessage, HumanMessage, ToolMessage
+from langchain_openai import ChatOpenAI
 
 
 def _fix_messages(messages: list) -> list:
@@ -21,11 +20,13 @@ def _fix_messages(messages: list) -> list:
     for msg in messages:
         # Flatten content if it's a list of blocks
         if isinstance(msg.content, list):
-            text = "".join(
-                block.get("text", "")
-                for block in msg.content
-                if isinstance(block, dict) and block.get("type") == "text"
-            )
+            parts = []
+            for block in msg.content:
+                if isinstance(block, str):
+                    parts.append(block)
+                elif isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+            text = "".join(parts)
         else:
             text = msg.content or ""
 
@@ -33,13 +34,8 @@ def _fix_messages(messages: list) -> list:
         if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", []):
             xml_parts = []
             for tool in msg.tool_calls:
-                args_xml = " ".join(
-                    f"<parameter={k}>{v}</parameter>" 
-                    for k, v in tool.get("args", {}).items()
-                )
-                xml_parts.append(
-                    f"<tool_call> <function={tool['name']}> {args_xml} </function> </tool_call>"
-                )
+                args_xml = " ".join(f"<parameter={k}>{json.dumps(v, ensure_ascii=False)}</parameter>" for k, v in tool.get("args", {}).items())
+                xml_parts.append(f"<tool_call> <function={tool['name']}> {args_xml} </function> </tool_call>")
             full_text = f"{text}\n" + "\n".join(xml_parts) if text else "\n".join(xml_parts)
             fixed.append(AIMessage(content=full_text.strip() or " "))
             continue
@@ -49,12 +45,12 @@ def _fix_messages(messages: list) -> list:
             tool_result_text = f"<tool_response>\n{text}\n</tool_response>"
             fixed.append(HumanMessage(content=tool_result_text))
             continue
-        
+
         # Fallback to prevent completely empty message content
         if not text.strip():
             text = " "
-            
-        fixed.append(msg.copy(update={"content": text}))
+
+        fixed.append(msg.model_copy(update={"content": text}))
 
     return fixed
 
@@ -73,24 +69,24 @@ def _parse_xml_tool_call_to_dict(content: str) -> tuple[str, list[dict]]:
         return content, []
 
     tool_calls = []
-    tool_call_blocks = re.finditer(r'<tool_call>(.*?)</tool_call>', content, re.DOTALL)
-    
+    tool_call_blocks = re.finditer(r"<tool_call>(.*?)</tool_call>", content, re.DOTALL)
+
     clean_content = content
     for block_match in tool_call_blocks:
         full_block = block_match.group(0)
         inner_content = block_match.group(1)
-        
-        func_match = re.search(r'<function=([^>]+)>', inner_content)
+
+        func_match = re.search(r"<function=([^>]+)>", inner_content)
         if not func_match:
             continue
         function_name = func_match.group(1).strip()
-        
+
         args = {}
-        param_pattern = re.compile(r'<parameter=([^>]+)>(.*?)</parameter>', re.DOTALL)
+        param_pattern = re.compile(r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL)
         for param_match in param_pattern.finditer(inner_content):
             key = param_match.group(1).strip()
             raw_value = param_match.group(2).strip()
-            
+
             # Attempt to deserialize string values into native Python types
             # to satisfy downstream Pydantic validation.
             parsed_value = raw_value
@@ -102,17 +98,13 @@ def _parse_xml_tool_call_to_dict(content: str) -> tuple[str, list[dict]]:
                         parsed_value = ast.literal_eval(raw_value)
                     except (ValueError, SyntaxError):
                         pass
-                        
+
             args[key] = parsed_value
-        
-        tool_calls.append({
-            "name": function_name,
-            "args": args,
-            "id": f"call_{uuid.uuid4().hex[:10]}"
-        })
-        
+
+        tool_calls.append({"name": function_name, "args": args, "id": f"call_{uuid.uuid4().hex[:10]}"})
+
         clean_content = clean_content.replace(full_block, "")
-    
+
     return clean_content.strip(), tool_calls
 
 
@@ -126,19 +118,19 @@ class MindIEChatModel(ChatOpenAI):
       to non-streaming generation and yielding simulated chunks.
     - Fixing over-escaped newline characters from gateway responses.
     """
-    
+
     def _patch_result_with_tools(self, result: ChatResult) -> ChatResult:
         """Apply post-generation fixes to the model result."""
         for gen in result.generations:
             msg = gen.message
-            
+
             if isinstance(msg.content, str):
                 # Fix over-escaped newlines returned by the gateway
                 msg.content = msg.content.replace("\\n", "\n")
-                
+
                 if "<tool_call>" in msg.content:
                     clean_content, extracted_tools = _parse_xml_tool_call_to_dict(msg.content)
-                    
+
                     if extracted_tools:
                         msg.content = clean_content
                         if getattr(msg, "tool_calls", None) is None:
@@ -147,15 +139,11 @@ class MindIEChatModel(ChatOpenAI):
         return result
 
     def _generate(self, messages, stop=None, run_manager=None, **kwargs):
-        result = super()._generate(
-            _fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs
-        )
+        result = super()._generate(_fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs)
         return self._patch_result_with_tools(result)
 
     async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
-        result = await super()._agenerate(
-            _fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs
-        )
+        result = await super()._agenerate(_fix_messages(messages), stop=stop, run_manager=run_manager, **kwargs)
         return self._patch_result_with_tools(result)
 
     async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
@@ -170,48 +158,23 @@ class MindIEChatModel(ChatOpenAI):
         # Fallback for tool-enabled requests:
         # MindIE currently drops choices when stream=True and tools are present.
         # We await the full generation and yield chunks to simulate streaming.
-        result = await self._agenerate(
-            messages, stop=stop, run_manager=run_manager, **kwargs
-        )
-        
+        result = await self._agenerate(messages, stop=stop, run_manager=run_manager, **kwargs)
+
         for gen in result.generations:
             msg = gen.message
             content = msg.content
             standard_tool_calls = getattr(msg, "tool_calls", [])
-            
+
             # Yield text in chunks to allow downstream UI/Markdown parsers to render smoothly
             if isinstance(content, str) and content:
-                chunk_size = 15 
+                chunk_size = 15
                 for i in range(0, len(content), chunk_size):
-                    chunk_text = content[i:i+chunk_size]
-                    chunk_msg = AIMessageChunk(
-                        content=chunk_text,
-                        id=msg.id,
-                        response_metadata=msg.response_metadata if i == 0 else {}
-                    )
-                    yield ChatGenerationChunk(
-                        message=chunk_msg,
-                        generation_info=gen.generation_info if i == 0 else None
-                    )
-                    await asyncio.sleep(0.01) 
-                
+                    chunk_text = content[i : i + chunk_size]
+                    chunk_msg = AIMessageChunk(content=chunk_text, id=msg.id, response_metadata=msg.response_metadata if i == 0 else {})
+                    yield ChatGenerationChunk(message=chunk_msg, generation_info=gen.generation_info if i == 0 else None)
+
                 if standard_tool_calls:
-                    yield ChatGenerationChunk(
-                        message=AIMessageChunk(
-                            content="",
-                            id=msg.id,
-                            tool_calls=standard_tool_calls,
-                            invalid_tool_calls=getattr(msg, "invalid_tool_calls", [])
-                        )
-                    )
+                    yield ChatGenerationChunk(message=AIMessageChunk(content="", id=msg.id, tool_calls=standard_tool_calls, invalid_tool_calls=getattr(msg, "invalid_tool_calls", [])))
             else:
-                chunk_msg = AIMessageChunk(
-                    content=content,
-                    id=msg.id,
-                    tool_calls=standard_tool_calls,
-                    invalid_tool_calls=getattr(msg, "invalid_tool_calls", [])
-                )
-                yield ChatGenerationChunk(
-                    message=chunk_msg,
-                    generation_info=gen.generation_info
-                )
+                chunk_msg = AIMessageChunk(content=content, id=msg.id, tool_calls=standard_tool_calls, invalid_tool_calls=getattr(msg, "invalid_tool_calls", []))
+                yield ChatGenerationChunk(message=chunk_msg, generation_info=gen.generation_info)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,7 +20,12 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["prompt-toolkit>=3.0.0", "pytest>=9.0.3", "ruff>=0.14.11"]
+dev = [
+    "prompt-toolkit>=3.0.0",
+    "pytest>=9.0.3",
+    "pytest-asyncio>=1.3.0",
+    "ruff>=0.14.11",
+]
 
 [tool.uv.workspace]
 members = ["packages/harness"]

--- a/backend/tests/test_mindie_provider.py
+++ b/backend/tests/test_mindie_provider.py
@@ -1,0 +1,432 @@
+"""
+Unit tests for MindIEChatModel adapter.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+# ── Import the module under test ──────────────────────────────────────────────
+from deerflow.models.mindie_provider import (
+    MindIEChatModel,
+    _fix_messages,
+    _parse_xml_tool_call_to_dict,
+)
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Helpers
+# ═════════════════════════════════════════════════════════════════════════════
+
+def _make_chat_result(content: str, tool_calls=None) -> ChatResult:
+    msg = AIMessage(content=content)
+    if tool_calls:
+        msg.tool_calls = tool_calls
+    gen = ChatGeneration(message=msg)
+    return ChatResult(generations=[gen])
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 1.  _fix_messages
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestFixMessages:
+
+    # ── list content → str ────────────────────────────────────────────────────
+
+    def test_list_content_extracted_to_str(self):
+        msg = HumanMessage(content=[
+            {"type": "text", "text": "Hello"},
+            {"type": "text", "text": " world"},
+        ])
+        result = _fix_messages([msg])
+        assert result[0].content == "Hello world"
+
+    def test_list_content_ignores_non_text_blocks(self):
+        msg = HumanMessage(content=[
+            {"type": "image_url", "image_url": "http://x.com/img.png"},
+            {"type": "text", "text": "caption"},
+        ])
+        result = _fix_messages([msg])
+        assert result[0].content == "caption"
+
+    def test_empty_list_content_becomes_space(self):
+        msg = HumanMessage(content=[])
+        result = _fix_messages([msg])
+        assert result[0].content == " "
+
+    # ── plain str content ─────────────────────────────────────────────────────
+
+    def test_plain_string_content_preserved(self):
+        msg = HumanMessage(content="hi there")
+        result = _fix_messages([msg])
+        assert result[0].content == "hi there"
+
+    def test_empty_string_content_becomes_space(self):
+        msg = HumanMessage(content="")
+        result = _fix_messages([msg])
+        assert result[0].content == " "
+
+    # ── AIMessage with tool_calls → XML ───────────────────────────────────────
+
+    def test_ai_message_with_tool_calls_serialised_to_xml(self):
+        msg = AIMessage(
+            content="Sure",
+            tool_calls=[{
+                "name": "get_weather",
+                "args": {"city": "London"},
+                "id": "call_abc",
+            }],
+        )
+        result = _fix_messages([msg])
+        out = result[0]
+        assert isinstance(out, AIMessage)
+        assert "<tool_call>" in out.content
+        assert "<function=get_weather>" in out.content
+        assert '<parameter=city>"London"</parameter>' in out.content
+        assert not getattr(out, "tool_calls", [])
+
+    def test_ai_message_text_preserved_before_xml(self):
+        msg = AIMessage(
+            content="Here you go",
+            tool_calls=[{"name": "search", "args": {"q": "pytest"}, "id": "x"}],
+        )
+        result = _fix_messages([msg])
+        assert result[0].content.startswith("Here you go")
+
+    def test_ai_message_multiple_tool_calls(self):
+        msg = AIMessage(
+            content="",
+            tool_calls=[
+                {"name": "tool_a", "args": {"x": 1}, "id": "id1"},
+                {"name": "tool_b", "args": {"y": 2}, "id": "id2"},
+            ],
+        )
+        result = _fix_messages([msg])
+        content = result[0].content
+        assert content.count("<tool_call>") == 2
+        assert "<function=tool_a>" in content
+        assert "<function=tool_b>" in content
+
+    # ── ToolMessage → HumanMessage ────────────────────────────────────────────
+
+    def test_tool_message_becomes_human_message(self):
+        msg = ToolMessage(content="42 degrees", tool_call_id="call_abc")
+        result = _fix_messages([msg])
+        out = result[0]
+        assert isinstance(out, HumanMessage)
+        assert "<tool_response>" in out.content
+        assert "42 degrees" in out.content
+
+    def test_tool_message_with_list_content(self):
+        msg = ToolMessage(
+            content=[{"type": "text", "text": "result"}],
+            tool_call_id="call_xyz",
+        )
+        result = _fix_messages([msg])
+        assert isinstance(result[0], HumanMessage)
+        assert "result" in result[0].content
+
+    # ── Mixed message list ────────────────────────────────────────────────────
+
+    def test_mixed_message_types_ordering_preserved(self):
+        msgs = [
+            HumanMessage(content="q"),
+            AIMessage(content="a"),
+            ToolMessage(content="tool out", tool_call_id="c1"),
+            HumanMessage(content="follow up"),
+        ]
+        result = _fix_messages(msgs)
+        assert len(result) == 4
+        assert isinstance(result[2], HumanMessage)  
+        assert result[3].content == "follow up"
+
+    # ── SystemMessage pass-through ────────────────────────────────────────────
+
+    def test_system_message_passed_through_unchanged(self):
+        msg = SystemMessage(content="You are helpful.")
+        result = _fix_messages([msg])
+        assert result[0].content == "You are helpful."
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 2.  _parse_xml_tool_call_to_dict
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestParseXmlToolCalls:
+
+    def test_no_tool_call_returns_original(self):
+        content = "Just a normal reply."
+        clean, calls = _parse_xml_tool_call_to_dict(content)
+        assert clean == content
+        assert calls == []
+
+    def test_single_tool_call_parsed(self):
+        content = (
+            "<tool_call>"
+            " <function=search>"
+            " <parameter=query>pytest</parameter>"
+            " </function>"
+            " </tool_call>"
+        )
+        clean, calls = _parse_xml_tool_call_to_dict(content)
+        assert clean == ""
+        assert len(calls) == 1
+        assert calls[0]["name"] == "search"
+        assert calls[0]["args"]["query"] == "pytest"
+        assert calls[0]["id"].startswith("call_")
+
+    def test_multiple_tool_calls_parsed(self):
+        content = (
+            "<tool_call><function=a><parameter=x>1</parameter></function></tool_call>"
+            "<tool_call><function=b><parameter=y>2</parameter></function></tool_call>"
+        )
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert len(calls) == 2
+        assert calls[0]["name"] == "a"
+        assert calls[1]["name"] == "b"
+
+    def test_text_before_tool_call_preserved(self):
+        content = "Here is the answer.\n<tool_call><function=f><parameter=k>v</parameter></function></tool_call>"
+        clean, calls = _parse_xml_tool_call_to_dict(content)
+        assert clean == "Here is the answer."
+        assert len(calls) == 1
+
+    def test_integer_param_deserialised(self):
+        content = "<tool_call><function=f><parameter=n>42</parameter></function></tool_call>"
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert calls[0]["args"]["n"] == 42  
+
+    def test_list_param_deserialised(self):
+        content = '<tool_call><function=f><parameter=lst>["a","b"]</parameter></function></tool_call>'
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert calls[0]["args"]["lst"] == ["a", "b"]
+
+    def test_dict_param_deserialised(self):
+        content = '<tool_call><function=f><parameter=d>{"k": 1}</parameter></function></tool_call>'
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert calls[0]["args"]["d"] == {"k": 1}
+
+    def test_bool_param_deserialised(self):
+        content = "<tool_call><function=f><parameter=flag>true</parameter></function></tool_call>"
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert calls[0]["args"]["flag"] is True
+
+    def test_malformed_param_stays_string(self):
+        content = "<tool_call><function=f><parameter=bad>{broken json</parameter></function></tool_call>"
+        _, calls = _parse_xml_tool_call_to_dict(content)
+        assert calls[0]["args"]["bad"] == "{broken json"
+
+    def test_non_string_input_returned_as_is(self):
+        result = _parse_xml_tool_call_to_dict(None)
+        assert result == (None, [])
+
+    def test_unique_ids_generated(self):
+        block = "<tool_call><function=f><parameter=k>v</parameter></function></tool_call>"
+        _, c1 = _parse_xml_tool_call_to_dict(block)
+        _, c2 = _parse_xml_tool_call_to_dict(block)
+        assert c1[0]["id"] != c2[0]["id"]
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 3.  MindIEChatModel._patch_result_with_tools
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestPatchResult:
+
+    def _model(self):
+        with patch.object(MindIEChatModel, "__init__", return_value=None):
+            m = MindIEChatModel.__new__(MindIEChatModel)
+        return m
+
+    def test_escaped_newlines_fixed(self):
+        model = self._model()
+        result = _make_chat_result("line1\\nline2")
+        patched = model._patch_result_with_tools(result)
+        assert patched.generations[0].message.content == "line1\nline2"
+
+    def test_xml_tool_calls_extracted(self):
+        model = self._model()
+        content = "<tool_call><function=calc><parameter=expr>1+1</parameter></function></tool_call>"
+        result = _make_chat_result(content)
+        patched = model._patch_result_with_tools(result)
+        msg = patched.generations[0].message
+        assert msg.content == ""
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0]["name"] == "calc"
+
+    def test_patch_result_appends_to_existing_tool_calls(self):
+        model = self._model()
+        existing = [{"name": "existing", "args": {}, "id": "e1"}]
+        content = "<tool_call><function=new_tool><parameter=k>v</parameter></function></tool_call>"
+        result = _make_chat_result(content, tool_calls=existing)
+        patched = model._patch_result_with_tools(result)
+        msg = patched.generations[0].message
+        assert len(msg.tool_calls) == 2
+        names = [tc["name"] for tc in msg.tool_calls]
+        assert "existing" in names
+        assert "new_tool" in names
+
+    def test_no_tool_call_content_unchanged(self):
+        model = self._model()
+        result = _make_chat_result("plain reply")
+        patched = model._patch_result_with_tools(result)
+        assert patched.generations[0].message.content == "plain reply"
+
+    def test_non_string_content_skipped(self):
+        model = self._model()
+        msg = AIMessage(content=[{"type": "text", "text": "hi"}])
+        gen = ChatGeneration(message=msg)
+        result = ChatResult(generations=[gen])
+        patched = model._patch_result_with_tools(result)
+        assert patched is not None
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 4.  MindIEChatModel._generate  (sync)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestGenerate:
+
+    def test_generate_calls_fix_messages_and_patch(self):
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._generate") as mock_super_gen, \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            mock_super_gen.return_value = _make_chat_result("hello")
+            model = MindIEChatModel.__new__(MindIEChatModel)
+
+            msgs = [HumanMessage(content="ping")]
+            result = model._generate(msgs)
+
+            assert mock_super_gen.called
+            called_msgs = mock_super_gen.call_args[0][0]
+            assert all(isinstance(m.content, str) for m in called_msgs)
+            assert result.generations[0].message.content == "hello"
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 5.  MindIEChatModel._agenerate  (async)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestAGenerate:
+
+    @pytest.mark.asyncio
+    async def test_agenerate_patches_result(self):
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._agenerate", new_callable=AsyncMock) as mock_ag, \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            mock_ag.return_value = _make_chat_result("world\\nfoo")
+            model = MindIEChatModel.__new__(MindIEChatModel)
+
+            result = await model._agenerate([HumanMessage(content="hi")])
+            assert result.generations[0].message.content == "world\nfoo"
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# 6.  MindIEChatModel._astream  (async generator)
+# ═════════════════════════════════════════════════════════════════════════════
+
+class TestAStream:
+
+    async def _collect(self, gen):
+        chunks = []
+        async for chunk in gen:
+            chunks.append(chunk)
+        return chunks
+
+    @pytest.mark.asyncio
+    async def test_no_tools_uses_real_stream(self):
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        async def fake_stream(*args, **kwargs):
+            for char in ["hel", "lo"]:
+                yield ChatGenerationChunk(message=AIMessageChunk(content=char))
+
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            model = MindIEChatModel.__new__(MindIEChatModel)
+            chunks = await self._collect(
+                model._astream([HumanMessage(content="hi")])   
+            )
+
+        assert "".join(c.message.content for c in chunks) == "hello"
+
+    @pytest.mark.asyncio
+    async def test_no_tools_fixes_escaped_newlines_in_stream(self):
+        from langchain_core.messages import AIMessageChunk
+        from langchain_core.outputs import ChatGenerationChunk
+
+        async def fake_stream(*args, **kwargs):
+            yield ChatGenerationChunk(message=AIMessageChunk(content="a\\nb"))
+
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            model = MindIEChatModel.__new__(MindIEChatModel)
+            chunks = await self._collect(
+                model._astream([HumanMessage(content="x")])
+            )
+
+        assert chunks[0].message.content == "a\nb"
+
+    @pytest.mark.asyncio
+    async def test_with_tools_fake_streams_text_in_chunks(self):
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            long_text = "A" * 50   
+            mock_ag.return_value = _make_chat_result(long_text)
+            model = MindIEChatModel.__new__(MindIEChatModel)
+
+            chunks = await self._collect(
+                model._astream(
+                    [HumanMessage(content="q")],
+                    tools=[{"type": "function", "function": {"name": "dummy"}}]
+                )
+            )
+
+        full = "".join(c.message.content for c in chunks)
+        assert full == long_text
+        assert len(chunks) > 1   
+
+    @pytest.mark.asyncio
+    async def test_with_tools_emits_tool_call_chunk(self):
+
+        tool_calls = [{"name": "fn", "args": {}, "id": "c1"}]
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            mock_ag.return_value = _make_chat_result("ok", tool_calls=tool_calls)
+            model = MindIEChatModel.__new__(MindIEChatModel)
+
+            chunks = await self._collect(
+                model._astream(
+                    [HumanMessage(content="q")],
+                    tools=[{"type": "function", "function": {"name": "fn"}}]
+                )
+            )
+
+        tool_chunks = [c for c in chunks if getattr(c.message, "tool_calls", [])]
+        assert tool_chunks, "No chunk carried tool_calls"
+        assert tool_chunks[-1].message.tool_calls[0]["name"] == "fn"
+
+    @pytest.mark.asyncio
+    async def test_with_tools_empty_text_still_emits_tool_chunk(self):
+        tool_calls = [{"name": "x", "args": {}, "id": "c2"}]
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
+             patch.object(MindIEChatModel, "__init__", return_value=None):
+
+            mock_ag.return_value = _make_chat_result("", tool_calls=tool_calls)
+            model = MindIEChatModel.__new__(MindIEChatModel)
+
+            chunks = await self._collect(
+                model._astream(
+                    [HumanMessage(content="q")],
+                    tools=[{"type": "function", "function": {"name": "x"}}]
+                )
+            )
+
+        assert any(getattr(c.message, "tool_calls", []) for c in chunks)

--- a/backend/tests/test_mindie_provider.py
+++ b/backend/tests/test_mindie_provider.py
@@ -19,6 +19,7 @@ from deerflow.models.mindie_provider import (
 # Helpers
 # ═════════════════════════════════════════════════════════════════════════════
 
+
 def _make_chat_result(content: str, tool_calls=None) -> ChatResult:
     msg = AIMessage(content=content)
     if tool_calls:
@@ -31,23 +32,27 @@ def _make_chat_result(content: str, tool_calls=None) -> ChatResult:
 # 1.  _fix_messages
 # ═════════════════════════════════════════════════════════════════════════════
 
-class TestFixMessages:
 
+class TestFixMessages:
     # ── list content → str ────────────────────────────────────────────────────
 
     def test_list_content_extracted_to_str(self):
-        msg = HumanMessage(content=[
-            {"type": "text", "text": "Hello"},
-            {"type": "text", "text": " world"},
-        ])
+        msg = HumanMessage(
+            content=[
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": " world"},
+            ]
+        )
         result = _fix_messages([msg])
         assert result[0].content == "Hello world"
 
     def test_list_content_ignores_non_text_blocks(self):
-        msg = HumanMessage(content=[
-            {"type": "image_url", "image_url": "http://x.com/img.png"},
-            {"type": "text", "text": "caption"},
-        ])
+        msg = HumanMessage(
+            content=[
+                {"type": "image_url", "image_url": "http://x.com/img.png"},
+                {"type": "text", "text": "caption"},
+            ]
+        )
         result = _fix_messages([msg])
         assert result[0].content == "caption"
 
@@ -73,11 +78,13 @@ class TestFixMessages:
     def test_ai_message_with_tool_calls_serialised_to_xml(self):
         msg = AIMessage(
             content="Sure",
-            tool_calls=[{
-                "name": "get_weather",
-                "args": {"city": "London"},
-                "id": "call_abc",
-            }],
+            tool_calls=[
+                {
+                    "name": "get_weather",
+                    "args": {"city": "London"},
+                    "id": "call_abc",
+                }
+            ],
         )
         result = _fix_messages([msg])
         out = result[0]
@@ -139,7 +146,7 @@ class TestFixMessages:
         ]
         result = _fix_messages(msgs)
         assert len(result) == 4
-        assert isinstance(result[2], HumanMessage)  
+        assert isinstance(result[2], HumanMessage)
         assert result[3].content == "follow up"
 
     # ── SystemMessage pass-through ────────────────────────────────────────────
@@ -154,8 +161,8 @@ class TestFixMessages:
 # 2.  _parse_xml_tool_call_to_dict
 # ═════════════════════════════════════════════════════════════════════════════
 
-class TestParseXmlToolCalls:
 
+class TestParseXmlToolCalls:
     def test_no_tool_call_returns_original(self):
         content = "Just a normal reply."
         clean, calls = _parse_xml_tool_call_to_dict(content)
@@ -163,13 +170,7 @@ class TestParseXmlToolCalls:
         assert calls == []
 
     def test_single_tool_call_parsed(self):
-        content = (
-            "<tool_call>"
-            " <function=search>"
-            " <parameter=query>pytest</parameter>"
-            " </function>"
-            " </tool_call>"
-        )
+        content = "<tool_call> <function=search> <parameter=query>pytest</parameter> </function> </tool_call>"
         clean, calls = _parse_xml_tool_call_to_dict(content)
         assert clean == ""
         assert len(calls) == 1
@@ -178,10 +179,7 @@ class TestParseXmlToolCalls:
         assert calls[0]["id"].startswith("call_")
 
     def test_multiple_tool_calls_parsed(self):
-        content = (
-            "<tool_call><function=a><parameter=x>1</parameter></function></tool_call>"
-            "<tool_call><function=b><parameter=y>2</parameter></function></tool_call>"
-        )
+        content = "<tool_call><function=a><parameter=x>1</parameter></function></tool_call><tool_call><function=b><parameter=y>2</parameter></function></tool_call>"
         _, calls = _parse_xml_tool_call_to_dict(content)
         assert len(calls) == 2
         assert calls[0]["name"] == "a"
@@ -196,7 +194,7 @@ class TestParseXmlToolCalls:
     def test_integer_param_deserialised(self):
         content = "<tool_call><function=f><parameter=n>42</parameter></function></tool_call>"
         _, calls = _parse_xml_tool_call_to_dict(content)
-        assert calls[0]["args"]["n"] == 42  
+        assert calls[0]["args"]["n"] == 42
 
     def test_list_param_deserialised(self):
         content = '<tool_call><function=f><parameter=lst>["a","b"]</parameter></function></tool_call>'
@@ -233,8 +231,8 @@ class TestParseXmlToolCalls:
 # 3.  MindIEChatModel._patch_result_with_tools
 # ═════════════════════════════════════════════════════════════════════════════
 
-class TestPatchResult:
 
+class TestPatchResult:
     def _model(self):
         with patch.object(MindIEChatModel, "__init__", return_value=None):
             m = MindIEChatModel.__new__(MindIEChatModel)
@@ -287,12 +285,10 @@ class TestPatchResult:
 # 4.  MindIEChatModel._generate  (sync)
 # ═════════════════════════════════════════════════════════════════════════════
 
+
 class TestGenerate:
-
     def test_generate_calls_fix_messages_and_patch(self):
-        with patch("deerflow.models.mindie_provider.ChatOpenAI._generate") as mock_super_gen, \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._generate") as mock_super_gen, patch.object(MindIEChatModel, "__init__", return_value=None):
             mock_super_gen.return_value = _make_chat_result("hello")
             model = MindIEChatModel.__new__(MindIEChatModel)
 
@@ -309,13 +305,11 @@ class TestGenerate:
 # 5.  MindIEChatModel._agenerate  (async)
 # ═════════════════════════════════════════════════════════════════════════════
 
-class TestAGenerate:
 
+class TestAGenerate:
     @pytest.mark.asyncio
     async def test_agenerate_patches_result(self):
-        with patch("deerflow.models.mindie_provider.ChatOpenAI._agenerate", new_callable=AsyncMock) as mock_ag, \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._agenerate", new_callable=AsyncMock) as mock_ag, patch.object(MindIEChatModel, "__init__", return_value=None):
             mock_ag.return_value = _make_chat_result("world\\nfoo")
             model = MindIEChatModel.__new__(MindIEChatModel)
 
@@ -327,8 +321,8 @@ class TestAGenerate:
 # 6.  MindIEChatModel._astream  (async generator)
 # ═════════════════════════════════════════════════════════════════════════════
 
-class TestAStream:
 
+class TestAStream:
     async def _collect(self, gen):
         chunks = []
         async for chunk in gen:
@@ -344,13 +338,9 @@ class TestAStream:
             for char in ["hel", "lo"]:
                 yield ChatGenerationChunk(message=AIMessageChunk(content=char))
 
-        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), patch.object(MindIEChatModel, "__init__", return_value=None):
             model = MindIEChatModel.__new__(MindIEChatModel)
-            chunks = await self._collect(
-                model._astream([HumanMessage(content="hi")])   
-            )
+            chunks = await self._collect(model._astream([HumanMessage(content="hi")]))
 
         assert "".join(c.message.content for c in chunks) == "hello"
 
@@ -362,52 +352,34 @@ class TestAStream:
         async def fake_stream(*args, **kwargs):
             yield ChatGenerationChunk(message=AIMessageChunk(content="a\\nb"))
 
-        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch("deerflow.models.mindie_provider.ChatOpenAI._astream", side_effect=fake_stream), patch.object(MindIEChatModel, "__init__", return_value=None):
             model = MindIEChatModel.__new__(MindIEChatModel)
-            chunks = await self._collect(
-                model._astream([HumanMessage(content="x")])
-            )
+            chunks = await self._collect(model._astream([HumanMessage(content="x")]))
 
         assert chunks[0].message.content == "a\nb"
 
     @pytest.mark.asyncio
     async def test_with_tools_fake_streams_text_in_chunks(self):
-        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
-            long_text = "A" * 50   
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, patch.object(MindIEChatModel, "__init__", return_value=None):
+            long_text = "A" * 50
             mock_ag.return_value = _make_chat_result(long_text)
             model = MindIEChatModel.__new__(MindIEChatModel)
 
-            chunks = await self._collect(
-                model._astream(
-                    [HumanMessage(content="q")],
-                    tools=[{"type": "function", "function": {"name": "dummy"}}]
-                )
-            )
+            chunks = await self._collect(model._astream([HumanMessage(content="q")], tools=[{"type": "function", "function": {"name": "dummy"}}]))
 
         full = "".join(c.message.content for c in chunks)
         assert full == long_text
-        assert len(chunks) > 1   
+        assert len(chunks) > 1
 
     @pytest.mark.asyncio
     async def test_with_tools_emits_tool_call_chunk(self):
 
         tool_calls = [{"name": "fn", "args": {}, "id": "c1"}]
-        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, patch.object(MindIEChatModel, "__init__", return_value=None):
             mock_ag.return_value = _make_chat_result("ok", tool_calls=tool_calls)
             model = MindIEChatModel.__new__(MindIEChatModel)
 
-            chunks = await self._collect(
-                model._astream(
-                    [HumanMessage(content="q")],
-                    tools=[{"type": "function", "function": {"name": "fn"}}]
-                )
-            )
+            chunks = await self._collect(model._astream([HumanMessage(content="q")], tools=[{"type": "function", "function": {"name": "fn"}}]))
 
         tool_chunks = [c for c in chunks if getattr(c.message, "tool_calls", [])]
         assert tool_chunks, "No chunk carried tool_calls"
@@ -416,17 +388,10 @@ class TestAStream:
     @pytest.mark.asyncio
     async def test_with_tools_empty_text_still_emits_tool_chunk(self):
         tool_calls = [{"name": "x", "args": {}, "id": "c2"}]
-        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, \
-             patch.object(MindIEChatModel, "__init__", return_value=None):
-
+        with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, patch.object(MindIEChatModel, "__init__", return_value=None):
             mock_ag.return_value = _make_chat_result("", tool_calls=tool_calls)
             model = MindIEChatModel.__new__(MindIEChatModel)
 
-            chunks = await self._collect(
-                model._astream(
-                    [HumanMessage(content="q")],
-                    tools=[{"type": "function", "function": {"name": "x"}}]
-                )
-            )
+            chunks = await self._collect(model._astream([HumanMessage(content="q")], tools=[{"type": "function", "function": {"name": "x"}}]))
 
         assert any(getattr(c.message, "tool_calls", []) for c in chunks)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -686,6 +686,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "prompt-toolkit" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -708,6 +709,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.14.11" },
 ]
@@ -2708,6 +2710,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3958,6 +3972,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
     { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
     { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -688,6 +688,7 @@ dependencies = [
 dev = [
     { name = "prompt-toolkit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -711,6 +712,7 @@ requires-dist = [
 dev = [
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "ruff", specifier = ">=0.14.11" },
 ]
 
@@ -3125,6 +3127,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -326,6 +326,27 @@ models:
   #       chat_template_kwargs:
   #         enable_thinking: true
 
+
+  # Example: Qwen3-Coder deployed on MindIE Engine
+  # - name: Qwen3_Coder_480B_MindIE
+  #   display_name: Qwen3-Coder-480B (MindIE)
+  #   use: deerflow.models.mindie_provider:MindIEChatModel
+  #   model: Qwen3-Coder-480B-A35B-Instruct-Client
+  #   base_url: http://localhost:8989/v1
+  #   api_key: $OPENAI_API_KEY
+  #   temperature: 0
+  #   max_retries: 1
+  #   supports_thinking: false
+  #   supports_vision: false
+  #   supports_reasoning_effort: false
+  #   # --- Advanced Network Settings ---
+  #   # Due to MindIE's streaming limitations with tool calling, the provider
+  #   # uses mock-streaming (awaiting full generation). Extended timeouts are required.
+  #   read_timeout: 900.0     # 15 minutes to prevent drops during long document generation
+  #   connect_timeout: 30.0
+  #   write_timeout: 60.0
+  #   pool_timeout: 30.0
+
 # ============================================================================
 # Tool Groups Configuration
 # ============================================================================


### PR DESCRIPTION
## 🔗 关联 Issue (Related Issue)
Ref #1462 

### **背景 / Motivation**
在 DeerFlow 2.0 默认通过 LangChain `ChatOpenAI` 接入华为 MindIE（昇腾推理引擎，特别是运行 Qwen3-Coder 模型）时，遇到了一系列底层兼容性问题（如：多模态内容格式报错、流式+工具调用返回空、XML 工具方言不被识别等），导致 Agent 无法正常运转。

本 PR 引入了专门的 `MindIEChatModel` 适配层，在不侵入现有标准 OpenAI 调用逻辑的前提下，完美解决了 MindIE 的接口对齐问题。

### **核心改动 / Key Changes**

**1. 新增 `MindIEChatModel` 封装层 (`backend/packages/harness/deerflow/models/mindie_provider.py`)**
* **入向消息降维与拍平 (`_fix_messages`)**：
    * 拦截并处理 LangChain 多模态的 `list[dict]` 内容结构，将其拍平为 MindIE 唯一接受的 `str` 格式。
    * **解决 Chat Template 崩溃问题**：针对 MindIE 不识别原生 `tool_calls` 属性和 `ToolMessage` 的情况，在发往服务端前，将工具调用反向序列化为 `<tool_call>` XML 文本，将工具执行结果伪装成带 `<tool_response>` 标签的 `HumanMessage`，确保底层 token 计算正常。
* **出向 XML 工具方言解析 (`_parse_xml_tool_calls` & `_patch_result`)**：
    * 拦截模型返回的带有 `<tool_call>` 的 XML 文本，利用正则提取并转换为 LangChain 标准的 JSON `tool_calls` 结构。
    * 内置类型反序列化（`ast.literal_eval`），防止列表/字典参数以纯字符串形式透传导致后续 Pydantic 校验失败。
* **实现动态“假流式”路由 (`_astream`)**：
    * **解决 MindIE 流式+工具冲突**：当请求携带 `tools` 时（MindIE 底层不支持该组合并会返回空结果），内部自动降级调用非流式的 `_agenerate` 获取完整响应，外部再切片包装为 `ChatGenerationChunk` yield 出去，既绕过了引擎 Bug，又满足了上层 LangGraph 对异步生成器的要求。普通对话依然走真实流式。
* **修复换行符过度转义**：在出向拦截时统一处理 `.replace("\\n", "\n")`，修复前端 Markdown 渲染糊行的问题。

**2. 针对性超时配置扩展 (`factory.py`)**
* 在 `create_chat_model` 中针对 `MindIEChatModel` 单独注入了带 `read=900.0` 级别 timeout 的 HTTP Client，以应对 MindIE 服务端较长的排队机制，防止流式连接被过早切断。

### **影响范围 / Impact**
* **安全/隔离性**：改动完全隔离。只有在 `config.yaml` 中明确配置了 `use: deerflow.models.mindie_provider:MindIEChatModel` 的模型才会走此逻辑，原有通过标准 `ChatOpenAI` 接入的模型不受任何影响。