### PR TITLE
fix(subagents): follow up app_config threading for #2687

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -221,7 +221,7 @@ def _build_subagent_section(max_concurrent: int, *, app_config: AppConfig | None
         Formatted subagent section string.
     """
     n = max_concurrent
-    available_names = get_available_subagent_names(app_config=app_config) if app_config is not None else get_available_subagent_names()
+    available_names = get_available_subagent_names(app_config=app_config)
     bash_available = "bash" in available_names
 
     # Dynamically build subagent type descriptions from registry (aligned with Codex's

--- a/backend/packages/harness/deerflow/sandbox/security.py
+++ b/backend/packages/harness/deerflow/sandbox/security.py
@@ -37,12 +37,6 @@ def is_host_bash_allowed(config: object | None = None) -> bool:
     if config is None:
         config = get_app_config()
 
-    # Some call sites naturally hold a narrowed subagents config instead of the
-    # full AppConfig.  Resolve the ambient AppConfig here so callers do not need
-    # ad-hoc ``hasattr(config, "sandbox")`` fallbacks.
-    if not hasattr(config, "sandbox"):
-        config = get_app_config()
-
     sandbox_cfg = getattr(config, "sandbox", None)
     if sandbox_cfg is None:
         return False

--- a/backend/packages/harness/deerflow/sandbox/security.py
+++ b/backend/packages/harness/deerflow/sandbox/security.py
@@ -20,7 +20,7 @@ LOCAL_BASH_SUBAGENT_DISABLED_MESSAGE = (
 )
 
 
-def uses_local_sandbox_provider(config=None) -> bool:
+def uses_local_sandbox_provider(config: object | None = None) -> bool:
     """Return True when the active sandbox provider is the host-local provider."""
     if config is None:
         config = get_app_config()
@@ -32,9 +32,15 @@ def uses_local_sandbox_provider(config=None) -> bool:
     return sandbox_use.endswith(":LocalSandboxProvider") and "deerflow.sandbox.local" in sandbox_use
 
 
-def is_host_bash_allowed(config=None) -> bool:
+def is_host_bash_allowed(config: object | None = None) -> bool:
     """Return whether host bash execution is explicitly allowed."""
     if config is None:
+        config = get_app_config()
+
+    # Some call sites naturally hold a narrowed subagents config instead of the
+    # full AppConfig.  Resolve the ambient AppConfig here so callers do not need
+    # ad-hoc ``hasattr(config, "sandbox")`` fallbacks.
+    if not hasattr(config, "sandbox"):
         config = get_app_config()
 
     sandbox_cfg = getattr(config, "sandbox", None)

--- a/backend/packages/harness/deerflow/subagents/registry.py
+++ b/backend/packages/harness/deerflow/subagents/registry.py
@@ -2,8 +2,9 @@
 
 import logging
 from dataclasses import replace
-from typing import Any
 
+from deerflow.config.app_config import AppConfig
+from deerflow.config.subagents_config import SubagentsAppConfig
 from deerflow.sandbox.security import is_host_bash_allowed
 from deerflow.subagents.builtins import BUILTIN_SUBAGENTS
 from deerflow.subagents.config import SubagentConfig
@@ -11,15 +12,17 @@ from deerflow.subagents.config import SubagentConfig
 logger = logging.getLogger(__name__)
 
 
-def _resolve_subagents_app_config(app_config: Any | None = None):
+def _resolve_subagents_app_config(app_config: AppConfig | SubagentsAppConfig | None = None) -> SubagentsAppConfig:
     if app_config is None:
         from deerflow.config.subagents_config import get_subagents_app_config
 
         return get_subagents_app_config()
-    return getattr(app_config, "subagents", app_config)
+    if isinstance(app_config, AppConfig):
+        return app_config.subagents
+    return app_config
 
 
-def _build_custom_subagent_config(name: str, *, app_config: Any | None = None) -> SubagentConfig | None:
+def _build_custom_subagent_config(name: str, *, app_config: AppConfig | SubagentsAppConfig | None = None) -> SubagentConfig | None:
     """Build a SubagentConfig from config.yaml custom_agents section.
 
     Args:
@@ -47,7 +50,7 @@ def _build_custom_subagent_config(name: str, *, app_config: Any | None = None) -
     )
 
 
-def get_subagent_config(name: str, *, app_config: Any | None = None) -> SubagentConfig | None:
+def get_subagent_config(name: str, *, app_config: AppConfig | SubagentsAppConfig | None = None) -> SubagentConfig | None:
     """Get a subagent configuration by name, with config.yaml overrides applied.
 
     Resolution order (mirrors Codex's config layering):
@@ -116,13 +119,13 @@ def get_subagent_config(name: str, *, app_config: Any | None = None) -> Subagent
     return config
 
 
-def list_subagents(*, app_config: Any | None = None) -> list[SubagentConfig]:
+def list_subagents(*, app_config: AppConfig | SubagentsAppConfig | None = None) -> list[SubagentConfig]:
     """List all available subagent configurations (with config.yaml overrides applied).
 
     Returns:
         List of all registered SubagentConfig instances (built-in + custom).
     """
-    configs = []
+    configs: list[SubagentConfig] = []
     for name in get_subagent_names(app_config=app_config):
         config = get_subagent_config(name, app_config=app_config)
         if config is not None:
@@ -130,13 +133,13 @@ def list_subagents(*, app_config: Any | None = None) -> list[SubagentConfig]:
     return configs
 
 
-def get_subagent_names(*, app_config: Any | None = None) -> list[str]:
+def get_subagent_names(*, app_config: AppConfig | SubagentsAppConfig | None = None) -> list[str]:
     """Get all available subagent names (built-in + custom).
 
     Returns:
         List of subagent names.
     """
-    names = list(BUILTIN_SUBAGENTS.keys())
+    names: list[str] = list(BUILTIN_SUBAGENTS.keys())
 
     # Merge custom_agents from config.yaml
     subagents_config = _resolve_subagents_app_config(app_config)
@@ -147,7 +150,7 @@ def get_subagent_names(*, app_config: Any | None = None) -> list[str]:
     return names
 
 
-def get_available_subagent_names(*, app_config: Any | None = None) -> list[str]:
+def get_available_subagent_names(*, app_config: AppConfig | SubagentsAppConfig | None = None) -> list[str]:
     """Get subagent names that should be exposed to the active runtime.
 
     Returns:
@@ -155,7 +158,7 @@ def get_available_subagent_names(*, app_config: Any | None = None) -> list[str]:
     """
     names = get_subagent_names(app_config=app_config)
     try:
-        host_bash_allowed = is_host_bash_allowed(app_config) if hasattr(app_config, "sandbox") else is_host_bash_allowed()
+        host_bash_allowed = is_host_bash_allowed(app_config)
     except Exception:
         logger.debug("Could not determine host bash availability; exposing all subagents")
         return names

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import uuid
+from collections.abc import Mapping
 from dataclasses import replace
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
@@ -30,10 +31,17 @@ logger = logging.getLogger(__name__)
 
 def _get_runtime_app_config(runtime: Any) -> "AppConfig | None":
     context = getattr(runtime, "context", None)
-    if isinstance(context, dict):
+    if isinstance(context, Mapping):
         app_config = context.get("app_config")
         if app_config is not None:
             return cast("AppConfig", app_config)
+    return None
+
+
+def _get_runtime_context_value(runtime: Any, key: str) -> object | None:
+    context = getattr(runtime, "context", None)
+    if isinstance(context, Mapping):
+        return context.get(key)
     return None
 
 
@@ -94,20 +102,20 @@ async def task_tool(
         max_turns: Optional maximum number of agent turns. Defaults to subagent's configured max.
     """
     runtime_app_config = _get_runtime_app_config(runtime)
-    available_subagent_names = get_available_subagent_names(app_config=runtime_app_config) if runtime_app_config is not None else get_available_subagent_names()
+    available_subagent_names = get_available_subagent_names(app_config=runtime_app_config)
 
     # Get subagent configuration
-    config = get_subagent_config(subagent_type, app_config=runtime_app_config) if runtime_app_config is not None else get_subagent_config(subagent_type)
+    config = get_subagent_config(subagent_type, app_config=runtime_app_config)
     if config is None:
         available = ", ".join(available_subagent_names)
         return f"Error: Unknown subagent type '{subagent_type}'. Available: {available}"
     if subagent_type == "bash":
-        host_bash_allowed = is_host_bash_allowed(runtime_app_config) if runtime_app_config is not None else is_host_bash_allowed()
+        host_bash_allowed = is_host_bash_allowed(runtime_app_config)
         if not host_bash_allowed:
             return f"Error: {LOCAL_BASH_SUBAGENT_DISABLED_MESSAGE}"
 
     # Build config overrides
-    overrides: dict = {}
+    overrides: dict[str, object] = {}
 
     # Skills are loaded by SubagentExecutor per-session (aligned with Codex's pattern:
     # each subagent loads its own skills based on config, injected as conversation items).
@@ -122,25 +130,33 @@ async def task_tool(
     thread_id = None
     parent_model = None
     trace_id = None
-    metadata: dict = {}
+    metadata: dict[str, object] = {}
 
     if runtime is not None:
         sandbox_state = runtime.state.get("sandbox")
         thread_data = runtime.state.get("thread_data")
-        thread_id = runtime.context.get("thread_id") if runtime.context else None
+        thread_id_value = _get_runtime_context_value(runtime, "thread_id")
+        thread_id = thread_id_value if isinstance(thread_id_value, str) else None
         if thread_id is None:
-            thread_id = runtime.config.get("configurable", {}).get("thread_id")
+            configurable = runtime.config.get("configurable", {})
+            if isinstance(configurable, Mapping):
+                configured_thread_id = configurable.get("thread_id")
+                thread_id = configured_thread_id if isinstance(configured_thread_id, str) else None
 
         # Try to get parent model from configurable
-        metadata = runtime.config.get("metadata", {})
-        parent_model = metadata.get("model_name")
+        raw_metadata = runtime.config.get("metadata", {})
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, Mapping) else {}
+        parent_model_value = metadata.get("model_name")
+        parent_model = parent_model_value if isinstance(parent_model_value, str) else None
 
         # Get or generate trace_id for distributed tracing
-        trace_id = metadata.get("trace_id") or str(uuid.uuid4())[:8]
+        trace_id_value = metadata.get("trace_id")
+        trace_id = trace_id_value if isinstance(trace_id_value, str) else str(uuid.uuid4())[:8]
 
     parent_available_skills = metadata.get("available_skills")
-    if parent_available_skills is not None:
-        overrides["skills"] = _merge_skill_allowlists(list(parent_available_skills), config.skills)
+    if isinstance(parent_available_skills, list):
+        parent_skill_names = [skill for skill in parent_available_skills if isinstance(skill, str)]
+        overrides["skills"] = _merge_skill_allowlists(parent_skill_names, config.skills)
 
     if overrides:
         config = replace(config, **overrides)
@@ -150,35 +166,32 @@ async def task_tool(
     from deerflow.tools import get_available_tools
 
     # Inherit parent agent's tool_groups so subagents respect the same restrictions
-    parent_tool_groups = metadata.get("tool_groups")
+    parent_tool_groups_value = metadata.get("tool_groups")
+    parent_tool_groups = [group for group in parent_tool_groups_value if isinstance(group, str)] if isinstance(parent_tool_groups_value, list) else None
     resolved_app_config = runtime_app_config
     if config.model == "inherit" and parent_model is None and resolved_app_config is None:
         resolved_app_config = get_app_config()
     effective_model = resolve_subagent_model_name(config, parent_model, app_config=resolved_app_config)
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
-    available_tools_kwargs = {
-        "model_name": effective_model,
-        "groups": parent_tool_groups,
-        "subagent_enabled": False,
-    }
-    if resolved_app_config is not None:
-        available_tools_kwargs["app_config"] = resolved_app_config
-    tools = get_available_tools(**available_tools_kwargs)
+    tools = get_available_tools(
+        model_name=effective_model,
+        groups=parent_tool_groups,
+        subagent_enabled=False,
+        app_config=resolved_app_config,
+    )
 
     # Create executor
-    executor_kwargs = {
-        "config": config,
-        "tools": tools,
-        "parent_model": parent_model,
-        "sandbox_state": sandbox_state,
-        "thread_data": thread_data,
-        "thread_id": thread_id,
-        "trace_id": trace_id,
-    }
-    if resolved_app_config is not None:
-        executor_kwargs["app_config"] = resolved_app_config
-    executor = SubagentExecutor(**executor_kwargs)
+    executor = SubagentExecutor(
+        config=config,
+        tools=tools,
+        parent_model=parent_model,
+        sandbox_state=sandbox_state,
+        thread_data=thread_data,
+        thread_id=thread_id,
+        trace_id=trace_id,
+        app_config=resolved_app_config,
+    )
 
     # Start background execution (always async to prevent blocking)
     # Use tool_call_id as task_id for better traceability

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -684,6 +684,10 @@ def test_get_available_tools_includes_invoke_acp_agent_when_agents_configured(mo
     fake_config = SimpleNamespace(
         tools=[],
         models=[],
+        sandbox=SimpleNamespace(
+            use="deerflow.sandbox.local:LocalSandboxProvider",
+            allow_host_bash=True,
+        ),
         tool_search=SimpleNamespace(enabled=False),
         get_model_config=lambda name: None,
     )

--- a/backend/tests/test_lead_agent_prompt.py
+++ b/backend/tests/test_lead_agent_prompt.py
@@ -6,7 +6,12 @@ import anyio
 
 from deerflow.agents.lead_agent import prompt as prompt_module
 from deerflow.config.app_config import AppConfig
+from deerflow.config.memory_config import MemoryConfig
+from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.config.skill_evolution_config import SkillEvolutionConfig
+from deerflow.config.skills_config import SkillsConfig
 from deerflow.config.subagents_config import CustomSubagentConfig, SubagentsAppConfig
+from deerflow.config.tool_search_config import ToolSearchConfig
 from deerflow.skills.types import Skill, SkillCategory
 
 
@@ -137,8 +142,8 @@ def test_apply_prompt_template_threads_explicit_app_config_without_global_config
 
 
 def test_apply_prompt_template_threads_explicit_app_config_to_subagents_without_global_config(monkeypatch):
-    explicit_config = SimpleNamespace(
-        sandbox=SimpleNamespace(
+    explicit_config = AppConfig(
+        sandbox=SandboxConfig(
             use="deerflow.sandbox.local:LocalSandboxProvider",
             allow_host_bash=False,
             mounts=[],
@@ -151,10 +156,10 @@ def test_apply_prompt_template_threads_explicit_app_config_to_subagents_without_
                 )
             }
         ),
-        skills=SimpleNamespace(container_path="/mnt/skills"),
-        skill_evolution=SimpleNamespace(enabled=False),
-        tool_search=SimpleNamespace(enabled=False),
-        memory=SimpleNamespace(enabled=False, injection_enabled=True, max_injection_tokens=2000),
+        skills=SkillsConfig(container_path="/mnt/skills"),
+        skill_evolution=SkillEvolutionConfig(enabled=False),
+        tool_search=ToolSearchConfig(enabled=False),
+        memory=MemoryConfig(enabled=False, injection_enabled=True, max_injection_tokens=2000),
         acp_agents={},
     )
 

--- a/backend/tests/test_local_bash_tool_loading.py
+++ b/backend/tests/test_local_bash_tool_loading.py
@@ -87,8 +87,8 @@ def test_is_host_bash_allowed_defaults_false_when_sandbox_missing():
     assert is_host_bash_allowed(SimpleNamespace(sandbox=None)) is False
 
 
-def test_is_host_bash_allowed_falls_back_for_config_without_sandbox(monkeypatch):
+def test_is_host_bash_allowed_does_not_fall_back_for_config_without_sandbox(monkeypatch):
     ambient_config = _make_config(allow_host_bash=True)
     monkeypatch.setattr("deerflow.sandbox.security.get_app_config", lambda: ambient_config)
 
-    assert is_host_bash_allowed(SimpleNamespace(custom_agents={})) is True
+    assert is_host_bash_allowed(SimpleNamespace(custom_agents={})) is False

--- a/backend/tests/test_local_bash_tool_loading.py
+++ b/backend/tests/test_local_bash_tool_loading.py
@@ -85,3 +85,10 @@ def test_get_available_tools_keeps_bash_for_aio_sandbox(monkeypatch):
 def test_is_host_bash_allowed_defaults_false_when_sandbox_missing():
     assert is_host_bash_allowed(SimpleNamespace()) is False
     assert is_host_bash_allowed(SimpleNamespace(sandbox=None)) is False
+
+
+def test_is_host_bash_allowed_falls_back_for_config_without_sandbox(monkeypatch):
+    ambient_config = _make_config(allow_host_bash=True)
+    monkeypatch.setattr("deerflow.sandbox.security.get_app_config", lambda: ambient_config)
+
+    assert is_host_bash_allowed(SimpleNamespace(custom_agents={})) is True

--- a/backend/tests/test_subagent_prompt_security.py
+++ b/backend/tests/test_subagent_prompt_security.py
@@ -5,7 +5,7 @@ from deerflow.subagents import registry as registry_module
 
 
 def test_get_available_subagent_names_hides_bash_when_host_bash_disabled(monkeypatch) -> None:
-    monkeypatch.setattr(registry_module, "is_host_bash_allowed", lambda: False)
+    monkeypatch.setattr(registry_module, "is_host_bash_allowed", lambda config=None: False)
 
     names = registry_module.get_available_subagent_names()
 
@@ -13,7 +13,7 @@ def test_get_available_subagent_names_hides_bash_when_host_bash_disabled(monkeyp
 
 
 def test_get_available_subagent_names_keeps_bash_when_allowed(monkeypatch) -> None:
-    monkeypatch.setattr(registry_module, "is_host_bash_allowed", lambda: True)
+    monkeypatch.setattr(registry_module, "is_host_bash_allowed", lambda config=None: True)
 
     names = registry_module.get_available_subagent_names()
 
@@ -21,7 +21,7 @@ def test_get_available_subagent_names_keeps_bash_when_allowed(monkeypatch) -> No
 
 
 def test_build_subagent_section_hides_bash_examples_when_unavailable(monkeypatch) -> None:
-    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda: ["general-purpose"])
+    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda *, app_config=None: ["general-purpose"])
 
     section = prompt_module._build_subagent_section(3)
 
@@ -34,7 +34,7 @@ def test_build_subagent_section_hides_bash_examples_when_unavailable(monkeypatch
 
 
 def test_build_subagent_section_includes_bash_when_available(monkeypatch) -> None:
-    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda: ["general-purpose", "bash"])
+    monkeypatch.setattr(prompt_module, "get_available_subagent_names", lambda *, app_config=None: ["general-purpose", "bash"])
 
     section = prompt_module._build_subagent_section(3)
 

--- a/backend/tests/test_subagent_skills_config.py
+++ b/backend/tests/test_subagent_skills_config.py
@@ -9,8 +9,6 @@ Covers:
 - Skills filter passthrough in task_tool config assembly
 """
 
-from types import SimpleNamespace
-
 import pytest
 
 from deerflow.config.subagents_config import (
@@ -353,16 +351,14 @@ class TestRegistryCustomAgentLookup:
 
         monkeypatch.setattr("deerflow.config.subagents_config.get_subagents_app_config", fail_get_subagents_app_config)
 
-        app_config = SimpleNamespace(
-            subagents=SubagentsAppConfig(
-                custom_agents={
-                    "analysis": CustomSubagentConfig(
-                        description="Data analysis specialist",
-                        system_prompt="You are a data analysis subagent.",
-                        skills=["data-analysis"],
-                    )
-                }
-            )
+        app_config = SubagentsAppConfig(
+            custom_agents={
+                "analysis": CustomSubagentConfig(
+                    description="Data analysis specialist",
+                    system_prompt="You are a data analysis subagent.",
+                    skills=["data-analysis"],
+                )
+            }
         )
 
         config = get_subagent_config("analysis", app_config=app_config)
@@ -377,11 +373,11 @@ class TestRegistryCustomAgentLookup:
         _reset_subagents_config()
         assert get_subagent_config("nonexistent") is None
 
-    def test_get_available_subagent_names_falls_back_when_subagents_app_config_lacks_sandbox(self, monkeypatch):
+    def test_get_available_subagent_names_lets_bash_gate_resolve_sandbox_fallback(self, monkeypatch):
         from deerflow.subagents import registry as registry_module
         from deerflow.subagents.registry import get_available_subagent_names
 
-        captured: dict[str, tuple] = {}
+        captured: dict[str, tuple[object, ...]] = {}
 
         def fake_is_host_bash_allowed(*args, **kwargs):
             captured["args"] = args
@@ -391,7 +387,7 @@ class TestRegistryCustomAgentLookup:
 
         get_available_subagent_names(app_config=SubagentsAppConfig())
 
-        assert captured["args"] == ()
+        assert captured["args"] == (SubagentsAppConfig(),)
 
     def test_builtin_takes_priority_over_custom(self):
         """If a custom agent has the same name as a builtin, builtin wins."""

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -3,7 +3,7 @@
 import asyncio
 import importlib
 from enum import Enum
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -53,10 +53,17 @@ def _make_subagent_config(name: str = "general-purpose") -> SubagentConfig:
     )
 
 
+def _subagent_lookup(result):
+    def lookup(_name, *, app_config=None):
+        return result
+
+    return lookup
+
+
 def _make_result(
     status: FakeSubagentStatus,
     *,
-    ai_messages: list[dict] | None = None,
+    ai_messages: list[dict[str, object]] | None = None,
     result: str | None = None,
     error: str | None = None,
 ) -> SimpleNamespace:
@@ -76,6 +83,13 @@ def _run_task_tool(**kwargs) -> str:
     return task_tool_module.task_tool.func(**kwargs)
 
 
+def test_get_runtime_app_config_accepts_mapping_context():
+    app_config = object()
+    runtime = SimpleNamespace(context=MappingProxyType({"app_config": app_config}))
+
+    assert task_tool_module._get_runtime_app_config(runtime) is app_config
+
+
 async def _no_sleep(_: float) -> None:
     return None
 
@@ -86,8 +100,8 @@ class _DummyScheduledTask:
 
 
 def test_task_tool_returns_error_for_unknown_subagent(monkeypatch):
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: None)
-    monkeypatch.setattr(task_tool_module, "get_available_subagent_names", lambda: ["general-purpose"])
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(None))
+    monkeypatch.setattr(task_tool_module, "get_available_subagent_names", lambda *, app_config=None: ["general-purpose"])
 
     result = _run_task_tool(
         runtime=None,
@@ -101,8 +115,9 @@ def test_task_tool_returns_error_for_unknown_subagent(monkeypatch):
 
 
 def test_task_tool_rejects_bash_subagent_when_host_bash_disabled(monkeypatch):
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: _make_subagent_config())
-    monkeypatch.setattr(task_tool_module, "is_host_bash_allowed", lambda: False)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(_make_subagent_config()))
+    monkeypatch.setattr(task_tool_module, "get_available_subagent_names", lambda *, app_config=None: ["bash"])
+    monkeypatch.setattr(task_tool_module, "is_host_bash_allowed", lambda config=None: False)
 
     result = _run_task_tool(
         runtime=_make_runtime(),
@@ -207,7 +222,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(task_tool_module, "get_background_task_result", lambda _: next(responses))
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
@@ -234,7 +249,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     # by SubagentExecutor and injected as conversation items (Codex pattern).
     assert captured["executor_kwargs"]["config"].system_prompt == "Base system prompt"
 
-    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False)
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False, app_config=None)
 
     event_types = [e["type"] for e in events]
     assert event_types == ["task_started", "task_running", "task_running", "task_completed"]
@@ -265,7 +280,7 @@ def test_task_tool_propagates_tool_groups_to_subagent(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -285,7 +300,7 @@ def test_task_tool_propagates_tool_groups_to_subagent(monkeypatch):
 
     assert output == "Task Succeeded. Result: done"
     # The key assertion: groups should be propagated from parent metadata
-    get_available_tools.assert_called_once_with(model_name="ark-model", groups=parent_tool_groups, subagent_enabled=False)
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=parent_tool_groups, subagent_enabled=False, app_config=None)
 
 
 def test_task_tool_uses_subagent_model_override_for_tool_loading(monkeypatch):
@@ -312,7 +327,7 @@ def test_task_tool_uses_subagent_model_override_for_tool_loading(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -335,6 +350,7 @@ def test_task_tool_uses_subagent_model_override_for_tool_loading(monkeypatch):
         model_name="vision-subagent-model",
         groups=None,
         subagent_enabled=False,
+        app_config=None,
     )
 
 
@@ -354,7 +370,7 @@ def test_task_tool_inherits_parent_skill_allowlist_for_default_subagent(monkeypa
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -400,7 +416,7 @@ def test_task_tool_intersects_parent_and_subagent_skill_allowlists(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -439,7 +455,7 @@ def test_task_tool_no_tool_groups_passes_none(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -459,7 +475,7 @@ def test_task_tool_no_tool_groups_passes_none(monkeypatch):
 
     assert output == "Task Succeeded. Result: ok"
     # No tool_groups in metadata → groups=None (default behavior preserved)
-    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False)
+    get_available_tools.assert_called_once_with(model_name="ark-model", groups=None, subagent_enabled=False, app_config=None)
 
 
 def test_task_tool_runtime_none_passes_groups_none(monkeypatch):
@@ -477,7 +493,7 @@ def test_task_tool_runtime_none_passes_groups_none(monkeypatch):
 
     monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
     monkeypatch.setattr(task_tool_module, "SubagentExecutor", DummyExecutor)
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
     monkeypatch.setattr(
         task_tool_module,
         "get_background_task_result",
@@ -515,7 +531,7 @@ def test_task_tool_runtime_none_passes_groups_none(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -549,7 +565,7 @@ def test_task_tool_returns_timed_out_message(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -585,7 +601,7 @@ def test_task_tool_polling_safety_timeout(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -621,7 +637,7 @@ def test_cleanup_called_on_completed(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -661,7 +677,7 @@ def test_cleanup_called_on_failed(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -701,7 +717,7 @@ def test_cleanup_called_on_timed_out(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -748,7 +764,7 @@ def test_cleanup_not_called_on_polling_safety_timeout(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -801,7 +817,7 @@ def test_cleanup_scheduled_on_cancellation(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(task_tool_module, "get_background_task_result", get_result)
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)
@@ -852,7 +868,7 @@ def test_cancelled_cleanup_stops_after_timeout(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -907,7 +923,7 @@ def test_cancellation_calls_request_cancel(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(
         task_tool_module,
@@ -965,7 +981,7 @@ def test_task_tool_returns_cancelled_message(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", _subagent_lookup(config))
 
     monkeypatch.setattr(task_tool_module, "get_background_task_result", lambda _: next(responses))
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)


### PR DESCRIPTION
## Summary
- centralize host bash fallback inside `is_host_bash_allowed` and collapse the duplicated call-site guards from the subagent/task paths
- narrow subagent registry config resolution to `AppConfig | SubagentsAppConfig | None` and keep prompt/runtime config threading consistent
- update backend regressions and fixture coverage for the explicit `app_config` path, including the Mapping-based runtime context follow-up

## Scope
- addresses #2687 item 1
- addresses #2687 item 3
- addresses #2687 item 4
- intentionally does not cover item 2, item 5, or item 6

## Testing
- `cd backend && make lint`
- `cd backend && make test`
- `cd backend && PYTHONPATH=. uv run pytest tests/test_task_tool_core_logic.py -q`