### PR TITLE
fix(frontend): defer thread id to onStart to avoid 404 on new chat

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -191,7 +191,7 @@ export default function AgentChatPage() {
 
                 <InputBox
                   className={cn("bg-background/5 w-full -translate-y-4")}
-                  isNewThread={isNewThread}
+                  isWelcomeMode={isNewThread}
                   threadId={threadId}
                   autoFocus={isNewThread}
                   status={

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -185,7 +185,7 @@ export default function ChatPage() {
                 {mountedRef.current ? (
                   <InputBox
                     className={cn("bg-background/5 w-full -translate-y-4")}
-                    isNewThread={isWelcomeMode}
+                    isWelcomeMode={isWelcomeMode}
                     threadId={threadId}
                     autoFocus={isWelcomeMode}
                     status={

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -58,10 +58,10 @@ export default function ChatPage() {
     threadId: isNewThread ? undefined : threadId,
     context: settings.context,
     isMock,
-    onSend: (_threadId) => {
-      setThreadId(_threadId);
-      setIsNewThread(false);
-    },
+    // No onSend handler: the LangGraph SDK eagerly fetches /history once it
+    // sees a thread id, so we must not forward the client-generated id until
+    // onStart (fired from onCreated, when the backend has the thread). See
+    // https://github.com/bytedance/deer-flow/issues/2746.
     onStart: (createdThreadId) => {
       setThreadId(createdThreadId);
       setIsNewThread(false);

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -35,6 +35,12 @@ export default function ChatPage() {
   const [showFollowups, setShowFollowups] = useState(false);
   const { threadId, setThreadId, isNewThread, setIsNewThread, isMock } =
     useThreadChat();
+  // `isNewThread` tracks whether the backend has the thread yet — gates the
+  // SDK's history fetch (see issue #2746).  `isWelcomeMode` is the visual
+  // welcome layout (centered input, hero, quick actions); we flip it to false
+  // the moment the user submits so the UI animates immediately, even though
+  // `isNewThread` stays true until the backend actually creates the thread.
+  const [isWelcomeMode, setIsWelcomeMode] = useState(isNewThread);
   const [settings, setSettings] = useThreadSettings(threadId);
   const [localSettings, setLocalSettings] = useLocalSettings();
   const { tokenUsageEnabled } = useModels();
@@ -44,6 +50,14 @@ export default function ChatPage() {
   useEffect(() => {
     mountedRef.current = true;
   }, []);
+
+  // Keep welcome layout in sync when navigating between threads (sidebar
+  // clicks, "new chat" button).  Submitting in /chats/new flips the layout
+  // via onSend below — `isNewThread` stays true until onStart, so this effect
+  // is harmless during the submit transition.
+  useEffect(() => {
+    setIsWelcomeMode(isNewThread);
+  }, [isNewThread]);
 
   const { showNotification } = useNotification();
 
@@ -58,10 +72,12 @@ export default function ChatPage() {
     threadId: isNewThread ? undefined : threadId,
     context: settings.context,
     isMock,
-    // No onSend handler: the LangGraph SDK eagerly fetches /history once it
-    // sees a thread id, so we must not forward the client-generated id until
-    // onStart (fired from onCreated, when the backend has the thread). See
-    // https://github.com/bytedance/deer-flow/issues/2746.
+    // onSend only animates the UI; do NOT flip `isNewThread` here — the
+    // LangGraph SDK eagerly fetches /history the moment it receives a
+    // thread id and assumes the thread exists on the backend (issue #2746).
+    onSend: () => {
+      setIsWelcomeMode(false);
+    },
     onStart: (createdThreadId) => {
       setThreadId(createdThreadId);
       setIsNewThread(false);
@@ -111,7 +127,7 @@ export default function ChatPage() {
           <header
             className={cn(
               "absolute top-0 right-0 left-0 z-30 flex h-12 shrink-0 items-center px-4",
-              isNewThread
+              isWelcomeMode
                 ? "bg-background/0 backdrop-blur-none"
                 : "bg-background/80 shadow-xs backdrop-blur",
             )}
@@ -135,7 +151,7 @@ export default function ChatPage() {
           <main className="flex min-h-0 max-w-full grow flex-col">
             <div className="flex size-full justify-center">
               <MessageList
-                className={cn("size-full", !isNewThread && "pt-10")}
+                className={cn("size-full", !isWelcomeMode && "pt-10")}
                 threadId={threadId}
                 thread={thread}
                 paddingBottom={messageListPaddingBottom}
@@ -149,8 +165,8 @@ export default function ChatPage() {
               <div
                 className={cn(
                   "relative w-full",
-                  isNewThread && "-translate-y-[calc(50vh-96px)]",
-                  isNewThread
+                  isWelcomeMode && "-translate-y-[calc(50vh-96px)]",
+                  isWelcomeMode
                     ? "max-w-(--container-width-sm)"
                     : "max-w-(--container-width-md)",
                 )}
@@ -169,9 +185,9 @@ export default function ChatPage() {
                 {mountedRef.current ? (
                   <InputBox
                     className={cn("bg-background/5 w-full -translate-y-4")}
-                    isNewThread={isNewThread}
+                    isNewThread={isWelcomeMode}
                     threadId={threadId}
-                    autoFocus={isNewThread}
+                    autoFocus={isWelcomeMode}
                     status={
                       thread.error
                         ? "error"
@@ -181,7 +197,7 @@ export default function ChatPage() {
                     }
                     context={settings.context}
                     extraHeader={
-                      isNewThread && <Welcome mode={settings.context.mode} />
+                      isWelcomeMode && <Welcome mode={settings.context.mode} />
                     }
                     disabled={
                       env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -106,7 +106,7 @@ export function InputBox({
   status = "ready",
   context,
   extraHeader,
-  isNewThread,
+  isWelcomeMode,
   threadId,
   initialValue,
   onContextChange,
@@ -126,7 +126,12 @@ export function InputBox({
     reasoning_effort?: "minimal" | "low" | "medium" | "high";
   };
   extraHeader?: React.ReactNode;
-  isNewThread?: boolean;
+  /**
+   * Whether to render the input in welcome layout (vertically centered,
+   * with hero + quick action suggestions).  This is purely a visual flag,
+   * decoupled from "the backend has created the thread" — see issue #2746.
+   */
+  isWelcomeMode?: boolean;
   threadId: string;
   initialValue?: string;
   onContextChange?: (
@@ -341,7 +346,7 @@ export function InputBox({
 
   const showFollowups =
     !disabled &&
-    !isNewThread &&
+    !isWelcomeMode &&
     !followupsHidden &&
     (followupsLoading || followups.length > 0);
 
@@ -846,12 +851,12 @@ export function InputBox({
             />
           </PromptInputTools>
         </PromptInputFooter>
-        {!isNewThread && (
+        {!isWelcomeMode && (
           <div className="bg-background absolute right-0 -bottom-[17px] left-0 z-0 h-4"></div>
         )}
       </PromptInput>
 
-      {isNewThread && searchParams.get("mode") !== "skill" && (
+      {isWelcomeMode && searchParams.get("mode") !== "skill" && (
         <div className="flex items-center justify-center pt-2">
           <SuggestionList />
         </div>

--- a/frontend/tests/e2e/chat-thread-init-ordering.spec.ts
+++ b/frontend/tests/e2e/chat-thread-init-ordering.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+import { handleRunStream, mockLangGraphAPI } from "./utils/mock-api";
+
+/**
+ * Regression for https://github.com/bytedance/deer-flow/issues/2746.
+ *
+ * On a brand-new chat, the LangGraph SDK's useStream eagerly fetches
+ * `/threads/{id}/history` the moment it receives a thread id, and the
+ * frontend's own `useThreadRuns` fires `GET /threads/{id}/runs` for the same
+ * reason.  Both endpoints assume the thread already exists on the backend;
+ * if the frontend forwards the (client-generated) thread id before
+ * `POST /runs/stream` has actually created the thread, both calls 404 in
+ * production.  This test pins the request ordering so the regression cannot
+ * re-appear silently.
+ */
+test.describe("Chat: thread API request ordering on first send", () => {
+  test("does not call /history or GET /runs before /runs/stream is initiated", async ({
+    page,
+  }) => {
+    type EventLog = {
+      phase: "sent" | "done";
+      url: string;
+      method: string;
+      ts: number;
+    };
+    const events: EventLog[] = [];
+
+    page.on("request", (req) => {
+      events.push({
+        phase: "sent",
+        url: req.url(),
+        method: req.method(),
+        ts: Date.now(),
+      });
+    });
+    page.on("requestfinished", (req) => {
+      events.push({
+        phase: "done",
+        url: req.url(),
+        method: req.method(),
+        ts: Date.now(),
+      });
+    });
+
+    mockLangGraphAPI(page);
+
+    // Slow down /runs/stream so any pre-create /history or /runs request
+    // would land well before the stream returns metadata, widening the
+    // race window the bug used to exploit.
+    await page.route(
+      "**/api/langgraph/threads/*/runs/stream",
+      async (route) => {
+        await new Promise((r) => setTimeout(r, 250));
+        return handleRunStream(route);
+      },
+    );
+    await page.route("**/api/langgraph/runs/stream", async (route) => {
+      await new Promise((r) => setTimeout(r, 250));
+      return handleRunStream(route);
+    });
+
+    await page.goto("/workspace/chats/new");
+
+    const textarea = page.getByPlaceholder(/how can i assist you/i);
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+    await textarea.fill("Hello");
+    await textarea.press("Enter");
+
+    // Wait for streaming response so all init requests have a chance to fire.
+    await expect(page.getByText("Hello from DeerFlow!")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const isHistory = (url: string) =>
+      /\/api\/langgraph\/threads\/[^/]+\/history/.test(url);
+    const isRunsList = (url: string, method: string) =>
+      method === "GET" &&
+      /\/api\/langgraph\/threads\/[^/]+\/runs(\?|$)/.test(url);
+    const isRunsStream = (url: string, method: string) =>
+      method === "POST" && /\/runs\/stream(\?|$)/.test(url);
+
+    const runsStreamSent = events.find(
+      (e) => e.phase === "sent" && isRunsStream(e.url, e.method),
+    );
+    expect(
+      runsStreamSent,
+      "Expected POST /runs/stream to be issued during send",
+    ).toBeDefined();
+
+    const earlyHistory = events.filter(
+      (e) =>
+        e.phase === "sent" && isHistory(e.url) && e.ts < runsStreamSent!.ts,
+    );
+    const earlyRunsList = events.filter(
+      (e) =>
+        e.phase === "sent" &&
+        isRunsList(e.url, e.method) &&
+        e.ts < runsStreamSent!.ts,
+    );
+
+    expect(
+      earlyHistory.map((e) => e.url),
+      "GET /history must not be issued before POST /runs/stream — see issue #2746",
+    ).toEqual([]);
+    expect(
+      earlyRunsList.map((e) => e.url),
+      "GET /runs must not be issued before POST /runs/stream — see issue #2746",
+    ).toEqual([]);
+  });
+});

--- a/frontend/tests/e2e/chat-thread-init-ordering.spec.ts
+++ b/frontend/tests/e2e/chat-thread-init-ordering.spec.ts
@@ -22,16 +22,20 @@ test.describe("Chat: thread API request ordering on first send", () => {
       phase: "sent" | "done";
       url: string;
       method: string;
-      ts: number;
+      seq: number;
     };
     const events: EventLog[] = [];
+    // Monotonic sequence number — Date.now() is millisecond-resolution and
+    // would let two requests share a timestamp, which would defeat the
+    // strict-ordering assertions below.
+    let nextSeq = 0;
 
     page.on("request", (req) => {
       events.push({
         phase: "sent",
         url: req.url(),
         method: req.method(),
-        ts: Date.now(),
+        seq: nextSeq++,
       });
     });
     page.on("requestfinished", (req) => {
@@ -39,7 +43,7 @@ test.describe("Chat: thread API request ordering on first send", () => {
         phase: "done",
         url: req.url(),
         method: req.method(),
-        ts: Date.now(),
+        seq: nextSeq++,
       });
     });
 
@@ -90,13 +94,13 @@ test.describe("Chat: thread API request ordering on first send", () => {
 
     const earlyHistory = events.filter(
       (e) =>
-        e.phase === "sent" && isHistory(e.url) && e.ts < runsStreamSent!.ts,
+        e.phase === "sent" && isHistory(e.url) && e.seq < runsStreamSent!.seq,
     );
     const earlyRunsList = events.filter(
       (e) =>
         e.phase === "sent" &&
         isRunsList(e.url, e.method) &&
-        e.ts < runsStreamSent!.ts,
+        e.seq < runsStreamSent!.seq,
     );
 
     expect(


### PR DESCRIPTION
## Problem

On a fresh `/workspace/chats/new`, the very first send used to fire two
404s before the backend even saw the thread:

```
GET /api/langgraph/threads/{tid}/runs?limit=10&offset=0   404
GET /api/langgraph/threads/{tid}/history                  404
```

Reported in #2746.

## Root cause

The LangGraph SDK's `useStream` (and the local `useThreadRuns`) treats
"a thread id is available" as "the thread already exists on the
backend" and eagerly fetches `/history` and `/runs` the moment a thread
id is forwarded.

`frontend/src/app/workspace/chats/[thread_id]/page.tsx` used to flip
`isNewThread = false` (and pass the client-generated UUID through to
`useThreadStream` → `useStream`) inside the **synchronous** `onSend`
callback, which runs *before* `thread.submit` actually creates the
thread on the backend. React re-rendered, the SDK saw the new id, and
both `/history` and `GET /runs` raced ahead of `POST /runs/stream`.

The SDK has a built-in guard for this — `threadIdStreamingRef` — but it
is only set inside `submit` (after the create call), so it cannot help
when the parent component pushes the id in early.

The agent chat page (`workspace/agents/[agent_name]/chats/[thread_id]`)
never had `onSend` wired this way and never exhibited the bug, which
confirmed the diagnosis.

## Fix

Split the two responsibilities `isNewThread` was conflating:

| State | Meaning | Flips false on |
|---|---|---|
| `isNewThread` | Backend has no thread yet — gates the thread id forwarded to the SDK | `onStart` (fired from `onCreated`, after the backend created the thread) |
| `isWelcomeMode` | Welcome layout (centered input, hero, quick actions, header background) | `onSend` (the moment the user submits, so the layout animates immediately) |

`isWelcomeMode` is kept in sync with `isNewThread` via an effect, so
sidebar navigation and the "new chat" button still behave correctly.
The `onSend` handler is preserved but only flips `isWelcomeMode`; it
no longer touches `isNewThread`, so the SDK never sees the
client-generated thread id before the backend has it.

This also unifies the chat page with the agent chat page in not
forwarding the thread id to the SDK before backend creation.

## Validation

Verified with a new Playwright E2E (`tests/e2e/chat-thread-init-ordering.spec.ts`)
that records request ordering on the first send from `/chats/new` and
asserts `GET /history` and `GET /runs` cannot precede `POST /runs/stream`.
Ordering is tracked with a monotonic sequence counter rather than a
millisecond timestamp so the assertion is tick-safe.

Bidirectional check:

| Code state | Result |
|---|---|
| Buggy (`onSend` restored to flip `isNewThread`) | `GET /history` recorded before `POST /runs/stream` → test **fails** with the exact symptom from #2746 |
| Fixed (this PR) | New regression passes; full E2E suite (15 tests) passes |

```
$ pnpm exec playwright test --reporter=list
...
  15 passed
```

`pnpm format` / `pnpm lint` / `pnpm typecheck` all clean.

Closes #2746
