### PR TITLE
fix(sandbox): use 128-bit deterministic IDs to prevent collisions

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -241,8 +241,11 @@ class AioSandboxProvider(SandboxProvider):
 
         Ensures all processes derive the same sandbox_id for a given thread,
         enabling cross-process sandbox discovery without shared memory.
+
+        Uses 128 bits (32 hex chars) of the SHA-256 hash to avoid collisions
+        at scale.
         """
-        return hashlib.sha256(thread_id.encode()).hexdigest()[:8]
+        return hashlib.sha256(thread_id.encode()).hexdigest()[:32]
 
     # ── Mount helpers ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Increased deterministic sandbox ID length from 8 hex chars (32 bits) to 32 hex chars (128 bits) of the SHA-256 hash
- The previous 32-bit namespace made collisions plausible at scale (~65K threads for 50% collision probability by birthday bound)
- 128 bits provides negligible collision risk even at millions of threads

## Test plan

- [ ] Verify generated sandbox IDs are 32 characters long
- [ ] Verify existing sandbox discovery (cross-process) still works with the new ID length
- [ ] Verify container naming still works correctly with longer IDs

Fixes #2539