### PR TITLE
fix(lint): remove duplicate is_dynamic_context_reminder definition

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -73,11 +73,6 @@ def _last_injected_date(messages: list) -> str | None:
     return None
 
 
-def is_dynamic_context_reminder(message: object) -> bool:
-    """Return whether *message* is a hidden dynamic-context reminder."""
-    return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_DYNAMIC_CONTEXT_REMINDER_KEY))
-
-
 def _is_user_injection_target(message: object) -> bool:
     """Return whether *message* can receive a dynamic-context reminder."""
     return isinstance(message, HumanMessage) and not is_dynamic_context_reminder(message) and message.name != _SUMMARY_MESSAGE_NAME


### PR DESCRIPTION
## Summary

- `is_dynamic_context_reminder` was defined twice in `dynamic_context_middleware.py` (lines 57 and 76), with identical signatures and bodies
- Removed the second redundant definition

## Test plan

- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)