### PR TITLE
fix: track message_count and last_ai_message in RunJournal

### DIFF
--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -223,6 +223,12 @@ class RunJournal(BaseCallbackHandler):
                 },
             )
 
+            # Message-level convenience fields (last AI text, total message count)
+            content = getattr(message, "content", None)
+            if isinstance(content, str) and content:
+                self._last_ai_msg = content
+            self._msg_count += 1
+
             # Token accumulation (dedup by langchain run_id to avoid double-counting
             # when the callback fires more than once for the same response)
             if self._track_tokens:


### PR DESCRIPTION
## Summary

`RunJournal._msg_count` and `RunJournal._last_ai_msg` were initialized in `__init__` but never updated by any callback. As a result, `get_completion_data()` always returned `message_count: 0` and `last_ai_message: null` for every run, regardless of how many messages were actually produced.

**Root cause:** `on_llm_end` already iterates over every AI message for token counting, but never touched `_msg_count` or `_last_ai_msg`.

**Fix:** Update both fields inside the existing `on_llm_end` message loop:

```python
# Message-level convenience fields (last AI text, total message count)
content = getattr(message, "content", None)
if isinstance(content, str) and content:
    self._last_ai_msg = content
self._msg_count += 1
```

`_last_ai_msg` is only updated when the content is a non-empty string, so tool-call-only responses (where `content` is a list or empty) do not overwrite a previous text response.

## Test plan

- [ ] Run journal tests: `pytest backend/tests/test_run_journal.py`
- [ ] Verify `get_completion_data()["message_count"]` is non-zero after a run
- [ ] Verify `get_completion_data()["last_ai_message"]` contains the last AI text response

Fixes #2849