### PR TITLE
docs: add RFCs for P1 harness hardening

### DIFF
--- a/backend/docs/rfc-p1-deferred-mcp-execution-gate.md
+++ b/backend/docs/rfc-p1-deferred-mcp-execution-gate.md
@@ -1,0 +1,73 @@
+# RFC: Gate Deferred MCP Tool Execution Until Promotion
+
+## Summary
+
+When `tool_search` is enabled, MCP tools should not be executable until the model has explicitly selected or promoted them through the deferred tool flow.
+
+Currently deferred MCP tools are hidden from model binding, but they still exist in the runtime tool set. If an unbound tool call is injected, restored from history, or produced by a permissive provider, the ToolNode can execute it directly.
+
+## Problem
+
+The deferred tool design has two intended effects:
+
+1. Keep large MCP tool schemas out of the model context.
+2. Force the model to discover/select a tool through `tool_search` before using it.
+
+The current implementation primarily does the first part. The complete MCP tool list is still passed into the executable tool collection, while middleware filters the list shown to the model.
+
+That leaves a bypass:
+
+1. `tool_search.enabled` is true.
+2. MCP tool `foo` is registered as deferred but not promoted.
+3. A model/provider emits a tool call for `foo`, or a saved AIMessage containing `foo` is resumed.
+4. The runtime router finds `foo` in the executable tools and runs it.
+
+For filesystem, browser, network, or SaaS MCP tools this is a capability boundary issue.
+
+## Affected Code
+
+- `backend/packages/harness/deerflow/tools/tools.py`
+- `backend/packages/harness/deerflow/tools/builtins/tool_search.py`
+- `backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py`
+- Runtime tool-call middleware around ToolNode execution
+
+## Goals
+
+- Make deferred tools non-executable until promoted.
+- Keep the model-visible schema filtering behavior.
+- Preserve current `tool_search` user experience.
+- Make bypass attempts produce a clear tool error, not a silent execution.
+
+## Non-Goals
+
+- Redesign MCP tool discovery.
+- Remove support for direct MCP binding when `tool_search` is disabled.
+- Change individual MCP server permissions.
+
+## Proposal
+
+Add an execution gate in a tool-call middleware:
+
+1. Track deferred tool names in the `DeferredToolRegistry`.
+2. Track promoted tool names separately.
+3. Before executing any tool call, check whether the name is deferred and not promoted.
+4. If so, return a ToolMessage error instructing the model to call `tool_search`.
+5. Once `tool_search` promotes a tool, allow that tool for the current run/context.
+
+This gate should run for both sync and async tool calls.
+
+The registry should also be scoped so subagent tool construction or nested calls cannot accidentally reset or overwrite the parent run's promoted tools.
+
+## Testing
+
+Add tests for:
+
+- Deferred MCP tool call before promotion returns an error and does not invoke the underlying tool.
+- Promoted MCP tool call executes normally.
+- Resumed message history containing an unpromoted MCP tool call is rejected.
+- Subagent tool construction does not clear the parent run's promoted registry.
+
+## Open Questions
+
+- Should promotion be per single tool call, per run, or per conversation turn?
+- Should the error include the closest matching deferred tool names, or only instruct `tool_search`?

--- a/backend/docs/rfc-p1-local-custom-mount-symlink-boundary.md
+++ b/backend/docs/rfc-p1-local-custom-mount-symlink-boundary.md
@@ -1,0 +1,75 @@
+# RFC: Enforce Local Custom Mount Boundaries After Symlink Resolution
+
+## Summary
+
+Local sandbox custom mounts should validate resolved filesystem paths against their configured mount roots before any read or write operation.
+
+The current implementation accepts custom mount virtual paths by prefix, then resolves them to host paths. If the mounted directory contains a symlink to an outside path, file operations can escape the intended mount boundary. Read-only checks can also be bypassed because the resolved target no longer appears to be inside the read-only mount.
+
+## Problem
+
+Custom mounts are useful for exposing trusted host directories to local sandbox tools. They are also a boundary: a path under `/mnt/data` should not be able to access arbitrary host paths unless that path is inside the configured host root.
+
+A risky sequence:
+
+1. Configure a read-only custom mount from `/host/data` to `/mnt/data`.
+2. `/host/data/link` is a symlink to `/tmp/outside`.
+3. The agent calls `write_file("/mnt/data/link/out.txt", ...)`.
+4. The virtual prefix check accepts `/mnt/data/...`.
+5. Local path resolution follows the symlink to `/tmp/outside/out.txt`.
+6. The read-only check no longer sees the resolved path as inside `/host/data`, so the write can proceed.
+
+The same issue can affect read, list, glob, grep, update, and command path resolution depending on how a symlink is reached.
+
+## Affected Code
+
+- `backend/packages/harness/deerflow/sandbox/tools.py`
+- `backend/packages/harness/deerflow/sandbox/local/local_sandbox.py`
+- `backend/packages/harness/deerflow/sandbox/local/local_sandbox_provider.py`
+
+## Goals
+
+- Ensure a custom mount path cannot escape its configured host root after symlink resolution.
+- Enforce `read_only` based on the matched custom mount, not only on the final resolved target.
+- Preserve support for legitimate symlinks that resolve inside the same mount root.
+- Add regression tests for symlink escape and read-only bypass.
+
+## Non-Goals
+
+- Treat `LocalSandboxProvider` as a secure isolation boundary for arbitrary host bash.
+- Change the public custom mount config schema.
+- Remove support for custom mounts.
+
+## Proposal
+
+Add a custom mount resolver that returns both:
+
+- the matched `PathMapping`
+- the resolved host path
+
+For every file operation on a custom mount:
+
+1. Match the virtual path to the longest container path prefix.
+2. Join the relative path to the mount's host root.
+3. Resolve the candidate path.
+4. Verify `candidate.relative_to(mount_root.resolve())`.
+5. Reject if the candidate escapes the mount root.
+6. If the operation writes and the matched mount is read-only, reject before opening the file.
+
+The read-only decision should come from the matched mapping. It should not depend on whether the symlink target is still under that mapping.
+
+Command path rewriting should apply the same resolver before executing host commands in local mode.
+
+## Testing
+
+Add tests covering:
+
+- Read-only mount with `link -> outside`: write is rejected.
+- Writable mount with `link -> outside`: write is rejected because it escapes the mount root.
+- Symlink inside the mount root: read/write behavior follows the mount's read-only flag.
+- `glob` and `grep` do not return paths outside the custom mount through symlink traversal.
+
+## Open Questions
+
+- Should custom mounts default to not following symlinks at all, or allow symlinks that stay inside the mount root?
+- Should error messages expose that a symlink escape was detected, or use the existing generic permission-denied wording?

--- a/backend/docs/rfc-p1-run-rollback-serialization.md
+++ b/backend/docs/rfc-p1-run-rollback-serialization.md
@@ -1,0 +1,78 @@
+# RFC: Serialize Run Interrupt and Rollback Cleanup
+
+## Summary
+
+DeerFlow should treat interrupted or rolling-back runs as still in flight until their worker task has actually stopped and any checkpoint rollback has completed.
+
+Today a run can be marked `interrupted` before the old worker finishes cleanup. A new run for the same thread may start during that gap and write a fresh checkpoint, then the old rollback can restore an older snapshot over it.
+
+## Problem
+
+The runtime run manager exposes `multitask_strategy=interrupt` and `multitask_strategy=rollback` so callers can replace work already running on a thread.
+
+The risky sequence is:
+
+1. Run A is executing on thread T.
+2. A cancel, interrupt, or rollback request arrives.
+3. Run A is marked as terminal or no longer considered active.
+4. Run B is accepted for the same thread.
+5. Run B writes new state/checkpoints.
+6. Run A's worker reaches its cancellation cleanup and performs rollback.
+7. The rollback restores Run A's previous snapshot over Run B's state.
+
+This is a state consistency bug, not only a reporting bug. The user can observe a successful newer run whose thread state later reverts.
+
+## Affected Code
+
+- `backend/packages/harness/deerflow/runtime/runs/manager.py`
+- `backend/packages/harness/deerflow/runtime/runs/worker.py`
+- Checkpointer rollback paths used by run cancellation cleanup
+
+## Goals
+
+- Prevent more than one mutable run cleanup path from touching the same thread state at a time.
+- Ensure rollback cannot overwrite a checkpoint created by a newer run.
+- Keep current interrupt and rollback semantics for callers, but make the internal lifecycle explicit.
+- Add regression tests that fail under delayed cancellation/rollback.
+
+## Non-Goals
+
+- Redesign the public run API.
+- Change checkpoint storage format.
+- Add distributed locking across multiple machines in the first patch.
+
+## Proposal
+
+Introduce non-terminal lifecycle states such as:
+
+- `cancelling`
+- `rolling_back`
+
+A run in either state must still count as in flight for the thread. The run manager should not accept a new mutable run for the same thread until the old worker has completed cancellation cleanup and rollback.
+
+Recommended behavior:
+
+1. `cancel()` and replacement strategies request cancellation and move the old run into `cancelling` or `rolling_back`.
+2. The old run remains in the active/inflight index for its thread.
+3. The worker performs rollback, emits final status, and only then transitions to a terminal state.
+4. The run manager removes the run from the thread inflight index only after worker cleanup completes.
+5. New runs for the same thread wait, reject, or queue according to the selected strategy.
+
+If waiting is not desirable for the HTTP request path, the API can return a clear conflict while the previous run is still cleaning up.
+
+## Testing
+
+Add a fake checkpointer/worker test that controls timing:
+
+1. Start Run A and let it reach a checkpoint.
+2. Trigger rollback with an artificial delay before rollback finishes.
+3. Attempt to start Run B during that delay.
+4. Assert Run B is not allowed to write until Run A cleanup completes.
+5. Assert final checkpoint/state belongs to Run B only after Run B actually runs.
+
+Also add a test for `interrupt` without rollback so the lifecycle rule is consistent.
+
+## Open Questions
+
+- Should replacement requests wait for cleanup or return conflict immediately?
+- Should thread-level serialization live in the run manager only, or also in the checkpointer as a final guard?

--- a/backend/docs/rfc-p1-runtime-context-config-compat.md
+++ b/backend/docs/rfc-p1-runtime-context-config-compat.md
@@ -1,0 +1,82 @@
+# RFC: Normalize LangGraph Runtime Context for Lead Agent Configuration
+
+## Summary
+
+The gateway should support LangGraph 0.6-style `config.context` for run-time agent options such as `model_name`, `thinking_enabled`, `is_plan_mode`, and `subagent_enabled`.
+
+Currently `build_run_config()` preserves `context`, but `make_lead_agent()` only reads `configurable`. Requests that use `config.context` therefore silently fall back to default model and runtime options.
+
+## Problem
+
+LangGraph 0.6 introduced `context` as the preferred place for run-level context. The gateway has code to avoid sending both `context` and `configurable`, but the lead agent factory still reads only:
+
+```python
+cfg = config.get("configurable", {})
+```
+
+Risky sequence:
+
+1. Client sends a run request with `config.context.model_name = "deepseek-v3"`.
+2. Gateway preserves `context` and skips `configurable`.
+3. `make_lead_agent()` reads an empty configurable dict.
+4. The requested model and flags are ignored.
+5. The run uses defaults without warning.
+
+This affects model selection, thinking mode, plan mode, subagent enablement, custom agent names, and other run-time knobs that are currently read from `configurable`.
+
+## Affected Code
+
+- `backend/app/gateway/services.py`
+- `backend/packages/harness/deerflow/agents/lead_agent/agent.py`
+- Tests around gateway run config and lead agent model resolution
+
+## Goals
+
+- Support both legacy `configurable` and newer `context` callers.
+- Avoid silent fallback when caller supplied valid run options.
+- Keep behavior consistent between gateway, SDK, and channel manager paths.
+- Add end-to-end tests that verify requested model/options reach `create_chat_model`.
+
+## Non-Goals
+
+- Remove support for `configurable`.
+- Pass arbitrary unvalidated request data into agent internals.
+- Change public option names.
+
+## Proposal
+
+Introduce a small normalization helper that builds the effective run options:
+
+1. Start with `config.get("configurable", {})`.
+2. Merge allowed keys from `config.get("context", {})`.
+3. Decide precedence. Recommended: explicit `context` wins for LangGraph 0.6 requests, while logging if both contain conflicting values.
+4. Use the normalized dict everywhere `make_lead_agent()` currently reads `configurable`.
+
+Allowed keys should include the existing runtime options:
+
+- `thread_id`
+- `model_name`
+- `model`
+- `thinking_enabled`
+- `reasoning_effort`
+- `is_plan_mode`
+- `subagent_enabled`
+- `max_concurrent_subagents`
+- `is_bootstrap`
+- `agent_name`
+
+The gateway can also inject `assistant_id` into `context.agent_name` when it is already operating in context mode.
+
+## Testing
+
+Add tests for:
+
+- `config.context.model_name` reaches `create_chat_model(name=...)`.
+- `config.context.subagent_enabled` enables task tooling/middleware.
+- `config.context.agent_name` selects the custom agent.
+- When both `context` and `configurable` are present with conflicting values, the chosen precedence is deterministic and logged.
+
+## Open Questions
+
+- Should normalization happen in the gateway only, or in `make_lead_agent()` so direct SDK callers get the same behavior?
+- Should unknown context keys be ignored, logged, or rejected?

--- a/backend/docs/rfc-p1-subagent-skill-allowlist-inheritance.md
+++ b/backend/docs/rfc-p1-subagent-skill-allowlist-inheritance.md
@@ -1,0 +1,72 @@
+# RFC: Inherit Parent Skill Allowlist in Subagents
+
+## Summary
+
+Subagents should never gain access to skills that the parent agent was not allowed to load.
+
+Today a parent custom agent can restrict skills, but a default subagent with `skills=None` loads all enabled skills from disk. That bypasses the parent agent's allowlist and can inject unrelated or unsafe skill instructions into the subagent context.
+
+## Problem
+
+Skill access is part of an agent's instruction boundary. If a configured agent allows only `safe-skill`, delegating work to a `general-purpose` subagent should not expand that boundary to every enabled skill.
+
+Current risky sequence:
+
+1. Parent agent config sets `skills: ["safe-skill"]`.
+2. An enabled custom skill exists on disk, for example `dangerous-skill`.
+3. Parent agent calls the `task` tool.
+4. The built-in subagent config has `skills=None`.
+5. `SubagentExecutor` treats `None` as "load all enabled skills".
+6. The subagent receives `dangerous-skill` as a system/developer message.
+
+This violates least privilege and makes subagent behavior depend on unrelated enabled skills.
+
+## Affected Code
+
+- `backend/packages/harness/deerflow/tools/builtins/task_tool.py`
+- `backend/packages/harness/deerflow/subagents/executor.py`
+- `backend/packages/harness/deerflow/subagents/registry.py`
+- Agent config loading that determines the parent skill allowlist
+
+## Goals
+
+- Parent agent skill allowlists constrain subagents by default.
+- Custom subagent skill config can further narrow, but not widen, parent access.
+- Preserve explicit `skills=[]` semantics for no skills.
+- Add tests for built-in and custom subagents.
+
+## Non-Goals
+
+- Redesign skill installation or enablement.
+- Remove the ability for a top-level agent with unrestricted skills to delegate to unrestricted subagents.
+- Change skill file format.
+
+## Proposal
+
+Pass the parent agent's effective skill allowlist into `task_tool` metadata or executor initialization.
+
+Effective subagent skills should be:
+
+- parent unrestricted + subagent unrestricted: all enabled skills
+- parent unrestricted + subagent allowlist: subagent allowlist
+- parent allowlist + subagent unrestricted: parent allowlist
+- parent allowlist + subagent allowlist: intersection
+- any side `[]`: no skills, or intersection semantics that yields empty
+
+If a custom subagent requests a skill outside the parent allowlist, log a warning and omit it.
+
+The same inheritance rule should apply whether the subagent is built-in or custom.
+
+## Testing
+
+Add tests for:
+
+- Parent `skills=["safe"]`, default subagent loads only `safe`.
+- Parent `skills=["safe"]`, custom subagent `skills=["safe", "other"]` loads only `safe`.
+- Parent unrestricted, custom subagent `skills=["safe"]` loads only `safe`.
+- Parent `skills=[]` causes subagent to load no skills.
+
+## Open Questions
+
+- Where should the parent effective skill list be stored so direct SDK usage and gateway usage behave the same?
+- Should the UI/API expose that a subagent skill request was narrowed by parent policy?


### PR DESCRIPTION
## Summary

Adds five RFC documents for the P1 harness issues found in review:

- serialize run interrupt/rollback cleanup — fixes discussion for #2505
- enforce local custom mount boundaries after symlink resolution — fixes discussion for #2506
- gate deferred MCP tool execution until promotion — fixes discussion for #2507
- inherit parent skill allowlists in subagents — fixes discussion for #2508
- normalize LangGraph runtime context for lead agent configuration — fixes discussion for #2509

## Tracking Issues

- #2505
- #2506
- #2507
- #2508
- #2509

## Notes

This PR is docs-only and intended to anchor issue discussion before implementation.

## Testing

Not run; documentation-only change.