### PR TITLE
fix(loop-detection): detect alternating tool-name cycles

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
@@ -34,6 +34,10 @@ _DEFAULT_WINDOW_SIZE = 20  # track last N tool calls
 _DEFAULT_MAX_TRACKED_THREADS = 100  # LRU eviction limit
 _DEFAULT_TOOL_FREQ_WARN = 30  # warn after 30 calls to the same tool type
 _DEFAULT_TOOL_FREQ_HARD_LIMIT = 50  # force-stop after 50 calls to the same tool type
+_DEFAULT_CYCLE_MIN_LEN = 2
+_DEFAULT_CYCLE_MAX_LEN = 4
+_DEFAULT_CYCLE_REPEATS_WARN = 3  # warn when a cycle repeats 3 times
+_DEFAULT_CYCLE_REPEATS_HARD = 4  # hard-stop at 4 repeats
 
 
 def _normalize_tool_call_args(raw_args: object) -> tuple[dict, str | None]:
@@ -155,6 +159,12 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             Default: 30.
         tool_freq_hard_limit: Number of calls to the same tool type before
             forcing a stop. Default: 50.
+        cycle_min_len: Minimum tool-name cycle length to detect. Default: 2.
+        cycle_max_len: Maximum tool-name cycle length to detect. Default: 4.
+        cycle_repeats_warn: Number of repeated cycles before injecting a
+            warning. Default: 3.
+        cycle_repeats_hard: Number of repeated cycles before forcing a stop.
+            Default: 4.
     """
 
     def __init__(
@@ -165,6 +175,10 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         max_tracked_threads: int = _DEFAULT_MAX_TRACKED_THREADS,
         tool_freq_warn: int = _DEFAULT_TOOL_FREQ_WARN,
         tool_freq_hard_limit: int = _DEFAULT_TOOL_FREQ_HARD_LIMIT,
+        cycle_min_len: int = _DEFAULT_CYCLE_MIN_LEN,
+        cycle_max_len: int = _DEFAULT_CYCLE_MAX_LEN,
+        cycle_repeats_warn: int = _DEFAULT_CYCLE_REPEATS_WARN,
+        cycle_repeats_hard: int = _DEFAULT_CYCLE_REPEATS_HARD,
     ):
         super().__init__()
         self.warn_threshold = warn_threshold
@@ -173,13 +187,19 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         self.max_tracked_threads = max_tracked_threads
         self.tool_freq_warn = tool_freq_warn
         self.tool_freq_hard_limit = tool_freq_hard_limit
+        self.cycle_min_len = cycle_min_len
+        self.cycle_max_len = cycle_max_len
+        self.cycle_repeats_warn = cycle_repeats_warn
+        self.cycle_repeats_hard = cycle_repeats_hard
         self._lock = threading.Lock()
         # Per-thread tracking using OrderedDict for LRU eviction
         self._history: OrderedDict[str, list[str]] = OrderedDict()
+        self._name_history: OrderedDict[str, list[str]] = OrderedDict()
         self._warned: dict[str, set[str]] = defaultdict(set)
         # Per-thread, per-tool-type cumulative call counts
         self._tool_freq: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
         self._tool_freq_warned: dict[str, set[str]] = defaultdict(set)
+        self._cycle_warned: dict[str, set[str]] = defaultdict(set)
 
     def _get_thread_id(self, runtime: Runtime) -> str:
         """Extract thread_id from runtime context for per-thread tracking."""
@@ -195,19 +215,49 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         """
         while len(self._history) > self.max_tracked_threads:
             evicted_id, _ = self._history.popitem(last=False)
+            self._name_history.pop(evicted_id, None)
             self._warned.pop(evicted_id, None)
             self._tool_freq.pop(evicted_id, None)
             self._tool_freq_warned.pop(evicted_id, None)
+            self._cycle_warned.pop(evicted_id, None)
             logger.debug("Evicted loop tracking for thread %s (LRU)", evicted_id)
+
+    @staticmethod
+    def _detect_cycle(names: list[str], min_len: int, max_len: int, min_repeats: int) -> str | None:
+        """Return the tail cycle pattern if tool names repeat in a short alternating cycle."""
+        if not names:
+            return None
+
+        for cycle_len in range(min_len, max_len + 1):
+            need = cycle_len * min_repeats
+            if len(names) < need:
+                continue
+
+            tail = names[-need:]
+            cycle = tail[:cycle_len]
+            if len(set(cycle)) < 2:
+                continue
+
+            ok = True
+            for i in range(0, need, cycle_len):
+                if tail[i : i + cycle_len] != cycle:
+                    ok = False
+                    break
+            if ok:
+                return "→".join(cycle)
+
+        return None
 
     def _track_and_check(self, state: AgentState, runtime: Runtime) -> tuple[str | None, bool]:
         """Track tool calls and check for loops.
 
-        Two detection layers:
+        Three detection layers:
           1. **Hash-based** (existing): catches identical tool call sets.
-          2. **Frequency-based** (new): catches the same *tool type* being
+          2. **Frequency-based**: catches the same *tool type* being
              called many times with varying arguments (e.g. ``read_file``
              on 40 different files).
+          3. **Cycle-based**: catches alternating short tool-name patterns
+             whose arguments differ on each call.
 
         Returns:
             (warning_message_or_none, should_hard_stop)
@@ -231,8 +281,10 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             # Touch / create entry (move to end for LRU)
             if thread_id in self._history:
                 self._history.move_to_end(thread_id)
+                self._name_history.move_to_end(thread_id)
             else:
                 self._history[thread_id] = []
+                self._name_history[thread_id] = []
                 self._evict_if_needed()
 
             history = self._history[thread_id]
@@ -304,6 +356,53 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
                             },
                         )
                         return _TOOL_FREQ_WARNING_MSG.format(tool_name=name, count=tc_count), False
+
+            # --- Layer 3: short alternating tool-name cycles ---
+            name_history = self._name_history[thread_id]
+            name_history.extend(name for name in tool_names if name)
+            max_cycle_window = max(
+                self.window_size * 4,
+                self.cycle_max_len * self.cycle_repeats_hard * 2,
+            )
+            if len(name_history) > max_cycle_window:
+                name_history[:] = name_history[-max_cycle_window:]
+
+            cycle = self._detect_cycle(
+                name_history,
+                self.cycle_min_len,
+                self.cycle_max_len,
+                self.cycle_repeats_hard,
+            )
+            if cycle:
+                logger.error(
+                    "Tool-name cycle hard limit reached — forcing stop",
+                    extra={
+                        "thread_id": thread_id,
+                        "cycle": cycle,
+                        "tools": tool_names,
+                    },
+                )
+                return _HARD_STOP_MSG, True
+
+            cycle = self._detect_cycle(
+                name_history,
+                self.cycle_min_len,
+                self.cycle_max_len,
+                self.cycle_repeats_warn,
+            )
+            if cycle:
+                warned = self._cycle_warned[thread_id]
+                if cycle not in warned:
+                    warned.add(cycle)
+                    logger.warning(
+                        "Tool-name cycle detected — injecting warning",
+                        extra={
+                            "thread_id": thread_id,
+                            "cycle": cycle,
+                            "tools": tool_names,
+                        },
+                    )
+                    return _WARNING_MSG, False
 
         return None, False
 
@@ -379,11 +478,15 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         with self._lock:
             if thread_id:
                 self._history.pop(thread_id, None)
+                self._name_history.pop(thread_id, None)
                 self._warned.pop(thread_id, None)
                 self._tool_freq.pop(thread_id, None)
                 self._tool_freq_warned.pop(thread_id, None)
+                self._cycle_warned.pop(thread_id, None)
             else:
                 self._history.clear()
+                self._name_history.clear()
                 self._warned.clear()
                 self._tool_freq.clear()
                 self._tool_freq_warned.clear()
+                self._cycle_warned.clear()

--- a/backend/tests/test_loop_detection_middleware.py
+++ b/backend/tests/test_loop_detection_middleware.py
@@ -34,6 +34,12 @@ def _bash_call(cmd="ls"):
     return {"name": "bash", "id": f"call_{cmd}", "args": {"command": cmd}}
 
 
+def _named_call(name, value):
+    if name == "read_file":
+        return {"name": name, "id": f"call_{name}_{value}", "args": {"path": f"/tmp/{value}.py"}}
+    return {"name": name, "id": f"call_{name}_{value}", "args": {"value": value}}
+
+
 class TestHashToolCalls:
     def test_same_calls_same_hash(self):
         a = _hash_tool_calls([_bash_call("ls")])
@@ -280,9 +286,12 @@ class TestLoopDetection:
         mw._apply(_make_state(tool_calls=call), runtime_new)
 
         assert "thread-0" not in mw._history
+        assert "thread-0" not in mw._name_history
         assert "thread-0" not in mw._tool_freq
         assert "thread-0" not in mw._tool_freq_warned
+        assert "thread-0" not in mw._cycle_warned
         assert "thread-new" in mw._history
+        assert "thread-new" in mw._name_history
         assert len(mw._history) == 3
 
     def test_thread_safe_mutations(self):
@@ -301,6 +310,100 @@ class TestLoopDetection:
 
         mw._apply(_make_state(tool_calls=call), runtime)
         assert "default" in mw._history
+
+
+class TestCycleDetection:
+    """Tests for alternating tool-name cycle detection (Layer 3)."""
+
+    def test_detect_cycle_static_helper(self):
+        assert LoopDetectionMiddleware._detect_cycle([], 2, 4, 3) is None
+        assert LoopDetectionMiddleware._detect_cycle(["a", "b", "a", "b"], 2, 4, 3) is None
+        assert LoopDetectionMiddleware._detect_cycle(["a", "b", "a", "b", "a", "b"], 2, 4, 3) == "a→b"
+        assert LoopDetectionMiddleware._detect_cycle(["a", "b", "a", "c", "a", "b"], 2, 4, 3) is None
+
+    def test_alternating_two_tools_warns_after_3_cycles(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        sequence = ["web_search", "web_fetch"] * 3
+
+        for i, name in enumerate(sequence[:-1]):
+            result = mw._apply(_make_state(tool_calls=[_named_call(name, i)]), runtime)
+            assert result is None
+
+        result = mw._apply(_make_state(tool_calls=[_named_call(sequence[-1], len(sequence))]), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, HumanMessage)
+        assert "LOOP DETECTED" in msg.content
+
+    def test_alternating_two_tools_hard_stops_after_4_cycles(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        sequence = ["web_search", "web_fetch"] * 4
+
+        for i, name in enumerate(sequence[:-1]):
+            mw._apply(_make_state(tool_calls=[_named_call(name, i)]), runtime)
+
+        result = mw._apply(_make_state(tool_calls=[_named_call(sequence[-1], len(sequence))]), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, AIMessage)
+        assert msg.tool_calls == []
+        assert _HARD_STOP_MSG in msg.content
+
+    def test_three_tool_cycle_detected(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        sequence = ["a", "b", "c"] * 4
+
+        for i, name in enumerate(sequence[:-1]):
+            mw._apply(_make_state(tool_calls=[_named_call(name, i)]), runtime)
+
+        result = mw._apply(_make_state(tool_calls=[_named_call(sequence[-1], len(sequence))]), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, AIMessage)
+        assert msg.tool_calls == []
+        assert _HARD_STOP_MSG in msg.content
+
+    def test_mixed_pattern_does_not_trigger(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        sequence = ["a", "b", "a", "c", "a", "b"]
+
+        for i, name in enumerate(sequence):
+            result = mw._apply(_make_state(tool_calls=[_named_call(name, i)]), runtime)
+            assert result is None
+
+    def test_existing_hash_detection_still_works(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        call = [_bash_call("ls")]
+
+        for _ in range(4):
+            mw._apply(_make_state(tool_calls=call), runtime)
+
+        result = mw._apply(_make_state(tool_calls=call), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, AIMessage)
+        assert msg.tool_calls == []
+        assert _HARD_STOP_MSG in msg.content
+
+    def test_per_tool_freq_detection_still_works(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+
+        for i in range(29):
+            result = mw._apply(_make_state(tool_calls=[_named_call("read_file", i)]), runtime)
+            assert result is None
+
+        result = mw._apply(_make_state(tool_calls=[_named_call("read_file", 29)]), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, HumanMessage)
+        assert "read_file" in msg.content
+        assert "LOOP DETECTED" in msg.content
 
 
 class TestAppendText:


### PR DESCRIPTION
## Summary

Adds a third detection layer to `LoopDetectionMiddleware` that catches short alternating tool-name patterns. The two existing layers miss `web_search → web_fetch → web_search → web_fetch → ...` loops because:

- **Layer 1 (hash)** compares full tool-call sets, so two calls with different args (different search terms / URLs) hash differently and never match.
- **Layer 2 (per-tool frequency)** only triggers when one tool name passes the threshold; alternation splits the count across two names so neither hits the limit fast enough.

Reported in #2569 with a trace showing 200+ alternating calls before the existing safeguards stopped the run.

## Why this matters

Cited evidence:

- [#2569](https://github.com/bytedance/deer-flow/issues/2569) shows the literal failure mode: 200+ tool calls of `web_search → web_fetch → web_search → web_fetch → ...` exhausting `recursion_limit`.
- The middleware's own docstring (lines 144-159 of `loop_detection_middleware.py`) describes the two existing layers and the gap they leave: alternation passes the hash check (different args) and the per-tool-frequency check (split count).
- The fix lands at the same module so all three layers stay co-located and configurable.

## Changes

`backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py`:

- New `_detect_cycle(names, min_len, max_len, min_repeats)` static helper that scans the tail of `names` for a length-L cycle repeating `min_repeats` times for any L in `[min_len, max_len]`. Skips single-name repeats via `len(set(cycle)) < 2` so it never overlaps with Layer 2.
- New per-thread `_name_history: OrderedDict[str, list[str]]` and `_cycle_warned: dict[str, set[str]]`.
- New constructor args (with defaults): `cycle_min_len=2`, `cycle_max_len=4`, `cycle_repeats_warn=3`, `cycle_repeats_hard=4`.
- Layer 3 runs after Layers 1 & 2 in `_track_and_check`. Hard limit returns `_HARD_STOP_MSG, True`. Warn returns `_WARNING_MSG, False` once per (thread, cycle) pair.
- LRU eviction in `_evict_if_needed` and the thread-reset path both clear the new dicts.

`backend/tests/test_loop_detection_middleware.py`:

- New `TestCycleDetection` class with 6 scenario tests:
  - 2-tool alternation warns at 3 cycles (6 calls).
  - 2-tool alternation hard-stops at 4 cycles (8 calls).
  - 3-tool cycle (`a, b, c`) hard-stops at 4 cycles (12 calls).
  - Mixed pattern (`a, b, a, c, a, b`) does NOT trigger.
  - Hash-based detection still works (regression).
  - Per-tool frequency still works (regression).
- Static unit tests of `_detect_cycle` for empty list, below-min length, exact hit, and near-miss.

## How to test

```
cd backend
uvx ruff check packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py tests/test_loop_detection_middleware.py
PYTHONPATH=. uv run pytest tests/test_loop_detection_middleware.py -v
```

Both pass locally: 53/53 tests pass, ruff clean.

A reviewer can also reproduce the original failure mode by feeding the middleware an alternating sequence and observing that warn fires by call 6 and hard stop by call 8 — vs the 200+ calls reported in #2569.

## AI assistance disclosure

Developed with Claude Code orchestrating Codex CLI (gpt-5.5 high). Adversarial review focused on layer ordering, single-tool overlap with Layer 2 (covered by `len(set(cycle)) < 2` guard), and eviction parity (verified the new dicts are cleared in both `_evict_if_needed` and the reset path).

Closes #2569
