### PR TITLE
fix: gate deferred MCP tool execution

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
@@ -63,10 +63,7 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
 
         tool_call_id = str(request.tool_call.get("id") or "missing_tool_call_id")
         return ToolMessage(
-            content=(
-                f"Error: Tool '{tool_name}' is deferred and has not been loaded yet. "
-                "Call tool_search first to fetch and promote this tool's schema, then retry."
-            ),
+            content=(f"Error: Tool '{tool_name}' is deferred and has not been loaded yet. Call tool_search first to fetch and promote this tool's schema, then retry."),
             tool_call_id=tool_call_id,
             name=tool_name,
             status="error",

--- a/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
@@ -38,7 +38,7 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
         if not registry:
             return request
 
-        deferred_names = {e.name for e in registry.entries}
+        deferred_names = registry.deferred_names
         active_tools = [t for t in request.tools if getattr(t, "name", None) not in deferred_names]
 
         if len(active_tools) < len(request.tools):
@@ -57,13 +57,12 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
         if not tool_name:
             return None
 
-        deferred_names = {e.name for e in registry.entries}
-        if tool_name not in deferred_names:
+        if not registry.contains(tool_name):
             return None
 
         tool_call_id = str(request.tool_call.get("id") or "missing_tool_call_id")
         return ToolMessage(
-            content=(f"Error: Tool '{tool_name}' is deferred and has not been loaded yet. Call tool_search first to fetch and promote this tool's schema, then retry."),
+            content=(f"Error: Tool '{tool_name}' is deferred and has not been promoted yet. Call tool_search first to expose and promote this tool's schema, then retry."),
             tool_call_id=tool_call_id,
             name=tool_name,
             status="error",

--- a/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
@@ -16,6 +16,9 @@ from typing import override
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,32 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
 
         return request.override(tools=active_tools)
 
+    def _blocked_tool_message(self, request: ToolCallRequest) -> ToolMessage | None:
+        from deerflow.tools.builtins.tool_search import get_deferred_registry
+
+        registry = get_deferred_registry()
+        if not registry:
+            return None
+
+        tool_name = str(request.tool_call.get("name") or "")
+        if not tool_name:
+            return None
+
+        deferred_names = {e.name for e in registry.entries}
+        if tool_name not in deferred_names:
+            return None
+
+        tool_call_id = str(request.tool_call.get("id") or "missing_tool_call_id")
+        return ToolMessage(
+            content=(
+                f"Error: Tool '{tool_name}' is deferred and has not been loaded yet. "
+                "Call tool_search first to fetch and promote this tool's schema, then retry."
+            ),
+            tool_call_id=tool_call_id,
+            name=tool_name,
+            status="error",
+        )
+
     @override
     def wrap_model_call(
         self,
@@ -52,9 +81,31 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
         return handler(self._filter_tools(request))
 
     @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        blocked = self._blocked_tool_message(request)
+        if blocked is not None:
+            return blocked
+        return handler(request)
+
+    @override
     async def awrap_model_call(
         self,
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
         return await handler(self._filter_tools(request))
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        blocked = self._blocked_tool_message(request)
+        if blocked is not None:
+            return blocked
+        return await handler(request)

--- a/backend/packages/harness/deerflow/tools/builtins/tool_search.py
+++ b/backend/packages/harness/deerflow/tools/builtins/tool_search.py
@@ -112,6 +112,15 @@ class DeferredToolRegistry:
     def entries(self) -> list[DeferredToolEntry]:
         return list(self._entries)
 
+    @property
+    def deferred_names(self) -> set[str]:
+        """Names of tools that are still hidden from model binding."""
+        return {entry.name for entry in self._entries}
+
+    def contains(self, name: str) -> bool:
+        """Return whether *name* is still deferred."""
+        return any(entry.name == name for entry in self._entries)
+
     def __len__(self) -> int:
         return len(self._entries)
 

--- a/backend/tests/test_tool_search.py
+++ b/backend/tests/test_tool_search.py
@@ -2,8 +2,10 @@
 
 import json
 import sys
+from types import SimpleNamespace
 
 import pytest
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import tool as langchain_tool
 
 from deerflow.config.tool_search_config import ToolSearchConfig, load_tool_search_config_from_dict
@@ -509,3 +511,50 @@ class TestToolSearchPromotion:
         assert "slack_send_message" not in remaining
         assert "slack_list_channels" not in remaining
         assert len(registry) == 4
+
+
+class TestDeferredToolExecutionGate:
+    def test_unpromoted_deferred_tool_call_is_blocked(self, registry):
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+        request = SimpleNamespace(tool_call={"name": "github_create_issue", "id": "call-1"})
+        called = False
+
+        def handler(_request):
+            nonlocal called
+            called = True
+            return ToolMessage(content="executed", tool_call_id="call-1", name="github_create_issue")
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        assert called is False
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.tool_call_id == "call-1"
+        assert "tool_search" in result.content
+        assert "github_create_issue" in result.content
+
+    @pytest.mark.anyio
+    async def test_unpromoted_deferred_tool_call_is_blocked_async(self, registry):
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+        request = SimpleNamespace(tool_call={"name": "github_create_issue", "id": "call-1"})
+        called = False
+
+        async def handler(_request):
+            nonlocal called
+            called = True
+            return ToolMessage(content="executed", tool_call_id="call-1", name="github_create_issue")
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        assert called is False
+        assert isinstance(result, ToolMessage)
+        assert result.status == "error"
+        assert result.tool_call_id == "call-1"
+        assert "tool_search" in result.content
+        assert "github_create_issue" in result.content

--- a/backend/tests/test_tool_search.py
+++ b/backend/tests/test_tool_search.py
@@ -85,6 +85,16 @@ class TestDeferredToolRegistry:
         assert "github_create_issue" in names
         assert "slack_send_message" in names
 
+    def test_deferred_names(self, registry):
+        names = registry.deferred_names
+        assert "github_create_issue" in names
+        assert "slack_send_message" in names
+        assert len(names) == 6
+
+    def test_contains(self, registry):
+        assert registry.contains("github_create_issue") is True
+        assert registry.contains("not_registered") is False
+
     def test_search_select_single(self, registry):
         results = registry.search("select:github_create_issue")
         assert len(results) == 1
@@ -535,6 +545,45 @@ class TestDeferredToolExecutionGate:
         assert result.tool_call_id == "call-1"
         assert "tool_search" in result.content
         assert "github_create_issue" in result.content
+
+    def test_promoted_deferred_tool_call_is_allowed(self, registry):
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        registry.promote({"github_create_issue"})
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+        request = SimpleNamespace(tool_call={"name": "github_create_issue", "id": "call-1"})
+        called = False
+
+        def handler(_request):
+            nonlocal called
+            called = True
+            return ToolMessage(content="executed", tool_call_id="call-1", name="github_create_issue")
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        assert called is True
+        assert isinstance(result, ToolMessage)
+        assert result.content == "executed"
+
+    def test_non_deferred_tool_call_is_allowed(self, registry):
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+        request = SimpleNamespace(tool_call={"name": "local_tool", "id": "call-1"})
+        called = False
+
+        def handler(_request):
+            nonlocal called
+            called = True
+            return ToolMessage(content="executed", tool_call_id="call-1", name="local_tool")
+
+        result = middleware.wrap_tool_call(request, handler)
+
+        assert called is True
+        assert isinstance(result, ToolMessage)
+        assert result.content == "executed"
 
     @pytest.mark.anyio
     async def test_unpromoted_deferred_tool_call_is_blocked_async(self, registry):


### PR DESCRIPTION
## Summary

Fixes #2507.

This adds an execution gate to the deferred tool middleware. Deferred MCP tools are still hidden from model binding as before, but now a direct tool call for an unpromoted deferred tool returns an error ToolMessage instead of invoking the underlying tool. Once tool_search promotes the tool, normal execution is allowed.

## Root Cause

tool_search deferred MCP schemas from model binding, but the full MCP tool list remained present in the executable ToolNode collection. That meant injected, restored, or provider-emitted tool calls could bypass promotion.

## Validation

- uv run --project backend python -m pytest backend/tests/test_tool_search.py backend/tests/test_tool_error_handling_middleware.py
- uv run --project backend python -m ruff check backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py backend/tests/test_tool_search.py
- graphify update .