### PR TITLE
fix(nginx): move error_log to main context for macOS compatibility

### DIFF
--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -1,7 +1,9 @@
+pid logs/nginx.pid;
+error_log logs/nginx-error.log;
+
 events {
     worker_connections 1024;
 }
-pid logs/nginx.pid;
 http {
     # Basic settings
     sendfile on;
@@ -12,7 +14,6 @@ http {
 
     # Logging
     access_log logs/nginx-access.log;
-    error_log logs/nginx-error.log;
 
     # Upstream servers (using 127.0.0.1 for local development)
     upstream gateway {


### PR DESCRIPTION
## Summary

- Move `error_log` directive from inside the `http {}` block to the main (top-level) context in `nginx.local.conf`
- This prevents Homebrew-installed nginx on macOS from failing with "Permission denied" when opening its compile-time default error_log path before parsing the http block
- Follows the same pattern as the existing `pid` directive fix in #870

## Test plan

- [ ] Verify `make dev` starts nginx successfully on macOS with Homebrew nginx (non-root)
- [ ] Verify `make dev` continues to work on Linux as before
- [ ] Verify nginx error_log is written to `$REPO_ROOT/logs/nginx-error.log`

Fixes #2568

🤖 Generated with [Claude Code](https://claude.com/claude-code)