### PR TITLE
fix(docker):force ngix to resolve upstream names at request time

### DIFF
--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -50,7 +50,7 @@ def test_nginx_routes_official_langgraph_prefix_to_gateway_api():
         assert "/api/langgraph-compat" not in content
         assert "proxy_pass http://langgraph" not in content
         assert "rewrite ^/api/langgraph/(.*) /api/$1 break;" in content
-        assert "proxy_pass http://gateway" in content
+        assert "proxy_pass http://gateway" in content or "proxy_pass http://$gateway_upstream" in content
 
 
 def test_frontend_rewrites_langgraph_prefix_to_gateway():

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -17,24 +17,16 @@ http {
     # Docker internal DNS (for resolving k3s hostname)
     resolver 127.0.0.11 valid=10s ipv6=off;
 
-    # Upstream servers (using Docker service names)
-    # NOTE: `zone` and `resolve` are nginx Plus-only features and are not
-    # available in the standard nginx:alpine image. Docker's internal DNS
-    # (127.0.0.11) handles service discovery; upstreams are resolved at
-    # nginx startup and remain valid for the lifetime of the deployment.
-    upstream gateway {
-        server gateway:8001;
-    }
-
-    upstream frontend {
-        server frontend:3000;
-    }
-
     # ── Main server (path-based routing) ─────────────────────────────────
     server {
         listen 2026 default_server;
         listen [::]:2026 default_server;
         server_name _;
+
+        # Resolve Docker service names at request time to avoid stale upstream
+        # IPs when containers restart and receive new addresses.
+        set $gateway_upstream gateway:8001;
+        set $frontend_upstream frontend:3000;
 
         # Hide CORS headers from upstream to prevent duplicates
         proxy_hide_header 'Access-Control-Allow-Origin';
@@ -56,7 +48,7 @@ http {
         # Rewrites /api/langgraph/* to /api/* before proxying to Gateway.
         location /api/langgraph/ {
             rewrite ^/api/langgraph/(.*) /api/$1 break;
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
 
             # Headers
@@ -82,7 +74,7 @@ http {
 
         # Custom API: Models endpoint
         location /api/models {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -92,7 +84,7 @@ http {
 
         # Custom API: Memory endpoint
         location /api/memory {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -102,7 +94,7 @@ http {
 
         # Custom API: MCP configuration endpoint
         location /api/mcp {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -112,7 +104,7 @@ http {
 
         # Custom API: Skills configuration endpoint
         location /api/skills {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -122,7 +114,7 @@ http {
 
         # Custom API: Agents endpoint
         location /api/agents {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -132,7 +124,7 @@ http {
 
         # Custom API: Uploads endpoint
         location ~ ^/api/threads/[^/]+/uploads {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -146,7 +138,7 @@ http {
 
         # Custom API: Other endpoints under /api/threads
         location ~ ^/api/threads {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -156,7 +148,7 @@ http {
 
         # API Documentation: Swagger UI
         location /docs {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -166,7 +158,7 @@ http {
 
         # API Documentation: ReDoc
         location /redoc {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -176,7 +168,7 @@ http {
 
         # API Documentation: OpenAPI Schema
         location /openapi.json {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -186,7 +178,7 @@ http {
 
         # Health check endpoint (gateway)
         location /health {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -210,7 +202,7 @@ http {
         # Catch-all for /api/ routes not covered above (e.g. /api/v1/auth/*).
         # More specific prefix and regex locations above still take precedence.
         location /api/ {
-            proxy_pass http://gateway;
+            proxy_pass http://$gateway_upstream;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
@@ -220,7 +212,7 @@ http {
 
         # All other requests go to frontend
         location / {
-            proxy_pass http://frontend;
+            proxy_pass http://$frontend_upstream;
             proxy_http_version 1.1;
 
             # Headers

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -17,19 +17,6 @@ http {
     # Docker internal DNS (for resolving k3s hostname)
     resolver 127.0.0.11 valid=10s ipv6=off;
 
-    # Upstream servers (using Docker service names)
-    # NOTE: `zone` and `resolve` are nginx Plus-only features and are not
-    # available in the standard nginx:alpine image. Docker's internal DNS
-    # (127.0.0.11) handles service discovery; upstreams are resolved at
-    # nginx startup and remain valid for the lifetime of the deployment.
-    upstream gateway {
-        server gateway:8001;
-    }
-
-    upstream frontend {
-        server frontend:3000;
-    }
-
     # ── Main server (path-based routing) ─────────────────────────────────
     server {
         listen 2026 default_server;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -14,8 +14,10 @@ http {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
-    # Docker internal DNS (for resolving k3s hostname)
-    resolver 127.0.0.11 valid=10s ipv6=off;
+    # Docker internal DNS (for resolving service hostnames).
+    # valid=0s disables DNS caching so every request triggers a fresh lookup,
+    # ensuring nginx never routes to a stale IP after a container restart.
+    resolver 127.0.0.11 valid=0s ipv6=off;
 
     # ── Main server (path-based routing) ─────────────────────────────────
     server {

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -14,10 +14,21 @@ http {
     access_log /dev/stdout;
     error_log /dev/stderr;
 
-    # Docker internal DNS (for resolving service hostnames).
-    # valid=0s disables DNS caching so every request triggers a fresh lookup,
-    # ensuring nginx never routes to a stale IP after a container restart.
-    resolver 127.0.0.11 valid=0s ipv6=off;
+    # Docker internal DNS (for resolving k3s hostname)
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    # Upstream servers (using Docker service names)
+    # NOTE: `zone` and `resolve` are nginx Plus-only features and are not
+    # available in the standard nginx:alpine image. Docker's internal DNS
+    # (127.0.0.11) handles service discovery; upstreams are resolved at
+    # nginx startup and remain valid for the lifetime of the deployment.
+    upstream gateway {
+        server gateway:8001;
+    }
+
+    upstream frontend {
+        server frontend:3000;
+    }
 
     # ── Main server (path-based routing) ─────────────────────────────────
     server {


### PR DESCRIPTION
Fixes #2672, currently resolves [gateway] at nginx startup, which can go stale after the gateway container restarts. I’m applying a fix to resolve upstream names at request time for both gateway and frontend.

This pull request updates the Nginx configuration to improve how upstream Docker services are resolved. Instead of using static upstream blocks that resolve service names only at Nginx startup, the configuration now resolves Docker service names dynamically at request time. This change helps prevent issues with stale IP addresses when containers are restarted and receive new addresses.

