### PR TITLE
fix(skills): enforce allowed-tools metadata

### DIFF
--- a/backend/packages/harness/deerflow/skills/parser.py
+++ b/backend/packages/harness/deerflow/skills/parser.py
@@ -64,10 +64,18 @@ def parse_skill_file(skill_file: Path, category: SkillCategory, relative_path: P
         if license_text is not None:
             license_text = str(license_text).strip() or None
 
+        allowed_tools = metadata.get("allowed-tools")
+        if allowed_tools is not None:
+            if not isinstance(allowed_tools, list) or not all(isinstance(item, str) for item in allowed_tools):
+                logger.error("allowed-tools in %s must be a list of strings", skill_file)
+                return None
+            allowed_tools = [item.strip() for item in allowed_tools if item.strip()] or []
+
         return Skill(
             name=name,
             description=description,
             license=license_text,
+            allowed_tools=allowed_tools,
             skill_dir=skill_file.parent,
             skill_file=skill_file,
             relative_path=relative_path or Path(skill_file.parent.name),

--- a/backend/packages/harness/deerflow/skills/types.py
+++ b/backend/packages/harness/deerflow/skills/types.py
@@ -23,6 +23,7 @@ class Skill:
     name: str
     description: str
     license: str | None
+    allowed_tools: list[str] | None
     skill_dir: Path
     skill_file: Path
     relative_path: Path  # Relative path from category root to skill directory

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -48,6 +48,45 @@ def _merge_skill_allowlists(parent: list[str] | None, child: list[str] | None) -
     return [skill for skill in child if skill in parent_set]
 
 
+def _resolve_allowed_tools_for_skills(skill_names: list[str] | None, *, app_config: "AppConfig | None" = None) -> list[str] | None:
+    """Return the union of allowed-tools declared by the selected skills.
+
+    None means "no skill in scope declared allowed-tools", so runtime behavior
+    stays backward-compatible. An empty list means the selected skills explicitly
+    deny all tools.
+    """
+    if skill_names is None:
+        return None
+
+    from deerflow.skills.storage import get_or_new_skill_storage
+
+    selected = set(skill_names)
+    declared: list[list[str]] = []
+    storage_kwargs = {"app_config": app_config} if app_config is not None else {}
+    try:
+        skills = get_or_new_skill_storage(**storage_kwargs).load_skills(enabled_only=True)
+    except FileNotFoundError:
+        # Preserve legacy behavior in minimal test/runtime environments that
+        # have skill names in memory but no materialized config/skills store.
+        return None
+
+    for skill in skills:
+        if skill.name in selected and skill.allowed_tools is not None:
+            declared.append(skill.allowed_tools)
+
+    if not declared:
+        return None
+
+    merged: list[str] = []
+    seen: set[str] = set()
+    for tool_list in declared:
+        for tool_name in tool_list:
+            if tool_name not in seen:
+                seen.add(tool_name)
+                merged.append(tool_name)
+    return merged
+
+
 @tool("task", parse_docstring=True)
 async def task_tool(
     runtime: ToolRuntime[ContextT, ThreadState],
@@ -155,6 +194,7 @@ async def task_tool(
     if config.model == "inherit" and parent_model is None and resolved_app_config is None:
         resolved_app_config = get_app_config()
     effective_model = resolve_subagent_model_name(config, parent_model, app_config=resolved_app_config)
+    allowed_tools = _resolve_allowed_tools_for_skills(config.skills, app_config=resolved_app_config)
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
     available_tools_kwargs = {
@@ -165,6 +205,9 @@ async def task_tool(
     if resolved_app_config is not None:
         available_tools_kwargs["app_config"] = resolved_app_config
     tools = get_available_tools(**available_tools_kwargs)
+    if allowed_tools is not None:
+        allowed_set = set(allowed_tools)
+        tools = [tool for tool in tools if tool.name in allowed_set]
 
     # Create executor
     executor_kwargs = {

--- a/backend/tests/test_lead_agent_skills.py
+++ b/backend/tests/test_lead_agent_skills.py
@@ -11,6 +11,7 @@ def _make_skill(name: str) -> Skill:
         name=name,
         description=f"Description for {name}",
         license="MIT",
+        allowed_tools=None,
         skill_dir=Path(f"/tmp/{name}"),
         skill_file=Path(f"/tmp/{name}/SKILL.md"),
         relative_path=Path(name),

--- a/backend/tests/test_skills_parser.py
+++ b/backend/tests/test_skills_parser.py
@@ -86,6 +86,27 @@ def test_parse_license_field(tmp_path):
     assert skill.license == "MIT"
 
 
+def test_parse_allowed_tools_field(tmp_path):
+    """allowed-tools is parsed into a normalized string list when present."""
+    skill_file = _write_skill(
+        tmp_path,
+        "name: my-skill\ndescription: Test\nallowed-tools:\n  - read_file\n  - bash\n",
+    )
+    skill = parse_skill_file(skill_file, category="custom")
+    assert skill is not None
+    assert skill.allowed_tools == ["read_file", "bash"]
+
+
+def test_parse_invalid_allowed_tools_returns_none(tmp_path):
+    """allowed-tools must be a list of strings."""
+    skill_file = _write_skill(
+        tmp_path,
+        "name: my-skill\ndescription: Test\nallowed-tools: bash\n",
+    )
+    skill = parse_skill_file(skill_file, category="custom")
+    assert skill is None
+
+
 def test_parse_missing_name_returns_none(tmp_path):
     """Skills missing a name field are rejected."""
     skill_file = _write_skill(tmp_path, "description: A test skill")

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -422,6 +422,59 @@ def test_task_tool_intersects_parent_and_subagent_skill_allowlists(monkeypatch):
     assert captured["config"].skills == ["safe-skill"]
 
 
+def test_task_tool_filters_tools_by_skill_allowed_tools(monkeypatch):
+    config = _make_subagent_config()
+    runtime = _make_runtime()
+    runtime.config["metadata"]["available_skills"] = ["safe-skill"]
+    events = []
+    captured = {}
+
+    class DummyTool:
+        def __init__(self, name: str):
+            self.name = name
+
+    class DummyExecutor:
+        def __init__(self, **kwargs):
+            captured["tools"] = kwargs["tools"]
+            captured["config"] = kwargs["config"]
+
+        def execute_async(self, prompt, task_id=None):
+            return task_id or "generated-task-id"
+
+    class DummySkill:
+        name = "safe-skill"
+        allowed_tools = ["read_file"]
+
+    storage = MagicMock()
+    storage.load_skills.return_value = [DummySkill()]
+    get_available_tools = MagicMock(return_value=[DummyTool("read_file"), DummyTool("bash")])
+
+    monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
+    monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(
+        task_tool_module,
+        "get_background_task_result",
+        lambda _: _make_result(FakeSubagentStatus.COMPLETED, result="done"),
+    )
+    monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
+    monkeypatch.setattr(task_tool_module.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr("deerflow.tools.get_available_tools", get_available_tools)
+    monkeypatch.setattr("deerflow.skills.storage.get_or_new_skill_storage", lambda **kwargs: storage)
+
+    output = _run_task_tool(
+        runtime=runtime,
+        description="执行任务",
+        prompt="use skills",
+        subagent_type="general-purpose",
+        tool_call_id="tc-skill-tools",
+    )
+
+    assert output == "Task Succeeded. Result: done"
+    assert captured["config"].skills == ["safe-skill"]
+    assert [tool.name for tool in captured["tools"]] == ["read_file"]
+
+
 def test_task_tool_no_tool_groups_passes_none(monkeypatch):
     """Verify that when metadata has no tool_groups, groups=None is passed (backward compat)."""
     config = _make_subagent_config()


### PR DESCRIPTION
## Summary
- parse `allowed-tools` from SKILL.md frontmatter into runtime skill metadata
- enforce declared tool allowlists for skill-scoped subagent execution while preserving legacy behavior for skills that do not declare the field
- add parser and task-tool regressions covering allowed-tools parsing and filtering behavior

## Why
Issue #2625 reports that `allowed-tools` is accepted in SKILL.md metadata but ignored at runtime. That leaves skill authors unable to narrow tool surfaces even though the metadata suggests they can. This patch makes the field real without changing the behavior of existing skills that omit it.

## Testing
- `.venv/bin/python -m pytest tests/test_skills_parser.py -q`
- `.venv/bin/python -m pytest tests/test_task_tool_core_logic.py -q`
- `.venv/bin/python -m pytest tests/test_lead_agent_skills.py -q`