### PR TITLE
fix: normalize missing tool call ids

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
@@ -1,4 +1,4 @@
-"""Middleware to fix dangling tool calls in message history.
+"""Middleware to fix malformed or dangling tool calls in message history.
 
 A dangling tool call occurs when an AIMessage contains tool_calls but there are
 no corresponding ToolMessages in the history (e.g., due to user interruption or
@@ -7,6 +7,9 @@ request cancellation). This causes LLM errors due to incomplete message format.
 This middleware intercepts the model call to detect and patch such gaps by
 inserting synthetic ToolMessages with an error indicator immediately after the
 AIMessage that made the tool calls, ensuring correct message ordering.
+It also normalizes model responses whose tool_calls are missing provider-safe
+string IDs, because LangChain only wraps string tool outputs into ToolMessages
+when a tool_call id is present.
 
 Note: Uses wrap_model_call instead of before_model to ensure patches are inserted
 at the correct positions (immediately after each dangling AIMessage), not appended
@@ -21,7 +24,9 @@ from typing import override
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
+
+from deerflow.agents.middlewares.tool_call_metadata import normalize_ai_message_tool_call_ids
 
 logger = logging.getLogger(__name__)
 
@@ -126,6 +131,34 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
         logger.warning(f"Injecting {patch_count} placeholder ToolMessage(s) for dangling tool calls")
         return patched
 
+    def _normalize_model_response(self, response: ModelCallResult) -> ModelCallResult:
+        """Return a model response whose AI tool calls all have provider-safe IDs."""
+        if isinstance(response, AIMessage):
+            return normalize_ai_message_tool_call_ids(response)
+
+        if not isinstance(response, ModelResponse):
+            return response
+
+        normalized_result = []
+        changed = False
+        for message in response.result:
+            if isinstance(message, AIMessage):
+                normalized_message = normalize_ai_message_tool_call_ids(message)
+                if normalized_message is not message:
+                    changed = True
+                normalized_result.append(normalized_message)
+            else:
+                normalized_result.append(message)
+
+        if not changed:
+            return response
+
+        logger.warning("Normalized missing tool call id(s) in model response")
+        return ModelResponse(
+            result=normalized_result,
+            structured_response=response.structured_response,
+        )
+
     @override
     def wrap_model_call(
         self,
@@ -135,7 +168,7 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
         patched = self._build_patched_messages(request.messages)
         if patched is not None:
             request = request.override(messages=patched)
-        return handler(request)
+        return self._normalize_model_response(handler(request))
 
     @override
     async def awrap_model_call(
@@ -146,4 +179,4 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
         patched = self._build_patched_messages(request.messages)
         if patched is not None:
             request = request.override(messages=patched)
-        return await handler(request)
+        return self._normalize_model_response(await handler(request))

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_call_metadata.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_call_metadata.py
@@ -2,17 +2,108 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import Any
 
 from langchain_core.messages import AIMessage
+
+
+def _valid_tool_call_id(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
 
 
 def _raw_tool_call_id(raw_tool_call: Any) -> str | None:
     if not isinstance(raw_tool_call, dict):
         return None
 
-    raw_id = raw_tool_call.get("id")
-    return raw_id if isinstance(raw_id, str) and raw_id else None
+    return _valid_tool_call_id(raw_tool_call.get("id"))
+
+
+def _stable_missing_tool_call_id(message: AIMessage, tool_call: dict[str, Any], index: int) -> str:
+    payload = {
+        "message_id": getattr(message, "id", None) or "",
+        "index": index,
+        "name": tool_call.get("name"),
+        "args": tool_call.get("args"),
+    }
+    encoded = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str, separators=(",", ":"))
+    digest = hashlib.sha1(encoded.encode("utf-8")).hexdigest()[:16]
+    return f"call_{digest}"
+
+
+def _sync_missing_raw_tool_call_ids(
+    additional_kwargs: dict[str, Any],
+    tool_calls: list[dict[str, Any]],
+) -> tuple[dict[str, Any], bool]:
+    raw_tool_calls = additional_kwargs.get("tool_calls")
+    if not isinstance(raw_tool_calls, list):
+        return additional_kwargs, False
+
+    changed = False
+    synced_raw_tool_calls: list[Any] = []
+    for index, raw_tool_call in enumerate(raw_tool_calls):
+        if not isinstance(raw_tool_call, dict):
+            synced_raw_tool_calls.append(raw_tool_call)
+            continue
+
+        raw_id = _raw_tool_call_id(raw_tool_call)
+        replacement_id = _valid_tool_call_id(tool_calls[index].get("id")) if index < len(tool_calls) else None
+        if raw_id or not replacement_id:
+            synced_raw_tool_calls.append(raw_tool_call)
+            continue
+
+        synced_raw_tool_call = dict(raw_tool_call)
+        synced_raw_tool_call["id"] = replacement_id
+        synced_raw_tool_calls.append(synced_raw_tool_call)
+        changed = True
+
+    if not changed:
+        return additional_kwargs, False
+
+    updated = dict(additional_kwargs)
+    updated["tool_calls"] = synced_raw_tool_calls
+    return updated, True
+
+
+def normalize_ai_message_tool_call_ids(message: AIMessage) -> AIMessage:
+    """Ensure AIMessage tool calls have string IDs and sync raw provider metadata."""
+    tool_calls = list(getattr(message, "tool_calls", None) or [])
+    additional_kwargs = dict(getattr(message, "additional_kwargs", {}) or {})
+    if not tool_calls:
+        synced_kwargs, raw_changed = _sync_missing_raw_tool_call_ids(additional_kwargs, [])
+        if raw_changed:
+            return message.model_copy(update={"additional_kwargs": synced_kwargs})
+        return message
+
+    raw_tool_calls = additional_kwargs.get("tool_calls")
+    normalized_tool_calls: list[dict[str, Any]] = []
+    changed = False
+    for index, tool_call in enumerate(tool_calls):
+        normalized_tool_call = dict(tool_call)
+        existing_id = _valid_tool_call_id(normalized_tool_call.get("id"))
+
+        raw_id = None
+        if isinstance(raw_tool_calls, list) and index < len(raw_tool_calls):
+            raw_id = _raw_tool_call_id(raw_tool_calls[index])
+
+        tool_call_id = existing_id or raw_id or _stable_missing_tool_call_id(message, normalized_tool_call, index)
+        if tool_call_id != normalized_tool_call.get("id"):
+            normalized_tool_call["id"] = tool_call_id
+            changed = True
+
+        normalized_tool_calls.append(normalized_tool_call)
+
+    synced_kwargs, raw_changed = _sync_missing_raw_tool_call_ids(additional_kwargs, normalized_tool_calls)
+    if not changed and not raw_changed:
+        return message
+
+    return message.model_copy(
+        update={
+            "tool_calls": normalized_tool_calls,
+            "additional_kwargs": synced_kwargs,
+        }
+    )
 
 
 def clone_ai_message_with_tool_calls(

--- a/backend/tests/test_dangling_tool_call_middleware.py
+++ b/backend/tests/test_dangling_tool_call_middleware.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from langchain.agents.middleware.types import ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from deerflow.agents.middlewares.dangling_tool_call_middleware import (
@@ -178,6 +179,97 @@ class TestWrapModelCall:
         handler.assert_called_once_with(patched_request)
         assert result == "response"
 
+    def test_normalizes_missing_tool_call_ids_in_model_response(self):
+        mw = DanglingToolCallMiddleware()
+        request = MagicMock()
+        request.messages = [HumanMessage(content="find cars")]
+        message = AIMessage(
+            content="",
+            id="run-123",
+            tool_calls=[
+                {
+                    "name": "vector_search",
+                    "args": {"keyword": "汽车"},
+                    "id": None,
+                    "type": "tool_call",
+                }
+            ],
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": None,
+                        "type": "function",
+                        "function": {"name": "vector_search", "arguments": '{"keyword":"汽车"}'},
+                    }
+                ]
+            },
+            response_metadata={"finish_reason": "tool_calls"},
+        )
+        response = ModelResponse(result=[message])
+        handler = MagicMock(return_value=response)
+
+        result = mw.wrap_model_call(request, handler)
+
+        normalized = result.result[0]
+        assert isinstance(normalized, AIMessage)
+        tool_call_id = normalized.tool_calls[0]["id"]
+        assert isinstance(tool_call_id, str)
+        assert tool_call_id.startswith("call_")
+        assert normalized.additional_kwargs["tool_calls"][0]["id"] == tool_call_id
+        assert normalized.response_metadata["finish_reason"] == "tool_calls"
+
+    def test_keeps_existing_tool_call_ids_in_model_response(self):
+        mw = DanglingToolCallMiddleware()
+        request = MagicMock()
+        request.messages = [HumanMessage(content="find cars")]
+        message = AIMessage(
+            content="",
+            id="run-123",
+            tool_calls=[_tc("vector_search", "call_existing")],
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": "call_existing",
+                        "type": "function",
+                        "function": {"name": "vector_search", "arguments": '{"keyword":"汽车"}'},
+                    }
+                ]
+            },
+        )
+        response = ModelResponse(result=[message])
+        handler = MagicMock(return_value=response)
+
+        result = mw.wrap_model_call(request, handler)
+
+        assert result is response
+        assert result.result[0].tool_calls[0]["id"] == "call_existing"
+        assert result.result[0].additional_kwargs["tool_calls"][0]["id"] == "call_existing"
+
+    def test_normalizes_direct_ai_message_model_response(self):
+        mw = DanglingToolCallMiddleware()
+        request = MagicMock()
+        request.messages = [HumanMessage(content="find cars")]
+        message = AIMessage(
+            content="",
+            id="run-direct-123",
+            tool_calls=[{"name": "vector_search", "args": {"keyword": "汽车"}, "id": None}],
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": None,
+                        "type": "function",
+                        "function": {"name": "vector_search", "arguments": '{"keyword":"汽车"}'},
+                    }
+                ]
+            },
+        )
+        handler = MagicMock(return_value=message)
+
+        result = mw.wrap_model_call(request, handler)
+
+        assert isinstance(result.tool_calls[0]["id"], str)
+        assert result.additional_kwargs["tool_calls"][0]["id"] == result.tool_calls[0]["id"]
+
 
 class TestAwrapModelCall:
     @pytest.mark.anyio
@@ -213,3 +305,30 @@ class TestAwrapModelCall:
 
         handler.assert_called_once_with(patched_request)
         assert result == "response"
+
+    @pytest.mark.anyio
+    async def test_async_normalizes_missing_tool_call_ids_in_model_response(self):
+        mw = DanglingToolCallMiddleware()
+        request = MagicMock()
+        request.messages = [HumanMessage(content="find cars")]
+        message = AIMessage(
+            content="",
+            id="run-async-123",
+            tool_calls=[{"name": "vector_search", "args": {"keyword": "汽车"}, "id": None}],
+            additional_kwargs={
+                "tool_calls": [
+                    {
+                        "id": None,
+                        "type": "function",
+                        "function": {"name": "vector_search", "arguments": '{"keyword":"汽车"}'},
+                    }
+                ]
+            },
+        )
+        handler = AsyncMock(return_value=ModelResponse(result=[message]))
+
+        result = await mw.awrap_model_call(request, handler)
+
+        normalized = result.result[0]
+        assert isinstance(normalized.tool_calls[0]["id"], str)
+        assert normalized.additional_kwargs["tool_calls"][0]["id"] == normalized.tool_calls[0]["id"]


### PR DESCRIPTION
## Summary
- normalize model responses whose AI tool calls are missing provider-safe string ids
- keep structured `AIMessage.tool_calls` and raw `additional_kwargs["tool_calls"]` ids in sync
- add regression coverage for missing-id tool calls so string-returning tools can be wrapped into ToolMessages

Fixes #2854

## Tests
- `uv run pytest tests/test_dangling_tool_call_middleware.py tests/test_tool_error_handling_middleware.py tests/test_subagent_limit_middleware.py tests/test_summarization_middleware.py tests/test_patched_openai.py`
- `uv run ruff check packages/harness/deerflow/agents/middlewares/tool_call_metadata.py packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py tests/test_dangling_tool_call_middleware.py`