### PR TITLE
fix(frontend): add engines field to package.json for Node.js and pnpm version requirements

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -113,5 +113,9 @@
   "ct3aMetadata": {
     "initVersion": "7.40.0"
   },
-  "packageManager": "pnpm@10.26.2"
+  "packageManager": "pnpm@10.26.2",
+  "engines": {
+    "node": ">=20",
+    "pnpm": ">=10"
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds the `engines` field to `frontend/package.json` to specify minimum version requirements for Node.js and pnpm, addressing issue #76.

## Problem

Without explicit engine requirements, developers might use incompatible Node.js or pnpm versions, leading to:
- Lock-file version mismatches
- Unexpected dependency resolution issues
- Problems parsing certain files (as reported in the original issue)

## Solution

Added the following to `package.json`:

```json
"engines": {
  "node": ">=20",
  "pnpm": ">=10"
}
```

These versions align with:
- `packageManager` field which specifies `pnpm@10.26.2`
- Modern Next.js features requiring Node.js 20+

## Testing

- [x] JSON is valid (verified with `jq`)
- [x] `pnpm install --frozen-lockfile` succeeds
- [x] `pnpm format` check passes
- [x] Minimal change (only `package.json` modified)

## Note

This contribution was developed with AI assistance.