### PR TITLE
fix(uploads): prevent duplicate filenames from overwriting each other

### DIFF
--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -12,6 +12,7 @@ from deerflow.config.paths import get_paths
 from deerflow.sandbox.sandbox_provider import SandboxProvider, get_sandbox_provider
 from deerflow.uploads.manager import (
     PathTraversalError,
+    claim_unique_filename,
     delete_file_safe,
     enrich_file_listing,
     ensure_uploads_dir,
@@ -106,6 +107,9 @@ async def upload_files(
         sandbox = sandbox_provider.get(sandbox_id)
     auto_convert_documents = _auto_convert_documents_enabled()
 
+    # Track filenames to prevent overwrites from duplicates in the same request.
+    claimed_filenames: set[str] = set()
+
     for file in files:
         if not file.filename:
             continue
@@ -115,6 +119,8 @@ async def upload_files(
         except ValueError:
             logger.warning(f"Skipping file with unsafe filename: {file.filename!r}")
             continue
+
+        safe_filename = claim_unique_filename(safe_filename, claimed_filenames)
 
         try:
             content = await file.read()


### PR DESCRIPTION
## Summary

- Added `claim_unique_filename` usage in the gateway upload endpoint to prevent duplicate filenames from overwriting each other
- The lower-level `upload manager` already had a `claim_unique_filename` helper that appends `_N` suffixes on collision, but the gateway path did not use it
- Duplicate filenames in a single multipart request or collisions with existing files now get unique stored names

## Test plan

- [ ] Upload two files with the same original filename in one request; both should be preserved with unique stored names
- [ ] Upload a file whose sanitized name already exists in the upload directory; it should not overwrite the old file
- [ ] Verify single-file upload behavior is unchanged

Fixes #2538

🤖 Generated with [Claude Code](https://claude.com/claude-code)