### PR TITLE
fix(frontend): join content array text blocks without newlines

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -139,7 +139,7 @@ export function extractTextFromMessage(message: Message) {
   if (Array.isArray(message.content)) {
     return message.content
       .map((content) => (content.type === "text" ? content.text : ""))
-      .join("\n")
+      .join("")
       .trim();
   }
   return "";
@@ -187,12 +187,12 @@ export function extractContentFromMessage(message: Message) {
             return content.text;
           case "image_url":
             const imageURL = extractURLFromImageURLContent(content.image_url);
-            return `![image](${imageURL})`;
+            return `\n![image](${imageURL})\n`;
           default:
             return "";
         }
       })
-      .join("\n")
+      .join("")
       .trim();
   }
   return "";


### PR DESCRIPTION
## Summary

- Changed `extractTextFromMessage` and `extractContentFromMessage` to use `.join("")` instead of `.join("\n")` when concatenating text blocks from content arrays
- Adjacent text blocks in Anthropic-style content arrays are semantically contiguous text — inserting newlines between them causes fragmented markdown rendering with fine-grained delta providers (e.g., DeepSeek via NewAPI)
- Image blocks are now wrapped with `\n` to remain standalone paragraphs

## Test plan

- [ ] Verify multi-block text content renders as continuous text without forced line breaks
- [ ] Verify image blocks render as standalone paragraphs
- [ ] Test with DeepSeek or similar fine-grained delta provider to confirm no fragmentation

Fixes #2501

🤖 Generated with [Claude Code](https://claude.com/claude-code)