### PR TITLE
fix(runtime): type runtime context and confirm summarization invariant (#2687)

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -242,7 +242,7 @@ def _build_middlewares(
     agent_name: str | None = None,
     custom_middlewares: list[AgentMiddleware] | None = None,
     *,
-    app_config: AppConfig | None = None,
+    app_config: AppConfig,
 ):
     """Build middleware chain based on runtime configuration.
 
@@ -254,11 +254,10 @@ def _build_middlewares(
     Returns:
         List of middleware instances.
     """
-    resolved_app_config = app_config or get_app_config()
-    middlewares = build_lead_runtime_middlewares(app_config=resolved_app_config, lazy_init=True)
+    middlewares = build_lead_runtime_middlewares(app_config=app_config, lazy_init=True)
 
     # Add summarization middleware if enabled
-    summarization_middleware = _create_summarization_middleware(app_config=resolved_app_config)
+    summarization_middleware = _create_summarization_middleware(app_config=app_config)
     if summarization_middleware is not None:
         middlewares.append(summarization_middleware)
 
@@ -270,23 +269,23 @@ def _build_middlewares(
         middlewares.append(todo_list_middleware)
 
     # Add TokenUsageMiddleware when token_usage tracking is enabled
-    if resolved_app_config.token_usage.enabled:
+    if app_config.token_usage.enabled:
         middlewares.append(TokenUsageMiddleware())
 
     # Add TitleMiddleware
-    middlewares.append(TitleMiddleware(app_config=resolved_app_config))
+    middlewares.append(TitleMiddleware(app_config=app_config))
 
     # Add MemoryMiddleware (after TitleMiddleware)
-    middlewares.append(MemoryMiddleware(agent_name=agent_name, memory_config=resolved_app_config.memory))
+    middlewares.append(MemoryMiddleware(agent_name=agent_name, memory_config=app_config.memory))
 
     # Add ViewImageMiddleware only if the current model supports vision.
     # Use the resolved runtime model_name from make_lead_agent to avoid stale config values.
-    model_config = resolved_app_config.get_model_config(model_name) if model_name else None
+    model_config = app_config.get_model_config(model_name) if model_name else None
     if model_config is not None and model_config.supports_vision:
         middlewares.append(ViewImageMiddleware())
 
     # Add DeferredToolFilterMiddleware to hide deferred tool schemas from model binding
-    if resolved_app_config.tool_search.enabled:
+    if app_config.tool_search.enabled:
         from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
 
         middlewares.append(DeferredToolFilterMiddleware())
@@ -298,7 +297,7 @@ def _build_middlewares(
         middlewares.append(SubagentLimitMiddleware(max_concurrent=max_concurrent_subagents))
 
     # LoopDetectionMiddleware — detect and break repetitive tool call loops
-    loop_detection_config = resolved_app_config.loop_detection
+    loop_detection_config = app_config.loop_detection
     if loop_detection_config.enabled:
         middlewares.append(LoopDetectionMiddleware.from_config(loop_detection_config))
 

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -52,7 +52,11 @@ def _resolve_model_name(requested_model_name: str | None = None, *, app_config: 
 
 def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> DeerFlowSummarizationMiddleware | None:
     """Create and configure the summarization middleware from config."""
-    resolved_app_config = app_config or get_app_config()
+    try:
+        resolved_app_config = app_config or get_app_config()
+    except Exception as exc:
+        logger.warning("Skipping summarization middleware; app config unavailable: %s", exc)
+        return None
     config = resolved_app_config.summarization
 
     if not config.enabled:

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -50,14 +50,9 @@ def _resolve_model_name(requested_model_name: str | None = None, *, app_config: 
     return default_model_name
 
 
-def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> DeerFlowSummarizationMiddleware | None:
+def _create_summarization_middleware(*, app_config: AppConfig) -> DeerFlowSummarizationMiddleware | None:
     """Create and configure the summarization middleware from config."""
-    try:
-        resolved_app_config = app_config or get_app_config()
-    except Exception as exc:
-        logger.warning("Skipping summarization middleware; app config unavailable: %s", exc)
-        return None
-    config = resolved_app_config.summarization
+    config = app_config.summarization
 
     if not config.enabled:
         return None
@@ -78,9 +73,9 @@ def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> 
     # as middleware rather than lead_agent (SummarizationMiddleware is a
     # LangChain built-in, so we tag the model at creation time).
     if config.model_name:
-        model = create_chat_model(name=config.model_name, thinking_enabled=False, app_config=resolved_app_config)
+        model = create_chat_model(name=config.model_name, thinking_enabled=False, app_config=app_config)
     else:
-        model = create_chat_model(thinking_enabled=False, app_config=resolved_app_config)
+        model = create_chat_model(thinking_enabled=False, app_config=app_config)
     model = model.with_config(tags=["middleware:summarize"])
 
     # Prepare kwargs
@@ -97,13 +92,13 @@ def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> 
         kwargs["summary_prompt"] = config.summary_prompt
 
     hooks: list[BeforeSummarizationHook] = []
-    if resolved_app_config.memory.enabled:
+    if app_config.memory.enabled:
         hooks.append(memory_flush_hook)
 
     # The logic below relies on two assumptions holding true: this factory is
     # the sole entry point for DeerFlowSummarizationMiddleware, and the runtime
     # config is not expected to change after startup.
-    skills_container_path = resolved_app_config.skills.container_path or "/mnt/skills"
+    skills_container_path = app_config.skills.container_path or "/mnt/skills"
 
     return DeerFlowSummarizationMiddleware(
         **kwargs,

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -230,7 +230,13 @@ class DeerFlowClient:
         kwargs: dict[str, Any] = {
             "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
             "tools": self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled),
-            "middleware": _build_middlewares(config, model_name=model_name, agent_name=self._agent_name, custom_middlewares=self._middlewares),
+            "middleware": _build_middlewares(
+                config,
+                model_name=model_name,
+                agent_name=self._agent_name,
+                custom_middlewares=self._middlewares,
+                app_config=self._app_config,
+            ),
             "system_prompt": apply_prompt_template(
                 subagent_enabled=subagent_enabled,
                 max_concurrent_subagents=max_concurrent_subagents,

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -21,7 +21,7 @@ import inspect
 import logging
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, Required, TypedDict, cast
 
 from langgraph.checkpoint.base import empty_checkpoint
 
@@ -41,12 +41,21 @@ logger = logging.getLogger(__name__)
 _VALID_LG_MODES = {"values", "updates", "checkpoints", "tasks", "debug", "messages", "custom"}
 
 
+class DeerFlowRuntimeContext(TypedDict, total=False):
+    """Typed shape of the runtime context dict passed to ``ToolRuntime.context``."""
+
+    thread_id: Required[str]
+    run_id: Required[str]
+    app_config: NotRequired[AppConfig]
+    agent_name: NotRequired[str]
+
+
 def _build_runtime_context(
     thread_id: str,
     run_id: str,
     caller_context: Any | None,
     app_config: AppConfig | None = None,
-) -> dict[str, Any]:
+) -> DeerFlowRuntimeContext:
     """Build the dict that becomes ``ToolRuntime.context`` for the run.
 
     Always includes ``thread_id`` and ``run_id``. Additional keys from the caller's
@@ -59,7 +68,7 @@ def _build_runtime_context(
     under ``config['configurable']['__pregel_runtime']`` — see
     ``langgraph.pregel.main`` where ``parent_runtime.merge(...)`` is invoked.
     """
-    runtime_ctx: dict[str, Any] = {"thread_id": thread_id, "run_id": run_id}
+    runtime_ctx: DeerFlowRuntimeContext = {"thread_id": thread_id, "run_id": run_id}
     if isinstance(caller_context, dict):
         for key, value in caller_context.items():
             runtime_ctx.setdefault(key, value)
@@ -85,7 +94,7 @@ class RunContext:
     app_config: AppConfig | None = field(default=None)
 
 
-def _install_runtime_context(config: dict, runtime_context: dict[str, Any]) -> None:
+def _install_runtime_context(config: dict, runtime_context: DeerFlowRuntimeContext) -> None:
     existing_context = config.get("context")
     if isinstance(existing_context, dict):
         existing_context.setdefault("thread_id", runtime_context["thread_id"])
@@ -216,7 +225,7 @@ async def run_agent(
         # without passing the official ``context=`` parameter.
         runtime_ctx = _build_runtime_context(thread_id, run_id, config.get("context"), ctx.app_config)
         _install_runtime_context(config, runtime_ctx)
-        runtime = Runtime(context=cast(Any, runtime_ctx), store=store)
+        runtime = Runtime(context=cast(Any, runtime_ctx), store=store)  # TODO(#2687): cast retained because Runtime.context expects Any and TypedDict is not assignable without it
         config.setdefault("configurable", {})["__pregel_runtime"] = runtime
 
         # Inject RunJournal as a LangChain callback handler.

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import uuid
 from dataclasses import replace
-from typing import TYPE_CHECKING, Annotated, Any, cast
+from typing import TYPE_CHECKING, Annotated, Any
 
 from langchain.tools import InjectedToolCallId, ToolRuntime, tool
 from langgraph.config import get_stream_writer
@@ -24,6 +24,7 @@ from deerflow.subagents.executor import (
 
 if TYPE_CHECKING:
     from deerflow.config.app_config import AppConfig
+    from deerflow.runtime.runs.worker import DeerFlowRuntimeContext
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +32,10 @@ logger = logging.getLogger(__name__)
 def _get_runtime_app_config(runtime: Any) -> "AppConfig | None":
     context = getattr(runtime, "context", None)
     if isinstance(context, dict):
-        app_config = context.get("app_config")
+        typed_context: DeerFlowRuntimeContext = context  # pyright: ignore[reportAssignmentType]
+        app_config = typed_context.get("app_config")
         if app_config is not None:
-            return cast("AppConfig", app_config)
+            return app_config
     return None
 
 

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -923,6 +923,7 @@ class TestEnsureAgent:
         # Verify agent_name propagation
         mock_build_middlewares.assert_called_once()
         assert mock_build_middlewares.call_args.kwargs.get("agent_name") == "custom-agent"
+        assert mock_build_middlewares.call_args.kwargs.get("app_config") is client._app_config
         mock_apply_prompt.assert_called_once()
         assert mock_apply_prompt.call_args.kwargs.get("agent_name") == "custom-agent"
         assert mock_apply_prompt.call_args.kwargs.get("available_skills") == {"test_skill"}

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -75,6 +75,11 @@ def test_internal_make_lead_agent_uses_explicit_app_config(monkeypatch):
     assert result["model"] is not None
 
 
+def test_create_summarization_middleware_returns_none_when_app_config_unavailable(monkeypatch):
+    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: (_ for _ in ()).throw(RuntimeError("not loaded")))
+    assert lead_agent_module._create_summarization_middleware() is None
+
+
 def test_make_lead_agent_uses_runtime_app_config_from_context_without_global_read(monkeypatch):
     app_config = _make_app_config([_make_model("context-model", supports_thinking=False)])
 

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -75,9 +75,11 @@ def test_internal_make_lead_agent_uses_explicit_app_config(monkeypatch):
     assert result["model"] is not None
 
 
-def test_create_summarization_middleware_returns_none_when_app_config_unavailable(monkeypatch):
-    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: (_ for _ in ()).throw(RuntimeError("not loaded")))
-    assert lead_agent_module._create_summarization_middleware() is None
+def test_create_summarization_middleware_requires_explicit_app_config():
+    create_summarization_middleware = getattr(lead_agent_module, "_create_summarization_middleware")
+
+    with pytest.raises(TypeError):
+        create_summarization_middleware()
 
 
 def test_make_lead_agent_uses_runtime_app_config_from_context_without_global_read(monkeypatch):
@@ -435,10 +437,10 @@ def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch
     fake_model.with_config.assert_called_once_with(tags=["middleware:summarize"])
 
 
-def test_create_summarization_middleware_threads_resolved_app_config_to_model(monkeypatch):
-    fallback_app_config = _make_app_config([_make_model("fallback-model", supports_thinking=False)])
-    fallback_app_config.summarization = SummarizationConfig(enabled=True, model_name="fallback-model")
-    fallback_app_config.memory = MemoryConfig(enabled=False)
+def test_create_summarization_middleware_threads_explicit_app_config_to_model(monkeypatch):
+    app_config = _make_app_config([_make_model("explicit-model", supports_thinking=False)])
+    app_config.summarization = SummarizationConfig(enabled=True, model_name="explicit-model")
+    app_config.memory = MemoryConfig(enabled=False)
 
     from unittest.mock import MagicMock
 
@@ -450,13 +452,16 @@ def test_create_summarization_middleware_threads_resolved_app_config_to_model(mo
         captured["app_config"] = app_config
         return fake_model
 
-    monkeypatch.setattr(lead_agent_module, "get_app_config", lambda: fallback_app_config)
+    def _raise_get_app_config():
+        raise AssertionError("ambient get_app_config() must not be used by summarization middleware")
+
+    monkeypatch.setattr(lead_agent_module, "get_app_config", _raise_get_app_config)
     monkeypatch.setattr(lead_agent_module, "create_chat_model", _fake_create_chat_model)
     monkeypatch.setattr(lead_agent_module, "DeerFlowSummarizationMiddleware", lambda **kwargs: kwargs)
 
-    lead_agent_module._create_summarization_middleware()
+    lead_agent_module._create_summarization_middleware(app_config=app_config)
 
-    assert captured["app_config"] is fallback_app_config
+    assert captured["app_config"] is app_config
 
 
 def test_memory_middleware_uses_explicit_memory_config_without_global_read(monkeypatch):


### PR DESCRIPTION
addresses #2687 item 5 and item 6

> Draft sequencing note: this PR is intended to be finalized after #2769 (items 1/3/4) and #2778 (item 2) land, then rebased onto that updated `main`. The implementation and audit below describe the post-merge target shape, not a compatibility layer for multiple intermediate states.

## Summary
- worker.py: introduce a typed DeerFlowRuntimeContext, annotate runtime helpers, keep the runtime cast with the #2687 TODO marker.
- task_tool.py: read runtime app config through the new typed runtime context instead of an untyped cast.
- agent.py: require middleware construction to receive `app_config` explicitly, removing the ambient `get_app_config()` fallback from both `_build_middlewares` and `_create_summarization_middleware`.
- client.py: thread `DeerFlowClient`'s preloaded `self._app_config` into `_build_middlewares` for the embedded-client path.
- tests: cover explicit summarization config threading, bare helper rejection, and embedded-client middleware config propagation.

## Invariant Audit (item 6)
This audit follows the config-threading direction established by the preceding #2687 PRs: config should be resolved at composition roots and then passed explicitly through runtime/middleware construction.

- `_build_middlewares`: now requires `app_config` explicitly and passes it to `_create_summarization_middleware` — safe.
- `make_lead_agent` → `_make_lead_agent`: passes `resolved_app_config` explicitly to `_build_middlewares` — safe.
- `DeerFlowClient._ensure_agent`: `DeerFlowClient.__init__` preloads config, and `_ensure_agent` now passes `self._app_config` into `_build_middlewares` — safe.
- Direct test invocations: previously omitted `app_config`; those tests now pass an explicit `AppConfig` or assert the bare helper call is invalid.

**Verdict: the explicit-config invariant is enforced in the target post-#2769/#2778 state.** Summarization middleware construction has a single config path, matching item 2's removal of duplicate config sources instead of preserving ambient fallbacks.

## File Summary
- `worker.py`: typed runtime context helpers and documented cast boundary.
- `task_tool.py`: typed access to runtime config.
- `agent.py`: single explicit `app_config` path for middleware construction.
- `client.py`: embedded client passes its preloaded app config into middleware construction.
- `test_lead_agent_model_resolution.py` / `test_client.py`: regression coverage for explicit config threading and no bare helper calls.

## Merge Plan
- Keep this PR as draft until #2769 and #2778 are merged.
- Rebase #2779 onto the updated `main` after those PRs land.
- Re-run backend `make lint` and `make test` after the rebase before marking ready for review.