### PR TITLE
fix(backend): handle UnicodeDecodeError and validate str_replace count

### DIFF
--- a/backend/app/gateway/routers/artifacts.py
+++ b/backend/app/gateway/routers/artifacts.py
@@ -175,9 +175,15 @@ async def get_artifact(thread_id: str, path: str, request: Request, download: bo
         return FileResponse(path=actual_path, filename=actual_path.name, media_type=mime_type, headers=_build_attachment_headers(actual_path.name))
 
     if mime_type and mime_type.startswith("text/"):
-        return PlainTextResponse(content=actual_path.read_text(encoding="utf-8"), media_type=mime_type)
+        try:
+            return PlainTextResponse(content=actual_path.read_text(encoding="utf-8"), media_type=mime_type)
+        except UnicodeDecodeError:
+            pass  # Fall through to binary response
 
     if is_text_file_by_content(actual_path):
-        return PlainTextResponse(content=actual_path.read_text(encoding="utf-8"), media_type=mime_type)
+        try:
+            return PlainTextResponse(content=actual_path.read_text(encoding="utf-8"), media_type=mime_type)
+        except UnicodeDecodeError:
+            pass  # Fall through to binary response
 
     return Response(content=actual_path.read_bytes(), media_type=mime_type, headers={"Content-Disposition": _build_content_disposition("inline", actual_path.name)})

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1569,6 +1569,9 @@ def str_replace_tool(
             if replace_all:
                 content = content.replace(old_str, new_str)
             else:
+                count = content.count(old_str)
+                if count > 1:
+                    return f"Error: The string to replace appears {count} times in {requested_path}. Use replace_all=True to replace all occurrences, or provide a more specific string that appears exactly once."
                 content = content.replace(old_str, new_str, 1)
             sandbox.write_file(path, content)
         return "OK"


### PR DESCRIPTION
## Summary

Improve robustness in two backend components:

### 1. Artifact serving: handle UnicodeDecodeError for non-UTF-8 text files

**File:** `backend/app/gateway/routers/artifacts.py`

The `get_artifact` endpoint calls `actual_path.read_text(encoding="utf-8")` after `is_text_file_by_content()` returns `True`. However, `is_text_file_by_content()` only checks for null bytes — a file can pass this check while still containing non-UTF-8 byte sequences (e.g., Latin-1, Shift-JIS encoded text files). This causes an unhandled `UnicodeDecodeError` resulting in a 500 error.

The `.skill` archive code path in the same file (lines 152-155) already handles this correctly with a `try/except UnicodeDecodeError` fallback to binary response.

**Fix:** Wrap both `read_text` calls in `try/except UnicodeDecodeError` that fall through to the binary `Response` path, consistent with the existing `.skill` archive handling.

### 2. str_replace tool: enforce single-occurrence when replace_all=False

**File:** `backend/packages/harness/deerflow/sandbox/tools.py`

The `str_replace_tool` docstring states: *"the substring to replace must appear exactly once in the file"* when `replace_all` is `False`. However, the implementation uses `content.replace(old_str, new_str, 1)` which silently replaces only the first occurrence regardless of how many exist. This can lead to unexpected edits when the agent intends to make a precise single replacement.

**Fix:** Add a count check before replacing. If `content.count(old_str) > 1`, return an error message telling the agent the string appears multiple times and suggesting either `replace_all=True` or a more specific string.

## Testing

- All 2792 existing tests pass
- `ruff check` passes
- `ruff format --check` passes