### PR TITLE
fix(runs): use persistent RunStore in list_runs to survive restarts

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -178,10 +178,27 @@ async def wait_run(thread_id: str, body: RunCreateRequest, request: Request) -> 
 @router.get("/{thread_id}/runs", response_model=list[RunResponse])
 @require_permission("runs", "read", owner_check=True)
 async def list_runs(thread_id: str, request: Request) -> list[RunResponse]:
-    """List all runs for a thread."""
-    run_mgr = get_run_manager(request)
-    records = await run_mgr.list_by_thread(thread_id)
-    return [_record_to_response(r) for r in records]
+    """List all runs for a thread.
+
+    Queries the persistent RunStore so that run history survives process
+    restarts (RunManager only tracks in-memory runs for the current session).
+    """
+    run_store = get_run_store(request)
+    records = await run_store.list_by_thread(thread_id)
+    return [
+        RunResponse(
+            run_id=r["run_id"],
+            thread_id=r.get("thread_id", thread_id),
+            assistant_id=r.get("assistant_id"),
+            status=r.get("status", ""),
+            metadata=r.get("metadata", {}),
+            kwargs=r.get("kwargs", {}),
+            multitask_strategy=r.get("multitask_strategy", "reject"),
+            created_at=r.get("created_at", ""),
+            updated_at=r.get("updated_at", ""),
+        )
+        for r in records
+    ]
 
 
 @router.get("/{thread_id}/runs/{run_id}", response_model=RunResponse)

--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -73,11 +73,6 @@ def _last_injected_date(messages: list) -> str | None:
     return None
 
 
-def is_dynamic_context_reminder(message: object) -> bool:
-    """Return whether *message* is a hidden dynamic-context reminder."""
-    return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_DYNAMIC_CONTEXT_REMINDER_KEY))
-
-
 def _is_user_injection_target(message: object) -> bool:
     """Return whether *message* can receive a dynamic-context reminder."""
     return isinstance(message, HumanMessage) and not is_dynamic_context_reminder(message) and message.name != _SUMMARY_MESSAGE_NAME


### PR DESCRIPTION
## Summary

- `GET /threads/{id}/runs` was backed by `RunManager.list_by_thread()`, which only reads its in-memory `_runs` dict
- After any process restart, the in-memory dict is empty → endpoint returns `[]`
- Frontend `useThreadRuns` received an empty list → `useThreadHistory` had no run IDs to query → summarized conversation history became invisible
- Fix: switch `list_runs` to query `RunStore.list_by_thread()` directly, which is the persistent (SQLite/Postgres) source already kept in sync on every run creation and status change

## Test plan

- [ ] Start the backend, create a conversation with multiple exchanges
- [ ] Restart the backend
- [ ] Navigate to the conversation — all historical messages should still be visible
- [ ] Verify that summarized (long) conversations also restore fully after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)