### PR TITLE
fix(frontend): disable word animation and add streaming performance fixes

### DIFF
--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -305,7 +305,7 @@ export const MessageBranchPage = ({
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
+  ({ className, isLoading, ...props }: MessageResponseProps & { isLoading?: boolean }) => (
     <Streamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
@@ -314,7 +314,9 @@ export const MessageResponse = memo(
       {...props}
     />
   ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children,
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.isLoading === nextProps.isLoading,
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -1,4 +1,5 @@
 import type { BaseStream } from "@langchain/langgraph-sdk/react";
+import { useEffect, useMemo } from "react";
 
 import {
   Conversation,
@@ -51,6 +52,58 @@ export function MessageList({
   const rehypePlugins = useRehypeSplitWordsIntoSpans(thread.isLoading);
   const updateSubtask = useUpdateSubtask();
   const messages = thread.messages;
+
+  // Batch subtask updates from messages to avoid calling updateSubtask during render
+  const pendingSubtaskUpdates = useMemo(() => {
+    const updates: Array<Partial<Subtask> & { id: string }> = [];
+    for (const message of messages) {
+      if (message.type === "ai") {
+        for (const toolCall of message.tool_calls ?? []) {
+          if (toolCall.name === "task") {
+            updates.push({
+              id: toolCall.id!,
+              subagent_type: toolCall.args.subagent_type,
+              description: toolCall.args.description,
+              prompt: toolCall.args.prompt,
+              status: "in_progress",
+            });
+          }
+        }
+      } else if (message.type === "tool") {
+        const taskId = message.tool_call_id;
+        if (taskId) {
+          const result = extractTextFromMessage(message);
+          if (result.startsWith("Task Succeeded. Result:")) {
+            updates.push({
+              id: taskId,
+              status: "completed",
+              result: result.split("Task Succeeded. Result:")[1]?.trim(),
+            });
+          } else if (result.startsWith("Task failed.")) {
+            updates.push({
+              id: taskId,
+              status: "failed",
+              error: result.split("Task failed.")[1]?.trim(),
+            });
+          } else if (result.startsWith("Task timed out")) {
+            updates.push({ id: taskId, status: "failed", error: result });
+          } else {
+            updates.push({ id: taskId, status: "in_progress" });
+          }
+        }
+      }
+    }
+    return updates;
+  }, [messages]);
+
+  // Apply subtask updates in useEffect to avoid rendering side effects
+  useEffect(() => {
+    for (const update of pendingSubtaskUpdates) {
+      updateSubtask(update);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingSubtaskUpdates, updateSubtask]);
+
   if (thread.isThreadLoading && messages.length === 0) {
     return <MessageListSkeleton />;
   }
@@ -123,46 +176,13 @@ export function MessageList({
               if (message.type === "ai") {
                 for (const toolCall of message.tool_calls ?? []) {
                   if (toolCall.name === "task") {
-                    const task: Subtask = {
+                    tasks.add({
                       id: toolCall.id!,
                       subagent_type: toolCall.args.subagent_type,
                       description: toolCall.args.description,
                       prompt: toolCall.args.prompt,
                       status: "in_progress",
-                    };
-                    updateSubtask(task);
-                    tasks.add(task);
-                  }
-                }
-              } else if (message.type === "tool") {
-                const taskId = message.tool_call_id;
-                if (taskId) {
-                  const result = extractTextFromMessage(message);
-                  if (result.startsWith("Task Succeeded. Result:")) {
-                    updateSubtask({
-                      id: taskId,
-                      status: "completed",
-                      result: result
-                        .split("Task Succeeded. Result:")[1]
-                        ?.trim(),
-                    });
-                  } else if (result.startsWith("Task failed.")) {
-                    updateSubtask({
-                      id: taskId,
-                      status: "failed",
-                      error: result.split("Task failed.")[1]?.trim(),
-                    });
-                  } else if (result.startsWith("Task timed out")) {
-                    updateSubtask({
-                      id: taskId,
-                      status: "failed",
-                      error: result,
-                    });
-                  } else {
-                    updateSubtask({
-                      id: taskId,
-                      status: "in_progress",
-                    });
+                    } as Subtask);
                   }
                 }
               }

--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -102,7 +102,7 @@ export function SubtaskCard({
                     {icon}
                     <FlipDisplay
                       className="max-w-[420px] truncate pb-1"
-                      uniqueKey={task.latestMessage?.id ?? ""}
+                      uniqueKey={taskId}
                     >
                       {task.status === "in_progress" &&
                       task.latestMessage &&

--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -19,7 +19,7 @@ import { ShineBorder } from "@/components/ui/shine-border";
 import { useI18n } from "@/core/i18n/hooks";
 import { hasToolCalls } from "@/core/messages/utils";
 import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
-import { streamdownPluginsWithWordAnimation } from "@/core/streamdown";
+import { streamdownPlugins } from "@/core/streamdown";
 import { useSubtask } from "@/core/tasks/context";
 import { explainLastToolCall } from "@/core/tools/utils";
 import { cn } from "@/lib/utils";
@@ -127,7 +127,7 @@ export function SubtaskCard({
             <ChainOfThoughtStep
               label={
                 <Streamdown
-                  {...streamdownPluginsWithWordAnimation}
+                  {...streamdownPlugins}
                   components={{ a: CitationLink }}
                 >
                   {task.prompt}

--- a/frontend/src/core/rehype/index.ts
+++ b/frontend/src/core/rehype/index.ts
@@ -48,9 +48,8 @@ export function rehypeSplitWordsIntoSpans() {
 }
 
 export function useRehypeSplitWordsIntoSpans(enabled = true) {
-  const rehypePlugins = useMemo(
-    () => (enabled ? [rehypeSplitWordsIntoSpans] : []),
-    [enabled],
-  );
+  // Always disable word animation - it's causing performance issues during
+  // streaming and history loading with no visible benefit
+  const rehypePlugins = useMemo(() => [], [enabled]);
   return rehypePlugins;
 }

--- a/frontend/src/core/tasks/context.tsx
+++ b/frontend/src/core/tasks/context.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useRef, useState } from "react";
 
 import type { Subtask } from "./types";
 
@@ -40,14 +40,41 @@ export function useSubtask(id: string) {
 
 export function useUpdateSubtask() {
   const { tasks, setTasks } = useSubtaskContext();
+  const pendingRef = useRef<Partial<Subtask> & { id: string } | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flushPending = useCallback(() => {
+    if (!pendingRef.current) return;
+    const task = pendingRef.current;
+    pendingRef.current = null;
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    const existing = tasks[task.id];
+    const merged = { ...existing, ...task } as Subtask;
+    // Only re-render if values actually changed
+    if (existing?.latestMessage !== merged.latestMessage || existing?.status !== merged.status) {
+      const newTasks = { ...tasks, [task.id]: merged };
+      setTasks(newTasks);
+    }
+  }, [tasks, setTasks]);
+
   const updateSubtask = useCallback(
     (task: Partial<Subtask> & { id: string }) => {
-      tasks[task.id] = { ...tasks[task.id], ...task } as Subtask;
-      if (task.latestMessage) {
-        setTasks({ ...tasks });
+      // Always update the pending ref (last write wins)
+      pendingRef.current = { ...pendingRef.current, ...task } as Partial<Subtask> & { id: string };
+
+      // Clear any existing flush timer
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
       }
+
+      // Use 50ms debounce to batch rapid updates
+      timeoutRef.current = setTimeout(flushPending, 50);
     },
-    [tasks, setTasks],
+    [flushPending],
   );
+
   return updateSubtask;
 }


### PR DESCRIPTION
## Summary

Comprehensive fix for frontend page freeze when loading history or processing streaming responses.

### Root Cause

The `rehypeSplitWordsIntoSpans` plugin creates thousands of DOM elements with CSS `animate-fade-in` class, one per word. During streaming or loading long message history, this causes severe CPU usage leading to page freeze.

### Fixes Applied

1. **Disabled word animation plugin** - Returns empty array regardless of `enabled` flag to prevent massive DOM creation

2. **FlipDisplay stable key** - Uses `taskId` instead of `task.latestMessage?.id`

3. **Throttled task_running events** - 50ms debounce in `updateSubtask`

4. **MessageResponse memo fix** - Added `isLoading` comparison

5. **Moved updateSubtask from render** - Batched in useMemo/useEffect

### Files Changed
- `frontend/src/core/rehype/index.ts` - Disable word animation
- `frontend/src/components/workspace/messages/subtask-card.tsx` - Stable key, no word animation
- `frontend/src/core/tasks/context.tsx` - Debounced updates
- `frontend/src/components/ai-elements/message.tsx` - Improved memo
- `frontend/src/components/workspace/messages/message-list.tsx` - Batch updates in useEffect

### Testing
Please verify:
1. Loading long conversation history is responsive
2. Streaming responses don't freeze the page
3. Subtask cards render correctly during task execution