### PR TITLE
fix(gateway): harden MCP config handling

### DIFF
--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -1,15 +1,23 @@
 import json
 import logging
+import os
+import tempfile
 from pathlib import Path
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
 
 from deerflow.config.extensions_config import ExtensionsConfig, get_extensions_config, reload_extensions_config
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["mcp"])
+
+_REDACTED_VALUE = "********"
+_MCP_CONFIG_ADMIN_TOKEN_ENV = "DEER_FLOW_MCP_CONFIG_ADMIN_TOKEN"
+_MCP_STDIO_ALLOWLIST_ENV = "DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST"
+_DEFAULT_STDIO_COMMAND_ALLOWLIST = {"npx", "uvx", "node", "python", "python3"}
+_SENSITIVE_OAUTH_FIELDS = {"client_secret", "refresh_token"}
 
 
 class McpOAuthConfigResponse(BaseModel):
@@ -63,11 +71,152 @@ class McpConfigUpdateRequest(BaseModel):
     )
 
 
+def _require_mcp_config_admin(authorization: str | None = Header(default=None)) -> None:
+    """Require a static bearer token when MCP config admin auth is configured."""
+    expected_token = os.getenv(_MCP_CONFIG_ADMIN_TOKEN_ENV)
+    if not expected_token:
+        return
+    if authorization != f"Bearer {expected_token}":
+        raise HTTPException(status_code=403, detail="MCP configuration admin token is required")
+
+
+def _redact_mapping_values(values: dict[str, str]) -> dict[str, str]:
+    return {key: _REDACTED_VALUE for key in values}
+
+
+def _redact_oauth_config(oauth: dict | None) -> dict | None:
+    if oauth is None:
+        return None
+    redacted = dict(oauth)
+    for key in _SENSITIVE_OAUTH_FIELDS:
+        if redacted.get(key):
+            redacted[key] = _REDACTED_VALUE
+    if isinstance(redacted.get("extra_token_params"), dict):
+        redacted["extra_token_params"] = _redact_mapping_values(redacted["extra_token_params"])
+    return redacted
+
+
+def _server_response_payload(server) -> dict:
+    payload = server.model_dump()
+    if payload.get("env"):
+        payload["env"] = _redact_mapping_values(payload["env"])
+    if payload.get("headers"):
+        payload["headers"] = _redact_mapping_values(payload["headers"])
+    payload["oauth"] = _redact_oauth_config(payload.get("oauth"))
+    return payload
+
+
+def _build_mcp_config_response(config) -> McpConfigResponse:
+    return McpConfigResponse(
+        mcp_servers={
+            name: McpServerConfigResponse(**_server_response_payload(server))
+            for name, server in config.mcp_servers.items()
+        },
+    )
+
+
+def _load_raw_config(config_path: Path) -> dict:
+    if not config_path.exists():
+        return {}
+    with open(config_path, encoding="utf-8") as f:
+        try:
+            loaded = json.load(f)
+        except json.JSONDecodeError:
+            return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _restore_redacted_mapping(new_values: dict[str, str], existing_values: dict | None) -> dict[str, str]:
+    if not isinstance(existing_values, dict):
+        existing_values = {}
+    restored = dict(new_values)
+    for key, value in list(restored.items()):
+        if value == _REDACTED_VALUE and key in existing_values:
+            restored[key] = existing_values[key]
+    return restored
+
+
+def _restore_redacted_oauth(new_oauth: dict | None, existing_oauth: dict | None) -> dict | None:
+    if new_oauth is None:
+        return None
+    if not isinstance(existing_oauth, dict):
+        existing_oauth = {}
+    restored = dict(new_oauth)
+    for key in _SENSITIVE_OAUTH_FIELDS:
+        if restored.get(key) == _REDACTED_VALUE and key in existing_oauth:
+            restored[key] = existing_oauth[key]
+    if isinstance(restored.get("extra_token_params"), dict):
+        existing_params = existing_oauth.get("extra_token_params") if isinstance(existing_oauth, dict) else {}
+        restored["extra_token_params"] = _restore_redacted_mapping(restored["extra_token_params"], existing_params)
+    return restored
+
+
+def _restore_redacted_mcp_values(config_data: dict, existing_raw_config: dict) -> None:
+    existing_servers = existing_raw_config.get("mcpServers")
+    if not isinstance(existing_servers, dict):
+        existing_servers = {}
+
+    for name, server_data in config_data.get("mcpServers", {}).items():
+        existing_server = existing_servers.get(name)
+        if not isinstance(existing_server, dict):
+            existing_server = {}
+        if isinstance(server_data.get("env"), dict):
+            server_data["env"] = _restore_redacted_mapping(server_data["env"], existing_server.get("env"))
+        if isinstance(server_data.get("headers"), dict):
+            server_data["headers"] = _restore_redacted_mapping(server_data["headers"], existing_server.get("headers"))
+        if isinstance(server_data.get("oauth"), dict):
+            server_data["oauth"] = _restore_redacted_oauth(server_data["oauth"], existing_server.get("oauth"))
+
+
+def _stdio_command_allowlist() -> set[str]:
+    raw = os.getenv(_MCP_STDIO_ALLOWLIST_ENV)
+    if raw is None:
+        return set(_DEFAULT_STDIO_COMMAND_ALLOWLIST)
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _validate_mcp_server_config(name: str, server: McpServerConfigResponse) -> None:
+    if server.type not in {"stdio", "sse", "http"}:
+        raise HTTPException(status_code=400, detail=f"Unsupported MCP server type for '{name}': {server.type}")
+
+    if server.type == "stdio":
+        if not server.command:
+            raise HTTPException(status_code=400, detail=f"MCP stdio server '{name}' requires a command")
+        command_name = Path(server.command).name
+        allowed = _stdio_command_allowlist()
+        if command_name not in allowed:
+            allowed_text = ", ".join(sorted(allowed)) or "(none)"
+            raise HTTPException(
+                status_code=400,
+                detail=f"MCP stdio command for '{name}' is not allowed: {command_name}. Allowed commands: {allowed_text}",
+            )
+        return
+
+    if not server.url:
+        raise HTTPException(status_code=400, detail=f"MCP {server.type} server '{name}' requires a url")
+    if not (server.url.startswith("http://") or server.url.startswith("https://")):
+        raise HTTPException(status_code=400, detail=f"MCP server '{name}' url must use http:// or https://")
+
+
+def _write_json_atomic(config_path: Path, config_data: dict) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=config_path.parent, delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        os.chmod(tmp_path, 0o600)
+        json.dump(config_data, tmp, indent=2)
+        tmp.write("\n")
+        tmp.flush()
+        os.fsync(tmp.fileno())
+    os.replace(tmp_path, config_path)
+    os.chmod(config_path, 0o600)
+
+
 @router.get(
     "/mcp/config",
     response_model=McpConfigResponse,
     summary="Get MCP Configuration",
     description="Retrieve the current Model Context Protocol (MCP) server configurations.",
+    dependencies=[Depends(_require_mcp_config_admin)],
 )
 async def get_mcp_configuration() -> McpConfigResponse:
     """Get the current MCP configuration.
@@ -92,7 +241,7 @@ async def get_mcp_configuration() -> McpConfigResponse:
     """
     config = get_extensions_config()
 
-    return McpConfigResponse(mcp_servers={name: McpServerConfigResponse(**server.model_dump()) for name, server in config.mcp_servers.items()})
+    return _build_mcp_config_response(config)
 
 
 @router.put(
@@ -100,6 +249,7 @@ async def get_mcp_configuration() -> McpConfigResponse:
     response_model=McpConfigResponse,
     summary="Update MCP Configuration",
     description="Update Model Context Protocol (MCP) server configurations and save to file.",
+    dependencies=[Depends(_require_mcp_config_admin)],
 )
 async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfigResponse:
     """Update the MCP configuration.
@@ -144,16 +294,20 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
 
         # Load current config to preserve skills configuration
         current_config = get_extensions_config()
+        existing_raw_config = _load_raw_config(config_path)
+
+        for name, server in request.mcp_servers.items():
+            _validate_mcp_server_config(name, server)
 
         # Convert request to dict format for JSON serialization
         config_data = {
             "mcpServers": {name: server.model_dump() for name, server in request.mcp_servers.items()},
             "skills": {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()},
         }
+        _restore_redacted_mcp_values(config_data, existing_raw_config)
 
         # Write the configuration to file
-        with open(config_path, "w", encoding="utf-8") as f:
-            json.dump(config_data, f, indent=2)
+        _write_json_atomic(config_path, config_data)
 
         logger.info(f"MCP configuration updated and saved to: {config_path}")
 
@@ -162,8 +316,10 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
 
         # Reload the configuration and update the global cache
         reloaded_config = reload_extensions_config()
-        return McpConfigResponse(mcp_servers={name: McpServerConfigResponse(**server.model_dump()) for name, server in reloaded_config.mcp_servers.items()})
+        return _build_mcp_config_response(reloaded_config)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to update MCP configuration: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to update MCP configuration: {str(e)}")

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -1,9 +1,11 @@
 import json
 import logging
 import os
+import secrets
 import tempfile
 from pathlib import Path
 from typing import Literal
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel, Field
@@ -16,6 +18,7 @@ router = APIRouter(prefix="/api", tags=["mcp"])
 _REDACTED_VALUE = "********"
 _MCP_CONFIG_ADMIN_TOKEN_ENV = "DEER_FLOW_MCP_CONFIG_ADMIN_TOKEN"
 _MCP_CONFIG_ALLOW_UNAUTH_ENV = "DEER_FLOW_MCP_CONFIG_ALLOW_UNAUTH"
+_MCP_HTTP_ALLOWED_HOSTS_ENV = "DEER_FLOW_MCP_HTTP_ALLOWED_HOSTS"
 _MCP_STDIO_ALLOWLIST_ENV = "DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST"
 _DEFAULT_STDIO_COMMAND_ALLOWLIST = {"npx", "uvx"}
 _SENSITIVE_OAUTH_FIELDS = {"client_secret", "refresh_token"}
@@ -75,11 +78,23 @@ class McpConfigUpdateRequest(BaseModel):
 def _require_mcp_config_admin(authorization: str | None = Header(default=None)) -> None:
     """Require a static bearer token unless unauthenticated config admin is explicitly enabled."""
     expected_token = os.getenv(_MCP_CONFIG_ADMIN_TOKEN_ENV)
-    if expected_token and authorization == f"Bearer {expected_token}":
-        return
+    if expected_token:
+        token = _parse_bearer_token(authorization)
+        if token is not None and secrets.compare_digest(token, expected_token):
+            return
+        raise HTTPException(status_code=403, detail="MCP configuration admin token is required")
     if not expected_token and os.getenv(_MCP_CONFIG_ALLOW_UNAUTH_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
         return
     raise HTTPException(status_code=403, detail="MCP configuration admin token is required")
+
+
+def _parse_bearer_token(authorization: str | None) -> str | None:
+    if authorization is None:
+        return None
+    parts = authorization.strip().split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1]
 
 
 def _redact_mapping_values(values: dict[str, str]) -> dict[str, str]:
@@ -278,6 +293,40 @@ def _stdio_command_allowlist() -> set[str]:
     return {item.strip() for item in raw.split(",") if item.strip() and "/" not in item and "\\" not in item}
 
 
+def _http_allowed_hosts() -> set[str]:
+    raw = os.getenv(_MCP_HTTP_ALLOWED_HOSTS_ENV)
+    if raw is None:
+        return set()
+    return {item.strip().lower() for item in raw.split(",") if item.strip()}
+
+
+def _host_matches_allowed_pattern(hostname: str, pattern: str) -> bool:
+    if pattern == "*":
+        return True
+    if pattern.startswith("*."):
+        suffix = pattern[1:]
+        return hostname.endswith(suffix) and hostname != pattern[2:]
+    return hostname == pattern
+
+
+def _validate_http_url(name: str, url: str | None, *, field_name: str) -> None:
+    if not url:
+        raise HTTPException(status_code=400, detail=f"MCP server '{name}' {field_name} is required")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc or not parsed.hostname:
+        raise HTTPException(status_code=400, detail=f"MCP server '{name}' {field_name} must use http:// or https://")
+
+    allowed_hosts = _http_allowed_hosts()
+    if allowed_hosts:
+        hostname = parsed.hostname.lower()
+        if not any(_host_matches_allowed_pattern(hostname, pattern) for pattern in allowed_hosts):
+            allowed_text = ", ".join(sorted(allowed_hosts))
+            raise HTTPException(
+                status_code=400,
+                detail=f"MCP server '{name}' {field_name} host is not allowed: {hostname}. Allowed hosts: {allowed_text}",
+            )
+
+
 def _validate_mcp_server_config(name: str, server: McpServerConfigResponse) -> None:
     if server.type not in {"stdio", "sse", "http"}:
         raise HTTPException(status_code=400, detail=f"Unsupported MCP server type for '{name}': {server.type}")
@@ -298,12 +347,22 @@ def _validate_mcp_server_config(name: str, server: McpServerConfigResponse) -> N
                 status_code=400,
                 detail=f"MCP stdio command for '{name}' is not allowed: {command_name}. Allowed commands: {allowed_text}",
             )
+        if server.oauth is not None:
+            raise HTTPException(status_code=400, detail=f"MCP stdio server '{name}' does not support OAuth configuration")
         return
 
-    if not server.url:
-        raise HTTPException(status_code=400, detail=f"MCP {server.type} server '{name}' requires a url")
-    if not (server.url.startswith("http://") or server.url.startswith("https://")):
-        raise HTTPException(status_code=400, detail=f"MCP server '{name}' url must use http:// or https://")
+    _validate_http_url(name, server.url, field_name="url")
+
+    if server.oauth is not None:
+        if server.oauth.enabled:
+            _validate_http_url(name, server.oauth.token_url, field_name="oauth.token_url")
+
+
+def _validate_extensions_config_data(config_data: dict) -> None:
+    try:
+        ExtensionsConfig.model_validate(config_data)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid MCP configuration: {e}") from e
 
 
 def _write_json_atomic(config_path: Path, config_data: dict) -> None:
@@ -340,7 +399,7 @@ async def get_mcp_configuration() -> McpConfigResponse:
                     "enabled": true,
                     "command": "npx",
                     "args": ["-y", "@modelcontextprotocol/server-github"],
-                    "env": {"GITHUB_TOKEN": "ghp_xxx"},
+                    "env": {"GITHUB_TOKEN": "********"},
                     "description": "GitHub MCP server for repository operations"
                 }
             }
@@ -413,6 +472,7 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
             "skills": {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()},
         }
         _restore_redacted_mcp_values(config_data, existing_raw_config)
+        _validate_extensions_config_data(config_data)
 
         # Write the configuration to file
         _write_json_atomic(config_path, config_data)

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -110,10 +110,7 @@ def _server_response_payload(server) -> dict:
 
 def _build_mcp_config_response(config) -> McpConfigResponse:
     return McpConfigResponse(
-        mcp_servers={
-            name: McpServerConfigResponse(**_server_response_payload(server))
-            for name, server in config.mcp_servers.items()
-        },
+        mcp_servers={name: McpServerConfigResponse(**_server_response_payload(server)) for name, server in config.mcp_servers.items()},
     )
 
 

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -15,8 +15,9 @@ router = APIRouter(prefix="/api", tags=["mcp"])
 
 _REDACTED_VALUE = "********"
 _MCP_CONFIG_ADMIN_TOKEN_ENV = "DEER_FLOW_MCP_CONFIG_ADMIN_TOKEN"
+_MCP_CONFIG_ALLOW_UNAUTH_ENV = "DEER_FLOW_MCP_CONFIG_ALLOW_UNAUTH"
 _MCP_STDIO_ALLOWLIST_ENV = "DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST"
-_DEFAULT_STDIO_COMMAND_ALLOWLIST = {"npx", "uvx", "node", "python", "python3"}
+_DEFAULT_STDIO_COMMAND_ALLOWLIST = {"npx", "uvx"}
 _SENSITIVE_OAUTH_FIELDS = {"client_secret", "refresh_token"}
 
 
@@ -72,12 +73,13 @@ class McpConfigUpdateRequest(BaseModel):
 
 
 def _require_mcp_config_admin(authorization: str | None = Header(default=None)) -> None:
-    """Require a static bearer token when MCP config admin auth is configured."""
+    """Require a static bearer token unless unauthenticated config admin is explicitly enabled."""
     expected_token = os.getenv(_MCP_CONFIG_ADMIN_TOKEN_ENV)
-    if not expected_token:
+    if expected_token and authorization == f"Bearer {expected_token}":
         return
-    if authorization != f"Bearer {expected_token}":
-        raise HTTPException(status_code=403, detail="MCP configuration admin token is required")
+    if not expected_token and os.getenv(_MCP_CONFIG_ALLOW_UNAUTH_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        return
+    raise HTTPException(status_code=403, detail="MCP configuration admin token is required")
 
 
 def _redact_mapping_values(values: dict[str, str]) -> dict[str, str]:
@@ -89,7 +91,7 @@ def _redact_oauth_config(oauth: dict | None) -> dict | None:
         return None
     redacted = dict(oauth)
     for key in _SENSITIVE_OAUTH_FIELDS:
-        if redacted.get(key):
+        if key in redacted and redacted[key] is not None:
             redacted[key] = _REDACTED_VALUE
     if isinstance(redacted.get("extra_token_params"), dict):
         redacted["extra_token_params"] = _redact_mapping_values(redacted["extra_token_params"])
@@ -126,28 +128,112 @@ def _load_raw_config(config_path: Path) -> dict:
     return loaded if isinstance(loaded, dict) else {}
 
 
-def _restore_redacted_mapping(new_values: dict[str, str], existing_values: dict | None) -> dict[str, str]:
+def _has_redacted_mapping_values(values: dict | None) -> bool:
+    return isinstance(values, dict) and any(value == _REDACTED_VALUE for value in values.values())
+
+
+def _has_redacted_oauth_values(oauth: dict | None) -> bool:
+    if not isinstance(oauth, dict):
+        return False
+    if any(oauth.get(key) == _REDACTED_VALUE for key in _SENSITIVE_OAUTH_FIELDS):
+        return True
+    return _has_redacted_mapping_values(oauth.get("extra_token_params"))
+
+
+def _require_redacted_boundary_unchanged(name: str, server_data: dict, existing_server: dict, *, secret_type: str) -> None:
+    if not isinstance(existing_server, dict) or not existing_server:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Redacted MCP {secret_type} values for '{name}' require an existing server configuration",
+        )
+
+    new_type = server_data.get("type") or "stdio"
+    existing_type = existing_server.get("type") or "stdio"
+    if new_type != existing_type:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Redacted MCP {secret_type} values for '{name}' cannot be reused after changing server type",
+        )
+
+    if new_type == "stdio":
+        command_changed = server_data.get("command") != existing_server.get("command")
+        args_changed = (server_data.get("args") or []) != (existing_server.get("args") or [])
+        if command_changed or args_changed:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Redacted MCP {secret_type} values for '{name}' cannot be reused after changing command or args",
+            )
+        return
+
+    if server_data.get("url") != existing_server.get("url"):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Redacted MCP {secret_type} values for '{name}' cannot be reused after changing url",
+        )
+
+
+def _require_oauth_redacted_boundary_unchanged(name: str, server_data: dict, existing_server: dict) -> None:
+    _require_redacted_boundary_unchanged(name, server_data, existing_server, secret_type="OAuth")
+    new_oauth = server_data.get("oauth") if isinstance(server_data.get("oauth"), dict) else {}
+    existing_oauth = existing_server.get("oauth") if isinstance(existing_server.get("oauth"), dict) else {}
+    for key in ("token_url", "grant_type", "client_id"):
+        new_value = new_oauth.get(key)
+        existing_value = existing_oauth.get(key)
+        if key == "grant_type":
+            new_value = new_value or "client_credentials"
+            existing_value = existing_value or "client_credentials"
+        if new_value != existing_value:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Redacted MCP OAuth values for '{name}' cannot be reused after changing oauth.{key}",
+            )
+
+
+def _restore_redacted_mapping(
+    new_values: dict[str, str],
+    existing_values: dict | None,
+    *,
+    name: str,
+    secret_type: str,
+) -> dict[str, str]:
     if not isinstance(existing_values, dict):
         existing_values = {}
     restored = dict(new_values)
     for key, value in list(restored.items()):
-        if value == _REDACTED_VALUE and key in existing_values:
-            restored[key] = existing_values[key]
+        if value != _REDACTED_VALUE:
+            continue
+        if key not in existing_values:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Redacted MCP {secret_type} value for '{name}' has no existing value for key '{key}'",
+            )
+        restored[key] = existing_values[key]
     return restored
 
 
-def _restore_redacted_oauth(new_oauth: dict | None, existing_oauth: dict | None) -> dict | None:
+def _restore_redacted_oauth(new_oauth: dict | None, existing_oauth: dict | None, *, name: str) -> dict | None:
     if new_oauth is None:
         return None
     if not isinstance(existing_oauth, dict):
         existing_oauth = {}
     restored = dict(new_oauth)
     for key in _SENSITIVE_OAUTH_FIELDS:
-        if restored.get(key) == _REDACTED_VALUE and key in existing_oauth:
-            restored[key] = existing_oauth[key]
+        if restored.get(key) != _REDACTED_VALUE:
+            continue
+        if key not in existing_oauth:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Redacted MCP OAuth value for '{name}' has no existing value for key '{key}'",
+            )
+        restored[key] = existing_oauth[key]
     if isinstance(restored.get("extra_token_params"), dict):
         existing_params = existing_oauth.get("extra_token_params") if isinstance(existing_oauth, dict) else {}
-        restored["extra_token_params"] = _restore_redacted_mapping(restored["extra_token_params"], existing_params)
+        restored["extra_token_params"] = _restore_redacted_mapping(
+            restored["extra_token_params"],
+            existing_params,
+            name=name,
+            secret_type="OAuth extra token parameter",
+        )
     return restored
 
 
@@ -160,19 +246,39 @@ def _restore_redacted_mcp_values(config_data: dict, existing_raw_config: dict) -
         existing_server = existing_servers.get(name)
         if not isinstance(existing_server, dict):
             existing_server = {}
+        if _has_redacted_mapping_values(server_data.get("env")):
+            _require_redacted_boundary_unchanged(name, server_data, existing_server, secret_type="environment")
+        if _has_redacted_mapping_values(server_data.get("headers")):
+            _require_redacted_boundary_unchanged(name, server_data, existing_server, secret_type="header")
+        if _has_redacted_oauth_values(server_data.get("oauth")):
+            _require_oauth_redacted_boundary_unchanged(name, server_data, existing_server)
         if isinstance(server_data.get("env"), dict):
-            server_data["env"] = _restore_redacted_mapping(server_data["env"], existing_server.get("env"))
+            server_data["env"] = _restore_redacted_mapping(
+                server_data["env"],
+                existing_server.get("env"),
+                name=name,
+                secret_type="environment",
+            )
         if isinstance(server_data.get("headers"), dict):
-            server_data["headers"] = _restore_redacted_mapping(server_data["headers"], existing_server.get("headers"))
+            server_data["headers"] = _restore_redacted_mapping(
+                server_data["headers"],
+                existing_server.get("headers"),
+                name=name,
+                secret_type="header",
+            )
         if isinstance(server_data.get("oauth"), dict):
-            server_data["oauth"] = _restore_redacted_oauth(server_data["oauth"], existing_server.get("oauth"))
+            server_data["oauth"] = _restore_redacted_oauth(
+                server_data["oauth"],
+                existing_server.get("oauth"),
+                name=name,
+            )
 
 
 def _stdio_command_allowlist() -> set[str]:
     raw = os.getenv(_MCP_STDIO_ALLOWLIST_ENV)
     if raw is None:
         return set(_DEFAULT_STDIO_COMMAND_ALLOWLIST)
-    return {item.strip() for item in raw.split(",") if item.strip()}
+    return {item.strip() for item in raw.split(",") if item.strip() and "/" not in item and "\\" not in item}
 
 
 def _validate_mcp_server_config(name: str, server: McpServerConfigResponse) -> None:
@@ -182,7 +288,12 @@ def _validate_mcp_server_config(name: str, server: McpServerConfigResponse) -> N
     if server.type == "stdio":
         if not server.command:
             raise HTTPException(status_code=400, detail=f"MCP stdio server '{name}' requires a command")
-        command_name = Path(server.command).name
+        command_name = server.command
+        if "/" in command_name or "\\" in command_name or command_name in {".", ".."}:
+            raise HTTPException(
+                status_code=400,
+                detail=f"MCP stdio command for '{name}' must be a bare executable name",
+            )
         allowed = _stdio_command_allowlist()
         if command_name not in allowed:
             allowed_text = ", ".join(sorted(allowed)) or "(none)"

--- a/backend/tests/test_gateway_mcp_router.py
+++ b/backend/tests/test_gateway_mcp_router.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import stat
 from unittest.mock import patch
 
 import pytest
@@ -149,6 +150,93 @@ def test_update_mcp_configuration_preserves_redacted_existing_values(tmp_path, m
     assert server["oauth"]["refresh_token"] == "$MCP_REFRESH_TOKEN"
     assert server["oauth"]["extra_token_params"]["audience"] == "$MCP_AUDIENCE"
     assert response.mcp_servers["secure"].env == {"TOKEN": mcp._REDACTED_VALUE}
+
+
+def test_update_mcp_configuration_writes_restrictive_permissions(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "local": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="stdio",
+                command="npx",
+                args=["-y", "@example/server"],
+            )
+        }
+    )
+    reloaded_config = ExtensionsConfig(
+        mcp_servers={
+            "local": McpServerConfig(
+                enabled=True,
+                type="stdio",
+                command="npx",
+                args=["-y", "@example/server"],
+            )
+        },
+        skills={},
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+        patch.object(mcp, "reload_extensions_config", return_value=reloaded_config),
+    ):
+        asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert stat.S_IMODE(config_path.stat().st_mode) == 0o600
+
+
+def test_update_mcp_configuration_rejects_invalid_oauth_before_write(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    original = {"mcpServers": {}, "skills": {}}
+    config_path.write_text(json.dumps(original), encoding="utf-8")
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "secure": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                oauth=mcp.McpOAuthConfigResponse(token_url=""),
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "oauth.token_url" in str(exc.value.detail)
+    assert json.loads(config_path.read_text(encoding="utf-8")) == original
+
+
+def test_update_mcp_configuration_enforces_http_host_allowlist(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
+    monkeypatch.setenv(mcp._MCP_HTTP_ALLOWED_HOSTS_ENV, "mcp.example.test,*.trusted.test")
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "secure": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="http",
+                url="https://evil.example.test",
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "host is not allowed" in str(exc.value.detail)
 
 
 def test_update_mcp_configuration_rejects_redacted_values_after_url_change(tmp_path) -> None:
@@ -343,5 +431,7 @@ def test_mcp_config_admin_token_fails_closed_unless_explicitly_allowed(monkeypat
     with pytest.raises(HTTPException) as exc:
         mcp._require_mcp_config_admin(None)
     assert exc.value.status_code == 403
+
+    mcp._require_mcp_config_admin("  bearer   secret-token  ")
 
     mcp._require_mcp_config_admin("Bearer secret-token")

--- a/backend/tests/test_gateway_mcp_router.py
+++ b/backend/tests/test_gateway_mcp_router.py
@@ -43,6 +43,32 @@ def test_get_mcp_configuration_redacts_sensitive_values(monkeypatch) -> None:
     assert server.oauth.extra_token_params == {"audience_secret": mcp._REDACTED_VALUE}
 
 
+def test_get_mcp_configuration_redacts_empty_oauth_secrets(monkeypatch) -> None:
+    config = ExtensionsConfig(
+        mcp_servers={
+            "secure": McpServerConfig(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                oauth=McpOAuthConfig(
+                    token_url="https://auth.example.test/token",
+                    client_secret="",
+                    refresh_token="",
+                ),
+            )
+        },
+        skills={},
+    )
+    monkeypatch.setattr(mcp, "get_extensions_config", lambda: config)
+
+    response = asyncio.run(mcp.get_mcp_configuration())
+    oauth = response.mcp_servers["secure"].oauth
+
+    assert oauth is not None
+    assert oauth.client_secret == mcp._REDACTED_VALUE
+    assert oauth.refresh_token == mcp._REDACTED_VALUE
+
+
 def test_update_mcp_configuration_preserves_redacted_existing_values(tmp_path, monkeypatch) -> None:
     config_path = tmp_path / "extensions_config.json"
     config_path.write_text(
@@ -125,6 +151,136 @@ def test_update_mcp_configuration_preserves_redacted_existing_values(tmp_path, m
     assert response.mcp_servers["secure"].env == {"TOKEN": mcp._REDACTED_VALUE}
 
 
+def test_update_mcp_configuration_rejects_redacted_values_after_url_change(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "secure": {
+                        "enabled": True,
+                        "type": "http",
+                        "url": "https://mcp.example.test",
+                        "headers": {"Authorization": "$MCP_AUTH_HEADER"},
+                    }
+                },
+                "skills": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "secure": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="http",
+                url="https://evil.example.test",
+                headers={"Authorization": mcp._REDACTED_VALUE},
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "changing url" in str(exc.value.detail)
+
+
+def test_update_mcp_configuration_rejects_redacted_oauth_after_token_url_change(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "secure": {
+                        "enabled": True,
+                        "type": "http",
+                        "url": "https://mcp.example.test",
+                        "oauth": {
+                            "token_url": "https://auth.example.test/token",
+                            "client_id": "client-id",
+                            "client_secret": "$MCP_CLIENT_SECRET",
+                        },
+                    }
+                },
+                "skills": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "secure": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                oauth=mcp.McpOAuthConfigResponse(
+                    token_url="https://evil.example.test/token",
+                    client_id="client-id",
+                    client_secret=mcp._REDACTED_VALUE,
+                ),
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "oauth.token_url" in str(exc.value.detail)
+
+
+def test_update_mcp_configuration_rejects_redacted_stdio_env_after_args_change(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local": {
+                        "enabled": True,
+                        "type": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@example/old-server"],
+                        "env": {"TOKEN": "$MCP_TOKEN"},
+                    }
+                },
+                "skills": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "local": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="stdio",
+                command="npx",
+                args=["-y", "@example/new-server"],
+                env={"TOKEN": mcp._REDACTED_VALUE},
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "changing command or args" in str(exc.value.detail)
+
+
 def test_update_mcp_configuration_rejects_disallowed_stdio_command(tmp_path) -> None:
     config_path = tmp_path / "extensions_config.json"
     config_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
@@ -146,11 +302,41 @@ def test_update_mcp_configuration_rejects_disallowed_stdio_command(tmp_path) -> 
             asyncio.run(mcp.update_mcp_configuration(request))
 
     assert exc.value.status_code == 400
+    assert "bare executable" in str(exc.value.detail)
+
+
+def test_update_mcp_configuration_rejects_default_python_stdio_command(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "python": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="stdio",
+                command="python",
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
     assert "not allowed" in str(exc.value.detail)
 
 
-def test_mcp_config_admin_token_is_optional_but_enforced_when_configured(monkeypatch) -> None:
+def test_mcp_config_admin_token_fails_closed_unless_explicitly_allowed(monkeypatch) -> None:
     monkeypatch.delenv(mcp._MCP_CONFIG_ADMIN_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(mcp._MCP_CONFIG_ALLOW_UNAUTH_ENV, raising=False)
+    with pytest.raises(HTTPException) as exc:
+        mcp._require_mcp_config_admin(None)
+    assert exc.value.status_code == 403
+
+    monkeypatch.setenv(mcp._MCP_CONFIG_ALLOW_UNAUTH_ENV, "true")
     mcp._require_mcp_config_admin(None)
 
     monkeypatch.setenv(mcp._MCP_CONFIG_ADMIN_TOKEN_ENV, "secret-token")

--- a/backend/tests/test_gateway_mcp_router.py
+++ b/backend/tests/test_gateway_mcp_router.py
@@ -1,0 +1,161 @@
+import asyncio
+import json
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.gateway.routers import mcp
+from deerflow.config.extensions_config import ExtensionsConfig, McpOAuthConfig, McpServerConfig
+
+
+def test_get_mcp_configuration_redacts_sensitive_values(monkeypatch) -> None:
+    config = ExtensionsConfig(
+        mcp_servers={
+            "secure": McpServerConfig(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                env={"TOKEN": "raw-token"},
+                headers={"Authorization": "Bearer raw-token"},
+                oauth=McpOAuthConfig(
+                    token_url="https://auth.example.test/token",
+                    client_id="client-id",
+                    client_secret="client-secret",
+                    refresh_token="refresh-token",
+                    extra_token_params={"audience_secret": "secret"},
+                ),
+            )
+        },
+        skills={},
+    )
+    monkeypatch.setattr(mcp, "get_extensions_config", lambda: config)
+
+    response = asyncio.run(mcp.get_mcp_configuration())
+    server = response.mcp_servers["secure"]
+
+    assert server.env == {"TOKEN": mcp._REDACTED_VALUE}
+    assert server.headers == {"Authorization": mcp._REDACTED_VALUE}
+    assert server.oauth is not None
+    assert server.oauth.client_id == "client-id"
+    assert server.oauth.client_secret == mcp._REDACTED_VALUE
+    assert server.oauth.refresh_token == mcp._REDACTED_VALUE
+    assert server.oauth.extra_token_params == {"audience_secret": mcp._REDACTED_VALUE}
+
+
+def test_update_mcp_configuration_preserves_redacted_existing_values(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "secure": {
+                        "enabled": True,
+                        "type": "http",
+                        "url": "https://mcp.example.test",
+                        "env": {"TOKEN": "$MCP_TOKEN"},
+                        "headers": {"Authorization": "$MCP_AUTH_HEADER"},
+                        "oauth": {
+                            "token_url": "https://auth.example.test/token",
+                            "client_id": "client-id",
+                            "client_secret": "$MCP_CLIENT_SECRET",
+                            "refresh_token": "$MCP_REFRESH_TOKEN",
+                            "extra_token_params": {"audience": "$MCP_AUDIENCE"},
+                        },
+                    }
+                },
+                "skills": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    current_config = ExtensionsConfig(mcp_servers={}, skills={})
+    reloaded_config = ExtensionsConfig(
+        mcp_servers={
+            "secure": McpServerConfig(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                env={"TOKEN": "resolved-token"},
+                headers={"Authorization": "resolved-header"},
+                oauth=McpOAuthConfig(
+                    token_url="https://auth.example.test/token",
+                    client_id="client-id",
+                    client_secret="resolved-secret",
+                    refresh_token="resolved-refresh",
+                    extra_token_params={"audience": "resolved-audience"},
+                ),
+            )
+        },
+        skills={},
+    )
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "secure": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.test",
+                env={"TOKEN": mcp._REDACTED_VALUE},
+                headers={"Authorization": mcp._REDACTED_VALUE},
+                oauth=mcp.McpOAuthConfigResponse(
+                    token_url="https://auth.example.test/token",
+                    client_id="client-id",
+                    client_secret=mcp._REDACTED_VALUE,
+                    refresh_token=mcp._REDACTED_VALUE,
+                    extra_token_params={"audience": mcp._REDACTED_VALUE},
+                ),
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=current_config),
+        patch.object(mcp, "reload_extensions_config", return_value=reloaded_config),
+    ):
+        response = asyncio.run(mcp.update_mcp_configuration(request))
+
+    written = json.loads(config_path.read_text(encoding="utf-8"))
+    server = written["mcpServers"]["secure"]
+    assert server["env"]["TOKEN"] == "$MCP_TOKEN"
+    assert server["headers"]["Authorization"] == "$MCP_AUTH_HEADER"
+    assert server["oauth"]["client_secret"] == "$MCP_CLIENT_SECRET"
+    assert server["oauth"]["refresh_token"] == "$MCP_REFRESH_TOKEN"
+    assert server["oauth"]["extra_token_params"]["audience"] == "$MCP_AUDIENCE"
+    assert response.mcp_servers["secure"].env == {"TOKEN": mcp._REDACTED_VALUE}
+
+
+def test_update_mcp_configuration_rejects_disallowed_stdio_command(tmp_path) -> None:
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(json.dumps({"mcpServers": {}, "skills": {}}), encoding="utf-8")
+    request = mcp.McpConfigUpdateRequest(
+        mcp_servers={
+            "shell": mcp.McpServerConfigResponse(
+                enabled=True,
+                type="stdio",
+                command="/bin/sh",
+            )
+        }
+    )
+
+    with (
+        patch.object(mcp.ExtensionsConfig, "resolve_config_path", return_value=config_path),
+        patch.object(mcp, "get_extensions_config", return_value=ExtensionsConfig(mcp_servers={}, skills={})),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(mcp.update_mcp_configuration(request))
+
+    assert exc.value.status_code == 400
+    assert "not allowed" in str(exc.value.detail)
+
+
+def test_mcp_config_admin_token_is_optional_but_enforced_when_configured(monkeypatch) -> None:
+    monkeypatch.delenv(mcp._MCP_CONFIG_ADMIN_TOKEN_ENV, raising=False)
+    mcp._require_mcp_config_admin(None)
+
+    monkeypatch.setenv(mcp._MCP_CONFIG_ADMIN_TOKEN_ENV, "secret-token")
+    with pytest.raises(HTTPException) as exc:
+        mcp._require_mcp_config_admin(None)
+    assert exc.value.status_code == 403
+
+    mcp._require_mcp_config_admin("Bearer secret-token")


### PR DESCRIPTION
## Summary
- redact MCP env, headers, OAuth secrets, and token params in config responses
- preserve existing raw secret placeholders when clients round-trip redacted values
- validate MCP server types, HTTP/SSE URLs, and stdio commands via allowlist
- write extensions config atomically with restrictive file permissions
- add optional bearer-token guard via `DEER_FLOW_MCP_CONFIG_ADMIN_TOKEN`

Fixes #2531

## Tests
- `PYTHONPATH=. uv run pytest tests/test_gateway_mcp_router.py tests/test_mcp_oauth.py tests/test_mcp_client_config.py -q`
- `uv run ruff check app/gateway/routers/mcp.py tests/test_gateway_mcp_router.py`
