### PR TITLE
enable token usage by default

### DIFF
--- a/backend/packages/harness/deerflow/config/token_usage_config.py
+++ b/backend/packages/harness/deerflow/config/token_usage_config.py
@@ -4,4 +4,4 @@ from pydantic import BaseModel, Field
 class TokenUsageConfig(BaseModel):
     """Configuration for token usage tracking."""
 
-    enabled: bool = Field(default=False, description="Enable token usage tracking middleware")
+    enabled: bool = Field(default=True, description="Enable token usage tracking middleware")

--- a/backend/tests/test_setup_wizard.py
+++ b/backend/tests/test_setup_wizard.py
@@ -313,7 +313,7 @@ class TestWriteConfigYaml:
                 {
                     "config_version": 5,
                     "log_level": "info",
-                    "token_usage": {"enabled": False},
+                    "token_usage": {"enabled": True},
                     "tool_groups": [{"name": "web"}, {"name": "file:read"}, {"name": "file:write"}, {"name": "bash"}],
                     "tools": [
                         {
@@ -361,7 +361,7 @@ class TestWriteConfigYaml:
             data = yaml.safe_load(f)
 
         assert data["log_level"] == "info"
-        assert data["token_usage"]["enabled"] is False
+        assert data["token_usage"]["enabled"] is True
         assert data["tool_groups"][0]["name"] == "web"
         assert data["summarization"]["max_tokens"] == 2048
         assert any(tool["name"] == "image_search" and tool["max_results"] == 5 for tool in data["tools"])

--- a/backend/tests/test_token_usage_config.py
+++ b/backend/tests/test_token_usage_config.py
@@ -1,0 +1,5 @@
+from deerflow.config.token_usage_config import TokenUsageConfig
+
+
+def test_token_usage_enabled_by_default():
+    assert TokenUsageConfig().enabled is True

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -30,7 +30,7 @@ log_level: info
 # When enabled, DeerFlow records input/output/total tokens per model call
 # and shows usage metadata in the workspace UI when providers return it.
 token_usage:
-  enabled: false
+  enabled: true
 
 # ============================================================================
 # Models Configuration

--- a/frontend/src/content/en/harness/middlewares.mdx
+++ b/frontend/src/content/en/harness/middlewares.mdx
@@ -110,7 +110,7 @@ Tracks LLM token consumption per model call and logs it at the `info` level. Use
 
 ```yaml
 token_usage:
-  enabled: false
+  enabled: true
 ```
 
 ---

--- a/frontend/src/content/zh/harness/middlewares.mdx
+++ b/frontend/src/content/zh/harness/middlewares.mdx
@@ -110,7 +110,7 @@ title:
 
 ```yaml
 token_usage:
-  enabled: false
+  enabled: true
 ```
 
 ---

--- a/frontend/tests/unit/core/settings/local.test.ts
+++ b/frontend/tests/unit/core/settings/local.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "vitest";
+
+import { DEFAULT_LOCAL_SETTINGS } from "@/core/settings/local";
+
+test("defaults token usage to header total plus per-turn breakdown", () => {
+  expect(DEFAULT_LOCAL_SETTINGS.tokenUsage).toEqual({
+    headerTotal: true,
+    inlineMode: "per_turn",
+  });
+});


### PR DESCRIPTION
## Summary

- enable token usage by default in the runtime config
- update `config.example.yaml` to match the new default
- keep the default UI behavior as header total + per-turn usage
- update related docs and setup wizard expectations
- add tests covering the backend default and frontend default display mode

## Why

Issue #2827 asks for token usage to be visible by default.

Before this change, the frontend already defaulted to showing token usage in the header and per turn, but fresh instances still had token usage disabled on the backend by default. That meant the UI default could not actually take effect unless users manually enabled the feature.

This change aligns the backend default, sample config, generated config expectations, and docs so token usage works out of the box.

## Validation

- `uv run --group dev pytest tests/test_token_usage_config.py tests/test_setup_wizard.py`
- `npx pnpm --dir frontend exec vitest run tests/unit/core/settings/local.test.ts`
- `npx pnpm --dir frontend exec vitest run tests/unit/core/messages/usage-model.test.ts`

## Related

- #2827
