### PR TITLE
fix: persist model_name to RunRow so by_model aggregation works

### DIFF
--- a/backend/packages/harness/deerflow/persistence/run/sql.py
+++ b/backend/packages/harness/deerflow/persistence/run/sql.py
@@ -181,6 +181,7 @@ class RunRepository(RunStore):
         last_ai_message: str | None = None,
         first_human_message: str | None = None,
         error: str | None = None,
+        model_name: str | None = None,
     ) -> None:
         """Update status + token usage + convenience fields on run completion."""
         values: dict[str, Any] = {
@@ -201,6 +202,8 @@ class RunRepository(RunStore):
             values["first_human_message"] = first_human_message[:2000]
         if error is not None:
             values["error"] = error
+        if model_name is not None:
+            values["model_name"] = model_name
         async with self._sf() as session:
             await session.execute(update(RunRow).where(RunRow.run_id == run_id).values(**values))
             await session.commit()

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -68,6 +68,9 @@ class RunJournal(BaseCallbackHandler):
         self._subagent_tokens = 0
         self._middleware_tokens = 0
 
+        # Model tracking (first LLM call wins)
+        self._model_name: str | None = None
+
         # Dedup: LangChain may fire on_llm_end multiple times for the same run_id
         self._counted_llm_run_ids: set[str] = set()
         self._counted_external_source_ids: set[str] = set()
@@ -150,6 +153,15 @@ class RunJournal(BaseCallbackHandler):
             len(messages),
             [len(batch) for batch in messages],
         )
+
+        # Extract model name from serialized config (e.g. ChatOpenAI → "gpt-4o").
+        if not self._model_name:
+            kwargs = serialized.get("kwargs") or {}
+            self._model_name = (
+                kwargs.get("model_name")
+                or kwargs.get("model")
+                or serialized.get("name")
+            )
 
         # Capture the first human message sent to any LLM in this run.
         if not self._first_human_msg and messages:
@@ -443,4 +455,5 @@ class RunJournal(BaseCallbackHandler):
             "message_count": self._msg_count,
             "last_ai_message": self._last_ai_msg,
             "first_human_message": self._first_human_msg,
+            "model_name": self._model_name,
         }

--- a/backend/packages/harness/deerflow/runtime/runs/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/runs/store/base.py
@@ -77,6 +77,7 @@ class RunStore(abc.ABC):
         last_ai_message: str | None = None,
         first_human_message: str | None = None,
         error: str | None = None,
+        model_name: str | None = None,
     ) -> None:
         pass
 

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -678,3 +678,54 @@ class TestChatModelStartHumanMessage:
         j.on_chat_model_start({}, [], run_id=uuid4(), tags=["lead_agent"])
         await j.flush()
         assert j._first_human_msg is None
+
+
+class TestModelNameExtraction:
+    """Tests for on_chat_model_start extracting the model name."""
+
+    @pytest.mark.anyio
+    async def test_extracts_model_name_from_serialized_kwargs(self, journal_setup):
+        """Model name is extracted from serialized.kwargs.model_name."""
+        j, _ = journal_setup
+        serialized = {"kwargs": {"model_name": "gpt-4o"}, "name": "ChatOpenAI"}
+        j.on_chat_model_start(serialized, [], run_id=uuid4())
+        assert j._model_name == "gpt-4o"
+
+    @pytest.mark.anyio
+    async def test_extracts_model_name_from_serialized_kwargs_model(self, journal_setup):
+        """Model name is extracted from serialized.kwargs.model (Anthropic format)."""
+        j, _ = journal_setup
+        serialized = {"kwargs": {"model": "claude-sonnet-4-6"}, "name": "ClaudeChatModel"}
+        j.on_chat_model_start(serialized, [], run_id=uuid4())
+        assert j._model_name == "claude-sonnet-4-6"
+
+    @pytest.mark.anyio
+    async def test_extracts_model_name_from_serialized_name(self, journal_setup):
+        """Falls back to serialized.name when kwargs has no model info."""
+        j, _ = journal_setup
+        serialized = {"name": "ChatAnthropic"}
+        j.on_chat_model_start(serialized, [], run_id=uuid4())
+        assert j._model_name == "ChatAnthropic"
+
+    @pytest.mark.anyio
+    async def test_model_name_not_overwritten(self, journal_setup):
+        """First model name wins; subsequent calls do not overwrite."""
+        j, _ = journal_setup
+        j.on_chat_model_start({"kwargs": {"model_name": "gpt-4o"}}, [], run_id=uuid4())
+        j.on_chat_model_start({"kwargs": {"model_name": "gpt-4o-mini"}}, [], run_id=uuid4())
+        assert j._model_name == "gpt-4o"
+
+    @pytest.mark.anyio
+    async def test_model_name_none_when_not_in_serialized(self, journal_setup):
+        """Model name stays None when serialized has no model info."""
+        j, _ = journal_setup
+        j.on_chat_model_start({}, [], run_id=uuid4())
+        assert j._model_name is None
+
+    @pytest.mark.anyio
+    async def test_completion_data_includes_model_name(self, journal_setup):
+        """get_completion_data returns the extracted model name."""
+        j, _ = journal_setup
+        j.on_chat_model_start({"kwargs": {"model_name": "claude-sonnet-4-20250514"}}, [], run_id=uuid4())
+        data = j.get_completion_data()
+        assert data["model_name"] == "claude-sonnet-4-20250514"


### PR DESCRIPTION
 ## Summary                                                                                                            
                                               
  Extract and persist model_name in RunRow so that per-model token usage aggregation works correctly.                   
   
  - Extract model name from LangChain serialized config in `on_chat_model_start` (kwargs.model_name → kwargs.model →    
  name fallback)                                                                                                        
  - Propagate through `get_completion_data()` and `update_run_completion()` to `RunRow.model_name`
  - Sync abstract base class `RunStore.update_run_completion` signature                                                 
                                                                                                                        
  ## Why                                                                                                                
                                                                                                                        
  Issue #2874: `/token-usage` by_model aggregation always returned `{"unknown": {...}}` because `RunRow.model_name` was 
  never written. The column existed, the query grouped by it, but the entire write path was missing — journal never
  extracted it, completion data omitted it, and the store method didn't accept it.                                      
                                                                  
  ## Validation                                                                                                         
  
  - 6 unit tests covering: OpenAI format, Anthropic format, name fallback, first-wins semantics, None when absent,      
  completion data inclusion                                       
  - `make test` passes                                                                                                  
  - `make lint` clean                                                                                                   
                                                                                                                        
    ## Related                                                                                                            
                                                                                                                        
  - #2874                           
                                                                  
