### PR TITLE
feat(discord): persist thread-channel mappings, fix 409 conflicts, and improve thread creation

### DIFF
--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from app.channels.base import Channel
 from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
+from app.channels.store import ChannelStore
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,12 @@ class DiscordChannel(Channel):
     Configuration keys (in ``config.yaml`` under ``channels.discord``):
         - ``bot_token``: Discord Bot token.
         - ``allowed_guilds``: (optional) List of allowed Discord guild IDs. Empty = allow all.
+        - ``mention_only``: (optional) If true, only respond when the bot is mentioned.
+        - ``allowed_channels``: (optional) List of channel IDs where messages are always accepted
+          (even when mention_only is true). Use for channels where you want the bot to respond
+          without mentions. Empty = mention_only applies everywhere.
+        - ``thread_mode``: (optional) If true, create a new thread for each reply (conversation grouping).
+          Default: same as ``mention_only``.
     """
 
     def __init__(self, bus: MessageBus, config: dict[str, Any]) -> None:
@@ -32,6 +39,21 @@ class DiscordChannel(Channel):
                 self._allowed_guilds.add(int(guild_id))
             except (TypeError, ValueError):
                 continue
+        self._mention_only: bool = bool(config.get("mention_only", False))
+        self._thread_mode: bool = config.get("thread_mode", self._mention_only)
+        self._allowed_channels: set[int] = set()
+        for channel_id in config.get("allowed_channels", []):
+            try:
+                self._allowed_channels.add(int(channel_id))
+            except (TypeError, ValueError):
+                continue
+
+        # Session tracking: channel_id -> thread_id (in-memory, persisted to store)
+        self._active_threads: dict[str, str] = {}
+        self._channel_store: ChannelStore | None = config.get("channel_store")
+
+        # Typing indicator management
+        self._typing_tasks: dict[str, asyncio.Task] = {}
 
         self._client = None
         self._thread: threading.Thread | None = None
@@ -75,7 +97,31 @@ class DiscordChannel(Channel):
 
         self._thread = threading.Thread(target=self._run_client, daemon=True)
         self._thread.start()
+        self._load_active_threads()
         logger.info("Discord channel started")
+
+    def _load_active_threads(self) -> None:
+        """Restore active threads from persisted store on startup."""
+        if self._channel_store is None:
+            return
+        for entry in self._channel_store.list_entries("discord"):
+            if "chat_id" in entry and "thread_id" in entry:
+                channel_id = entry["chat_id"]
+                thread_id = entry["thread_id"]
+                self._active_threads[channel_id] = thread_id
+        if self._active_threads:
+            logger.info("[Discord] restored %d thread mappings from store", len(self._active_threads))
+        else:
+            logger.debug("[Discord] no thread mappings found in store")
+
+    def _save_thread(self, channel_id: str, thread_id: str) -> None:
+        """Persist a thread mapping to the store."""
+        if self._channel_store is None:
+            return
+        try:
+            self._channel_store.set_thread_id("discord", channel_id, thread_id, topic_id=thread_id)
+        except Exception:
+            logger.exception("[Discord] failed to save thread mapping for channel %s", channel_id)
 
     async def stop(self) -> None:
         self._running = False
@@ -100,6 +146,9 @@ class DiscordChannel(Channel):
         logger.info("Discord channel stopped")
 
     async def send(self, msg: OutboundMessage) -> None:
+        # Stop typing indicator once we're sending the response
+        self._stop_typing(msg.chat_id, msg.thread_ts)
+
         target = await self._resolve_target(msg)
         if target is None:
             logger.error("[Discord] target not found for chat_id=%s thread_ts=%s", msg.chat_id, msg.thread_ts)
@@ -130,6 +179,41 @@ class DiscordChannel(Channel):
             logger.exception("[Discord] failed to upload file: %s", attachment.filename)
             return False
 
+    async def _start_typing(self, channel, chat_id: str, thread_ts: str | None = None) -> None:
+        """Starts a loop to send periodic typing indicators."""
+        target_id = thread_ts or chat_id
+        if target_id in self._typing_tasks:
+            return  # Already typing for this target
+
+        async def _typing_loop():
+            try:
+                while True:
+                    try:
+                        await channel.typing()
+                    except Exception:
+                        pass
+                    await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                pass
+
+        task = asyncio.create_task(_typing_loop())
+        self._typing_tasks[target_id] = task
+
+    def _stop_typing(self, chat_id: str, thread_ts: str | None = None) -> None:
+        """Stops the typing loop for a specific target."""
+        target_id = thread_ts or chat_id
+        task = self._typing_tasks.pop(target_id, None)
+        if task and not task.done():
+            task.cancel()
+            logger.debug("[Discord] stopped typing indicator for target %s", target_id)
+
+    async def _add_reaction(self, message) -> None:
+        """Add a checkmark reaction to acknowledge the message was received."""
+        try:
+            await message.add_reaction("✅")
+        except Exception:
+            logger.debug("[Discord] failed to add reaction to message %s", message.id, exc_info=True)
+
     async def _on_message(self, message) -> None:
         if not self._running or not self._client:
             return
@@ -152,15 +236,139 @@ class DiscordChannel(Channel):
         if self._discord_module is None:
             return
 
-        if isinstance(message.channel, self._discord_module.Thread):
-            chat_id = str(message.channel.parent_id or message.channel.id)
-            thread_id = str(message.channel.id)
+        # Determine whether the bot is mentioned in this message
+        user = self._client.user if self._client else None
+        if user:
+            bot_mention = user.mention  # <@ID>
+            alt_mention = f"<@!{user.id}>"  # <@!ID> (ping variant)
+            standard_mention = f"<@{user.id}>"
         else:
-            thread = await self._create_thread(message)
-            if thread is None:
+            bot_mention = None
+            alt_mention = None
+            standard_mention = ""
+        has_mention = (bot_mention and bot_mention in message.content) or (alt_mention and alt_mention in message.content) or (standard_mention and standard_mention in message.content)
+
+        # Strip mention from text for processing
+        if has_mention:
+            text = text.replace(bot_mention or "", "").replace(alt_mention or "", "").replace(standard_mention or "", "").strip()
+            # Don't return early if text is empty — still process the mention (e.g., create thread)
+
+        # --- Determine thread/channel routing and typing target ---
+        thread_id = None
+        chat_id = None
+        typing_target = None  # The Discord object to type into
+
+        if isinstance(message.channel, self._discord_module.Thread):
+            # --- Message already inside a thread ---
+            thread_obj = message.channel
+            thread_id = str(thread_obj.id)
+            chat_id = str(thread_obj.parent_id or thread_obj.id)
+            typing_target = thread_obj
+
+            # If this is a known active thread, process normally
+            if thread_id in self._active_threads.values():
+                msg_type = InboundMessageType.COMMAND if text.startswith("/") else InboundMessageType.CHAT
+                inbound = self._make_inbound(
+                    chat_id=chat_id,
+                    user_id=str(message.author.id),
+                    text=text,
+                    msg_type=msg_type,
+                    thread_ts=thread_id,
+                    metadata={
+                        "guild_id": str(guild.id) if guild else None,
+                        "channel_id": str(message.channel.id),
+                        "message_id": str(message.id),
+                    },
+                )
+                inbound.topic_id = thread_id
+                self._publish(inbound)
+                # Start typing indicator in the thread
+                if typing_target:
+                    asyncio.create_task(self._start_typing(typing_target, chat_id, thread_id))
+                asyncio.create_task(self._add_reaction(message))
                 return
-            chat_id = str(message.channel.id)
-            thread_id = str(thread.id)
+
+            # Thread not tracked (orphaned) — create new thread and handle below
+            logger.debug("[Discord] message in orphaned thread %s, will create new thread", thread_id)
+            thread_id = None
+            typing_target = None
+
+        # Track whether the original message was posted in a thread
+        message_in_thread = message.thread is not None
+        channel_id = str(message.channel.id)
+
+        # Check if there's an active thread for this channel
+        if channel_id in self._active_threads:
+            # respect mention_only: if enabled, only process messages that mention the bot
+            # (unless the channel is in allowed_channels)
+            # Thread messages are always allowed through (continuation within a thread)
+            if not message_in_thread and self._mention_only and not has_mention and channel_id not in self._allowed_channels:
+                logger.debug("[Discord] skipping no-@ message in channel %s (not in thread)", channel_id)
+                return
+            # mention_only + fresh @ → create new thread instead of routing to existing one
+            if self._mention_only and has_mention:
+                thread_obj = await self._create_thread(message)
+                if thread_obj is not None:
+                    target_thread_id = str(thread_obj.id)
+                    self._active_threads[channel_id] = target_thread_id
+                    self._save_thread(channel_id, target_thread_id)
+                    thread_id = target_thread_id
+                    chat_id = channel_id
+                    typing_target = thread_obj
+                    logger.info("[Discord] created new thread %s in channel %s on mention (replacing existing thread)", target_thread_id, channel_id)
+                else:
+                    logger.info("[Discord] thread creation failed in channel %s, falling back to channel replies", channel_id)
+                    thread_id = channel_id
+                    chat_id = channel_id
+                    typing_target = message.channel
+            else:
+                # Existing session → route to the existing thread
+                target_thread_id = self._active_threads[channel_id]
+                logger.debug("[Discord] routing message in channel %s to existing thread %s", channel_id, target_thread_id)
+                thread_id = target_thread_id
+                chat_id = channel_id
+        elif self._mention_only and not has_mention and channel_id not in self._allowed_channels:
+            # Not mentioned and not in an allowed channel → skip
+            logger.debug("[Discord] skipping message without mention in channel %s", channel_id)
+            return
+        elif self._mention_only and has_mention:
+            # First mention in this channel → create thread
+            thread_obj = await self._create_thread(message)
+            if thread_obj is not None:
+                    target_thread_id = str(thread_obj.id)
+                    self._active_threads[channel_id] = target_thread_id
+                    self._save_thread(channel_id, target_thread_id)
+                    thread_id = target_thread_id
+                    chat_id = channel_id
+                    typing_target = thread_obj  # Type into the new thread
+                    logger.info("[Discord] created thread %s in channel %s for user %s", target_thread_id, channel_id, message.author.display_name)
+            else:
+                # Fallback: thread creation failed (disabled/permissions), reply in channel
+                logger.info("[Discord] thread creation failed in channel %s, falling back to channel replies", channel_id)
+                thread_id = channel_id
+                chat_id = channel_id
+                typing_target = message.channel  # Type into the channel
+        elif self._thread_mode:
+            # thread_mode but mention_only is False → create thread anyway for conversation grouping
+            thread_obj = await self._create_thread(message)
+            if thread_obj is None:
+                # Thread creation failed (disabled/permissions), fall back to channel replies
+                logger.info("[Discord] thread creation failed in channel %s, falling back to channel replies", channel_id)
+                thread_id = channel_id
+                chat_id = channel_id
+                typing_target = message.channel  # Type into the channel
+            else:
+                target_thread_id = str(thread_obj.id)
+                self._active_threads[channel_id] = target_thread_id
+                self._save_thread(channel_id, target_thread_id)
+                thread_id = target_thread_id
+                chat_id = channel_id
+                typing_target = thread_obj  # Type into the new thread
+        else:
+            # No threading — reply directly in channel
+            thread_id = channel_id
+            chat_id = channel_id
+            typing_target = message.channel  # Type into the channel
 
         msg_type = InboundMessageType.COMMAND if text.startswith("/") else InboundMessageType.CHAT
         inbound = self._make_inbound(
@@ -177,6 +385,15 @@ class DiscordChannel(Channel):
         )
         inbound.topic_id = thread_id
 
+        # Start typing indicator in the correct target (thread or channel)
+        if typing_target:
+            asyncio.create_task(self._start_typing(typing_target, chat_id, thread_id))
+
+        self._publish(inbound)
+        asyncio.create_task(self._add_reaction(message))
+
+    def _publish(self, inbound) -> None:
+        """Publish an inbound message to the main event loop."""
         if self._main_loop and self._main_loop.is_running():
             future = asyncio.run_coroutine_threadsafe(self.bus.publish_inbound(inbound), self._main_loop)
             future.add_done_callback(lambda f: logger.exception("[Discord] publish_inbound failed", exc_info=f.exception()) if f.exception() else None)
@@ -198,14 +415,40 @@ class DiscordChannel(Channel):
 
     async def _create_thread(self, message):
         try:
+            if self._discord_module is None:
+                return None
+
+            # Only TextChannel (type 0) and NewsChannel (type 10) support threads
+            channel_type = message.channel.type
+            if channel_type not in (
+                self._discord_module.ChannelType.text,
+                self._discord_module.ChannelType.news,
+            ):
+                logger.info(
+                    "[Discord] channel type %s (%s) does not support threads",
+                    channel_type.value,
+                    channel_type.name,
+                )
+                return None
+
             thread_name = f"deerflow-{message.author.display_name}-{message.id}"[:100]
             return await message.create_thread(name=thread_name)
+        except self._discord_module.errors.HTTPException as exc:
+            if exc.code == 50024:
+                logger.info(
+                    "[Discord] cannot create thread in channel %s (error code 50024): %s",
+                    message.channel.id,
+                    channel_type.name if (channel_type := message.channel.type) else "unknown",
+                )
+            else:
+                logger.exception(
+                    "[Discord] failed to create thread for message=%s (HTTPException %s)",
+                    message.id,
+                    exc.code,
+                )
+            return None
         except Exception:
             logger.exception("[Discord] failed to create thread for message=%s (threads may be disabled or missing permissions)", message.id)
-            try:
-                await message.channel.send("Could not create a thread for your message. Please check that threads are enabled in this channel.")
-            except Exception:
-                pass
             return None
 
     async def _resolve_target(self, msg: OutboundMessage):

--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -26,7 +26,7 @@ class DiscordChannel(Channel):
         - ``allowed_channels``: (optional) List of channel IDs where messages are always accepted
           (even when mention_only is true). Use for channels where you want the bot to respond
           without mentions. Empty = mention_only applies everywhere.
-        - ``thread_mode``: (optional) If true, create a new thread for each reply (conversation grouping).
+        - ``thread_mode``: (optional) If true, group a channel conversation into a thread.
           Default: same as ``mention_only``.
     """
 
@@ -41,12 +41,9 @@ class DiscordChannel(Channel):
                 continue
         self._mention_only: bool = bool(config.get("mention_only", False))
         self._thread_mode: bool = config.get("thread_mode", self._mention_only)
-        self._allowed_channels: set[int] = set()
+        self._allowed_channels: set[str] = set()
         for channel_id in config.get("allowed_channels", []):
-            try:
-                self._allowed_channels.add(int(channel_id))
-            except (TypeError, ValueError):
-                continue
+            self._allowed_channels.add(str(channel_id))
 
         # Session tracking: channel_id -> thread_id (in-memory, persisted to store)
         self._active_threads: dict[str, str] = {}
@@ -147,7 +144,8 @@ class DiscordChannel(Channel):
 
     async def send(self, msg: OutboundMessage) -> None:
         # Stop typing indicator once we're sending the response
-        self._stop_typing(msg.chat_id, msg.thread_ts)
+        stop_future = asyncio.run_coroutine_threadsafe(self._stop_typing(msg.chat_id, msg.thread_ts), self._discord_loop)
+        await asyncio.wrap_future(stop_future)
 
         target = await self._resolve_target(msg)
         if target is None:
@@ -160,6 +158,9 @@ class DiscordChannel(Channel):
             await asyncio.wrap_future(send_future)
 
     async def send_file(self, msg: OutboundMessage, attachment: ResolvedAttachment) -> bool:
+        stop_future = asyncio.run_coroutine_threadsafe(self._stop_typing(msg.chat_id, msg.thread_ts), self._discord_loop)
+        await asyncio.wrap_future(stop_future)
+
         target = await self._resolve_target(msg)
         if target is None:
             logger.error("[Discord] target not found for file upload chat_id=%s thread_ts=%s", msg.chat_id, msg.thread_ts)
@@ -199,7 +200,7 @@ class DiscordChannel(Channel):
         task = asyncio.create_task(_typing_loop())
         self._typing_tasks[target_id] = task
 
-    def _stop_typing(self, chat_id: str, thread_ts: str | None = None) -> None:
+    async def _stop_typing(self, chat_id: str, thread_ts: str | None = None) -> None:
         """Stops the typing loop for a specific target."""
         target_id = thread_ts or chat_id
         task = self._typing_tasks.pop(target_id, None)
@@ -327,6 +328,7 @@ class DiscordChannel(Channel):
                 logger.debug("[Discord] routing message in channel %s to existing thread %s", channel_id, target_thread_id)
                 thread_id = target_thread_id
                 chat_id = channel_id
+                typing_target = await self._get_channel_or_thread(target_thread_id)
         elif self._mention_only and not has_mention and channel_id not in self._allowed_channels:
             # Not mentioned and not in an allowed channel → skip
             logger.debug("[Discord] skipping message without mention in channel %s", channel_id)
@@ -335,13 +337,13 @@ class DiscordChannel(Channel):
             # First mention in this channel → create thread
             thread_obj = await self._create_thread(message)
             if thread_obj is not None:
-                    target_thread_id = str(thread_obj.id)
-                    self._active_threads[channel_id] = target_thread_id
-                    self._save_thread(channel_id, target_thread_id)
-                    thread_id = target_thread_id
-                    chat_id = channel_id
-                    typing_target = thread_obj  # Type into the new thread
-                    logger.info("[Discord] created thread %s in channel %s for user %s", target_thread_id, channel_id, message.author.display_name)
+                target_thread_id = str(thread_obj.id)
+                self._active_threads[channel_id] = target_thread_id
+                self._save_thread(channel_id, target_thread_id)
+                thread_id = target_thread_id
+                chat_id = channel_id
+                typing_target = thread_obj  # Type into the new thread
+                logger.info("[Discord] created thread %s in channel %s for user %s", target_thread_id, channel_id, message.author.display_name)
             else:
                 # Fallback: thread creation failed (disabled/permissions), reply in channel
                 logger.info("[Discord] thread creation failed in channel %s, falling back to channel replies", channel_id)

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -787,13 +787,22 @@ class ChannelManager:
             return
 
         logger.info("[Manager] invoking runs.wait(thread_id=%s, text=%r)", thread_id, msg.text[:100])
-        result = await client.runs.wait(
-            thread_id,
-            assistant_id,
-            input={"messages": [{"role": "human", "content": msg.text}]},
-            config=run_config,
-            context=run_context,
-        )
+        try:
+            result = await client.runs.wait(
+                thread_id,
+                assistant_id,
+                input={"messages": [{"role": "human", "content": msg.text}]},
+                config=run_config,
+                context=run_context,
+                multitask_strategy="reject",
+            )
+        except Exception as exc:
+            if _is_thread_busy_error(exc):
+                logger.warning("[Manager] thread busy (concurrent run rejected): thread_id=%s", thread_id)
+                await self._send_error(msg, THREAD_BUSY_MESSAGE)
+                return
+            else:
+                raise
 
         response_text = _extract_response_text(result)
         artifacts = _extract_artifacts(result)

--- a/backend/app/channels/service.py
+++ b/backend/app/channels/service.py
@@ -167,6 +167,8 @@ class ChannelService:
             return False
 
         try:
+            config = dict(config)
+            config["channel_store"] = self.store
             channel = channel_cls(bus=self.bus, config=config)
             self._channels[name] = channel
             await channel.start()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 
 [project.optional-dependencies]
 postgres = ["deerflow-harness[postgres]"]
+discord = ["discord.py>=2.7.0"]
 
 [dependency-groups]
 dev = [

--- a/backend/tests/test_mindie_provider.py
+++ b/backend/tests/test_mindie_provider.py
@@ -454,7 +454,6 @@ class TestAStream:
 
     @pytest.mark.asyncio
     async def test_with_tools_emits_tool_call_chunk(self):
-
         tool_calls = [{"name": "fn", "args": {}, "id": "c1"}]
         with patch.object(MindIEChatModel, "_agenerate", new_callable=AsyncMock) as mock_ag, patch.object(MindIEChatModel, "__init__", return_value=None):
             mock_ag.return_value = _make_chat_result("ok", tool_calls=tool_calls)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -763,6 +763,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+discord = [
+    { name = "discord-py" },
+]
 postgres = [
     { name = "deerflow-harness", extra = ["postgres"] },
 ]
@@ -781,6 +784,7 @@ requires-dist = [
     { name = "deerflow-harness", editable = "packages/harness" },
     { name = "deerflow-harness", extras = ["postgres"], marker = "extra == 'postgres'", editable = "packages/harness" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
+    { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.7.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
@@ -795,7 +799,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
     { name = "wecom-aibot-python-sdk", specifier = ">=0.1.6" },
 ]
-provides-extras = ["postgres"]
+provides-extras = ["postgres", "discord"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -921,6 +925,19 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/44/102dede3f371277598df6aa9725b82e3add068c729333c7a5dbc12764579/dingtalk_stream-0.24.3-py3-none-any.whl", hash = "sha256:2160403656985962878bf60cdf5adf41619f21067348e06f07a7c7eebf5943ad", size = 27813, upload-time = "2025-10-24T09:36:57.497Z" },
+]
+
+[[package]]
+name = "discord-py"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/57/9a2d9abdabdc9db8ef28ce0cf4129669e1c8717ba28d607b5ba357c4de3b/discord_py-2.7.1.tar.gz", hash = "sha256:24d5e6a45535152e4b98148a9dd6b550d25dc2c9fb41b6d670319411641249da", size = 1106326, upload-time = "2026-03-03T18:40:46.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/a7/17208c3b3f92319e7fad259f1c6d5a5baf8fd0654c54846ced329f83c3eb/discord_py-2.7.1-py3-none-any.whl", hash = "sha256:849dca2c63b171146f3a7f3f8acc04248098e9e6203412ce3cf2745f284f7439", size = 1227550, upload-time = "2026-03-03T18:40:44.492Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1029,6 +1029,14 @@ run_events:
 #     client_secret: $DINGTALK_CLIENT_SECRET
 #     allowed_users: []               # empty = allow all
 #     card_template_id: ""            # Optional: AI Card template ID for streaming updates
+#
+#   discord:
+#     enabled: false
+#     bot_token: $DISCORD_BOT_TOKEN
+#     allowed_guilds: []              # empty = allow all guilds; can also be a single guild ID
+#     mention_only: false             # If true, only respond when bot is mentioned or commands are used
+#     allowed_channels: []              # Optional: channel IDs exempt from mention_only (bot responds without mention)
+#     thread_mode: false               # If true, create a new thread for each reply (conversation grouping)
 
 # ============================================================================
 # Guardrails Configuration

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1034,9 +1034,9 @@ run_events:
 #     enabled: false
 #     bot_token: $DISCORD_BOT_TOKEN
 #     allowed_guilds: []              # empty = allow all guilds; can also be a single guild ID
-#     mention_only: false             # If true, only respond when bot is mentioned or commands are used
+#     mention_only: false             # If true, only respond when the bot is mentioned
 #     allowed_channels: []              # Optional: channel IDs exempt from mention_only (bot responds without mention)
-#     thread_mode: false               # If true, create a new thread for each reply (conversation grouping)
+#     thread_mode: false               # If true, group a channel conversation into a thread
 
 # ============================================================================
 # Guardrails Configuration

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -171,6 +171,7 @@ services:
       - DEER_FLOW_HOST_BASE_DIR=${DEER_FLOW_ROOT}/backend/.deer-flow
       - DEER_FLOW_HOST_SKILLS_PATH=${DEER_FLOW_ROOT}/skills
       - DEER_FLOW_SANDBOX_HOST=host.docker.internal
+      - UV_EXTRAS=discord
     env_file:
       - ../.env
     extra_hosts:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -70,6 +70,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Memory endpoint
@@ -80,6 +83,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: MCP configuration endpoint
@@ -90,6 +96,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Skills configuration endpoint
@@ -100,6 +109,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Agents endpoint
@@ -110,6 +122,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Uploads endpoint
@@ -124,6 +139,10 @@ http {
             # Large file upload support
             client_max_body_size 100M;
             proxy_request_buffering off;
+
+            # Disable response buffering to avoid permission errors
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Other endpoints under /api/threads
@@ -134,6 +153,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: Swagger UI
@@ -144,6 +166,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: ReDoc
@@ -154,6 +179,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: OpenAPI Schema
@@ -164,6 +192,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Health check endpoint (gateway)
@@ -174,6 +205,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # ── Provisioner API (sandbox management) ────────────────────────
@@ -187,6 +221,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Catch-all for /api/ routes not covered above (e.g. /api/v1/auth/*).
@@ -198,6 +235,11 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable buffering to avoid permission errors when nginx
+            # runs as a non-root user (e.g. local development).
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # All other requests go to frontend

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -70,6 +70,11 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # Disable buffering to avoid permission errors when nginx
+            # runs as a non-root user (e.g. local development).
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Memory endpoint
@@ -80,6 +85,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: MCP configuration endpoint
@@ -90,6 +98,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Skills configuration endpoint
@@ -100,6 +111,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Agents endpoint
@@ -110,6 +124,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Uploads endpoint
@@ -124,6 +141,10 @@ http {
             # Large file upload support
             client_max_body_size 100M;
             proxy_request_buffering off;
+
+            # Disable response buffering to avoid permission errors
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Custom API: Other endpoints under /api/threads
@@ -134,6 +155,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: Swagger UI
@@ -144,6 +168,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: ReDoc
@@ -154,6 +181,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # API Documentation: OpenAPI Schema
@@ -164,6 +194,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Health check endpoint (gateway)
@@ -174,6 +207,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # Catch-all for any /api/* prefix not matched by a more specific block above.
@@ -193,6 +229,11 @@ http {
             # Auth endpoints set HttpOnly cookies — make sure nginx doesn't
             # strip the Set-Cookie header from upstream responses.
             proxy_pass_header Set-Cookie;
+
+            # Disable buffering to avoid permission errors when nginx
+            # runs as a non-root user (e.g. local development).
+            proxy_buffering off;
+            proxy_cache off;
         }
 
         # All other requests go to frontend

--- a/scripts/detect_uv_extras.py
+++ b/scripts/detect_uv_extras.py
@@ -152,6 +152,8 @@ def detect_from_config(path: Path) -> list[str]:
         extras.add("postgres")
     if (section_value(lines, "checkpointer", "type") or "").lower() == "postgres":
         extras.add("postgres")
+    if (section_value(lines, "channels.discord", "enabled") or "").lower() == "true":
+        extras.add("discord")
     return sorted(extras)
 
 


### PR DESCRIPTION
## Summary

- **Persist Discord thread-channel mappings** to ChannelStore for recovery after restart (fixes mappings lost when server restarts)
- **Fix 409 concurrent run conflicts** by adding `multitask_strategy="reject"` to runs.wait()
- **Add mention_only mode** — only process messages that mention the bot (skip all others)
- **Create new threads on `@`** in mention_only mode, replacing existing thread
- **Handle orphaned threads** — create new thread and reset context when bot joins an existing thread
- **Allow thread replies without `@`** while still skipping no-`@` messages in the main channel
- **Add checkmark reaction** to acknowledge received Discord messages
- **Move discord.py to optional dependency** with auto-detection from config.yaml
- **Add Nginx proxy buffering fixes** for streaming responses

## Changes

| File | Description |
|------|-------------|
| `discord.py` | Core Discord bot persistence, mention_only mode, thread handling |
| `manager.py` | multitask_strategy="reject" for 409 conflicts |
| `service.py` | channel_store injection for persistence |
| `pyproject.toml` | Optional discord.py dependency |
| `config.example.yaml` | New Discord settings (mention_only, allowed_channels) |
| `nginx.conf` / `nginx.local.conf` | Proxy buffering fixes for streaming |

## Testing

- Verified 16 Discord channel mappings restored from store.json on restart
- `make docker-logs` confirms `[Discord] restored 16 thread mappings from store`
- No regressions in existing Discord bot behavior

## Notes

This PR is related to #2842 which adds the same mention-only/threading features. Both target `upstream/main`. Choose either #2842 or #2900 — not both.