### PR TITLE
fix(task): remove max_turns parameter from task tool interface

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -266,7 +266,7 @@ Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → 
    - `setup_agent` - Bootstrap-only: persist a brand-new custom agent's `SOUL.md` and `config.yaml`. Bound only when `is_bootstrap=True`.
    - `update_agent` - Custom-agent-only: persist self-updates to the current agent's `SOUL.md` / `config.yaml` from inside a normal chat (partial update + atomic write). Bound when `agent_name` is set and `is_bootstrap=False`.
 4. **Subagent tool** (if enabled):
-   - `task` - Delegate to subagent (description, prompt, subagent_type, max_turns)
+   - `task` - Delegate to subagent (description, prompt, subagent_type)
 
 **Community tools** (`packages/harness/deerflow/community/`):
 - `tavily/` - Web search (5 results default) and web fetch (4KB limit)

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -55,7 +55,6 @@ async def task_tool(
     prompt: str,
     subagent_type: str,
     tool_call_id: Annotated[str, InjectedToolCallId],
-    max_turns: int | None = None,
 ) -> str:
     """Delegate a task to a specialized subagent that runs in its own context.
 
@@ -91,7 +90,6 @@ async def task_tool(
         description: A short (3-5 word) description of the task for logging/display. ALWAYS PROVIDE THIS PARAMETER FIRST.
         prompt: The task description for the subagent. Be specific and clear about what needs to be done. ALWAYS PROVIDE THIS PARAMETER SECOND.
         subagent_type: The type of subagent to use. ALWAYS PROVIDE THIS PARAMETER THIRD.
-        max_turns: Optional maximum number of agent turns. Defaults to subagent's configured max.
     """
     runtime_app_config = _get_runtime_app_config(runtime)
     available_subagent_names = get_available_subagent_names(app_config=runtime_app_config) if runtime_app_config is not None else get_available_subagent_names()
@@ -112,9 +110,6 @@ async def task_tool(
     # Skills are loaded by SubagentExecutor per-session (aligned with Codex's pattern:
     # each subagent loads its own skills based on config, injected as conversation items).
     # No longer appended to system_prompt here.
-
-    if max_turns is not None:
-        overrides["max_turns"] = max_turns
 
     # Extract parent context from runtime
     sandbox_state = None

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -221,7 +221,6 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
         prompt="collect diagnostics",
         subagent_type="general-purpose",
         tool_call_id="tc-123",
-        max_turns=7,
     )
 
     assert output == "Task Succeeded. Result: all done"
@@ -229,7 +228,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     assert captured["task_id"] == "tc-123"
     assert captured["executor_kwargs"]["thread_id"] == "thread-1"
     assert captured["executor_kwargs"]["parent_model"] == "ark-model"
-    assert captured["executor_kwargs"]["config"].max_turns == 7
+    assert captured["executor_kwargs"]["config"].max_turns == 50  # uses configured default
     # Skills are no longer appended to system_prompt; they are loaded per-session
     # by SubagentExecutor and injected as conversation items (Codex pattern).
     assert captured["executor_kwargs"]["config"].system_prompt == "Base system prompt"

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -228,7 +228,7 @@ def test_task_tool_emits_running_and_completed_events(monkeypatch):
     assert captured["task_id"] == "tc-123"
     assert captured["executor_kwargs"]["thread_id"] == "thread-1"
     assert captured["executor_kwargs"]["parent_model"] == "ark-model"
-    assert captured["executor_kwargs"]["config"].max_turns == 50  # uses configured default
+    assert captured["executor_kwargs"]["config"].max_turns == config.max_turns
     # Skills are no longer appended to system_prompt; they are loaded per-session
     # by SubagentExecutor and injected as conversation items (Codex pattern).
     assert captured["executor_kwargs"]["config"].system_prompt == "Base system prompt"


### PR DESCRIPTION
## Summary

- Removed `max_turns` parameter from the `task` tool's public interface
- Subagents now always use their admin-configured `max_turns` (per-agent overrides and global defaults in `config.yaml`), preventing callers from bypassing the configured limits
- Updated test to assert the configured default is used instead of a caller-supplied value
- Updated `CLAUDE.md` to reflect the updated tool signature

## Motivation

Two reasons for this removal:

1. **Lead agent sets it incorrectly anyway** — in practice the lead agent has no reliable basis for choosing a meaningful `max_turns` value, so whatever it passes tends to be wrong or arbitrary.

2. **Design philosophy** — `max_turns` is an infrastructure-level concern owned by the operator (via `config.yaml` per-agent overrides and global defaults). It should not be a dial that the lead agent can turn at runtime. Exposing it as a tool parameter leaks an admin-facing knob into the agent's decision space where it doesn't belong.

## Test plan

- [x] `test_task_tool_core_logic.py` — all 20 tests pass
- [x] Full test suite — 3053 passed, 0 new failures
- [x] Lint (`ruff check` + `ruff format`) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)