### PR TITLE
docs: add benchmark recursion reproducibility kit

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -565,6 +565,7 @@ See `docs/` directory for detailed documentation:
 - [CONFIGURATION.md](docs/CONFIGURATION.md) - Configuration options
 - [ARCHITECTURE.md](docs/ARCHITECTURE.md) - Architecture details
 - [API.md](docs/API.md) - API reference
+- [BENCHMARKS.md](docs/BENCHMARKS.md) - Recursion-limit profiles and reproducibility guidance for long-horizon evaluations
 - [SETUP.md](docs/SETUP.md) - Setup guide
 - [FILE_UPLOAD.md](docs/FILE_UPLOAD.md) - File upload feature
 - [PATH_EXAMPLES.md](docs/PATH_EXAMPLES.md) - Path types and usage

--- a/backend/README.md
+++ b/backend/README.md
@@ -404,6 +404,7 @@ uv run pytest
 - [Configuration Guide](docs/CONFIGURATION.md)
 - [Architecture Details](docs/ARCHITECTURE.md)
 - [API Reference](docs/API.md)
+- [Benchmark Recursion Profiles](docs/BENCHMARKS.md)
 - [File Upload](docs/FILE_UPLOAD.md)
 - [Path Examples](docs/PATH_EXAMPLES.md)
 - [Context Summarization](docs/summarization.md)

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -110,6 +110,9 @@ starting point for plan-mode or subagent-heavy runs. Clients can still set
 `recursion_limit` explicitly in the request body; increase it if you run deeply
 nested subagent graphs.
 
+For benchmark runs, see [Benchmark Recursion Profiles](BENCHMARKS.md) for
+GAIA, SWE-bench Lite, and generic long-horizon profile recommendations.
+
 **Configurable Options:**
 - `model_name` (string): Override the default model
 - `thinking_enabled` (boolean): Enable extended thinking for supported models
@@ -646,4 +649,6 @@ curl -X POST http://localhost:2026/api/langgraph/threads/abc123/runs \
 > The unified Gateway path defaults `config.recursion_limit` to 100 for
 > plan-mode and subagent-heavy runs. Clients may still set
 > `config.recursion_limit` explicitly — see the [Create Run](#create-run)
-> section for details.
+> section for details and
+> [Benchmark Recursion Profiles](BENCHMARKS.md) for long-horizon evaluation
+> profiles.

--- a/backend/docs/BENCHMARKS.md
+++ b/backend/docs/BENCHMARKS.md
@@ -1,0 +1,121 @@
+# Benchmark Recursion Profiles
+
+This guide records reproducible run-config defaults for long-horizon DeerFlow evaluations. It is based on the discussion in [issue #2820](https://github.com/bytedance/deer-flow/issues/2820), where SWE-bench Lite and GAIA runs often exhausted the graph step budget before the agent reached a final patch or answer.
+
+## Why Recursion Limits Matter
+
+LangGraph's native `recursion_limit` default is 25. DeerFlow's Gateway and IM-channel paths raise that to 100, but direct `/api/langgraph/*` clients and external benchmark harnesses must set the limit explicitly.
+
+For repository-repair benchmarks, a run can spend many graph steps on legitimate exploration before writing a patch:
+
+1. Read the issue.
+2. Inspect the repository layout.
+3. Read related files.
+4. Locate the implementation and tests.
+5. Write a fix.
+6. Run tests.
+7. Debug and iterate.
+
+The issue #2820 traces indicate that SWE-bench tasks can spend 50-80 steps on exploration alone. A limit of 150 can therefore still terminate useful runs before the model starts the fix.
+
+## Recommended Profiles
+
+| Profile | Recursion limit | Use case |
+| --- | ---: | --- |
+| `gaia` | 150 | GAIA-style multi-step tool-use tasks. |
+| `swebench-lite` | 250 | SWE-bench Lite repository-repair tasks. |
+| `long-horizon` | 250 | Generic long-horizon DeerFlow evaluations. |
+
+These values are starting points, not correctness guarantees. Larger repositories, slower tool-use strategies, or subagent-heavy runs may need more headroom. Raising the limit only removes an artificial stop condition; it does not fix pathological loops.
+
+## Generate A Run Config
+
+Use `scripts/benchmark_run_config.py` to generate the `config` object for a benchmark harness or direct LangGraph API request:
+
+```bash
+python scripts/benchmark_run_config.py --profile swebench-lite
+```
+
+Output:
+
+```json
+{
+  "recursion_limit": 250
+}
+```
+
+Add model and mode overrides when a benchmark run needs them:
+
+```bash
+python scripts/benchmark_run_config.py \
+  --profile swebench-lite \
+  --model-name k2.6 \
+  --thinking-enabled \
+  --plan-mode \
+  --subagent-enabled
+```
+
+Output:
+
+```json
+{
+  "configurable": {
+    "is_plan_mode": true,
+    "model_name": "k2.6",
+    "subagent_enabled": true,
+    "thinking_enabled": true
+  },
+  "recursion_limit": 250
+}
+```
+
+Override the profile limit only when the benchmark matrix explicitly records the override:
+
+```bash
+python scripts/benchmark_run_config.py --profile swebench-lite --recursion-limit 300
+```
+
+## Direct API Example
+
+For direct `/api/langgraph/*` calls, put the generated JSON under the request body's `config` key:
+
+```bash
+curl -X POST http://localhost:2026/api/langgraph/threads/<thread_id>/runs \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": {
+      "messages": [
+        {"role": "user", "content": "<benchmark task prompt>"}
+      ]
+    },
+    "config": {
+      "recursion_limit": 250,
+      "configurable": {
+        "model_name": "k2.6",
+        "thinking_enabled": true
+      }
+    },
+    "stream_mode": ["values", "messages-tuple", "custom"]
+  }'
+```
+
+## Reproducibility Checklist
+
+Record these fields for every benchmark run:
+
+- DeerFlow commit SHA.
+- Benchmark name and dataset split.
+- Model provider and model name.
+- Generated profile name and full run config JSON.
+- Sandbox provider and host resources.
+- Whether plan mode and subagents were enabled.
+- Loop-detection configuration.
+- Failure classification, especially recursion-limit stops, loop-detection stops, empty patches, and network/tool failures.
+
+This metadata makes it possible to distinguish an underpowered recursion limit from model/tool-use behavior or loop-detection behavior.
+
+## Relationship To Loop Detection
+
+Issue #2820 also links benchmark quality to loop-detection work in #2517 and related issues. The benchmark profiles in this document do not change loop-detection thresholds or behavior. Use them to remove obvious recursion-limit noise first, then analyze remaining failures separately.
+
+If raising the recursion limit mostly converts `GraphRecursionError` failures into repeated scaffold files, repeated search scripts, or empty patches, treat that as loop/tool-use evidence rather than a reason to keep increasing the limit.

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -16,6 +16,7 @@ This directory contains detailed documentation for the DeerFlow backend.
 | Document | Description |
 |----------|-------------|
 | [STREAMING.md](STREAMING.md) | Token-level streaming design: Gateway vs DeerFlowClient paths, `stream_mode` semantics, per-id dedup |
+| [BENCHMARKS.md](BENCHMARKS.md) | Recursion-limit profiles and reproducibility guidance for long-horizon evaluations |
 | [FILE_UPLOAD.md](FILE_UPLOAD.md) | File upload functionality |
 | [PATH_EXAMPLES.md](PATH_EXAMPLES.md) | Path types and usage examples |
 | [summarization.md](summarization.md) | Context summarization feature |
@@ -49,6 +50,7 @@ docs/
 ├── summarization.md           # Summarization feature
 ├── plan_mode_usage.md         # Plan mode feature
 ├── STREAMING.md               # Token-level streaming design
+├── BENCHMARKS.md              # Benchmark recursion profiles
 ├── AUTO_TITLE_GENERATION.md   # Title generation
 ├── TITLE_GENERATION_IMPLEMENTATION.md  # Title implementation details
 └── TODO.md                    # Roadmap and issues

--- a/backend/tests/test_benchmark_run_config.py
+++ b/backend/tests/test_benchmark_run_config.py
@@ -1,0 +1,91 @@
+"""Tests for scripts/benchmark_run_config.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "benchmark_run_config.py"
+
+
+spec = importlib.util.spec_from_file_location("deerflow_benchmark_run_config", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+benchmark_run_config = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = benchmark_run_config
+spec.loader.exec_module(benchmark_run_config)
+
+
+@pytest.mark.parametrize(
+    ("profile", "recursion_limit"),
+    [
+        ("gaia", 150),
+        ("swebench-lite", 250),
+        ("long-horizon", 250),
+    ],
+)
+def test_profile_defaults(profile: str, recursion_limit: int) -> None:
+    assert benchmark_run_config.build_config(profile) == {"recursion_limit": recursion_limit}
+
+
+def test_configurable_overrides_are_included_only_when_set() -> None:
+    config = benchmark_run_config.build_config(
+        "swebench-lite",
+        recursion_limit=300,
+        model_name="k2.6",
+        thinking_enabled=True,
+        is_plan_mode=True,
+        subagent_enabled=True,
+    )
+
+    assert config == {
+        "recursion_limit": 300,
+        "configurable": {
+            "model_name": "k2.6",
+            "thinking_enabled": True,
+            "is_plan_mode": True,
+            "subagent_enabled": True,
+        },
+    }
+
+
+def test_cli_emits_json_config(capsys) -> None:
+    result = benchmark_run_config.main(
+        [
+            "--profile",
+            "swebench-lite",
+            "--model-name",
+            "k2.6",
+            "--thinking-enabled",
+            "--indent",
+            "0",
+        ]
+    )
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out) == {
+        "recursion_limit": 250,
+        "configurable": {
+            "model_name": "k2.6",
+            "thinking_enabled": True,
+        },
+    }
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-an-int"])
+def test_recursion_limit_must_be_positive(value: str) -> None:
+    with pytest.raises(SystemExit):
+        benchmark_run_config.parse_args(["--profile", "gaia", "--recursion-limit", value])
+
+
+def test_cli_default_indent_is_pretty_printed(capsys) -> None:
+    """Default --indent (2) must produce pretty-printed JSON across multiple lines."""
+    assert benchmark_run_config.main(["--profile", "gaia"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("{\n")
+    assert '\n  "recursion_limit": 150' in out
+    assert json.loads(out) == {"recursion_limit": 150}

--- a/scripts/benchmark_run_config.py
+++ b/scripts/benchmark_run_config.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Emit reproducible LangGraph run configs for DeerFlow benchmark runs.
+
+The profiles here intentionally cover only runtime knobs that DeerFlow owns.
+They do not install or run GAIA/SWE-bench harnesses; instead they produce the
+``config`` object that those harnesses or direct ``/api/langgraph`` calls should
+send for long-horizon agent evaluations.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchmarkProfile:
+    """Benchmark-specific run configuration defaults."""
+
+    recursion_limit: int
+    description: str
+
+
+PROFILES: dict[str, BenchmarkProfile] = {
+    "gaia": BenchmarkProfile(
+        recursion_limit=150,
+        description="GAIA-style multi-step tool-use tasks; issue #2820 suggests 100-150.",
+    ),
+    "swebench-lite": BenchmarkProfile(
+        recursion_limit=250,
+        description="SWE-bench Lite repository-repair tasks; issue #2820 suggests 250+.",
+    ),
+    "long-horizon": BenchmarkProfile(
+        recursion_limit=250,
+        description="Generic long-horizon DeerFlow evaluation profile.",
+    ),
+}
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be >= 0")
+    return parsed
+
+
+def build_config(
+    profile_name: str,
+    *,
+    recursion_limit: int | None = None,
+    model_name: str | None = None,
+    thinking_enabled: bool | None = None,
+    is_plan_mode: bool | None = None,
+    subagent_enabled: bool | None = None,
+) -> dict[str, Any]:
+    """Build the LangGraph ``config`` object for a benchmark profile."""
+    profile = PROFILES[profile_name]
+    config: dict[str, Any] = {
+        "recursion_limit": recursion_limit if recursion_limit is not None else profile.recursion_limit,
+    }
+    configurable: dict[str, Any] = {}
+    if model_name is not None:
+        configurable["model_name"] = model_name
+    if thinking_enabled is not None:
+        configurable["thinking_enabled"] = thinking_enabled
+    if is_plan_mode is not None:
+        configurable["is_plan_mode"] = is_plan_mode
+    if subagent_enabled is not None:
+        configurable["subagent_enabled"] = subagent_enabled
+    if configurable:
+        config["configurable"] = configurable
+    return config
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Print a DeerFlow benchmark run config as JSON.",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=sorted(PROFILES),
+        required=True,
+        help="Benchmark profile to emit.",
+    )
+    parser.add_argument(
+        "--recursion-limit",
+        type=_positive_int,
+        help="Override the profile recursion limit.",
+    )
+    parser.add_argument("--model-name", help="Optional model_name configurable override.")
+    parser.add_argument("--thinking-enabled", action="store_true", help="Set configurable.thinking_enabled=true.")
+    parser.add_argument("--plan-mode", action="store_true", help="Set configurable.is_plan_mode=true.")
+    parser.add_argument("--subagent-enabled", action="store_true", help="Set configurable.subagent_enabled=true.")
+    parser.add_argument(
+        "--indent",
+        type=_nonnegative_int,
+        default=2,
+        help="JSON indentation level. Use 0 for compact output.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    config = build_config(
+        args.profile,
+        recursion_limit=args.recursion_limit,
+        model_name=args.model_name,
+        thinking_enabled=True if args.thinking_enabled else None,
+        is_plan_mode=True if args.plan_mode else None,
+        subagent_enabled=True if args.subagent_enabled else None,
+    )
+    indent = None if args.indent == 0 else args.indent
+    sys.stdout.write(json.dumps(config, indent=indent, sort_keys=True))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Addresses [#2820](https://github.com/bytedance/deer-flow/issues/2820) (the recursion-limit + reproducibility scope; loop-detection work is intentionally left to #2517 / #2590 / #2724).

The RFC describes how SWE-bench Lite and GAIA runs through DeerFlow often exhausted the graph step budget before the agent reached a final patch or answer, and explicitly flags this as "mostly documentation/config/test-harness work." This PR delivers exactly that:

- A small **stdlib-only** CLI helper (`scripts/benchmark_run_config.py`) that emits a reproducible LangGraph `config` object for three benchmark profiles.
- A new **`backend/docs/BENCHMARKS.md`** that explains the recursion-limit landscape (LangGraph default 25 → Gateway/channels default 100 → benchmark profiles), records reproducibility metadata to capture per run, and explicitly warns against confusing "raise the recursion limit" with "fix loop detection."

**No runtime defaults change.** Normal Gateway and channel runs keep their existing recursion behavior; only benchmark harnesses (or direct `/api/langgraph/*` callers) opt into the profiles.

## What changed

**New: `scripts/benchmark_run_config.py`** (137 lines, stdlib only)

Three frozen `BenchmarkProfile` defaults derived from the issue's recommendation table:

| Profile | Recursion limit | Source |
|---|---:|---|
| `gaia` | 150 | issue #2820 suggested 100–150 |
| `swebench-lite` | 250 | issue #2820 suggested 250+ |
| `long-horizon` | 250 | generic profile for τ-bench-style runs |

The script accepts the profile name plus optional overrides for `recursion_limit`, `model_name`, `thinking_enabled`, `is_plan_mode`, `subagent_enabled`, and `--indent`. Output is JSON with `sort_keys=True` so two runs with the same flags produce byte-identical config objects (cheap reproducibility property for diffing across benchmark runs).

```bash
$ python scripts/benchmark_run_config.py --profile swebench-lite --model-name k2.6 --thinking-enabled
{
  "configurable": {
    "model_name": "k2.6",
    "thinking_enabled": true
  },
  "recursion_limit": 250
}
```

**New: `backend/docs/BENCHMARKS.md`** (121 lines)

- Why recursion limits matter for long-horizon evaluations.
- The three profiles and when to use each.
- CLI usage examples (default profile, full overrides, hard override).
- A `curl` example wiring the generated JSON into a `/api/langgraph/threads/{id}/runs` request.
- A reproducibility checklist of what to record per benchmark run (DeerFlow SHA, dataset split, model, full config JSON, sandbox provider, loop-detection config, failure classification).
- Explicit "Relationship To Loop Detection" section: these profiles do not change loop-detection thresholds, and if raising the recursion limit just converts `GraphRecursionError` into repeated scaffold files or empty patches, treat that as loop/tool-use evidence rather than a reason to keep increasing the limit.

**Doc cross-references:** `backend/CLAUDE.md`, `backend/README.md`, `backend/docs/README.md`, and `backend/docs/API.md` (both relevant sections) link to the new doc.

**Tests** (`backend/tests/test_benchmark_run_config.py`, 9 tests):

- Profile defaults parametrized over all 3 profiles.
- Override path: every `configurable` field set, plus `recursion_limit` override.
- CLI happy path producing valid JSON.
- CLI default-indent path producing pretty-printed JSON.
- 3 invalid `--recursion-limit` cases (`0`, `-1`, `not-an-int`).

## Test plan

```bash
cd backend && uv run pytest tests/test_benchmark_run_config.py -q
cd backend && uv run ruff check ../scripts/benchmark_run_config.py tests/test_benchmark_run_config.py
```

9 passed locally. ruff clean.

## Verified factual claims

The doc cites DeerFlow defaults that I verified against the source:

- Gateway default `recursion_limit=100` → `backend/app/gateway/services.py:192`
- IM-channel default → `backend/app/channels/manager.py:31`
- DeerFlowClient default → `backend/packages/harness/deerflow/client.py:207`
- LangGraph native default of 25 already cited in `backend/docs/API.md:108` and `:655`

## Out of scope (intentional, called out in the doc)

- LoopDetectionMiddleware refactor (#2517 / #2590 / #2724) — orthogonal work; the doc warns users not to conflate the two.
- Installing or executing GAIA/SWE-bench harnesses — this PR emits the `config` object those harnesses or direct callers should send. It does not introduce harness dependencies.
- Per-model thresholds and τ-bench/WebArena/MINT/MLE-bench specific profiles — left as roadmap items in the RFC.

## Why this matters

For anyone running DeerFlow against long-horizon benchmarks today, the practical workflow is "guess at a recursion limit, get a `GraphRecursionError`, raise it, repeat." This PR gives a single reproducible source of truth for those defaults and makes the trade-offs explicit, so benchmark results become comparable across runs and contributors don't keep rediscovering the same noise floor.
