### PR TITLE
fix(runtime): protect sync singleton init/reset with threading.Lock

### DIFF
--- a/backend/packages/harness/deerflow/agents/checkpointer/provider.py
+++ b/backend/packages/harness/deerflow/agents/checkpointer/provider.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from collections.abc import Iterator
 
 from langgraph.types import Checkpointer
@@ -98,6 +99,7 @@ def _sync_checkpointer_cm(config: CheckpointerConfig) -> Iterator[Checkpointer]:
 
 _checkpointer: Checkpointer | None = None
 _checkpointer_ctx = None  # open context manager keeping the connection alive
+_checkpointer_lock = threading.Lock()
 
 
 def get_checkpointer() -> Checkpointer:
@@ -114,36 +116,32 @@ def get_checkpointer() -> Checkpointer:
     if _checkpointer is not None:
         return _checkpointer
 
-    # Ensure app config is loaded before checking checkpointer config
-    # This prevents returning InMemorySaver when config.yaml actually has a checkpointer section
-    # but hasn't been loaded yet
-    from deerflow.config.app_config import _app_config
-    from deerflow.config.checkpointer_config import get_checkpointer_config
+    with _checkpointer_lock:
+        if _checkpointer is not None:
+            return _checkpointer
 
-    config = get_checkpointer_config()
+        from deerflow.config.app_config import _app_config
+        from deerflow.config.checkpointer_config import get_checkpointer_config
 
-    if config is None and _app_config is None:
-        # Only load app config lazily when neither the app config nor an explicit
-        # checkpointer config has been initialized yet. This keeps tests that
-        # intentionally set the global checkpointer config isolated from any
-        # ambient config.yaml on disk.
-        try:
-            get_app_config()
-        except FileNotFoundError:
-            # In test environments without config.yaml, this is expected.
-            pass
         config = get_checkpointer_config()
-    if config is None:
-        from langgraph.checkpoint.memory import InMemorySaver
 
-        logger.info("Checkpointer: using InMemorySaver (in-process, not persistent)")
-        _checkpointer = InMemorySaver()
+        if config is None and _app_config is None:
+            try:
+                get_app_config()
+            except FileNotFoundError:
+                pass
+            config = get_checkpointer_config()
+        if config is None:
+            from langgraph.checkpoint.memory import InMemorySaver
+
+            logger.info("Checkpointer: using InMemorySaver (in-process, not persistent)")
+            _checkpointer = InMemorySaver()
+            return _checkpointer
+
+        _checkpointer_ctx = _sync_checkpointer_cm(config)
+        _checkpointer = _checkpointer_ctx.__enter__()
+
         return _checkpointer
-
-    _checkpointer_ctx = _sync_checkpointer_cm(config)
-    _checkpointer = _checkpointer_ctx.__enter__()
-
-    return _checkpointer
 
 
 def reset_checkpointer() -> None:
@@ -153,13 +151,14 @@ def reset_checkpointer() -> None:
     Useful in tests or after a configuration change.
     """
     global _checkpointer, _checkpointer_ctx
-    if _checkpointer_ctx is not None:
-        try:
-            _checkpointer_ctx.__exit__(None, None, None)
-        except Exception:
-            logger.warning("Error during checkpointer cleanup", exc_info=True)
-        _checkpointer_ctx = None
-    _checkpointer = None
+    with _checkpointer_lock:
+        if _checkpointer_ctx is not None:
+            try:
+                _checkpointer_ctx.__exit__(None, None, None)
+            except Exception:
+                logger.warning("Error during checkpointer cleanup", exc_info=True)
+            _checkpointer_ctx = None
+        _checkpointer = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/packages/harness/deerflow/runtime/store/provider.py
+++ b/backend/packages/harness/deerflow/runtime/store/provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import threading
 from collections.abc import Iterator
 
 from langgraph.store.base import BaseStore
@@ -98,6 +99,7 @@ def _sync_store_cm(config) -> Iterator[BaseStore]:
 
 _store: BaseStore | None = None
 _store_ctx = None  # open context manager keeping the connection alive
+_store_lock = threading.Lock()
 
 
 def get_store() -> BaseStore:
@@ -115,30 +117,32 @@ def get_store() -> BaseStore:
     if _store is not None:
         return _store
 
-    # Lazily load app config, mirroring the checkpointer singleton pattern so
-    # that tests that set the global checkpointer config explicitly remain isolated.
-    from deerflow.config.app_config import _app_config
-    from deerflow.config.checkpointer_config import get_checkpointer_config
+    with _store_lock:
+        if _store is not None:
+            return _store
 
-    config = get_checkpointer_config()
+        from deerflow.config.app_config import _app_config
+        from deerflow.config.checkpointer_config import get_checkpointer_config
 
-    if config is None and _app_config is None:
-        try:
-            get_app_config()
-        except FileNotFoundError:
-            pass
         config = get_checkpointer_config()
 
-    if config is None:
-        from langgraph.store.memory import InMemoryStore
+        if config is None and _app_config is None:
+            try:
+                get_app_config()
+            except FileNotFoundError:
+                pass
+            config = get_checkpointer_config()
 
-        logger.warning("No 'checkpointer' section in config.yaml — using InMemoryStore for the store. Thread list will be lost on server restart. Configure a sqlite or postgres backend for persistence.")
-        _store = InMemoryStore()
+        if config is None:
+            from langgraph.store.memory import InMemoryStore
+
+            logger.warning("No 'checkpointer' section in config.yaml — using InMemoryStore for the store. Thread list will be lost on server restart. Configure a sqlite or postgres backend for persistence.")
+            _store = InMemoryStore()
+            return _store
+
+        _store_ctx = _sync_store_cm(config)
+        _store = _store_ctx.__enter__()
         return _store
-
-    _store_ctx = _sync_store_cm(config)
-    _store = _store_ctx.__enter__()
-    return _store
 
 
 def reset_store() -> None:
@@ -148,13 +152,14 @@ def reset_store() -> None:
     Useful in tests or after a configuration change.
     """
     global _store, _store_ctx
-    if _store_ctx is not None:
-        try:
-            _store_ctx.__exit__(None, None, None)
-        except Exception:
-            logger.warning("Error during store cleanup", exc_info=True)
-        _store_ctx = None
-    _store = None
+    with _store_lock:
+        if _store_ctx is not None:
+            try:
+                _store_ctx.__exit__(None, None, None)
+            except Exception:
+                logger.warning("Error during store cleanup", exc_info=True)
+            _store_ctx = None
+        _store = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_singleton_lock.py
+++ b/backend/tests/test_singleton_lock.py
@@ -1,0 +1,135 @@
+"""Tests for thread-safe singleton initialization in checkpointer and store providers."""
+
+import threading
+
+import pytest
+
+import deerflow.config.app_config as app_config_module
+from deerflow.agents.checkpointer import get_checkpointer, reset_checkpointer
+from deerflow.config.checkpointer_config import set_checkpointer_config
+from deerflow.runtime.store.provider import get_store, reset_store
+
+
+@pytest.fixture(autouse=True)
+def _reset_singletons():
+    app_config_module._app_config = None
+    set_checkpointer_config(None)
+    reset_checkpointer()
+    reset_store()
+    yield
+    app_config_module._app_config = None
+    set_checkpointer_config(None)
+    reset_checkpointer()
+    reset_store()
+
+
+class TestCheckpointerSingletonConcurrency:
+    def test_concurrent_get_returns_same_instance(self):
+        set_checkpointer_config(None)
+        results = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            results.append(id(get_checkpointer()))
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 8
+        assert len(set(results)) == 1
+
+    def test_reset_during_init_is_serialized(self):
+        set_checkpointer_config(None)
+        errors = []
+
+        def init_worker():
+            try:
+                get_checkpointer()
+            except Exception as e:
+                errors.append(e)
+
+        def reset_worker():
+            try:
+                reset_checkpointer()
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for _ in range(4):
+            threads.append(threading.Thread(target=init_worker))
+            threads.append(threading.Thread(target=reset_worker))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+    def test_get_after_reset_returns_valid_instance(self):
+        set_checkpointer_config(None)
+        first = get_checkpointer()
+        reset_checkpointer()
+        second = get_checkpointer()
+        assert first is not None
+        assert second is not None
+
+
+class TestStoreSingletonConcurrency:
+    def test_concurrent_get_returns_same_instance(self):
+        set_checkpointer_config(None)
+        results = []
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            results.append(id(get_store()))
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(results) == 8
+        assert len(set(results)) == 1
+
+    def test_reset_during_init_is_serialized(self):
+        set_checkpointer_config(None)
+        errors = []
+
+        def init_worker():
+            try:
+                get_store()
+            except Exception as e:
+                errors.append(e)
+
+        def reset_worker():
+            try:
+                reset_store()
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for _ in range(4):
+            threads.append(threading.Thread(target=init_worker))
+            threads.append(threading.Thread(target=reset_worker))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+
+    def test_get_after_reset_returns_valid_instance(self):
+        set_checkpointer_config(None)
+        first = get_store()
+        reset_store()
+        second = get_store()
+        assert first is not None
+        assert second is not None


### PR DESCRIPTION
## Summary

`get_checkpointer()` and `get_store()` use lazy-init singletons without locks. Concurrent calls can race past the `if instance is None` check and create multiple instances, leaking DB connections/file handles. `reset_*()` interleaved with `get_*()` can also cause state inconsistency.

Applied double-check locking pattern to both providers:
- Added `threading.Lock` to `checkpointer/provider.py` and `store/provider.py`
- `get_*()` checks without lock first (fast path), then re-checks inside lock
- `reset_*()` holds lock during cleanup to prevent interleaving with init

Closes #2549

## Test plan
- [x] Added `TestCheckpointerSingletonConcurrency` (3 tests)
  - 8 concurrent threads get the same instance
  - Reset during init is serialized without errors
  - Get after reset returns a valid new instance
- [x] Added `TestStoreSingletonConcurrency` (3 tests) — same coverage
- [x] `ruff check` and `ruff format --check` pass