### PR TITLE
fix(memory): prevent 'Event loop is closed' in LLM calls caused by memory updater

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/queue.py
@@ -1,5 +1,7 @@
 """Memory update queue with debounce mechanism."""
 
+from __future__ import annotations
+
 import logging
 import threading
 import time

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -8,9 +8,12 @@ import json
 import logging
 import math
 import re
+import threading
 import uuid
 from collections.abc import Awaitable
 from typing import Any
+
+import httpx
 
 from deerflow.agents.memory.prompt import (
     MEMORY_UPDATE_PROMPT,
@@ -25,6 +28,32 @@ from deerflow.config.memory_config import get_memory_config
 from deerflow.models import create_chat_model
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Dedicated event loop for memory-update async work.
+#
+# Using asyncio.run() would create a new event loop and CLOSE it after each
+# call.  langchain_openai caches a single httpx.AsyncClient per (base_url,
+# timeout) via @lru_cache (_cached_async_httpx_client).  Connections created
+# inside a short-lived asyncio.run() are bound to that temporary loop.  When
+# the loop closes, those connections become invalid.  The main agent later
+# reuses them from the pool and hits "RuntimeError: Event loop is closed".
+#
+# The fix: run all memory-update coroutines on a single, never-closing loop
+# and give that loop its OWN httpx.AsyncClient so its connections are
+# completely isolated from the main agent's cached client.
+# ---------------------------------------------------------------------------
+_MEMORY_LOOP: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+_MEMORY_LOOP_THREAD = threading.Thread(
+    target=_MEMORY_LOOP.run_forever,
+    name="memory-event-loop",
+    daemon=True,
+)
+_MEMORY_LOOP_THREAD.start()
+
+# Dedicated httpx client whose connections are always bound to _MEMORY_LOOP.
+_MEMORY_HTTP_CLIENT: httpx.AsyncClient = httpx.AsyncClient()
+atexit.register(lambda: asyncio.run_coroutine_threadsafe(_MEMORY_HTTP_CLIENT.aclose(), _MEMORY_LOOP))
 
 _SYNC_MEMORY_UPDATER_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
     max_workers=4,
@@ -218,22 +247,20 @@ def _extract_text(content: Any) -> str:
 
 
 def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
-    """Run an async memory update from sync code, including nested-loop contexts."""
+    """Run an async memory update from sync code on the dedicated memory loop.
+
+    Uses a persistent dedicated event loop instead of asyncio.run() to prevent
+    closing the loop after each call.  asyncio.run() closes the loop on return,
+    which invalidates any connections the memory updater's httpx client created
+    in that loop — those stale connections then pollute the shared @lru_cache'd
+    client used by the main agent, causing 'Event loop is closed' errors on the
+    next LLM call.
+    """
     handed_off = False
-
     try:
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            loop = None
-
-        if loop is not None and loop.is_running():
-            future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(asyncio.run, coro)
-            handed_off = True
-            return future.result()
-
-        handed_off = True
-        return asyncio.run(coro)
+        future = asyncio.run_coroutine_threadsafe(coro, _MEMORY_LOOP)
+        handed_off = True  # coroutine is now owned by _MEMORY_LOOP
+        return future.result()
     except Exception:
         if not handed_off:
             close = getattr(coro, "close", None)
@@ -242,11 +269,10 @@ def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
                     close()
                 except Exception:
                     logger.debug(
-                        "Failed to close un-awaited memory update coroutine",
+                        "Failed to close un-scheduled memory update coroutine",
                         exc_info=True,
                     )
-
-        logger.exception("Failed to run async memory update from sync context")
+        logger.exception("Failed to run async memory update")
         return False
 
 
@@ -311,7 +337,10 @@ class MemoryUpdater:
         """Get the model for memory updates."""
         config = get_memory_config()
         model_name = self._model_name or config.model_name
-        return create_chat_model(name=model_name, thinking_enabled=False)
+        # Pass the dedicated httpx client so memory LLM calls never share the
+        # @lru_cache'd client used by the main agent, preventing cross-loop
+        # connection contamination.
+        return create_chat_model(name=model_name, thinking_enabled=False, http_async_client=_MEMORY_HTTP_CLIENT)
 
     def _build_correction_hint(
         self,

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -69,7 +69,11 @@ def _ensure_memory_loop() -> tuple[asyncio.AbstractEventLoop, httpx.AsyncClient]
             assert _MEMORY_HTTP_CLIENT is not None
             return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT
         loop = asyncio.new_event_loop()
-        client = httpx.AsyncClient()
+        # timeout=None: no httpx-level timeout — defer to the LangChain/OpenAI
+        # SDK's own timeout settings (configured per model in config.yaml).  A
+        # hard httpx default (5 s) would override those and cause spurious failures
+        # on models with intentionally high latencies.
+        client = httpx.AsyncClient(timeout=None)
         threading.Thread(
             target=_start_memory_loop,
             args=(loop,),
@@ -296,6 +300,11 @@ def _run_async_update_sync(coro: Coroutine[Any, Any, bool]) -> bool:
     in that loop — those stale connections then pollute the shared @lru_cache'd
     client used by the main agent, causing 'Event loop is closed' errors on the
     next LLM call.
+
+    Note: this function blocks the calling thread.  In production it is only
+    invoked from a threading.Timer callback (a plain OS thread, not an asyncio
+    event loop thread), so blocking is safe.  Callers in async contexts should
+    use aupdate_memory() instead.
     """
     loop, _ = _ensure_memory_loop()
     handed_off = False
@@ -303,10 +312,10 @@ def _run_async_update_sync(coro: Coroutine[Any, Any, bool]) -> bool:
         future = asyncio.run_coroutine_threadsafe(coro, loop)
         handed_off = True  # coroutine is now owned by _MEMORY_LOOP
         try:
-            return future.result(timeout=60)
+            return future.result(timeout=300)
         except concurrent.futures.TimeoutError:
             future.cancel()
-            logger.warning("Memory update timed out after 60 s; cancelled")
+            logger.warning("Memory update timed out after 300 s; cancelled")
             return False
     except Exception:
         if not handed_off:
@@ -389,7 +398,7 @@ class MemoryUpdater:
         # and would raise TypeError.
         app_cfg = get_app_config()
         model_cfg = app_cfg.get_model_config(model_name)
-        extra: dict = {}
+        extra: dict[str, Any] = {}
         if model_cfg is not None and model_cfg.use.startswith("langchain_openai:"):
             _, client = _ensure_memory_loop()
             extra["http_async_client"] = client

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import atexit
-import concurrent.futures
 import copy
 import json
 import logging
@@ -24,6 +23,7 @@ from deerflow.agents.memory.storage import (
     get_memory_storage,
     utc_now_iso_z,
 )
+from deerflow.config import get_app_config
 from deerflow.config.memory_config import get_memory_config
 from deerflow.models import create_chat_model
 
@@ -44,8 +44,16 @@ logger = logging.getLogger(__name__)
 # completely isolated from the main agent's cached client.
 # ---------------------------------------------------------------------------
 _MEMORY_LOOP: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+
+
+def _run_memory_loop() -> None:
+    """Thread target: register the loop for this thread, then run it forever."""
+    asyncio.set_event_loop(_MEMORY_LOOP)
+    _MEMORY_LOOP.run_forever()
+
+
 _MEMORY_LOOP_THREAD = threading.Thread(
-    target=_MEMORY_LOOP.run_forever,
+    target=_run_memory_loop,
     name="memory-event-loop",
     daemon=True,
 )
@@ -53,13 +61,20 @@ _MEMORY_LOOP_THREAD.start()
 
 # Dedicated httpx client whose connections are always bound to _MEMORY_LOOP.
 _MEMORY_HTTP_CLIENT: httpx.AsyncClient = httpx.AsyncClient()
-atexit.register(lambda: asyncio.run_coroutine_threadsafe(_MEMORY_HTTP_CLIENT.aclose(), _MEMORY_LOOP))
 
-_SYNC_MEMORY_UPDATER_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
-    max_workers=4,
-    thread_name_prefix="memory-updater-sync",
-)
-atexit.register(lambda: _SYNC_MEMORY_UPDATER_EXECUTOR.shutdown(wait=False))
+
+def _shutdown_memory_loop() -> None:
+    """Gracefully close the dedicated HTTP client and stop the memory loop."""
+    try:
+        future = asyncio.run_coroutine_threadsafe(_MEMORY_HTTP_CLIENT.aclose(), _MEMORY_LOOP)
+        future.result(timeout=5)
+    except Exception:
+        pass
+    finally:
+        _MEMORY_LOOP.call_soon_threadsafe(_MEMORY_LOOP.stop)
+
+
+atexit.register(_shutdown_memory_loop)
 
 
 def _create_empty_memory() -> dict[str, Any]:
@@ -337,10 +352,15 @@ class MemoryUpdater:
         """Get the model for memory updates."""
         config = get_memory_config()
         model_name = self._model_name or config.model_name
-        # Pass the dedicated httpx client so memory LLM calls never share the
-        # @lru_cache'd client used by the main agent, preventing cross-loop
-        # connection contamination.
-        return create_chat_model(name=model_name, thinking_enabled=False, http_async_client=_MEMORY_HTTP_CLIENT)
+        # Only inject the dedicated httpx client for OpenAI-compatible models.
+        # Other providers (Anthropic, Ollama, etc.) do not accept http_async_client
+        # and would raise TypeError.
+        app_cfg = get_app_config()
+        model_cfg = app_cfg.get_model_config(model_name)
+        extra: dict = {}
+        if model_cfg is not None and model_cfg.use.startswith("langchain_openai:"):
+            extra["http_async_client"] = _MEMORY_HTTP_CLIENT
+        return create_chat_model(name=model_name, thinking_enabled=False, **extra)
 
     def _build_correction_hint(
         self,

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -9,7 +9,7 @@ import math
 import re
 import threading
 import uuid
-from collections.abc import Awaitable, Coroutine
+from collections.abc import Coroutine
 from typing import Any
 
 import httpx
@@ -30,55 +30,73 @@ from deerflow.models import create_chat_model
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Dedicated event loop for memory-update async work.
+# Dedicated event loop for memory-update async work — lazy-initialized.
 #
-# Using asyncio.run() would create a new event loop and CLOSE it after each
-# call.  langchain_openai caches a single httpx.AsyncClient per (base_url,
-# timeout) via @lru_cache (_cached_async_httpx_client).  Connections created
-# inside a short-lived asyncio.run() are bound to that temporary loop.  When
-# the loop closes, those connections become invalid.  The main agent later
-# reuses them from the pool and hits "RuntimeError: Event loop is closed".
+# The loop, thread, and httpx client are created on first call to
+# _run_async_update_sync() (i.e. only when a memory update is actually
+# triggered), so import-time overhead is zero in processes/tests that never
+# execute memory updates.
 #
-# The fix: run all memory-update coroutines on a single, never-closing loop
-# and give that loop its OWN httpx.AsyncClient so its connections are
-# completely isolated from the main agent's cached client.
+# Background: asyncio.run() creates a new event loop and CLOSES it after
+# each call.  langchain_openai caches a single httpx.AsyncClient per
+# (base_url, timeout) via @lru_cache.  Connections created inside the
+# short-lived loop are bound to that loop; once it closes they become
+# invalid but stay in the pool, causing "RuntimeError: Event loop is
+# closed" when the main agent reuses them.
 # ---------------------------------------------------------------------------
-_MEMORY_LOOP: asyncio.AbstractEventLoop = asyncio.new_event_loop()
+_MEMORY_LOOP: asyncio.AbstractEventLoop | None = None
+_MEMORY_HTTP_CLIENT: httpx.AsyncClient | None = None
+_MEMORY_INIT_LOCK = threading.Lock()
+_MEMORY_ATEXIT_REGISTERED = False
 
 
-def _run_memory_loop() -> None:
+def _start_memory_loop(loop: asyncio.AbstractEventLoop) -> None:
     """Thread target: register the loop for this thread, then run it forever."""
-    asyncio.set_event_loop(_MEMORY_LOOP)
-    _MEMORY_LOOP.run_forever()
+    asyncio.set_event_loop(loop)
+    loop.run_forever()
 
 
-_MEMORY_LOOP_THREAD = threading.Thread(
-    target=_run_memory_loop,
-    name="memory-event-loop",
-    daemon=True,
-)
-_MEMORY_LOOP_THREAD.start()
-
-# Dedicated httpx client whose connections are always bound to _MEMORY_LOOP.
-_MEMORY_HTTP_CLIENT: httpx.AsyncClient = httpx.AsyncClient()
+def _ensure_memory_loop() -> tuple[asyncio.AbstractEventLoop, httpx.AsyncClient]:
+    """Lazily create the dedicated memory event loop and HTTP client on first use."""
+    global _MEMORY_LOOP, _MEMORY_HTTP_CLIENT, _MEMORY_ATEXIT_REGISTERED
+    if _MEMORY_LOOP is not None:
+        return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
+    with _MEMORY_INIT_LOCK:
+        if _MEMORY_LOOP is not None:
+            return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
+        loop = asyncio.new_event_loop()
+        client = httpx.AsyncClient()
+        threading.Thread(
+            target=_start_memory_loop,
+            args=(loop,),
+            name="memory-event-loop",
+            daemon=True,
+        ).start()
+        _MEMORY_LOOP = loop
+        _MEMORY_HTTP_CLIENT = client
+        if not _MEMORY_ATEXIT_REGISTERED:
+            atexit.register(_shutdown_memory_loop)
+            _MEMORY_ATEXIT_REGISTERED = True
+    return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
 
 
 def _shutdown_memory_loop() -> None:
     """Gracefully close the dedicated HTTP client and stop the memory loop."""
+    loop = _MEMORY_LOOP
+    client = _MEMORY_HTTP_CLIENT
+    if loop is None:
+        return
     try:
-        future = asyncio.run_coroutine_threadsafe(_MEMORY_HTTP_CLIENT.aclose(), _MEMORY_LOOP)
+        future = asyncio.run_coroutine_threadsafe(client.aclose(), loop)  # type: ignore[union-attr]
         future.result(timeout=5)
     except Exception:
         pass
     finally:
         try:
-            if not _MEMORY_LOOP.is_closed():
-                _MEMORY_LOOP.call_soon_threadsafe(_MEMORY_LOOP.stop)
+            if not loop.is_closed():
+                loop.call_soon_threadsafe(loop.stop)
         except Exception:
             pass
-
-
-atexit.register(_shutdown_memory_loop)
 
 
 def _create_empty_memory() -> dict[str, Any]:
@@ -275,9 +293,10 @@ def _run_async_update_sync(coro: Coroutine[Any, Any, bool]) -> bool:
     client used by the main agent, causing 'Event loop is closed' errors on the
     next LLM call.
     """
+    loop, _ = _ensure_memory_loop()
     handed_off = False
     try:
-        future = asyncio.run_coroutine_threadsafe(coro, _MEMORY_LOOP)
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
         handed_off = True  # coroutine is now owned by _MEMORY_LOOP
         try:
             return future.result(timeout=60)
@@ -368,7 +387,8 @@ class MemoryUpdater:
         model_cfg = app_cfg.get_model_config(model_name)
         extra: dict = {}
         if model_cfg is not None and model_cfg.use.startswith("langchain_openai:"):
-            extra["http_async_client"] = _MEMORY_HTTP_CLIENT
+            _, client = _ensure_memory_loop()
+            extra["http_async_client"] = client
         return create_chat_model(name=model_name, thinking_enabled=False, **extra)
 
     def _build_correction_hint(

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -27,6 +27,7 @@ from deerflow.agents.memory.storage import (
 from deerflow.config import get_app_config
 from deerflow.config.memory_config import get_memory_config
 from deerflow.models import create_chat_model
+from deerflow.reflection import resolve_class
 
 logger = logging.getLogger(__name__)
 
@@ -378,6 +379,23 @@ def _fact_content_key(content: Any) -> str | None:
     return stripped.casefold()
 
 
+def _uses_chatopenai_async_client(model_use: str) -> bool:
+    """Return whether the provider class is ChatOpenAI-based.
+
+    This includes direct ``langchain_openai:*`` classes and local wrappers
+    that subclass ``langchain_openai.ChatOpenAI`` (e.g.
+    ``deerflow.models.patched_openai:PatchedChatOpenAI``).
+    """
+    if model_use.startswith("langchain_openai:"):
+        return True
+    try:
+        model_class = resolve_class(model_use)
+    except (ImportError, ValueError):
+        return False
+
+    return any(base.__name__ == "ChatOpenAI" and base.__module__.startswith("langchain_openai") for base in model_class.__mro__)
+
+
 class MemoryUpdater:
     """Updates memory using LLM based on conversation context."""
 
@@ -399,7 +417,7 @@ class MemoryUpdater:
         app_cfg = get_app_config()
         model_cfg = app_cfg.get_model_config(model_name)
         extra: dict[str, Any] = {}
-        if model_cfg is not None and model_cfg.use.startswith("langchain_openai:"):
+        if model_cfg is not None and _uses_chatopenai_async_client(model_cfg.use):
             _, client = _ensure_memory_loop()
             extra["http_async_client"] = client
         return create_chat_model(name=model_name, thinking_enabled=False, **extra)

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -9,7 +9,7 @@ import math
 import re
 import threading
 import uuid
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Coroutine
 from typing import Any
 
 import httpx
@@ -71,7 +71,11 @@ def _shutdown_memory_loop() -> None:
     except Exception:
         pass
     finally:
-        _MEMORY_LOOP.call_soon_threadsafe(_MEMORY_LOOP.stop)
+        try:
+            if not _MEMORY_LOOP.is_closed():
+                _MEMORY_LOOP.call_soon_threadsafe(_MEMORY_LOOP.stop)
+        except Exception:
+            pass
 
 
 atexit.register(_shutdown_memory_loop)
@@ -261,7 +265,7 @@ def _extract_text(content: Any) -> str:
     return str(content)
 
 
-def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
+def _run_async_update_sync(coro: Coroutine[Any, Any, bool]) -> bool:
     """Run an async memory update from sync code on the dedicated memory loop.
 
     Uses a persistent dedicated event loop instead of asyncio.run() to prevent
@@ -275,7 +279,12 @@ def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
     try:
         future = asyncio.run_coroutine_threadsafe(coro, _MEMORY_LOOP)
         handed_off = True  # coroutine is now owned by _MEMORY_LOOP
-        return future.result()
+        try:
+            return future.result(timeout=60)
+        except TimeoutError:
+            future.cancel()
+            logger.warning("Memory update timed out after 60 s; cancelled")
+            return False
     except Exception:
         if not handed_off:
             close = getattr(coro, "close", None)

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import atexit
+import concurrent.futures
 import copy
 import json
 import logging
@@ -60,10 +61,13 @@ def _ensure_memory_loop() -> tuple[asyncio.AbstractEventLoop, httpx.AsyncClient]
     """Lazily create the dedicated memory event loop and HTTP client on first use."""
     global _MEMORY_LOOP, _MEMORY_HTTP_CLIENT, _MEMORY_ATEXIT_REGISTERED
     if _MEMORY_LOOP is not None:
-        return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
+        # Already initialized — both globals are non-None at this point.
+        assert _MEMORY_HTTP_CLIENT is not None
+        return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT
     with _MEMORY_INIT_LOCK:
         if _MEMORY_LOOP is not None:
-            return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
+            assert _MEMORY_HTTP_CLIENT is not None
+            return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT
         loop = asyncio.new_event_loop()
         client = httpx.AsyncClient()
         threading.Thread(
@@ -77,7 +81,7 @@ def _ensure_memory_loop() -> tuple[asyncio.AbstractEventLoop, httpx.AsyncClient]
         if not _MEMORY_ATEXIT_REGISTERED:
             atexit.register(_shutdown_memory_loop)
             _MEMORY_ATEXIT_REGISTERED = True
-    return _MEMORY_LOOP, _MEMORY_HTTP_CLIENT  # type: ignore[return-value]
+    return loop, client
 
 
 def _shutdown_memory_loop() -> None:
@@ -300,7 +304,7 @@ def _run_async_update_sync(coro: Coroutine[Any, Any, bool]) -> bool:
         handed_off = True  # coroutine is now owned by _MEMORY_LOOP
         try:
             return future.result(timeout=60)
-        except TimeoutError:
+        except concurrent.futures.TimeoutError:
             future.cancel()
             logger.warning("Memory update timed out after 60 s; cancelled")
             return False

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -8,6 +8,7 @@ from deerflow.agents.memory.updater import (
     MemoryUpdater,
     _extract_text,
     _run_async_update_sync,
+    _uses_chatopenai_async_client,
     clear_memory_data,
     create_memory_fact,
     delete_memory_fact,
@@ -40,6 +41,22 @@ def _memory_config(**overrides: object) -> MemoryConfig:
     for key, value in overrides.items():
         setattr(config, key, value)
     return config
+
+
+def test_uses_chatopenai_async_client_accepts_langchain_openai_provider_path() -> None:
+    assert _uses_chatopenai_async_client("langchain_openai:ChatOpenAI") is True
+
+
+def test_uses_chatopenai_async_client_accepts_patched_chatopenai_subclass() -> None:
+    assert _uses_chatopenai_async_client("deerflow.models.patched_openai:PatchedChatOpenAI") is True
+
+
+def test_uses_chatopenai_async_client_rejects_non_chatopenai_class() -> None:
+    class _DummyModel:
+        pass
+
+    with patch("deerflow.agents.memory.updater.resolve_class", return_value=_DummyModel):
+        assert _uses_chatopenai_async_client("dummy.provider:Model") is False
 
 
 def test_apply_updates_skips_existing_duplicate_and_preserves_removals() -> None:

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -682,8 +682,8 @@ class TestUpdateMemoryStructuredResponse:
 
         with (
             patch(
-                "deerflow.agents.memory.updater._SYNC_MEMORY_UPDATER_EXECUTOR.submit",
-                side_effect=RuntimeError("executor down"),
+                "deerflow.agents.memory.updater.asyncio.run_coroutine_threadsafe",
+                side_effect=RuntimeError("loop unavailable"),
             ),
         ):
             msg = MagicMock()
@@ -718,8 +718,8 @@ class TestRunAsyncUpdateSync:
         awaitable = CloseableAwaitable()
 
         with patch(
-            "deerflow.agents.memory.updater._SYNC_MEMORY_UPDATER_EXECUTOR.submit",
-            side_effect=RuntimeError("executor down"),
+            "deerflow.agents.memory.updater.asyncio.run_coroutine_threadsafe",
+            side_effect=RuntimeError("loop unavailable"),
         ):
 
             async def run_in_loop():


### PR DESCRIPTION
## Problem

When a conversation finishes, the MemoryUpdateQueue fires a threading.Timer callback that calls updater.update_memory(), which internally called asyncio.run() in that background thread.

asyncio.run() creates a new event loop, runs the LLM call through it, then closes the loop on return.

langchain_openai caches a single httpx.AsyncClient per (base_url, timeout) pair using @lru_cache on _cached_async_httpx_client. The HTTP connection opened inside the short-lived asyncio.run() loop is bound to that loop. Once the loop closes, the connection is stale but still in the shared pool.

The main agent then reuses that stale connection for the next LLM call and hits RuntimeError: Event loop is closed during stream teardown.

## Root Cause

_run_async_update_sync() in updater.py used asyncio.run(coro) (directly or through executor.submit(asyncio.run, coro)). Both paths close the temporary loop after completion, corrupting reuse in the shared cached AsyncClient.

## Fix

Add a dedicated persistent event loop (_MEMORY_LOOP) running in a daemon thread, and a dedicated httpx.AsyncClient (_MEMORY_HTTP_CLIENT) for memory updates.

### Core changes

- _run_async_update_sync() now uses asyncio.run_coroutine_threadsafe(coro, loop) so the loop is never closed per call.
- Type annotation tightened from Awaitable[bool] to Coroutine[Any, Any, bool].
- future.result() uses a bounded 300s wait and catches concurrent.futures.TimeoutError; on timeout it cancels the future and logs a warning.
- The loop thread sets asyncio.set_event_loop(loop) before run_forever().
- The dedicated client is created as httpx.AsyncClient(timeout=None), deferring timeout behavior to model/SDK config instead of httpx default timeout.
- Loop/thread/client initialization is lazy via _ensure_memory_loop(), avoiding import-time background resources.
- _shutdown_memory_loop() is registered once via atexit after first initialization and performs bounded client close + guarded loop stop.
- Removed the old unused _SYNC_MEMORY_UPDATER_EXECUTOR path.

### Provider compatibility update

- _get_model() now injects http_async_client for all ChatOpenAI-based providers, not only use strings starting with langchain_openai:.
- Added _uses_chatopenai_async_client(model_use), which resolves the configured class and checks MRO for langchain_openai.ChatOpenAI ancestry.
- This includes wrappers/subclasses such as deerflow.models.patched_openai:PatchedChatOpenAI, preserving loop/client isolation for those models too.

### Type-safety cleanup

- Removed stale type ignores around _ensure_memory_loop() returns by enforcing non-None invariants.
- Typed kwargs map as dict[str, Any] where passed into create_chat_model().

## Testing

- pytest tests/test_memory_queue.py tests/test_memory_updater.py -> 54 passed
- ruff check packages/harness/deerflow/agents/memory/updater.py tests/test_memory_updater.py -> passed

Additional tests added for _uses_chatopenai_async_client:
- direct langchain_openai provider path
- PatchedChatOpenAI subclass path
- negative non-ChatOpenAI class case