### PR TITLE
fix: restrict public sandbox and artifact boundaries

### DIFF
--- a/backend/app/gateway/path_utils.py
+++ b/backend/app/gateway/path_utils.py
@@ -26,3 +26,11 @@ def resolve_thread_virtual_path(thread_id: str, virtual_path: str) -> Path:
     except ValueError as e:
         status = 403 if "traversal" in str(e) else 400
         raise HTTPException(status_code=status, detail=str(e))
+
+
+def resolve_thread_artifact_path(thread_id: str, virtual_path: str) -> Path:
+    normalized = virtual_path if virtual_path.startswith("/") else f"/{virtual_path}"
+    try:
+        return get_paths().resolve_output_virtual_path(thread_id, normalized)
+    except ValueError as e:
+        raise HTTPException(status_code=403, detail=str(e))

--- a/backend/app/gateway/routers/artifacts.py
+++ b/backend/app/gateway/routers/artifacts.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import FileResponse, PlainTextResponse, Response
 
-from app.gateway.path_utils import resolve_thread_virtual_path
+from app.gateway.path_utils import resolve_thread_artifact_path
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ async def get_artifact(thread_id: str, path: str, request: Request, download: bo
         skill_file_path = path[: marker_pos + len(".skill")]  # e.g., "mnt/user-data/outputs/my-skill.skill"
         internal_path = path[marker_pos + len(skill_marker) :]  # e.g., "SKILL.md"
 
-        actual_skill_path = resolve_thread_virtual_path(thread_id, skill_file_path)
+        actual_skill_path = resolve_thread_artifact_path(thread_id, skill_file_path)
 
         if not actual_skill_path.exists():
             raise HTTPException(status_code=404, detail=f"Skill file not found: {skill_file_path}")
@@ -152,7 +152,7 @@ async def get_artifact(thread_id: str, path: str, request: Request, download: bo
         except UnicodeDecodeError:
             return Response(content=content, media_type=mime_type or "application/octet-stream", headers=cache_headers)
 
-    actual_path = resolve_thread_virtual_path(thread_id, path)
+    actual_path = resolve_thread_artifact_path(thread_id, path)
 
     logger.info(f"Resolving artifact path: thread_id={thread_id}, requested_path={path}, actual_path={actual_path}")
 

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -1183,10 +1183,11 @@ class DeerFlowClient:
             FileNotFoundError: If the artifact does not exist.
             ValueError: If the path is invalid.
         """
+        normalized = path if path.startswith("/") else f"/{path}"
         try:
-            actual = get_paths().resolve_virtual_path(thread_id, path)
+            actual = get_paths().resolve_output_virtual_path(thread_id, normalized)
         except ValueError as exc:
-            if "traversal" in str(exc):
+            if "traversal" in str(exc) or "outside outputs" in str(exc):
                 from deerflow.uploads.manager import PathTraversalError
 
                 raise PathTraversalError("Path traversal detected") from exc

--- a/backend/packages/harness/deerflow/config/paths.py
+++ b/backend/packages/harness/deerflow/config/paths.py
@@ -280,6 +280,24 @@ class Paths:
 
         return actual
 
+    def resolve_output_virtual_path(self, thread_id: str, virtual_path: str) -> Path:
+        stripped = virtual_path.lstrip("/")
+        prefix = VIRTUAL_PATH_PREFIX.lstrip("/")
+
+        if stripped != prefix and not stripped.startswith(prefix + "/"):
+            raise ValueError(f"Path must start with /{prefix}")
+
+        relative = stripped[len(prefix) :].lstrip("/")
+        outputs_base = self.sandbox_outputs_dir(thread_id).resolve()
+        actual = (self.sandbox_user_data_dir(thread_id) / relative).resolve()
+
+        try:
+            actual.relative_to(outputs_base)
+        except ValueError:
+            raise ValueError("Access denied: artifact path outside outputs")
+
+        return actual
+
 
 # ── Singleton ────────────────────────────────────────────────────────────
 

--- a/backend/tests/test_artifacts_router.py
+++ b/backend/tests/test_artifacts_router.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 from starlette.responses import FileResponse
 
+import app.gateway.path_utils as path_utils
 import app.gateway.routers.artifacts as artifacts_router
+from deerflow.config.paths import Paths
 
 ACTIVE_ARTIFACT_CASES = [
     ("poc.html", "<html><body><script>alert('xss')</script></body></html>"),
@@ -19,6 +21,63 @@ ACTIVE_ARTIFACT_CASES = [
 
 def _make_request(query_string: bytes = b"") -> Request:
     return Request({"type": "http", "method": "GET", "path": "/", "headers": [], "query_string": query_string})
+
+
+def test_resolve_output_virtual_path_accepts_outputs_file(tmp_path) -> None:
+    paths = Paths(base_dir=tmp_path)
+
+    resolved = paths.resolve_output_virtual_path("thread-1", "/mnt/user-data/outputs/report.txt")
+
+    assert resolved == (tmp_path / "threads" / "thread-1" / "user-data" / "outputs" / "report.txt").resolve()
+
+
+@pytest.mark.parametrize(
+    "virtual_path",
+    [
+        "/mnt/user-data/uploads/secret.txt",
+        "/mnt/user-data/workspace/notes.txt",
+        "/mnt/user-data/outputs/../uploads/secret.txt",
+    ],
+)
+def test_resolve_output_virtual_path_rejects_non_output_paths(tmp_path, virtual_path: str) -> None:
+    paths = Paths(base_dir=tmp_path)
+
+    with pytest.raises(ValueError):
+        paths.resolve_output_virtual_path("thread-1", virtual_path)
+
+
+def test_resolve_thread_artifact_path_rejects_upload_path(tmp_path, monkeypatch) -> None:
+    thread_id = "thread-1"
+    paths = Paths(base_dir=tmp_path)
+    upload = tmp_path / "threads" / thread_id / "user-data" / "uploads" / "secret.txt"
+    upload.parent.mkdir(parents=True)
+    upload.write_text("secret", encoding="utf-8")
+
+    monkeypatch.setattr(path_utils, "get_paths", lambda: paths)
+
+    with pytest.raises(artifacts_router.HTTPException) as exc_info:
+        path_utils.resolve_thread_artifact_path(thread_id, "/mnt/user-data/uploads/secret.txt")
+
+    assert exc_info.value.status_code == 403
+
+
+def test_get_artifact_uses_artifact_only_resolver(tmp_path, monkeypatch) -> None:
+    thread_id = "thread-1"
+    paths = Paths(base_dir=tmp_path)
+    artifact = tmp_path / "threads" / thread_id / "user-data" / "outputs" / "note.txt"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_text("hello", encoding="utf-8")
+
+    def forbidden_generic_resolver(_thread_id: str, _virtual_path: str):
+        raise AssertionError("generic resolver must not serve artifact routes")
+
+    monkeypatch.setattr(path_utils, "get_paths", lambda: paths)
+    monkeypatch.setattr(paths, "resolve_virtual_path", forbidden_generic_resolver)
+
+    response = asyncio.run(artifacts_router.get_artifact(thread_id, "mnt/user-data/outputs/note.txt", _make_request()))
+
+    assert response.status_code == 200
+    assert bytes(response.body).decode("utf-8") == "hello"
 
 
 def test_get_artifact_reads_utf8_text_file_on_windows_locale(tmp_path, monkeypatch) -> None:
@@ -33,7 +92,7 @@ def test_get_artifact_reads_utf8_text_file_on_windows_locale(tmp_path, monkeypat
         return original_read_text(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "read_text", read_text_with_gbk_default)
-    monkeypatch.setattr(artifacts_router, "resolve_thread_virtual_path", lambda _thread_id, _path: artifact_path)
+    monkeypatch.setattr(artifacts_router, "resolve_thread_artifact_path", lambda _thread_id, _path: artifact_path)
 
     request = _make_request()
     response = asyncio.run(artifacts_router.get_artifact("thread-1", "mnt/user-data/outputs/note.txt", request))
@@ -47,7 +106,7 @@ def test_get_artifact_forces_download_for_active_content(tmp_path, monkeypatch, 
     artifact_path = tmp_path / filename
     artifact_path.write_text(content, encoding="utf-8")
 
-    monkeypatch.setattr(artifacts_router, "resolve_thread_virtual_path", lambda _thread_id, _path: artifact_path)
+    monkeypatch.setattr(artifacts_router, "resolve_thread_artifact_path", lambda _thread_id, _path: artifact_path)
 
     response = asyncio.run(artifacts_router.get_artifact("thread-1", f"mnt/user-data/outputs/{filename}", _make_request()))
 
@@ -61,7 +120,7 @@ def test_get_artifact_forces_download_for_active_content_in_skill_archive(tmp_pa
     with zipfile.ZipFile(skill_path, "w") as zip_ref:
         zip_ref.writestr(filename, content)
 
-    monkeypatch.setattr(artifacts_router, "resolve_thread_virtual_path", lambda _thread_id, _path: skill_path)
+    monkeypatch.setattr(artifacts_router, "resolve_thread_artifact_path", lambda _thread_id, _path: skill_path)
 
     response = asyncio.run(artifacts_router.get_artifact("thread-1", f"mnt/user-data/outputs/sample.skill/{filename}", _make_request()))
 
@@ -73,7 +132,7 @@ def test_get_artifact_download_false_does_not_force_attachment(tmp_path, monkeyp
     artifact_path = tmp_path / "note.txt"
     artifact_path.write_text("hello", encoding="utf-8")
 
-    monkeypatch.setattr(artifacts_router, "resolve_thread_virtual_path", lambda _thread_id, _path: artifact_path)
+    monkeypatch.setattr(artifacts_router, "resolve_thread_artifact_path", lambda _thread_id, _path: artifact_path)
 
     app = FastAPI()
     app.include_router(artifacts_router.router)
@@ -91,7 +150,7 @@ def test_get_artifact_download_true_forces_attachment_for_skill_archive(tmp_path
     with zipfile.ZipFile(skill_path, "w") as zip_ref:
         zip_ref.writestr("notes.txt", "hello")
 
-    monkeypatch.setattr(artifacts_router, "resolve_thread_virtual_path", lambda _thread_id, _path: skill_path)
+    monkeypatch.setattr(artifacts_router, "resolve_thread_artifact_path", lambda _thread_id, _path: skill_path)
 
     app = FastAPI()
     app.include_router(artifacts_router.router)

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -2994,16 +2994,27 @@ class TestBugArtifactPrefixMatchTooLoose:
         with pytest.raises(ValueError, match="must start with"):
             client.get_artifact("t1", "mnt/user-data-evil/secret.txt")
 
-    def test_exact_prefix_without_subpath_accepted(self, client):
-        """Bare 'mnt/user-data' is accepted (will later fail as directory, not at prefix)."""
+    def test_exact_prefix_without_subpath_rejected_for_artifacts(self, client):
+        """Bare 'mnt/user-data' is outside the artifact output boundary."""
         with tempfile.TemporaryDirectory() as tmp:
             paths = Paths(base_dir=tmp)
             paths.sandbox_user_data_dir("t1").mkdir(parents=True)
 
             with patch("deerflow.client.get_paths", return_value=paths):
-                # Accepted at prefix check, but fails because it's a directory.
-                with pytest.raises(ValueError, match="not a file"):
+                with pytest.raises(PathTraversalError):
                     client.get_artifact("t1", "mnt/user-data")
+
+    def test_artifact_upload_path_rejected(self, client):
+        """get_artifact must not read uploaded files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            paths = Paths(base_dir=tmp)
+            upload = paths.sandbox_uploads_dir("t1") / "secret.txt"
+            upload.parent.mkdir(parents=True)
+            upload.write_text("secret")
+
+            with patch("deerflow.client.get_paths", return_value=paths):
+                with pytest.raises(PathTraversalError):
+                    client.get_artifact("t1", "mnt/user-data/uploads/secret.txt")
 
 
 class TestBugListUploadsDeadCode:

--- a/backend/tests/test_client_e2e.py
+++ b/backend/tests/test_client_e2e.py
@@ -513,6 +513,19 @@ class TestArtifactAccess:
         with pytest.raises((PermissionError, ValueError, FileNotFoundError)):
             c.get_artifact("test-thread", "mnt/user-data/outputs/../../etc/passwd")
 
+    def test_get_artifact_rejects_outputs_escape_to_uploads(self, e2e_env):
+        """Artifacts cannot escape outputs to read uploaded files."""
+        from deerflow.config.paths import get_paths
+
+        c = DeerFlowClient(checkpointer=None, thinking_enabled=False)
+        tid = str(uuid.uuid4())
+        upload = get_paths().sandbox_uploads_dir(tid) / "secret.txt"
+        upload.parent.mkdir(parents=True, exist_ok=True)
+        upload.write_text("secret")
+
+        with pytest.raises((PermissionError, ValueError, FileNotFoundError)):
+            c.get_artifact(tid, "mnt/user-data/outputs/../uploads/secret.txt")
+
 
 # ---------------------------------------------------------------------------
 # Step 9: Skill installation (no LLM needed)

--- a/backend/tests/test_nginx_provisioner_exposure.py
+++ b/backend/tests/test_nginx_provisioner_exposure.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _nginx_config() -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    return (repo_root / "docker" / "nginx" / "nginx.conf").read_text(encoding="utf-8")
+
+
+def test_nginx_does_not_route_public_sandboxes_to_provisioner():
+    config = _nginx_config()
+
+    assert "location /api/sandboxes" not in config
+    assert "provisioner:8002" not in config
+    assert "$provisioner_upstream" not in config
+
+
+def test_nginx_still_routes_gateway_thread_endpoints():
+    config = _nginx_config()
+
+    assert "location ~ ^/api/threads" in config
+    assert "proxy_pass http://gateway;" in config

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -200,19 +200,6 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # ── Provisioner API (sandbox management) ────────────────────────
-        # Use a variable so nginx resolves provisioner at request time (not startup).
-        # This allows nginx to start even when provisioner container is not running.
-        location /api/sandboxes {
-            set $provisioner_upstream provisioner:8002;
-            proxy_pass http://$provisioner_upstream;
-            proxy_http_version 1.1;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
         # All other requests go to frontend
         location / {
             proxy_pass http://frontend;


### PR DESCRIPTION
## Summary
- Remove the public nginx route to provisioner `/api/sandboxes`, keeping provisioner access internal to the compose network.
- Add output-only artifact path resolution for gateway and client artifact reads while preserving generic virtual path resolution for non-artifact callers.
- Cover uploads/workspace/traversal rejection and valid output artifact behavior with regression tests.

## Test plan
- [x] `uv run pytest backend/tests/test_nginx_provisioner_exposure.py backend/tests/test_artifacts_router.py backend/tests/test_client.py backend/tests/test_client_e2e.py::TestArtifactAccess::test_get_artifact_happy_path backend/tests/test_client_e2e.py::TestArtifactAccess::test_get_artifact_nested_path backend/tests/test_client_e2e.py::TestArtifactAccess::test_get_artifact_nonexistent_raises backend/tests/test_client_e2e.py::TestArtifactAccess::test_get_artifact_traversal_within_prefix_blocked backend/tests/test_client_e2e.py::TestArtifactAccess::test_get_artifact_rejects_outputs_escape_to_uploads -q`
- [x] `uv run python -m py_compile packages/harness/deerflow/config/paths.py packages/harness/deerflow/client.py app/gateway/path_utils.py app/gateway/routers/artifacts.py`
- [x] `git diff --check`