### PR TITLE
fix(sandbox): support extra mounts in provisioner mode

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -183,7 +183,7 @@ class AioSandboxProvider(SandboxProvider):
         provisioner_url = self._config.get("provisioner_url")
         if provisioner_url:
             logger.info(f"Using remote sandbox backend with provisioner at {provisioner_url}")
-            return RemoteSandboxBackend(provisioner_url=provisioner_url)
+            return RemoteSandboxBackend(provisioner_url=provisioner_url, config_mounts=self._config["mounts"])
 
         logger.info("Using local container sandbox backend")
         return LocalContainerBackend(

--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -183,7 +183,10 @@ class AioSandboxProvider(SandboxProvider):
         provisioner_url = self._config.get("provisioner_url")
         if provisioner_url:
             logger.info(f"Using remote sandbox backend with provisioner at {provisioner_url}")
-            return RemoteSandboxBackend(provisioner_url=provisioner_url, config_mounts=self._config["mounts"])
+            return RemoteSandboxBackend(
+                provisioner_url=provisioner_url,
+                config_mounts=self._config.get("mounts") or [],
+            )
 
         logger.info("Using local container sandbox backend")
         return LocalContainerBackend(

--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -215,12 +215,7 @@ class RemoteSandboxBackend(SandboxBackend):
     @staticmethod
     def _is_provisioner_builtin_mount(container_path: str) -> bool:
         """Return true for mount paths the provisioner already creates itself."""
-        return (
-            container_path == "/mnt/skills"
-            or container_path.startswith("/mnt/skills/")
-            or container_path == "/mnt/user-data"
-            or container_path.startswith("/mnt/user-data/")
-        )
+        return container_path == "/mnt/skills" or container_path.startswith("/mnt/skills/") or container_path == "/mnt/user-data" or container_path.startswith("/mnt/user-data/")
 
     def _provisioner_destroy(self, sandbox_id: str) -> None:
         """DELETE /api/sandboxes/{sandbox_id} → destroy Pod + Service."""

--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -175,17 +175,25 @@ class RemoteSandboxBackend(SandboxBackend):
     def _serialize_extra_mounts(self, extra_mounts: list[tuple[str, str, bool]] | None = None) -> list[dict[str, object]]:
         """Serialize configured and runtime mounts for the provisioner API."""
         mounts: list[dict[str, object]] = []
+        seen_container_paths: set[str] = set()
 
         for mount in self._config_mounts:
+            normalized_container_path = mount.container_path.rstrip("/") or "/"
+            if self._is_provisioner_builtin_mount(normalized_container_path):
+                logger.warning("Skipping provisioner built-in config mount target: %s", mount.container_path)
+                continue
+            if normalized_container_path in seen_container_paths:
+                logger.warning("Skipping duplicate provisioner config mount target: %s", mount.container_path)
+                continue
+            seen_container_paths.add(normalized_container_path)
             mounts.append(
                 {
                     "host_path": mount.host_path,
-                    "container_path": mount.container_path,
+                    "container_path": normalized_container_path,
                     "read_only": mount.read_only,
                 }
             )
 
-        seen_container_paths = {str(mount["container_path"]).rstrip("/") or "/" for mount in mounts}
         for host_path, container_path, read_only in extra_mounts or []:
             normalized_container_path = container_path.rstrip("/") or "/"
             if self._is_provisioner_builtin_mount(normalized_container_path):
@@ -207,7 +215,12 @@ class RemoteSandboxBackend(SandboxBackend):
     @staticmethod
     def _is_provisioner_builtin_mount(container_path: str) -> bool:
         """Return true for mount paths the provisioner already creates itself."""
-        return container_path == "/mnt/skills" or container_path.startswith("/mnt/user-data/")
+        return (
+            container_path == "/mnt/skills"
+            or container_path.startswith("/mnt/skills/")
+            or container_path == "/mnt/user-data"
+            or container_path.startswith("/mnt/user-data/")
+        )
 
     def _provisioner_destroy(self, sandbox_id: str) -> None:
         """DELETE /api/sandboxes/{sandbox_id} → destroy Pod + Service."""

--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -42,14 +42,16 @@ class RemoteSandboxBackend(SandboxBackend):
           provisioner_url: http://provisioner:8002
     """
 
-    def __init__(self, provisioner_url: str):
+    def __init__(self, provisioner_url: str, config_mounts: list | None = None):
         """Initialize with the provisioner service URL.
 
         Args:
             provisioner_url: URL of the provisioner service
                              (e.g., ``http://provisioner:8002``).
+            config_mounts: Configured sandbox mounts to pass to the provisioner.
         """
         self._provisioner_url = provisioner_url.rstrip("/")
+        self._config_mounts = config_mounts or []
 
     @property
     def provisioner_url(self) -> str:
@@ -143,16 +145,20 @@ class RemoteSandboxBackend(SandboxBackend):
         user_id: str | None = None,
     ) -> SandboxInfo:
         """POST /api/sandboxes → create Pod + Service."""
-        del extra_mounts
         effective_user_id = user_id or get_effective_user_id()
+        payload = {
+            "sandbox_id": sandbox_id,
+            "thread_id": thread_id,
+            "user_id": effective_user_id,
+        }
+        serialized_mounts = self._serialize_extra_mounts(extra_mounts)
+        if serialized_mounts:
+            payload["extra_mounts"] = serialized_mounts
+
         try:
             resp = requests.post(
                 f"{self._provisioner_url}/api/sandboxes",
-                json={
-                    "sandbox_id": sandbox_id,
-                    "thread_id": thread_id,
-                    "user_id": effective_user_id,
-                },
+                json=payload,
                 timeout=30,
             )
             resp.raise_for_status()
@@ -165,6 +171,43 @@ class RemoteSandboxBackend(SandboxBackend):
         except requests.RequestException as exc:
             logger.error(f"Provisioner create failed for {sandbox_id}: {exc}")
             raise RuntimeError(f"Provisioner create failed: {exc}") from exc
+
+    def _serialize_extra_mounts(self, extra_mounts: list[tuple[str, str, bool]] | None = None) -> list[dict[str, object]]:
+        """Serialize configured and runtime mounts for the provisioner API."""
+        mounts: list[dict[str, object]] = []
+
+        for mount in self._config_mounts:
+            mounts.append(
+                {
+                    "host_path": mount.host_path,
+                    "container_path": mount.container_path,
+                    "read_only": mount.read_only,
+                }
+            )
+
+        seen_container_paths = {str(mount["container_path"]).rstrip("/") or "/" for mount in mounts}
+        for host_path, container_path, read_only in extra_mounts or []:
+            normalized_container_path = container_path.rstrip("/") or "/"
+            if self._is_provisioner_builtin_mount(normalized_container_path):
+                continue
+            if normalized_container_path in seen_container_paths:
+                logger.warning("Skipping duplicate provisioner extra mount target: %s", container_path)
+                continue
+            seen_container_paths.add(normalized_container_path)
+            mounts.append(
+                {
+                    "host_path": host_path,
+                    "container_path": normalized_container_path,
+                    "read_only": read_only,
+                }
+            )
+
+        return mounts
+
+    @staticmethod
+    def _is_provisioner_builtin_mount(container_path: str) -> bool:
+        """Return true for mount paths the provisioner already creates itself."""
+        return container_path == "/mnt/skills" or container_path.startswith("/mnt/user-data/")
 
     def _provisioner_destroy(self, sandbox_id: str) -> None:
         """DELETE /api/sandboxes/{sandbox_id} → destroy Pod + Service."""

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -56,6 +56,17 @@ def _make_provider(tmp_path):
     return provider
 
 
+def test_create_backend_provisioner_without_mounts_uses_empty_mounts(tmp_path):
+    """Provisioner mode should not require sandbox.mounts to be configured."""
+    provider = _make_provider(tmp_path)
+    provider._config = {"provisioner_url": "http://provisioner:8002"}
+
+    backend = provider._create_backend()
+
+    assert backend.provisioner_url == "http://provisioner:8002"
+    assert backend._serialize_extra_mounts() == []
+
+
 def test_get_thread_mounts_includes_acp_workspace(tmp_path, monkeypatch):
     """_get_thread_mounts must include /mnt/acp-workspace (read-only) for docker sandbox."""
     aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")

--- a/backend/tests/test_provisioner_pvc_volumes.py
+++ b/backend/tests/test_provisioner_pvc_volumes.py
@@ -2,6 +2,11 @@
 
 import pytest
 
+
+def _allow_extra_mount_host_paths(provisioner_module, *paths: str) -> None:
+    provisioner_module.EXTRA_MOUNT_HOST_PATH_ALLOWLIST = ",".join(paths)
+
+
 # ── _build_volumes ─────────────────────────────────────────────────────
 
 
@@ -81,6 +86,7 @@ class TestBuildVolumes:
 
     def test_extra_mounts_are_added_as_hostpath_volumes(self, provisioner_module):
         """Caller-provided mounts should become extra hostPath volumes."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
         extra_mounts = [
             provisioner_module.ExtraMountRequest(
                 host_path="/host/shared",
@@ -152,6 +158,7 @@ class TestBuildVolumeMounts:
 
     def test_extra_mounts_are_added_as_volume_mounts(self, provisioner_module):
         """Caller-provided mounts should become extra container mounts."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
         extra_mounts = [
             provisioner_module.ExtraMountRequest(
                 host_path="/host/shared",
@@ -169,6 +176,7 @@ class TestBuildVolumeMounts:
 
     def test_rejects_duplicate_extra_mount_targets(self, provisioner_module):
         """Extra mounts may not collide with each other or built-in mount paths."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
         extra_mounts = [
             provisioner_module.ExtraMountRequest(
                 host_path="/host/a",
@@ -195,8 +203,34 @@ class TestBuildVolumeMounts:
         with pytest.raises(ValueError, match="host_path must be absolute"):
             provisioner_module._build_volume_mounts("thread-1", extra_mounts)
 
+    def test_rejects_extra_mount_host_paths_without_allowlist(self, provisioner_module):
+        """Extra hostPath mounts must be explicitly allowed by the operator."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/shared",
+                container_path="/mnt/shared",
+            )
+        ]
+
+        with pytest.raises(ValueError, match="ALLOWLIST"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
+    def test_rejects_extra_mount_host_paths_outside_allowlist(self, provisioner_module):
+        """Allowed host paths must be inside an allowlisted base directory."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host/shared")
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/shared2",
+                container_path="/mnt/shared",
+            )
+        ]
+
+        with pytest.raises(ValueError, match="ALLOWLIST"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
     def test_rejects_reserved_extra_mount_subpaths(self, provisioner_module):
         """Extra mounts may not shadow provisioner-managed mount trees."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
         extra_mounts = [
             provisioner_module.ExtraMountRequest(
                 host_path="/host/user-data",
@@ -250,6 +284,7 @@ class TestBuildPodVolumes:
 
     def test_pod_includes_extra_mounts(self, provisioner_module):
         """Pod spec should wire extra volumes and volume mounts together."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
         extra_mounts = [
             provisioner_module.ExtraMountRequest(
                 host_path="/host/shared",

--- a/backend/tests/test_provisioner_pvc_volumes.py
+++ b/backend/tests/test_provisioner_pvc_volumes.py
@@ -94,7 +94,7 @@ class TestBuildVolumes:
         extra_volume = volumes[2]
         assert extra_volume.name == "extra-mount-0"
         assert extra_volume.host_path.path == "/host/shared"
-        assert extra_volume.host_path.type == "Directory"
+        assert extra_volume.host_path.type == "DirectoryOrCreate"
 
 
 # ── _build_volume_mounts ───────────────────────────────────────────────
@@ -193,6 +193,28 @@ class TestBuildVolumeMounts:
         ]
 
         with pytest.raises(ValueError, match="host_path must be absolute"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
+    def test_rejects_reserved_extra_mount_subpaths(self, provisioner_module):
+        """Extra mounts may not shadow provisioner-managed mount trees."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/user-data",
+                container_path="/mnt/user-data/workspace",
+            )
+        ]
+
+        with pytest.raises(ValueError, match="reserved"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/skills",
+                container_path="/mnt/skills/nested",
+            )
+        ]
+
+        with pytest.raises(ValueError, match="reserved"):
             provisioner_module._build_volume_mounts("thread-1", extra_mounts)
 
 

--- a/backend/tests/test_provisioner_pvc_volumes.py
+++ b/backend/tests/test_provisioner_pvc_volumes.py
@@ -1,5 +1,6 @@
 """Regression tests for provisioner PVC volume support."""
 
+import pytest
 
 # ── _build_volumes ─────────────────────────────────────────────────────
 
@@ -78,6 +79,23 @@ class TestBuildVolumes:
         assert volumes[0].name == "skills"
         assert volumes[1].name == "user-data"
 
+    def test_extra_mounts_are_added_as_hostpath_volumes(self, provisioner_module):
+        """Caller-provided mounts should become extra hostPath volumes."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/shared",
+                container_path="/mnt/shared",
+                read_only=True,
+            )
+        ]
+
+        volumes = provisioner_module._build_volumes("thread-1", extra_mounts)
+
+        extra_volume = volumes[2]
+        assert extra_volume.name == "extra-mount-0"
+        assert extra_volume.host_path.path == "/host/shared"
+        assert extra_volume.host_path.type == "Directory"
+
 
 # ── _build_volume_mounts ───────────────────────────────────────────────
 
@@ -132,6 +150,51 @@ class TestBuildVolumeMounts:
         """Should always return exactly two mounts."""
         assert len(provisioner_module._build_volume_mounts("t")) == 2
 
+    def test_extra_mounts_are_added_as_volume_mounts(self, provisioner_module):
+        """Caller-provided mounts should become extra container mounts."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/shared",
+                container_path="/mnt/shared/",
+                read_only=True,
+            )
+        ]
+
+        mounts = provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
+        extra_mount = mounts[2]
+        assert extra_mount.name == "extra-mount-0"
+        assert extra_mount.mount_path == "/mnt/shared"
+        assert extra_mount.read_only is True
+
+    def test_rejects_duplicate_extra_mount_targets(self, provisioner_module):
+        """Extra mounts may not collide with each other or built-in mount paths."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/a",
+                container_path="/mnt/shared",
+            ),
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/b",
+                container_path="/mnt/shared/",
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="duplicate"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
+    def test_rejects_relative_extra_mount_host_paths(self, provisioner_module):
+        """Kubernetes hostPath mounts must be absolute host paths."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="relative/path",
+                container_path="/mnt/shared",
+            )
+        ]
+
+        with pytest.raises(ValueError, match="host_path must be absolute"):
+            provisioner_module._build_volume_mounts("thread-1", extra_mounts)
+
 
 # ── _build_pod integration ─────────────────────────────────────────────
 
@@ -162,3 +225,19 @@ class TestBuildPodVolumes:
         assert pod.spec.volumes[1].persistent_volume_claim is not None
         userdata_mount = pod.spec.containers[0].volume_mounts[1]
         assert userdata_mount.sub_path == "deer-flow/users/user-7/threads/thread-1/user-data"
+
+    def test_pod_includes_extra_mounts(self, provisioner_module):
+        """Pod spec should wire extra volumes and volume mounts together."""
+        extra_mounts = [
+            provisioner_module.ExtraMountRequest(
+                host_path="/host/shared",
+                container_path="/mnt/shared",
+                read_only=False,
+            )
+        ]
+
+        pod = provisioner_module._build_pod("sandbox-1", "thread-1", extra_mounts=extra_mounts)
+
+        assert pod.spec.volumes[2].name == "extra-mount-0"
+        assert pod.spec.containers[0].volume_mounts[2].name == "extra-mount-0"
+        assert pod.spec.containers[0].volume_mounts[2].mount_path == "/mnt/shared"

--- a/backend/tests/test_provisioner_pvc_volumes.py
+++ b/backend/tests/test_provisioner_pvc_volumes.py
@@ -298,3 +298,30 @@ class TestBuildPodVolumes:
         assert pod.spec.volumes[2].name == "extra-mount-0"
         assert pod.spec.containers[0].volume_mounts[2].name == "extra-mount-0"
         assert pod.spec.containers[0].volume_mounts[2].mount_path == "/mnt/shared"
+
+    def test_pod_normalizes_extra_mounts_once(self, provisioner_module, monkeypatch):
+        """Pod creation should pass validated mounts to child builders unchanged."""
+        _allow_extra_mount_host_paths(provisioner_module, "/host")
+        original_normalize = provisioner_module._normalize_extra_mounts
+        call_count = 0
+
+        def spy_normalize(extra_mounts):
+            nonlocal call_count
+            call_count += 1
+            return original_normalize(extra_mounts)
+
+        monkeypatch.setattr(provisioner_module, "_normalize_extra_mounts", spy_normalize)
+
+        provisioner_module._build_pod(
+            "sandbox-1",
+            "thread-1",
+            extra_mounts=[
+                provisioner_module.ExtraMountRequest(
+                    host_path="/host/shared",
+                    container_path="/mnt/shared/",
+                    read_only=False,
+                )
+            ],
+        )
+
+        assert call_count == 1

--- a/backend/tests/test_remote_sandbox_backend.py
+++ b/backend/tests/test_remote_sandbox_backend.py
@@ -224,6 +224,51 @@ def test_provisioner_create_sends_configured_mounts(monkeypatch):
     assert info.sandbox_url == "http://sandbox.local"
 
 
+def test_provisioner_create_normalizes_configured_mounts(monkeypatch):
+    backend = RemoteSandboxBackend(
+        "http://provisioner:8002/",
+        config_mounts=[
+            SimpleNamespace(
+                host_path="/host/user-data",
+                container_path="/mnt/user-data/workspace",
+                read_only=False,
+            ),
+            SimpleNamespace(
+                host_path="/host/skills",
+                container_path="/mnt/skills",
+                read_only=True,
+            ),
+            SimpleNamespace(
+                host_path="/host/shared",
+                container_path="/mnt/shared/",
+                read_only=True,
+            ),
+            SimpleNamespace(
+                host_path="/host/duplicate",
+                container_path="/mnt/shared",
+                read_only=False,
+            ),
+        ],
+    )
+    posted_payloads: list[dict] = []
+
+    def mock_post(url: str, json: dict, timeout: int):
+        posted_payloads.append(json)
+        return _StubResponse(payload={"sandbox_id": "sandbox-1", "sandbox_url": "http://sandbox.local"})
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    backend.create("thread-1", "sandbox-1")
+
+    assert posted_payloads[0]["extra_mounts"] == [
+        {
+            "host_path": "/host/shared",
+            "container_path": "/mnt/shared",
+            "read_only": True,
+        }
+    ]
+
+
 def test_provisioner_create_sends_runtime_mounts_not_already_created_by_provisioner(monkeypatch):
     backend = RemoteSandboxBackend("http://provisioner:8002")
 

--- a/backend/tests/test_remote_sandbox_backend.py
+++ b/backend/tests/test_remote_sandbox_backend.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 import requests
 
@@ -184,6 +186,77 @@ def test_provisioner_create_accepts_anonymous_thread_id(monkeypatch):
     info = backend.create(None, "anon123")
     assert info.sandbox_id == "anon123"
     assert info.sandbox_url == "http://k3s:31002"
+
+
+def test_provisioner_create_sends_configured_mounts(monkeypatch):
+    backend = RemoteSandboxBackend(
+        "http://provisioner:8002/",
+        config_mounts=[
+            SimpleNamespace(
+                host_path="/host/shared",
+                container_path="/mnt/shared",
+                read_only=True,
+            )
+        ],
+    )
+
+    def mock_post(url: str, json: dict, timeout: int):
+        assert url == "http://provisioner:8002/api/sandboxes"
+        assert json == {
+            "sandbox_id": "sandbox-1",
+            "thread_id": "thread-1",
+            "user_id": "test-user-autouse",
+            "extra_mounts": [
+                {
+                    "host_path": "/host/shared",
+                    "container_path": "/mnt/shared",
+                    "read_only": True,
+                }
+            ],
+        }
+        assert timeout == 30
+        return _StubResponse(payload={"sandbox_id": "sandbox-1", "sandbox_url": "http://sandbox.local"})
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    info = backend.create("thread-1", "sandbox-1")
+    assert info.sandbox_id == "sandbox-1"
+    assert info.sandbox_url == "http://sandbox.local"
+
+
+def test_provisioner_create_sends_runtime_mounts_not_already_created_by_provisioner(monkeypatch):
+    backend = RemoteSandboxBackend("http://provisioner:8002")
+
+    def mock_post(url: str, json: dict, timeout: int):
+        assert url == "http://provisioner:8002/api/sandboxes"
+        assert json == {
+            "sandbox_id": "sandbox-1",
+            "thread_id": "thread-1",
+            "user_id": "test-user-autouse",
+            "extra_mounts": [
+                {
+                    "host_path": "/host/acp",
+                    "container_path": "/mnt/acp-workspace",
+                    "read_only": True,
+                }
+            ],
+        }
+        assert timeout == 30
+        return _StubResponse(payload={"sandbox_id": "sandbox-1", "sandbox_url": "http://sandbox.local"})
+
+    monkeypatch.setattr(requests, "post", mock_post)
+
+    info = backend.create(
+        "thread-1",
+        "sandbox-1",
+        extra_mounts=[
+            ("/host/thread/workspace", "/mnt/user-data/workspace", False),
+            ("/host/skills", "/mnt/skills", True),
+            ("/host/acp", "/mnt/acp-workspace", True),
+        ],
+    )
+    assert info.sandbox_id == "sandbox-1"
+    assert info.sandbox_url == "http://sandbox.local"
 
 
 def test_provisioner_create_raises_runtime_error_on_request_exception(monkeypatch):

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -999,6 +999,13 @@ sandbox:
 #   provisioner_url: http://provisioner:8002
 #   # Note: provisioner-created Pods use the provisioner's SANDBOX_IMAGE
 #   # environment variable, not sandbox.image from this config file.
+#
+#   # Optional: Additional hostPath mounts for sandbox Pods.
+#   # host_path must be an absolute path accessible by the Kubernetes node.
+#   # mounts:
+#   #   - host_path: /path/on/host
+#   #     container_path: /home/user/shared
+#   #     read_only: false
 
 # ============================================================================
 # Subagents Configuration

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1001,7 +1001,8 @@ sandbox:
 #   # environment variable, not sandbox.image from this config file.
 #
 #   # Optional: Additional hostPath mounts for sandbox Pods.
-#   # host_path must be an absolute path accessible by the Kubernetes node.
+#   # host_path must be an absolute path accessible by the Kubernetes node
+#   # and allowed by the provisioner's EXTRA_MOUNT_HOST_PATH_ALLOWLIST env var.
 #   # mounts:
 #   #   - host_path: /path/on/host
 #   #     container_path: /home/user/shared

--- a/docker/provisioner/README.md
+++ b/docker/provisioner/README.md
@@ -240,6 +240,11 @@ docker exec deer-flow-provisioner curl -X POST http://localhost:8002/api/sandbox
   -H "Content-Type: application/json" \
   -d '{"sandbox_id":"test-001","thread_id":"thread-001","user_id":"user-001"}'
 
+# Create a sandbox with an additional hostPath mount
+docker exec deer-flow-provisioner curl -X POST http://localhost:8002/api/sandboxes \
+  -H "Content-Type: application/json" \
+  -d '{"sandbox_id":"test-002","thread_id":"thread-002","extra_mounts":[{"host_path":"/absolute/host/path","container_path":"/mnt/shared","read_only":true}]}'
+
 # Check sandbox status
 docker exec deer-flow-provisioner curl http://localhost:8002/api/sandboxes/test-001
 

--- a/docker/provisioner/README.md
+++ b/docker/provisioner/README.md
@@ -145,6 +145,7 @@ The provisioner is configured via environment variables (set in [docker-compose-
 | `KUBECONFIG_PATH` | `/root/.kube/config` | Path to kubeconfig **inside** the provisioner container |
 | `NODE_HOST` | `host.docker.internal` | Hostname that backend containers use to reach host NodePorts |
 | `K8S_API_SERVER` | (from kubeconfig) | Override K8s API server URL (e.g., `https://host.docker.internal:26443`) |
+| `EXTRA_MOUNT_HOST_PATH_ALLOWLIST` | empty (disabled) | Comma-separated host base directories that `extra_mounts.host_path` may use |
 
 ### Custom sandbox image
 
@@ -241,6 +242,7 @@ docker exec deer-flow-provisioner curl -X POST http://localhost:8002/api/sandbox
   -d '{"sandbox_id":"test-001","thread_id":"thread-001","user_id":"user-001"}'
 
 # Create a sandbox with an additional hostPath mount
+# Requires EXTRA_MOUNT_HOST_PATH_ALLOWLIST to include /absolute/host or a parent path.
 docker exec deer-flow-provisioner curl -X POST http://localhost:8002/api/sandboxes \
   -H "Content-Type: application/json" \
   -d '{"sandbox_id":"test-002","thread_id":"thread-002","extra_mounts":[{"host_path":"/absolute/host/path","container_path":"/mnt/shared","read_only":true}]}'
@@ -341,7 +343,7 @@ docker exec deer-flow-gateway curl -s $SANDBOX_URL/v1/sandbox
 
 ## Security Considerations
 
-1. **HostPath Volumes**: The provisioner mounts host directories into sandbox Pods by default. Ensure these paths contain only trusted data. For production, prefer PVC-based volumes (set `SKILLS_PVC_NAME` and `USERDATA_PVC_NAME`) to avoid node-specific data loss risks.
+1. **HostPath Volumes**: The provisioner mounts host directories into sandbox Pods by default. Ensure these paths contain only trusted data. For production, prefer PVC-based volumes (set `SKILLS_PVC_NAME` and `USERDATA_PVC_NAME`) to avoid node-specific data loss risks. Additional `extra_mounts` hostPath requests are disabled unless `EXTRA_MOUNT_HOST_PATH_ALLOWLIST` is set, and requested paths must be inside one of those allowed directories.
 
 2. **Resource Limits**: Each sandbox Pod has CPU, memory, and storage limits to prevent resource exhaustion.
 

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -97,6 +97,18 @@ def join_host_path(base: str, *parts: str) -> str:
     return str(result)
 
 
+def _validate_thread_id(thread_id: str) -> str:
+    if not re.match(SAFE_THREAD_ID_PATTERN, thread_id):
+        raise ValueError(
+            "Invalid thread_id: only alphanumeric characters, hyphens, and underscores are allowed."
+        )
+    return thread_id
+
+
+def _is_absolute_host_path(path: str) -> bool:
+    return path.startswith("/") or bool(re.match(r"^[A-Za-z]:[\\/]", path)) or path.startswith("\\\\")
+
+
 # ── K8s client setup ────────────────────────────────────────────────────
 
 core_v1: k8s_client.CoreV1Api | None = None
@@ -212,10 +224,17 @@ app = FastAPI(title="DeerFlow Sandbox Provisioner", lifespan=lifespan)
 # ── Request / Response models ───────────────────────────────────────────
 
 
+class ExtraMountRequest(BaseModel):
+    host_path: str
+    container_path: str
+    read_only: bool = False
+
+
 class CreateSandboxRequest(BaseModel):
     sandbox_id: str
     thread_id: str = Field(pattern=SAFE_THREAD_ID_PATTERN)
     user_id: str = Field(default=DEFAULT_USER_ID, pattern=SAFE_USER_ID_PATTERN)
+    extra_mounts: list[ExtraMountRequest] = Field(default_factory=list)
 
 
 class SandboxResponse(BaseModel):
@@ -240,7 +259,39 @@ def _sandbox_url(node_port: int) -> str:
     return f"http://{NODE_HOST}:{node_port}"
 
 
-def _build_volumes(thread_id: str) -> list[k8s_client.V1Volume]:
+def _normalize_extra_mounts(extra_mounts: list[ExtraMountRequest] | None) -> list[ExtraMountRequest]:
+    """Validate and normalize caller-provided hostPath mounts."""
+    normalized: list[ExtraMountRequest] = []
+    seen_container_paths = {"/mnt/skills", "/mnt/user-data"}
+
+    for mount in extra_mounts or []:
+        host_path = mount.host_path
+        container_path = mount.container_path.rstrip("/") or "/"
+
+        if not host_path:
+            raise ValueError("extra_mounts.host_path must not be empty")
+        if not _is_absolute_host_path(host_path):
+            raise ValueError(f"extra_mounts.host_path must be absolute: {host_path}")
+        if not container_path.startswith("/"):
+            raise ValueError(f"extra_mounts.container_path must be absolute: {mount.container_path}")
+        if container_path == "/":
+            raise ValueError("extra_mounts.container_path must not be the filesystem root")
+        if container_path in seen_container_paths:
+            raise ValueError(f"duplicate or reserved extra_mounts.container_path: {container_path}")
+        seen_container_paths.add(container_path)
+
+        normalized.append(
+            ExtraMountRequest(
+                host_path=host_path,
+                container_path=container_path,
+                read_only=mount.read_only,
+            )
+        )
+
+    return normalized
+
+
+def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None = None) -> list[k8s_client.V1Volume]:
     """Build volume list: PVC when configured, otherwise hostPath."""
     if SKILLS_PVC_NAME:
         skills_vol = k8s_client.V1Volume(
@@ -275,10 +326,25 @@ def _build_volumes(thread_id: str) -> list[k8s_client.V1Volume]:
             ),
         )
 
-    return [skills_vol, userdata_vol]
+    volumes = [skills_vol, userdata_vol]
+    for index, mount in enumerate(_normalize_extra_mounts(extra_mounts)):
+        volumes.append(
+            k8s_client.V1Volume(
+                name=f"extra-mount-{index}",
+                host_path=k8s_client.V1HostPathVolumeSource(
+                    path=mount.host_path,
+                    type="Directory",
+                ),
+            )
+        )
 
+    return volumes
 
-def _build_volume_mounts(thread_id: str, user_id: str = DEFAULT_USER_ID) -> list[k8s_client.V1VolumeMount]:
+def _build_volume_mounts(
+    thread_id: str,
+    user_id: str = DEFAULT_USER_ID,
+    extra_mounts: list[ExtraMountRequest] | None = None,
+) -> list[k8s_client.V1VolumeMount]:
     """Build volume mount list, using subPath for PVC user-data."""
     userdata_mount = k8s_client.V1VolumeMount(
         name="user-data",
@@ -288,7 +354,7 @@ def _build_volume_mounts(thread_id: str, user_id: str = DEFAULT_USER_ID) -> list
     if USERDATA_PVC_NAME:
         userdata_mount.sub_path = f"deer-flow/users/{user_id}/threads/{thread_id}/user-data"
 
-    return [
+    mounts = [
         k8s_client.V1VolumeMount(
             name="skills",
             mount_path="/mnt/skills",
@@ -297,9 +363,27 @@ def _build_volume_mounts(thread_id: str, user_id: str = DEFAULT_USER_ID) -> list
         userdata_mount,
     ]
 
+    for index, mount in enumerate(_normalize_extra_mounts(extra_mounts)):
+        mounts.append(
+            k8s_client.V1VolumeMount(
+                name=f"extra-mount-{index}",
+                mount_path=mount.container_path,
+                read_only=mount.read_only,
+            )
+        )
 
-def _build_pod(sandbox_id: str, thread_id: str, user_id: str = DEFAULT_USER_ID) -> k8s_client.V1Pod:
+    return mounts
+
+
+def _build_pod(
+    sandbox_id: str,
+    thread_id: str,
+    user_id: str = DEFAULT_USER_ID,
+    extra_mounts: list[ExtraMountRequest] | None = None,
+) -> k8s_client.V1Pod:
     """Construct a Pod manifest for a single sandbox."""
+    thread_id = _validate_thread_id(thread_id)
+    extra_mounts = _normalize_extra_mounts(extra_mounts)
     return k8s_client.V1Pod(
         metadata=k8s_client.V1ObjectMeta(
             name=_pod_name(sandbox_id),
@@ -356,14 +440,14 @@ def _build_pod(sandbox_id: str, thread_id: str, user_id: str = DEFAULT_USER_ID) 
                             "ephemeral-storage": "500Mi",
                         },
                     ),
-                    volume_mounts=_build_volume_mounts(thread_id, user_id=user_id),
+                    volume_mounts=_build_volume_mounts(thread_id, user_id=user_id, extra_mounts=extra_mounts),
                     security_context=k8s_client.V1SecurityContext(
                         privileged=False,
                         allow_privilege_escalation=True,
                     ),
                 )
             ],
-            volumes=_build_volumes(thread_id),
+            volumes=_build_volumes(thread_id, extra_mounts),
             restart_policy="Always",
         ),
     )
@@ -440,6 +524,10 @@ async def create_sandbox(req: CreateSandboxRequest):
     sandbox_id = req.sandbox_id
     thread_id = req.thread_id
     user_id = req.user_id
+    try:
+        extra_mounts = _normalize_extra_mounts(req.extra_mounts)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     logger.info(
         "Received request to create sandbox '%s' for thread '%s' user '%s'",
@@ -459,7 +547,10 @@ async def create_sandbox(req: CreateSandboxRequest):
 
     # ── Create Pod ───────────────────────────────────────────────────
     try:
-        core_v1.create_namespaced_pod(K8S_NAMESPACE, _build_pod(sandbox_id, thread_id, user_id=user_id))
+        core_v1.create_namespaced_pod(
+            K8S_NAMESPACE,
+            _build_pod(sandbox_id, thread_id, user_id=user_id, extra_mounts=extra_mounts),
+        )
         logger.info(f"Created Pod {_pod_name(sandbox_id)}")
     except ApiException as exc:
         if exc.status != 409:  # 409 = AlreadyExists

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -30,7 +30,9 @@ Architecture (docker-compose-dev):
 from __future__ import annotations
 
 import logging
+import ntpath
 import os
+import posixpath
 import re
 import time
 from contextlib import asynccontextmanager
@@ -74,6 +76,10 @@ KUBECONFIG_PATH = os.environ.get("KUBECONFIG_PATH", "/root/.kube/config")
 # services on the host Kubernetes node.  On Docker Desktop for macOS this
 # is ``host.docker.internal``; on Linux it may be the host's LAN IP.
 NODE_HOST = os.environ.get("NODE_HOST", "host.docker.internal")
+EXTRA_MOUNT_HOST_PATH_ALLOWLIST = os.environ.get(
+    "EXTRA_MOUNT_HOST_PATH_ALLOWLIST",
+    "",
+)
 
 
 def join_host_path(base: str, *parts: str) -> str:
@@ -107,6 +113,49 @@ def _validate_thread_id(thread_id: str) -> str:
 
 def _is_absolute_host_path(path: str) -> bool:
     return path.startswith("/") or bool(re.match(r"^[A-Za-z]:[\\/]", path)) or path.startswith("\\\\")
+
+
+def _is_windows_host_path(path: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:[\\/]", path)) or path.startswith("\\\\")
+
+
+def _normalize_host_path_for_policy(path: str) -> tuple[str, str]:
+    if _is_windows_host_path(path):
+        return "windows", ntpath.normcase(ntpath.normpath(path))
+    return "posix", posixpath.normpath(path).rstrip("/") or "/"
+
+
+def _extra_mount_host_path_allowlist() -> list[str]:
+    return [path.strip() for path in EXTRA_MOUNT_HOST_PATH_ALLOWLIST.split(",") if path.strip()]
+
+
+def _is_extra_mount_host_path_allowed(host_path: str) -> bool:
+    allowed_base_paths = _extra_mount_host_path_allowlist()
+    if not allowed_base_paths:
+        return False
+
+    host_kind, normalized_host_path = _normalize_host_path_for_policy(host_path)
+    for base_path in allowed_base_paths:
+        if not _is_absolute_host_path(base_path):
+            raise ValueError("EXTRA_MOUNT_HOST_PATH_ALLOWLIST entries must be absolute")
+
+        base_kind, normalized_base_path = _normalize_host_path_for_policy(base_path)
+        if host_kind != base_kind:
+            continue
+
+        try:
+            common_path = (
+                ntpath.commonpath([normalized_base_path, normalized_host_path])
+                if host_kind == "windows"
+                else posixpath.commonpath([normalized_base_path, normalized_host_path])
+            )
+        except ValueError:
+            continue
+
+        if common_path == normalized_base_path:
+            return True
+
+    return False
 
 
 def _is_reserved_extra_mount_path(container_path: str) -> bool:
@@ -281,6 +330,8 @@ def _normalize_extra_mounts(extra_mounts: list[ExtraMountRequest] | None) -> lis
             raise ValueError("extra_mounts.host_path must not be empty")
         if not _is_absolute_host_path(host_path):
             raise ValueError(f"extra_mounts.host_path must be absolute: {host_path}")
+        if not _is_extra_mount_host_path_allowed(host_path):
+            raise ValueError(f"extra_mounts.host_path is not in EXTRA_MOUNT_HOST_PATH_ALLOWLIST: {host_path}")
         if not container_path.startswith("/"):
             raise ValueError(f"extra_mounts.container_path must be absolute: {mount.container_path}")
         if container_path == "/":
@@ -351,8 +402,9 @@ def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None 
 
 def _build_volume_mounts(
     thread_id: str,
-    user_id: str = DEFAULT_USER_ID,
     extra_mounts: list[ExtraMountRequest] | None = None,
+    *,
+    user_id: str = DEFAULT_USER_ID,
 ) -> list[k8s_client.V1VolumeMount]:
     """Build volume mount list, using subPath for PVC user-data."""
     userdata_mount = k8s_client.V1VolumeMount(

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -109,6 +109,15 @@ def _is_absolute_host_path(path: str) -> bool:
     return path.startswith("/") or bool(re.match(r"^[A-Za-z]:[\\/]", path)) or path.startswith("\\\\")
 
 
+def _is_reserved_extra_mount_path(container_path: str) -> bool:
+    return (
+        container_path == "/mnt/skills"
+        or container_path.startswith("/mnt/skills/")
+        or container_path == "/mnt/user-data"
+        or container_path.startswith("/mnt/user-data/")
+    )
+
+
 # ── K8s client setup ────────────────────────────────────────────────────
 
 core_v1: k8s_client.CoreV1Api | None = None
@@ -262,7 +271,7 @@ def _sandbox_url(node_port: int) -> str:
 def _normalize_extra_mounts(extra_mounts: list[ExtraMountRequest] | None) -> list[ExtraMountRequest]:
     """Validate and normalize caller-provided hostPath mounts."""
     normalized: list[ExtraMountRequest] = []
-    seen_container_paths = {"/mnt/skills", "/mnt/user-data"}
+    seen_container_paths: set[str] = set()
 
     for mount in extra_mounts or []:
         host_path = mount.host_path
@@ -276,7 +285,7 @@ def _normalize_extra_mounts(extra_mounts: list[ExtraMountRequest] | None) -> lis
             raise ValueError(f"extra_mounts.container_path must be absolute: {mount.container_path}")
         if container_path == "/":
             raise ValueError("extra_mounts.container_path must not be the filesystem root")
-        if container_path in seen_container_paths:
+        if _is_reserved_extra_mount_path(container_path) or container_path in seen_container_paths:
             raise ValueError(f"duplicate or reserved extra_mounts.container_path: {container_path}")
         seen_container_paths.add(container_path)
 
@@ -333,7 +342,7 @@ def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None 
                 name=f"extra-mount-{index}",
                 host_path=k8s_client.V1HostPathVolumeSource(
                     path=mount.host_path,
-                    type="Directory",
+                    type="DirectoryOrCreate",
                 ),
             )
         )

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -351,7 +351,12 @@ def _normalize_extra_mounts(extra_mounts: list[ExtraMountRequest] | None) -> lis
     return normalized
 
 
-def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None = None) -> list[k8s_client.V1Volume]:
+def _build_volumes(
+    thread_id: str,
+    extra_mounts: list[ExtraMountRequest] | None = None,
+    *,
+    normalize_extra_mounts: bool = True,
+) -> list[k8s_client.V1Volume]:
     """Build volume list: PVC when configured, otherwise hostPath."""
     if SKILLS_PVC_NAME:
         skills_vol = k8s_client.V1Volume(
@@ -387,7 +392,12 @@ def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None 
         )
 
     volumes = [skills_vol, userdata_vol]
-    for index, mount in enumerate(_normalize_extra_mounts(extra_mounts)):
+    prepared_extra_mounts = (
+        _normalize_extra_mounts(extra_mounts)
+        if normalize_extra_mounts
+        else extra_mounts or []
+    )
+    for index, mount in enumerate(prepared_extra_mounts):
         volumes.append(
             k8s_client.V1Volume(
                 name=f"extra-mount-{index}",
@@ -400,11 +410,13 @@ def _build_volumes(thread_id: str, extra_mounts: list[ExtraMountRequest] | None 
 
     return volumes
 
+
 def _build_volume_mounts(
     thread_id: str,
     extra_mounts: list[ExtraMountRequest] | None = None,
     *,
     user_id: str = DEFAULT_USER_ID,
+    normalize_extra_mounts: bool = True,
 ) -> list[k8s_client.V1VolumeMount]:
     """Build volume mount list, using subPath for PVC user-data."""
     userdata_mount = k8s_client.V1VolumeMount(
@@ -424,7 +436,12 @@ def _build_volume_mounts(
         userdata_mount,
     ]
 
-    for index, mount in enumerate(_normalize_extra_mounts(extra_mounts)):
+    prepared_extra_mounts = (
+        _normalize_extra_mounts(extra_mounts)
+        if normalize_extra_mounts
+        else extra_mounts or []
+    )
+    for index, mount in enumerate(prepared_extra_mounts):
         mounts.append(
             k8s_client.V1VolumeMount(
                 name=f"extra-mount-{index}",
@@ -441,10 +458,16 @@ def _build_pod(
     thread_id: str,
     user_id: str = DEFAULT_USER_ID,
     extra_mounts: list[ExtraMountRequest] | None = None,
+    *,
+    normalize_extra_mounts: bool = True,
 ) -> k8s_client.V1Pod:
     """Construct a Pod manifest for a single sandbox."""
     thread_id = _validate_thread_id(thread_id)
-    extra_mounts = _normalize_extra_mounts(extra_mounts)
+    prepared_extra_mounts = (
+        _normalize_extra_mounts(extra_mounts)
+        if normalize_extra_mounts
+        else extra_mounts or []
+    )
     return k8s_client.V1Pod(
         metadata=k8s_client.V1ObjectMeta(
             name=_pod_name(sandbox_id),
@@ -501,14 +524,23 @@ def _build_pod(
                             "ephemeral-storage": "500Mi",
                         },
                     ),
-                    volume_mounts=_build_volume_mounts(thread_id, user_id=user_id, extra_mounts=extra_mounts),
+                    volume_mounts=_build_volume_mounts(
+                        thread_id,
+                        extra_mounts=prepared_extra_mounts,
+                        user_id=user_id,
+                        normalize_extra_mounts=False,
+                    ),
                     security_context=k8s_client.V1SecurityContext(
                         privileged=False,
                         allow_privilege_escalation=True,
                     ),
                 )
             ],
-            volumes=_build_volumes(thread_id, extra_mounts),
+            volumes=_build_volumes(
+                thread_id,
+                extra_mounts=prepared_extra_mounts,
+                normalize_extra_mounts=False,
+            ),
             restart_policy="Always",
         ),
     )
@@ -610,7 +642,13 @@ async def create_sandbox(req: CreateSandboxRequest):
     try:
         core_v1.create_namespaced_pod(
             K8S_NAMESPACE,
-            _build_pod(sandbox_id, thread_id, user_id=user_id, extra_mounts=extra_mounts),
+            _build_pod(
+                sandbox_id,
+                thread_id,
+                user_id=user_id,
+                extra_mounts=extra_mounts,
+                normalize_extra_mounts=False,
+            ),
         )
         logger.info(f"Created Pod {_pod_name(sandbox_id)}")
     except ApiException as exc:


### PR DESCRIPTION
## Summary

- Pass configured sandbox mounts through `RemoteSandboxBackend` to the provisioner create API.
- Add provisioner `extra_mounts` request support and wire those mounts into Kubernetes hostPath volumes and container volumeMounts.
- Keep provisioner-created `/mnt/skills` and `/mnt/user-data/*` mounts from being duplicated while preserving runtime mounts such as `/mnt/acp-workspace`.
- Document provisioner-mode custom mounts and remove stale task-tool test monkeypatches for the current subagent skill-loading path.

## Root Cause

`AioSandboxProvider` handed configured mounts only to `LocalContainerBackend`; provisioner mode created pods from a fixed manifest and `RemoteSandboxBackend` did not send mount metadata. As a result, `sandbox.mounts` worked in local container mode but was ignored when `provisioner_url` selected the Kubernetes provisioner backend.

## Testing

- `cd backend && make lint`
- `cd backend && make test` → 2047 passed, 15 skipped
- `cd backend && uv run pytest tests/test_remote_sandbox_backend.py tests/test_provisioner_pvc_volumes.py tests/test_task_tool_core_logic.py::test_task_tool_propagates_tool_groups_to_subagent tests/test_task_tool_core_logic.py::test_task_tool_no_tool_groups_passes_none tests/test_task_tool_core_logic.py::test_task_tool_runtime_none_passes_groups_none -q` → 28 passed

Closes #2480