### PR TITLE
feat(sandbox): attach sandbox containers to a Docker network

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -152,6 +152,7 @@ class AioSandboxProvider(SandboxProvider):
             container_prefix=self._config["container_prefix"],
             config_mounts=self._config["mounts"],
             environment=self._config["environment"],
+            network=self._config["network"],
         )
 
     # ── Configuration ────────────────────────────────────────────────────
@@ -164,6 +165,15 @@ class AioSandboxProvider(SandboxProvider):
         idle_timeout = getattr(sandbox_config, "idle_timeout", None)
         replicas = getattr(sandbox_config, "replicas", None)
 
+        # Network override priority: env var > config field > None (legacy port-mapped mode).
+        # ``DEER_FLOW_SANDBOX_NETWORK`` lets compose files inject the network without
+        # rewriting ``config.yaml``; an empty value explicitly opts out.
+        env_network = os.environ.get("DEER_FLOW_SANDBOX_NETWORK")
+        if env_network is not None:
+            network = env_network or None
+        else:
+            network = getattr(sandbox_config, "network", None) or None
+
         return {
             "image": sandbox_config.image or DEFAULT_IMAGE,
             "port": sandbox_config.port or DEFAULT_PORT,
@@ -172,6 +182,7 @@ class AioSandboxProvider(SandboxProvider):
             "replicas": replicas if replicas is not None else DEFAULT_REPLICAS,
             "mounts": sandbox_config.mounts or [],
             "environment": self._resolve_env_vars(sandbox_config.environment or {}),
+            "network": network,
             # provisioner URL for dynamic pod management (e.g. http://provisioner:8002)
             "provisioner_url": getattr(sandbox_config, "provisioner_url", None) or "",
         }

--- a/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
@@ -107,6 +107,7 @@ class LocalContainerBackend(SandboxBackend):
         container_prefix: str,
         config_mounts: list,
         environment: dict[str, str],
+        network: str | None = None,
     ):
         """Initialize the local container backend.
 
@@ -116,6 +117,11 @@ class LocalContainerBackend(SandboxBackend):
             container_prefix: Prefix for container names (e.g., "deer-flow-sandbox").
             config_mounts: Volume mount configurations from config (list of VolumeMountConfig).
             environment: Environment variables to inject into containers.
+            network: Optional Docker network name. When set and the runtime is Docker,
+                sandbox containers are attached to this network (no host port mapping)
+                and reachable at ``http://<container_name>:8080``. Apple Container does
+                not support Docker user-defined networks, so this argument is ignored
+                with a warning when the runtime resolves to ``container``.
         """
         self._image = image
         self._base_port = base_port
@@ -123,6 +129,46 @@ class LocalContainerBackend(SandboxBackend):
         self._config_mounts = config_mounts
         self._environment = environment
         self._runtime = self._detect_runtime()
+        self._network = self._resolve_network(network)
+
+    def _resolve_network(self, network: str | None) -> str | None:
+        """Decide whether to use Docker network mode for this backend instance.
+
+        Returns the network name when usable, ``None`` otherwise. Logs at
+        ``warning`` when the user requested a network but the runtime cannot
+        honor it, so misconfiguration is visible without breaking startup.
+        """
+        if not network:
+            return None
+        if self._runtime != "docker":
+            logger.warning(
+                "Sandbox network=%r requested but runtime is %r; falling back to host port mapping. Apple Container does not support Docker user-defined networks.",
+                network,
+                self._runtime,
+            )
+            return None
+        if not self._docker_network_exists(network):
+            # Fail loud rather than silently falling back: a missing network
+            # almost always means a config or compose-file mistake. Operators
+            # need to see the error so they can either ``docker network create``
+            # it or unset ``DEER_FLOW_SANDBOX_NETWORK``.
+            raise RuntimeError(f"Configured sandbox network {network!r} does not exist. Create it (`docker network create {network}`) or unset DEER_FLOW_SANDBOX_NETWORK / sandbox.network in config.yaml.")
+        logger.info("Sandbox network mode enabled: containers will join Docker network %r and be reachable at http://<container_name>:%d", network, self._base_port)
+        return network
+
+    def _docker_network_exists(self, network: str) -> bool:
+        """Return ``True`` if ``docker network inspect`` succeeds for ``network``."""
+        try:
+            result = subprocess.run(
+                ["docker", "network", "inspect", network],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            return result.returncode == 0
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            logger.warning(f"docker network inspect failed for {network!r}: {e}")
+            return False
 
     @property
     def runtime(self) -> str:
@@ -174,13 +220,34 @@ class LocalContainerBackend(SandboxBackend):
         """
         container_name = f"{self._container_prefix}-{sandbox_id}"
 
+        if self._network:
+            # Network mode: no host port mapping, no port allocation, no port-conflict
+            # retry. Container-name conflicts (a sibling process beat us to start) are
+            # still possible and resolved via discover/adopt as in the legacy path.
+            try:
+                container_id = self._start_container(container_name, port=None, extra_mounts=extra_mounts)
+            except RuntimeError as exc:
+                err_lower = str(exc).lower()
+                if "is already in use by container" in err_lower or "conflict. the container name" in err_lower:
+                    logger.warning(f"Container name {container_name} already in use, attempting to discover existing sandbox instance")
+                    existing = self.discover(sandbox_id)
+                    if existing is not None:
+                        return existing
+                raise
+            return SandboxInfo(
+                sandbox_id=sandbox_id,
+                sandbox_url=f"http://{container_name}:{self._base_port}",
+                container_name=container_name,
+                container_id=container_id,
+            )
+
         # Retry loop: if Docker rejects the port (e.g. a stale container still
         # holds the binding after a process restart), skip that port and try the
         # next one.  The socket-bind check in get_free_port mirrors Docker's
         # 0.0.0.0 bind, but Docker's port-release can be slightly asynchronous,
         # so a reactive fallback here ensures we always make progress.
         _next_start = self._base_port
-        container_id: str | None = None
+        container_id = None
         port: int = 0
         for _attempt in range(10):
             port = get_free_port(start_port=_next_start)
@@ -226,7 +293,12 @@ class LocalContainerBackend(SandboxBackend):
         stop_target = info.container_id or info.container_name
         if stop_target:
             self._stop_container(stop_target)
-        # Extract port from sandbox_url for release
+
+        # Network mode does not allocate host ports, so there is nothing to
+        # release. The legacy host-port path extracts the port from the URL
+        # and returns it to the global allocator.
+        if self._network:
+            return
         try:
             from urllib.parse import urlparse
 
@@ -259,12 +331,15 @@ class LocalContainerBackend(SandboxBackend):
         if not self._is_container_running(container_name):
             return None
 
-        port = self._get_container_port(container_name)
-        if port is None:
-            return None
+        if self._network:
+            sandbox_url = f"http://{container_name}:{self._base_port}"
+        else:
+            port = self._get_container_port(container_name)
+            if port is None:
+                return None
+            sandbox_host = os.environ.get("DEER_FLOW_SANDBOX_HOST", "localhost")
+            sandbox_url = f"http://{sandbox_host}:{port}"
 
-        sandbox_host = os.environ.get("DEER_FLOW_SANDBOX_HOST", "localhost")
-        sandbox_url = f"http://{sandbox_host}:{port}"
         if not wait_for_sandbox_ready(sandbox_url, timeout=5):
             return None
 
@@ -337,7 +412,12 @@ class LocalContainerBackend(SandboxBackend):
                 continue
             created_at, host_port = data
             sandbox_id = container_name[len(self._container_prefix) + 1 :]
-            sandbox_url = f"http://{sandbox_host}:{host_port}" if host_port else ""
+            if self._network:
+                # Network mode containers have no host port mapping; the URL is
+                # the container name on the shared Docker network.
+                sandbox_url = f"http://{container_name}:{self._base_port}"
+            else:
+                sandbox_url = f"http://{sandbox_host}:{host_port}" if host_port else ""
 
             infos.append(
                 SandboxInfo(
@@ -402,14 +482,15 @@ class LocalContainerBackend(SandboxBackend):
     def _start_container(
         self,
         container_name: str,
-        port: int,
+        port: int | None,
         extra_mounts: list[tuple[str, str, bool]] | None = None,
     ) -> str:
         """Start a new container.
 
         Args:
             container_name: Name for the container.
-            port: Host port to map to container port 8080.
+            port: Host port to map to container port 8080. ``None`` in network
+                mode (no host port mapping; reach via container name DNS).
             extra_mounts: Additional volume mounts.
 
         Returns:
@@ -424,16 +505,17 @@ class LocalContainerBackend(SandboxBackend):
         if self._runtime == "docker":
             cmd.extend(["--security-opt", "seccomp=unconfined"])
 
-        cmd.extend(
-            [
-                "--rm",
-                "-d",
-                "-p",
-                f"{port}:8080",
-                "--name",
-                container_name,
-            ]
-        )
+        cmd.extend(["--rm", "-d", "--name", container_name])
+
+        if self._network:
+            cmd.extend(["--network", self._network])
+        else:
+            if port is None:
+                # Defensive: should never happen — caller passes a port unless
+                # network mode is on, and network mode is mutually exclusive
+                # with the legacy path.
+                raise RuntimeError("port must be provided when sandbox network mode is disabled")
+            cmd.extend(["-p", f"{port}:8080"])
 
         # Environment variables
         for key, value in self._environment.items():

--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -25,6 +25,11 @@ class SandboxConfig(BaseModel):
         idle_timeout: Idle timeout in seconds before sandbox is released (default: 600 = 10 minutes). Set to 0 to disable.
         mounts: List of volume mounts to share directories with the container
         environment: Environment variables to inject into the container (values starting with $ are resolved from host env)
+        network: Optional Docker network to attach sandbox containers to. When set, the gateway/langgraph
+            container reaches the sandbox via ``http://<container_name>:<port>`` over the shared network
+            instead of mapping the sandbox port to the host and routing through ``host.docker.internal``.
+            Recommended for ``make docker-start`` deployments. Ignored on Apple Container, which does not
+            support Docker user-defined networks. Override at runtime with ``DEER_FLOW_SANDBOX_NETWORK``.
     """
 
     use: str = Field(
@@ -62,6 +67,15 @@ class SandboxConfig(BaseModel):
     environment: dict[str, str] = Field(
         default_factory=dict,
         description="Environment variables to inject into the sandbox container. Values starting with $ will be resolved from host environment variables.",
+    )
+    network: str | None = Field(
+        default=None,
+        description=(
+            "Optional Docker network to attach sandbox containers to. "
+            "When set, sandboxes are reachable at http://<container_name>:<port> "
+            "over the shared network instead of being port-mapped to the host. "
+            "Override with DEER_FLOW_SANDBOX_NETWORK."
+        ),
     )
 
     bash_output_max_chars: int = Field(

--- a/backend/tests/test_aio_sandbox_local_backend_network.py
+++ b/backend/tests/test_aio_sandbox_local_backend_network.py
@@ -1,0 +1,236 @@
+"""Tests for the Docker network mode in :class:`LocalContainerBackend`.
+
+The legacy port-mapping path stays the default; these tests pin the new
+network-mode behavior introduced for issue #2600 — sandbox containers
+join a shared Docker network and are reached via container-name DNS so
+the gateway/langgraph processes do not have to route through
+``host-gateway``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from deerflow.community.aio_sandbox.local_backend import LocalContainerBackend
+from deerflow.community.aio_sandbox.sandbox_info import SandboxInfo
+
+
+def _make_backend(*, network: str | None, runtime: str = "docker", network_exists: bool = True) -> LocalContainerBackend:
+    """Construct a backend with the runtime and network-existence checks stubbed.
+
+    Patches ``_detect_runtime`` and ``_docker_network_exists`` so tests do
+    not depend on the host having Docker installed.
+    """
+    with (
+        patch.object(LocalContainerBackend, "_detect_runtime", return_value=runtime),
+        patch.object(LocalContainerBackend, "_docker_network_exists", return_value=network_exists),
+    ):
+        return LocalContainerBackend(
+            image="test-image:latest",
+            base_port=8080,
+            container_prefix="deer-flow-sandbox",
+            config_mounts=[],
+            environment={},
+            network=network,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_network
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_network_returns_none_when_unset() -> None:
+    backend = _make_backend(network=None)
+    assert backend._network is None
+
+
+def test_resolve_network_keeps_name_when_docker_and_network_exists() -> None:
+    backend = _make_backend(network="deer-flow")
+    assert backend._network == "deer-flow"
+
+
+def test_resolve_network_falls_back_to_none_for_apple_container() -> None:
+    backend = _make_backend(network="deer-flow", runtime="container")
+    assert backend._network is None
+
+
+def test_resolve_network_raises_when_network_missing() -> None:
+    with pytest.raises(RuntimeError, match="does not exist"):
+        _make_backend(network="missing-net", network_exists=False)
+
+
+# ---------------------------------------------------------------------------
+# _start_container command construction
+# ---------------------------------------------------------------------------
+
+
+def test_start_container_uses_network_flag_in_network_mode() -> None:
+    backend = _make_backend(network="deer-flow")
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001 - subprocess.run signature
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="cid123\n", stderr="")
+
+    with patch("deerflow.community.aio_sandbox.local_backend.subprocess.run", side_effect=fake_run):
+        backend._start_container("deer-flow-sandbox-abc", port=None, extra_mounts=None)
+
+    cmd = captured["cmd"]
+    assert "--network" in cmd
+    assert cmd[cmd.index("--network") + 1] == "deer-flow"
+    # Network mode must NOT publish a host port.
+    assert "-p" not in cmd
+    # Container name still set.
+    assert "--name" in cmd
+    assert cmd[cmd.index("--name") + 1] == "deer-flow-sandbox-abc"
+
+
+def test_start_container_uses_port_publish_in_legacy_mode() -> None:
+    backend = _make_backend(network=None)
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_run(cmd, **kwargs):  # noqa: ANN001
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="cid456\n", stderr="")
+
+    with patch("deerflow.community.aio_sandbox.local_backend.subprocess.run", side_effect=fake_run):
+        backend._start_container("deer-flow-sandbox-xyz", port=9999, extra_mounts=None)
+
+    cmd = captured["cmd"]
+    assert "--network" not in cmd
+    assert "-p" in cmd
+    assert cmd[cmd.index("-p") + 1] == "9999:8080"
+
+
+def test_start_container_rejects_missing_port_in_legacy_mode() -> None:
+    backend = _make_backend(network=None)
+    with pytest.raises(RuntimeError, match="port must be provided"):
+        backend._start_container("deer-flow-sandbox-zzz", port=None, extra_mounts=None)
+
+
+# ---------------------------------------------------------------------------
+# create() — SandboxInfo URL shape
+# ---------------------------------------------------------------------------
+
+
+def test_create_returns_container_name_url_in_network_mode() -> None:
+    backend = _make_backend(network="deer-flow")
+
+    with patch.object(LocalContainerBackend, "_start_container", return_value="cid-net") as start:
+        info = backend.create("thread-1", "sandbox-net-1")
+
+    start.assert_called_once_with("deer-flow-sandbox-sandbox-net-1", port=None, extra_mounts=None)
+    assert info.sandbox_url == "http://deer-flow-sandbox-sandbox-net-1:8080"
+    assert info.container_name == "deer-flow-sandbox-sandbox-net-1"
+    assert info.container_id == "cid-net"
+
+
+def test_create_returns_host_port_url_in_legacy_mode(monkeypatch) -> None:
+    backend = _make_backend(network=None)
+
+    with (
+        patch("deerflow.community.aio_sandbox.local_backend.get_free_port", return_value=8123),
+        patch.object(LocalContainerBackend, "_start_container", return_value="cid-host"),
+    ):
+        monkeypatch.delenv("DEER_FLOW_SANDBOX_HOST", raising=False)
+        info = backend.create("thread-2", "sandbox-host-2")
+
+    assert info.sandbox_url == "http://localhost:8123"
+    assert info.container_name == "deer-flow-sandbox-sandbox-host-2"
+
+
+def test_create_in_network_mode_skips_get_free_port() -> None:
+    backend = _make_backend(network="deer-flow")
+
+    with (
+        patch("deerflow.community.aio_sandbox.local_backend.get_free_port") as get_free_port,
+        patch.object(LocalContainerBackend, "_start_container", return_value="cid"),
+    ):
+        backend.create("thread-3", "sandbox-3")
+
+    get_free_port.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# discover() — URL shape
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_container_name_url_in_network_mode() -> None:
+    backend = _make_backend(network="deer-flow")
+
+    with (
+        patch.object(LocalContainerBackend, "_is_container_running", return_value=True),
+        patch.object(LocalContainerBackend, "_get_container_port") as get_port,
+        patch("deerflow.community.aio_sandbox.local_backend.wait_for_sandbox_ready", return_value=True),
+    ):
+        info = backend.discover("sandbox-disc")
+
+    # _get_container_port must NOT be called in network mode — there is no
+    # host port mapping to look up.
+    get_port.assert_not_called()
+    assert info is not None
+    assert info.sandbox_url == "http://deer-flow-sandbox-sandbox-disc:8080"
+
+
+def test_discover_uses_host_port_in_legacy_mode(monkeypatch) -> None:
+    backend = _make_backend(network=None)
+
+    with (
+        patch.object(LocalContainerBackend, "_is_container_running", return_value=True),
+        patch.object(LocalContainerBackend, "_get_container_port", return_value=9090),
+        patch("deerflow.community.aio_sandbox.local_backend.wait_for_sandbox_ready", return_value=True),
+    ):
+        monkeypatch.delenv("DEER_FLOW_SANDBOX_HOST", raising=False)
+        info = backend.discover("sandbox-disc-legacy")
+
+    assert info is not None
+    assert info.sandbox_url == "http://localhost:9090"
+
+
+# ---------------------------------------------------------------------------
+# destroy() — port release behavior
+# ---------------------------------------------------------------------------
+
+
+def test_destroy_skips_release_port_in_network_mode() -> None:
+    backend = _make_backend(network="deer-flow")
+    info = SandboxInfo(
+        sandbox_id="x",
+        sandbox_url="http://deer-flow-sandbox-x:8080",
+        container_name="deer-flow-sandbox-x",
+        container_id="cid",
+    )
+
+    with (
+        patch.object(LocalContainerBackend, "_stop_container") as stop,
+        patch("deerflow.community.aio_sandbox.local_backend.release_port") as release,
+    ):
+        backend.destroy(info)
+
+    stop.assert_called_once()
+    release.assert_not_called()
+
+
+def test_destroy_releases_port_in_legacy_mode() -> None:
+    backend = _make_backend(network=None)
+    info = SandboxInfo(
+        sandbox_id="x",
+        sandbox_url="http://localhost:8123",
+        container_name="deer-flow-sandbox-x",
+        container_id="cid",
+    )
+
+    with (
+        patch.object(LocalContainerBackend, "_stop_container"),
+        patch("deerflow.community.aio_sandbox.local_backend.release_port") as release,
+    ):
+        backend.destroy(info)
+
+    release.assert_called_once_with(8123)

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -106,6 +106,78 @@ def test_get_thread_mounts_preserves_windows_host_path_style(tmp_path, monkeypat
     assert container_paths["/mnt/acp-workspace"] == r"C:\Users\demo\deer-flow\backend\.deer-flow\threads\thread-10\acp-workspace"
 
 
+# ── Network mode config plumbing (issue #2600) ───────────────────────────────
+
+
+def _load_config(monkeypatch, *, sandbox_attrs: dict, env_network: str | None | object = "__unset__"):
+    """Drive ``AioSandboxProvider._load_config`` with a synthetic sandbox config.
+
+    ``sandbox_attrs`` is merged onto a stub returned by ``get_app_config``.
+    ``env_network`` controls the ``DEER_FLOW_SANDBOX_NETWORK`` env var: pass
+    a string to set, ``None`` to set it to empty, or leave ``"__unset__"`` to
+    delete it. Returns the resolved config dict.
+    """
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+
+    sandbox_stub = MagicMock(spec=[])
+    defaults = {
+        "image": None,
+        "port": None,
+        "container_prefix": None,
+        "idle_timeout": None,
+        "replicas": None,
+        "mounts": [],
+        "environment": {},
+        "network": None,
+        "provisioner_url": None,
+    }
+    defaults.update(sandbox_attrs)
+    for key, value in defaults.items():
+        setattr(sandbox_stub, key, value)
+
+    config_stub = MagicMock(spec=[])
+    config_stub.sandbox = sandbox_stub
+    monkeypatch.setattr(aio_mod, "get_app_config", lambda: config_stub)
+
+    if env_network == "__unset__":
+        monkeypatch.delenv("DEER_FLOW_SANDBOX_NETWORK", raising=False)
+    elif env_network is None:
+        monkeypatch.setenv("DEER_FLOW_SANDBOX_NETWORK", "")
+    else:
+        monkeypatch.setenv("DEER_FLOW_SANDBOX_NETWORK", env_network)
+
+    return aio_mod.AioSandboxProvider._load_config(MagicMock())
+
+
+def test_load_config_network_defaults_to_none(monkeypatch):
+    config = _load_config(monkeypatch, sandbox_attrs={})
+    assert config["network"] is None
+
+
+def test_load_config_picks_up_network_from_config_field(monkeypatch):
+    config = _load_config(monkeypatch, sandbox_attrs={"network": "deer-flow"})
+    assert config["network"] == "deer-flow"
+
+
+def test_load_config_env_var_overrides_config_field(monkeypatch):
+    config = _load_config(
+        monkeypatch,
+        sandbox_attrs={"network": "from-config"},
+        env_network="from-env",
+    )
+    assert config["network"] == "from-env"
+
+
+def test_load_config_empty_env_var_explicitly_disables_network(monkeypatch):
+    """``DEER_FLOW_SANDBOX_NETWORK=`` (empty string) is the documented opt-out."""
+    config = _load_config(
+        monkeypatch,
+        sandbox_attrs={"network": "from-config"},
+        env_network=None,
+    )
+    assert config["network"] is None
+
+
 def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatch):
     """Unlock should not run if exclusive locking itself fails."""
     aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -170,6 +170,12 @@ services:
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
+      # Sandbox network mode: AioSandboxProvider attaches sandbox containers to
+      # the same Docker network so gateway/langgraph reach them via container
+      # name DNS instead of host-gateway. ``DEER_FLOW_SANDBOX_HOST`` is kept as
+      # a no-op fallback for users who explicitly disable network mode by
+      # setting ``DEER_FLOW_SANDBOX_NETWORK=`` (empty string).
+      - DEER_FLOW_SANDBOX_NETWORK=deer-flow-dev
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
     env_file:
       - ../.env
@@ -227,6 +233,8 @@ services:
       - DEER_FLOW_HOME=/app/backend/.deer-flow
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
+      # Sandbox network mode (see gateway service for details).
+      - DEER_FLOW_SANDBOX_NETWORK=deer-flow-dev
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
     env_file:
       - ../.env
@@ -247,6 +255,11 @@ volumes:
 
 networks:
   deer-flow-dev:
+    # Explicit ``name`` keeps the actual Docker network name stable
+    # (``deer-flow-dev`` rather than ``<project>_deer-flow-dev``) so sandbox
+    # containers attached via ``--network deer-flow-dev`` always join the
+    # correct network regardless of the compose project prefix.
+    name: deer-flow-dev
     driver: bridge
     ipam:
       config:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -106,6 +106,12 @@ services:
       # DooD path/network translation
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_HOME}
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_REPO_ROOT}/skills
+      # Sandbox network mode: AioSandboxProvider attaches sandbox containers to
+      # the same Docker network so gateway/langgraph reach them via container
+      # name DNS instead of host-gateway. ``DEER_FLOW_SANDBOX_HOST`` is kept as
+      # a no-op fallback for users who explicitly disable network mode by
+      # setting ``DEER_FLOW_SANDBOX_NETWORK=`` (empty string).
+      - DEER_FLOW_SANDBOX_NETWORK=deer-flow
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
     env_file:
       - ../.env
@@ -156,6 +162,8 @@ services:
       - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/backend/extensions_config.json
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_HOME}
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_REPO_ROOT}/skills
+      # Sandbox network mode (see gateway service for details).
+      - DEER_FLOW_SANDBOX_NETWORK=deer-flow
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
       # LangSmith tracing: set LANGSMITH_TRACING=true and LANGSMITH_API_KEY in .env to enable.
     env_file:
@@ -199,4 +207,9 @@ services:
       retries: 6
 networks:
   deer-flow:
+    # Explicit ``name`` keeps the actual Docker network name stable
+    # (``deer-flow`` rather than ``<project>_deer-flow``) so sandbox
+    # containers attached via ``--network deer-flow`` always join the
+    # correct network regardless of the compose project prefix.
+    name: deer-flow
     driver: bridge


### PR DESCRIPTION
## What

Add an opt-in Docker network mode for the AIO sandbox backend. When `sandbox.network` (or env var `DEER_FLOW_SANDBOX_NETWORK`) is set, sandbox containers join that Docker network and the gateway/langgraph reach them by container name DNS (`http://<container_name>:8080`), bypassing the `host-gateway` round-trip that the issue reports as unreliable. The legacy host-port path stays the default and remains untouched for bare-metal `make dev`, Apple Container, and any setup that explicitly clears the env var.

Closes #2600. Related: #2438 (the same reporter's earlier bug whose root cause this PR addresses), #2081 (independent recovery layer; the two are complementary, not overlapping).

## Why

`docker/docker-compose.yaml` puts `gateway` and `langgraph` on the `deer-flow` network and mounts `/var/run/docker.sock`. When `LocalContainerBackend._start_container` runs `docker run -p HOST:8080`, the resulting sandbox container does **not** join `deer-flow` — it lands on Docker's default bridge. To reach it, the in-container code routes through `host.docker.internal:HOST_PORT`, which works on Docker Desktop but is brittle on Linux: `host-gateway` resolves through `iptables`/`nftables` rules that fail silently under several common host network configurations, including rootless Docker, custom firewalls, and host IP changes (laptop switching networks). DNS succeeds, TCP `connect` times out, and `langgraph` declares the sandbox dead even though `localhost:HOST_PORT` works fine on the host shell.

In addition the host-port path carries:

- a 50+ line port-conflict retry / `release_port` loop in `_start_container`,
- `_get_container_port` / `_extract_host_port` extra `docker` subprocess calls,
- a `0.0.0.0` exposure of every sandbox to the host network surface.

Putting the sandbox on the same Docker network deletes all three. Container-name DNS is resolved by Docker's embedded resolver inside the network namespace, no host routing involved.

## How

**Config and env var**

`SandboxConfig` gains `network: str | None`. `AioSandboxProvider._load_config` resolves the value with priority: env var `DEER_FLOW_SANDBOX_NETWORK` > `sandbox.network` > `None`. An empty env-var string is the documented opt-out, so users can keep the default `config.yaml` but flip back to legacy mode at runtime.

**Backend**

`LocalContainerBackend.__init__` accepts `network` and runs `_resolve_network`:

- If unset → `None` (legacy mode).
- If the runtime is Apple Container → `None` + warning. Apple Container does not implement Docker user-defined networks; silently failing later would be worse than degrading to the legacy path.
- If `docker network inspect <name>` fails → raise `RuntimeError` with an actionable message. A missing network almost always means a config or compose-file mistake; failing loud at backend init beats discovering it on the first agent tool call.

In network mode:

- `_start_container` adds `--network <name>` and skips `-p`.
- `create` builds `sandbox_url = http://<container_name>:<base_port>`, skips `get_free_port`, and skips the port-conflict retry loop. Container-name conflicts (a sibling process started the same `sandbox_id`) still resolve via `discover()`.
- `discover` and `list_running` build the same URL shape and skip `_get_container_port` / `docker port` calls.
- `destroy` skips `release_port` because no host port was reserved.

The legacy path is byte-for-byte unchanged. Both paths live in the same backend instance; the branch is on `self._network`.

**Compose files**

`docker/docker-compose.yaml` and `docker-compose-dev.yaml` inject `DEER_FLOW_SANDBOX_NETWORK` into the gateway and langgraph services and pin the network with explicit `name:` so the actual Docker network name (`deer-flow` or `deer-flow-dev`) matches what the env var says, regardless of the compose project prefix that `docker compose -p` would otherwise add. `DEER_FLOW_SANDBOX_HOST=host.docker.internal` and the `extra_hosts: host-gateway` line are kept as no-op fallbacks for users who explicitly disable network mode.

## Testing

```
$ make lint
All checks passed!
310 files already formatted

$ uv run pytest
2148 passed, 15 skipped, 4 warnings in 100.44s (0:01:40)
```

### Unit and integration tests

`tests/test_aio_sandbox_local_backend_network.py` (14 cases):

- `_resolve_network` returns `None` when unset, keeps the name when Docker + network exists, falls back to `None` for Apple Container, raises when the network does not exist.
- `_start_container` produces `--network <name>` (no `-p`) in network mode, produces `-p PORT:8080` (no `--network`) in legacy mode, and rejects a missing port in legacy mode.
- `create` returns `http://<container_name>:8080` in network mode and `http://localhost:PORT` in legacy mode; `get_free_port` is not called in network mode.
- `discover` skips `_get_container_port` and returns the container-name URL in network mode; uses host:port in legacy mode.
- `destroy` skips `release_port` in network mode and calls it in legacy mode.

`tests/test_aio_sandbox_provider.py` (4 new cases): `_load_config` priority — default `None` → config field → env var overrides config → empty env var as explicit opt-out.

### Live Docker verification

The above tests cover argument construction. To verify the actual physical behavior — that container-name DNS resolves on the shared network and that the host port is no longer required — I ran the patched `LocalContainerBackend` directly against the local Docker daemon. Used `nginx:alpine` rebuilt to listen on 8080 instead of pulling the GB-sized AIO sandbox image; the test exercises real `docker run` / `docker inspect`, real network attachment, and real cross-container HTTP.

**Network mode**:

```
[ok] runtime=docker  network=deer-flow-test
[ok] container started: deer-flow-sandbox-cdff6435
[ok] sandbox_url: http://deer-flow-sandbox-cdff6435:8080
[ok] networks: {"deer-flow-test": {"NetworkID":"311d609a18d3...", "IPAddress":"172.26.0.2", ...
                "DNSNames":["deer-flow-sandbox-cdff6435","8c228b401f47"]}}
[ok] published ports: {"80/tcp":null,"8080/tcp":null}    ← no host port mapping
[ok] sibling curl exit=0  http_status=200                 ← reached via container-name DNS
[ok] destroy() removed the container cleanly
```

**Legacy mode** (network=None) — backward compatibility:

```
[ok] runtime=docker  network=None (legacy mode)
[ok] container started: deer-flow-sandbox-legacy-f0a030ba
[ok] sandbox_url: http://localhost:18080
[ok] published ports: {"8080/tcp":[{"HostIp":"0.0.0.0","HostPort":"18080"}, ...]}
[ok] localhost:18080 curl exit=0  http_status=200
[ok] destroy() removed the container cleanly
```

### Honest scope of the verification

What this PR's tests prove:

- The new code attaches sandbox containers to the requested Docker network.
- No host port is published in network mode.
- Container-name DNS resolution works on the shared network and HTTP traverses it.
- The legacy host-port path is byte-for-byte unchanged and still works.

What I cannot reproduce locally:

- The original symptom from #2438 / #2600 — `host-gateway` connection failures — was reported on Linux hosts where `iptables`/`nftables` routing for the host gateway behaves erratically. My host is macOS Docker Desktop where `host-gateway` works reliably, so I cannot show a before-state failure that this PR turns into a success on the same machine. What this PR does is remove the `host-gateway` round-trip from the failure path entirely; container-name DNS replaces it. If the host network is unhealthy, sandbox reachability now degrades to the same conditions as gateway↔langgraph reachability (which already share this network), rather than depending on a separate routing path.

@cw1427 it would help if you can validate this on the environment where you originally hit the failure — `make docker-start` with this branch should pick up `DEER_FLOW_SANDBOX_NETWORK=deer-flow-dev` automatically.

### Compatibility

- Default behavior unchanged when `DEER_FLOW_SANDBOX_NETWORK` and `sandbox.network` are both unset.
- Apple Container deployments degrade to the legacy path with a warning, not an error.
- Users who have customized their `config.yaml` with `sandbox.network=...` get the new behavior; everyone else is unaffected.
- Compose files keep `DEER_FLOW_SANDBOX_HOST` and `extra_hosts: host-gateway` as fallback so flipping `DEER_FLOW_SANDBOX_NETWORK=` (empty) puts the deployment back into legacy mode without further changes.
