### PR TITLE
fix(frontend): resolve 404 when creating new agent

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -102,7 +102,7 @@ export default function NewAgentPage() {
   const threadId = useMemo(() => uuid(), []);
 
   const { thread, sendMessage } = useThreadStream({
-    threadId: step === "chat" ? threadId : undefined,
+    threadId: undefined,
     context: {
       mode: "flash",
       is_bootstrap: true,


### PR DESCRIPTION
Fixes #2658

## Summary

- Creating an agent from `/workspace/agents/new` failed with `POST /api/langgraph/threads/{uuid}/runs/stream 404 (Thread not found)`. See #2658 for the full bug report and reproduction.
- Root cause: the page pre-generated a UUID with `useMemo(() => uuid(), [])` and passed it as `threadId` to `useThreadStream` once `step === "chat"`. The LangGraph SDK then treated the thread as already-existing and POSTed a run on it, but the backend had never seen that id.
- After #2566 introduced multi-tenant owner checks on `/runs/*` (`@require_permission("runs", "create", owner_check=True)` in `backend/app/gateway/routers/thread_runs.py`), `ThreadMetaStore.check_access` returns false for unknown threads and 404s. Before #2566 the request silently succeeded because no owner check existed.
- Fix: pass `threadId: undefined` to `useThreadStream`. The pre-generated UUID is still forwarded via `SubmitOptions.threadId` in `sendMessage` (`frontend/src/core/threads/hooks.ts:462`), so the SDK creates the new thread with that exact id (writing the owner row), then `onCreated` rebinds the hook to that id for follow-up sends. This matches the pattern already used by `frontend/src/app/workspace/chats/[thread_id]/page.tsx:57` for new chats.

## Test plan

- [ ] Open `/workspace/agents/new`, enter a name, confirm — chat starts streaming without 404.
- [ ] Send a follow-up message in the same agent-creation chat — bound to the same thread id.
- [ ] Trigger "Save" (`setup_agent` tool) — agent is created and the success card appears.
- [ ] Verify the existing chats flow (`/workspace/chats/...`) still works for both new and existing threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)