### PR TITLE
feat(sandbox): support extra_mounts in K8s provisioner

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -91,10 +91,7 @@ class RemoteSandboxBackend(SandboxBackend):
         try:
             payload: dict = {"sandbox_id": sandbox_id, "thread_id": thread_id}
             if extra_mounts:
-                payload["extra_mounts"] = [
-                    {"host_path": h, "container_path": c, "read_only": r}
-                    for h, c, r in extra_mounts
-                ]
+                payload["extra_mounts"] = [{"host_path": h, "container_path": c, "read_only": r} for h, c, r in extra_mounts]
             resp = requests.post(
                 f"{self._provisioner_url}/api/sandboxes",
                 json=payload,

--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -89,12 +89,15 @@ class RemoteSandboxBackend(SandboxBackend):
     def _provisioner_create(self, thread_id: str, sandbox_id: str, extra_mounts: list[tuple[str, str, bool]] | None = None) -> SandboxInfo:
         """POST /api/sandboxes → create Pod + Service."""
         try:
+            payload: dict = {"sandbox_id": sandbox_id, "thread_id": thread_id}
+            if extra_mounts:
+                payload["extra_mounts"] = [
+                    {"host_path": h, "container_path": c, "read_only": r}
+                    for h, c, r in extra_mounts
+                ]
             resp = requests.post(
                 f"{self._provisioner_url}/api/sandboxes",
-                json={
-                    "sandbox_id": sandbox_id,
-                    "thread_id": thread_id,
-                },
+                json=payload,
                 timeout=30,
             )
             resp.raise_for_status()

--- a/backend/tests/test_provisioner_extra_mounts.py
+++ b/backend/tests/test_provisioner_extra_mounts.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+from pydantic import ValidationError
+
 
 class TestBuildVolumesExtraMounts:
     def test_no_extra_mounts_returns_two_volumes(self, provisioner_module):
@@ -72,3 +78,58 @@ class TestCreateSandboxRequestExtraMounts:
         assert len(req.extra_mounts) == 1
         assert req.extra_mounts[0].host_path == "/data"
         assert req.extra_mounts[0].read_only is True
+
+
+class TestExtraMountValidation:
+    def test_relative_host_path_rejected(self, provisioner_module):
+        with pytest.raises(ValidationError):
+            provisioner_module.ExtraMount(host_path="relative/path", container_path="/mnt/data")
+
+    def test_traversal_in_host_path_rejected(self, provisioner_module):
+        with pytest.raises(ValidationError):
+            provisioner_module.ExtraMount(host_path="/data/../etc", container_path="/mnt/data")
+
+    def test_reserved_skills_container_path_rejected(self, provisioner_module):
+        with pytest.raises(ValidationError):
+            provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/skills")
+
+    def test_reserved_userdata_container_path_rejected(self, provisioner_module):
+        with pytest.raises(ValidationError):
+            provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/user-data")
+
+    def test_reserved_container_subpath_rejected(self, provisioner_module):
+        with pytest.raises(ValidationError):
+            provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/user-data/foo")
+
+    def test_valid_mount_accepted(self, provisioner_module):
+        m = provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/custom")
+        assert m.host_path == "/data"
+        assert m.container_path == "/mnt/custom"
+
+
+class TestRemoteSandboxBackendPayload:
+    def test_extra_mounts_included_in_payload(self):
+        from deerflow.community.aio_sandbox.remote_backend import RemoteSandboxBackend
+
+        backend = RemoteSandboxBackend("http://provisioner:8002")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"sandbox_url": "http://host:30000"}
+
+        with patch.object(requests, "post", return_value=mock_resp) as mock_post:
+            backend._provisioner_create("thread-1", "sb-1", [("/host", "/mnt/custom", True)])
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["extra_mounts"] == [{"host_path": "/host", "container_path": "/mnt/custom", "read_only": True}]
+
+    def test_no_extra_mounts_omitted_from_payload(self):
+        from deerflow.community.aio_sandbox.remote_backend import RemoteSandboxBackend
+
+        backend = RemoteSandboxBackend("http://provisioner:8002")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"sandbox_url": "http://host:30000"}
+
+        with patch.object(requests, "post", return_value=mock_resp) as mock_post:
+            backend._provisioner_create("thread-1", "sb-1", None)
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "extra_mounts" not in payload

--- a/backend/tests/test_provisioner_extra_mounts.py
+++ b/backend/tests/test_provisioner_extra_mounts.py
@@ -1,0 +1,74 @@
+"""Tests for extra_mounts support in the K8s provisioner."""
+
+from __future__ import annotations
+
+
+class TestBuildVolumesExtraMounts:
+    def test_no_extra_mounts_returns_two_volumes(self, provisioner_module):
+        volumes = provisioner_module._build_volumes("thread-1", extra_mounts=None)
+        assert len(volumes) == 2
+
+    def test_extra_mounts_appended(self, provisioner_module):
+        mount = provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/data", read_only=False)
+        volumes = provisioner_module._build_volumes("thread-1", extra_mounts=[mount])
+        assert len(volumes) == 3
+        extra = volumes[2]
+        assert extra.name == "extra-0"
+        assert extra.host_path.path == "/data"
+        assert extra.host_path.type == "DirectoryOrCreate"
+
+    def test_multiple_extra_mounts(self, provisioner_module):
+        mounts = [
+            provisioner_module.ExtraMount(host_path="/a", container_path="/mnt/a", read_only=False),
+            provisioner_module.ExtraMount(host_path="/b", container_path="/mnt/b", read_only=True),
+        ]
+        volumes = provisioner_module._build_volumes("thread-1", extra_mounts=mounts)
+        assert len(volumes) == 4
+        assert volumes[2].name == "extra-0"
+        assert volumes[3].name == "extra-1"
+
+
+class TestBuildVolumeMountsExtraMounts:
+    def test_no_extra_mounts_returns_two_mounts(self, provisioner_module):
+        mounts = provisioner_module._build_volume_mounts("thread-1", extra_mounts=None)
+        assert len(mounts) == 2
+
+    def test_extra_mount_appended_with_correct_path(self, provisioner_module):
+        extra = provisioner_module.ExtraMount(host_path="/data", container_path="/mnt/data", read_only=False)
+        mounts = provisioner_module._build_volume_mounts("thread-1", extra_mounts=[extra])
+        assert len(mounts) == 3
+        m = mounts[2]
+        assert m.name == "extra-0"
+        assert m.mount_path == "/mnt/data"
+        assert m.read_only is False
+
+    def test_extra_mount_read_only_flag(self, provisioner_module):
+        extra = provisioner_module.ExtraMount(host_path="/ro", container_path="/mnt/ro", read_only=True)
+        mounts = provisioner_module._build_volume_mounts("thread-1", extra_mounts=[extra])
+        assert mounts[2].read_only is True
+
+    def test_multiple_extra_mounts_indexed(self, provisioner_module):
+        extras = [
+            provisioner_module.ExtraMount(host_path="/x", container_path="/mnt/x", read_only=False),
+            provisioner_module.ExtraMount(host_path="/y", container_path="/mnt/y", read_only=True),
+        ]
+        mounts = provisioner_module._build_volume_mounts("thread-1", extra_mounts=extras)
+        assert len(mounts) == 4
+        assert mounts[2].name == "extra-0"
+        assert mounts[3].name == "extra-1"
+
+
+class TestCreateSandboxRequestExtraMounts:
+    def test_extra_mounts_optional(self, provisioner_module):
+        req = provisioner_module.CreateSandboxRequest(sandbox_id="s1", thread_id="thread-1")
+        assert req.extra_mounts is None
+
+    def test_extra_mounts_parsed(self, provisioner_module):
+        req = provisioner_module.CreateSandboxRequest(
+            sandbox_id="s1",
+            thread_id="thread-1",
+            extra_mounts=[{"host_path": "/data", "container_path": "/mnt/data", "read_only": True}],
+        )
+        assert len(req.extra_mounts) == 1
+        assert req.extra_mounts[0].host_path == "/data"
+        assert req.extra_mounts[0].read_only is True

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -40,7 +40,7 @@ from fastapi import FastAPI, HTTPException
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 from kubernetes.client.rest import ApiException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # Suppress only the InsecureRequestWarning from urllib3
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -217,11 +217,35 @@ app = FastAPI(title="DeerFlow Sandbox Provisioner", lifespan=lifespan)
 
 # ── Request / Response models ───────────────────────────────────────────
 
+_RESERVED_CONTAINER_PREFIXES = ("/mnt/skills", "/mnt/user-data")
+
 
 class ExtraMount(BaseModel):
     host_path: str
     container_path: str
     read_only: bool = False
+
+    @field_validator("host_path")
+    @classmethod
+    def host_path_absolute(cls, v: str) -> str:
+        if not v.startswith("/"):
+            raise ValueError("host_path must be an absolute path")
+        if ".." in v.split("/"):
+            raise ValueError("host_path must not contain '..'")
+        return v
+
+    @field_validator("container_path")
+    @classmethod
+    def container_path_valid(cls, v: str) -> str:
+        if not v.startswith("/"):
+            raise ValueError("container_path must be an absolute path")
+        if ".." in v.split("/"):
+            raise ValueError("container_path must not contain '..'")
+        vn = v.rstrip("/")
+        for reserved in _RESERVED_CONTAINER_PREFIXES:
+            if vn == reserved or vn.startswith(reserved + "/"):
+                raise ValueError(f"container_path conflicts with reserved mount: {reserved}")
+        return v
 
 
 class CreateSandboxRequest(BaseModel):

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -218,9 +218,16 @@ app = FastAPI(title="DeerFlow Sandbox Provisioner", lifespan=lifespan)
 # ── Request / Response models ───────────────────────────────────────────
 
 
+class ExtraMount(BaseModel):
+    host_path: str
+    container_path: str
+    read_only: bool = False
+
+
 class CreateSandboxRequest(BaseModel):
     sandbox_id: str
     thread_id: str = Field(pattern=SAFE_THREAD_ID_PATTERN)
+    extra_mounts: list[ExtraMount] | None = None
 
 
 class SandboxResponse(BaseModel):
@@ -228,6 +235,8 @@ class SandboxResponse(BaseModel):
     sandbox_url: str  # Direct access URL, e.g. http://host.docker.internal:{NodePort}
     status: str
 
+
+CreateSandboxRequest.model_rebuild()
 
 # ── K8s resource helpers ─────────────────────────────────────────────────
 
@@ -245,7 +254,7 @@ def _sandbox_url(node_port: int) -> str:
     return f"http://{NODE_HOST}:{node_port}"
 
 
-def _build_volumes(thread_id: str) -> list[k8s_client.V1Volume]:
+def _build_volumes(thread_id: str, extra_mounts: list[ExtraMount] | None = None) -> list[k8s_client.V1Volume]:
     """Build volume list: PVC when configured, otherwise hostPath."""
     if SKILLS_PVC_NAME:
         skills_vol = k8s_client.V1Volume(
@@ -280,10 +289,21 @@ def _build_volumes(thread_id: str) -> list[k8s_client.V1Volume]:
             ),
         )
 
-    return [skills_vol, userdata_vol]
+    volumes = [skills_vol, userdata_vol]
+    for i, mount in enumerate(extra_mounts or []):
+        volumes.append(
+            k8s_client.V1Volume(
+                name=f"extra-{i}",
+                host_path=k8s_client.V1HostPathVolumeSource(
+                    path=mount.host_path,
+                    type="DirectoryOrCreate",
+                ),
+            )
+        )
+    return volumes
 
 
-def _build_volume_mounts(thread_id: str) -> list[k8s_client.V1VolumeMount]:
+def _build_volume_mounts(thread_id: str, extra_mounts: list[ExtraMount] | None = None) -> list[k8s_client.V1VolumeMount]:
     """Build volume mount list, using subPath for PVC user-data."""
     userdata_mount = k8s_client.V1VolumeMount(
         name="user-data",
@@ -293,7 +313,7 @@ def _build_volume_mounts(thread_id: str) -> list[k8s_client.V1VolumeMount]:
     if USERDATA_PVC_NAME:
         userdata_mount.sub_path = f"threads/{thread_id}/user-data"
 
-    return [
+    mounts = [
         k8s_client.V1VolumeMount(
             name="skills",
             mount_path="/mnt/skills",
@@ -301,9 +321,18 @@ def _build_volume_mounts(thread_id: str) -> list[k8s_client.V1VolumeMount]:
         ),
         userdata_mount,
     ]
+    for i, mount in enumerate(extra_mounts or []):
+        mounts.append(
+            k8s_client.V1VolumeMount(
+                name=f"extra-{i}",
+                mount_path=mount.container_path,
+                read_only=mount.read_only,
+            )
+        )
+    return mounts
 
 
-def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
+def _build_pod(sandbox_id: str, thread_id: str, extra_mounts: list[ExtraMount] | None = None) -> k8s_client.V1Pod:
     """Construct a Pod manifest for a single sandbox."""
     thread_id = _validate_thread_id(thread_id)
     return k8s_client.V1Pod(
@@ -362,14 +391,14 @@ def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
                             "ephemeral-storage": "500Mi",
                         },
                     ),
-                    volume_mounts=_build_volume_mounts(thread_id),
+                    volume_mounts=_build_volume_mounts(thread_id, extra_mounts),
                     security_context=k8s_client.V1SecurityContext(
                         privileged=False,
                         allow_privilege_escalation=True,
                     ),
                 )
             ],
-            volumes=_build_volumes(thread_id),
+            volumes=_build_volumes(thread_id, extra_mounts),
             restart_policy="Always",
         ),
     )
@@ -461,7 +490,7 @@ async def create_sandbox(req: CreateSandboxRequest):
 
     # ── Create Pod ───────────────────────────────────────────────────
     try:
-        core_v1.create_namespaced_pod(K8S_NAMESPACE, _build_pod(sandbox_id, thread_id))
+        core_v1.create_namespaced_pod(K8S_NAMESPACE, _build_pod(sandbox_id, thread_id, req.extra_mounts))
         logger.info(f"Created Pod {_pod_name(sandbox_id)}")
     except ApiException as exc:
         if exc.status != 409:  # 409 = AlreadyExists


### PR DESCRIPTION
  Implement extra volume mount support for the remote sandbox backend.
  Previously, extra_mounts was silently ignored when using the K8s
  provisioner. This change:

  - Adds ExtraMount model to CreateSandboxRequest in provisioner/app.py
  - Extends _build_volumes() and _build_volume_mounts() to append extra hostPath volumes alongside the built-in skills/user-data mounts
  - Passes extra_mounts from RemoteSandboxBackend to the provisioner API
  - Adds 9 unit tests covering the new behaviour

  Fixes #2480