### PR TITLE
fix: normalize_input now handles all message types correctly

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from fastapi import HTTPException, Request
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from app.gateway.deps import get_checkpointer, get_run_manager, get_store, get_stream_bridge
 from deerflow.runtime import (
@@ -84,10 +84,25 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
             if isinstance(msg, dict):
                 role = msg.get("role", msg.get("type", "user"))
                 content = msg.get("content", "")
-                if role in ("user", "human"):
+                role_lower = role.lower()
+
+                if role_lower in ("user", "human"):
                     converted.append(HumanMessage(content=content))
+                elif role_lower == "ai" or role_lower == "assistant":
+                    converted.append(AIMessage(content=content))
+                elif role_lower == "system":
+                    converted.append(SystemMessage(content=content))
+                elif role_lower == "tool":
+                    tool_call_id = msg.get("tool_call_id") or msg.get("tool_callId") or ""
+                    name = msg.get("name")
+                    tool_msg_kwargs = {
+                        "content": content,
+                        "tool_call_id": tool_call_id,
+                    }
+                    if name:
+                        tool_msg_kwargs["name"] = name
+                    converted.append(ToolMessage(**tool_msg_kwargs))
                 else:
-                    # TODO: handle other message types (system, ai, tool)
                     converted.append(HumanMessage(content=content))
             else:
                 converted.append(msg)

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -81,6 +81,118 @@ def test_normalize_input_passthrough():
     assert result == {"custom_key": "value"}
 
 
+def test_normalize_input_ai_message():
+    from langchain_core.messages import AIMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({"messages": [{"role": "ai", "content": "I'm an AI"}]})
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], AIMessage)
+    assert result["messages"][0].content == "I'm an AI"
+
+
+def test_normalize_input_assistant_message():
+    from langchain_core.messages import AIMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({"messages": [{"role": "assistant", "content": "I'm an assistant"}]})
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], AIMessage)
+    assert result["messages"][0].content == "I'm an assistant"
+
+
+def test_normalize_input_system_message():
+    from langchain_core.messages import SystemMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({"messages": [{"role": "system", "content": "You are a helpful assistant"}]})
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert result["messages"][0].content == "You are a helpful assistant"
+
+
+def test_normalize_input_tool_message():
+    from langchain_core.messages import ToolMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({
+        "messages": [{
+            "role": "tool",
+            "content": "tool result",
+            "tool_call_id": "call_123",
+            "name": "my_tool"
+        }]
+    })
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].content == "tool result"
+    assert result["messages"][0].tool_call_id == "call_123"
+    assert result["messages"][0].name == "my_tool"
+
+
+def test_normalize_input_tool_message_with_tool_callId():
+    from langchain_core.messages import ToolMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({
+        "messages": [{
+            "role": "tool",
+            "content": "tool result",
+            "tool_callId": "call_456"
+        }]
+    })
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].tool_call_id == "call_456"
+
+
+def test_normalize_input_mixed_messages():
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({
+        "messages": [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "Hello"},
+            {"role": "ai", "content": "Hi there"},
+            {"role": "tool", "content": "result", "tool_call_id": "call_1"},
+        ]
+    })
+    assert len(result["messages"]) == 4
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert isinstance(result["messages"][1], HumanMessage)
+    assert isinstance(result["messages"][2], AIMessage)
+    assert isinstance(result["messages"][3], ToolMessage)
+
+
+def test_normalize_input_role_case_insensitive():
+    from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({
+        "messages": [
+            {"role": "USER", "content": "uppercase user"},
+            {"role": "AI", "content": "uppercase ai"},
+            {"role": "System", "content": "mixed case system"},
+            {"role": "Human", "content": "mixed case human"},
+            {"role": "ASSISTANT", "content": "uppercase assistant"},
+        ]
+    })
+    assert len(result["messages"]) == 5
+    assert isinstance(result["messages"][0], HumanMessage)
+    assert isinstance(result["messages"][1], AIMessage)
+    assert isinstance(result["messages"][2], SystemMessage)
+    assert isinstance(result["messages"][3], HumanMessage)
+    assert isinstance(result["messages"][4], AIMessage)
+
+
 def test_build_run_config_basic():
     from app.gateway.services import build_run_config
 


### PR DESCRIPTION
## Summary

This PR fixes the `normalize_input` function in `app/gateway/services.py` to properly handle all message types (AI, System, Tool messages) instead of treating everything as a HumanMessage.

## Changes Made

1. **Updated imports** in `services.py`:
   - Added `AIMessage`, `SystemMessage`, `ToolMessage` to the imports from `langchain_core.messages`

2. **Enhanced `normalize_input` function**:
   - Added support for `AIMessage` when role is "ai" or "assistant"
   - Added support for `SystemMessage` when role is "system"
   - Added support for `ToolMessage` when role is "tool", including:
     - `tool_call_id` (supports both `tool_call_id` and `tool_callId` keys)
     - `name` field (optional)
   - Made role comparison case-insensitive using `role.lower()`

3. **Added comprehensive test coverage** in `tests/test_gateway_services.py`:
   - `test_normalize_input_ai_message`: Tests AI message conversion
   - `test_normalize_input_assistant_message`: Tests assistant role (alias for ai)
   - `test_normalize_input_system_message`: Tests system message conversion
   - `test_normalize_input_tool_message`: Tests tool message with all fields
   - `test_normalize_input_tool_message_with_tool_callId`: Tests camelCase tool_callId key
   - `test_normalize_input_mixed_messages`: Tests mixed message types in one input
   - `test_normalize_input_role_case_insensitive`: Tests case-insensitive role handling

## Background

The original `normalize_input` function had a TODO comment indicating that other message types (system, ai, tool) were not properly handled. This PR addresses that limitation, which is important for:
- Proper handling of conversation history with AI responses
- Correct processing of system prompts
- Proper tool call result handling

This fix ensures compatibility with LangGraph Platform's message format when the input includes different message types.
