### PR TITLE
fix(harness): reject blank model strings in CustomSubagentConfig

### DIFF
--- a/backend/packages/harness/deerflow/config/subagents_config.py
+++ b/backend/packages/harness/deerflow/config/subagents_config.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -54,8 +54,16 @@ class CustomSubagentConfig(BaseModel):
     )
     model: str = Field(
         default="inherit",
+        min_length=1,
         description="Model to use - 'inherit' uses parent's model",
     )
+
+    @field_validator("model")
+    @classmethod
+    def _reject_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("model must not be blank")
+        return v
     max_turns: int = Field(
         default=50,
         ge=1,


### PR DESCRIPTION
## Summary

- Added `min_length=1` to `CustomSubagentConfig.model` field
- Added `@field_validator("model")` that rejects whitespace-only strings with a clear error message
- Aligns with `SubagentOverrideConfig.model` which already had `min_length=1`

## Test plan

- [ ] Blank model string (`""`) fails config validation with clear error
- [ ] Whitespace-only model string (`"   "`) fails validation
- [ ] Missing model continues to default to "inherit"
- [ ] Valid model string continues to work

Fixes #2545

🤖 Generated with [Claude Code](https://claude.com/claude-code)