### PR TITLE
[security] fix(sandbox): bind local Docker ports to loopback

### DIFF
--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -259,6 +259,8 @@ sandbox:
 
 When you configure `sandbox.mounts`, DeerFlow exposes those `container_path` values in the agent prompt so the agent can discover and operate on mounted directories directly instead of assuming everything must live under `/mnt/user-data`.
 
+For bare-metal Docker sandbox runs that use localhost, DeerFlow binds the sandbox HTTP port to `127.0.0.1` by default so it is not exposed on every host interface. Docker-outside-of-Docker deployments that connect through `host.docker.internal` keep the broad legacy bind for compatibility. Set `DEER_FLOW_SANDBOX_BIND_HOST` explicitly if your deployment needs a different bind address.
+
 ### Skills
 
 Configure the skills directory for specialized workflows:

--- a/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
@@ -127,6 +127,31 @@ def _format_container_command_for_log(cmd: list[str]) -> str:
     return shlex.join(cmd)
 
 
+def _is_loopback_sandbox_host(host: str) -> bool:
+    return host.strip().lower() in {"", "localhost", "127.0.0.1", "::1", "[::1]"}
+
+
+def _resolve_docker_bind_host(sandbox_host: str | None = None, bind_host: str | None = None) -> str:
+    """Choose the host interface for legacy Docker ``-p`` sandbox publishing.
+
+    Bare-metal/local runs talk to sandboxes through localhost and should not
+    expose the sandbox HTTP API on every host interface.  Docker-outside-of-
+    Docker deployments commonly use ``host.docker.internal`` from another
+    container; keep their legacy broad bind unless operators opt into a
+    narrower bind with ``DEER_FLOW_SANDBOX_BIND_HOST``.
+    """
+    explicit_bind = bind_host if bind_host is not None else os.environ.get("DEER_FLOW_SANDBOX_BIND_HOST")
+    if explicit_bind is not None:
+        explicit_bind = explicit_bind.strip()
+        if explicit_bind:
+            return explicit_bind
+
+    host = sandbox_host if sandbox_host is not None else os.environ.get("DEER_FLOW_SANDBOX_HOST", "localhost")
+    if _is_loopback_sandbox_host(host):
+        return "127.0.0.1"
+    return "0.0.0.0"
+
+
 class LocalContainerBackend(SandboxBackend):
     """Backend that manages sandbox containers locally using Docker or Apple Container.
 
@@ -465,12 +490,17 @@ class LocalContainerBackend(SandboxBackend):
         if self._runtime == "docker":
             cmd.extend(["--security-opt", "seccomp=unconfined"])
 
+        if self._runtime == "docker":
+            port_mapping = f"{_resolve_docker_bind_host()}:{port}:8080"
+        else:
+            port_mapping = f"{port}:8080"
+
         cmd.extend(
             [
                 "--rm",
                 "-d",
                 "-p",
-                f"{port}:8080",
+                port_mapping,
                 "--name",
                 container_name,
             ]

--- a/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
@@ -127,8 +127,16 @@ def _format_container_command_for_log(cmd: list[str]) -> str:
     return shlex.join(cmd)
 
 
+def _normalize_sandbox_host(host: str) -> str:
+    return host.strip().lower()
+
+
+def _is_ipv6_loopback_sandbox_host(host: str) -> bool:
+    return _normalize_sandbox_host(host) in {"::1", "[::1]"}
+
+
 def _is_loopback_sandbox_host(host: str) -> bool:
-    return host.strip().lower() in {"", "localhost", "127.0.0.1", "::1", "[::1]"}
+    return _normalize_sandbox_host(host) in {"", "localhost", "127.0.0.1", "::1", "[::1]"}
 
 
 def _resolve_docker_bind_host(sandbox_host: str | None = None, bind_host: str | None = None) -> str:
@@ -138,7 +146,9 @@ def _resolve_docker_bind_host(sandbox_host: str | None = None, bind_host: str | 
     expose the sandbox HTTP API on every host interface.  Docker-outside-of-
     Docker deployments commonly use ``host.docker.internal`` from another
     container; keep their legacy broad bind unless operators opt into a
-    narrower bind with ``DEER_FLOW_SANDBOX_BIND_HOST``.
+    narrower bind with ``DEER_FLOW_SANDBOX_BIND_HOST``.  When operators choose
+    an IPv6 loopback sandbox host, bind Docker to IPv6 loopback as well so the
+    advertised sandbox URL and published socket use the same address family.
     """
     explicit_bind = bind_host if bind_host is not None else os.environ.get("DEER_FLOW_SANDBOX_BIND_HOST")
     if explicit_bind is not None:
@@ -147,6 +157,8 @@ def _resolve_docker_bind_host(sandbox_host: str | None = None, bind_host: str | 
             return explicit_bind
 
     host = sandbox_host if sandbox_host is not None else os.environ.get("DEER_FLOW_SANDBOX_HOST", "localhost")
+    if _is_ipv6_loopback_sandbox_host(host):
+        return "[::1]"
     if _is_loopback_sandbox_host(host):
         return "127.0.0.1"
     return "0.0.0.0"

--- a/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py
@@ -154,13 +154,18 @@ def _resolve_docker_bind_host(sandbox_host: str | None = None, bind_host: str | 
     if explicit_bind is not None:
         explicit_bind = explicit_bind.strip()
         if explicit_bind:
+            logger.debug("Docker sandbox bind: %s (explicit bind host override)", explicit_bind)
             return explicit_bind
 
     host = sandbox_host if sandbox_host is not None else os.environ.get("DEER_FLOW_SANDBOX_HOST", "localhost")
     if _is_ipv6_loopback_sandbox_host(host):
+        logger.debug("Docker sandbox bind: [::1] (IPv6 loopback sandbox host)")
         return "[::1]"
     if _is_loopback_sandbox_host(host):
+        logger.debug("Docker sandbox bind: 127.0.0.1 (loopback default)")
         return "127.0.0.1"
+
+    logger.debug("Docker sandbox bind: 0.0.0.0 (non-loopback sandbox host compatibility)")
     return "0.0.0.0"
 
 

--- a/backend/tests/test_aio_sandbox_local_backend.py
+++ b/backend/tests/test_aio_sandbox_local_backend.py
@@ -2,7 +2,13 @@ import logging
 import os
 from types import SimpleNamespace
 
-from deerflow.community.aio_sandbox.local_backend import LocalContainerBackend, _format_container_command_for_log, _format_container_mount, _redact_container_command_for_log
+from deerflow.community.aio_sandbox.local_backend import (
+    LocalContainerBackend,
+    _format_container_command_for_log,
+    _format_container_mount,
+    _redact_container_command_for_log,
+    _resolve_docker_bind_host,
+)
 
 
 def test_format_container_mount_uses_mount_syntax_for_docker_windows_paths():
@@ -116,3 +122,84 @@ def test_start_container_logs_redacted_env_values(monkeypatch, caplog):
     assert "NORMAL=<redacted>" in log_output
     assert "secret-value" not in log_output
     assert "visible-value" not in log_output
+
+
+def _capture_start_container_command(monkeypatch, backend: LocalContainerBackend, runtime: str = "docker") -> list[str]:
+    monkeypatch.setattr(backend, "_runtime", runtime)
+    captured_cmd: list[str] = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return SimpleNamespace(stdout="container-id\n", stderr="", returncode=0)
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    backend._start_container("sandbox-test", 18080)
+    return captured_cmd
+
+
+def test_resolve_docker_bind_host_defaults_loopback_for_localhost(monkeypatch):
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_HOST", raising=False)
+
+    assert _resolve_docker_bind_host() == "127.0.0.1"
+
+
+def test_resolve_docker_bind_host_keeps_dood_compatibility(monkeypatch):
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "host.docker.internal")
+
+    assert _resolve_docker_bind_host() == "0.0.0.0"
+
+
+def test_resolve_docker_bind_host_allows_explicit_override(monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "localhost")
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_BIND_HOST", "192.0.2.10")
+
+    assert _resolve_docker_bind_host() == "192.0.2.10"
+
+
+def test_start_container_binds_local_docker_port_to_loopback_by_default(monkeypatch):
+    backend = LocalContainerBackend(
+        image="sandbox:latest",
+        base_port=8080,
+        container_prefix="sandbox",
+        config_mounts=[],
+        environment={},
+    )
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_HOST", raising=False)
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+
+    captured_cmd = _capture_start_container_command(monkeypatch, backend)
+
+    assert captured_cmd[captured_cmd.index("-p") + 1] == "127.0.0.1:18080:8080"
+
+
+def test_start_container_keeps_broad_bind_for_dood_sandbox_host(monkeypatch):
+    backend = LocalContainerBackend(
+        image="sandbox:latest",
+        base_port=8080,
+        container_prefix="sandbox",
+        config_mounts=[],
+        environment={},
+    )
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "host.docker.internal")
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+
+    captured_cmd = _capture_start_container_command(monkeypatch, backend)
+
+    assert captured_cmd[captured_cmd.index("-p") + 1] == "0.0.0.0:18080:8080"
+
+
+def test_start_container_keeps_apple_container_port_format(monkeypatch):
+    backend = LocalContainerBackend(
+        image="sandbox:latest",
+        base_port=8080,
+        container_prefix="sandbox",
+        config_mounts=[],
+        environment={},
+    )
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_BIND_HOST", "127.0.0.1")
+
+    captured_cmd = _capture_start_container_command(monkeypatch, backend, runtime="container")
+
+    assert captured_cmd[captured_cmd.index("-p") + 1] == "18080:8080"

--- a/backend/tests/test_aio_sandbox_local_backend.py
+++ b/backend/tests/test_aio_sandbox_local_backend.py
@@ -158,6 +158,14 @@ def test_resolve_docker_bind_host_uses_ipv6_loopback_for_ipv6_sandbox_host(monke
     assert _resolve_docker_bind_host() == "[::1]"
 
 
+def test_resolve_docker_bind_host_logs_selected_bind_reason(caplog):
+    with caplog.at_level(logging.DEBUG, logger="deerflow.community.aio_sandbox.local_backend"):
+        assert _resolve_docker_bind_host(sandbox_host="localhost", bind_host="") == "127.0.0.1"
+
+    messages = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Docker sandbox bind: 127.0.0.1 (loopback default)" in messages
+
+
 def test_resolve_docker_bind_host_allows_explicit_override(monkeypatch):
     monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "localhost")
     monkeypatch.setenv("DEER_FLOW_SANDBOX_BIND_HOST", "192.0.2.10")

--- a/backend/tests/test_aio_sandbox_local_backend.py
+++ b/backend/tests/test_aio_sandbox_local_backend.py
@@ -151,6 +151,13 @@ def test_resolve_docker_bind_host_keeps_dood_compatibility(monkeypatch):
     assert _resolve_docker_bind_host() == "0.0.0.0"
 
 
+def test_resolve_docker_bind_host_uses_ipv6_loopback_for_ipv6_sandbox_host(monkeypatch):
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "[::1]")
+
+    assert _resolve_docker_bind_host() == "[::1]"
+
+
 def test_resolve_docker_bind_host_allows_explicit_override(monkeypatch):
     monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "localhost")
     monkeypatch.setenv("DEER_FLOW_SANDBOX_BIND_HOST", "192.0.2.10")
@@ -188,6 +195,22 @@ def test_start_container_keeps_broad_bind_for_dood_sandbox_host(monkeypatch):
     captured_cmd = _capture_start_container_command(monkeypatch, backend)
 
     assert captured_cmd[captured_cmd.index("-p") + 1] == "0.0.0.0:18080:8080"
+
+
+def test_start_container_binds_ipv6_sandbox_host_to_ipv6_loopback(monkeypatch):
+    backend = LocalContainerBackend(
+        image="sandbox:latest",
+        base_port=8080,
+        container_prefix="sandbox",
+        config_mounts=[],
+        environment={},
+    )
+    monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "[::1]")
+    monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
+
+    captured_cmd = _capture_start_container_command(monkeypatch, backend)
+
+    assert captured_cmd[captured_cmd.index("-p") + 1] == "[::1]:18080:8080"
 
 
 def test_start_container_keeps_apple_container_port_format(monkeypatch):


### PR DESCRIPTION
## Summary

This PR hardens the legacy local Docker sandbox port binding so localhost-based sandbox runs do not expose the sandbox HTTP API on every host interface by default.

- Binds local Docker sandbox `-p` mappings to `127.0.0.1` when `DEER_FLOW_SANDBOX_HOST` is unset or loopback.
- Preserves Docker-outside-of-Docker compatibility by keeping the broad bind when `DEER_FLOW_SANDBOX_HOST=host.docker.internal` or another non-loopback host is configured.
- Adds `DEER_FLOW_SANDBOX_BIND_HOST` as an explicit operator override for deployments that need a different bind address.
- Adds regression coverage for default Docker, DooD compatibility, explicit override, and Apple Container port formatting.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Legacy local Docker sandbox binds to all host interfaces by default | A localhost-oriented sandbox HTTP API can become reachable from other hosts on the same network when Docker publishes `HOST:8080` without an explicit bind address. | Medium / defense-in-depth hardening |

## Before this PR

- Legacy local Docker sandbox containers were started with a bare Docker publish mapping:
  ```text
  -p <host_port>:8080
  ```
- Docker treats that form as a broad host bind, equivalent to publishing on all host interfaces.
- The test suite did not lock in whether local sandbox ports should bind to loopback or all interfaces.

## After this PR

- Localhost-based Docker sandbox runs publish as:
  ```text
  -p 127.0.0.1:<host_port>:8080
  ```
- DooD / containerized deployments that access the host through `host.docker.internal` keep the previous broad bind for compatibility.
- Operators can explicitly choose a different bind address with:
  ```text
  DEER_FLOW_SANDBOX_BIND_HOST=<address>
  ```
- Regression tests cover the secure default and compatibility cases.

## Explicit operator choice

Secure default for local/bare-metal runs:

```bash
unset DEER_FLOW_SANDBOX_HOST
unset DEER_FLOW_SANDBOX_BIND_HOST
# Docker publish mapping becomes: 127.0.0.1:<port>:8080
```

Compatibility mode for Docker-outside-of-Docker deployments:

```bash
export DEER_FLOW_SANDBOX_HOST=host.docker.internal
# Docker publish mapping remains: 0.0.0.0:<port>:8080
```

Explicit override when an operator intentionally needs a different bind address:

```bash
export DEER_FLOW_SANDBOX_BIND_HOST=192.0.2.10
# Docker publish mapping becomes: 192.0.2.10:<port>:8080
```

## Why this matters

The sandbox HTTP service is intended to be consumed by DeerFlow as an internal/local execution component. Publishing that port on every host interface can unintentionally widen the trust boundary in developer, demo, or self-hosted environments where the host is reachable from a LAN or shared network.

Binding loopback-compatible runs to `127.0.0.1` makes the secure local behavior explicit while preserving compatibility for deployments that intentionally need cross-container host reachability.

## How this differs from related public PRs

This is intentionally scoped to a residual legacy local Docker path:

- #2495 addresses authentication for the provisioner sandbox-management API.
- #2528 addresses nginx exposure of `/api/sandboxes` to the provisioner.
- #2602 adds Docker-network sandbox mode and notes the legacy `-p HOST:8080` behavior, but keeps the legacy host-port path available for compatibility.

This PR does not duplicate those changes. It hardens the remaining legacy local Docker `-p` fallback by choosing a loopback bind for localhost-based runs.

## Attack flow

```text
Developer/operator starts a local Docker sandbox
    -> DeerFlow runs `docker run -p <port>:8080 ...`
        -> Docker publishes the sandbox API on all host interfaces
            -> another host on the reachable network can connect to the sandbox HTTP port
```

## Affected code

| Issue | Files |
|-------|-------|
| Legacy local Docker sandbox broad bind | `backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py`, `backend/tests/test_aio_sandbox_local_backend.py`, `backend/docs/CONFIGURATION.md` |

## Root cause

Legacy local Docker sandbox broad bind:

- Docker `-p <host_port>:<container_port>` defaults to all host interfaces when no host bind address is supplied.
- The local Docker sandbox launcher did not distinguish localhost/bare-metal runs from DooD deployments that require host-wide reachability.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Legacy local Docker sandbox broad bind | 6.5 Medium | `CVSS:3.1/AV:A/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L` |

Rationale: this is deployment- and network-topology-dependent hardening. In a reachable LAN/shared-network environment, a service intended for local DeerFlow use may become accessible to adjacent-network clients. The patch reduces the default exposure without removing the compatibility path.

## Safe reproduction steps

1. On vulnerable code, exercise the local Docker container start path with a fixed sandbox port.
2. Capture the constructed Docker command.
3. Observe the bare publish mapping:
   ```text
   -p 18080:8080
   ```
4. With this PR, the default localhost path emits:
   ```text
   -p 127.0.0.1:18080:8080
   ```
5. With `DEER_FLOW_SANDBOX_HOST=host.docker.internal`, the compatibility path still emits:
   ```text
   -p 0.0.0.0:18080:8080
   ```

## Expected vulnerable behavior

Pre-patch local Docker sandbox command construction produced a bare Docker publish argument:

```text
18080:8080
```

That form does not restrict the bind to loopback.

## Changes in this PR

- Adds `_resolve_docker_bind_host()` to choose the Docker bind address from sandbox host settings and explicit operator override.
- Uses `127.0.0.1:<port>:8080` for localhost-compatible local Docker sandbox runs.
- Preserves `0.0.0.0:<port>:8080` for non-loopback sandbox hosts such as `host.docker.internal`.
- Leaves Apple Container port formatting unchanged.
- Documents the default and override in the backend configuration guide.
- Adds regression tests for all covered bind-address branches.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Sandbox runtime | `backend/packages/harness/deerflow/community/aio_sandbox/local_backend.py` | Adds bind-host resolution and applies it to Docker port publishing. |
| Tests | `backend/tests/test_aio_sandbox_local_backend.py` | Adds command-construction and helper regression tests. |
| Documentation | `backend/docs/CONFIGURATION.md` | Documents default loopback binding, DooD compatibility, and explicit override. |

## Maintainer impact

- The patch is limited to local Docker sandbox command construction and related docs/tests.
- Existing DooD deployments using `host.docker.internal` keep their previous broad bind behavior.
- Operators needing a custom bind address can set `DEER_FLOW_SANDBOX_BIND_HOST` explicitly.
- Frontend, provisioner, Kubernetes sandbox behavior, and Apple Container port syntax are not changed.

## Fix rationale

Localhost-based sandbox runs should not silently publish the sandbox HTTP API beyond localhost. Adding the host portion to Docker `-p` makes that boundary explicit and regression-testable, while the compatibility branch avoids breaking containerized deployments that intentionally require host-wide reachability.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Targeted local sandbox regression tests passed.
- [x] Ruff format check passed for touched Python files.
- [x] Ruff lint passed for touched Python files.
- [x] Python compile check passed for touched Python files.
- [x] Git whitespace check passed.
- [x] Added-line secret/sink scan found no findings.

Executed with:

```bash
cd backend
uv run pytest tests/test_aio_sandbox_local_backend.py -q
uv run ruff format --check packages/harness/deerflow/community/aio_sandbox/local_backend.py tests/test_aio_sandbox_local_backend.py
uv run ruff check packages/harness/deerflow/community/aio_sandbox/local_backend.py tests/test_aio_sandbox_local_backend.py
uv run python -m compileall -q packages/harness/deerflow/community/aio_sandbox/local_backend.py tests/test_aio_sandbox_local_backend.py
cd ..
git diff --check
```

Additional local validation:

```text
No added-line secret/sink hits
```

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: exact per-phase token telemetry was not available in this local workflow.

## Disclosure notes

- This PR is bounded to the legacy local Docker sandbox port-publishing path.
- It does not claim to replace provisioner authentication, nginx routing hardening, or Docker-network sandbox mode.
- No unrelated files were changed.
