### PR TITLE
[security] fix(upload): reject symlinked upload destinations

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -420,7 +420,13 @@ async def _ingest_inbound_files(thread_id: str, msg: InboundMessage) -> list[dic
     if not msg.files:
         return []
 
-    from deerflow.uploads.manager import claim_unique_filename, ensure_uploads_dir, normalize_filename
+    from deerflow.uploads.manager import (
+        UnsafeUploadPathError,
+        claim_unique_filename,
+        ensure_uploads_dir,
+        normalize_filename,
+        write_upload_file_no_symlink,
+    )
 
     uploads_dir = ensure_uploads_dir(thread_id)
     seen_names = {entry.name for entry in uploads_dir.iterdir() if entry.is_file()}
@@ -471,7 +477,10 @@ async def _ingest_inbound_files(thread_id: str, msg: InboundMessage) -> list[dic
 
             dest = uploads_dir / safe_name
             try:
-                dest.write_bytes(data)
+                dest = write_upload_file_no_symlink(uploads_dir, safe_name, data)
+            except UnsafeUploadPathError:
+                logger.warning("[Manager] skipping inbound file with unsafe destination: %s", safe_name)
+                continue
             except Exception:
                 logger.exception("[Manager] failed to write inbound file: %s", dest)
                 continue

--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -15,6 +15,7 @@ from deerflow.runtime.user_context import get_effective_user_id
 from deerflow.sandbox.sandbox_provider import SandboxProvider, get_sandbox_provider
 from deerflow.uploads.manager import (
     PathTraversalError,
+    UnsafeUploadPathError,
     delete_file_safe,
     enrich_file_listing,
     ensure_uploads_dir,
@@ -23,6 +24,7 @@ from deerflow.uploads.manager import (
     normalize_filename,
     upload_artifact_url,
     upload_virtual_path,
+    write_upload_file_no_symlink,
 )
 from deerflow.utils.file_conversion import CONVERTIBLE_EXTENSIONS, convert_file_to_markdown
 
@@ -200,16 +202,15 @@ async def upload_files(
             continue
 
         try:
-            file_path = uploads_dir / safe_filename
+            content = await file.read()
+            file_size = len(content)
+            total_size += file_size
+            if file_size > limits.max_file_size:
+                raise HTTPException(status_code=413, detail=f"File too large: {safe_filename}")
+            if total_size > limits.max_total_size:
+                raise HTTPException(status_code=413, detail="Total upload size too large")
+            file_path = write_upload_file_no_symlink(uploads_dir, safe_filename, content)
             written_paths.append(file_path)
-            file_size, total_size = await _write_upload_file_streaming(
-                file,
-                file_path,
-                display_filename=safe_filename,
-                max_single_file_size=limits.max_file_size,
-                max_total_size=limits.max_total_size,
-                total_size=total_size,
-            )
 
             virtual_path = upload_virtual_path(safe_filename)
 
@@ -246,6 +247,9 @@ async def upload_files(
         except HTTPException as e:
             _cleanup_uploaded_paths(written_paths)
             raise e
+        except UnsafeUploadPathError as e:
+            logger.warning("Skipping upload with unsafe destination %s: %s", file.filename, e)
+            continue
         except Exception as e:
             logger.error(f"Failed to upload {file.filename}: {e}")
             _cleanup_uploaded_paths(written_paths)

--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -5,7 +5,7 @@ import os
 import stat
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.gateway.authz import require_permission
 from app.gateway.deps import get_config
@@ -22,9 +22,9 @@ from deerflow.uploads.manager import (
     get_uploads_dir,
     list_files_in_dir,
     normalize_filename,
+    open_upload_file_no_symlink,
     upload_artifact_url,
     upload_virtual_path,
-    write_upload_file_no_symlink,
 )
 from deerflow.utils.file_conversion import CONVERTIBLE_EXTENSIONS, convert_file_to_markdown
 
@@ -44,6 +44,7 @@ class UploadResponse(BaseModel):
     success: bool
     files: list[dict[str, str]]
     message: str
+    skipped_files: list[str] = Field(default_factory=list)
 
 
 class UploadLimits(BaseModel):
@@ -118,25 +119,36 @@ def _cleanup_uploaded_paths(paths: list[os.PathLike[str] | str]) -> None:
             logger.warning("Failed to clean up upload path after rejected request: %s", path, exc_info=True)
 
 
-async def _read_upload_file_with_limits(
+async def _write_upload_file_with_limits(
     file: UploadFile,
     *,
+    uploads_dir: os.PathLike[str] | str,
     display_filename: str,
     max_single_file_size: int,
     max_total_size: int,
     total_size: int,
-) -> tuple[bytes, int, int]:
+) -> tuple[os.PathLike[str] | str, int, int]:
     file_size = 0
-    chunks = []
-    while chunk := await file.read(UPLOAD_CHUNK_SIZE):
-        file_size += len(chunk)
-        total_size += len(chunk)
-        if file_size > max_single_file_size:
-            raise HTTPException(status_code=413, detail=f"File too large: {display_filename}")
-        if total_size > max_total_size:
-            raise HTTPException(status_code=413, detail="Total upload size too large")
-        chunks.append(chunk)
-    return b"".join(chunks), file_size, total_size
+    file_path, fh = open_upload_file_no_symlink(uploads_dir, display_filename)
+    try:
+        while chunk := await file.read(UPLOAD_CHUNK_SIZE):
+            file_size += len(chunk)
+            total_size += len(chunk)
+            if file_size > max_single_file_size:
+                raise HTTPException(status_code=413, detail=f"File too large: {display_filename}")
+            if total_size > max_total_size:
+                raise HTTPException(status_code=413, detail="Total upload size too large")
+            fh.write(chunk)
+    except Exception:
+        fh.close()
+        try:
+            os.unlink(file_path)
+        except FileNotFoundError:
+            pass
+        raise
+    else:
+        fh.close()
+    return file_path, file_size, total_size
 
 
 def _auto_convert_documents_enabled(app_config: AppConfig) -> bool:
@@ -178,6 +190,7 @@ async def upload_files(
     uploaded_files = []
     written_paths = []
     sandbox_sync_targets = []
+    skipped_files = []
     total_size = 0
 
     sandbox_provider = get_sandbox_provider()
@@ -201,14 +214,14 @@ async def upload_files(
             continue
 
         try:
-            content, file_size, total_size = await _read_upload_file_with_limits(
+            file_path, file_size, total_size = await _write_upload_file_with_limits(
                 file,
+                uploads_dir=uploads_dir,
                 display_filename=safe_filename,
                 max_single_file_size=limits.max_file_size,
                 max_total_size=limits.max_total_size,
                 total_size=total_size,
             )
-            file_path = write_upload_file_no_symlink(uploads_dir, safe_filename, content)
             written_paths.append(file_path)
 
             virtual_path = upload_virtual_path(safe_filename)
@@ -248,6 +261,7 @@ async def upload_files(
             raise e
         except UnsafeUploadPathError as e:
             logger.warning("Skipping upload with unsafe destination %s: %s", file.filename, e)
+            skipped_files.append(safe_filename)
             continue
         except Exception as e:
             logger.error(f"Failed to upload {file.filename}: {e}")
@@ -259,10 +273,15 @@ async def upload_files(
             _make_file_sandbox_writable(file_path)
             sandbox.update_file(virtual_path, file_path.read_bytes())
 
+    message = f"Successfully uploaded {len(uploaded_files)} file(s)"
+    if skipped_files:
+        message += f"; skipped {len(skipped_files)} unsafe file(s)"
+
     return UploadResponse(
-        success=True,
+        success=not skipped_files,
         files=uploaded_files,
-        message=f"Successfully uploaded {len(uploaded_files)} file(s)",
+        message=message,
+        skipped_files=skipped_files,
     )
 
 

--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -118,26 +118,25 @@ def _cleanup_uploaded_paths(paths: list[os.PathLike[str] | str]) -> None:
             logger.warning("Failed to clean up upload path after rejected request: %s", path, exc_info=True)
 
 
-async def _write_upload_file_streaming(
+async def _read_upload_file_with_limits(
     file: UploadFile,
-    file_path: os.PathLike[str] | str,
     *,
     display_filename: str,
     max_single_file_size: int,
     max_total_size: int,
     total_size: int,
-) -> tuple[int, int]:
+) -> tuple[bytes, int, int]:
     file_size = 0
-    with open(file_path, "wb") as output:
-        while chunk := await file.read(UPLOAD_CHUNK_SIZE):
-            file_size += len(chunk)
-            total_size += len(chunk)
-            if file_size > max_single_file_size:
-                raise HTTPException(status_code=413, detail=f"File too large: {display_filename}")
-            if total_size > max_total_size:
-                raise HTTPException(status_code=413, detail="Total upload size too large")
-            output.write(chunk)
-    return file_size, total_size
+    chunks = []
+    while chunk := await file.read(UPLOAD_CHUNK_SIZE):
+        file_size += len(chunk)
+        total_size += len(chunk)
+        if file_size > max_single_file_size:
+            raise HTTPException(status_code=413, detail=f"File too large: {display_filename}")
+        if total_size > max_total_size:
+            raise HTTPException(status_code=413, detail="Total upload size too large")
+        chunks.append(chunk)
+    return b"".join(chunks), file_size, total_size
 
 
 def _auto_convert_documents_enabled(app_config: AppConfig) -> bool:
@@ -202,13 +201,13 @@ async def upload_files(
             continue
 
         try:
-            content = await file.read()
-            file_size = len(content)
-            total_size += file_size
-            if file_size > limits.max_file_size:
-                raise HTTPException(status_code=413, detail=f"File too large: {safe_filename}")
-            if total_size > limits.max_total_size:
-                raise HTTPException(status_code=413, detail="Total upload size too large")
+            content, file_size, total_size = await _read_upload_file_with_limits(
+                file,
+                display_filename=safe_filename,
+                max_single_file_size=limits.max_file_size,
+                max_total_size=limits.max_total_size,
+                total_size=total_size,
+            )
             file_path = write_upload_file_no_symlink(uploads_dir, safe_filename, content)
             written_paths.append(file_path)
 

--- a/backend/packages/harness/deerflow/uploads/manager.py
+++ b/backend/packages/harness/deerflow/uploads/manager.py
@@ -4,8 +4,10 @@ Pure business logic — no FastAPI/HTTP dependencies.
 Both Gateway and Client delegate to these functions.
 """
 
+import errno
 import os
 import re
+import stat
 from pathlib import Path
 from urllib.parse import quote
 
@@ -15,6 +17,10 @@ from deerflow.runtime.user_context import get_effective_user_id
 
 class PathTraversalError(ValueError):
     """Raised when a path escapes its allowed base directory."""
+
+
+class UnsafeUploadPathError(ValueError):
+    """Raised when an upload destination is not a safe regular file path."""
 
 
 # thread_id must be alphanumeric, hyphens, underscores, or dots only.
@@ -107,6 +113,45 @@ def validate_path_traversal(path: Path, base: Path) -> None:
         path.resolve().relative_to(base.resolve())
     except ValueError:
         raise PathTraversalError("Path traversal detected") from None
+
+
+def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> Path:
+    """Write upload bytes without following a pre-existing destination symlink.
+
+    Upload directories may be mounted into local sandboxes. A sandbox process can
+    therefore leave a symlink at a future upload filename. Normal ``Path.write_bytes``
+    follows that link and can overwrite files outside the uploads directory with
+    gateway privileges. This helper rejects symlink destinations and uses
+    ``O_NOFOLLOW`` where available so the final path component cannot be raced into
+    a symlink between validation and open.
+    """
+    safe_name = normalize_filename(filename)
+    dest = base_dir / safe_name
+
+    try:
+        st = os.lstat(dest)
+    except FileNotFoundError:
+        st = None
+
+    if st is not None and not stat.S_ISREG(st.st_mode):
+        raise UnsafeUploadPathError(f"Upload destination is not a regular file: {safe_name}")
+
+    validate_path_traversal(dest, base_dir)
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    try:
+        fd = os.open(dest, flags, 0o666)
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.EISDIR, errno.ENOTDIR}:
+            raise UnsafeUploadPathError(f"Unsafe upload destination: {safe_name}") from exc
+        raise
+
+    with os.fdopen(fd, "wb") as fh:
+        fh.write(data)
+    return dest
 
 
 def list_files_in_dir(directory: Path) -> dict:

--- a/backend/packages/harness/deerflow/uploads/manager.py
+++ b/backend/packages/harness/deerflow/uploads/manager.py
@@ -115,8 +115,8 @@ def validate_path_traversal(path: Path, base: Path) -> None:
         raise PathTraversalError("Path traversal detected") from None
 
 
-def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> Path:
-    """Write upload bytes without following a pre-existing destination symlink.
+def open_upload_file_no_symlink(base_dir: Path, filename: str) -> tuple[Path, object]:
+    """Open an upload destination for safe streaming writes.
 
     Upload directories may be mounted into local sandboxes. A sandbox process can
     therefore leave a symlink at a future upload filename. Normal ``Path.write_bytes``
@@ -157,12 +157,19 @@ def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> 
         if not stat.S_ISREG(opened_stat.st_mode) or opened_stat.st_nlink != 1:
             raise UnsafeUploadPathError(f"Upload destination is not an exclusive regular file: {safe_name}")
         os.ftruncate(fd, 0)
-        with os.fdopen(fd, "wb") as fh:
-            fd = -1
-            fh.write(data)
+        fh = os.fdopen(fd, "wb")
+        fd = -1
     finally:
         if fd >= 0:
             os.close(fd)
+    return dest, fh
+
+
+def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> Path:
+    """Write upload bytes without following a pre-existing destination symlink."""
+    dest, fh = open_upload_file_no_symlink(base_dir, filename)
+    with fh:
+        fh.write(data)
     return dest
 
 

--- a/backend/packages/harness/deerflow/uploads/manager.py
+++ b/backend/packages/harness/deerflow/uploads/manager.py
@@ -138,19 +138,29 @@ def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> 
 
     validate_path_traversal(dest, base_dir)
 
-    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    if not hasattr(os, "O_NOFOLLOW"):
+        raise UnsafeUploadPathError("Upload writes require O_NOFOLLOW support")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW
 
     try:
-        fd = os.open(dest, flags, 0o666)
+        fd = os.open(dest, flags, 0o600)
     except OSError as exc:
         if exc.errno in {errno.ELOOP, errno.EISDIR, errno.ENOTDIR}:
             raise UnsafeUploadPathError(f"Unsafe upload destination: {safe_name}") from exc
         raise
 
-    with os.fdopen(fd, "wb") as fh:
-        fh.write(data)
+    try:
+        opened_stat = os.fstat(fd)
+        if not stat.S_ISREG(opened_stat.st_mode) or opened_stat.st_nlink != 1:
+            raise UnsafeUploadPathError(f"Upload destination is not an exclusive regular file: {safe_name}")
+        os.ftruncate(fd, 0)
+        with os.fdopen(fd, "wb") as fh:
+            fd = -1
+            fh.write(data)
+    finally:
+        if fd >= 0:
+            os.close(fd)
     return dest
 
 

--- a/backend/packages/harness/deerflow/uploads/manager.py
+++ b/backend/packages/harness/deerflow/uploads/manager.py
@@ -142,11 +142,13 @@ def write_upload_file_no_symlink(base_dir: Path, filename: str, data: bytes) -> 
         raise UnsafeUploadPathError("Upload writes require O_NOFOLLOW support")
 
     flags = os.O_WRONLY | os.O_CREAT | os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
 
     try:
         fd = os.open(dest, flags, 0o600)
     except OSError as exc:
-        if exc.errno in {errno.ELOOP, errno.EISDIR, errno.ENOTDIR}:
+        if exc.errno in {errno.ELOOP, errno.EISDIR, errno.ENOTDIR, errno.ENXIO, errno.EAGAIN}:
             raise UnsafeUploadPathError(f"Unsafe upload destination: {safe_name}") from exc
         raise
 

--- a/backend/tests/test_channel_file_attachments.py
+++ b/backend/tests/test_channel_file_attachments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -282,6 +283,73 @@ class TestInboundFileIngestion:
         assert result == []
         assert not outside_file.exists()
         assert (uploads_dir / "victim.txt").is_symlink()
+
+    def test_rejects_dangling_symlink_destination(self, tmp_path):
+        from app.channels import manager
+
+        uploads_dir = tmp_path / "uploads"
+        uploads_dir.mkdir()
+        missing_target = tmp_path / "missing-created.txt"
+        (uploads_dir / "victim.txt").symlink_to(missing_target)
+
+        msg = InboundMessage(
+            channel_name="test-channel",
+            chat_id="chat-1",
+            user_id="user-1",
+            text="see attachment",
+            files=[{"filename": "victim.txt", "url": "https://example.invalid/victim.txt"}],
+        )
+
+        async def fake_reader(file_info, client):
+            return b"attacker data"
+
+        with (
+            patch("deerflow.uploads.manager.ensure_uploads_dir", return_value=uploads_dir),
+            patch.dict(manager.INBOUND_FILE_READERS, {"test-channel": fake_reader}, clear=False),
+        ):
+            result = _run(manager._ingest_inbound_files("thread-1", msg))
+
+        assert result == []
+        assert not missing_target.exists()
+        assert (uploads_dir / "victim.txt").is_symlink()
+
+    def test_hardlinked_existing_file_is_not_overwritten(self, tmp_path):
+        from app.channels import manager
+
+        uploads_dir = tmp_path / "uploads"
+        uploads_dir.mkdir()
+        outside_file = tmp_path / "outside-created.txt"
+        outside_file.write_text("protected", encoding="utf-8")
+        os.link(outside_file, uploads_dir / "victim.txt")
+
+        msg = InboundMessage(
+            channel_name="test-channel",
+            chat_id="chat-1",
+            user_id="user-1",
+            text="see attachment",
+            files=[{"filename": "victim.txt", "url": "https://example.invalid/victim.txt"}],
+        )
+
+        async def fake_reader(file_info, client):
+            return b"new attachment data"
+
+        with (
+            patch("deerflow.uploads.manager.ensure_uploads_dir", return_value=uploads_dir),
+            patch.dict(manager.INBOUND_FILE_READERS, {"test-channel": fake_reader}, clear=False),
+        ):
+            result = _run(manager._ingest_inbound_files("thread-1", msg))
+
+        assert result == [
+            {
+                "filename": "victim_1.txt",
+                "size": len(b"new attachment data"),
+                "path": "/mnt/user-data/uploads/victim_1.txt",
+                "is_image": False,
+            }
+        ]
+        assert outside_file.read_text(encoding="utf-8") == "protected"
+        assert (uploads_dir / "victim.txt").read_text(encoding="utf-8") == "protected"
+        assert (uploads_dir / "victim_1.txt").read_bytes() == b"new attachment data"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_channel_file_attachments.py
+++ b/backend/tests/test_channel_file_attachments.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from app.channels.base import Channel
-from app.channels.message_bus import MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.message_bus import InboundMessage, MessageBus, OutboundMessage, ResolvedAttachment
 
 
 def _run(coro):
@@ -246,6 +246,42 @@ class TestResolveAttachments:
 
         assert len(result) == 1
         assert result[0].filename == "data.csv"
+
+
+# ---------------------------------------------------------------------------
+# Inbound file ingestion tests
+# ---------------------------------------------------------------------------
+
+
+class TestInboundFileIngestion:
+    def test_rejects_preexisting_symlink_destination(self, tmp_path):
+        from app.channels import manager
+
+        uploads_dir = tmp_path / "uploads"
+        uploads_dir.mkdir()
+        outside_file = tmp_path / "outside-created.txt"
+        (uploads_dir / "victim.txt").symlink_to(outside_file)
+
+        msg = InboundMessage(
+            channel_name="test-channel",
+            chat_id="chat-1",
+            user_id="user-1",
+            text="see attachment",
+            files=[{"filename": "victim.txt", "url": "https://example.invalid/victim.txt"}],
+        )
+
+        async def fake_reader(file_info, client):
+            return b"attacker data"
+
+        with (
+            patch("deerflow.uploads.manager.ensure_uploads_dir", return_value=uploads_dir),
+            patch.dict(manager.INBOUND_FILE_READERS, {"test-channel": fake_reader}, clear=False),
+        ):
+            result = _run(manager._ingest_inbound_files("thread-1", msg))
+
+        assert result == []
+        assert not outside_file.exists()
+        assert (uploads_dir / "victim.txt").is_symlink()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_uploads_manager.py
+++ b/backend/tests/test_uploads_manager.py
@@ -1,6 +1,8 @@
 """Tests for deerflow.uploads.manager — shared upload management logic."""
 
+import errno
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -120,6 +122,22 @@ class TestWriteUploadFileNoSymlink:
             write_upload_file_no_symlink(tmp_path, "notes.txt", b"hello")
 
         assert not (tmp_path / "notes.txt").exists()
+
+    def test_open_uses_nonblocking_flag_when_available(self, tmp_path):
+        with patch("deerflow.uploads.manager.os.open", side_effect=OSError(errno.ENXIO, "no reader")) as open_mock:
+            with pytest.raises(UnsafeUploadPathError, match="Unsafe upload destination"):
+                write_upload_file_no_symlink(tmp_path, "pipe.txt", b"hello")
+
+        flags = open_mock.call_args.args[1]
+        assert flags & os.O_NONBLOCK
+
+    @pytest.mark.parametrize("open_errno", [errno.ENXIO, errno.EAGAIN])
+    def test_nonblocking_special_file_open_errors_are_unsafe(self, tmp_path, open_errno):
+        with patch("deerflow.uploads.manager.os.open", side_effect=OSError(open_errno, "would block")):
+            with pytest.raises(UnsafeUploadPathError, match="Unsafe upload destination"):
+                write_upload_file_no_symlink(tmp_path, "pipe.txt", b"hello")
+
+        assert not (tmp_path / "pipe.txt").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_uploads_manager.py
+++ b/backend/tests/test_uploads_manager.py
@@ -115,6 +115,17 @@ class TestWriteUploadFileNoSymlink:
         assert dest == tmp_path / "notes.txt"
         assert dest.read_bytes() == b"hello"
 
+    def test_overwrites_existing_regular_file_with_single_link(self, tmp_path):
+        dest = tmp_path / "notes.txt"
+        dest.write_bytes(b"old contents")
+        assert os.stat(dest).st_nlink == 1
+
+        result = write_upload_file_no_symlink(tmp_path, "notes.txt", b"new contents")
+
+        assert result == dest
+        assert dest.read_bytes() == b"new contents"
+        assert os.stat(dest).st_nlink == 1
+
     def test_fails_closed_without_no_follow_support(self, tmp_path, monkeypatch):
         monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
 

--- a/backend/tests/test_uploads_manager.py
+++ b/backend/tests/test_uploads_manager.py
@@ -1,14 +1,18 @@
 """Tests for deerflow.uploads.manager — shared upload management logic."""
 
+import os
+
 import pytest
 
 from deerflow.uploads.manager import (
     PathTraversalError,
+    UnsafeUploadPathError,
     claim_unique_filename,
     delete_file_safe,
     list_files_in_dir,
     normalize_filename,
     validate_path_traversal,
+    write_upload_file_no_symlink,
 )
 
 # ---------------------------------------------------------------------------
@@ -95,6 +99,27 @@ class TestValidatePathTraversal:
             raise
         with pytest.raises(PathTraversalError, match="traversal"):
             validate_path_traversal(link, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# write_upload_file_no_symlink
+# ---------------------------------------------------------------------------
+
+
+class TestWriteUploadFileNoSymlink:
+    def test_writes_new_file(self, tmp_path):
+        dest = write_upload_file_no_symlink(tmp_path, "notes.txt", b"hello")
+
+        assert dest == tmp_path / "notes.txt"
+        assert dest.read_bytes() == b"hello"
+
+    def test_fails_closed_without_no_follow_support(self, tmp_path, monkeypatch):
+        monkeypatch.delattr(os, "O_NOFOLLOW", raising=False)
+
+        with pytest.raises(UnsafeUploadPathError, match="O_NOFOLLOW"):
+            write_upload_file_no_symlink(tmp_path, "notes.txt", b"hello")
+
+        assert not (tmp_path / "notes.txt").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -447,8 +447,10 @@ def test_upload_files_rejects_preexisting_symlink_destination(tmp_path):
         file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
         result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
 
-    assert result.success is True
+    assert result.success is False
     assert result.files == []
+    assert result.skipped_files == ["victim.txt"]
+    assert "skipped 1 unsafe file" in result.message
     assert outside_file.read_text(encoding="utf-8") == "protected"
     assert (thread_uploads_dir / "victim.txt").is_symlink()
 
@@ -470,8 +472,9 @@ def test_upload_files_rejects_dangling_symlink_destination(tmp_path):
         file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
         result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
 
-    assert result.success is True
+    assert result.success is False
     assert result.files == []
+    assert result.skipped_files == ["victim.txt"]
     assert not missing_target.exists()
     assert (thread_uploads_dir / "victim.txt").is_symlink()
 
@@ -494,8 +497,9 @@ def test_upload_files_rejects_hardlinked_destination_without_truncating(tmp_path
         file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
         result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
 
-    assert result.success is True
+    assert result.success is False
     assert result.files == []
+    assert result.skipped_files == ["victim.txt"]
     assert outside_file.read_text(encoding="utf-8") == "protected"
     assert (thread_uploads_dir / "victim.txt").read_text(encoding="utf-8") == "protected"
 

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import stat
 from io import BytesIO
 from pathlib import Path
@@ -450,6 +451,53 @@ def test_upload_files_rejects_preexisting_symlink_destination(tmp_path):
     assert result.files == []
     assert outside_file.read_text(encoding="utf-8") == "protected"
     assert (thread_uploads_dir / "victim.txt").is_symlink()
+
+
+def test_upload_files_rejects_dangling_symlink_destination(tmp_path):
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+    missing_target = tmp_path / "missing-target.txt"
+    (thread_uploads_dir / "victim.txt").symlink_to(missing_target)
+
+    provider = MagicMock()
+    provider.uses_thread_data_mounts = True
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=provider),
+    ):
+        file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
+        result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
+
+    assert result.success is True
+    assert result.files == []
+    assert not missing_target.exists()
+    assert (thread_uploads_dir / "victim.txt").is_symlink()
+
+
+def test_upload_files_rejects_hardlinked_destination_without_truncating(tmp_path):
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("protected", encoding="utf-8")
+    os.link(outside_file, thread_uploads_dir / "victim.txt")
+
+    provider = MagicMock()
+    provider.uses_thread_data_mounts = True
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=provider),
+    ):
+        file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
+        result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
+
+    assert result.success is True
+    assert result.files == []
+    assert outside_file.read_text(encoding="utf-8") == "protected"
+    assert (thread_uploads_dir / "victim.txt").read_text(encoding="utf-8") == "protected"
 
 
 def test_delete_uploaded_file_removes_generated_markdown_companion(tmp_path):

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -500,6 +500,30 @@ def test_upload_files_rejects_hardlinked_destination_without_truncating(tmp_path
     assert (thread_uploads_dir / "victim.txt").read_text(encoding="utf-8") == "protected"
 
 
+def test_upload_files_overwrites_existing_regular_file(tmp_path):
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+    existing_file = thread_uploads_dir / "notes.txt"
+    existing_file.write_bytes(b"old upload")
+    assert existing_file.stat().st_nlink == 1
+
+    provider = MagicMock()
+    provider.uses_thread_data_mounts = True
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=provider),
+    ):
+        file = UploadFile(filename="notes.txt", file=BytesIO(b"new upload"))
+        result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
+
+    assert result.success is True
+    assert [file_info["filename"] for file_info in result.files] == ["notes.txt"]
+    assert existing_file.read_bytes() == b"new upload"
+    assert existing_file.stat().st_nlink == 1
+
+
 def test_delete_uploaded_file_removes_generated_markdown_companion(tmp_path):
     thread_uploads_dir = tmp_path / "uploads"
     thread_uploads_dir.mkdir(parents=True)

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -428,6 +428,30 @@ def test_upload_files_rejects_dotdot_and_dot_filenames(tmp_path):
     assert [f.name for f in thread_uploads_dir.iterdir()] == ["passwd"]
 
 
+def test_upload_files_rejects_preexisting_symlink_destination(tmp_path):
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+    outside_file = tmp_path / "outside.txt"
+    outside_file.write_text("protected", encoding="utf-8")
+    (thread_uploads_dir / "victim.txt").symlink_to(outside_file)
+
+    provider = MagicMock()
+    provider.uses_thread_data_mounts = True
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=provider),
+    ):
+        file = UploadFile(filename="victim.txt", file=BytesIO(b"attacker upload"))
+        result = asyncio.run(uploads.upload_files("thread-local", files=[file]))
+
+    assert result.success is True
+    assert result.files == []
+    assert outside_file.read_text(encoding="utf-8") == "protected"
+    assert (thread_uploads_dir / "victim.txt").is_symlink()
+
+
 def test_delete_uploaded_file_removes_generated_markdown_companion(tmp_path):
     thread_uploads_dir = tmp_path / "uploads"
     thread_uploads_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

This PR hardens DeerFlow's upload write paths against symlink-following writes in thread upload directories.

Thread upload directories can be mounted into local sandboxes as writable user-data. If a symlink already exists at a future upload filename, the previous upload paths used normal path-following writes and could write uploaded bytes through that symlink. This patch routes HTTP uploads and inbound channel attachment ingestion through a shared no-symlink write helper.

## Security issues covered

| Issue | Impact | Fixed paths |
| --- | --- | --- |
| Symlink-following upload destination writes | A pre-existing symlink in a thread upload directory could cause uploaded bytes to be written outside the intended uploads root with backend-side privileges. | HTTP uploads and inbound channel file ingestion |

## Before this PR

- HTTP uploads wrote bytes with `Path.write_bytes()` under the thread uploads directory.
- Inbound channel file ingestion also wrote attachment bytes with `Path.write_bytes()`.
- `normalize_filename()` removed direct path traversal, but the final filesystem object could still be a symlink.
- A writable sandbox mount could leave a symlink in `/mnt/user-data/uploads`, and a later backend upload with the same filename would follow it.

## After this PR

- Upload writes go through `write_upload_file_no_symlink()`.
- Pre-existing symlinks, directories, and other non-regular destinations are rejected before writing.
- The helper uses `O_NOFOLLOW` where available so the final path component cannot be swapped into a symlink between validation and open.
- HTTP uploads skip unsafe destinations instead of writing through them.
- Inbound channel file ingestion skips unsafe attachment destinations instead of writing through them.

## Why this matters

Upload roots are a boundary between user-controlled thread data and backend-owned host filesystem operations. A sandbox or channel path that can create names inside the thread uploads directory should not be able to redirect later backend writes outside that directory.

Without the no-symlink write boundary, uploaded content can become an arbitrary host-side file write primitive when the attacker can pre-place a symlink under the mounted upload directory.

## How this differs from #2557 and #2558

This is in the same path-safety family as the recent symlink/path hardening work, but it fixes a different boundary:

- #2557 constrained `view_image` reads to thread data paths.
- #2558 hardened local custom mount symlink escapes.
- This PR hardens the upload admission/write path itself: the point where backend code writes incoming upload or attachment bytes into a thread uploads directory.

Those prior fixes prevent other read/mount escape paths. They do not remove the need to reject symlinked upload destinations before backend-side writes.

## Attack flow

1. A thread uses a local sandbox with writable thread upload data mounted into the sandbox.
2. Code running in that sandbox creates a symlink at a future upload filename, for example:
   ```sh
   ln -s /host/path/to/target /mnt/user-data/uploads/victim.txt
   ```
3. A later HTTP upload or inbound channel attachment uses the filename `victim.txt`.
4. Before this PR, the backend write followed the symlink and wrote uploaded bytes to the symlink target.
5. After this PR, the destination is rejected as unsafe and the symlink target is left untouched.

## Affected code

| Area | File |
| --- | --- |
| HTTP upload route | `backend/app/gateway/routers/uploads.py` |
| Inbound channel attachment ingestion | `backend/app/channels/manager.py` |
| Shared upload helper | `backend/packages/harness/deerflow/uploads/manager.py` |
| Regression tests | `backend/tests/test_uploads_router.py`, `backend/tests/test_channel_file_attachments.py` |

## Root cause

- Filename normalization prevented direct `../` traversal, but did not validate the existing destination filesystem object.
- Normal `Path.write_bytes()` follows symlinks by design.
- Thread uploads directories can be shared with sandbox-controlled code, so pre-existing destination entries must be treated as untrusted.

## CVSS assessment

Issue: symlink-following upload destination write

CVSS v3.1: 8.1 High

Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:H`

Rationale: exploitation requires the attacker to influence a thread upload directory, but once that condition is met the vulnerable write is network-reachable through upload/attachment ingestion and can overwrite or create host-side files reachable by the backend process.

## Safe reproduction steps

The regression tests added in this PR model the vulnerable behavior without touching real host files:

1. Create a temporary thread uploads directory.
2. Create a file outside that uploads directory.
3. Place a symlink named `victim.txt` inside the uploads directory pointing to the outside file.
4. Submit an HTTP upload named `victim.txt`.
5. Verify the outside file is unchanged and no uploaded file is accepted for that unsafe destination.

The inbound channel regression follows the same pattern for channel-delivered file metadata and verifies the unsafe destination is skipped.

## Expected vulnerable behavior

On vulnerable code, a pre-existing symlink at the upload destination is followed by `Path.write_bytes()`, so attacker-controlled upload bytes are written to the symlink target outside the uploads root.

## Changes in this PR

- Adds `UnsafeUploadPathError` and `write_upload_file_no_symlink()` to the shared upload manager.
- Rejects non-regular pre-existing destination entries before writing.
- Uses `os.open()` with `O_NOFOLLOW` when available to protect the final path component during open.
- Updates the HTTP upload route to use the shared safe writer.
- Updates inbound channel file ingestion to use the shared safe writer.
- Adds focused regressions for HTTP upload and inbound channel symlink destinations.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Shared upload safety | `backend/packages/harness/deerflow/uploads/manager.py` | Added no-symlink upload writer and unsafe-destination exception. |
| HTTP uploads | `backend/app/gateway/routers/uploads.py` | Writes through the no-symlink helper and skips unsafe destinations. |
| Channel ingestion | `backend/app/channels/manager.py` | Writes inbound attachments through the no-symlink helper and skips unsafe destinations. |
| Tests | `backend/tests/test_uploads_router.py`, `backend/tests/test_channel_file_attachments.py` | Added symlink-destination regression coverage. |

## Maintainer impact

- Normal uploads to new files and existing regular files continue to work.
- Unsafe destinations are skipped instead of followed.
- Existing listing behavior already ignores non-regular directory entries, so this aligns write behavior with the intended uploads-root boundary.
- The patch is intentionally scoped to upload/attachment writes and does not change sandbox mounting behavior.

## Fix rationale

The correct security boundary is the final destination opened by backend code, not only the user-supplied filename string. Rejecting non-regular entries and using `O_NOFOLLOW` makes the upload write path enforce that boundary at the filesystem operation that matters.

## Type of change

- [x] Security hardening / vulnerability fix
- [x] Regression tests
- [ ] Documentation update
- [ ] Refactor only

## Test plan

From `backend/`:

```bash
uv run pytest -q tests/test_uploads_router.py tests/test_channel_file_attachments.py
uv run ruff check app/gateway/routers/uploads.py app/channels/manager.py packages/harness/deerflow/uploads/manager.py tests/test_uploads_router.py tests/test_channel_file_attachments.py
uv run python -m compileall -q app/gateway/routers/uploads.py app/channels/manager.py packages/harness/deerflow/uploads/manager.py tests/test_uploads_router.py tests/test_channel_file_attachments.py
git diff --check
```

Additional local check:

```text
added-line secret scan: NO FINDINGS
```

## Disclosure notes

This PR is intentionally bounded to symlink-following upload and inbound attachment writes. It does not claim to address every possible path-safety issue in sandbox mounts or artifact reads; it complements the existing path hardening by closing the backend upload-write admission path.
