### PR TITLE
[security] fix(auth): reject cross-site auth POSTs

### DIFF
--- a/backend/app/gateway/csrf_middleware.py
+++ b/backend/app/gateway/csrf_middleware.py
@@ -21,7 +21,7 @@ CSRF_TOKEN_LENGTH = 64  # bytes
 
 def is_secure_request(request: Request) -> bool:
     """Detect whether the original client request was made over HTTPS."""
-    return request.headers.get("x-forwarded-proto", request.url.scheme) == "https"
+    return _request_scheme(request) == "https"
 
 
 def generate_csrf_token() -> str:
@@ -127,9 +127,15 @@ def _forwarded_param(request: Request, name: str) -> str | None:
     return None
 
 
+def _request_scheme(request: Request) -> str:
+    """Resolve the original request scheme from trusted proxy headers."""
+    scheme = _forwarded_param(request, "proto") or _first_header_value(request.headers.get("x-forwarded-proto")) or request.url.scheme
+    return scheme.lower()
+
+
 def _request_origin(request: Request) -> str | None:
     """Build the origin for the URL the browser is targeting."""
-    scheme = _forwarded_param(request, "proto") or _first_header_value(request.headers.get("x-forwarded-proto")) or request.url.scheme
+    scheme = _request_scheme(request)
     host = _forwarded_param(request, "host") or _first_header_value(request.headers.get("x-forwarded-host")) or request.headers.get("host") or request.url.netloc
 
     forwarded_port = _first_header_value(request.headers.get("x-forwarded-port"))

--- a/backend/app/gateway/csrf_middleware.py
+++ b/backend/app/gateway/csrf_middleware.py
@@ -4,8 +4,10 @@ Per RFC-001:
 State-changing operations require CSRF protection.
 """
 
+import os
 import secrets
 from collections.abc import Callable
+from urllib.parse import urlsplit
 
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -61,6 +63,103 @@ def is_auth_endpoint(request: Request) -> bool:
     return request.url.path.rstrip("/") in _AUTH_EXEMPT_PATHS
 
 
+def _host_with_optional_port(hostname: str, port: int | None, scheme: str) -> str:
+    """Return normalized host[:port], omitting default ports."""
+    host = hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+
+    if port is None or (scheme == "http" and port == 80) or (scheme == "https" and port == 443):
+        return host
+    return f"{host}:{port}"
+
+
+def _normalize_origin(origin: str) -> str | None:
+    """Return a normalized scheme://host[:port] origin, or None for invalid input."""
+    try:
+        parsed = urlsplit(origin.strip())
+        port = parsed.port
+    except ValueError:
+        return None
+
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"} or not parsed.hostname:
+        return None
+
+    # Browser Origin is only scheme/host/port. Reject URL-shaped or credentialed values.
+    if parsed.username or parsed.password or parsed.path or parsed.query or parsed.fragment:
+        return None
+
+    return f"{scheme}://{_host_with_optional_port(parsed.hostname, port, scheme)}"
+
+
+def _configured_cors_origins() -> set[str]:
+    """Return explicit configured browser origins that may call auth routes."""
+    origins = set()
+    for raw_origin in os.environ.get("GATEWAY_CORS_ORIGINS", "").split(","):
+        origin = raw_origin.strip()
+        if not origin or origin == "*":
+            continue
+        normalized = _normalize_origin(origin)
+        if normalized:
+            origins.add(normalized)
+    return origins
+
+
+def _first_header_value(value: str | None) -> str | None:
+    """Return the first value from a comma-separated proxy header."""
+    if not value:
+        return None
+    first = value.split(",", 1)[0].strip()
+    return first or None
+
+
+def _forwarded_param(request: Request, name: str) -> str | None:
+    """Extract a parameter from the first RFC 7239 Forwarded header entry."""
+    forwarded = _first_header_value(request.headers.get("forwarded"))
+    if not forwarded:
+        return None
+
+    for part in forwarded.split(";"):
+        key, sep, value = part.strip().partition("=")
+        if sep and key.lower() == name:
+            return value.strip().strip('"') or None
+    return None
+
+
+def _request_origin(request: Request) -> str | None:
+    """Build the origin for the URL the browser is targeting."""
+    scheme = _forwarded_param(request, "proto") or _first_header_value(request.headers.get("x-forwarded-proto")) or request.url.scheme
+    host = _forwarded_param(request, "host") or _first_header_value(request.headers.get("x-forwarded-host")) or request.headers.get("host") or request.url.netloc
+
+    forwarded_port = _first_header_value(request.headers.get("x-forwarded-port"))
+    if forwarded_port and ":" not in host.rsplit("]", 1)[-1]:
+        host = f"{host}:{forwarded_port}"
+
+    return _normalize_origin(f"{scheme}://{host}")
+
+
+def is_allowed_auth_origin(request: Request) -> bool:
+    """Allow auth POSTs only from the same origin or explicit configured origins.
+
+    Login/register/initialize are exempt from the double-submit token because
+    first-time browser clients do not have a CSRF token yet. They still create
+    a session cookie, so browser requests with a hostile Origin header must be
+    rejected to prevent login CSRF / session fixation. Requests without Origin
+    are allowed for non-browser clients such as curl and mobile integrations.
+    """
+    origin = request.headers.get("origin")
+    if not origin:
+        return True
+
+    normalized_origin = _normalize_origin(origin)
+    if normalized_origin is None:
+        return False
+
+    request_origin = _request_origin(request)
+    return normalized_origin in _configured_cors_origins() or (request_origin is not None and normalized_origin == request_origin)
+
+
 class CSRFMiddleware(BaseHTTPMiddleware):
     """Middleware that implements CSRF protection using Double Submit Cookie pattern."""
 
@@ -69,6 +168,12 @@ class CSRFMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next: Callable) -> Response:
         _is_auth = is_auth_endpoint(request)
+
+        if should_check_csrf(request) and _is_auth and not is_allowed_auth_origin(request):
+            return JSONResponse(
+                status_code=403,
+                content={"detail": "Cross-site auth request denied."},
+            )
 
         if should_check_csrf(request) and not _is_auth:
             cookie_token = request.cookies.get(CSRF_COOKIE_NAME)

--- a/backend/tests/test_csrf_middleware.py
+++ b/backend/tests/test_csrf_middleware.py
@@ -123,6 +123,7 @@ def test_auth_post_allows_rfc_forwarded_same_origin():
 
     assert response.status_code == 200
     assert response.cookies.get("csrf_token")
+    assert "secure" in response.headers["set-cookie"].lower()
 
 
 def test_auth_post_allows_explicit_configured_origin(monkeypatch):

--- a/backend/tests/test_csrf_middleware.py
+++ b/backend/tests/test_csrf_middleware.py
@@ -1,0 +1,218 @@
+"""Tests for CSRF middleware."""
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from app.gateway.csrf_middleware import CSRFMiddleware
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+
+    @app.post("/api/v1/auth/login/local")
+    async def login_local():
+        return {"ok": True}
+
+    @app.post("/api/v1/auth/register")
+    async def register():
+        return {"ok": True}
+
+    @app.post("/api/threads/abc/runs/stream")
+    async def protected_mutation():
+        return {"ok": True}
+
+    return app
+
+
+def test_auth_post_rejects_cross_origin_browser_request():
+    """CSRF-exempt auth routes must not accept hostile browser origins.
+
+    Login/register endpoints intentionally skip the double-submit token because
+    first-time callers do not have a token yet. They still set an auth session,
+    so a hostile cross-site form POST must be rejected to avoid login CSRF /
+    session fixation.
+    """
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://evil.example"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site auth request denied."
+
+
+def test_auth_post_allows_same_origin_browser_request():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://deerflow.example"},
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_auth_post_rejects_malformed_origin_with_path():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://deerflow.example/path"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site auth request denied."
+    assert response.cookies.get("csrf_token") is None
+
+
+def test_auth_post_rejects_malformed_origin_with_invalid_port():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://deerflow.example:bad"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site auth request denied."
+    assert response.cookies.get("csrf_token") is None
+
+
+def test_auth_post_allows_same_origin_default_port_equivalence():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://deerflow.example:443"},
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_auth_post_allows_forwarded_same_origin():
+    client = TestClient(_make_app(), base_url="http://internal:8000")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={
+            "Origin": "https://deerflow.example",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "deerflow.example, internal:8000",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_auth_post_allows_rfc_forwarded_same_origin():
+    client = TestClient(_make_app(), base_url="http://internal:8000")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={
+            "Origin": "https://deerflow.example",
+            "Forwarded": "proto=https;host=deerflow.example",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_auth_post_allows_explicit_configured_origin(monkeypatch):
+    monkeypatch.setenv("GATEWAY_CORS_ORIGINS", "https://app.example")
+    client = TestClient(_make_app(), base_url="https://api.example")
+
+    response = client.post(
+        "/api/v1/auth/register",
+        headers={"Origin": "https://app.example"},
+    )
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_auth_post_does_not_treat_wildcard_cors_as_allowed_origin(monkeypatch):
+    monkeypatch.setenv("GATEWAY_CORS_ORIGINS", "*")
+    client = TestClient(_make_app(), base_url="https://api.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://evil.example"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cross-site auth request denied."
+
+
+def test_auth_post_sets_strict_samesite_csrf_cookie():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/v1/auth/login/local",
+        headers={"Origin": "https://deerflow.example"},
+    )
+
+    assert response.status_code == 200
+    set_cookie = response.headers["set-cookie"].lower()
+    assert "csrf_token=" in set_cookie
+    assert "samesite=strict" in set_cookie
+    assert "secure" in set_cookie
+
+
+def test_auth_post_without_origin_still_allows_non_browser_clients():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post("/api/v1/auth/login/local")
+
+    assert response.status_code == 200
+    assert response.cookies.get("csrf_token")
+
+
+def test_non_auth_mutation_still_requires_double_submit_token():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={"Origin": "https://deerflow.example"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CSRF token missing. Include X-CSRF-Token header."
+
+
+def test_non_auth_mutation_allows_valid_double_submit_token():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+    client.cookies.set("csrf_token", "known-token")
+
+    response = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={
+            "Origin": "https://deerflow.example",
+            "X-CSRF-Token": "known-token",
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_non_auth_mutation_rejects_mismatched_double_submit_token():
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+    client.cookies.set("csrf_token", "cookie-token")
+
+    response = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={
+            "Origin": "https://deerflow.example",
+            "X-CSRF-Token": "header-token",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "CSRF token mismatch."


### PR DESCRIPTION
## Summary

This PR hardens the browser authentication boundary around CSRF-exempt auth endpoints.

Auth routes such as `/api/v1/auth/login/local` intentionally skip the double-submit CSRF token because first-time browser clients do not have a CSRF cookie yet. Before this change, those same endpoints also accepted browser POSTs with a hostile `Origin`, which allowed login CSRF/session fixation: a malicious site could submit the victim browser to DeerFlow with attacker-controlled credentials and cause later victim activity to be saved under the attacker account.

This PR:
- rejects CSRF-exempt auth POSTs when the browser `Origin` is neither same-origin nor explicitly configured in `GATEWAY_CORS_ORIGINS`;
- preserves same-origin auth, explicitly configured dev/CORS origins, and no-`Origin` non-browser clients;
- keeps the existing double-submit CSRF behavior unchanged for ordinary state-changing API routes;
- adds focused middleware regression tests for hostile origins, forwarded proxy headers, malformed origins, CORS-origin compatibility, and double-submit behavior.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Login CSRF / session fixation on CSRF-exempt auth POSTs | A hostile site can force a victim browser into an attacker-controlled account; later prompts, uploads, memories, and generated artifacts may be associated with that attacker-visible account | Medium |

## Before this PR

- `/api/v1/auth/login/local`, `/register`, `/initialize`, and `/logout` were exempt from CSRF token validation.
- `/api/v1/auth/login/local` accepts browser-form-postable credentials through `OAuth2PasswordRequestForm`.
- A cross-site form POST could reach the auth endpoint without CORS or a CSRF token.
- A successful auth response could set DeerFlow session cookies in the victim browser.
- There were no regression tests covering hostile `Origin` handling on CSRF-exempt auth routes.

## After this PR

- CSRF-exempt auth POSTs now reject hostile browser origins with `403`.
- Same-origin browser login/register/setup flows continue to work.
- Explicitly configured `GATEWAY_CORS_ORIGINS` continue to work for split frontend/backend deployments.
- Requests without an `Origin` header continue to work for non-browser clients such as curl/mobile integrations.
- Existing double-submit CSRF checks for non-auth mutations are unchanged and covered by tests.

## Why this matters

Cookie `SameSite=Lax` does not prevent a top-level cross-site form POST from causing the target site to set cookies on the response. Because login is a session-creating endpoint, a malicious page can submit attacker-known DeerFlow credentials and silently switch the victim browser into the attacker account.

The attacker does not steal the victim's existing DeerFlow account. The risk is session confusion and data capture: after the forced login, the victim may enter prompts, upload files, or generate artifacts that the attacker can later access by logging into the same attacker-controlled account.

## Attack flow

```text
Hostile web page with auto-submitting login form
    -> POST /api/v1/auth/login/local with attacker credentials
        -> CSRF-exempt auth route accepts hostile browser Origin
            -> DeerFlow sets session cookies for the attacker account in the victim browser
                -> Later victim activity is stored under attacker-visible account state
```

## Affected code

| Issue | Files |
|-------|-------|
| Login CSRF / session fixation | `backend/app/gateway/csrf_middleware.py`, `backend/app/gateway/routers/auth.py` |

## Root cause

Issue: login CSRF / session fixation
- The auth endpoints were correctly exempted from double-submit CSRF for first-call usability, but there was no compensating browser-origin check.
- The login endpoint accepts standard form encoding, so a hostile site can trigger it with a top-level HTML form POST without needing CORS access.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Login CSRF / session fixation | 6.5 Medium | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N` |

Rationale:
- Network-reachable web attack requiring victim interaction with a hostile page.
- No DeerFlow privileges are required for the attacker beyond having or creating an attacker-controlled account on the target instance.
- The primary impact is confidentiality of victim-entered prompts/uploads/artifacts after the forced login; this PR does not claim direct victim account takeover.

## Safe reproduction steps

1. On vulnerable code, host this minimal page on another origin:

   ```html
   <!doctype html>
   <form action="https://deerflow.example/api/v1/auth/login/local" method="POST">
     <input name="username" value="attacker@example.com">
     <input name="password" value="attacker-known-password">
   </form>
   <script>document.forms[0].submit()</script>
   ```

2. Have a victim browser visit the page.
3. The browser submits a cross-site form POST to DeerFlow.
4. On vulnerable code, the auth route processes the request because it is CSRF-exempt.
5. The victim browser receives DeerFlow auth cookies for the attacker account.
6. Any later work the victim performs in DeerFlow is associated with that attacker account.

The regression test `test_auth_post_rejects_cross_origin_browser_request` captures the safe proof without requiring real credentials.

## Expected vulnerable behavior

- Cross-origin browser POSTs to `/api/v1/auth/login/local` were accepted.
- The middleware generated a CSRF cookie after the auth POST rather than rejecting the hostile origin.
- No test failed for hostile browser origins on auth endpoints.

## Changes in this PR

- Adds strict Origin normalization for scheme, host, and non-default port.
- Rejects malformed browser Origin values such as URL-shaped origins with paths or invalid ports.
- Computes the request origin using direct host headers plus `X-Forwarded-*` and RFC 7239 `Forwarded` proxy headers.
- Allows same-origin auth POSTs and explicit `GATEWAY_CORS_ORIGINS` entries.
- Ignores wildcard CORS (`*`) for auth-origin bypass purposes.
- Preserves no-`Origin` behavior for non-browser clients.
- Adds focused CSRF middleware regression coverage.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Middleware | `backend/app/gateway/csrf_middleware.py` | Added auth-origin validation helpers and a `403` rejection path for hostile auth POST origins |
| Tests | `backend/tests/test_csrf_middleware.py` | Added regression tests for hostile origins, same-origin/default-port matching, forwarded proxy headers, configured origins, wildcard rejection, no-Origin clients, and double-submit CSRF behavior |

## Maintainer impact

- The patch is limited to CSRF middleware and focused tests.
- It does not change auth provider logic, JWT creation, password validation, frontend routes, or non-auth CSRF semantics.
- Same-origin deployments keep the existing behavior.
- Split frontend/backend deployments can continue to use explicit `GATEWAY_CORS_ORIGINS`.
- Non-browser clients that do not send `Origin` remain compatible.

## Suggested fix rationale

Origin checking is the appropriate compensating control for session-creating endpoints that cannot require a pre-existing CSRF token. It blocks browser-driven cross-site login/register/setup requests while avoiding a bootstrap problem for legitimate first-time auth flows.

The helper fails closed for malformed browser Origin values, handles common reverse-proxy headers, and keeps ordinary double-submit checks unchanged for all other state-changing routes.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Auth-origin regression tests pass.
- [x] Existing auth/auth-middleware tests pass.
- [x] Ruff check passes for touched files.
- [x] Ruff format check passes for touched files.
- [x] Python compile check passes for touched files.
- [x] Git whitespace check passes.

Executed with:

```bash
cd backend
uv run pytest -q tests/test_csrf_middleware.py tests/test_auth_middleware.py tests/test_auth.py
uv run ruff check app/gateway/csrf_middleware.py tests/test_csrf_middleware.py
uv run ruff format --check app/gateway/csrf_middleware.py tests/test_csrf_middleware.py
uv run python -m compileall -q app/gateway/csrf_middleware.py tests/test_csrf_middleware.py
git diff --check
```

Result:
- `111 passed, 1 warning` for the targeted pytest command.
- Ruff, format check, compile check, and `git diff --check` passed.
- The remaining warning is from an existing `test_auth_middleware.py` cookie-use deprecation and is unrelated to this patch.

## Token usage

- discovery tokens: partial/unknown
- validation tokens: partial/unknown
- duplicate-check tokens: partial/unknown
- PR/writeup tokens: partial/unknown
- total tokens: partial/unknown
- notes: This PR came from an interactive security review with delegated review passes; exact end-to-end token accounting is not available from the local tool output.

## Disclosure notes

- This PR is intentionally bounded to login CSRF/session-fixation style behavior on CSRF-exempt auth POSTs.
- It does not claim victim account takeover or credential theft.
- It does not modify unrelated management APIs or the MCP config issue family already covered publicly in #2531/#1646/#2667.
- No unrelated files are changed.
