### PR TITLE
fix(frontend): remove rehypeRaw from streamdownPlugins

### DIFF
--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -1,5 +1,4 @@
 import rehypeKatex from "rehype-katex";
-import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { StreamdownProps } from "streamdown";
@@ -12,7 +11,6 @@ export const streamdownPlugins = {
     [remarkMath, { singleDollarTextMath: true }],
   ] as StreamdownProps["remarkPlugins"],
   rehypePlugins: [
-    rehypeRaw,
     [rehypeKatex, { output: "html" }],
   ] as StreamdownProps["rehypePlugins"],
 };
@@ -28,14 +26,10 @@ export const streamdownPluginsWithWordAnimation = {
   ] as StreamdownProps["rehypePlugins"],
 };
 
-// Plugins for reasoning/thinking content — derived from streamdownPlugins but without rehypeRaw,
-// to prevent LLM-hallucinated HTML tags (e.g. <simd>) from being rendered as DOM elements.
-export const reasoningPlugins = {
-  remarkPlugins: streamdownPlugins.remarkPlugins,
-  rehypePlugins: streamdownPlugins.rehypePlugins?.filter(
-    (p) => p !== rehypeRaw,
-  ) as StreamdownProps["rehypePlugins"],
-};
+// Plugins for reasoning/thinking content — same as streamdownPlugins.
+// rehypeRaw was removed from streamdownPlugins to prevent LLM-hallucinated
+// HTML tags (e.g. <simd>) from being rendered as DOM elements.
+export const reasoningPlugins = streamdownPlugins;
 
 // Plugins for human messages - no autolink to prevent URL bleeding into adjacent text
 export const humanMessagePlugins = {

--- a/frontend/tests/unit/core/streamdown/plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown/plugins.test.ts
@@ -1,13 +1,16 @@
-import rehypeRaw from "rehype-raw";
 import { expect, test } from "vitest";
 
 import { reasoningPlugins, streamdownPlugins } from "@/core/streamdown/plugins";
 
-test("streamdownPlugins includes rehypeRaw", () => {
-  expect(streamdownPlugins.rehypePlugins).toContain(rehypeRaw);
+test("streamdownPlugins does not include rehypeRaw", () => {
+  const flat = streamdownPlugins.rehypePlugins?.flat();
+  expect(flat).toBeDefined();
+  // rehypeRaw should not be present — it renders LLM-hallucinated HTML tags
+  for (const entry of flat ?? []) {
+    expect(typeof entry).not.toBe("function" as never);
+  }
 });
 
-test("reasoningPlugins does not include rehypeRaw", () => {
-  const flat = reasoningPlugins.rehypePlugins?.flat();
-  expect(flat).not.toContain(rehypeRaw);
+test("reasoningPlugins is the same as streamdownPlugins", () => {
+  expect(reasoningPlugins).toBe(streamdownPlugins);
 });


### PR DESCRIPTION
## Summary

- Removed `rehypeRaw` from `streamdownPlugins` to prevent LLM-hallucinated HTML tags from being rendered as real DOM elements
- `rehypeRaw` caused React hydration errors when LLM output contained isolated/invalid HTML tags like `<dt>`, `<ee>`, `<simd>`
- Simplified `reasoningPlugins` to directly alias `streamdownPlugins` (no longer needs to filter out rehypeRaw)
- Updated corresponding test to verify rehypeRaw is absent

## Test plan

- [ ] Verify AI messages render correctly without raw HTML interpretation
- [ ] Verify math/KaTeX rendering still works
- [ ] Verify reasoning content renders correctly
- [ ] Run `frontend/tests/unit/core/streamdown/plugins.test.ts`

Fixes #2502

🤖 Generated with [Claude Code](https://claude.com/claude-code)