### PR TITLE
fix: hide summary messages from chat UI

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -22,6 +22,7 @@ import { TokenUsageIndicator } from "@/components/workspace/token-usage-indicato
 import { Tooltip } from "@/components/workspace/tooltip";
 import { useAgent } from "@/core/agents";
 import { useI18n } from "@/core/i18n/hooks";
+import { filterVisibleMessages } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
@@ -89,7 +90,7 @@ export default function AgentChatPage() {
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {
         let body = "Conversation finished";
-        const lastMessage = state.messages[state.messages.length - 1];
+        const lastMessage = filterVisibleMessages(state.messages).at(-1);
         if (lastMessage) {
           const textContent = textOfMessage(lastMessage);
           if (textContent) {

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -21,6 +21,7 @@ import { TodoList } from "@/components/workspace/todo-list";
 import { TokenUsageIndicator } from "@/components/workspace/token-usage-indicator";
 import { Welcome } from "@/components/workspace/welcome";
 import { useI18n } from "@/core/i18n/hooks";
+import { filterVisibleMessages } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
@@ -92,7 +93,7 @@ export default function ChatPage() {
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {
         let body = "Conversation finished";
-        const lastMessage = state.messages.at(-1);
+        const lastMessage = filterVisibleMessages(state.messages).at(-1);
         if (lastMessage) {
           const textContent = textOfMessage(lastMessage);
           if (textContent) {

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -373,6 +373,10 @@ export function isHiddenFromUIMessage(message: Message) {
   );
 }
 
+export function filterVisibleMessages(messages: Message[]) {
+  return messages.filter((message) => !isHiddenFromUIMessage(message));
+}
+
 /**
  * Represents a file stored in message additional_kwargs.files.
  * Used for optimistic UI (uploading state) and structured file metadata.

--- a/frontend/src/core/threads/export.ts
+++ b/frontend/src/core/threads/export.ts
@@ -3,6 +3,7 @@ import type { Message } from "@langchain/langgraph-sdk";
 import {
   extractContentFromMessage,
   extractReasoningContentFromMessage,
+  filterVisibleMessages,
   hasContent,
   hasToolCalls,
   stripUploadedFilesTag,
@@ -41,7 +42,7 @@ export function formatThreadAsMarkdown(
     "",
   ];
 
-  for (const message of messages) {
+  for (const message of filterVisibleMessages(messages)) {
     if (message.type === "human") {
       const content = formatMessageContent(message);
       if (content) {
@@ -92,7 +93,7 @@ export function formatThreadAsJSON(
     thread_id: thread.thread_id,
     created_at: thread.created_at,
     exported_at: new Date().toISOString(),
-    messages: messages.map((msg) => ({
+    messages: filterVisibleMessages(messages).map((msg) => ({
       type: msg.type,
       id: msg.id,
       content: typeof msg.content === "string" ? msg.content : msg.content,

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -11,7 +11,11 @@ import { getAPIClient } from "../api";
 import { fetch } from "../api/fetcher";
 import { getBackendBaseURL } from "../config";
 import { useI18n } from "../i18n/hooks";
-import type { FileInMessage } from "../messages/utils";
+import {
+  filterVisibleMessages,
+  isHiddenFromUIMessage,
+  type FileInMessage,
+} from "../messages/utils";
 import type { LocalSettings } from "../settings";
 import { useUpdateSubtask } from "../tasks/context";
 import type { UploadedFileInfo } from "../uploads";
@@ -80,6 +84,13 @@ function mergeMessages(
     ...threadMessages,
     ...optimisticMessages,
   ];
+}
+
+function visibleMessageIdentities(messages: Message[]) {
+  return messages
+    .filter((message) => !isHiddenFromUIMessage(message))
+    .map(messageIdentity)
+    .filter((id): id is string => Boolean(id));
 }
 
 function messageIdentity(message: Message): string | undefined {
@@ -228,7 +239,10 @@ export function useThreadStream({
           if (m.id !== undefined && m.id === _lastKeepMessage?.id) {
             break;
           }
-          if (!summarizedRef.current?.has(m.id ?? "")) {
+          if (
+            !isHiddenFromUIMessage(m) &&
+            !summarizedRef.current?.has(m.id ?? "")
+          ) {
             _movedMessages.push(m);
           }
         }
@@ -318,7 +332,8 @@ export function useThreadStream({
   // Optimistic messages shown before the server stream responds
   const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
   const [isUploading, setIsUploading] = useState(false);
-  const humanMessageCount = thread.messages.filter(
+  const visibleThreadMessages = filterVisibleMessages(thread.messages);
+  const humanMessageCount = visibleThreadMessages.filter(
     (m) => m.type === "human",
   ).length;
   const latestMessageCountsRef = useRef({ humanMessageCount });
@@ -353,9 +368,7 @@ export function useThreadStream({
       pendingUsageBaselineMessageIdsRef.current.size === 0
     ) {
       pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
+        visibleMessageIdentities(thread.messages),
       );
     }
   }, [thread.isLoading, thread.messages]);
@@ -395,9 +408,7 @@ export function useThreadStream({
       // messages so we can wait for the server's copy of the user input.
       prevHumanMsgCountRef.current = humanMessageCount;
       pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
+        visibleMessageIdentities(thread.messages),
       );
 
       // Build optimistic files list with uploading status
@@ -579,14 +590,16 @@ export function useThreadStream({
     messagesRef.current = thread.messages;
   }
 
+  const visibleHistory = filterVisibleMessages(history);
+  const visibleOptimisticMessages = filterVisibleMessages(optimisticMessages);
   const mergedMessages = mergeMessages(
-    history,
-    thread.messages,
-    optimisticMessages,
+    visibleHistory,
+    visibleThreadMessages,
+    visibleOptimisticMessages,
   );
   const pendingUsageMessages = thread.isLoading
     ? getMessagesAfterBaseline(
-        thread.messages,
+        visibleThreadMessages,
         pendingUsageBaselineMessageIdsRef.current,
       )
     : [];

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -2,6 +2,7 @@ import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
 import {
+  filterVisibleMessages,
   getAssistantTurnUsageMessages,
   getMessageGroups,
 } from "@/core/messages/utils";
@@ -62,4 +63,46 @@ test("aggregates token usage messages once per assistant turn", () => {
       (groupMessages) => groupMessages?.map((message) => message.id) ?? null,
     ),
   ).toEqual([null, null, ["ai-1", "ai-2"], null, ["ai-3"]]);
+});
+
+test("filters hidden summary messages before display", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Visible user request",
+    },
+    {
+      id: "summary-1",
+      type: "human",
+      name: "summary",
+      content: "Here is a summary of the conversation to date...",
+    },
+    {
+      id: "hidden-1",
+      type: "ai",
+      content: "Hidden internal task",
+      additional_kwargs: { hide_from_ui: true },
+    },
+    {
+      id: "loop-warning-1",
+      type: "ai",
+      name: "loop_warning",
+      content: "Hidden loop warning",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "Visible answer",
+    },
+  ] as Message[];
+
+  expect(filterVisibleMessages(messages).map((message) => message.id)).toEqual([
+    "human-1",
+    "ai-1",
+  ]);
+  expect(getMessageGroups(messages).map((group) => group.id)).toEqual([
+    "human-1",
+    "ai-1",
+  ]);
 });

--- a/frontend/tests/unit/core/threads/export.test.ts
+++ b/frontend/tests/unit/core/threads/export.test.ts
@@ -1,0 +1,63 @@
+import type { Message } from "@langchain/langgraph-sdk";
+import { expect, test } from "vitest";
+
+import {
+  formatThreadAsJSON,
+  formatThreadAsMarkdown,
+} from "@/core/threads/export";
+import type { AgentThread } from "@/core/threads/types";
+
+const thread = {
+  thread_id: "thread-1",
+  created_at: "2026-05-11T00:00:00.000Z",
+  values: { title: "Export test" },
+} as AgentThread;
+
+test("omits hidden summary messages from markdown export", () => {
+  const messages = [
+    {
+      id: "summary-1",
+      type: "human",
+      name: "summary",
+      content: "Here is a summary of the conversation to date...",
+    },
+    {
+      id: "human-1",
+      type: "human",
+      content: "What happened?",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "Only visible messages are exported.",
+    },
+  ] as Message[];
+
+  const markdown = formatThreadAsMarkdown(thread, messages);
+
+  expect(markdown).toContain("What happened?");
+  expect(markdown).toContain("Only visible messages are exported.");
+  expect(markdown).not.toContain("Here is a summary of the conversation");
+});
+
+test("omits hidden summary messages from json export", () => {
+  const messages = [
+    {
+      id: "summary-1",
+      type: "human",
+      name: "summary",
+      content: "Here is a summary of the conversation to date...",
+    },
+    {
+      id: "human-1",
+      type: "human",
+      content: "Visible message",
+    },
+  ] as Message[];
+
+  const json = JSON.parse(formatThreadAsJSON(thread, messages)) as {
+    messages: Array<{ id: string }>;
+  };
+
+  expect(json.messages.map((message) => message.id)).toEqual(["human-1"]);
+});


### PR DESCRIPTION
## Summary
- add a shared visible-message filter for internal messages such as summarization context
- prevent `name="summary"` messages from leaking into live chat display, pending usage, notifications, and exports
- add unit tests covering hidden-message filtering and export output

Fixes #2804

## Tests
- `pnpm test -- tests/unit/core/messages/utils.test.ts tests/unit/core/threads/export.test.ts`
- `pnpm exec eslint 'src/app/workspace/chats/[thread_id]/page.tsx' 'src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx' src/core/messages/utils.ts src/core/threads/hooks.ts src/core/threads/export.ts tests/unit/core/messages/utils.test.ts tests/unit/core/threads/export.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec prettier --check src/core/messages/utils.ts src/core/threads/hooks.ts src/core/threads/export.ts tests/unit/core/messages/utils.test.ts tests/unit/core/threads/export.test.ts 'src/app/workspace/chats/[thread_id]/page.tsx' 'src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx'`