### PR TITLE
fix(docker,docs): improve production Docker config and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,9 +131,8 @@ Host Machine
 Docker Compose (deer-flow-dev)
   ├→ nginx (port 2026) ← Reverse proxy
   ├→ web (port 3000) ← Frontend with hot-reload
-  ├→ api (port 8001) ← Gateway API with hot-reload
-   ├→ langgraph (port 2024) ← LangGraph server with hot-reload
-   └→ provisioner (optional, port 8002) ← Started only in provisioner/K8s sandbox mode
+  ├→ api (port 8001) ← Gateway API + embedded agent runtime with hot-reload
+  └→ provisioner (optional, port 8002) ← Started only in provisioner/K8s sandbox mode
 ```
 
 **Benefits of Docker Development**:
@@ -186,15 +185,11 @@ If you need to start services individually:
 
 1. **Start backend services**:
    ```bash
-   # Terminal 1: Start LangGraph Server (port 2024)
-   cd backend
-   make dev
-
-   # Terminal 2: Start Gateway API (port 8001)
+   # Terminal 1: Start Gateway API (port 8001)
    cd backend
    make gateway
 
-   # Terminal 3: Start Frontend (port 3000)
+   # Terminal 2: Start Frontend (port 3000)
    cd frontend
    pnpm dev
    ```
@@ -212,7 +207,7 @@ If you need to start services individually:
 
 The nginx configuration provides:
 - Unified entry point on port 2026
-- Routes `/api/langgraph/*` to LangGraph Server (2024)
+- Routes `/api/langgraph/*` to Gateway embedded runtime (8001)
 - Routes other `/api/*` endpoints to Gateway API (8001)
 - Routes non-API requests to Frontend (3000)
 - Centralized CORS handling
@@ -234,12 +229,16 @@ deer-flow/
 │       ├── nginx.conf      # Nginx config for Docker
 │       └── nginx.local.conf # Nginx config for local dev
 ├── backend/                 # Backend application
-│   ├── src/
+│   ├── app/
 │   │   ├── gateway/        # Gateway API (port 8001)
-│   │   ├── agents/         # LangGraph agents (port 2024)
-│   │   ├── mcp/            # Model Context Protocol integration
-│   │   ├── skills/         # Skills system
-│   │   └── sandbox/        # Sandbox execution
+│   │   └── channels/       # IM platform integrations
+│   ├── packages/
+│   │   └── harness/deerflow/  # Agent framework package
+│   │       ├── agents/     # LangGraph agents
+│   │       ├── mcp/        # Model Context Protocol integration
+│   │       ├── skills/     # Skills system
+│   │       ├── sandbox/    # Sandbox execution
+│   │       └── models/     # Model factory
 │   ├── docs/               # Backend documentation
 │   └── Makefile            # Backend commands
 ├── frontend/               # Frontend application
@@ -256,8 +255,7 @@ Browser
   ↓
 Nginx (port 2026) ← Unified entry point
   ├→ Frontend (port 3000) ← / (non-API requests)
-  ├→ Gateway API (port 8001) ← /api/models, /api/mcp, /api/skills, /api/threads/*/artifacts
-  └→ LangGraph Server (port 2024) ← /api/langgraph/* (agent interactions)
+  └→ Gateway API (port 8001) ← /api/* (models, mcp, skills, threads, agents)
 ```
 
 ## Development Workflow

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,12 +29,19 @@ services:
       - "${PORT:-2026}:2026"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf.template:ro
-    command: >
-      sh -c "cp /etc/nginx/nginx.conf.template /etc/nginx/nginx.conf
-      && nginx -g 'daemon off;'"
+    command:
+      - sh
+      - -c
+      - |
+        set -e
+        cp /etc/nginx/nginx.conf.template /etc/nginx/nginx.conf
+        test -e /proc/net/if_inet6 || sed -i '/^[[:space:]]*listen[[:space:]]\+\[::\]:2026;/d' /etc/nginx/nginx.conf
+        exec nginx -g 'daemon off;'
     depends_on:
-      - frontend
-      - gateway
+      gateway:
+        condition: service_healthy
+      frontend:
+        condition: service_healthy
     networks:
       - deer-flow
     restart: unless-stopped
@@ -57,6 +64,12 @@ services:
     networks:
       - deer-flow
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
 
   # ── Gateway API ────────────────────────────────────────────────────────────
   gateway:
@@ -109,6 +122,12 @@ services:
     networks:
       - deer-flow
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+      start_period: 15s
 
   # ── Sandbox Provisioner (optional, Kubernetes mode) ────────────────────────
   provisioner:
@@ -141,6 +160,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 6
+      start_period: 15s
 networks:
   deer-flow:
     driver: bridge


### PR DESCRIPTION
## Summary

Fixes several inconsistencies between the production and dev Docker Compose configurations, and updates outdated documentation in CONTRIBUTING.md.

## Changes

### Docker (`docker/docker-compose.yaml`)

1. **Add IPv6 detection to production nginx command** — The dev compose file (`docker-compose-dev.yaml`) includes logic to strip `listen [::]:2026` when `/proc/net/if_inet6` is absent, preventing nginx startup failures on systems without IPv6 support. The production compose file was missing this. Now both files use the same pattern.

2. **Add healthchecks to gateway and frontend services** — The nginx service depends on gateway and frontend, but without healthchecks there was no way to ensure they were actually ready before nginx started. Added healthchecks (matching the pattern used by the provisioner service) and updated nginx's `depends_on` to use `condition: service_healthy`.

3. **Add missing `start_period` to provisioner healthcheck** — The dev compose file includes `start_period: 15s` for the provisioner healthcheck, but the production file was missing it. This gives the provisioner time to initialize before health checks begin failing.

### Documentation (`CONTRIBUTING.md`)

4. **Update project structure tree** — The documented structure referenced a non-existent `backend/src/` directory. Updated to reflect the actual layout: `backend/app/` (gateway, channels) and `backend/packages/harness/deerflow/` (agents, sandbox, models, skills, etc.).

5. **Update architecture diagrams** — Removed references to a separate LangGraph Server on port 2024, which no longer exists in DeerFlow 2.0. The agent runtime is now embedded in the Gateway on port 8001. Updated the Docker Architecture diagram, the main Architecture diagram, the Manual Service Control section, and the Nginx Configuration description.

## Testing

- Verified YAML syntax of the modified `docker-compose.yaml`
- Changes are configuration/documentation only; no code logic changes