### PR TITLE
fix(frontend): restore localhost fallback for getGatewayConfig in prod mode (#2705)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,14 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 
 # Set to "false" to disable Swagger UI, ReDoc, and OpenAPI schema in production
 # GATEWAY_ENABLE_DOCS=false
+
+# ── Frontend SSR → Gateway wiring ─────────────────────────────────────────────
+# The Next.js server uses these to reach the Gateway during SSR (auth checks,
+# /api/* rewrites). They default to localhost values that match `make dev` and
+# `make start`, so most local users do not need to set them.
+#
+# Override only when the Gateway is not on localhost:8001 (e.g. when the
+# frontend and gateway run on different hosts, in containers with a service
+# alias, or behind a different port). docker-compose already sets these.
+# DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://localhost:8001
+# DEER_FLOW_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:2026

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -14,3 +14,8 @@
 # Only set these if you need to connect to backend services directly
 # NEXT_PUBLIC_BACKEND_BASE_URL="http://localhost:8001"
 # NEXT_PUBLIC_LANGGRAPH_BASE_URL="http://localhost:2024"
+
+# Server-only Gateway wiring used by SSR (auth checks, /api/* rewrites).
+# Defaults to localhost — only override for non-local deployments.
+# DEER_FLOW_INTERNAL_GATEWAY_BASE_URL="http://localhost:8001"
+# DEER_FLOW_TRUSTED_ORIGINS="http://localhost:3000,http://localhost:2026"

--- a/frontend/src/core/auth/gateway-config.ts
+++ b/frontend/src/core/auth/gateway-config.ts
@@ -12,12 +12,9 @@ let _cached: GatewayConfig | null = null;
 export function getGatewayConfig(): GatewayConfig {
   if (_cached) return _cached;
 
-  const isDev = process.env.NODE_ENV === "development";
-
   const rawUrl = process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?.trim();
   const internalGatewayUrl =
-    rawUrl?.replace(/\/+$/, "") ??
-    (isDev ? "http://localhost:8001" : undefined);
+    rawUrl?.replace(/\/+$/, "") ?? "http://localhost:8001";
 
   const rawOrigins = process.env.DEER_FLOW_TRUSTED_ORIGINS?.trim();
   const trustedOrigins = rawOrigins
@@ -25,9 +22,7 @@ export function getGatewayConfig(): GatewayConfig {
         .split(",")
         .map((s) => s.trim())
         .filter(Boolean)
-    : isDev
-      ? ["http://localhost:3000"]
-      : undefined;
+    : ["http://localhost:3000"];
 
   _cached = gatewayConfigSchema.parse({ internalGatewayUrl, trustedOrigins });
   return _cached;

--- a/frontend/src/core/auth/gateway-config.ts
+++ b/frontend/src/core/auth/gateway-config.ts
@@ -14,7 +14,9 @@ export function getGatewayConfig(): GatewayConfig {
 
   const rawUrl = process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?.trim();
   const internalGatewayUrl =
-    rawUrl?.replace(/\/+$/, "") ?? "http://localhost:8001";
+    rawUrl && rawUrl.length > 0
+      ? rawUrl.replace(/\/+$/, "")
+      : "http://127.0.0.1:8001";
 
   const rawOrigins = process.env.DEER_FLOW_TRUSTED_ORIGINS?.trim();
   const trustedOrigins = rawOrigins

--- a/frontend/tests/unit/core/auth/gateway-config.test.ts
+++ b/frontend/tests/unit/core/auth/gateway-config.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const ENV_KEYS = [
+  "NODE_ENV",
+  "DEER_FLOW_INTERNAL_GATEWAY_BASE_URL",
+  "DEER_FLOW_TRUSTED_ORIGINS",
+] as const;
+
+type EnvSnapshot = Partial<
+  Record<(typeof ENV_KEYS)[number], string | undefined>
+>;
+
+function snapshotEnv(): EnvSnapshot {
+  const snapshot: EnvSnapshot = {};
+  for (const key of ENV_KEYS) {
+    snapshot[key] = process.env[key];
+  }
+  return snapshot;
+}
+
+function setEnv(key: (typeof ENV_KEYS)[number], value: string | undefined) {
+  // NODE_ENV is typed as a readonly literal union, so we go through the
+  // index signature to keep the test compiler-friendly across cases.
+  const env = process.env as Record<string, string | undefined>;
+  if (value === undefined) {
+    delete env[key];
+  } else {
+    env[key] = value;
+  }
+}
+
+function restoreEnv(snapshot: EnvSnapshot) {
+  for (const key of ENV_KEYS) {
+    setEnv(key, snapshot[key]);
+  }
+}
+
+async function loadFreshConfig() {
+  vi.resetModules();
+  return await import("@/core/auth/gateway-config");
+}
+
+describe("getGatewayConfig", () => {
+  let saved: EnvSnapshot;
+
+  beforeEach(() => {
+    saved = snapshotEnv();
+    setEnv("DEER_FLOW_INTERNAL_GATEWAY_BASE_URL", undefined);
+    setEnv("DEER_FLOW_TRUSTED_ORIGINS", undefined);
+  });
+
+  afterEach(() => {
+    restoreEnv(saved);
+  });
+
+  test("returns localhost defaults when env is unset in development", async () => {
+    setEnv("NODE_ENV", "development");
+
+    const { getGatewayConfig } = await loadFreshConfig();
+    const cfg = getGatewayConfig();
+
+    expect(cfg.internalGatewayUrl).toBe("http://localhost:8001");
+    expect(cfg.trustedOrigins).toEqual(["http://localhost:3000"]);
+  });
+
+  test("returns localhost defaults when env is unset in production (regression: issue #2705)", async () => {
+    setEnv("NODE_ENV", "production");
+
+    const { getGatewayConfig } = await loadFreshConfig();
+
+    expect(() => getGatewayConfig()).not.toThrow();
+    const cfg = getGatewayConfig();
+    expect(cfg.internalGatewayUrl).toBe("http://localhost:8001");
+    expect(cfg.trustedOrigins).toEqual(["http://localhost:3000"]);
+  });
+
+  test("uses env values verbatim when set, regardless of NODE_ENV", async () => {
+    setEnv("NODE_ENV", "production");
+    setEnv("DEER_FLOW_INTERNAL_GATEWAY_BASE_URL", "https://gw.example.com/");
+    setEnv(
+      "DEER_FLOW_TRUSTED_ORIGINS",
+      "https://app.example.com, https://admin.example.com",
+    );
+
+    const { getGatewayConfig } = await loadFreshConfig();
+    const cfg = getGatewayConfig();
+
+    expect(cfg.internalGatewayUrl).toBe("https://gw.example.com");
+    expect(cfg.trustedOrigins).toEqual([
+      "https://app.example.com",
+      "https://admin.example.com",
+    ]);
+  });
+
+  test("trims and filters empty entries in trustedOrigins", async () => {
+    setEnv("NODE_ENV", "production");
+    setEnv("DEER_FLOW_INTERNAL_GATEWAY_BASE_URL", "https://gw.example.com");
+    setEnv(
+      "DEER_FLOW_TRUSTED_ORIGINS",
+      " https://a.example , ,https://b.example ",
+    );
+
+    const { getGatewayConfig } = await loadFreshConfig();
+    const cfg = getGatewayConfig();
+
+    expect(cfg.trustedOrigins).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ]);
+  });
+});

--- a/frontend/tests/unit/core/auth/gateway-config.test.ts
+++ b/frontend/tests/unit/core/auth/gateway-config.test.ts
@@ -59,7 +59,7 @@ describe("getGatewayConfig", () => {
     const { getGatewayConfig } = await loadFreshConfig();
     const cfg = getGatewayConfig();
 
-    expect(cfg.internalGatewayUrl).toBe("http://localhost:8001");
+    expect(cfg.internalGatewayUrl).toBe("http://127.0.0.1:8001");
     expect(cfg.trustedOrigins).toEqual(["http://localhost:3000"]);
   });
 
@@ -70,7 +70,7 @@ describe("getGatewayConfig", () => {
 
     expect(() => getGatewayConfig()).not.toThrow();
     const cfg = getGatewayConfig();
-    expect(cfg.internalGatewayUrl).toBe("http://localhost:8001");
+    expect(cfg.internalGatewayUrl).toBe("http://127.0.0.1:8001");
     expect(cfg.trustedOrigins).toEqual(["http://localhost:3000"]);
   });
 


### PR DESCRIPTION
## Problem

Closes #2705.

After `make start` (PROD mode), any SSR-rendered route under
`/workspace/*` or `/(auth)/*` returns **500** with the following zod
error in `logs/frontend.log`:

```
Error: [
  { "code": "invalid_type", "expected": "string", "received": "undefined",
    "path": ["internalGatewayUrl"], "message": "Required" },
  { "code": "invalid_type", "expected": "array",  "received": "undefined",
    "path": ["trustedOrigins"], "message": "Required" }
]
```

`make dev` (DEV mode) works fine. The same `make start` flow has been
working for the Docker paths because `docker-compose.yaml` /
`docker-compose-dev.yaml` happen to inject the env vars, but the
host-mode `make start` (`scripts/serve.sh --prod`) does not.

## Root Cause

`frontend/src/core/auth/gateway-config.ts` gates its localhost fallback
on `NODE_ENV === "development"`. In PROD mode (`pnpm preview` →
`next start`, `NODE_ENV=production`) the fallback is `undefined` and
zod throws. The error is then re-thrown by `app/(auth)/layout.tsx` /
`app/workspace/layout.tsx` and surfaces as a 500.

This is also internally inconsistent with `frontend/next.config.js`,
which already falls back to `http://127.0.0.1:8001` for the same env
var unconditionally. The `NODE_ENV` switch is the wrong abstraction
for "force explicit config in prod" — it cannot distinguish a local
prod preview from a real deployment, and request-time zod crashes are
the wrong failure mode for misconfiguration.

## Fix

1. Drop the `NODE_ENV` gating in `getGatewayConfig()` and use the same
   localhost defaults as `next.config.js`. Real deployments enforce
   explicit configuration through deployment templates
   (`docker-compose.yaml` already sets both vars), not request-time
   crashes.
2. Document `DEER_FLOW_INTERNAL_GATEWAY_BASE_URL` and
   `DEER_FLOW_TRUSTED_ORIGINS` in both `.env.example` and
   `frontend/.env.example` so deployers know they exist.
3. Add unit coverage for the four logical paths (dev/prod × env-set/
   env-unset, plus origin trimming).

`trustedOrigins` is currently parsed but has no downstream consumer in
the repo (likely reserved for the not-yet-active BetterAuth wiring),
so the new default is side-effect-free.

## Validation

### Reverse repro on `main` (proves the bug is real)

Temporarily restored the old `gateway-config.ts` from `main`,
rebuilt + ran `pnpm start` with no env vars set:

| Path | Status |
| --- | --- |
| `localhost:3000/workspace` | **500** |
| `localhost:3000/login` | **500** |
| Frontend log | zod error matches issue #2705 byte-for-byte |

### Forward end-to-end on this branch (`make start` daemon mode)

Full stack via the exact entry the reporter used:

| Path | Status |
| --- | --- |
| `localhost:2026/` | 200 |
| `localhost:2026/workspace` | **307 → /login** ✓ |
| `localhost:2026/login` | **200** ✓ |
| `localhost:2026/api/v1/auth/setup-status` | 200 (gateway via nginx) |
| `localhost:3000/workspace` (direct) | 307 ✓ |
| `logs/frontend.log` | no zod, no `⨯`, no traces |

### CI gates run locally

- `pnpm lint` — clean
- `pnpm format` (prettier `--check`) — clean
- `pnpm typecheck` — clean
- `pnpm test` — 9 files / 37 cases, all pass (4 new cases for
  `getGatewayConfig`)
- Backend `ruff check` / `ruff format --check` — clean (no backend
  changes, sanity check only)

### Cross-validation

- Repo-wide `grep` confirms `DEER_FLOW_INTERNAL_GATEWAY_BASE_URL` is
  read only by `next.config.js` (already has the same fallback) and
  `gateway-config.ts`; backend does not read it.
- `DEER_FLOW_TRUSTED_ORIGINS` is read only by `gateway-config.ts`,
  with no downstream consumer in code, so the new default array is
  inert.
- Docker paths (`docker-compose.yaml:56`, `docker-compose-dev.yaml:109`)
  set both vars explicitly and continue to take precedence over the
  defaults — verified by the "uses env values verbatim when set" unit
  test.
