### PR TITLE
fix(nginx): add catch-all /api/ location for auth routes

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -207,6 +207,17 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Catch-all for /api/ routes not covered above (e.g. /api/v1/auth/*).
+        # More specific prefix and regex locations above still take precedence.
+        location /api/ {
+            proxy_pass http://gateway;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         # All other requests go to frontend
         location / {
             proxy_pass http://frontend;


### PR DESCRIPTION
## Problem

After the recent refactor (7bf618de) that removed the langgraph upstream and switched to Gateway-embedded runtime, the nginx config added individual `/api/*` prefix location blocks for specific routes (`/api/langgraph/`, `/api/models`, `/api/memory`, `/api/mcp`, `/api/skills`, `/api/agents`, `/api/threads/*`, `/api/sandboxes`). However, **`/api/v1/auth/*` routes were not covered** by any explicit location block.

This causes auth endpoints (`/api/v1/auth/login/local`, `/api/v1/auth/register`, `/api/v1/auth/setup-status`, `/api/v1/auth/me`, etc.) to fall through to the frontend catch-all `location /`.

### Impact

In **Docker production builds** (`make up`), the Next.js frontend has its API rewrites baked at build time pointing to `http://127.0.0.1:8001`. From the frontend container's perspective, `127.0.0.1:8001` is the frontend container itself (not the gateway), so auth requests fail with:

```
Error: connect ECONNREFUSED 127.0.0.1:8001
```

Users see "network error" when trying to register or log in.

### Root Cause

The `location /` catch-all proxies to the frontend. The frontend's built-in Next.js rewrites then try to forward auth requests to `http://127.0.0.1:8001`, which is localhost inside the frontend container — not the gateway container. The nginx proxy never forwards these requests to the gateway.

## Fix

Add a catch-all `location /api/` block **after** all the more specific prefix and regex locations:

```nginx
location /api/ {
    proxy_pass http://gateway;
    ...
}
```

nginx's location matching priority ensures the more specific locations above still take precedence:
- `/api/langgraph/` → rewrite to `/api/*` → gateway
- `/api/models` → gateway
- `/api/memory` → gateway
- `/api/mcp` → gateway
- `/api/skills` → gateway
- `/api/agents` → gateway
- `/api/threads/*` → gateway
- `/api/sandboxes` → provisioner
- **`/api/v1/*` (auth) → gateway** ← NEW
- **`/api/*` (any future routes) → gateway** ← NEW
- `/*` → frontend

This also future-proofs against new `/api/*` routes being added to the gateway without needing corresponding nginx location blocks.

## Test Plan

- [ ] `curl /api/v1/auth/setup-status` returns `{"needs_setup": true}` (not 500 or ECONNREFUSED)
- [ ] User registration at `/login` works without "network error"
- [ ] User login and `/api/v1/auth/me` return proper responses
- [ ] Existing `/api/langgraph/*`, `/api/models`, `/api/threads/*` routes still work
- [ ] `/api/sandboxes` still routes to provisioner