### PR TITLE
fix(tools): make write_file append discoverable in model-facing schema

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -243,7 +243,7 @@ Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → 
 - `bash` - Execute commands with path translation and error handling
 - `ls` - Directory listing (tree format, max 2 levels)
 - `read_file` - Read file contents with optional line range
-- `write_file` - Write/append to files, creates directories
+- `write_file` - Write/append to files, creates directories; overwrites by default and exposes the `append` argument in the model-facing schema for end-of-file writes
 - `str_replace` - Substring replacement (single or all occurrences); same-path serialization is scoped to `(sandbox.id, path)` so isolated sandboxes do not contend on identical virtual paths inside one process
 
 ### Subagent System (`packages/harness/deerflow/subagents/`)

--- a/backend/README.md
+++ b/backend/README.md
@@ -79,7 +79,7 @@ Per-thread isolated execution with virtual path translation:
 - **Skills path**: `/mnt/skills` → `deer-flow/skills/` directory
 - **Skills loading**: Recursively discovers nested `SKILL.md` files under `skills/{public,custom}` and preserves nested container paths
 - **File-write safety**: `str_replace` serializes read-modify-write per `(sandbox.id, path)` so isolated sandboxes keep concurrency even when virtual paths match
-- **Tools**: `bash`, `ls`, `read_file`, `write_file`, `str_replace` (`bash` is disabled by default when using `LocalSandboxProvider`; use `AioSandboxProvider` for isolated shell access)
+- **Tools**: `bash`, `ls`, `read_file`, `write_file`, `str_replace` (`write_file` overwrites by default and exposes `append` for end-of-file writes; `bash` is disabled by default when using `LocalSandboxProvider`; use `AioSandboxProvider` for isolated shell access)
 
 ### Subagent System
 

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1499,12 +1499,13 @@ def write_file_tool(
     content: str,
     append: bool = False,
 ) -> str:
-    """Write text content to a file.
+    """Write text content to a file. By default this overwrites the target file; set append to true to add content to the end without replacing existing content.
 
     Args:
         description: Explain why you are writing to this file in short words. ALWAYS PROVIDE THIS PARAMETER FIRST.
         path: The **absolute** path to the file to write to. ALWAYS PROVIDE THIS PARAMETER SECOND.
         content: The content to write to the file. ALWAYS PROVIDE THIS PARAMETER THIRD.
+        append: Whether to append content to the end of the file instead of overwriting it. Defaults to false.
     """
     try:
         sandbox = ensure_sandbox_initialized(runtime)

--- a/backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py
@@ -20,7 +20,7 @@ def _get_runtime_user_id(runtime: Runtime) -> str:
     return get_effective_user_id()
 
 
-@tool
+@tool(parse_docstring=True)
 def setup_agent(
     soul: str,
     description: str,

--- a/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
@@ -67,7 +67,7 @@ def _cleanup_temps(temps: list[Path]) -> None:
             logger.debug("Failed to clean up temp file %s", tmp, exc_info=True)
 
 
-@tool
+@tool(parse_docstring=True)
 def update_agent(
     runtime: Runtime,
     soul: str | None = None,

--- a/backend/tests/test_tool_args_schema_no_pydantic_warning.py
+++ b/backend/tests/test_tool_args_schema_no_pydantic_warning.py
@@ -104,12 +104,5 @@ def test_write_file_append_is_discoverable_in_tool_schema() -> None:
 @pytest.mark.parametrize("tool_obj", [case[0] for case in _TOOL_CASES], ids=[case[0].name for case in _TOOL_CASES])
 def test_model_facing_tool_parameters_have_descriptions(tool_obj) -> None:
     """Every model-facing tool parameter should explain when and how to use it."""
-    missing_descriptions = [
-        field_name
-        for field_name, field in tool_obj.tool_call_schema.model_fields.items()
-        if not field.description
-    ]
-    assert missing_descriptions == [], (
-        f"{tool_obj.name} has model-facing parameters without descriptions: {missing_descriptions}. "
-        "Add an Args: section to the tool's docstring and ensure @tool(parse_docstring=True) is set."
-    )
+    missing_descriptions = [field_name for field_name, field in tool_obj.tool_call_schema.model_fields.items() if not field.description]
+    assert missing_descriptions == [], f"{tool_obj.name} has model-facing parameters without descriptions: {missing_descriptions}. Add an Args: section to the tool's docstring and ensure @tool(parse_docstring=True) is set."

--- a/backend/tests/test_tool_args_schema_no_pydantic_warning.py
+++ b/backend/tests/test_tool_args_schema_no_pydantic_warning.py
@@ -89,3 +89,27 @@ def test_tool_args_schema_does_not_emit_pydantic_context_warning(tool_obj, extra
 
     pydantic_warnings = [w for w in caught if "PydanticSerializationUnexpectedValue" in str(w.message)]
     assert not pydantic_warnings, f"{tool_obj.name} args_schema.model_dump() emitted Pydantic context serialization warnings: {[str(w.message) for w in pydantic_warnings]}"
+
+
+def test_write_file_append_is_discoverable_in_tool_schema() -> None:
+    """``append`` must be visible and described in the model-facing tool schema."""
+    assert "append" in write_file_tool.description
+
+    append_field = write_file_tool.tool_call_schema.model_fields["append"]
+    assert append_field.default is False
+    assert append_field.description
+    assert "append" in append_field.description
+
+
+@pytest.mark.parametrize("tool_obj", [case[0] for case in _TOOL_CASES], ids=[case[0].name for case in _TOOL_CASES])
+def test_model_facing_tool_parameters_have_descriptions(tool_obj) -> None:
+    """Every model-facing tool parameter should explain when and how to use it."""
+    missing_descriptions = [
+        field_name
+        for field_name, field in tool_obj.tool_call_schema.model_fields.items()
+        if not field.description
+    ]
+    assert missing_descriptions == [], (
+        f"{tool_obj.name} has model-facing parameters without descriptions: {missing_descriptions}. "
+        "Add an Args: section to the tool's docstring and ensure @tool(parse_docstring=True) is set."
+    )


### PR DESCRIPTION
## Summary

Closes #2831.

The `write_file` sandbox tool already supported `append=False` (default) with `append=True` for end-of-file writes, but the parsed docstring omitted the `append` argument from the model-facing schema. The LLM never saw it as a callable parameter, so segmented writes to long files always overwrote the previous segment.

This is a discoverability fix only — **no runtime file-writing behavior changes**.

## What changed

**Targeted fix (`write_file`)**
- `backend/packages/harness/deerflow/sandbox/tools.py` — `write_file_tool` docstring now describes the overwrite default and the append path; the new `append:` line in the `Args:` section gets parsed into the schema field's description.
- `backend/CLAUDE.md` and `backend/README.md` — sandbox tool list updated to match.

**Class-of-bug regression (prevents this for any future tool)**
- `backend/tests/test_tool_args_schema_no_pydantic_warning.py` adds two tests:
  - `test_write_file_append_is_discoverable_in_tool_schema` — asserts the property (`"append"` mentioned in description, field has a non-empty description, default is `False`) rather than exact phrasing, so future copyedits won't break it.
  - `test_model_facing_tool_parameters_have_descriptions` — parametrized over the existing `_TOOL_CASES` matrix; walks every tool's `tool_call_schema` and asserts every parameter has a non-empty description. Failure message names the tool, the missing parameter(s), and the fix recipe.

**Found and fixed by the new generic test**
- `backend/packages/harness/deerflow/tools/builtins/setup_agent_tool.py` and `.../update_agent_tool.py` — flipped `@tool` → `@tool(parse_docstring=True)`. Both already had complete `Args:` docstrings; the flag just lets langchain parse them into per-field schema descriptions instead of silently discarding them. No change to either tool's behavior or its surface area.

## Test plan

```bash
cd backend && uv run pytest \
  tests/test_setup_agent_tool.py \
  tests/test_update_agent_tool.py \
  tests/test_tool_args_schema_no_pydantic_warning.py \
  tests/test_sandbox_tools_security.py::test_str_replace_and_append_on_same_path_should_preserve_both_updates \
  -q
```

50 passed locally. `ruff check` clean on touched files.

## Why this matters

Per #2831 (Chinese): when an LLM writes a long file in segments, it never knows about `append`, so each `write_file` call truncates the previous segment. Surfacing `append` in the model-facing schema is the minimal fix that addresses the actual root cause (model lacks the option), and the class-of-bug regression test ensures the next undocumented parameter trips CI instead of an end user.
