### PR TITLE
fix(middleware): avoid recompressing retained summaries

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
@@ -136,6 +136,10 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
             return None
 
         messages_to_summarize, preserved_messages = self._partition_with_skill_rescue(messages, cutoff_index)
+        if self._would_only_recompress_existing_summary(messages_to_summarize, preserved_messages):
+            logger.debug("Skipping summarization because it would only recompress an existing summary")
+            return None
+
         self._fire_hooks(messages_to_summarize, preserved_messages, runtime)
         summary = self._create_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
@@ -161,6 +165,10 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
             return None
 
         messages_to_summarize, preserved_messages = self._partition_with_skill_rescue(messages, cutoff_index)
+        if self._would_only_recompress_existing_summary(messages_to_summarize, preserved_messages):
+            logger.debug("Skipping summarization because it would only recompress an existing summary")
+            return None
+
         self._fire_hooks(messages_to_summarize, preserved_messages, runtime)
         summary = await self._acreate_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
@@ -227,6 +235,44 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
             remaining.append(msg)
 
         return remaining, rescued + preserved
+
+    def _would_only_recompress_existing_summary(
+        self,
+        messages_to_summarize: list[AnyMessage],
+        preserved_messages: list[AnyMessage],
+    ) -> bool:
+        """Return True when summarization would only rewrite the prior summary."""
+        if not messages_to_summarize:
+            return False
+
+        for message in messages_to_summarize:
+            if not (isinstance(message, HumanMessage) and message.name == "summary"):
+                return False
+
+        return self._preserved_messages_would_retrigger(preserved_messages)
+
+    def _preserved_messages_would_retrigger(self, preserved_messages: list[AnyMessage]) -> bool:
+        """Return True when token-based summarization cannot reduce state below its trigger."""
+        if not preserved_messages:
+            return False
+        total_tokens = self.token_counter(preserved_messages)
+        for kind, value in self._trigger_conditions:
+            if kind == "tokens" and total_tokens >= value:
+                return True
+            if kind == "tokens" and self._should_summarize_based_on_reported_tokens(preserved_messages, value):
+                return True
+            if kind == "fraction":
+                max_input_tokens = self._get_profile_limits()
+                if max_input_tokens is None:
+                    continue
+                threshold = int(max_input_tokens * value)
+                if threshold <= 0:
+                    threshold = 1
+                if total_tokens >= threshold:
+                    return True
+                if self._should_summarize_based_on_reported_tokens(preserved_messages, threshold):
+                    return True
+        return False
 
     def _find_skill_bundles(
         self,

--- a/backend/tests/test_summarization_middleware.py
+++ b/backend/tests/test_summarization_middleware.py
@@ -34,6 +34,7 @@ def _middleware(
     before_summarization=None,
     trigger=("messages", 4),
     keep=("messages", 2),
+    token_counter=len,
     skill_file_read_tool_names=None,
     preserve_recent_skill_count: int = 0,
     preserve_recent_skill_tokens: int = 0,
@@ -45,7 +46,7 @@ def _middleware(
         model=model,
         trigger=trigger,
         keep=keep,
-        token_counter=len,
+        token_counter=token_counter,
         before_summarization=before_summarization,
         skill_file_read_tool_names=skill_file_read_tool_names,
         preserve_recent_skill_count=preserve_recent_skill_count,
@@ -75,6 +76,10 @@ def _skill_conversation() -> list:
     ]
 
 
+def _content_length_token_counter(messages) -> int:
+    return sum(len(str(message.content)) for message in messages)
+
+
 def test_before_summarization_hook_receives_messages_before_compression() -> None:
     captured: list[SummarizationEvent] = []
     middleware = _middleware(before_summarization=[captured.append])
@@ -98,6 +103,50 @@ def test_before_summarization_hook_not_called_when_threshold_not_met() -> None:
 
     assert captured == []
     assert result is None
+
+
+def test_summarization_still_compresses_old_history_when_preserved_messages_exceed_trigger() -> None:
+    captured: list[SummarizationEvent] = []
+    middleware = _middleware(
+        before_summarization=[captured.append],
+        trigger=("tokens", 100),
+        keep=("messages", 2),
+        token_counter=_content_length_token_counter,
+    )
+    messages = [
+        HumanMessage(content="old question"),
+        AIMessage(content="old answer"),
+        HumanMessage(content="x" * 80),
+        AIMessage(content="y" * 80),
+    ]
+
+    result = middleware.before_model({"messages": messages}, _runtime())
+
+    assert result is not None
+    assert len(captured) == 1
+    assert [message.content for message in captured[0].messages_to_summarize] == ["old question", "old answer"]
+    assert isinstance(result["messages"][0], RemoveMessage)
+    assert result["messages"][1].name == "summary"
+
+
+def test_summarization_skips_when_only_existing_summary_would_be_recompressed() -> None:
+    captured: list[SummarizationEvent] = []
+    middleware = _middleware(
+        before_summarization=[captured.append],
+        trigger=("tokens", 100),
+        keep=("messages", 2),
+        token_counter=_content_length_token_counter,
+    )
+    messages = [
+        HumanMessage(content="Here is a summary of the conversation to date:\n\nold summary", name="summary"),
+        HumanMessage(content="x" * 80),
+        AIMessage(content="y" * 80),
+    ]
+
+    result = middleware.before_model({"messages": messages}, _runtime())
+
+    assert result is None
+    assert captured == []
 
 
 def test_before_summarization_hook_exception_does_not_block_compression(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
## Summary

Fix a summarization middleware loop where an existing retained summary can be summarized again when the preserved message tail still exceeds token-based trigger conditions.

This keeps normal first-pass summarization behavior intact, while avoiding summary-of-summary recompression when there is no real older conversation history left to reduce.

Closes #2622.

## Root Cause

`DeerFlowSummarizationMiddleware` decides whether summarization should run before partitioning messages into the compressible history and the preserved tail.

When the preserved tail alone is still large enough to trigger token or fraction-based summarization, the next pass may select only the existing `HumanMessage(name="summary")` as the compressible portion. In that case, summarization cannot reduce the oversized preserved tail, and instead repeatedly rewrites the previous summary.

## Fix

After partitioning, skip summarization only when both conditions are true:

- the messages selected for summarization are all existing DeerFlow summary messages
- the preserved messages alone would still trigger token or fraction-based summarization

This still allows the middleware to summarize real older conversation history, even when the preserved tail is large.

## Tests

- `cd backend && uv run pytest tests/test_summarization_middleware.py -q`
- `cd backend && make lint` (run locally as `mingw32-make lint` on Windows)
