### PR TITLE
fix(docker): set UTF-8 locale to prevent ASCII encoding errors in minimal containers

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,6 +50,12 @@ COPY backend ./backend
 RUN --mount=type=cache,target=/root/.cache/uv \
     sh -c "cd backend && UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple} uv sync ${UV_EXTRAS:+--extra $UV_EXTRAS}"
 
+# UTF-8 locale prevents UnicodeEncodeError on Chinese/emoji content in minimal
+# containers (NAS, Alpine-based hosts) where the default encoding is ASCII.
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONIOENCODING=utf-8
+
 # ── Stage 2: Dev ──────────────────────────────────────────────────────────────
 # Retains compiler toolchain from builder so startup-time `uv sync` can build
 # source distributions in development containers.
@@ -65,6 +71,10 @@ CMD ["sh", "-c", "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app 
 # ── Stage 3: Runtime ──────────────────────────────────────────────────────────
 # Clean image without build-essential — reduces size (~200 MB) and attack surface.
 FROM python:3.12-slim-bookworm
+
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV PYTHONIOENCODING=utf-8
 
 # Copy Node.js runtime from builder (provides npx for MCP servers)
 COPY --from=builder /usr/bin/node /usr/bin/node

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -51,7 +51,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     sh -c "cd backend && UV_INDEX_URL=${UV_INDEX_URL:-https://pypi.org/simple} uv sync ${UV_EXTRAS:+--extra $UV_EXTRAS}"
 
 # UTF-8 locale prevents UnicodeEncodeError on Chinese/emoji content in minimal
-# containers (NAS, Alpine-based hosts) where the default encoding is ASCII.
+# containers where locale configuration may be missing and the default encoding is not UTF-8.
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 ENV PYTHONIOENCODING=utf-8


### PR DESCRIPTION
Fixed #2684
The Docker container lacks locale configuration, causing Python to default to ASCII encoding.

Add the following to the Dockerfile's runtime stage:

 ```
 ENV LANG=C.UTF-8
  ENV LC_ALL=C.UTF-8
  ENV PYTHONIOENCODING=utf-8

```