### PR TITLE
feat: Apify community integration — Actor execution and web search, web fetch

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -49,7 +49,7 @@ deer-flow/
 │   │           ├── models/            # Model factory with thinking/vision support
 │   │           ├── skills/            # Skills discovery, loading, parsing
 │   │           ├── config/            # Configuration system (app, model, sandbox, tool, etc.)
-│   │           ├── community/         # Community tools (tavily, jina_ai, firecrawl, image_search, aio_sandbox)
+│   │           ├── community/         # Community tools (tavily, jina_ai, firecrawl, image_search, aio_sandbox, apify)
 │   │           ├── reflection/        # Dynamic module loading (resolve_variable, resolve_class)
 │   │           ├── utils/             # Utilities (network, readability)
 │   │           └── client.py          # Embedded Python client (DeerFlowClient)
@@ -270,6 +270,7 @@ Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → 
 - `tavily/` - Web search (5 results default) and web fetch (4KB limit)
 - `jina_ai/` - Web fetch via Jina reader API with readability extraction
 - `firecrawl/` - Web scraping via Firecrawl API
+- `apify/` - Web search and web fetch via Apify actors, plus async actor runner (`apify_actor_discover`, `apify_actor_start`, `apify_actor_await`) for structured data scraping from social platforms and e-commerce sites; requires `APIFY_API_TOKEN`
 
 **ACP agent tools**:
 - `invoke_acp_agent` - Invokes external ACP-compatible agents from `config.yaml`

--- a/backend/packages/harness/deerflow/community/apify/tools.py
+++ b/backend/packages/harness/deerflow/community/apify/tools.py
@@ -1,0 +1,332 @@
+import asyncio
+import json
+import os
+
+from apify_client import ApifyClient
+from langchain.tools import tool
+from langgraph.config import get_stream_writer
+
+from deerflow.config import get_app_config
+
+# Terminal statuses as returned by the Apify API (note: hyphen in "TIMED-OUT").
+# "TIMED_OUT" (underscore) is a separate local-poll sentinel used by this integration
+# when the actor is still running but our local timeout_secs deadline is exceeded.
+TERMINAL_STATUSES = {"SUCCEEDED", "FAILED", "ABORTED", "TIMED-OUT"}
+
+
+def _get_apify_client(tool_name: str) -> ApifyClient:
+    config = get_app_config().get_tool_config(tool_name)
+    api_key = None
+    if config is not None and "api_key" in config.model_extra:
+        api_key = config.model_extra.get("api_key")
+    if not api_key:
+        api_key = os.environ.get("APIFY_API_TOKEN")
+    if not api_key:
+        raise ValueError(f"APIFY_API_TOKEN is not configured. Set it as tools[{tool_name}].api_key in config.yaml or as the APIFY_API_TOKEN environment variable.")
+    return ApifyClient(api_key)
+
+
+@tool("web_search", parse_docstring=True)
+def web_search_tool(query: str) -> str:
+    """Search the web.
+
+    Args:
+        query: The query to search for.
+    """
+    try:
+        config = get_app_config().get_tool_config("web_search")
+        max_results = 5
+        if config is not None:
+            max_results = config.model_extra.get("max_results", max_results)
+
+        client = _get_apify_client("web_search")
+        run = client.actor("apify/google-search-scraper").call(
+            run_input={
+                "queries": [query],
+                "maxPagesPerQuery": 1,
+                "resultsPerPage": max_results,
+            }
+        )
+
+        items = list(client.dataset(run["defaultDatasetId"]).iterate_items(limit=1))
+        organic = items[0].get("organicResults", []) if items else []
+
+        normalized = [
+            {
+                "title": r.get("title", "") or "",
+                "url": r.get("url", "") or "",
+                "snippet": r.get("description", "") or "",
+            }
+            for r in organic[:max_results]
+        ]
+        return json.dumps(normalized, indent=2, ensure_ascii=False)
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@tool("web_fetch", parse_docstring=True)
+def web_fetch_tool(url: str) -> str:
+    """Fetch the contents of a web page at a given URL.
+    Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
+    This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
+    Do NOT add www. to URLs that do NOT have them.
+    URLs must include the schema: https://example.com is a valid URL while example.com is an invalid URL.
+
+    Args:
+        url: The URL to fetch the contents of.
+    """
+    try:
+        config = get_app_config().get_tool_config("web_fetch")
+        crawler_type = "cheerio"
+        if config is not None:
+            crawler_type = config.model_extra.get("crawler_type", crawler_type)
+
+        client = _get_apify_client("web_fetch")
+        run = client.actor("apify/website-content-crawler").call(
+            run_input={
+                "startUrls": [{"url": url}],
+                "maxCrawlPages": 1,
+                "crawlerType": crawler_type,
+            }
+        )
+
+        items = list(client.dataset(run["defaultDatasetId"]).iterate_items(limit=1))
+        if not items:
+            return "Error: No content found"
+
+        item = items[0]
+        title = item.get("title", "Untitled") or "Untitled"
+        content = item.get("markdown", "") or item.get("text", "")
+
+        if not content:
+            return "Error: No content found"
+
+        # Truncate on UTF-8 byte boundary to keep payload size predictable
+        encoded = content.encode("utf-8")
+        if len(encoded) > 4096:
+            truncated = encoded[:4096].decode("utf-8", errors="ignore")
+            suffix = "\n\n[Content truncated]"
+        else:
+            truncated = content
+            suffix = ""
+        return f"# {title}\n\n{truncated}{suffix}"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@tool("apify_actor_discover", parse_docstring=True)
+def apify_actor_discover_tool(query: str = "", actor_id: str = "") -> str:
+    """Search the Apify Store for actors, or fetch an actor's input schema.
+    Use before apify_actor_start on an unfamiliar actor to learn what input it expects.
+    Provide query to search the store, or actor_id to fetch a specific actor's schema. Not both.
+
+    Args:
+        query: Search term to find actors in the Apify Store. E.g. 'instagram scraper'.
+        actor_id: Actor ID to fetch its input schema. Accepts 'username/actor-name' (e.g. 'apify/instagram-scraper') or a plain ID (e.g. 'h7sDV53CddomktSi5').
+    """
+    if not query and not actor_id:
+        return "Error: provide either query or actor_id, not neither"
+    if query and actor_id:
+        return "Error: provide either query or actor_id, not both"
+
+    try:
+        config = get_app_config().get_tool_config("apify_actor_discover")
+        limit = 10
+        if config is not None:
+            limit = config.model_extra.get("max_results", limit)
+
+        client = _get_apify_client("apify_actor_discover")
+
+        if query:
+            result = client.store().list(search=query, limit=limit)
+            actors = []
+            for a in result.items:
+                username = a.get("username") or ""
+                name = a.get("name") or ""
+                if not username or not name:
+                    continue
+                actors.append(
+                    {
+                        "actorId": f"{username}/{name}",
+                        "title": a.get("title") or "",
+                        "description": (a.get("description") or "")[:200],
+                    }
+                )
+            return json.dumps(
+                {"action": "store_search", "query": query, "count": len(actors), "actors": actors},
+                indent=2,
+                ensure_ascii=False,
+            )
+
+        actor = client.actor(actor_id).get()
+        if not actor:
+            return f"Error: actor '{actor_id}' not found"
+
+        input_schema = None
+        try:
+            versions = client.actor(actor_id).versions().list()
+            if versions.items:
+                latest_version_number = versions.items[-1].get("versionNumber")
+                if latest_version_number:
+                    version_detail = client.actor(actor_id).version(latest_version_number).get()
+                    raw_schema = version_detail.get("inputSchema") if version_detail else None
+                else:
+                    raw_schema = versions.items[-1].get("inputSchema")
+                # inputSchema may be stored as a JSON string; parse it to avoid double-encoding
+                if isinstance(raw_schema, str):
+                    try:
+                        input_schema = json.loads(raw_schema)
+                    except json.JSONDecodeError:
+                        input_schema = raw_schema
+                else:
+                    input_schema = raw_schema
+        except Exception:
+            pass  # input schema is best-effort
+
+        return json.dumps(
+            {
+                "action": "actor_schema",
+                "actorId": actor_id,
+                "title": actor.get("title") or "",
+                "description": (actor.get("description") or "")[:500],
+                "inputSchema": input_schema,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@tool("apify_actor_start", parse_docstring=True)
+def apify_actor_start_tool(actor_id: str, run_input: str, description: str = "") -> str:
+    """Start an Apify actor run asynchronously and return a run reference immediately.
+    The actor runs in the background — use apify_actor_await with the returned run_id and dataset_id to wait for results.
+    To run multiple actors in parallel, call this tool once per actor, then call apify_actor_await for each run.
+    You MUST call this tool directly when asked to start an actor — do not ask for clarification.
+
+    Args:
+        actor_id: The Apify actor ID. Accepts 'username/actor-name' (e.g. 'apify/instagram-scraper') or a plain ID (e.g. 'h7sDV53CddomktSi5'). Must not be empty.
+        run_input: The actor input as a JSON-encoded string. Use "{}" for no input. E.g. '{"query": "test"}'.
+        description: Optional human-readable label for this run, e.g. 'Scraping TikTok profile @apify'.
+    """
+    if not actor_id:
+        return "Error: actor_id must not be empty"
+
+    try:
+        parsed_input = json.loads(run_input)
+    except json.JSONDecodeError as e:
+        return f"Error: run_input is not valid JSON — {str(e)}"
+
+    try:
+        config = get_app_config().get_tool_config("apify_actor_start")
+        timeout_secs = None
+        memory_mbytes = None
+        if config is not None:
+            timeout_secs = config.model_extra.get("timeout_secs")
+            memory_mbytes = config.model_extra.get("memory_mbytes")
+
+        client = _get_apify_client("apify_actor_start")
+
+        start_kwargs: dict = {"run_input": parsed_input}
+        if timeout_secs is not None:
+            start_kwargs["timeout_secs"] = timeout_secs
+        if memory_mbytes is not None:
+            start_kwargs["memory_mbytes"] = memory_mbytes
+
+        run = client.actor(actor_id).start(**start_kwargs)
+        ref: dict = {
+            "runId": run["id"],
+            "actorId": actor_id,
+            "datasetId": run["defaultDatasetId"],
+            "status": run["status"],
+        }
+        if description:
+            ref["description"] = description
+        return json.dumps({"action": "start", "runs": [ref]}, indent=2, ensure_ascii=False)
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+
+@tool("apify_actor_await", parse_docstring=True)
+async def apify_actor_await_tool(run_id: str, dataset_id: str, description: str = "") -> str:
+    """Wait for a previously started Apify actor run to complete and return its results.
+    Polls the run status internally until it reaches a terminal state, streaming progress
+    events. A single call handles all polling — loop detection never fires.
+
+    Args:
+        run_id: The run ID from apify_actor_start (runs[0].runId).
+        dataset_id: The dataset ID from apify_actor_start (runs[0].datasetId).
+        description: Optional human-readable label for this run, e.g. 'Waiting for TikTok scraper'.
+    """
+    if not run_id:
+        return "Error: run_id must not be empty"
+
+    config = get_app_config().get_tool_config("apify_actor_await")
+    poll_interval_secs = 5
+    timeout_secs = 300
+    max_items = 50
+    if config is not None:
+        poll_interval_secs = config.model_extra.get("poll_interval_secs", poll_interval_secs)
+        timeout_secs = config.model_extra.get("timeout_secs", timeout_secs)
+        max_items = config.model_extra.get("max_items", max_items)
+
+    client = _get_apify_client("apify_actor_await")
+    writer = get_stream_writer()
+
+    loop = asyncio.get_running_loop()
+    start_time = loop.time()
+    deadline = start_time + timeout_secs
+
+    writer({"type": "apify_run_polling", "runId": run_id, "status": "WAITING", "elapsed_secs": 0})
+
+    try:
+        while loop.time() < deadline:
+            run = await asyncio.to_thread(client.run(run_id).get)
+            elapsed = int(loop.time() - start_time)
+
+            if not run:
+                writer({"type": "apify_run_failed", "runId": run_id, "status": "NOT_FOUND", "elapsed_secs": elapsed})
+                entry: dict = {"runId": run_id, "status": "NOT_FOUND", "error": "Run not found"}
+                if description:
+                    entry["description"] = description
+                return json.dumps(entry, ensure_ascii=False)
+
+            status = run.get("status", "")
+
+            if status in TERMINAL_STATUSES:
+                if status != "SUCCEEDED":
+                    writer({"type": "apify_run_failed", "runId": run_id, "status": status, "elapsed_secs": elapsed})
+                    entry = {"runId": run_id, "status": status, "error": f"Run {status.lower()}"}
+                    if description:
+                        entry["description"] = description
+                    return json.dumps(entry, indent=2, ensure_ascii=False)
+
+                # Use the fresh run's dataset ID in case it differs from the one passed in
+                resolved_dataset_id = run.get("defaultDatasetId") or dataset_id
+                items = await asyncio.to_thread(lambda: list(client.dataset(resolved_dataset_id).iterate_items(limit=max_items)))
+                writer({"type": "apify_run_completed", "runId": run_id, "status": "SUCCEEDED", "elapsed_secs": elapsed, "resultCount": len(items)})
+                entry = {"runId": run_id, "status": "SUCCEEDED", "resultCount": len(items), "results": items}
+                if description:
+                    entry["description"] = description
+                return json.dumps(entry, indent=2, ensure_ascii=False)
+
+            writer({"type": "apify_run_polling", "runId": run_id, "status": status, "elapsed_secs": elapsed})
+            await asyncio.sleep(poll_interval_secs)
+
+    except asyncio.CancelledError:
+        writer({"type": "apify_run_cancelled", "runId": run_id})
+        raise
+    except Exception as e:
+        elapsed = int(loop.time() - start_time)
+        writer({"type": "apify_run_failed", "runId": run_id, "status": "ERROR", "elapsed_secs": elapsed})
+        entry = {"runId": run_id, "status": "ERROR", "error": str(e)}
+        if description:
+            entry["description"] = description
+        return json.dumps(entry, indent=2, ensure_ascii=False)
+
+    elapsed = int(loop.time() - start_time)
+    entry = {"runId": run_id, "error": f"Run did not complete within {timeout_secs}s", "status": "TIMED_OUT"}
+    if description:
+        entry["description"] = description
+    return json.dumps(entry, indent=2, ensure_ascii=False)

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tavily-python>=0.7.17",
     "firecrawl-py>=1.15.0",
     "tiktoken>=0.8.0",
+    "apify-client>=1.8.0,<3",
     "ddgs>=9.10.0",
     "duckdb>=1.4.4",
     "langchain-google-genai>=4.2.1",

--- a/backend/tests/test_apify_tools.py
+++ b/backend/tests/test_apify_tools.py
@@ -1,0 +1,886 @@
+"""Unit tests for the Apify community tools."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, call, patch
+
+
+def _make_tool_config(api_key="test-key", **extra):
+    """Return a mock tool config with a default test API key and optional field overrides."""
+    cfg = MagicMock()
+    cfg.model_extra = {"api_key": api_key, **extra}
+    return cfg
+
+
+class TestWebSearchTool:
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_normalized_json(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(max_results=3)
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"organicResults": [{"title": "T", "url": "https://example.com", "description": "S"}]}])
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        result = web_search_tool.invoke({"query": "test"})
+
+        assert json.loads(result) == [{"title": "T", "url": "https://example.com", "snippet": "S"}]
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_max_results_from_config(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(max_results=7)
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"organicResults": []}])
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        web_search_tool.invoke({"query": "test"})
+
+        mock_apify_cls.return_value.actor.return_value.call.assert_called_once_with(run_input={"queries": ["test"], "maxPagesPerQuery": 1, "resultsPerPage": 7})
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_api_key_from_config(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(api_key="my-apify-key", max_results=5)
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"organicResults": []}])
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        web_search_tool.invoke({"query": "test"})
+
+        mock_apify_cls.assert_called_with("my-apify-key")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_string_on_exception(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.call.side_effect = RuntimeError("actor failed")
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        result = web_search_tool.invoke({"query": "test"})
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_caps_results_at_max_results(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(max_results=2)
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        organic = [{"title": f"T{i}", "url": f"https://example.com/{i}", "description": "S"} for i in range(5)]
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"organicResults": organic}])
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        result = web_search_tool.invoke({"query": "test"})
+
+        assert len(json.loads(result)) == 2
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_defaults_when_config_is_none(self, mock_get_app_config, mock_apify_cls):
+        # Omit max_results to verify the default of 5 is used.
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"organicResults": []}])
+
+        from deerflow.community.apify.tools import web_search_tool
+
+        web_search_tool.invoke({"query": "test"})
+
+        mock_apify_cls.return_value.actor.return_value.call.assert_called_once_with(run_input={"queries": ["test"], "maxPagesPerQuery": 1, "resultsPerPage": 5})
+
+
+class TestWebFetchTool:
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_markdown_with_title(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(crawler_type="cheerio")
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "My Page", "markdown": "Hello world", "text": ""}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result == "# My Page\n\nHello world"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_crawler_type_from_config(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(crawler_type="playwright:firefox")
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "Page", "markdown": "content", "text": ""}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        web_fetch_tool.invoke({"url": "https://example.com"})
+
+        mock_apify_cls.return_value.actor.return_value.call.assert_called_once_with(run_input={"startUrls": [{"url": "https://example.com"}], "maxCrawlPages": 1, "crawlerType": "playwright:firefox"})
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_falls_back_to_text_when_no_markdown(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "Page", "markdown": "", "text": "plain text fallback"}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result == "# Page\n\nplain text fallback"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_no_items(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result == "Error: No content found"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_truncates_content_to_4096_bytes(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        long_content = "x" * 5000
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "Page", "markdown": long_content, "text": ""}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result.endswith("\n\n[Content truncated]")
+        # Body is exactly 4096 bytes of ASCII content
+        body = result[len("# Page\n\n") : -len("\n\n[Content truncated]")]
+        assert len(body.encode("utf-8")) <= 4096
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_no_truncation_marker_when_short(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "Page", "markdown": "short content", "text": ""}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert "[Content truncated]" not in result
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_string_on_exception(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.call.side_effect = RuntimeError("network error")
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_defaults_when_no_optional_config(self, mock_get_app_config, mock_apify_cls):
+        # Omit crawler_type to verify the default of "cheerio" is used.
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        mock_run = {"defaultDatasetId": "dataset-123"}
+        mock_apify_cls.return_value.actor.return_value.call.return_value = mock_run
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"title": "Page", "markdown": "content", "text": ""}])
+
+        from deerflow.community.apify.tools import web_fetch_tool
+
+        web_fetch_tool.invoke({"url": "https://example.com"})
+
+        mock_apify_cls.return_value.actor.return_value.call.assert_called_once_with(run_input={"startUrls": [{"url": "https://example.com"}], "maxCrawlPages": 1, "crawlerType": "cheerio"})
+
+
+class TestApifyActorDiscoverTool:
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_store_search_returns_actor_list(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_result = MagicMock()
+        mock_result.items = [
+            {"username": "apify", "name": "instagram-scraper", "title": "Instagram Scraper", "description": "Scrapes Instagram"},
+        ]
+        mock_apify_cls.return_value.store.return_value.list.return_value = mock_result
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"query": "instagram"}))
+
+        assert result["action"] == "store_search"
+        assert result["count"] == 1
+        assert result["actors"][0]["actorId"] == "apify/instagram-scraper"
+        mock_apify_cls.return_value.store.return_value.list.assert_called_once_with(search="instagram", limit=10)
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_store_search_filters_actors_with_missing_fields(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_result = MagicMock()
+        mock_result.items = [
+            {"username": "", "name": "test", "title": "T", "description": "D"},
+            {"username": "apify", "name": "", "title": "T", "description": "D"},
+            {"username": "apify", "name": "valid", "title": "Valid", "description": "OK"},
+        ]
+        mock_apify_cls.return_value.store.return_value.list.return_value = mock_result
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"query": "test"}))
+
+        assert result["count"] == 1
+        assert result["actors"][0]["actorId"] == "apify/valid"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_actor_schema_fetches_via_version_detail(self, mock_get_app_config, mock_apify_cls):
+        """inputSchema is fetched from the version detail endpoint, not the version list."""
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.get.return_value = {"title": "My Actor", "description": "Desc"}
+        mock_versions = MagicMock()
+        mock_versions.items = [{"versionNumber": "0.1"}]
+        mock_apify_cls.return_value.actor.return_value.versions.return_value.list.return_value = mock_versions
+        mock_apify_cls.return_value.actor.return_value.version.return_value.get.return_value = {"inputSchema": '{"type": "object", "properties": {}}'}
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"actor_id": "apify/my-actor"}))
+
+        assert result["action"] == "actor_schema"
+        assert result["actorId"] == "apify/my-actor"
+        # JSON string inputSchema is parsed into a dict to avoid double-encoding
+        assert result["inputSchema"] == {"type": "object", "properties": {}}
+        mock_apify_cls.return_value.actor.return_value.version.assert_called_once_with("0.1")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_actor_schema_preserves_dict_input_schema(self, mock_get_app_config, mock_apify_cls):
+        """inputSchema that is already a dict is returned as-is."""
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.get.return_value = {"title": "My Actor", "description": "Desc"}
+        mock_versions = MagicMock()
+        mock_versions.items = [{"versionNumber": "1.0"}]
+        mock_apify_cls.return_value.actor.return_value.versions.return_value.list.return_value = mock_versions
+        mock_apify_cls.return_value.actor.return_value.version.return_value.get.return_value = {"inputSchema": {"type": "object"}}
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"actor_id": "apify/my-actor"}))
+
+        assert result["inputSchema"] == {"type": "object"}
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_actor_schema_returns_none_when_versions_raises(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.get.return_value = {"title": "My Actor", "description": "Desc"}
+        mock_apify_cls.return_value.actor.return_value.versions.return_value.list.side_effect = RuntimeError("API error")
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"actor_id": "apify/my-actor"}))
+
+        assert result["action"] == "actor_schema"
+        assert result["inputSchema"] is None
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_actor_not_found(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.get.return_value = None
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = apify_actor_discover_tool.invoke({"actor_id": "apify/nonexistent"})
+
+        assert "Error" in result and "not found" in result
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_accepts_plain_actor_id(self, mock_get_app_config, mock_apify_cls):
+        """Plain IDs like 'h7sDV53CddomktSi5' are valid — client accepts both formats."""
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.get.return_value = {"title": "YouTube Scraper", "description": "..."}
+        mock_versions = MagicMock()
+        mock_versions.items = []
+        mock_apify_cls.return_value.actor.return_value.versions.return_value.list.return_value = mock_versions
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = json.loads(apify_actor_discover_tool.invoke({"actor_id": "h7sDV53CddomktSi5"}))
+
+        assert result["action"] == "actor_schema"
+        mock_apify_cls.return_value.actor.assert_called_with("h7sDV53CddomktSi5")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_neither_provided(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = apify_actor_discover_tool.invoke({"query": "", "actor_id": ""})
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_both_provided(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = apify_actor_discover_tool.invoke({"query": "instagram", "actor_id": "apify/test"})
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_string_on_exception(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.store.return_value.list.side_effect = RuntimeError("network error")
+
+        from deerflow.community.apify.tools import apify_actor_discover_tool
+
+        result = apify_actor_discover_tool.invoke({"query": "test"})
+
+        assert result.startswith("Error:")
+
+
+class TestApifyActorStartTool:
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_run_reference_in_array(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = json.loads(apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"}))
+
+        assert result["action"] == "start"
+        assert isinstance(result["runs"], list)
+        assert len(result["runs"]) == 1
+        ref = result["runs"][0]
+        assert ref["runId"] == "run-123"
+        assert ref["actorId"] == "apify/test"
+        assert ref["datasetId"] == "ds-456"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_description_included_when_provided(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = json.loads(apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}", "description": "my-run"}))
+
+        assert result["runs"][0]["description"] == "my-run"
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_description_absent_when_not_provided(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = json.loads(apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"}))
+
+        assert "description" not in result["runs"][0]
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_calls_start_not_call(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"})
+
+        mock_apify_cls.return_value.actor.return_value.start.assert_called_once()
+        mock_apify_cls.return_value.actor.return_value.call.assert_not_called()
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_timeout_secs_from_config(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(timeout_secs=60)
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"})
+
+        mock_apify_cls.return_value.actor.return_value.start.assert_called_once_with(run_input={}, timeout_secs=60)
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_no_timeout_when_not_in_config(self, mock_get_app_config, mock_apify_cls):
+        # Omit timeout_secs and memory_mbytes to verify neither is forwarded to .start().
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"})
+
+        mock_apify_cls.return_value.actor.return_value.start.assert_called_once_with(run_input={})
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_memory_mbytes_from_config(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config(memory_mbytes=1024)
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"})
+
+        mock_apify_cls.return_value.actor.return_value.start.assert_called_once_with(run_input={}, memory_mbytes=1024)
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_for_empty_actor_id(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = None
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = apify_actor_start_tool.invoke({"actor_id": "", "run_input": "{}"})
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_accepts_plain_actor_id(self, mock_get_app_config, mock_apify_cls):
+        """Plain IDs like 'h7sDV53CddomktSi5' are valid — client accepts both formats."""
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.return_value = {"id": "run-123", "defaultDatasetId": "ds-456", "status": "RUNNING"}
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = json.loads(apify_actor_start_tool.invoke({"actor_id": "h7sDV53CddomktSi5", "run_input": "{}"}))
+
+        assert result["action"] == "start"
+        mock_apify_cls.return_value.actor.assert_called_with("h7sDV53CddomktSi5")
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_invalid_json_run_input(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = None
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "not json"})
+
+        assert "Error: run_input is not valid JSON" in result
+
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_string_on_exception(self, mock_get_app_config, mock_apify_cls):
+        mock_get_app_config.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.actor.return_value.start.side_effect = RuntimeError("API error")
+
+        from deerflow.community.apify.tools import apify_actor_start_tool
+
+        result = apify_actor_start_tool.invoke({"actor_id": "apify/test", "run_input": "{}"})
+
+        assert result.startswith("Error:")
+
+
+class TestApifyActorAwaitTool:
+    """Tests for apify_actor_await_tool — single async call, no agent looping."""
+
+    def _run(self, coro):
+        """Run a coroutine in a fresh event loop for test isolation."""
+        return asyncio.run(coro)
+
+    def _make_mock_writer(self):
+        return MagicMock()
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_results_when_succeeded_immediately(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"}
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([{"item": 1}])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "SUCCEEDED"
+        assert result["resultCount"] == 1
+        assert result["results"] == [{"item": 1}]
+        mock_sleep.assert_not_called()  # finished on first check, no sleep needed
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_polls_until_succeeded(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        responses = [
+            {"status": "RUNNING", "defaultDatasetId": "ds-1"},
+            {"status": "RUNNING", "defaultDatasetId": "ds-1"},
+            {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"},
+        ]
+        mock_apify_cls.return_value.run.return_value.get.side_effect = responses
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "SUCCEEDED"
+        assert mock_sleep.call_count == 2  # slept after each RUNNING response
+        # Every sleep call uses the default poll interval
+        mock_sleep.assert_has_calls([call(5), call(5)])
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_poll_interval_from_config(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config(poll_interval_secs=10, timeout_secs=300, max_items=50)
+        responses = [
+            {"status": "RUNNING", "defaultDatasetId": "ds-1"},
+            {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"},
+        ]
+        mock_apify_cls.return_value.run.return_value.get.side_effect = responses
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"}))
+
+        mock_sleep.assert_called_once_with(10)
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_failed(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "FAILED", "defaultDatasetId": "ds-1"}
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "FAILED"
+        assert "error" in result
+        mock_sleep.assert_not_called()
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_aborted(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "ABORTED", "defaultDatasetId": "ds-1"}
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "ABORTED"
+        assert "error" in result
+        mock_sleep.assert_not_called()
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_apify_timed_out(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        """TIMED-OUT (hyphen) is an Apify API terminal status — distinct from our local TIMED_OUT."""
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "TIMED-OUT", "defaultDatasetId": "ds-1"}
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "TIMED-OUT"
+        assert "error" in result
+        mock_sleep.assert_not_called()
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_description_included_on_succeeded(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"}
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1", "description": "my-run"})))
+
+        assert result["description"] == "my-run"
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_description_included_on_failed(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "FAILED", "defaultDatasetId": "ds-1"}
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1", "description": "my-run"})))
+
+        assert result["description"] == "my-run"
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_when_run_not_found(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = None
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "NOT_FOUND"
+        assert "error" in result
+        assert result["runId"] == "r1"
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_emits_terminal_event_when_run_not_found(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = None
+        writer_fn = self._make_mock_writer()
+        mock_writer.return_value = writer_fn
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"}))
+
+        event_types = [c.args[0]["type"] for c in writer_fn.call_args_list]
+        assert "apify_run_failed" in event_types
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_for_empty_run_id(self, mock_cfg, mock_apify_cls, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = None
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = self._run(apify_actor_await_tool.ainvoke({"run_id": "", "dataset_id": "ds-1"}))
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_fresh_dataset_id_from_run(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        """Dataset ID from the fresh run object takes precedence over the passed-in value."""
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "SUCCEEDED", "defaultDatasetId": "fresh-ds"}
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "stale-ds"}))
+
+        mock_apify_cls.return_value.dataset.assert_called_with("fresh-ds")
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_uses_config_values(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config(poll_interval_secs=10, timeout_secs=60, max_items=5)
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"}
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"}))
+
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.assert_called_once_with(limit=5)
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_error_on_sdk_exception(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        """Non-CancelledError exceptions from the SDK are caught and returned as error JSON."""
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.side_effect = RuntimeError("network timeout")
+        writer_fn = self._make_mock_writer()
+        mock_writer.return_value = writer_fn
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "ERROR"
+        assert "network timeout" in result["error"]
+        # An apify_run_failed event must be emitted so the frontend knows the run ended
+        event_types = [c.args[0]["type"] for c in writer_fn.call_args_list]
+        assert "apify_run_failed" in event_types
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_streams_polling_events(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        responses = [
+            {"status": "RUNNING", "defaultDatasetId": "ds-1"},
+            {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"},
+        ]
+        mock_apify_cls.return_value.run.return_value.get.side_effect = responses
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        writer_fn = self._make_mock_writer()
+        mock_writer.return_value = writer_fn
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"}))
+
+        events = [c.args[0] for c in writer_fn.call_args_list]
+        event_types = [e["type"] for e in events]
+        # First event must be the initial WAITING signal before any polling
+        assert events[0] == {"type": "apify_run_polling", "runId": "r1", "status": "WAITING", "elapsed_secs": 0}
+        # Intermediate RUNNING event and final completion event must both appear
+        assert "apify_run_polling" in event_types
+        assert event_types[-1] == "apify_run_completed"
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_times_out_when_deadline_exceeded(self, mock_cfg, mock_apify_cls, mock_writer):
+        """With timeout_secs=0 the deadline is start_time+0. By the time the while
+        condition is evaluated, real time has advanced past it, so the tool returns
+        TIMED_OUT without needing to patch the event loop."""
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config(poll_interval_secs=0, timeout_secs=0, max_items=50)
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "RUNNING", "defaultDatasetId": "ds-1"}
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "TIMED_OUT"
+        assert "error" in result
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_streams_failure_event(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "FAILED", "defaultDatasetId": "ds-1"}
+        writer_fn = self._make_mock_writer()
+        mock_writer.return_value = writer_fn
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"}))
+
+        event_types = [c.args[0]["type"] for c in writer_fn.call_args_list]
+        assert "apify_run_failed" in event_types
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.sleep", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_returns_empty_results_when_dataset_empty(self, mock_cfg, mock_apify_cls, mock_sleep, mock_writer):
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_apify_cls.return_value.run.return_value.get.return_value = {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"}
+        mock_apify_cls.return_value.dataset.return_value.iterate_items.return_value = iter([])
+        mock_writer.return_value = self._make_mock_writer()
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "SUCCEEDED"
+        assert result["resultCount"] == 0
+        assert result["results"] == []
+
+    @patch("deerflow.community.apify.tools.get_stream_writer")
+    @patch("deerflow.community.apify.tools.asyncio.to_thread", new_callable=AsyncMock)
+    @patch("deerflow.community.apify.tools.ApifyClient")
+    @patch("deerflow.community.apify.tools.get_app_config")
+    def test_blocking_calls_use_asyncio_to_thread(self, mock_cfg, mock_apify_cls, mock_to_thread, mock_writer):
+        """Blocking SDK calls (run.get and dataset.iterate_items) must be offloaded to a thread
+        via asyncio.to_thread so the event loop is not blocked during polling."""
+        mock_cfg.return_value.get_tool_config.return_value = _make_tool_config()
+        mock_writer.return_value = self._make_mock_writer()
+
+        # First to_thread call returns the run status; second returns the dataset items list
+        mock_to_thread.side_effect = [
+            {"status": "SUCCEEDED", "defaultDatasetId": "ds-1"},
+            [{"item": 1}],
+        ]
+
+        from deerflow.community.apify.tools import apify_actor_await_tool
+
+        result = json.loads(self._run(apify_actor_await_tool.ainvoke({"run_id": "r1", "dataset_id": "ds-1"})))
+
+        assert result["status"] == "SUCCEEDED"
+        # Both blocking SDK calls must go through to_thread, not be called directly
+        assert mock_to_thread.call_count == 2

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -209,6 +209,30 @@ wheels = [
 ]
 
 [[package]]
+name = "apify-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "apify-shared" },
+    { name = "colorama" },
+    { name = "impit" },
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/6a/b872d6bbc84c6aaf27b455492c6ff1bd057fea302c5d40619c733d48a718/apify_client-2.5.0.tar.gz", hash = "sha256:daa2af6a50e573f78bd46a4728a3f2be76cee93cf5c4ff9d0fd38b6756792689", size = 377916, upload-time = "2026-02-18T13:03:16.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/82/4fe19adfa6b962ab8a740782b6246b7c499f13edccac24733f015d895725/apify_client-2.5.0-py3-none-any.whl", hash = "sha256:4aa6172bed92d83f2d2bbe1f95cfaab2e147a834dfa007e309fd0b4709423316", size = 86996, upload-time = "2026-02-18T13:03:14.891Z" },
+]
+
+[[package]]
+name = "apify-shared"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/88/8833a8bba9044ce134bb2e57fbb626f1ddbeecac964bc2e2b652a50fadd1/apify_shared-2.2.0.tar.gz", hash = "sha256:ad48a96084e3c38faa1bac723a47929a1bb2c771544da2f0cb503eabdecfc79a", size = 45534, upload-time = "2026-01-15T10:17:14.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/7c/9607852e2bb324fa40a5b967e162dea1b3c76b429cf90b602e4a202c101a/apify_shared-2.2.0-py3-none-any.whl", hash = "sha256:667d4d00ac3cf8091702640547387ac5c72a1df402bbb3923f7a401bc25d9d50", size = 16408, upload-time = "2026-01-15T10:17:13.103Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -719,6 +743,7 @@ source = { editable = "packages/harness" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "agent-sandbox" },
+    { name = "apify-client" },
     { name = "ddgs" },
     { name = "dotenv" },
     { name = "duckdb" },
@@ -760,6 +785,7 @@ pymupdf = [
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.4.0" },
     { name = "agent-sandbox", specifier = ">=0.0.19" },
+    { name = "apify-client", specifier = ">=1.8.0,<3" },
     { name = "ddgs", specifier = ">=9.10.0" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "duckdb", specifier = ">=1.4.4" },
@@ -1348,6 +1374,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "impit"
+version = "0.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/e3/a765812d447714a9606e388325b59602ae61a7da6e59cd981a5dd2eedb11/impit-0.12.0.tar.gz", hash = "sha256:c9a29ba3cee820d2a0f11596a056e8316497b2e7e2ec789db180d72d35d344ac", size = 148594, upload-time = "2026-03-06T13:39:47.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/d0/1c2bad1095b23c693bab9509368c530ef8a16126bfd923de39e06ee4985e/impit-0.12.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:050d2f2e75180040922772fa5be00bd307c0787adf946a2db77a59c91ba61dbd", size = 3799136, upload-time = "2026-03-06T13:38:40.886Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/2a/8f4907d14ef7d071b973cc5b7878b91cfdb83e4b7aa52a10bcd4765205be/impit-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47e30b5ab61cba593479229111e2751c3afe5ae3053e0aaffdb524cbf407cec6", size = 3665914, upload-time = "2026-03-06T13:38:42.89Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5d/3da766bac2735d4cd1182ff16f32b8016ac9c048210141681383b27e3c7f/impit-0.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e707517ac3fc9a71d04d916daca38a3ebc76f7e7e02e59ec96383c29197a3da", size = 4004295, upload-time = "2026-03-06T13:38:44.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/29/a7b42490b3494e4c008a6116e87451d69fa7a0592be8c2bca11ec6804c31/impit-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:70134fe43547ec27631946fb638707ca3bb6a1acbdb535280d38aaf95ca3c0e2", size = 3872222, upload-time = "2026-03-06T13:38:46.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/02/5d3e2624345e78b5fcb29dfa01aa1f152e3bf317ddb372e60c5761c04fcd/impit-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9d4d6a4708e32763921c3eae75f77cd33dc777dfe804ea24ec777b2f1a305577", size = 4084224, upload-time = "2026-03-06T13:38:48.845Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e9/aabfff707579346a9db90c57816e4838969c8e9966e78754f8f8eae28b06/impit-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1cb1ef17b84c7883dc0ff0073b8240986ceacf628faad7deb9e1add811d2008e", size = 4232048, upload-time = "2026-03-06T13:38:51.18Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/68/7f90989ddb6f66948579f139b9c9f750a9b4989b55fb74248453aa4a0f18/impit-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:89264e48d864526b84cb3a620f26715013becf5c143942a2c9c05de124700133", size = 3677940, upload-time = "2026-03-06T13:38:52.953Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/b1/a7cb954b72306055f5672ad635227d8b8b495dab14a6ca289c8c71430e96/impit-0.12.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:d75b2a17fea6e4d02af08da7dd72852f23c70e167c168c43c3fb1f8b307be0d9", size = 3799190, upload-time = "2026-03-06T13:38:54.691Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e7/6152812b98896aa792086100d9f40b64570fcb5e2441a0222ae110ff6d19/impit-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e39731ec656857f5c445b7035e32f7ae99f126b9934bc08e55e837143192bfd", size = 3666041, upload-time = "2026-03-06T13:38:56.826Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a8/1dfdc748c980ca4604f99e06e0e430e237806056c761fc9f19ea3e70e228/impit-0.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:950837440cebba6466fc319ce7131aa720954b603f805b919a9a9837ce8e3834", size = 4004426, upload-time = "2026-03-06T13:38:58.946Z" },
+    { url = "https://files.pythonhosted.org/packages/52/cd/103a0f466a0ff957c7e24de2e38bd9c23b1bf4c39c269f2f014b1c15f304/impit-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:cb00b49b85def8a94f1717f1f91ea0d96b39b98b1c5e5343ea43ecd5087f9c08", size = 3872242, upload-time = "2026-03-06T13:39:00.687Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/de44068629e7807c4aaf939c87c04fe5e97e3b2f581cdbe68c362b779897/impit-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a6fc27136dbac34495d7f947c244b32db25a49d9c175e557b8d1838eec64a68", size = 4083853, upload-time = "2026-03-06T13:39:02.431Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/0e699ce9064648541e3676ef3287745cfce6d14b6aaaccf4a1e86dd69a80/impit-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:818d95b4958c451e230f8215b2ab920d521999bb53bb84438cf8b0b8efa37c7e", size = 4232069, upload-time = "2026-03-06T13:39:05.294Z" },
+    { url = "https://files.pythonhosted.org/packages/64/59/2869356464ac123c32b5fa53d912b2acc3156e932475dd02e64779099c83/impit-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:e1cbdce736ea66b2da3fe82a2c5961fe1fce35d98bcfb3130600dc78824b1fda", size = 3678217, upload-time = "2026-03-06T13:39:06.983Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/df495e9e1e23b6ec6b5a0a23b0b2b38a6666044bdfdc9b7b34d657dd8d06/impit-0.12.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:d508c287eae4645cde6f506ffa7e103706676dd72b85fe42940f6eb2159711bb", size = 3799269, upload-time = "2026-03-06T13:39:08.74Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/a0/dd79cd8b8315b4ddfd81ffd98c44728e40bdc0ea03e857db02814a262ca4/impit-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0b28289e9506a83ab3d372daec5bf7d7bcad0b386ed2c646cdce312250bc89d6", size = 3665883, upload-time = "2026-03-06T13:39:10.471Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9a/1b633977728fe79802478fa03144ee5cfb66683889d3ce842afd2846b75a/impit-0.12.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41d24979132f13b77573da44ca5894ed36d82ffcc8407959e32087afc1bd395c", size = 4005477, upload-time = "2026-03-06T13:39:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/90/9e3fa3f6ad6754ab7813e75e750201d956084b19ec8aa0df0a257ae1be4e/impit-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:00b29070c410594af878cfcd87e1f039e1b24b6e0989842700c285da65d1f934", size = 3872180, upload-time = "2026-03-06T13:39:14.291Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/2153114da2ec93a493c7e1440d06b542772d728b3286541b655128ec04b7/impit-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b9942b8208c0b0e95eec1f479f60def0c16249fdd346693e68c90b9cb41cc6c8", size = 4083682, upload-time = "2026-03-06T13:39:16.286Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b2/76d50922e2973d5631e2a7329c32e1cec39be7bd26077e797fd132401b5d/impit-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:1dc2702225eadbd501b748e4c435126a6b1ecab0578bb81da0ef364ee642c80b", size = 4232459, upload-time = "2026-03-06T13:39:18.302Z" },
+    { url = "https://files.pythonhosted.org/packages/44/32/7b1d30540b92276e7f8ebd281e319bf661c7ba461a611e89fefd3d6a6443/impit-0.12.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9d622e3f3bfc62f2cd3a7dbd036d5932f7578f7a329731709a366085f6eb4187", size = 3799126, upload-time = "2026-03-06T13:39:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/16/911eafb12a8d0954c9260559d9e0658b72b2fda02e5a6ef08c8fb418beab/impit-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:547fe4ee89001d3073590df6d4d985a727b09adb8aa2697a2ce97e8ecfdd3125", size = 3666157, upload-time = "2026-03-06T13:39:22.496Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/122e636d8139ddb44c5543d3dd976a74c10a8a4bf9738f74f57eac143d7d/impit-0.12.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1b973041bcb1ef7d57ade5c649ba4bd5dd7417cdbba3a3d399d6a1e578672b5", size = 4004895, upload-time = "2026-03-06T13:39:24.938Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/4812bd6f8c72152d3b2c718f5dfa06a4389dee7720340aaad42ba72ef3ac/impit-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:120574e7749036683337e0f4ffa924c7dc020e67f00f48515b1e3d2eb07491e0", size = 3872457, upload-time = "2026-03-06T13:39:27.041Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/f6bceaab2fa49ef9f740e0bf5ac80c66051e2a08b45f1eeb7b400095c655/impit-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:365e6bd562a55bacb80efbffa5f6a92c927789f7229b25af14e4bdec45e3798a", size = 4084106, upload-time = "2026-03-06T13:39:29.206Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d4/e4b5186411703d0f57c9c1c172a859622a226268cb61cee99d7fb7a93258/impit-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:36e858d3198c0c3cfcd2833adde300b831184925518909828555a17f61ab99bd", size = 4232106, upload-time = "2026-03-06T13:39:31.985Z" },
+    { url = "https://files.pythonhosted.org/packages/37/c8/d7401673a5ab290357503597b6b8d54e90f296f9f53f1ce93b756a82e08a/impit-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:ef5c129d5ae69f1fbab9ede66fd81ff2e8b277ddd47e7cbdb12bc7035e389ad8", size = 3678100, upload-time = "2026-03-06T13:39:34.357Z" },
+    { url = "https://files.pythonhosted.org/packages/51/b8/07d27c8a6f22a211f94d21c13cf3eabb09e10ad9d72d7f873bb77c9ed816/impit-0.12.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ad14a03cd2c44b3cbc79ae8cdc0717fe7b797d49fa11315751700f17dacef9f5", size = 3799520, upload-time = "2026-03-06T13:39:36.066Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/dc/ae90a5e77645bc059313cb3794d81ca2fc8d3456a6c5071237f414c2eb04/impit-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3a8dee56d4d9c941f3641025692a037fd6a120ceb6a447e5195dd0f149b7bcf9", size = 3665673, upload-time = "2026-03-06T13:39:38.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/e9/52e8a89f1c06137595ae421f34e3c9558681e13eb1c6418564acb80dda5a/impit-0.12.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6df30d4760cb6223db110061c147cb15a9e1e830c25a6a4ce9b0fde5728704ec", size = 4005490, upload-time = "2026-03-06T13:39:40.469Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/45/2dfd122e2952aef8266476c2955f56d4aa26f367d9deea1d994faf1d0ee8/impit-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:10d4686d0cdf11028ef9a5cdf842d8eb77863ed4b338d42328c61c83176f95a2", size = 3872188, upload-time = "2026-03-06T13:39:42.092Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/86f42e3d1554615f0a158b69b14cf821a1d806baff731427230b0b5a6996/impit-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:edca130ddcbfa731ebd875b4c7b2b5531083d845c1222ae33d4ef405144846eb", size = 4083719, upload-time = "2026-03-06T13:39:44.092Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7c/7ba4b99307bb084ab0891dccf1689195657a6ac675f7d1a8b0f134973fe2/impit-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:58c26d748480f7a937f6777503b1a88beda8bf548a7275238de8dc34edaa94bc", size = 4232704, upload-time = "2026-03-06T13:39:45.838Z" },
 ]
 
 [[package]]
@@ -2048,6 +2115,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -379,6 +379,15 @@ tools:
   #   max_results: 5
   #   # api_key: $FIRECRAWL_API_KEY
 
+  # Web search tool (uses Apify Google Search Scraper, requires APIFY_API_TOKEN)
+  # NOTE: Only one web_search provider can be active at a time.
+  # Comment out the Tavily/Jina/other web_search entry above before enabling this one.
+  # - name: web_search
+  #   group: web
+  #   use: deerflow.community.apify.tools:web_search_tool
+  #   max_results: 5
+  #   api_key: $APIFY_API_TOKEN
+
   # Web fetch tool (uses Exa)
   # NOTE: Only one web_fetch provider can be active at a time.
   # Comment out the Jina AI web_fetch entry below before enabling this one.
@@ -409,6 +418,36 @@ tools:
   #   group: web
   #   use: deerflow.community.firecrawl.tools:web_fetch_tool
   #   # api_key: $FIRECRAWL_API_KEY
+
+  # Web fetch tool (uses Apify Website Content Crawler, requires APIFY_API_TOKEN)
+  # NOTE: Only one web_fetch provider can be active at a time.
+  # Comment out the Jina AI/other web_fetch entry above before enabling this one.
+  # crawler_type options: "cheerio" (fast, no JS), "playwright:firefox" (JS-heavy pages)
+  # - name: web_fetch
+  #   group: web
+  #   use: deerflow.community.apify.tools:web_fetch_tool
+  #   crawler_type: cheerio
+  #   api_key: $APIFY_API_TOKEN
+
+  # Apify async actor tools — discover/start/await pattern for parallel actor runs
+  # - name: apify_actor_discover
+  #   group: web
+  #   use: deerflow.community.apify.tools:apify_actor_discover_tool
+  #   max_results: 10
+  #   api_key: $APIFY_API_TOKEN
+  # - name: apify_actor_start
+  #   group: web
+  #   use: deerflow.community.apify.tools:apify_actor_start_tool
+  #   # timeout_secs: 3600   # optional: override Apify platform default
+  #   # memory_mbytes: 1024  # optional: override Apify platform default
+  #   api_key: $APIFY_API_TOKEN
+  # - name: apify_actor_await
+  #   group: web
+  #   use: deerflow.community.apify.tools:apify_actor_await_tool
+  #   poll_interval_secs: 5   # seconds between Apify API status checks
+  #   timeout_secs: 300       # give up after this many seconds (default 5 min)
+  #   max_items: 50
+  #   api_key: $APIFY_API_TOKEN
 
   # Image search tool (uses DuckDuckGo)
   # Use this to find reference images before image generation

--- a/skills/public/apify-scraper/SKILL.md
+++ b/skills/public/apify-scraper/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: apify-scraper
+description: Use this skill for ALL web scraping tasks. Trigger on: scrape Instagram, scrape Facebook, scrape YouTube, scrape TikTok, collect Google Maps listings, scrape e-commerce products, scrape TripAdvisor reviews, scrape Booking.com hotels, or ANY task that requires collecting structured data from a specific website or social platform.
+---
+
+# Apify Ultimate Scraper Skill
+
+## Core Rule
+
+Never call `apify_actor_discover` for tasks in the routing table below.
+Always use the exact actor IDs listed here. Load the reference file to get the input template before calling `apify_actor_start`.
+
+## Actor Routing Table
+
+| Task | Actor ID | Reference |
+|------|----------|-----------|
+| Instagram profiles | apify/instagram-profile-scraper | references/instagram.md |
+| Instagram posts/hashtags | apify/instagram-post-scraper | references/instagram.md |
+| Instagram comments | apify/instagram-comment-scraper | references/instagram.md |
+| Instagram reels | apify/instagram-reel-scraper | references/instagram.md |
+| Google Maps listings | compass/crawler-google-places | references/google-maps.md |
+| YouTube videos/channels | streamers/youtube-scraper | references/youtube.md |
+| TikTok profiles/videos | clockworks/tiktok-scraper | references/tiktok.md |
+| Facebook pages/posts | apify/facebook-pages-scraper | references/facebook.md |
+| E-commerce products | apify/e-commerce-scraping-tool | references/ecommerce.md |
+| Booking.com hotels | voyager/booking-scraper | references/ecommerce.md |
+| TripAdvisor reviews | maxcopell/tripadvisor-reviews | references/ecommerce.md |
+
+## Workflow
+
+1. Match the user's task to a row in the routing table.
+2. Load the reference file for that actor using `read_file`.
+3. Populate the input template with values from the user's request.
+4. Call `apify_actor_start` with the actor ID and populated input.
+5. Call `apify_actor_await` passing `run_id` (from `runs[0].runId`) and `dataset_id` (from `runs[0].datasetId`).
+6. If the result has `status: FAILED`, `ABORTED`, or `TIMED-OUT`, report the error to the user. Do not retry automatically.
+
+**Multiple parallel actors:** call `apify_actor_start` once per actor first, then call `apify_actor_await` for each run in sequence.
+
+## When to Fall Back to Discovery
+
+Only use `apify_actor_discover` when the task does not match any row above. In that case:
+1. Read `references/actor-catalog.md` for the curated shortlist.
+2. Pick the most specific actor ID.
+3. Call `apify_actor_discover` with `actor_id` (not `query`) to fetch that actor's input schema.
+4. Build the input from the schema, then proceed with `apify_actor_start`.

--- a/skills/public/apify-scraper/references/actor-catalog.md
+++ b/skills/public/apify-scraper/references/actor-catalog.md
@@ -1,0 +1,91 @@
+# Actor Catalog
+
+Curated list of 56 Apify actors. Use this when the routing table in SKILL.md does not match the user's task. Pick the most specific actor, then call `apify_actor_discover` with its ID to get the input schema before starting.
+
+Actor IDs use `owner/name` format as required by the Apify client.
+
+## Instagram (12 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| apify/instagram-profile-scraper | Public profile data |
+| apify/instagram-post-scraper | Posts and captions |
+| apify/instagram-comment-scraper | Comments on posts |
+| apify/instagram-hashtag-scraper | Hashtag listings |
+| apify/instagram-hashtag-stats | Hashtag statistics |
+| apify/instagram-reel-scraper | Reels |
+| apify/instagram-search-scraper | Search users/hashtags/locations |
+| apify/instagram-tagged-scraper | Tagged posts |
+| apify/instagram-followers-count-scraper | Follower counts |
+| apify/instagram-scraper | General purpose Instagram scraper |
+| apify/instagram-api-scraper | Instagram via API |
+| apify/export-instagram-comments-posts | Bulk export of comments and posts |
+
+## Facebook (14 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| apify/facebook-pages-scraper | Page info and posts |
+| apify/facebook-page-contact-information | Contact details from pages |
+| apify/facebook-posts-scraper | Posts and feeds |
+| apify/facebook-comments-scraper | Comments on posts |
+| apify/facebook-likes-scraper | Reaction data |
+| apify/facebook-reviews-scraper | Page reviews |
+| apify/facebook-groups-scraper | Group content |
+| apify/facebook-events-scraper | Events |
+| apify/facebook-ads-scraper | Ads and campaigns |
+| apify/facebook-search-scraper | Search results |
+| apify/facebook-reels-scraper | Reels |
+| apify/facebook-photos-scraper | Photos |
+| apify/facebook-marketplace-scraper | Marketplace listings |
+| apify/facebook-followers-following-scraper | Follower and following lists |
+
+## TikTok (14 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| clockworks/tiktok-scraper | General TikTok scraper (profiles + hashtags) |
+| clockworks/free-tiktok-scraper | Free tier TikTok scraper |
+| clockworks/tiktok-profile-scraper | Creator profile data |
+| clockworks/tiktok-video-scraper | Individual videos |
+| clockworks/tiktok-comments-scraper | Comments on videos |
+| clockworks/tiktok-followers-scraper | Follower data |
+| clockworks/tiktok-user-search-scraper | Search for users |
+| clockworks/tiktok-hashtag-scraper | Hashtag feeds |
+| clockworks/tiktok-sound-scraper | Sound and music data |
+| clockworks/tiktok-ads-scraper | Ads |
+| clockworks/tiktok-discover-scraper | Discover page content |
+| clockworks/tiktok-explore-scraper | Explore content |
+| clockworks/tiktok-trends-scraper | Trending content |
+| clockworks/tiktok-live-scraper | Live stream data |
+
+## YouTube (5 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| streamers/youtube-scraper | Videos, channels, search results |
+| streamers/youtube-channel-scraper | Channel metadata and video list |
+| streamers/youtube-comments-scraper | Comments on videos |
+| streamers/youtube-shorts-scraper | Shorts |
+| streamers/youtube-video-scraper-by-hashtag | Videos by hashtag |
+
+## Google Maps (4 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| compass/crawler-google-places | Business listings with reviews |
+| compass/google-maps-extractor | Map data extraction |
+| compass/google-maps-reviews-scraper | Reviews for a specific place |
+| poidata/google-maps-email-extractor | Email addresses from business listings |
+
+## Search / E-Commerce / Other (7 actors)
+
+| Actor ID | Description |
+|----------|-------------|
+| apify/google-search-scraper | Google SERP results |
+| apify/google-trends-scraper | Google Trends data |
+| voyager/booking-scraper | Booking.com hotel listings |
+| voyager/booking-reviews-scraper | Booking.com reviews |
+| maxcopell/tripadvisor-reviews | TripAdvisor reviews |
+| vdrmota/contact-info-scraper | Contact information extraction from websites |
+| apify/e-commerce-scraping-tool | Generic e-commerce product scraper |

--- a/skills/public/apify-scraper/references/ecommerce.md
+++ b/skills/public/apify-scraper/references/ecommerce.md
@@ -1,0 +1,108 @@
+# E-Commerce Actors
+
+## Actor: apify/e-commerce-scraping-tool
+
+Generic e-commerce scraper supporting Amazon, eBay, and other online shops. Returns product name, price, rating, reviews count, availability.
+
+### Input Template
+
+```json
+{
+  "startUrls": [
+    {"url": "<PRODUCT_LISTING_URL>"}
+  ],
+  "maxItems": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startUrls | array of objects | Product listing or search result URLs |
+| maxItems | integer | Max products to return |
+
+### Example
+
+User: "Scrape laptop prices from Amazon"
+
+```json
+{
+  "startUrls": [{"url": "https://www.amazon.com/s?k=laptop"}],
+  "maxItems": 20
+}
+```
+
+---
+
+## Actor: voyager/booking-scraper
+
+Scrapes Booking.com hotel listings: name, price, rating, location, amenities, availability.
+
+### Input Template
+
+```json
+{
+  "startUrls": [
+    {"url": "https://www.booking.com/searchresults.html?ss=<DESTINATION>&checkin=<YYYY-MM-DD>&checkout=<YYYY-MM-DD>&group_adults=2"}
+  ],
+  "maxItems": 20
+}
+```
+
+**Note:** If the user provides a copied Booking.com URL from their browser, use it directly. If only a destination is given, construct the URL with `ss=<destination>`. Checkin/checkout dates are optional but improve result quality — ask the user if relevant.
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startUrls | array of objects | Booking.com search results URL |
+| maxItems | integer | Max hotels to return |
+
+### Example
+
+User: "Find hotels in Prague on Booking.com for June 1–7, 2 adults"
+
+```json
+{
+  "startUrls": [{"url": "https://www.booking.com/searchresults.html?ss=Prague&checkin=2025-06-01&checkout=2025-06-07&group_adults=2"}],
+  "maxItems": 20
+}
+```
+
+---
+
+## Actor: maxcopell/tripadvisor-reviews
+
+Scrapes reviews from TripAdvisor for restaurants, hotels, and attractions.
+
+### Input Template
+
+```json
+{
+  "startUrls": [
+    {"url": "<TRIPADVISOR_LISTING_URL>"}
+  ],
+  "maxItems": 50
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startUrls | array of objects | Direct URL to a TripAdvisor restaurant, hotel, or attraction page |
+| maxItems | integer | Max reviews to return |
+
+**Note:** A direct TripAdvisor listing URL is required. If the user gives only a name/location, use `web_search` to find the TripAdvisor page URL first (e.g. search `"Cafe Savoy Prague TripAdvisor"`), then use that URL.
+
+### Example
+
+User: "Get reviews for Cafe Savoy in Prague on TripAdvisor"
+
+```json
+{
+  "startUrls": [{"url": "https://www.tripadvisor.com/Restaurant_Review-g274707-d1058505-Reviews-Cafe_Savoy-Prague_Bohemia.html"}],
+  "maxItems": 50
+}
+```

--- a/skills/public/apify-scraper/references/facebook.md
+++ b/skills/public/apify-scraper/references/facebook.md
@@ -1,0 +1,46 @@
+# Facebook Actor
+
+## Actor: apify/facebook-pages-scraper
+
+Scrapes public Facebook pages: page info, recent posts, likes, comments, reactions, contact details.
+
+### Input Template
+
+```json
+{
+  "startUrls": [
+    {"url": "https://www.facebook.com/<PAGE_NAME>"}
+  ],
+  "maxPosts": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| startUrls | array of objects | URLs of Facebook pages to scrape |
+| maxPosts | integer | Max posts to scrape per page (default 20) |
+| maxPostComments | integer | Max comments per post. Omit for no comments. |
+| maxReviews | integer | Max reviews to scrape. Omit to skip reviews. |
+
+### Examples
+
+User: "Scrape the Apify Facebook page and get its latest posts"
+
+```json
+{
+  "startUrls": [{"url": "https://www.facebook.com/apifytech"}],
+  "maxPosts": 20
+}
+```
+
+User: "Get Facebook page info and 5 posts with their comments for NASA"
+
+```json
+{
+  "startUrls": [{"url": "https://www.facebook.com/NASA"}],
+  "maxPosts": 5,
+  "maxPostComments": 10
+}
+```

--- a/skills/public/apify-scraper/references/google-maps.md
+++ b/skills/public/apify-scraper/references/google-maps.md
@@ -1,0 +1,57 @@
+# Google Maps Actor
+
+## Actor: compass/crawler-google-places
+
+Scrapes business listings from Google Maps: name, address, rating, reviews count, phone, website, opening hours, coordinates.
+
+### Input Template
+
+```json
+{
+  "searchStringsArray": ["<SEARCH QUERY>"],
+  "maxCrawledPlacesPerSearch": 20,
+  "language": "en"
+}
+```
+
+Include `locationQuery` when the search term alone is ambiguous (e.g. "coffee shops" without a city):
+
+```json
+{
+  "searchStringsArray": ["coffee shops"],
+  "locationQuery": "Prague, Czech Republic",
+  "maxCrawledPlacesPerSearch": 20,
+  "language": "en"
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| searchStringsArray | array of strings | Search queries, same as typing into Google Maps. E.g. `["coffee shops Prague"]` |
+| maxCrawledPlacesPerSearch | integer | Max results per query (default 20, max ~120) |
+| language | string | Results language code. E.g. `"en"`, `"cs"`, `"de"` |
+| locationQuery | string | Optional — center the search on a specific location. Use when the query doesn't contain a location. E.g. `"Prague, Czech Republic"` |
+
+### Examples
+
+User: "Find coffee shops in Prague city centre"
+
+```json
+{
+  "searchStringsArray": ["coffee shops Prague city centre"],
+  "maxCrawledPlacesPerSearch": 20,
+  "language": "en"
+}
+```
+
+User: "Get all Italian restaurants in Berlin with their ratings"
+
+```json
+{
+  "searchStringsArray": ["Italian restaurants Berlin"],
+  "maxCrawledPlacesPerSearch": 40,
+  "language": "en"
+}
+```

--- a/skills/public/apify-scraper/references/instagram.md
+++ b/skills/public/apify-scraper/references/instagram.md
@@ -1,0 +1,149 @@
+# Instagram Actors
+
+## Actor: apify/instagram-profile-scraper
+
+Scrapes public profile data: bio, follower/following counts, post count, verified status.
+
+### Input Template
+
+```json
+{
+  "usernames": ["<USERNAME>"],
+  "resultsLimit": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| usernames | array of strings | Instagram usernames without @. E.g. `["apify", "nasa"]` |
+| resultsLimit | integer | Max profiles to return (default 20) |
+
+### Example
+
+User: "Get Instagram profile info for @apify"
+
+```json
+{
+  "usernames": ["apify"],
+  "resultsLimit": 1
+}
+```
+
+---
+
+## Actor: apify/instagram-post-scraper
+
+Scrapes posts from a profile, hashtag, or location. Returns captions, likes, comments count, media URLs.
+
+### Input Template
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/<USERNAME>/"],
+  "resultsLimit": 50
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| directUrls | array of strings | Profile URL (`/username/`), hashtag URL (`/explore/tags/ai/`), or individual post URL (`/p/ABC123/`) |
+| resultsLimit | integer | Max posts to scrape |
+
+### Examples
+
+User: "Scrape the last 20 posts from @apify"
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/apify/"],
+  "resultsLimit": 20
+}
+```
+
+User: "Find posts tagged #artificialintelligence"
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/explore/tags/artificialintelligence/"],
+  "resultsLimit": 30
+}
+```
+
+User: "Get data from this Instagram post https://www.instagram.com/p/ABC123/"
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/p/ABC123/"],
+  "resultsLimit": 1
+}
+```
+
+---
+
+## Actor: apify/instagram-comment-scraper
+
+Scrapes comments from Instagram posts.
+
+### Input Template
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/p/<POST_ID>/"],
+  "resultsLimit": 100
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| directUrls | array of strings | Direct post URLs in format `https://www.instagram.com/p/<POST_ID>/` |
+| resultsLimit | integer | Max comments to scrape |
+
+### Example
+
+User: "Get 50 comments from this Instagram post"
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/p/ABC123/"],
+  "resultsLimit": 50
+}
+```
+
+---
+
+## Actor: apify/instagram-reel-scraper
+
+Scrapes Instagram Reels: video URL, description, play count, like count, author.
+
+### Input Template
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/<USERNAME>/reels/"],
+  "resultsLimit": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| directUrls | array of strings | Profile reels URL or individual reel URL |
+| resultsLimit | integer | Max reels to scrape |
+
+### Example
+
+User: "Get the latest reels from @apify"
+
+```json
+{
+  "directUrls": ["https://www.instagram.com/apify/reels/"],
+  "resultsLimit": 20
+}
+```

--- a/skills/public/apify-scraper/references/tiktok.md
+++ b/skills/public/apify-scraper/references/tiktok.md
@@ -1,0 +1,51 @@
+# TikTok Actor
+
+## Actor: clockworks/tiktok-scraper
+
+Scrapes TikTok profiles, videos, and hashtags. Returns video descriptions, play counts, like counts, comments, author details.
+
+### Input Template — Profiles
+
+```json
+{
+  "profiles": ["<USERNAME>"],
+  "resultsPerPage": 20
+}
+```
+
+### Input Template — Hashtag
+
+```json
+{
+  "hashtags": ["<HASHTAG>"],
+  "resultsPerPage": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| profiles | array of strings | TikTok usernames **without** `@`. Strip it before passing. E.g. `["tiktok", "apify"]` not `["@tiktok"]` |
+| hashtags | array of strings | Hashtags **without** `#`. E.g. `["ai", "programming"]` not `["#ai"]` |
+| resultsPerPage | integer | Max results to return per profile or hashtag |
+
+### Examples
+
+User: "Get recent videos from TikTok user @apify"
+
+```json
+{
+  "profiles": ["apify"],
+  "resultsPerPage": 30
+}
+```
+
+User: "Scrape TikTok videos with hashtag #artificialintelligence"
+
+```json
+{
+  "hashtags": ["artificialintelligence"],
+  "resultsPerPage": 50
+}
+```

--- a/skills/public/apify-scraper/references/youtube.md
+++ b/skills/public/apify-scraper/references/youtube.md
@@ -1,0 +1,53 @@
+# YouTube Actor
+
+## Actor: streamers/youtube-scraper
+
+Scrapes YouTube videos, channels, and search results. Returns title, description, view count, like count, published date, channel info.
+
+### Input Template — Search
+
+```json
+{
+  "searchKeywords": "<SEARCH QUERY>",
+  "maxResults": 20
+}
+```
+
+### Input Template — Specific Channel or Video
+
+```json
+{
+  "startUrls": [
+    {"url": "https://www.youtube.com/@<CHANNEL_HANDLE>"}
+  ],
+  "maxResults": 20
+}
+```
+
+### Key Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| searchKeywords | string | Search query. Used when you want to search YouTube, not scrape a specific channel |
+| startUrls | array of objects | Direct URLs to channels, videos, or playlists. Use instead of searchKeywords for specific targets |
+| maxResults | integer | Max videos/results to return |
+
+### Examples
+
+User: "Find the top 10 YouTube videos about LLM benchmarking"
+
+```json
+{
+  "searchKeywords": "LLM benchmarking 2025",
+  "maxResults": 10
+}
+```
+
+User: "Scrape the latest 20 videos from the Apify YouTube channel"
+
+```json
+{
+  "startUrls": [{"url": "https://www.youtube.com/@apify"}],
+  "maxResults": 20
+}
+```


### PR DESCRIPTION
Adds [Apify](https://apify.com) as a community provider under `deerflow/community/apify/`.

Apify is a marketplace for AI tools and web automation with 25,000+ ready-made tools called Actors — built, published, and maintained by a large developer community. This integration gives DeerFlow agents direct access to that catalog: browse Apify Store, start any Actor, and get structured results back in the conversation — without leaving the agent loop. Social platforms, e-commerce, maps, search engines — if an Actor exists for it, the agent can run it. `web_search` and `web_fetch` are also included as drop-in replacements for users already on Apify.

| Prompt | What runs |
|--------|-----------|
| `Scrape the Instagram profile @apify` | skill routing → `apify_actor_start/await` |
| `Get the latest 5 videos from the Apify YouTube channel` | skill routing → `apify_actor_start/await` |
| `Find a Reddit scraper on Apify and run it for r/MachineLearning` | `apify_actor_discover` → `start` → `await` |
| `Search for latest news about LangGraph` | `web_search` |
| `Fetch the content of https://apify.com` | `web_fetch` |

## Summary

Five new tools:

- `web_search` — backed by `apify/google-search-scraper`, same interface as the Tavily/Jina tools
- `web_fetch` — backed by `apify/website-content-crawler`, output truncated at 4096 UTF-8 bytes
- `apify_actor_discover` — search Apify Store by keyword, or fetch an Actor's input schema by ID
- `apify_actor_start` — start an Actor run asynchronously, returns a run reference immediately
- `apify_actor_await` — poll a run to completion, stream progress events, return up to N results

The start/await split lets the agent fan out multiple Actor runs in parallel.

One new public skill — `skills/public/apify-scraper/` — with a routing table of known Actors (Instagram, TikTok, YouTube, Facebook, Google Maps, e-commerce) and per-Actor input templates in `references/`. Recommended when using the Actor tools: the skill injects exact Actor IDs and ready-made input templates into the agent's context, so it skips `apify_actor_discover` entirely for covered tasks. This saves one round-trip API call and avoids the agent picking a suboptimal Actor from search results.

## Implementation notes

**Auth** — `APIFY_API_TOKEN` env var or `api_key` per-tool in `config.yaml`. Error message names the exact config path if neither is set.

**Async** — `apify_actor_await_tool` is `async def`. Blocking SDK calls (`run.get`, `dataset.iterate_items`) go through `asyncio.to_thread`, same pattern as `jina_ai`.

**Streaming** — `apify_actor_await_tool` emits custom events via `get_stream_writer()`: `apify_run_polling`, `apify_run_completed`, `apify_run_failed`, `apify_run_cancelled`.

**Timeout** — local deadline via `loop.time()`; returns `TIMED_OUT` to the agent without cancelling the run on the platform.

**Dependency** — `apify-client>=1.8.0,<3` added to `pyproject.toml`.

## Config

All five tools are in `config.example.yaml` as commented-out examples. The `web_search`/`web_fetch` blocks include a note to disable the existing provider first (tool names must be unique).

Minimal setup:

```yaml
tools:
  - name: web_search
    group: web
    use: deerflow.community.apify.tools:web_search_tool
    api_key: $APIFY_API_TOKEN

  - name: web_fetch
    group: web
    use: deerflow.community.apify.tools:web_fetch_tool
    crawler_type: cheerio
    api_key: $APIFY_API_TOKEN

  - name: apify_actor_discover
    group: web
    use: deerflow.community.apify.tools:apify_actor_discover_tool
    api_key: $APIFY_API_TOKEN

  - name: apify_actor_start
    group: web
    use: deerflow.community.apify.tools:apify_actor_start_tool
    api_key: $APIFY_API_TOKEN

  - name: apify_actor_await
    group: web
    use: deerflow.community.apify.tools:apify_actor_await_tool
    poll_interval_secs: 5
    timeout_secs: 300
    max_items: 50
    api_key: $APIFY_API_TOKEN
```

## Validation

```bash
# unit tests
PYTHONPATH=. uv run pytest backend/tests/test_apify_tools.py -v   # 54 tests

# lint
uv run ruff check backend/packages/harness/deerflow/community/apify/tools.py
uv run ruff check backend/tests/test_apify_tools.py

# harness boundary (no app.* imports from deerflow.*)
PYTHONPATH=. uv run pytest backend/tests/test_harness_boundary.py
```

Live test: requires `APIFY_API_TOKEN` and the `apify-scraper` skill enabled in the Skills panel.
