### PR TITLE
feat(dev): add pre-commit hooks for ruff, eslint, and prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,19 @@
 repos:
-  # Backend: ruff lint + format
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.10
+  # Backend: ruff lint + format via uv (uses the same ruff version as backend deps)
+  - repo: local
     hooks:
       - id: ruff
         name: ruff lint
-        args: [--fix]
+        entry: bash -c 'cd backend && uv run ruff check --fix "${@/#backend\//}"' --
+        language: system
+        types_or: [python]
+        files: ^backend/
       - id: ruff-format
+        name: ruff format
+        entry: bash -c 'cd backend && uv run ruff format "${@/#backend\//}"' --
+        language: system
+        types_or: [python]
+        files: ^backend/
 
   # Frontend: eslint + prettier (must run from frontend/ for node_modules resolution)
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  # Backend: ruff lint + format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.10
+    hooks:
+      - id: ruff
+        name: ruff lint
+        args: [--fix]
+      - id: ruff-format
+
+  # Frontend: eslint + prettier (must run from frontend/ for node_modules resolution)
+  - repo: local
+    hooks:
+      - id: frontend-eslint
+        name: eslint (frontend)
+        entry: bash -c 'cd frontend && npx eslint --fix "${@/#frontend\//}"' --
+        language: system
+        types_or: [javascript, tsx, ts]
+        files: ^frontend/
+
+      - id: frontend-prettier
+        name: prettier (frontend)
+        entry: bash -c 'cd frontend && npx prettier --write "${@/#frontend\//}"' --
+        language: system
+        files: ^frontend/
+        types_or: [javascript, tsx, ts, json, css]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,7 +166,7 @@ Required tools:
 
 1. **Configure the application** (same as Docker setup above)
 
-2. **Install dependencies**:
+2. **Install dependencies** (this also sets up pre-commit hooks):
    ```bash
    make install
    ```

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ install:
 	@echo "Installing frontend dependencies..."
 	@cd frontend && pnpm install
 	@echo "Installing pre-commit hooks..."
-	@pip install -q pre-commit 2>/dev/null; pre-commit install 2>/dev/null || echo "  (pre-commit skipped — install it with: pip install pre-commit && pre-commit install)"
+	@$(BACKEND_UV_RUN) --with pre-commit pre-commit install
 	@echo "✓ All dependencies installed"
 	@echo ""
 	@echo "=========================================="

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:
 	@echo "  make config          - Generate local config files (aborts if config already exists)"
 	@echo "  make config-upgrade  - Merge new fields from config.example.yaml into config.yaml"
 	@echo "  make check           - Check if all required tools are installed"
-	@echo "  make install         - Install all dependencies (frontend + backend)"
+	@echo "  make install         - Install all dependencies (frontend + backend + pre-commit hooks)"
 	@echo "  make setup-sandbox   - Pre-pull sandbox container image (recommended)"
 	@echo "  make dev             - Start all services in development mode (with hot-reloading)"
 	@echo "  make dev-pro         - Start in dev + Gateway mode (experimental, no LangGraph server)"
@@ -73,6 +73,8 @@ install:
 	@cd backend && uv sync
 	@echo "Installing frontend dependencies..."
 	@cd frontend && pnpm install
+	@echo "Installing pre-commit hooks..."
+	@pip install -q pre-commit 2>/dev/null; pre-commit install 2>/dev/null || echo "  (pre-commit skipped — install it with: pip install pre-commit && pre-commit install)"
 	@echo "✓ All dependencies installed"
 	@echo ""
 	@echo "=========================================="

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ On Windows, run the local development flow from Git Bash. Native `cmd.exe` and P
 
 2. **Install dependencies**:
    ```bash
-   make install  # Install backend + frontend dependencies
+   make install  # Install backend + frontend dependencies + pre-commit hooks
    ```
 
 3. **(Optional) Pre-pull sandbox image**:


### PR DESCRIPTION
This pull request introduces pre-commit hooks for both backend and frontend code, aiming to automate code linting and formatting before commits. The installation process is updated to include pre-commit hook setup, and documentation is revised to reflect these changes.

**Pre-commit hook integration:**

* Added a `.pre-commit-config.yaml` file to configure pre-commit hooks for backend (`ruff` lint and format) and frontend (`eslint` and `prettier`) checks.
* Modified the `Makefile` so that `make install` now installs pre-commit hooks in addition to backend and frontend dependencies.

**Documentation updates:**

* Updated the `Makefile` help text to indicate that `make install` now sets up pre-commit hooks.
* Updated `README.md` and `CONTRIBUTING.md` to clarify that `make install` installs dependencies and pre-commit hooks. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L267-R267) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L169-R169)