### PR TITLE
fix(tests): drop stale monkeypatch from #2253, main is red

### DIFF
--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -201,7 +201,6 @@ def test_task_tool_propagates_tool_groups_to_subagent(monkeypatch):
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -242,7 +241,6 @@ def test_task_tool_no_tool_groups_passes_none(monkeypatch):
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -281,7 +279,6 @@ def test_task_tool_runtime_none_passes_groups_none(monkeypatch):
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
-    monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",


### PR DESCRIPTION
> 先道个歉 🙏 —— 这是我自己 #2253 带进去的 bug，合并没多久 `main` 就红了，恳请 reviewer 帮忙加急看一下，以免后续 PR 都被 block 住。

## 现象

`backend-unit-tests` job 在 `tests/test_task_tool_core_logic.py` 上有三个 case 挂掉（参考 failed run [#24845360403](https://github.com/bytedance/deer-flow/actions/runs/24845360403/job/72730752505)）：

```
AttributeError: <module 'deerflow.tools.builtins.task_tool' ...>
  has no attribute 'get_skills_prompt_section'
```

失败的 case：
- `test_task_tool_propagates_tool_groups_to_subagent`
- `test_task_tool_no_tool_groups_passes_none`
- `test_task_tool_runtime_none_passes_groups_none`

## 根因

`get_skills_prompt_section` 的真实定义在 `packages/harness/deerflow/agents/lead_agent/prompt.py:603`，`task_tool.py` 从头到尾没有 import 它。

#2253 早期实现确实是在 `task_tool` 里直接拼 skills prompt、测试里 mock 掉它。后来实现改成「每个 subagent 按自己的 config 加载 skills、以 conversation items 形式注入」，`task_tool` 已经不再走这条路径（见 `packages/harness/deerflow/tools/builtins/task_tool.py:80` 的注释「No longer appended to system_prompt here.」）。测试里那三行 `monkeypatch.setattr` 漏删了，`monkeypatch.setattr` 默认 `raising=True`，找不到属性直接抛 `AttributeError`。

## 修复

删掉三处孤立的 `monkeypatch.setattr(task_tool_module, "get_skills_prompt_section", lambda: "")`。没有新增逻辑，也不改生产代码。

## 验证

本地 16/16 通过：

```
$ cd backend && PYTHONPATH=. uv run pytest tests/test_task_tool_core_logic.py -v
...
tests/test_task_tool_core_logic.py::test_task_tool_propagates_tool_groups_to_subagent PASSED
tests/test_task_tool_core_logic.py::test_task_tool_no_tool_groups_passes_none PASSED
tests/test_task_tool_core_logic.py::test_task_tool_runtime_none_passes_groups_none PASSED
...
============================== 16 passed in 0.70s ==============================
```

## Test plan
- [x] `pytest tests/test_task_tool_core_logic.py -v` 本地 16/16 绿
- [ ] CI `backend-unit-tests` 绿

再次抱歉添麻烦。