### PR TITLE
Make loop detection configurable

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -313,6 +313,10 @@ def _build_middlewares(
                 max_tracked_threads=loop_detection_config.max_tracked_threads,
                 tool_freq_warn=loop_detection_config.tool_freq_warn,
                 tool_freq_hard_limit=loop_detection_config.tool_freq_hard_limit,
+                tool_freq_overrides={
+                    name: (o.warn, o.hard_limit)
+                    for name, o in loop_detection_config.tool_freq_overrides.items()
+                },
             )
         )
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -303,7 +303,7 @@ def _build_middlewares(
         middlewares.append(SubagentLimitMiddleware(max_concurrent=max_concurrent_subagents))
 
     # LoopDetectionMiddleware — detect and break repetitive tool call loops
-    loop_detection_config = app_config.loop_detection
+    loop_detection_config = resolved_app_config.loop_detection
     if loop_detection_config.enabled:
         middlewares.append(
             LoopDetectionMiddleware(

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -303,7 +303,18 @@ def _build_middlewares(
         middlewares.append(SubagentLimitMiddleware(max_concurrent=max_concurrent_subagents))
 
     # LoopDetectionMiddleware — detect and break repetitive tool call loops
-    middlewares.append(LoopDetectionMiddleware())
+    loop_detection_config = app_config.loop_detection
+    if loop_detection_config.enabled:
+        middlewares.append(
+            LoopDetectionMiddleware(
+                warn_threshold=loop_detection_config.warn_threshold,
+                hard_limit=loop_detection_config.hard_limit,
+                window_size=loop_detection_config.window_size,
+                max_tracked_threads=loop_detection_config.max_tracked_threads,
+                tool_freq_warn=loop_detection_config.tool_freq_warn,
+                tool_freq_hard_limit=loop_detection_config.tool_freq_hard_limit,
+            )
+        )
 
     # Inject custom middlewares before ClarificationMiddleware
     if custom_middlewares:

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -313,10 +313,7 @@ def _build_middlewares(
                 max_tracked_threads=loop_detection_config.max_tracked_threads,
                 tool_freq_warn=loop_detection_config.tool_freq_warn,
                 tool_freq_hard_limit=loop_detection_config.tool_freq_hard_limit,
-                tool_freq_overrides={
-                    name: (o.warn, o.hard_limit)
-                    for name, o in loop_detection_config.tool_freq_overrides.items()
-                },
+                tool_freq_overrides={name: (o.warn, o.hard_limit) for name, o in loop_detection_config.tool_freq_overrides.items()},
             )
         )
 

--- a/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
@@ -165,6 +165,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         max_tracked_threads: int = _DEFAULT_MAX_TRACKED_THREADS,
         tool_freq_warn: int = _DEFAULT_TOOL_FREQ_WARN,
         tool_freq_hard_limit: int = _DEFAULT_TOOL_FREQ_HARD_LIMIT,
+        tool_freq_overrides: dict[str, tuple[int, int]] | None = None,
     ):
         super().__init__()
         self.warn_threshold = warn_threshold
@@ -173,6 +174,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         self.max_tracked_threads = max_tracked_threads
         self.tool_freq_warn = tool_freq_warn
         self.tool_freq_hard_limit = tool_freq_hard_limit
+        self._tool_freq_overrides: dict[str, tuple[int, int]] = tool_freq_overrides or {}
         self._lock = threading.Lock()
         # Per-thread tracking using OrderedDict for LRU eviction
         self._history: OrderedDict[str, list[str]] = OrderedDict()
@@ -280,7 +282,12 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
                 freq[name] += 1
                 tc_count = freq[name]
 
-                if tc_count >= self.tool_freq_hard_limit:
+                if name in self._tool_freq_overrides:
+                    eff_warn, eff_hard = self._tool_freq_overrides[name]
+                else:
+                    eff_warn, eff_hard = self.tool_freq_warn, self.tool_freq_hard_limit
+
+                if tc_count >= eff_hard:
                     logger.error(
                         "Tool frequency hard limit reached — forcing stop",
                         extra={
@@ -291,7 +298,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
                     )
                     return _TOOL_FREQ_HARD_STOP_MSG.format(tool_name=name, count=tc_count), True
 
-                if tc_count >= self.tool_freq_warn:
+                if tc_count >= eff_warn:
                     warned = self._tool_freq_warned[thread_id]
                     if name not in warned:
                         warned.add(name)

--- a/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
@@ -155,6 +155,14 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             Default: 30.
         tool_freq_hard_limit: Number of calls to the same tool type before
             forcing a stop. Default: 50.
+        tool_freq_overrides: Per-tool overrides for frequency thresholds,
+            keyed by tool name. Each value is a ``(warn, hard_limit)`` tuple
+            that replaces ``tool_freq_warn`` / ``tool_freq_hard_limit`` for
+            that specific tool. Tools not listed here fall back to the global
+            thresholds. Useful for raising limits on intentionally
+            high-frequency tools (e.g. ``bash`` in batch pipelines) without
+            weakening protection on all other tools. Default: ``None``
+            (no overrides).
     """
 
     def __init__(

--- a/backend/packages/harness/deerflow/config/__init__.py
+++ b/backend/packages/harness/deerflow/config/__init__.py
@@ -1,5 +1,6 @@
 from .app_config import get_app_config
 from .extensions_config import ExtensionsConfig, get_extensions_config
+from .loop_detection_config import LoopDetectionConfig
 from .memory_config import MemoryConfig, get_memory_config
 from .paths import Paths, get_paths
 from .skill_evolution_config import SkillEvolutionConfig
@@ -20,6 +21,7 @@ __all__ = [
     "SkillsConfig",
     "ExtensionsConfig",
     "get_extensions_config",
+    "LoopDetectionConfig",
     "MemoryConfig",
     "get_memory_config",
     "get_tracing_config",

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -14,6 +14,7 @@ from deerflow.config.checkpointer_config import CheckpointerConfig, load_checkpo
 from deerflow.config.database_config import DatabaseConfig
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_config_from_dict
+from deerflow.config.loop_detection_config import LoopDetectionConfig
 from deerflow.config.memory_config import MemoryConfig, load_memory_config_from_dict
 from deerflow.config.model_config import ModelConfig
 from deerflow.config.run_events_config import RunEventsConfig
@@ -97,6 +98,7 @@ class AppConfig(BaseModel):
     subagents: SubagentsAppConfig = Field(default_factory=SubagentsAppConfig, description="Subagent runtime configuration")
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig, description="Guardrail middleware configuration")
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig, description="LLM circuit breaker configuration")
+    loop_detection: LoopDetectionConfig = Field(default_factory=LoopDetectionConfig, description="Loop detection middleware configuration")
     model_config = ConfigDict(extra="allow")
     database: DatabaseConfig = Field(default_factory=DatabaseConfig, description="Unified database backend configuration")
     run_events: RunEventsConfig = Field(default_factory=RunEventsConfig, description="Run event storage configuration")

--- a/backend/packages/harness/deerflow/config/loop_detection_config.py
+++ b/backend/packages/harness/deerflow/config/loop_detection_config.py
@@ -3,6 +3,24 @@
 from pydantic import BaseModel, Field, model_validator
 
 
+class ToolFreqOverride(BaseModel):
+    """Per-tool frequency threshold override.
+
+    Can be higher or lower than the global defaults. Commonly used to raise
+    thresholds for high-frequency tools like bash in batch workflows (e.g.
+    RNA-seq pipelines) without weakening protection on every other tool.
+    """
+
+    warn: int = Field(ge=1)
+    hard_limit: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def _validate(self) -> "ToolFreqOverride":
+        if self.hard_limit < self.warn:
+            raise ValueError("hard_limit must be >= warn")
+        return self
+
+
 class LoopDetectionConfig(BaseModel):
     """Configuration for repetitive tool-call loop detection."""
 
@@ -39,6 +57,14 @@ class LoopDetectionConfig(BaseModel):
         default=50,
         ge=1,
         description="Number of calls to the same tool type before forcing a stop",
+    )
+    tool_freq_overrides: dict[str, ToolFreqOverride] = Field(
+        default_factory=dict,
+        description=(
+            "Per-tool overrides for tool_freq_warn / tool_freq_hard_limit, keyed by tool name. "
+            "Values can be higher or lower than the global defaults. "
+            "Commonly used to raise thresholds for high-frequency tools like bash."
+        ),
     )
 
     @model_validator(mode="after")

--- a/backend/packages/harness/deerflow/config/loop_detection_config.py
+++ b/backend/packages/harness/deerflow/config/loop_detection_config.py
@@ -1,0 +1,51 @@
+"""Configuration for loop detection middleware."""
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class LoopDetectionConfig(BaseModel):
+    """Configuration for repetitive tool-call loop detection."""
+
+    enabled: bool = Field(
+        default=True,
+        description="Whether to enable repetitive tool-call loop detection",
+    )
+    warn_threshold: int = Field(
+        default=3,
+        ge=1,
+        description="Number of identical tool-call sets before injecting a warning",
+    )
+    hard_limit: int = Field(
+        default=5,
+        ge=1,
+        description="Number of identical tool-call sets before forcing a stop",
+    )
+    window_size: int = Field(
+        default=20,
+        ge=1,
+        description="Number of recent tool-call sets to track per thread",
+    )
+    max_tracked_threads: int = Field(
+        default=100,
+        ge=1,
+        description="Maximum number of thread histories to keep in memory",
+    )
+    tool_freq_warn: int = Field(
+        default=30,
+        ge=1,
+        description="Number of calls to the same tool type before injecting a frequency warning",
+    )
+    tool_freq_hard_limit: int = Field(
+        default=50,
+        ge=1,
+        description="Number of calls to the same tool type before forcing a stop",
+    )
+
+    @model_validator(mode="after")
+    def validate_thresholds(self) -> "LoopDetectionConfig":
+        """Ensure hard stop cannot happen before the warning threshold."""
+        if self.hard_limit < self.warn_threshold:
+            raise ValueError("hard_limit must be greater than or equal to warn_threshold")
+        if self.tool_freq_hard_limit < self.tool_freq_warn:
+            raise ValueError("tool_freq_hard_limit must be greater than or equal to tool_freq_warn")
+        return self

--- a/backend/packages/harness/deerflow/config/loop_detection_config.py
+++ b/backend/packages/harness/deerflow/config/loop_detection_config.py
@@ -60,11 +60,7 @@ class LoopDetectionConfig(BaseModel):
     )
     tool_freq_overrides: dict[str, ToolFreqOverride] = Field(
         default_factory=dict,
-        description=(
-            "Per-tool overrides for tool_freq_warn / tool_freq_hard_limit, keyed by tool name. "
-            "Values can be higher or lower than the global defaults. "
-            "Commonly used to raise thresholds for high-frequency tools like bash."
-        ),
+        description=("Per-tool overrides for tool_freq_warn / tool_freq_hard_limit, keyed by tool name. Values can be higher or lower than the global defaults. Commonly used to raise thresholds for high-frequency tools like bash."),
     )
 
     @model_validator(mode="after")

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -8,17 +8,20 @@ from unittest.mock import MagicMock
 import pytest
 
 from deerflow.agents.lead_agent import agent as lead_agent_module
+from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
 from deerflow.config.app_config import AppConfig
+from deerflow.config.loop_detection_config import LoopDetectionConfig
 from deerflow.config.memory_config import MemoryConfig
 from deerflow.config.model_config import ModelConfig
 from deerflow.config.sandbox_config import SandboxConfig
 from deerflow.config.summarization_config import SummarizationConfig
 
 
-def _make_app_config(models: list[ModelConfig]) -> AppConfig:
+def _make_app_config(models: list[ModelConfig], loop_detection: LoopDetectionConfig | None = None) -> AppConfig:
     return AppConfig(
         models=models,
         sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"),
+        loop_detection=loop_detection or LoopDetectionConfig(),
     )
 
 
@@ -288,6 +291,59 @@ def test_build_middlewares_passes_explicit_app_config_to_shared_factory(monkeypa
         "lazy_init": True,
     }
     assert middlewares[0] == "base-middleware"
+
+
+def test_build_middlewares_uses_loop_detection_config(monkeypatch):
+    app_config = _make_app_config(
+        [_make_model("safe-model", supports_thinking=False)],
+        loop_detection=LoopDetectionConfig(
+            warn_threshold=7,
+            hard_limit=9,
+            window_size=30,
+            max_tracked_threads=40,
+            tool_freq_warn=50,
+            tool_freq_hard_limit=60,
+        ),
+    )
+
+    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: app_config)
+    monkeypatch.setattr(lead_agent_module, "build_lead_runtime_middlewares", lambda *, app_config, lazy_init=True: [])
+    monkeypatch.setattr(lead_agent_module, "_create_summarization_middleware", lambda *, app_config=None: None)
+    monkeypatch.setattr(lead_agent_module, "_create_todo_list_middleware", lambda is_plan_mode: None)
+
+    middlewares = lead_agent_module._build_middlewares(
+        {"configurable": {"is_plan_mode": False, "subagent_enabled": False}},
+        model_name="safe-model",
+        app_config=app_config,
+    )
+
+    loop_detection = next(m for m in middlewares if isinstance(m, LoopDetectionMiddleware))
+    assert loop_detection.warn_threshold == 7
+    assert loop_detection.hard_limit == 9
+    assert loop_detection.window_size == 30
+    assert loop_detection.max_tracked_threads == 40
+    assert loop_detection.tool_freq_warn == 50
+    assert loop_detection.tool_freq_hard_limit == 60
+
+
+def test_build_middlewares_omits_loop_detection_when_disabled(monkeypatch):
+    app_config = _make_app_config(
+        [_make_model("safe-model", supports_thinking=False)],
+        loop_detection=LoopDetectionConfig(enabled=False),
+    )
+
+    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: app_config)
+    monkeypatch.setattr(lead_agent_module, "build_lead_runtime_middlewares", lambda *, app_config, lazy_init=True: [])
+    monkeypatch.setattr(lead_agent_module, "_create_summarization_middleware", lambda *, app_config=None: None)
+    monkeypatch.setattr(lead_agent_module, "_create_todo_list_middleware", lambda is_plan_mode: None)
+
+    middlewares = lead_agent_module._build_middlewares(
+        {"configurable": {"is_plan_mode": False, "subagent_enabled": False}},
+        model_name="safe-model",
+        app_config=app_config,
+    )
+
+    assert not any(isinstance(m, LoopDetectionMiddleware) for m in middlewares)
 
 
 def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch):

--- a/backend/tests/test_loop_detection_config.py
+++ b/backend/tests/test_loop_detection_config.py
@@ -58,21 +58,15 @@ class TestLoopDetectionConfig:
             LoopDetectionConfig(tool_freq_warn=5, tool_freq_hard_limit=4)
 
     def test_tool_freq_override_valid(self):
-        config = LoopDetectionConfig(
-            tool_freq_overrides={"bash": {"warn": 150, "hard_limit": 300}}
-        )
+        config = LoopDetectionConfig(tool_freq_overrides={"bash": {"warn": 150, "hard_limit": 300}})
         override = config.tool_freq_overrides["bash"]
         assert override.warn == 150
         assert override.hard_limit == 300
 
     def test_tool_freq_override_rejects_zero_warn(self):
         with pytest.raises(ValueError):
-            LoopDetectionConfig(
-                tool_freq_overrides={"bash": {"warn": 0, "hard_limit": 10}}
-            )
+            LoopDetectionConfig(tool_freq_overrides={"bash": {"warn": 0, "hard_limit": 10}})
 
     def test_tool_freq_override_rejects_hard_limit_below_warn(self):
         with pytest.raises(ValueError, match="hard_limit"):
-            LoopDetectionConfig(
-                tool_freq_overrides={"bash": {"warn": 100, "hard_limit": 50}}
-            )
+            LoopDetectionConfig(tool_freq_overrides={"bash": {"warn": 100, "hard_limit": 50}})

--- a/backend/tests/test_loop_detection_config.py
+++ b/backend/tests/test_loop_detection_config.py
@@ -56,3 +56,23 @@ class TestLoopDetectionConfig:
     def test_rejects_tool_freq_hard_limit_below_warn_threshold(self):
         with pytest.raises(ValueError, match="tool_freq_hard_limit"):
             LoopDetectionConfig(tool_freq_warn=5, tool_freq_hard_limit=4)
+
+    def test_tool_freq_override_valid(self):
+        config = LoopDetectionConfig(
+            tool_freq_overrides={"bash": {"warn": 150, "hard_limit": 300}}
+        )
+        override = config.tool_freq_overrides["bash"]
+        assert override.warn == 150
+        assert override.hard_limit == 300
+
+    def test_tool_freq_override_rejects_zero_warn(self):
+        with pytest.raises(ValueError):
+            LoopDetectionConfig(
+                tool_freq_overrides={"bash": {"warn": 0, "hard_limit": 10}}
+            )
+
+    def test_tool_freq_override_rejects_hard_limit_below_warn(self):
+        with pytest.raises(ValueError, match="hard_limit"):
+            LoopDetectionConfig(
+                tool_freq_overrides={"bash": {"warn": 100, "hard_limit": 50}}
+            )

--- a/backend/tests/test_loop_detection_config.py
+++ b/backend/tests/test_loop_detection_config.py
@@ -1,0 +1,58 @@
+"""Tests for loop detection configuration."""
+
+import pytest
+
+from deerflow.config.loop_detection_config import LoopDetectionConfig
+
+
+class TestLoopDetectionConfig:
+    def test_defaults_match_middleware_defaults(self):
+        config = LoopDetectionConfig()
+
+        assert config.enabled is True
+        assert config.warn_threshold == 3
+        assert config.hard_limit == 5
+        assert config.window_size == 20
+        assert config.max_tracked_threads == 100
+        assert config.tool_freq_warn == 30
+        assert config.tool_freq_hard_limit == 50
+
+    def test_accepts_custom_values(self):
+        config = LoopDetectionConfig(
+            enabled=False,
+            warn_threshold=10,
+            hard_limit=20,
+            window_size=50,
+            max_tracked_threads=200,
+            tool_freq_warn=60,
+            tool_freq_hard_limit=80,
+        )
+
+        assert config.enabled is False
+        assert config.warn_threshold == 10
+        assert config.hard_limit == 20
+        assert config.window_size == 50
+        assert config.max_tracked_threads == 200
+        assert config.tool_freq_warn == 60
+        assert config.tool_freq_hard_limit == 80
+
+    def test_rejects_zero_thresholds(self):
+        with pytest.raises(ValueError):
+            LoopDetectionConfig(warn_threshold=0)
+
+        with pytest.raises(ValueError):
+            LoopDetectionConfig(hard_limit=0)
+
+        with pytest.raises(ValueError):
+            LoopDetectionConfig(tool_freq_warn=0)
+
+        with pytest.raises(ValueError):
+            LoopDetectionConfig(tool_freq_hard_limit=0)
+
+    def test_rejects_hard_limit_below_warn_threshold(self):
+        with pytest.raises(ValueError, match="hard_limit"):
+            LoopDetectionConfig(warn_threshold=5, hard_limit=4)
+
+    def test_rejects_tool_freq_hard_limit_below_warn_threshold(self):
+        with pytest.raises(ValueError, match="tool_freq_hard_limit"):
+            LoopDetectionConfig(tool_freq_warn=5, tool_freq_hard_limit=4)

--- a/backend/tests/test_loop_detection_middleware.py
+++ b/backend/tests/test_loop_detection_middleware.py
@@ -616,6 +616,37 @@ class TestToolFrequencyDetection:
         assert result is not None
         assert "read_file" in result["messages"][0].content
 
+    def test_override_tool_uses_override_thresholds(self):
+        """A tool in tool_freq_overrides uses its own thresholds, not the global ones."""
+        mw = LoopDetectionMiddleware(
+            tool_freq_warn=5,
+            tool_freq_hard_limit=10,
+            tool_freq_overrides={"bash": (50, 100)},
+        )
+        runtime = _make_runtime()
+
+        # 10 bash calls — would hit global hard_limit=10, but bash override is 100
+        for i in range(10):
+            result = mw._apply(_make_state(tool_calls=[_bash_call(f"cmd_{i}")]), runtime)
+            assert result is None, f"unexpected trigger on call {i + 1}"
+
+    def test_non_override_tool_falls_back_to_global(self):
+        """A tool NOT in tool_freq_overrides uses the global warn/hard_limit."""
+        mw = LoopDetectionMiddleware(
+            tool_freq_warn=3,
+            tool_freq_hard_limit=6,
+            tool_freq_overrides={"bash": (50, 100)},
+        )
+        runtime = _make_runtime()
+
+        for i in range(2):
+            mw._apply(_make_state(tool_calls=[self._read_call(f"/file_{i}.py")]), runtime)
+
+        # 3rd read_file call hits global warn=3 (read_file has no override)
+        result = mw._apply(_make_state(tool_calls=[self._read_call("/file_2.py")]), runtime)
+        assert result is not None
+        assert "read_file" in result["messages"][0].content
+
     def test_hash_detection_takes_priority(self):
         """Hash-based hard stop fires before frequency check for identical calls."""
         mw = LoopDetectionMiddleware(

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,7 +12,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 8
+config_version: 9
 
 # ============================================================================
 # Logging
@@ -492,6 +492,21 @@ tools:
 
 tool_search:
   enabled: false
+
+# ============================================================================
+# Loop Detection Configuration
+# ============================================================================
+# Detect and interrupt repeated identical tool-call loops.
+# Frequency thresholds are safety limits for repeated use of the same tool type.
+
+loop_detection:
+  enabled: true
+  warn_threshold: 3
+  hard_limit: 5
+  window_size: 20
+  max_tracked_threads: 100
+  tool_freq_warn: 30
+  tool_freq_hard_limit: 50
 
 # ============================================================================
 # Sandbox Configuration

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -507,6 +507,14 @@ loop_detection:
   max_tracked_threads: 100
   tool_freq_warn: 30
   tool_freq_hard_limit: 50
+  # Per-tool overrides for tool_freq_warn / tool_freq_hard_limit. Values can be
+  # higher or lower than the global defaults. Commonly used to raise thresholds
+  # for high-frequency tools like bash in batch workflows (e.g. RNA-seq pipelines)
+  # without weakening protection on every other tool.
+  # tool_freq_overrides:
+  #   bash:
+  #     warn: 150
+  #     hard_limit: 300
 
 # ============================================================================
 # Sandbox Configuration


### PR DESCRIPTION
## Summary

Expose `LoopDetectionMiddleware` thresholds through `config.yaml` while preserving the current defaults.

This adds configurable values for:

- `enabled`
- `warn_threshold`
- `hard_limit`
- `window_size`
- `max_tracked_threads`
- `tool_freq_warn`
- `tool_freq_hard_limit`

It also allows disabling the middleware when users need an immediate workaround for false positives.

Refs bytedance/deer-flow#2517

## Validation

- `uv run ruff check packages/harness/deerflow/config/loop_detection_config.py packages/harness/deerflow/agents/lead_agent/agent.py tests/test_loop_detection_config.py tests/test_lead_agent_model_resolution.py`
- `uv run pytest tests/test_loop_detection_config.py tests/test_loop_detection_middleware.py tests/test_lead_agent_model_resolution.py`
- `DEER_FLOW_CONFIG_PATH=/tmp/deer-flow-unit-config.yaml uv run pytest --ignore=tests/test_client_live.py`

Result: `2134 passed, 17 skipped, 4 warnings`
