### PR TITLE
fix(memory): scope queue merge key to (thread_id, agent_name) and skip idle reschedule

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/queue.py
@@ -107,7 +107,7 @@ class MemoryUpdateQueue:
         reinforcement_detected: bool,
     ) -> None:
         existing_context = next(
-            (context for context in self._queue if context.thread_id == thread_id),
+            (context for context in self._queue if context.thread_id == thread_id and context.agent_name == agent_name),
             None,
         )
         merged_correction_detected = correction_detected or (existing_context.correction_detected if existing_context is not None else False)
@@ -120,7 +120,7 @@ class MemoryUpdateQueue:
             reinforcement_detected=merged_reinforcement_detected,
         )
 
-        self._queue = [c for c in self._queue if c.thread_id != thread_id]
+        self._queue = [c for c in self._queue if not (c.thread_id == thread_id and c.agent_name == agent_name)]
         self._queue.append(context)
 
     def _reset_timer(self) -> None:
@@ -150,8 +150,10 @@ class MemoryUpdateQueue:
 
         with self._lock:
             if self._processing:
-                # Preserve immediate flush semantics even if another worker is active.
-                self._schedule_timer(0)
+                # Only reschedule if there is pending work; avoids spinning zero-delay
+                # timers when add_nowait/flush_nowait fire while the worker is busy.
+                if self._queue:
+                    self._schedule_timer(0)
                 return
 
             if not self._queue:

--- a/backend/tests/test_memory_queue.py
+++ b/backend/tests/test_memory_queue.py
@@ -129,9 +129,10 @@ def test_add_nowait_cancels_existing_timer_and_starts_immediate_timer() -> None:
     created_timer.start.assert_called_once_with()
 
 
-def test_process_queue_reschedules_immediately_when_already_processing() -> None:
+def test_process_queue_reschedules_immediately_when_already_processing_and_work_pending() -> None:
     queue = MemoryUpdateQueue()
     queue._processing = True
+    queue._queue = [ConversationContext(thread_id="thread-1", messages=["msg"])]
     created_timer = MagicMock()
 
     with patch("deerflow.agents.memory.queue.threading.Timer", return_value=created_timer) as timer_cls:
@@ -140,6 +141,47 @@ def test_process_queue_reschedules_immediately_when_already_processing() -> None
     timer_cls.assert_called_once_with(0, queue._process_queue)
     assert created_timer.daemon is True
     created_timer.start.assert_called_once_with()
+
+
+def test_process_queue_does_not_reschedule_when_already_processing_and_queue_empty() -> None:
+    queue = MemoryUpdateQueue()
+    queue._processing = True
+    created_timer = MagicMock()
+
+    with patch("deerflow.agents.memory.queue.threading.Timer", return_value=created_timer) as timer_cls:
+        queue._process_queue()
+
+    timer_cls.assert_not_called()
+
+
+def test_enqueue_two_agents_same_thread_stored_independently() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="thread-1", messages=["agent-a-msg"], agent_name="agent-a")
+        queue.add(thread_id="thread-1", messages=["agent-b-msg"], agent_name="agent-b")
+
+    assert len(queue._queue) == 2
+    names = {c.agent_name for c in queue._queue}
+    assert names == {"agent-a", "agent-b"}
+
+
+def test_enqueue_same_agent_same_thread_merges() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="thread-1", messages=["first"], agent_name="agent-a", correction_detected=True)
+        queue.add(thread_id="thread-1", messages=["second"], agent_name="agent-a", correction_detected=False)
+
+    assert len(queue._queue) == 1
+    assert queue._queue[0].messages == ["second"]
+    assert queue._queue[0].correction_detected is True
 
 
 def test_flush_nowait_is_non_blocking() -> None:


### PR DESCRIPTION
Fixes #2547
Fixes #2548

## Problem

**Issue #2547 — wrong merge key in memory queue**
`_enqueue_locked` matched pending queue entries by `thread_id` alone. When two agents ran on the same thread and both called `add()` before the debounce fired, the second call silently replaced the first, dropping the first agent's conversation from the pending batch.

**Issue #2548 — zero-delay timer spin when busy**
`_process_queue` always called `_schedule_timer(0)` when `_processing` was `True`, even if the queue was empty. Repeated calls to `add_nowait` or `flush_nowait` during an active processing run would each create a new zero-delay timer, causing unnecessary wakeups and scheduling overhead.

## Solution

**#2547:** Changed the deduplication key from `thread_id` to `(thread_id, agent_name)`. Entries for different agents on the same thread are now kept as separate queue items and processed independently.

**#2548:** Added a guard in `_process_queue` so the follow-up zero-delay timer is only scheduled when `self._queue` actually contains pending work. No-op reschedules no longer occur.

## Testing

Updated `test_memory_queue.py`:
- Replaced the old `test_process_queue_reschedules_immediately_when_already_processing` with two focused tests covering the with-work and no-work branches of the busy-guard.
- Added `test_enqueue_two_agents_same_thread_stored_independently` to verify the new (thread_id, agent_name) key keeps separate entries.
- Added `test_enqueue_same_agent_same_thread_merges` to confirm same-agent deduplication still works.

All 11 tests pass (`uv run pytest tests/test_memory_queue.py -v`).