### PR TITLE
feat(frontend): forward X-authentik headers in SSR auth check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# AV-fork ownership: divergence-sensitive paths require review
+# Upstream (bytedance/deer-flow) has no CODEOWNERS; this is AV-only.
+
+# CI/CD workflows (AV-divergence: build-images, upstream-sync)
+/.github/workflows/  @wesly
+
+# Sandbox provisioner (AV-extension)
+/docker/provisioner/  @wesly

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install backend dependencies
         working-directory: backend

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -53,8 +53,8 @@ jobs:
             context: frontend
             dockerfile: Dockerfile
           - service: provisioner
-            context: .
-            dockerfile: docker/provisioner/Dockerfile
+            context: docker/provisioner
+            dockerfile: Dockerfile
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,95 @@
+name: Build images (gateway + frontend + provisioner)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - backend/**
+      - frontend/**
+      - docker/provisioner/**
+      - .github/workflows/build-images.yml
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Build only this service (gateway|frontend|provisioner|all)"
+        required: false
+        default: "all"
+        type: choice
+        options: [all, gateway, frontend, provisioner]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  matrix:
+    name: Resolve build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.set.outputs.services }}
+    steps:
+      - name: Pick services
+        id: set
+        run: |
+          if [[ "${{ github.event.inputs.service }}" == "" || "${{ github.event.inputs.service }}" == "all" ]]; then
+            echo 'services=["gateway","frontend","provisioner"]' >> "$GITHUB_OUTPUT"
+          else
+            echo "services=[\"${{ github.event.inputs.service }}\"]" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build ${{ matrix.service }}
+    needs: matrix
+    runs-on: stax-builder
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.matrix.outputs.services) }}
+        include:
+          - service: gateway
+            context: backend
+            dockerfile: Dockerfile
+          - service: frontend
+            context: frontend
+            dockerfile: Dockerfile
+          - service: provisioner
+            context: .
+            dockerfile: docker/provisioner/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Log in to Harbor
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ secrets.HARBOR_REGISTRY }}
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver-opts: network=host
+
+      - name: Compute tag
+        id: tag
+        run: echo "sha=sha-$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}
+            ${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:latest
+          cache-from: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache,mode=max
+
+      - name: Summary
+        run: |
+          echo "### Built deer-flow-${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tag: \`${{ steps.tag.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Image: \`${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -45,15 +45,24 @@ jobs:
       fail-fast: false
       matrix:
         service: ${{ fromJSON(needs.matrix.outputs.services) }}
+        # build_context: dir passed to buildx as build context (`.` = repo root).
+        #   Backend/frontend Dockerfiles do `COPY backend ./backend` and
+        #   `COPY frontend ./frontend` so they need the repo-root layout.
+        # dockerfile_dir: dir used to construct the dockerfile path.
         include:
           - service: gateway
-            context: backend
+            build_context: .
+            dockerfile_dir: backend
             dockerfile: Dockerfile
           - service: frontend
-            context: frontend
+            build_context: .
+            dockerfile_dir: frontend
             dockerfile: Dockerfile
           - service: provisioner
-            context: docker/provisioner
+            # Provisioner Dockerfile does `COPY app.py .` — needs its own dir
+            # as context so app.py resolves against docker/provisioner/app.py.
+            build_context: docker/provisioner
+            dockerfile_dir: docker/provisioner
             dockerfile: Dockerfile
     steps:
       - name: Checkout
@@ -78,18 +87,21 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+          context: ${{ matrix.build_context }}
+          file: ${{ matrix.dockerfile_dir }}/${{ matrix.dockerfile }}
           platforms: linux/amd64
           push: true
+          # Push to anomalous-ventures (local Harbor project) — `ghcr` is a
+          # proxy project and rejects pushes (denied: can not push artifact
+          # to a proxy project: ghcr).
           tags: |
-            ${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}
-            ${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:latest
-          cache-from: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache
-          cache-to: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache,mode=max
+            ${{ secrets.HARBOR_REGISTRY }}/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}
+            ${{ secrets.HARBOR_REGISTRY }}/anomalous-ventures/deer-flow-${{ matrix.service }}:latest
+          cache-from: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache
+          cache-to: type=registry,ref=${{ secrets.HARBOR_REGISTRY }}/anomalous-ventures/deer-flow-${{ matrix.service }}:buildcache,mode=max
 
       - name: Summary
         run: |
           echo "### Built deer-flow-${{ matrix.service }}" >> "$GITHUB_STEP_SUMMARY"
           echo "- Tag: \`${{ steps.tag.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Image: \`${{ secrets.HARBOR_REGISTRY }}/ghcr/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Image: \`${{ secrets.HARBOR_REGISTRY }}/anomalous-ventures/deer-flow-${{ matrix.service }}:${{ steps.tag.outputs.sha }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 
@@ -55,7 +55,7 @@ jobs:
           SKIP_ENV_VALIDATION: '1'
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -13,15 +13,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         working-directory: backend
@@ -35,10 +35,10 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,96 @@
+name: Upstream rebase (bytedance/deer-flow)
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"  # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Fetch upstream + open rebase PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork (full history)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "github-actions[bot]"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/bytedance/deer-flow.git || true
+          git fetch upstream main
+
+      - name: Compute drift
+        id: drift
+        run: |
+          AHEAD=$(git rev-list --count upstream/main..HEAD)
+          BEHIND=$(git rev-list --count HEAD..upstream/main)
+          echo "ahead=$AHEAD" >> "$GITHUB_OUTPUT"
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          echo "Fork is $AHEAD ahead, $BEHIND behind upstream/main"
+
+      - name: Skip when in sync
+        if: steps.drift.outputs.behind == '0'
+        run: |
+          echo "Already up to date with upstream/main; nothing to do."
+          exit 0
+
+      - name: Create or update sync branch
+        if: steps.drift.outputs.behind != '0'
+        id: branch
+        run: |
+          BRANCH="chore/upstream-sync-$(date -u +%Y%m%d)"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          git checkout -B "$BRANCH" upstream/main
+          # cherry-pick AV-only commits (matrix workflow + provisioner ctx fix etc.)
+          # detected as commits on origin/main not in upstream/main
+          AV_COMMITS=$(git rev-list --reverse upstream/main..origin/main)
+          if [ -n "$AV_COMMITS" ]; then
+            echo "Replaying AV-only commits onto upstream/main:"
+            echo "$AV_COMMITS"
+            for sha in $AV_COMMITS; do
+              git cherry-pick -x "$sha" || {
+                echo "Conflict on $sha -- abort and surface in PR body."
+                git cherry-pick --abort
+                echo "conflict_sha=$sha" >> "$GITHUB_OUTPUT"
+                break
+              }
+            done
+          fi
+          git push origin "$BRANCH" --force-with-lease
+
+      - name: Open pull request
+        if: steps.drift.outputs.behind != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="${{ steps.branch.outputs.branch }}"
+          BODY="Automated weekly upstream rebase.
+
+          Behind upstream/main: ${{ steps.drift.outputs.behind }} commits
+          Ahead (AV-only): ${{ steps.drift.outputs.ahead }} commits
+
+          Replays AV-specific commits onto fresh upstream tip.
+          Manual review required: validate build-images workflow + provisioner context still apply, then squash-merge."
+
+          if gh pr list --head "$BRANCH" --json number --jq 'length' | grep -q '^0$'; then
+            gh pr create \
+              --title "chore(upstream): weekly rebase $(date -u +%Y-%m-%d)" \
+              --body "$BODY" \
+              --head "$BRANCH" \
+              --base main
+          else
+            echo "PR already exists for $BRANCH; updating description."
+            PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+            gh pr edit "$PR" --body "$BODY"
+          fi

--- a/AV-NOTES.md
+++ b/AV-NOTES.md
@@ -1,0 +1,38 @@
+# AV Overlay -- Anomalous-Ventures fork of bytedance/deer-flow
+
+This is a fork of [bytedance/deer-flow](https://github.com/bytedance/deer-flow), maintained by Anomalous-Ventures to integrate the agent harness into the **STAX** Kubernetes platform.
+
+The upstream README documents what DeerFlow is and how to run it locally. This file documents what's **different** in this fork.
+
+---
+
+## What's different from upstream
+
+| File | Purpose | Why we added it |
+|------|---------|-----------------|
+| `.github/workflows/build-images.yml` | Matrix build of `gateway` / `frontend` / `provisioner` images, pushed to `harbor.spooty.io` via the AV ARC pool. | Upstream's `container.yaml` only builds the all-in-one sandbox image; the agent components themselves are expected to run from `pip install`. We need pinned multi-arch images for K8s. |
+| `.github/workflows/upstream-sync.yml` | Weekly cron + manual dispatch that fetches `bytedance/deer-flow:main`, cherry-picks AV-only commits on top, and opens a PR. | Keeps the fork rebaseable without manual `git fetch upstream` work. |
+| `AV-NOTES.md` | This file. | Make the overlay self-documenting; new contributors don't have to grep workflows to understand the delta. |
+
+Anything else (source tree, configs, upstream workflows like `e2e-tests.yml` / `lint-check.yml`) is unmodified from upstream and follows the upstream contributor guide.
+
+## How this fork integrates with STAX
+
+- **Pulumi stack:** [`pulumi/stacks/27-deer-flow`](https://github.com/Anomalous-Ventures/stax/tree/main/pulumi/stacks/27-deer-flow) in the `Anomalous-Ventures/stax` repo deploys the gateway / frontend / provisioner images built here into the `llm` namespace, with isolated sandbox pods in `deer-flow-sandboxes`.
+- **Bootstrap state:** [`pulumi/stacks/27-deer-flow/BOOTSTRAP_STATUS.md`](https://github.com/Anomalous-Ventures/stax/blob/main/pulumi/stacks/27-deer-flow/BOOTSTRAP_STATUS.md) is the live source of truth for what's deployed, what's blocked, and what helper script unblocks each phase.
+- **QA:** Sentinel TestPlan at [`Anomalous-Ventures/sentinel/plans/deer-flow.yaml`](https://github.com/Anomalous-Ventures/sentinel/blob/main/plans/deer-flow.yaml) is the merge gate (9 checkpoints, 4 hard-fail covering health/UI/gateway-API/echo-task, 5 soft-fail covering langfuse/sandbox/searxng/litellm/ollama).
+- **Wiki page:** [.github wiki -- Deer-Flow](https://github.com/Anomalous-Ventures/.github/wiki/Deer-Flow) for the high-level overview.
+
+## Upstream rebase policy
+
+The `upstream-sync.yml` workflow runs every Monday 07:00 UTC and on manual dispatch. It opens a PR titled `chore: upstream sync YYYYMMDD` if the fork is behind. Review pattern:
+
+1. Check the PR's diff for any breaking changes in components STAX depends on (gateway HTTP API, provisioner contract, frontend `data-testid` selectors used by Sentinel).
+2. If selectors change, update `Anomalous-Ventures/sentinel/plans/deer-flow.yaml` in the **same** merge.
+3. Merge fast -- keeping this fork close to upstream minimizes cherry-pick conflicts.
+
+## Don't do here
+
+- Don't add product features. Push those upstream first; we want a thin overlay.
+- Don't add deployment manifests (Helm / Kustomize). All deploy logic lives in `Anomalous-Ventures/stax`.
+- Don't add cloud / paid model providers. STAX is local-models-only via Ollama / vLLM / LiteLLM.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,12 +3,19 @@
 # Stage 2 (dev):     retains toolchain for dev containers (uv sync at startup)
 # Stage 3 (runtime): clean image without compiler toolchain for production
 
+# Base registry: defaults to mirror.gcr.io (Google's pull-through cache of Docker Hub
+# library/* -- no rate limit, no auth). Avoids docker.io anon 100/6h/IP cap that wedged
+# stax CI builds on 2026-05-09. Override w/ --build-arg BASE_REGISTRY=docker.io for
+# upstream/local dev, or harbor.spooty.io/dockerhub once that proxy has upstream creds.
+ARG BASE_REGISTRY=mirror.gcr.io
 # UV source image (override for restricted networks that cannot reach ghcr.io)
 ARG UV_IMAGE=ghcr.io/astral-sh/uv:0.7.20
+ARG DOCKER_CLI_IMAGE=${BASE_REGISTRY}/library/docker:cli
 FROM ${UV_IMAGE} AS uv-source
+FROM ${DOCKER_CLI_IMAGE} AS docker-cli-src
 
 # ── Stage 1: Builder ──────────────────────────────────────────────────────────
-FROM python:3.12-slim-bookworm AS builder
+FROM ${BASE_REGISTRY}/library/python:3.12-slim-bookworm AS builder
 
 ARG NODE_MAJOR=22
 ARG APT_MIRROR
@@ -62,7 +69,7 @@ ENV PYTHONIOENCODING=utf-8
 FROM builder AS dev
 
 # Install Docker CLI (for DooD: allows starting sandbox containers via host Docker socket)
-COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli-src /usr/local/bin/docker /usr/local/bin/docker
 
 EXPOSE 8001 2024
 
@@ -70,7 +77,7 @@ CMD ["sh", "-c", "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app 
 
 # ── Stage 3: Runtime ──────────────────────────────────────────────────────────
 # Clean image without build-essential — reduces size (~200 MB) and attack surface.
-FROM python:3.12-slim-bookworm
+FROM ${BASE_REGISTRY}/library/python:3.12-slim-bookworm
 
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -83,7 +90,7 @@ RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/bin/npm \
     && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/bin/npx
 
 # Install Docker CLI (for DooD: allows starting sandbox containers via host Docker socket)
-COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker-cli-src /usr/local/bin/docker /usr/local/bin/docker
 
 # Install uv (source image overridable via UV_IMAGE build arg)
 COPY --from=uv-source /uv /uvx /usr/local/bin/

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.gateway.auth_middleware import AuthMiddleware
+from app.gateway.authentik_trust_middleware import AuthentikTrustMiddleware
 from app.gateway.config import get_gateway_config
 from app.gateway.csrf_middleware import CSRFMiddleware
 from app.gateway.deps import langgraph_runtime
@@ -306,6 +307,12 @@ This gateway provides custom endpoints for models, MCP configuration, skills, an
 
     # CSRF: Double Submit Cookie pattern for state-changing requests
     app.add_middleware(CSRFMiddleware)
+
+    # Authentik forward-auth trust: opt-in via DEER_FLOW_AUTHENTIK_TRUST_ENABLED.
+    # Mounted AFTER CSRF/Auth so it runs BEFORE them on inbound requests --
+    # it injects the synthesized access_token cookie that AuthMiddleware
+    # then validates normally.
+    app.add_middleware(AuthentikTrustMiddleware)
 
     # CORS: when GATEWAY_CORS_ORIGINS is set (dev without nginx), add CORS middleware.
     # In production, nginx handles CORS and no middleware is needed.

--- a/backend/app/gateway/authentik_trust_middleware.py
+++ b/backend/app/gateway/authentik_trust_middleware.py
@@ -1,0 +1,152 @@
+"""Authentik forward-auth trust middleware.
+
+When the deer-flow ingress sits behind Traefik + Authentik forward-auth, the
+proxy strips the Authentik cookie and re-injects identity headers on the
+request to the backend. We trust these headers to mint a local session
+cookie, so users who have already authenticated to Authentik are not asked
+for a second set of credentials at the deer-flow login form.
+
+Activation requires the env var ``DEER_FLOW_AUTHENTIK_TRUST_ENABLED=true``.
+The trusted email header defaults to ``X-authentik-email`` (case-insensitive
+header lookup is handled by Starlette).
+
+Flow per request:
+
+1. If trust disabled, pass-through.
+2. If request already carries a valid ``access_token`` cookie, pass-through.
+3. If no Authentik email header is present, pass-through (will hit
+   AuthMiddleware which will 401 non-public paths).
+4. Resolve / auto-create the local user keyed on the Authentik email.
+5. Mint a JWT, inject it as a synthetic ``cookie`` request header so
+   ``AuthMiddleware`` finds it on the same request, AND set the cookie
+   on the response so the browser keeps it for subsequent requests.
+
+The middleware is opt-in via env to keep the default (non-Authentik)
+deployment posture unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from collections.abc import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+_TRUST_ENV_VAR = "DEER_FLOW_AUTHENTIK_TRUST_ENABLED"
+_EMAIL_HEADER_ENV = "DEER_FLOW_AUTHENTIK_EMAIL_HEADER"
+_DEFAULT_EMAIL_HEADER = "X-authentik-email"
+
+
+def _is_enabled() -> bool:
+    return os.environ.get(_TRUST_ENV_VAR, "").lower() in ("1", "true", "yes")
+
+
+def _email_header_name() -> str:
+    return os.environ.get(_EMAIL_HEADER_ENV) or _DEFAULT_EMAIL_HEADER
+
+
+def _inject_cookie_header(request: Request, token: str) -> None:
+    """Mutate request scope so downstream AuthMiddleware sees access_token."""
+    scope = request.scope
+    raw_headers: list[tuple[bytes, bytes]] = list(scope.get("headers", []))
+    cookie_idx: int | None = None
+    existing_cookie = b""
+    for i, (k, v) in enumerate(raw_headers):
+        if k.lower() == b"cookie":
+            cookie_idx = i
+            existing_cookie = v
+            break
+
+    new_pair = f"access_token={token}".encode()
+    if existing_cookie:
+        new_value = existing_cookie + b"; " + new_pair
+    else:
+        new_value = new_pair
+
+    if cookie_idx is None:
+        raw_headers.append((b"cookie", new_value))
+    else:
+        raw_headers[cookie_idx] = (b"cookie", new_value)
+    scope["headers"] = raw_headers
+    # Starlette caches parsed cookies on the Request object; reset so the
+    # next .cookies access re-parses the mutated header.
+    if hasattr(request, "_cookies"):
+        try:
+            del request._cookies  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+
+class AuthentikTrustMiddleware(BaseHTTPMiddleware):
+    """Mint a local session cookie from an upstream Authentik email header."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if not _is_enabled():
+            return await call_next(request)
+
+        if request.cookies.get("access_token"):
+            return await call_next(request)
+
+        header_name = _email_header_name()
+        email = request.headers.get(header_name)
+        if not email:
+            return await call_next(request)
+
+        token: str | None = None
+        try:
+            from app.gateway.auth import create_access_token
+            from app.gateway.deps import get_local_provider
+
+            provider = get_local_provider()
+            user = await provider.get_user_by_email(email)
+            if user is None:
+                # Authentik already authenticated this principal, so we
+                # never need to know its password locally. Use a random
+                # 32-byte secret as the placeholder hash so the
+                # /login/local route (still a valid path) cannot be used
+                # to impersonate the user with a guessable credential.
+                user = await provider.create_user(
+                    email=email,
+                    password=secrets.token_urlsafe(32),
+                    system_role="user",
+                    needs_setup=False,
+                )
+                logger.info("authentik-trust: auto-created local user for %s", email)
+            token = create_access_token(str(user.id), token_version=user.token_version)
+            _inject_cookie_header(request, token)
+        except Exception as exc:  # noqa: BLE001 — broad catch is deliberate; trust-middleware must never fail-open
+            logger.exception("authentik-trust: failed to mint session for %s: %s", email, exc)
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        # Cache the cookie on the browser so subsequent requests skip the
+        # mint path. SameSite=lax matches _set_session_cookie in
+        # routers/auth.py. Secure flag tracks the proxy-resolved scheme.
+        is_https = request.headers.get("x-forwarded-proto", request.url.scheme) == "https"
+        # Best-effort: pull token_expiry_days from auth config if available.
+        try:
+            from app.gateway.auth.config import get_auth_config
+
+            max_age = get_auth_config().token_expiry_days * 24 * 3600 if is_https else None
+        except Exception:  # noqa: BLE001
+            max_age = None
+
+        response.set_cookie(
+            key="access_token",
+            value=token,
+            httponly=True,
+            secure=is_https,
+            samesite="lax",
+            max_age=max_age,
+        )
+        return response

--- a/docker/provisioner/Dockerfile
+++ b/docker/provisioner/Dockerfile
@@ -1,4 +1,9 @@
-FROM python:3.12-slim-bookworm
+# Base registry: defaults to mirror.gcr.io (Google's pull-through cache of Docker Hub
+# library/* -- no rate limit, no auth). Avoids docker.io anon 100/6h/IP cap that wedged
+# stax CI builds on 2026-05-09. Override w/ --build-arg BASE_REGISTRY=docker.io for
+# upstream/local dev, or harbor.spooty.io/dockerhub once that proxy has upstream creds.
+ARG BASE_REGISTRY=mirror.gcr.io
+FROM ${BASE_REGISTRY}/library/python:3.12-slim-bookworm
 
 ARG APT_MIRROR
 ARG PIP_INDEX_URL

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,11 +3,16 @@
 #   --target dev   — install deps only, run `pnpm dev` at container start
 #   --target prod  — full build baked in, run `pnpm start` at container start (default if no --target is specified)
 
+# Base registry: defaults to mirror.gcr.io (Google's pull-through cache of Docker Hub
+# library/* -- no rate limit, no auth). Avoids docker.io anon 100/6h/IP cap that wedged
+# stax CI builds on 2026-05-09. Override w/ --build-arg BASE_REGISTRY=docker.io for
+# upstream/local dev, or harbor.spooty.io/dockerhub once that proxy has upstream creds.
+ARG BASE_REGISTRY=mirror.gcr.io
 ARG PNPM_STORE_PATH=/root/.local/share/pnpm/store
 ARG NPM_REGISTRY
 
 # ── Base: shared setup ────────────────────────────────────────────────────────
-FROM node:22-alpine AS base
+FROM ${BASE_REGISTRY}/library/node:22-alpine AS base
 ARG PNPM_STORE_PATH
 ARG NPM_REGISTRY
 # Configure corepack registry before installing pnpm so the download itself
@@ -35,7 +40,7 @@ RUN cd /app/frontend && pnpm install --frozen-lockfile
 RUN cd /app/frontend && SKIP_ENV_VALIDATION=1 pnpm build
 
 # ── Prod: minimal runtime with pre-built output ───────────────────────────────
-FROM node:22-alpine AS prod
+FROM ${BASE_REGISTRY}/library/node:22-alpine AS prod
 ARG PNPM_STORE_PATH
 ARG NPM_REGISTRY
 RUN if [ -n "${NPM_REGISTRY}" ]; then \

--- a/frontend/src/core/auth/server.ts
+++ b/frontend/src/core/auth/server.ts
@@ -1,9 +1,48 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import { getGatewayConfig } from "./gateway-config";
 import { type AuthResult, userSchema } from "./types";
 
 const SSR_AUTH_TIMEOUT_MS = 5_000;
+
+// Trust middleware path: when Traefik forward-auth has Authentik-authenticated the
+// request, it injects X-authentik-* headers. The gateway's AuthentikTrustMiddleware
+// mints an access_token cookie on /api/v1/auth/me when these headers are present.
+// SSR forwards them so the user never sees the native /login form post-Authentik.
+type SsoCookieOptions = {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  path?: string;
+  maxAge?: number;
+  expires?: Date;
+};
+
+function parseSetCookie(
+  setCookie: string,
+): { name: string; value: string; options: SsoCookieOptions } | null {
+  const parts = setCookie.split(";").map((p) => p.trim());
+  const [first, ...attrs] = parts;
+  if (!first) return null;
+  const eq = first.indexOf("=");
+  if (eq === -1) return null;
+  const name = first.slice(0, eq);
+  const value = first.slice(eq + 1);
+  const options: SsoCookieOptions = {};
+  for (const attr of attrs) {
+    const [k, v] = attr.split("=").map((s) => s.trim());
+    const key = k?.toLowerCase();
+    if (key === "httponly") options.httpOnly = true;
+    else if (key === "secure") options.secure = true;
+    else if (key === "samesite" && v) {
+      const sv = v.toLowerCase();
+      if (sv === "lax" || sv === "strict" || sv === "none") options.sameSite = sv;
+    } else if (key === "path" && v) options.path = v;
+    else if (key === "max-age" && v) options.maxAge = Number(v);
+    else if (key === "expires" && v) options.expires = new Date(v);
+  }
+  return { name, value, options };
+}
 
 /**
  * Fetch the authenticated user from the gateway using the request's cookies.
@@ -33,6 +72,55 @@ export async function getServerSideUser(): Promise<AuthResult> {
   }
 
   if (!sessionCookie) {
+    // SSO trust path: if Traefik forward-auth proved the user via Authentik, it
+    // injected X-authentik-* headers. Forward them to gateway /api/v1/auth/me;
+    // the AuthentikTrustMiddleware mints an access_token cookie which we relay
+    // back to the browser. User never sees the native /login form.
+    const hdrs = await headers();
+    const auEmail = hdrs.get("x-authentik-email");
+    const auUser = hdrs.get("x-authentik-username");
+    if (auEmail && auUser) {
+      const ssoController = new AbortController();
+      const ssoTimeout = setTimeout(
+        () => ssoController.abort(),
+        SSR_AUTH_TIMEOUT_MS,
+      );
+      try {
+        const ssoRes = await fetch(`${internalGatewayUrl}/api/v1/auth/me`, {
+          headers: {
+            "X-authentik-email": auEmail,
+            "X-authentik-username": auUser,
+          },
+          cache: "no-store",
+          signal: ssoController.signal,
+        });
+        clearTimeout(ssoTimeout);
+        if (ssoRes.ok) {
+          const setCookieHdr = ssoRes.headers.get("set-cookie");
+          if (setCookieHdr) {
+            const parsed = parseSetCookie(setCookieHdr);
+            if (parsed) {
+              cookieStore.set(parsed.name, parsed.value, parsed.options);
+            }
+          }
+          const userParsed = userSchema.safeParse(await ssoRes.json());
+          if (userParsed.success) {
+            if (userParsed.data.needs_setup) {
+              return { tag: "needs_setup", user: userParsed.data };
+            }
+            return { tag: "authenticated", user: userParsed.data };
+          }
+          console.error(
+            "[SSR auth] Malformed /auth/me trust response:",
+            userParsed.error,
+          );
+        }
+      } catch {
+        clearTimeout(ssoTimeout);
+        // Trust path unreachable — fall through to native unauthenticated flow.
+      }
+    }
+
     // No session — check whether the system has been initialised yet.
     const setupController = new AbortController();
     const setupTimeout = setTimeout(


### PR DESCRIPTION
## Summary
- Closes the browser SSO loop. PR #8 added the gateway-side AuthentikTrustMiddleware; this PR adds the FE-side glue.
- When SSR `getServerSideUser` finds no `access_token` cookie BUT sees `X-authentik-email` + `X-authentik-username` on the incoming request (set by Traefik forward-auth), it relays those headers to gateway `/api/v1/auth/me`. The middleware mints an `access_token` JWT and returns it via `Set-Cookie`. SSR parses that header and propagates the cookie via Next.js `cookies().set` so the browser receives it on the same response.

## Test plan
- BE half already proven last session via direct curl: `X-authentik-email` -> 200 + `Set-Cookie: access_token=eyJ...; HttpOnly; Path=/; SameSite=lax` (gateway 22:43Z log).
- FE half validated post-deploy on stax 27-deer-flow via `sentinel validate -p plans/deer-flow.yaml` against `https://deer-flow.spooty.io/workspace`. Pre-fix sentinel showed `ui-loads-after-sso` hard-fail; this PR is the missing piece.

## Changes
| File | Description |
|------|-------------|
| frontend/src/core/auth/server.ts | Added trust-path: forward X-authentik-* headers, parse Set-Cookie, propagate via cookies().set |