### PR TITLE
fix: avoid duplicate call to extractReasoningContentFromMessage

### DIFF
--- a/frontend/src/components/workspace/messages/message-group.tsx
+++ b/frontend/src/components/workspace/messages/message-group.tsx
@@ -451,7 +451,7 @@ function convertToSteps(messages: Message[]): CoTStep[] {
           id: message.id,
           messageId: message.id,
           type: "reasoning",
-          reasoning: extractReasoningContentFromMessage(message),
+          reasoning,
         };
         steps.push(step);
       }


### PR DESCRIPTION
## Summary
  - In `convertToSteps()` within `message-group.tsx`, `extractReasoningContentFromMessage(message)` was called twice for the same message — once to check if reasoning exists and again to
  assign it to the step object.
  - Reuse the already-extracted `reasoning` variable via ES6 shorthand property syntax, avoiding the redundant function call.

  ## Test plan
  - [x] `pnpm check` (ESLint + TypeScript type check) passes
  - [ ] Confirm reasoning steps still render correctly in the chat UI
  - [ ] No behavioral change — pure refactor to eliminate unnecessary duplicate call