### PR TITLE
fix(packaging): declare requests as a direct dependency of deerflow-harness

### DIFF
--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic>=2.12.5",
     "pyyaml>=6.0.3",
     "readabilipy>=0.3.0",
+    "requests>=2.32.0",
     "tavily-python>=0.7.17",
     "firecrawl-py>=1.15.0",
     "tiktoken>=0.8.0",


### PR DESCRIPTION
## Summary

`deerflow-harness` uses `requests` in 3 files but never declared it as a dependency in `pyproject.toml`. Standalone installs could fail with `ModuleNotFoundError: No module named 'requests'`.

Affected files:
- `deerflow/community/aio_sandbox/backend.py`
- `deerflow/community/aio_sandbox/remote_backend.py`
- `deerflow/community/infoquest/infoquest_client.py`

Closes #2551

## Test plan
- [x] Verified all 3 files that import `requests` are within the harness package
- [x] Confirmed `requests` is not transitively guaranteed by any existing dependency
- [x] `ruff check` and `ruff format --check` pass