### PR TITLE
fix: use new_event_loop() to prevent RuntimeError event loop is closed

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -221,6 +221,18 @@ def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
     """Run an async memory update from sync code, including nested-loop contexts."""
     handed_off = False
 
+    def _run_coro() -> bool:
+        # Always create a fresh event loop to avoid reusing a closed loop.
+        # asyncio.run() is not safe to call multiple times from the same thread
+        # because it caches the loop internally; using new_event_loop() directly
+        # ensures each call gets a clean loop.
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
     try:
         try:
             loop = asyncio.get_running_loop()
@@ -228,12 +240,12 @@ def _run_async_update_sync(coro: Awaitable[bool]) -> bool:
             loop = None
 
         if loop is not None and loop.is_running():
-            future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(asyncio.run, coro)
+            future = _SYNC_MEMORY_UPDATER_EXECUTOR.submit(_run_coro)
             handed_off = True
             return future.result()
 
         handed_off = True
-        return asyncio.run(coro)
+        return _run_coro()
     except Exception:
         if not handed_off:
             close = getattr(coro, "close", None)


### PR DESCRIPTION
## Summary

_run_async_update_sync() in deerflow/agents/memory/updater.py uses syncio.run() to execute the memory update coroutine from a ThreadPoolExecutor worker thread. When the main thread has already closed its event loop, syncio.run() may reuse the stale loop reference, causing RuntimeError: event loop is closed.

## Fix

Replace syncio.run() with an explicit pattern that always creates a fresh loop:

`python
def _run_coro():
    loop = asyncio.new_event_loop()
    asyncio.set_event_loop(loop)
    try:
        return loop.run_until_complete(coro)
    finally:
        loop.close()
`

This ensures each invocation gets an independent, freshly-created loop regardless of the state of any other loop in the process.

## Testing

Run multiple memory updates concurrently from sync code paths to verify no event loop errors occur.

Closes #2615
