### PR TITLE
fix(skills): harden .skill archive installation

### DIFF
--- a/backend/packages/harness/deerflow/skills/installer.py
+++ b/backend/packages/harness/deerflow/skills/installer.py
@@ -17,6 +17,13 @@ from deerflow.skills.validation import _validate_skill_frontmatter
 
 logger = logging.getLogger(__name__)
 
+MAX_ARCHIVE_SIZE_BYTES = 50 * 1024 * 1024
+MAX_COMPRESSED_ARCHIVE_SIZE_BYTES = 25 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 500
+MAX_ARCHIVE_MEMBER_SIZE_BYTES = 5 * 1024 * 1024
+MAX_ARCHIVE_MEMBER_NAME_BYTES = 255
+NESTED_ARCHIVE_EXTENSIONS = (".zip", ".skill", ".tar", ".tgz", ".gz", ".7z", ".rar")
+
 
 class SkillAlreadyExistsError(ValueError):
     """Raised when a skill with the same name is already installed."""
@@ -46,6 +53,24 @@ def is_symlink_member(info: zipfile.ZipInfo) -> bool:
     return stat.S_ISLNK(mode)
 
 
+def has_control_characters(name: str) -> bool:
+    """Return True if a zip member name contains NUL or control characters."""
+    return any(ord(char) < 32 or ord(char) == 127 for char in name)
+
+
+def has_too_long_path_component(name: str) -> bool:
+    """Return True if any path component exceeds common filesystem name limits."""
+    return any(len(part.encode("utf-8")) > MAX_ARCHIVE_MEMBER_NAME_BYTES for part in PurePosixPath(name).parts)
+
+
+def is_nested_archive_member(info: zipfile.ZipInfo) -> bool:
+    """Return True if the member is itself an archive payload."""
+    if info.is_dir():
+        return False
+    normalized = posixpath.normpath(info.filename.replace("\\", "/")).rstrip("/")
+    return normalized.lower().endswith(NESTED_ARCHIVE_EXTENSIONS)
+
+
 def should_ignore_archive_entry(path: Path) -> bool:
     """Return True for macOS metadata dirs and dotfiles."""
     return path.name.startswith(".") or path.name == "__MACOSX"
@@ -73,30 +98,49 @@ def resolve_skill_dir_from_archive(temp_path: Path) -> Path:
 def safe_extract_skill_archive(
     zip_ref: zipfile.ZipFile,
     dest_path: Path,
-    max_total_size: int = 512 * 1024 * 1024,
+    max_total_size: int = MAX_ARCHIVE_SIZE_BYTES,
+    max_entries: int = MAX_ARCHIVE_ENTRIES,
+    max_member_size: int = MAX_ARCHIVE_MEMBER_SIZE_BYTES,
 ) -> None:
     """Safely extract a skill archive with security protections.
 
     Protections:
     - Reject absolute paths and directory traversal (..).
-    - Skip symlink entries instead of materialising them.
-    - Enforce a hard limit on total uncompressed size (zip bomb defence).
+    - Reject symlink entries instead of materialising them.
+    - Enforce hard limits on entry count and uncompressed sizes.
+    - Reject nested archives and unsafe member names.
 
     Raises:
         ValueError: If unsafe members or size limit exceeded.
     """
     dest_root = dest_path.resolve()
     total_written = 0
+    infos = zip_ref.infolist()
 
-    for info in zip_ref.infolist():
+    if len(infos) > max_entries:
+        raise ValueError(f"Skill archive contains too many entries ({len(infos)} > {max_entries})")
+
+    declared_size = sum(info.file_size for info in infos)
+    if declared_size > max_total_size:
+        raise ValueError("Skill archive is too large or appears highly compressed.")
+
+    for info in infos:
         if is_unsafe_zip_member(info):
             raise ValueError(f"Archive contains unsafe member path: {info.filename!r}")
 
         if is_symlink_member(info):
-            logger.warning("Skipping symlink entry in skill archive: %s", info.filename)
-            continue
+            raise ValueError(f"Archive contains symlink member: {info.filename!r}")
 
         normalized_name = posixpath.normpath(info.filename.replace("\\", "/"))
+        if normalized_name in {"", "."} or has_control_characters(info.filename):
+            raise ValueError(f"Archive contains unsafe member name: {info.filename!r}")
+        if has_too_long_path_component(normalized_name):
+            raise ValueError(f"Archive member name is too long: {info.filename!r}")
+        if is_nested_archive_member(info):
+            raise ValueError(f"Archive contains nested archive member: {info.filename!r}")
+        if info.file_size > max_member_size:
+            raise ValueError(f"Archive member is too large: {info.filename!r}")
+
         member_path = dest_root.joinpath(*PurePosixPath(normalized_name).parts)
         if not member_path.resolve().is_relative_to(dest_root):
             raise ValueError(f"Zip entry escapes destination: {info.filename!r}")
@@ -118,7 +162,7 @@ def install_skill_from_archive(
     zip_path: str | Path,
     *,
     skills_root: Path | None = None,
-) -> dict:
+) -> dict[str, bool | str]:
     """Install a skill from a .skill archive (ZIP).
 
     Args:
@@ -142,6 +186,8 @@ def install_skill_from_archive(
         raise ValueError(f"Path is not a file: {zip_path}")
     if path.suffix != ".skill":
         raise ValueError("File must have .skill extension")
+    if path.stat().st_size > MAX_COMPRESSED_ARCHIVE_SIZE_BYTES:
+        raise ValueError("Skill archive file is too large.")
 
     if skills_root is None:
         skills_root = get_skills_root_path()

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -2459,8 +2459,8 @@ class TestInstallSkillSecurity:
                 with pytest.raises(ValueError, match="unsafe"):
                     client.install_skill(archive)
 
-    def test_symlinks_skipped_during_extraction(self, client):
-        """Symlink entries in the archive are skipped (never written to disk)."""
+    def test_symlinks_rejected_during_extraction(self, client):
+        """Symlink entries in the archive reject installation outright."""
         import stat as stat_mod
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -2478,12 +2478,10 @@ class TestInstallSkillSecurity:
             (skills_root / "custom").mkdir(parents=True)
 
             with patch("deerflow.skills.installer.get_skills_root_path", return_value=skills_root):
-                result = client.install_skill(archive)
+                with pytest.raises(ValueError, match="symlink"):
+                    client.install_skill(archive)
 
-            assert result["success"] is True
-            installed = skills_root / "custom" / "sym-skill"
-            assert (installed / "SKILL.md").exists()
-            assert not (installed / "sneaky_link").exists()
+            assert not (skills_root / "custom" / "sym-skill").exists()
 
     def test_invalid_skill_name_rejected(self, client):
         """Skill names containing special characters are rejected."""

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -1,5 +1,7 @@
 import errno
 import json
+import stat
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -33,6 +35,37 @@ def _make_skill(name: str, *, enabled: bool) -> Skill:
         category="public",
         enabled=enabled,
     )
+
+
+def test_install_skill_router_rejects_symlink_archive(monkeypatch, tmp_path):
+    archive = tmp_path / "sym-skill.skill"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("sym-skill/SKILL.md", "---\nname: sym-skill\ndescription: test\n---\nBody")
+        link_info = zipfile.ZipInfo("sym-skill/sneaky_link")
+        link_info.external_attr = (stat.S_IFLNK | 0o777) << 16
+        zf.writestr(link_info, "/etc/passwd")
+
+    skills_root = tmp_path / "skills"
+    (skills_root / "custom").mkdir(parents=True)
+    refresh_calls = []
+
+    async def _refresh():
+        refresh_calls.append("refresh")
+
+    monkeypatch.setattr("app.gateway.routers.skills.resolve_thread_virtual_path", lambda _thread_id, _path: archive)
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_skills_system_prompt_cache_async", _refresh)
+    monkeypatch.setattr("deerflow.skills.installer.get_skills_root_path", lambda: skills_root)
+
+    app = FastAPI()
+    app.include_router(skills_router.router)
+
+    with TestClient(app) as client:
+        response = client.post("/api/skills/install", json={"thread_id": "thread-1", "path": "mnt/user-data/outputs/sym-skill.skill"})
+
+    assert response.status_code == 400
+    assert "symlink" in response.json()["detail"]
+    assert refresh_calls == []
+    assert not (skills_root / "custom" / "sym-skill").exists()
 
 
 def test_custom_skills_router_lifecycle(monkeypatch, tmp_path):

--- a/backend/tests/test_skills_installer.py
+++ b/backend/tests/test_skills_installer.py
@@ -133,7 +133,7 @@ class TestSafeExtract:
             with pytest.raises(ValueError, match="unsafe"):
                 safe_extract_skill_archive(zf, dest)
 
-    def test_skips_symlinks(self, tmp_path):
+    def test_rejects_symlinks(self, tmp_path):
         zip_path = tmp_path / "sym.zip"
         with zipfile.ZipFile(zip_path, "w") as zf:
             info = zipfile.ZipInfo("link.txt")
@@ -143,9 +143,50 @@ class TestSafeExtract:
         dest = tmp_path / "out"
         dest.mkdir()
         with zipfile.ZipFile(zip_path) as zf:
-            safe_extract_skill_archive(zf, dest)
-        assert (dest / "normal.txt").exists()
+            with pytest.raises(ValueError, match="symlink"):
+                safe_extract_skill_archive(zf, dest)
         assert not (dest / "link.txt").exists()
+
+    def test_rejects_too_many_entries(self, tmp_path):
+        zip_path = self._make_zip(tmp_path, {f"file-{i}.txt": "x" for i in range(4)})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="too many entries"):
+                safe_extract_skill_archive(zf, dest, max_entries=3)
+
+    def test_rejects_oversized_member(self, tmp_path):
+        zip_path = self._make_zip(tmp_path, {"large.txt": "x" * 10})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="member is too large"):
+                safe_extract_skill_archive(zf, dest, max_member_size=5)
+
+    @pytest.mark.parametrize("extension", ["zip", "skill", "tar", "tgz", "gz", "7z", "rar"])
+    def test_rejects_nested_archives(self, tmp_path, extension):
+        zip_path = self._make_zip(tmp_path, {f"payload.{extension}": "nested"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="nested archive"):
+                safe_extract_skill_archive(zf, dest)
+
+    def test_rejects_control_character_in_member_name(self, tmp_path):
+        zip_path = self._make_zip(tmp_path, {"bad\x01name.txt": "x"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="unsafe member name"):
+                safe_extract_skill_archive(zf, dest)
+
+    def test_rejects_too_long_member_name(self, tmp_path):
+        zip_path = self._make_zip(tmp_path, {f"{'a' * 256}.txt": "x"})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="name is too long"):
+                safe_extract_skill_archive(zf, dest)
 
     def test_normal_archive(self, tmp_path):
         zip_path = self._make_zip(
@@ -200,6 +241,13 @@ class TestInstallSkillFromArchive:
         bad_path.write_text("not a skill")
         with pytest.raises(ValueError, match=".skill"):
             install_skill_from_archive(bad_path)
+
+    def test_oversized_archive_file_rejected_before_open(self, tmp_path, monkeypatch):
+        zip_path = tmp_path / "large.skill"
+        zip_path.write_bytes(b"x" * 11)
+        monkeypatch.setattr("deerflow.skills.installer.MAX_COMPRESSED_ARCHIVE_SIZE_BYTES", 10)
+        with pytest.raises(ValueError, match="archive file is too large"):
+            install_skill_from_archive(zip_path, skills_root=tmp_path / "skills")
 
     def test_bad_frontmatter(self, tmp_path):
         zip_path = tmp_path / "bad.skill"


### PR DESCRIPTION
## Summary

Closes #2618.

This adds small installer hardening for .skill archives:
- reject symlink entries instead of partially installing archives
- cap compressed size, total uncompressed size, per-file size, and entry count
- reject nested archives and unsafe member names
- keep valid .skill installs unchanged

## Tests

- `cd backend && uv run pytest tests/test_skills_installer.py -v`
- `cd backend && uv run pytest tests/test_client.py::TestInstallSkillSecurity -v`
- `cd backend && uv run pytest tests/test_skills_custom_router.py::test_install_skill_router_rejects_symlink_archive -v`
- `cd backend && make lint`
- `cd backend && make test`
