### PR TITLE
fix(frontend): proxy LangGraph SSE without buffering

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,13 +3,11 @@
  * for Docker builds.
  */
 import "./src/env.js";
+import {
+  hasConfiguredEnvValue,
+  resolveInternalGatewayUrl,
+} from "./src/core/gateway-url.js";
 
-function getInternalServiceURL(envKey, fallbackURL) {
-  const configured = process.env[envKey]?.trim();
-  return configured && configured.length > 0
-    ? configured.replace(/\/+$/, "")
-    : fallbackURL;
-}
 import nextra from "nextra";
 
 const withNextra = nextra({});
@@ -26,55 +24,50 @@ const config = {
   },
   devIndicators: false,
   async rewrites() {
-    const rewrites = [];
-    const gatewayURL = getInternalServiceURL(
-      "DEER_FLOW_INTERNAL_GATEWAY_BASE_URL",
-      "http://127.0.0.1:8001",
-    );
+    const beforeFiles = [];
+    const fallback = [];
+    const gatewayURL = resolveInternalGatewayUrl();
 
-    if (!process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL) {
-      rewrites.push({
+    if (!hasConfiguredEnvValue(process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL)) {
+      fallback.push({
         source: "/api/langgraph",
         destination: `${gatewayURL}/api`,
       });
-      rewrites.push({
+      fallback.push({
         source: "/api/langgraph/:path*",
         destination: `${gatewayURL}/api/:path*`,
       });
     }
 
-    if (!process.env.NEXT_PUBLIC_BACKEND_BASE_URL) {
-      rewrites.push({
+    if (!hasConfiguredEnvValue(process.env.NEXT_PUBLIC_BACKEND_BASE_URL)) {
+      beforeFiles.push({
         source: "/api/agents",
         destination: `${gatewayURL}/api/agents`,
       });
-      rewrites.push({
+      beforeFiles.push({
         source: "/api/agents/:path*",
         destination: `${gatewayURL}/api/agents/:path*`,
       });
-      rewrites.push({
+      beforeFiles.push({
         source: "/api/skills",
         destination: `${gatewayURL}/api/skills`,
       });
-      rewrites.push({
+      beforeFiles.push({
         source: "/api/skills/:path*",
         destination: `${gatewayURL}/api/skills/:path*`,
       });
 
-      // Catch-all for remaining gateway API routes (models, threads, memory,
-      // mcp, artifacts, uploads, suggestions, runs, etc.) that don't have
-      // their own NEXT_PUBLIC_* env var toggle.
-      //
-      // NOTE: this must come AFTER the /api/langgraph rewrite above so that
-      // LangGraph-compatible routes keep their public prefix while Gateway
-      // receives its native /api/* paths.
-      rewrites.push({
+      fallback.push({
         source: "/api/:path*",
         destination: `${gatewayURL}/api/:path*`,
       });
     }
 
-    return rewrites;
+    return {
+      beforeFiles,
+      afterFiles: [],
+      fallback,
+    };
   },
 };
 

--- a/frontend/src/app/api/langgraph/_lib/stream-proxy.ts
+++ b/frontend/src/app/api/langgraph/_lib/stream-proxy.ts
@@ -1,0 +1,100 @@
+import { type NextRequest } from "next/server";
+
+import {
+  hasConfiguredEnvValue,
+  resolveInternalGatewayUrl,
+} from "@/core/gateway-url.js";
+
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+function getConnectionHeaderNames(headers: Headers) {
+  return (
+    headers
+      .get("connection")
+      ?.split(",")
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean) ?? []
+  );
+}
+
+function deleteHopByHopHeaders(
+  headers: Headers,
+  additionalNames: string[] = [],
+) {
+  for (const name of [...HOP_BY_HOP_HEADERS, ...additionalNames]) {
+    headers.delete(name);
+  }
+}
+
+function buildGatewayUrl(path: string[], search: string) {
+  const pathname = ["api", ...path.map(encodeURIComponent)].join("/");
+  return `${resolveInternalGatewayUrl()}/${pathname}${search}`;
+}
+
+function buildHeaders(request: NextRequest) {
+  const headers = new Headers(request.headers);
+  deleteHopByHopHeaders(headers, getConnectionHeaderNames(headers));
+  for (const name of ["host", "content-length"]) {
+    headers.delete(name);
+  }
+  headers.set("accept-encoding", "identity");
+  return headers;
+}
+
+export async function proxyLangGraphStream(
+  request: NextRequest,
+  path: string[],
+) {
+  if (hasConfiguredEnvValue(process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL)) {
+    return new Response(null, { status: 404 });
+  }
+
+  const target = buildGatewayUrl(path, request.nextUrl.search);
+  const method = request.method.toUpperCase();
+  const hasBody = !["GET", "HEAD", "OPTIONS"].includes(method);
+  const init: RequestInit & { duplex?: "half" } = {
+    method,
+    headers: buildHeaders(request),
+    redirect: "manual",
+    cache: "no-store",
+    signal: request.signal,
+  };
+
+  if (hasBody) {
+    init.body = request.body;
+    init.duplex = "half";
+  }
+
+  let upstream;
+  try {
+    upstream = await fetch(target, init);
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Gateway connection failed" }),
+      {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+
+  const headers = new Headers(upstream.headers);
+  deleteHopByHopHeaders(headers, getConnectionHeaderNames(headers));
+  headers.delete("content-length");
+  headers.set("X-Accel-Buffering", "no");
+
+  return new Response(upstream.body, {
+    status: upstream.status,
+    statusText: upstream.statusText,
+    headers,
+  });
+}

--- a/frontend/src/app/api/langgraph/runs/stream/route.ts
+++ b/frontend/src/app/api/langgraph/runs/stream/route.ts
@@ -1,0 +1,16 @@
+import { type NextRequest } from "next/server";
+
+import { proxyLangGraphStream } from "@/app/api/langgraph/_lib/stream-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+async function proxyStatelessRunStream(request: NextRequest) {
+  // Covers the LangGraph SDK's threadId == null stream endpoint.
+  return proxyLangGraphStream(request, ["runs", "stream"]);
+}
+
+export const GET = proxyStatelessRunStream;
+export const HEAD = proxyStatelessRunStream;
+export const POST = proxyStatelessRunStream;
+export const OPTIONS = proxyStatelessRunStream;

--- a/frontend/src/app/api/langgraph/threads/[threadId]/runs/[runId]/stream/route.ts
+++ b/frontend/src/app/api/langgraph/threads/[threadId]/runs/[runId]/stream/route.ts
@@ -1,0 +1,29 @@
+import { type NextRequest } from "next/server";
+
+import { proxyLangGraphStream } from "@/app/api/langgraph/_lib/stream-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params:
+    | { threadId: string; runId: string }
+    | Promise<{ threadId: string; runId: string }>;
+};
+
+async function proxyRunJoinStream(request: NextRequest, context: RouteContext) {
+  // Keep resumable/join streams on the same direct proxy path as new run streams.
+  const { threadId, runId } = await Promise.resolve(context.params);
+  return proxyLangGraphStream(request, [
+    "threads",
+    threadId,
+    "runs",
+    runId,
+    "stream",
+  ]);
+}
+
+export const GET = proxyRunJoinStream;
+export const HEAD = proxyRunJoinStream;
+export const POST = proxyRunJoinStream;
+export const OPTIONS = proxyRunJoinStream;

--- a/frontend/src/app/api/langgraph/threads/[threadId]/runs/stream/route.ts
+++ b/frontend/src/app/api/langgraph/threads/[threadId]/runs/stream/route.ts
@@ -1,0 +1,22 @@
+import { type NextRequest } from "next/server";
+
+import { proxyLangGraphStream } from "@/app/api/langgraph/_lib/stream-proxy";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: { threadId: string } | Promise<{ threadId: string }>;
+};
+
+async function proxyRunStream(request: NextRequest, context: RouteContext) {
+  // Keep run streams out of Next rewrites because the dev proxy can buffer SSE
+  // events on Windows. Returning the upstream body directly preserves streaming.
+  const { threadId } = await Promise.resolve(context.params);
+  return proxyLangGraphStream(request, ["threads", threadId, "runs", "stream"]);
+}
+
+export const GET = proxyRunStream;
+export const HEAD = proxyRunStream;
+export const POST = proxyRunStream;
+export const OPTIONS = proxyRunStream;

--- a/frontend/src/core/auth/gateway-config.ts
+++ b/frontend/src/core/auth/gateway-config.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { resolveInternalGatewayUrl } from "../gateway-url.js";
+
 const gatewayConfigSchema = z.object({
   internalGatewayUrl: z.string().url(),
   trustedOrigins: z.array(z.string()).min(1),
@@ -12,11 +14,7 @@ let _cached: GatewayConfig | null = null;
 export function getGatewayConfig(): GatewayConfig {
   if (_cached) return _cached;
 
-  const rawUrl = process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?.trim();
-  const internalGatewayUrl =
-    rawUrl && rawUrl.length > 0
-      ? rawUrl.replace(/\/+$/, "")
-      : "http://127.0.0.1:8001";
+  const internalGatewayUrl = resolveInternalGatewayUrl();
 
   const rawOrigins = process.env.DEER_FLOW_TRUSTED_ORIGINS?.trim();
   const trustedOrigins = rawOrigins

--- a/frontend/src/core/gateway-url.js
+++ b/frontend/src/core/gateway-url.js
@@ -1,0 +1,32 @@
+export const DEFAULT_INTERNAL_GATEWAY_URL = "http://127.0.0.1:8001";
+
+/**
+ * @param {string | undefined | null} value
+ * @returns {boolean}
+ */
+export function hasConfiguredEnvValue(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * @param {string} url
+ * @returns {string}
+ */
+export function normalizeGatewayUrl(url) {
+  return url.trim().replace(/\/+$/, "");
+}
+
+/**
+ * @param {{ DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?: string | undefined }} [env]
+ * @param {string} [fallbackURL]
+ * @returns {string}
+ */
+export function resolveInternalGatewayUrl(
+  env = process.env,
+  fallbackURL = DEFAULT_INTERNAL_GATEWAY_URL,
+) {
+  const configured = env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?.trim();
+  return configured && configured.length > 0
+    ? normalizeGatewayUrl(configured)
+    : normalizeGatewayUrl(fallbackURL);
+}

--- a/frontend/tests/unit/app/api/langgraph-stream-routes.test.ts
+++ b/frontend/tests/unit/app/api/langgraph-stream-routes.test.ts
@@ -1,0 +1,353 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+async function loadRunStreamRoute() {
+  vi.resetModules();
+  return await import("@/app/api/langgraph/threads/[threadId]/runs/stream/route");
+}
+
+async function loadStatelessRunStreamRoute() {
+  vi.resetModules();
+  return await import("@/app/api/langgraph/runs/stream/route");
+}
+
+async function loadJoinStreamRoute() {
+  vi.resetModules();
+  return await import("@/app/api/langgraph/threads/[threadId]/runs/[runId]/stream/route");
+}
+
+function makeRunContext(threadId: string) {
+  return {
+    params: { threadId },
+  };
+}
+
+function makeJoinContext(threadId: string, runId: string) {
+  return {
+    params: { threadId, runId },
+  };
+}
+
+describe("LangGraph stream route proxies", () => {
+  const originalGatewayBaseUrl =
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL =
+      "http://gateway.example/base/";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+    if (originalGatewayBaseUrl === undefined) {
+      delete process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+    } else {
+      process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL = originalGatewayBaseUrl;
+    }
+  });
+
+  test("proxies new run streams to the gateway stream endpoint", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const request = new NextRequest(
+      "http://localhost:3000/api/langgraph/threads/ignored/runs/stream?after=a%2Fb",
+      {
+        method: "POST",
+        body: JSON.stringify({ ok: true }),
+      },
+    );
+    await POST(request, makeRunContext("thread/a?b"));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/threads/thread%2Fa%3Fb/runs/stream?after=a%2Fb",
+      expect.objectContaining({ method: "POST", signal: request.signal }),
+    );
+  });
+
+  test("proxies stateless run streams to the gateway stream endpoint", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadStatelessRunStreamRoute();
+    const request = new NextRequest(
+      "http://localhost:3000/api/langgraph/runs/stream?after=a%2Fb",
+      {
+        method: "POST",
+        body: JSON.stringify({ ok: true }),
+      },
+    );
+    await POST(request);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/runs/stream?after=a%2Fb",
+      expect.objectContaining({ method: "POST", signal: request.signal }),
+    );
+  });
+
+  test("proxies resumable join streams to the gateway stream endpoint", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await loadJoinStreamRoute();
+    const request = new NextRequest(
+      "http://localhost:3000/api/langgraph/threads/ignored/runs/ignored/stream",
+    );
+    await GET(request, makeJoinContext("thread-id", "run/id"));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/threads/thread-id/runs/run%2Fid/stream",
+      expect.objectContaining({ method: "GET", signal: request.signal }),
+    );
+  });
+
+  test("strips proxy headers while forwarding auth headers and streamed body", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const request = new NextRequest(
+      "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+      {
+        method: "POST",
+        headers: {
+          host: "localhost:3000",
+          connection: "keep-alive, x-remove",
+          "content-length": "123",
+          "transfer-encoding": "chunked",
+          cookie: "access_token=abc",
+          "x-csrf-token": "csrf",
+          "accept-encoding": "gzip, br",
+          "x-remove": "secret",
+        },
+        body: JSON.stringify({ ok: true }),
+      },
+    );
+    const body = request.body;
+
+    await POST(request, makeRunContext("thread-id"));
+
+    const fetchCalls = fetchMock.mock.calls as unknown as [
+      string,
+      RequestInit & { duplex?: "half" },
+    ][];
+    const init = fetchCalls[0]?.[1];
+    expect(init).toBeDefined();
+    expect(init?.method).toBe("POST");
+    expect(init?.body).toBe(body);
+    expect(init?.duplex).toBe("half");
+    const headers = init?.headers as Headers;
+    expect(headers.get("host")).toBeNull();
+    expect(headers.get("connection")).toBeNull();
+    expect(headers.get("content-length")).toBeNull();
+    expect(headers.get("transfer-encoding")).toBeNull();
+    expect(headers.get("x-remove")).toBeNull();
+    expect(headers.get("cookie")).toBe("access_token=abc");
+    expect(headers.get("x-csrf-token")).toBe("csrf");
+    expect(headers.get("accept-encoding")).toBe("identity");
+  });
+
+  test("streams upstream bodies while preserving response headers", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: metadata\n\n"));
+        controller.close();
+      },
+    });
+    const fetchMock = vi.fn(
+      async () =>
+        new Response(stream, {
+          status: 201,
+          statusText: "Created",
+          headers: {
+            "cache-control": "private, no-store",
+            "content-length": "999",
+            connection: "close, x-response-remove",
+            "transfer-encoding": "chunked",
+            "x-response-remove": "secret",
+          },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    expect(response.status).toBe(201);
+    expect(response.statusText).toBe("Created");
+    expect(response.body).toBe(stream);
+    expect(response.headers.get("cache-control")).toBe("private, no-store");
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+    expect(response.headers.get("content-length")).toBeNull();
+    expect(response.headers.get("connection")).toBeNull();
+    expect(response.headers.get("transfer-encoding")).toBeNull();
+    expect(response.headers.get("x-response-remove")).toBeNull();
+  });
+
+  test("does not synthesize cache-control when upstream omits it", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    expect(response.headers.get("cache-control")).toBeNull();
+  });
+
+  test("forwards OPTIONS requests without a body", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { OPTIONS } = await loadRunStreamRoute();
+    const request = new NextRequest(
+      "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+      {
+        method: "OPTIONS",
+        headers: {
+          origin: "http://localhost:3000",
+          "access-control-request-method": "POST",
+        },
+      },
+    );
+    const response = await OPTIONS(request, makeRunContext("thread-id"));
+
+    const fetchCalls = fetchMock.mock.calls as unknown as [
+      string,
+      RequestInit & { duplex?: "half" },
+    ][];
+    const init = fetchCalls[0]?.[1];
+    const headers = init?.headers as Headers;
+
+    expect(response.status).toBe(204);
+    expect(init?.method).toBe("OPTIONS");
+    expect(init?.body).toBeUndefined();
+    expect(init?.duplex).toBeUndefined();
+    expect(headers.get("origin")).toBe("http://localhost:3000");
+    expect(headers.get("access-control-request-method")).toBe("POST");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/threads/thread-id/runs/stream",
+      expect.objectContaining({ method: "OPTIONS" }),
+    );
+  });
+
+  test("forwards HEAD requests without a body", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { HEAD } = await loadRunStreamRoute();
+    const response = await HEAD(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "HEAD",
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    const fetchCalls = fetchMock.mock.calls as unknown as [
+      string,
+      RequestInit & { duplex?: "half" },
+    ][];
+    const init = fetchCalls[0]?.[1];
+    expect(response.status).toBe(204);
+    expect(init?.method).toBe("HEAD");
+    expect(init?.body).toBeUndefined();
+    expect(init?.duplex).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/threads/thread-id/runs/stream",
+      expect.objectContaining({ method: "HEAD" }),
+    );
+  });
+
+  test("does not expose same-origin stream routes when external LangGraph URL is configured", async () => {
+    process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL = "https://langgraph.example";
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("treats blank external LangGraph URL as unconfigured", async () => {
+    process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL = "   ";
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await loadRunStreamRoute();
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://gateway.example/base/api/threads/thread-id/runs/stream",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  test("returns 502 when the gateway is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("connection refused");
+      }),
+    );
+
+    const { POST } = await loadRunStreamRoute();
+    const response = await POST(
+      new NextRequest(
+        "http://localhost:3000/api/langgraph/threads/thread-id/runs/stream",
+        {
+          method: "POST",
+          body: JSON.stringify({ ok: true }),
+        },
+      ),
+      makeRunContext("thread-id"),
+    );
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error).toBe("Gateway connection failed");
+  });
+});

--- a/frontend/tests/unit/core/gateway-url.test.ts
+++ b/frontend/tests/unit/core/gateway-url.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  hasConfiguredEnvValue,
+  resolveInternalGatewayUrl,
+} from "@/core/gateway-url.js";
+
+describe("gateway URL helpers", () => {
+  test("normalizes configured gateway and fallback URLs", () => {
+    expect(
+      resolveInternalGatewayUrl(
+        { DEER_FLOW_INTERNAL_GATEWAY_BASE_URL: " http://gateway/base/// " },
+        "http://fallback///",
+      ),
+    ).toBe("http://gateway/base");
+
+    expect(resolveInternalGatewayUrl({}, "http://fallback///")).toBe(
+      "http://fallback",
+    );
+  });
+
+  test("treats empty and whitespace env values as unconfigured", () => {
+    expect(hasConfiguredEnvValue(undefined)).toBe(false);
+    expect(hasConfiguredEnvValue("")).toBe(false);
+    expect(hasConfiguredEnvValue("  \t ")).toBe(false);
+    expect(hasConfiguredEnvValue("http://gateway")).toBe(true);
+  });
+});

--- a/frontend/tests/unit/next-config.test.ts
+++ b/frontend/tests/unit/next-config.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+async function loadConfig() {
+  vi.resetModules();
+  return (await import("../../next.config.js")).default;
+}
+
+type Rewrite = {
+  source: string;
+  destination: string;
+};
+
+type RewriteGroups = {
+  beforeFiles: Rewrite[];
+  afterFiles: Rewrite[];
+  fallback: Rewrite[];
+};
+
+async function loadRewrites() {
+  const config = await loadConfig();
+  expect(config.rewrites).toBeDefined();
+  const rewrites = (await config.rewrites?.()) as RewriteGroups;
+  expect(Array.isArray(rewrites)).toBe(false);
+  return rewrites;
+}
+
+describe("next config rewrites", () => {
+  const originalBackendBaseUrl = process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+  const originalGatewayBaseUrl =
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+  const originalLangGraphBaseUrl = process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+
+  afterEach(() => {
+    if (originalBackendBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_BACKEND_BASE_URL = originalBackendBaseUrl;
+    }
+    if (originalGatewayBaseUrl === undefined) {
+      delete process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+    } else {
+      process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL = originalGatewayBaseUrl;
+    }
+    if (originalLangGraphBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL = originalLangGraphBaseUrl;
+    }
+  });
+
+  test("keeps gateway catch-all as fallback so app routes can win first", async () => {
+    delete process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+    delete process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL =
+      "http://gateway.example/base/";
+
+    const rewrites = await loadRewrites();
+
+    expect(rewrites.afterFiles).toEqual([]);
+    expect(rewrites.beforeFiles).toContainEqual({
+      source: "/api/agents",
+      destination: "http://gateway.example/base/api/agents",
+    });
+    expect(rewrites.beforeFiles).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "/api/langgraph/:path*" }),
+      ]),
+    );
+    expect(rewrites.fallback).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/api/langgraph",
+          destination: "http://gateway.example/base/api",
+        },
+        {
+          source: "/api/langgraph/:path*",
+          destination: "http://gateway.example/base/api/:path*",
+        },
+      ]),
+    );
+    expect(rewrites.fallback).toContainEqual({
+      source: "/api/:path*",
+      destination: "http://gateway.example/base/api/:path*",
+    });
+  });
+
+  test("preserves fallback coverage for gateway routes not explicitly listed", async () => {
+    delete process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+    delete process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+    delete process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL;
+
+    const rewrites = await loadRewrites();
+
+    expect(rewrites.fallback).toContainEqual(
+      expect.objectContaining({
+        source: "/api/:path*",
+        destination: "http://127.0.0.1:8001/api/:path*",
+      }),
+    );
+  });
+
+  test("does not add LangGraph fallback rewrites when external LangGraph URL is configured", async () => {
+    delete process.env.NEXT_PUBLIC_BACKEND_BASE_URL;
+    delete process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL;
+    process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL = "https://langgraph.example";
+
+    const rewrites = await loadRewrites();
+
+    expect(rewrites.fallback).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "/api/langgraph/:path*" }),
+      ]),
+    );
+    expect(rewrites.fallback).toContainEqual({
+      source: "/api/:path*",
+      destination: "http://127.0.0.1:8001/api/:path*",
+    });
+  });
+
+  test("treats blank public backend and LangGraph URLs as unconfigured", async () => {
+    process.env.NEXT_PUBLIC_BACKEND_BASE_URL = "  ";
+    process.env.NEXT_PUBLIC_LANGGRAPH_BASE_URL = "\t";
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL =
+      "http://gateway.example/base/";
+
+    const rewrites = await loadRewrites();
+
+    expect(rewrites.beforeFiles).toContainEqual({
+      source: "/api/agents",
+      destination: "http://gateway.example/base/api/agents",
+    });
+    expect(rewrites.fallback).toEqual(
+      expect.arrayContaining([
+        {
+          source: "/api/langgraph/:path*",
+          destination: "http://gateway.example/base/api/:path*",
+        },
+        {
+          source: "/api/:path*",
+          destination: "http://gateway.example/base/api/:path*",
+        },
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## 问题原因

Windows 本地开发环境中，LangGraph SSE 通过 Next rewrites 转发到 gateway 时会被前端代理路径缓冲，浏览器端不能稳定增量收到事件；普通 rewrite 代理也不适合直接承载长连接 stream。

## 修改内容

- 为 LangGraph SSE stream endpoint 增加专用 App Router Route Handler，直接透传 upstream response body，避免中间层缓冲。
- 将 LangGraph stream 相关 rewrite 放到 fallback，让新增的 App Router stream route 优先生效。
- 仅接管 stream 路径，普通 `/api/langgraph/*` 继续走 gateway fallback rewrite，降低非流式 API 副作用。
- 规范 stream 代理请求和响应 header 处理，剥离 hop-by-hop header，并保留必要的流式行为。

## 关联 issue

fix https://github.com/bytedance/deer-flow/issues/2785

related https://github.com/bytedance/deer-flow/issues/2995

---

## Problem Cause

In the local Windows development environment, LangGraph SSE requests proxied to the gateway through Next rewrites were buffered by the frontend proxy path, so the browser could not reliably receive events incrementally. A normal rewrite proxy is also a poor fit for carrying a long-lived stream connection directly.

## Changes

- Added a dedicated App Router Route Handler for the LangGraph SSE stream endpoint, passing through the upstream response body directly to avoid intermediate buffering.
- Moved the LangGraph stream-related rewrites to fallback so the new App Router stream route can take precedence.
- Took over only the stream path, while ordinary `/api/langgraph/*` requests continue using the gateway fallback rewrite to reduce side effects on non-streaming APIs.
- Normalized stream proxy request and response header handling, stripped hop-by-hop headers, and preserved required streaming behavior.

## Related Issue

Fixes https://github.com/bytedance/deer-flow/issues/2785