### PR TITLE
feat(loop-detection): add escape hatches for legitimate batch tool calls

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -174,7 +174,7 @@ Lead-agent middlewares are assembled in strict append order across `packages/har
 14. **ViewImageMiddleware** - Injects base64 image data before LLM call (conditional on vision support)
 15. **DeferredToolFilterMiddleware** - Hides deferred tool schemas from the bound model until tool search is enabled (optional)
 16. **SubagentLimitMiddleware** - Truncates excess `task` tool calls from model response to enforce `MAX_CONCURRENT_SUBAGENTS` limit (optional, if `subagent_enabled`)
-17. **LoopDetectionMiddleware** - Detects repeated tool-call loops; hard-stop responses clear both structured `tool_calls` and raw provider tool-call metadata before forcing a final text answer
+17. **LoopDetectionMiddleware** - Detects repeated tool-call loops; supports `loop_detection_disabled`, `batch_friendly_tools`, and `_loop_detection_skip` escape hatches; hard-stop responses clear both structured `tool_calls` and raw provider tool-call metadata before forcing a final text answer
 18. **ClarificationMiddleware** - Intercepts `ask_clarification` tool calls, interrupts via `Command(goto=END)` (must be last)
 
 ### Configuration System

--- a/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py
@@ -132,9 +132,17 @@ _TOOL_FREQ_WARNING_MSG = (
     "[LOOP DETECTED] You have called {tool_name} {count} times without producing a final answer. Stop calling tools and produce your final answer now. If you cannot complete the task, summarize what you accomplished so far."
 )
 
-_HARD_STOP_MSG = "[FORCED STOP] Repeated tool calls exceeded the safety limit. Producing final answer with results collected so far."
+_HARD_STOP_MSG = (
+    "[FORCED STOP] Repeated tool calls exceeded the safety limit. Producing final answer with results collected so far. "
+    "If this is an intentional batch workflow, use runtime context loop_detection_disabled, configure batch_friendly_tools, "
+    "or set _loop_detection_skip=true in a tool call's args."
+)
 
-_TOOL_FREQ_HARD_STOP_MSG = "[FORCED STOP] Tool {tool_name} called {count} times — exceeded the per-tool safety limit. Producing final answer with results collected so far."
+_TOOL_FREQ_HARD_STOP_MSG = (
+    "[FORCED STOP] Tool {tool_name} called {count} times — exceeded the per-tool safety limit. "
+    "Producing final answer with results collected so far. If this is an intentional batch workflow, use runtime context "
+    "loop_detection_disabled, configure batch_friendly_tools, or set _loop_detection_skip=true in a tool call's args."
+)
 
 
 class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
@@ -155,6 +163,8 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             Default: 30.
         tool_freq_hard_limit: Number of calls to the same tool type before
             forcing a stop. Default: 50.
+        batch_friendly_tools: Tool names to exclude from both hash-based and
+            frequency-based loop detection. Default: None.
     """
 
     def __init__(
@@ -165,6 +175,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         max_tracked_threads: int = _DEFAULT_MAX_TRACKED_THREADS,
         tool_freq_warn: int = _DEFAULT_TOOL_FREQ_WARN,
         tool_freq_hard_limit: int = _DEFAULT_TOOL_FREQ_HARD_LIMIT,
+        batch_friendly_tools: set[str] | frozenset[str] | None = None,
     ):
         super().__init__()
         self.warn_threshold = warn_threshold
@@ -173,6 +184,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         self.max_tracked_threads = max_tracked_threads
         self.tool_freq_warn = tool_freq_warn
         self.tool_freq_hard_limit = tool_freq_hard_limit
+        self.batch_friendly_tools = frozenset(batch_friendly_tools or ())
         self._lock = threading.Lock()
         # Per-thread tracking using OrderedDict for LRU eviction
         self._history: OrderedDict[str, list[str]] = OrderedDict()
@@ -200,6 +212,22 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
             self._tool_freq_warned.pop(evicted_id, None)
             logger.debug("Evicted loop tracking for thread %s (LRU)", evicted_id)
 
+    def _filter_tracked_calls(self, tool_calls: list[dict]) -> list[dict]:
+        """Return calls that should participate in loop tracking."""
+        tracked_calls = []
+        for tool_call in tool_calls:
+            name = tool_call.get("name", "")
+            if name in self.batch_friendly_tools:
+                continue
+
+            args, _ = _normalize_tool_call_args(tool_call.get("args", {}))
+            if args.get("_loop_detection_skip") is True:
+                continue
+
+            tracked_calls.append(tool_call)
+
+        return tracked_calls
+
     def _track_and_check(self, state: AgentState, runtime: Runtime) -> tuple[str | None, bool]:
         """Track tool calls and check for loops.
 
@@ -212,6 +240,9 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         Returns:
             (warning_message_or_none, should_hard_stop)
         """
+        if (getattr(runtime, "context", None) or {}).get("loop_detection_disabled"):
+            return None, False
+
         messages = state.get("messages", [])
         if not messages:
             return None, False
@@ -224,8 +255,12 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
         if not tool_calls:
             return None, False
 
+        tracked_calls = self._filter_tracked_calls(tool_calls)
+        if not tracked_calls:
+            return None, False
+
         thread_id = self._get_thread_id(runtime)
-        call_hash = _hash_tool_calls(tool_calls)
+        call_hash = _hash_tool_calls(tracked_calls)
 
         with self._lock:
             # Touch / create entry (move to end for LRU)
@@ -241,7 +276,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
                 history[:] = history[-self.window_size :]
 
             count = history.count(call_hash)
-            tool_names = [tc.get("name", "?") for tc in tool_calls]
+            tool_names = [tc.get("name", "?") for tc in tracked_calls]
 
             # --- Layer 1: hash-based (identical call sets) ---
             if count >= self.hard_limit:
@@ -273,7 +308,7 @@ class LoopDetectionMiddleware(AgentMiddleware[AgentState]):
 
             # --- Layer 2: per-tool-type frequency ---
             freq = self._tool_freq[thread_id]
-            for tc in tool_calls:
+            for tc in tracked_calls:
                 name = tc.get("name", "")
                 if not name:
                     continue

--- a/backend/tests/test_loop_detection_middleware.py
+++ b/backend/tests/test_loop_detection_middleware.py
@@ -303,6 +303,85 @@ class TestLoopDetection:
         assert "default" in mw._history
 
 
+class TestEscapeHatches:
+    def test_batch_friendly_tools_skip_hash_layer(self):
+        mw = LoopDetectionMiddleware(batch_friendly_tools={"bash"})
+        runtime = _make_runtime()
+        call = [_bash_call("ls")]
+
+        for _ in range(6):
+            result = mw._apply(_make_state(tool_calls=call), runtime)
+            assert result is None
+
+    def test_batch_friendly_tools_skip_frequency_layer(self):
+        mw = LoopDetectionMiddleware(batch_friendly_tools={"bash"})
+        runtime = _make_runtime()
+
+        for i in range(60):
+            result = mw._apply(_make_state(tool_calls=[_bash_call(f"cmd_{i}")]), runtime)
+            assert result is None
+
+    def test_loop_detection_skip_marker_in_args(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        call = [
+            {
+                "name": "bash",
+                "id": "call_skip",
+                "args": {"command": "ls", "_loop_detection_skip": True},
+            }
+        ]
+
+        for _ in range(6):
+            result = mw._apply(_make_state(tool_calls=call), runtime)
+            assert result is None
+
+        assert call[0]["args"]["_loop_detection_skip"] is True
+
+    def test_runtime_loop_detection_disabled(self):
+        mw = LoopDetectionMiddleware()
+        runtime = _make_runtime()
+        runtime.context["loop_detection_disabled"] = True
+        call = [_bash_call("ls")]
+
+        for _ in range(6):
+            result = mw._apply(_make_state(tool_calls=call), runtime)
+            assert result is None
+
+        assert mw._history == {}
+        assert mw._tool_freq == {}
+
+    def test_hard_stop_message_includes_escape_hatch_hint(self):
+        mw = LoopDetectionMiddleware(warn_threshold=2, hard_limit=3)
+        runtime = _make_runtime()
+        call = [_bash_call("ls")]
+
+        for _ in range(2):
+            mw._apply(_make_state(tool_calls=call), runtime)
+
+        result = mw._apply(_make_state(tool_calls=call), runtime)
+        assert result is not None
+        content = result["messages"][0].content
+        assert "loop_detection_disabled" in content
+        assert "batch_friendly_tools" in content
+        assert "_loop_detection_skip" in content
+
+    def test_no_regression_when_no_escape_hatches_configured(self):
+        mw = LoopDetectionMiddleware(warn_threshold=2, hard_limit=4)
+        runtime = _make_runtime()
+        call = [_bash_call("ls")]
+
+        for _ in range(3):
+            mw._apply(_make_state(tool_calls=call), runtime)
+
+        result = mw._apply(_make_state(tool_calls=call), runtime)
+        assert result is not None
+        msg = result["messages"][0]
+        assert isinstance(msg, AIMessage)
+        assert msg.tool_calls == []
+        assert _HARD_STOP_MSG in msg.content
+
+
 class TestAppendText:
     """Unit tests for LoopDetectionMiddleware._append_text."""
 


### PR DESCRIPTION
## Closes #2511

Scientific workflows (RNA-seq differential expression, parameter sweeps, multi-file analysis) legitimately call the same tool many times in succession. The current `LoopDetectionMiddleware` hash + frequency layers fire on these workflows and force-stop the run with no way to opt out.

## Change

Three orthogonal escape hatches, plus a clearer error message:

| Mechanism | Scope | Set by |
|-----------|-------|--------|
| `batch_friendly_tools={\"bash\", ...}` | Per-tool, all calls | Middleware constructor |
| `_loop_detection_skip: true` in tool args | Single call | Tool author |
| `loop_detection_disabled: true` in runtime context | Whole run | CLI flag / agent config |

Calls excluded by any mechanism are not appended to `_history` or counted in `_tool_freq` — they are effectively invisible to detection. Other calls in the same response keep being tracked normally.

When the middleware does fire a hard stop, the message now mentions all three escape hatches so the user has a discoverable path out:

```
[FORCED STOP] Repeated tool calls exceeded the safety limit. Producing
final answer with results collected so far. If this is an intentional
batch workflow, use runtime context loop_detection_disabled, configure
batch_friendly_tools, or set _loop_detection_skip=true in a tool call's args.
```

## Tests

`backend/tests/test_loop_detection_middleware.py` adds a `TestEscapeHatches` class with 6 cases:

- `test_batch_friendly_tools_skip_hash_layer` — 6 identical bash calls with bash batch-friendly: no hard stop.
- `test_batch_friendly_tools_skip_frequency_layer` — 60 varying-args bash calls: no warning, no hard stop.
- `test_loop_detection_skip_marker_in_args` — 6 identical calls with `_loop_detection_skip=true`: no hard stop.
- `test_runtime_loop_detection_disabled` — 6 identical calls with runtime override: no hard stop, no state recorded.
- `test_hard_stop_message_includes_escape_hatch_hint` — default config triggers hard stop, asserts the hint text contains all three mechanism names.
- `test_no_regression_when_no_escape_hatches_configured` — default behavior unchanged.

```
============================== 52 passed in 0.15s ==============================
```

## Verification

- [x] `cd backend && PYTHONPATH=. uv run pytest tests/test_loop_detection_middleware.py -v` — 52 passed
- [x] `cd backend && uvx ruff check packages/harness/deerflow/agents/middlewares/loop_detection_middleware.py tests/test_loop_detection_middleware.py` — clean
- [x] `cd backend && uvx ruff format --check ...` — clean
- [x] `backend/CLAUDE.md` middleware-chain bullet updated to mention the new escape hatches.

## Coordination

Coordinates with #2569's alternating-pattern detector (separate PR): that one tightens detection for cases the current logic misses, this one loosens it for cases the current logic over-fires on. Together they make detection more accurate without regressing existing behavior.

🤖 Built with assistance from Claude Code and Codex.