### PR TITLE
feat(debug): print presented file paths with physical resolution

### DIFF
--- a/backend/debug.py
+++ b/backend/debug.py
@@ -79,7 +79,9 @@ async def main():
     from langgraph.runtime import Runtime
 
     from deerflow.agents import make_lead_agent
+    from deerflow.config.paths import get_paths
     from deerflow.mcp import initialize_mcp_tools
+    from deerflow.runtime.user_context import get_effective_user_id
 
     # Initialize MCP tools at startup
     try:
@@ -113,6 +115,8 @@ async def main():
         print("Tip: `uv sync --group dev` to enable arrow-key & history support")
     print("=" * 50)
 
+    seen_artifacts: set[str] = set()
+
     while True:
         try:
             if session:
@@ -133,6 +137,22 @@ async def main():
             if result.get("messages"):
                 last_message = result["messages"][-1]
                 print(f"\nAgent: {last_message.content}")
+
+            # Show files presented to the user this turn (new artifacts only)
+            artifacts = result.get("artifacts") or []
+            new_artifacts = [p for p in artifacts if p not in seen_artifacts]
+            if new_artifacts:
+                thread_id = config["configurable"]["thread_id"]
+                user_id = get_effective_user_id()
+                paths = get_paths()
+                print("\n[Presented files]")
+                for virtual in new_artifacts:
+                    try:
+                        physical = paths.resolve_virtual_path(thread_id, virtual, user_id=user_id)
+                        print(f"  - {virtual}\n    → {physical}")
+                    except ValueError as exc:
+                        print(f"  - {virtual}    (failed to resolve physical path: {exc})")
+                seen_artifacts.update(new_artifacts)
 
         except (KeyboardInterrupt, EOFError):
             print("\nGoodbye!")


### PR DESCRIPTION
## Summary

Surface artifacts produced via the `present_files` tool in the CLI
debug REPL (`backend/debug.py`) so headless clients without a frontend
can locate output files. Each turn prints newly added artifacts plus
their resolved host filesystem path.

## Changes

- `backend/debug.py:82-84` — import `get_paths` and `get_effective_user_id` for virtual-to-physical path resolution.
- `backend/debug.py:118` — track session-level `seen_artifacts` so repeats are not re-printed.
- `backend/debug.py:141-155` — after each `agent.ainvoke`, diff `result["artifacts"]` against `seen_artifacts`, print each new virtual path together with its resolved host path; on `ValueError` from `resolve_virtual_path` (bad prefix / path traversal), fall back to printing the virtual path with the error message.

## Motivation

`debug.py` only prints the last `AIMessage.content`, which means files
delivered via the `present_files` tool — stored in `state["artifacts"]`
and rendered as cards in the web UI — are invisible to anyone running
the agent through the VS Code `Debug Lead Agent` launch config or other
headless entry points.

The fix is source-agnostic: any file that flows through `present_files`
is shown, whether it originates from an ACP agent, a subagent, or a
direct sandbox write by the lead agent. The resolved host path is
`Cmd+Click`-able in VS Code's integrated terminal, so the file can be
opened directly without leaving the debugger.

Path normalization happens in `present_file_tool._normalize_presented_filepath`,
so this change inherits the same `/mnt/user-data/outputs/` contract as
the frontend's artifact list.