### PR TITLE
Preserve LangGraph message roles in Gateway run input

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ DeerFlow runs the agent runtime inside the Gateway API. Development mode enables
 | **Restart** | `./scripts/serve.sh --restart [flags]` | `./scripts/docker.sh restart` | — |
 
 Gateway owns `/api/langgraph/*` and translates those public LangGraph-compatible paths to its native `/api/*` routers behind nginx.
+Run inputs sent with a `messages` list preserve standard LangChain-compatible roles such as `user`, `system`, `assistant`, and `tool` when Gateway builds agent state.
 
 #### Docker Production Deployment
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -227,6 +227,8 @@ CORS is same-origin by default when requests enter through nginx on port 2026. S
 
 Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runtime, all other `/api/*` → Gateway REST APIs.
 
+Gateway run input normalization uses LangChain message conversion for dict entries in `input.messages`, preserving standard `user`, `system`, `assistant`/`ai`, and `tool` roles before passing state to the agent.
+
 ### Sandbox System (`packages/harness/deerflow/sandbox/`)
 
 **Interface**: Abstract `Sandbox` with `execute_command`, `read_file`, `write_file`, `list_dir`

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -15,7 +15,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from fastapi import HTTPException, Request
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, convert_to_messages
 
 from app.gateway.deps import get_run_context, get_run_manager, get_stream_bridge
 from app.gateway.utils import sanitize_log_param
@@ -83,13 +83,10 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
         converted = []
         for msg in messages:
             if isinstance(msg, dict):
-                role = msg.get("role", msg.get("type", "user"))
-                content = msg.get("content", "")
-                if role in ("user", "human"):
-                    converted.append(HumanMessage(content=content))
-                else:
-                    # TODO: handle other message types (system, ai, tool)
-                    converted.append(HumanMessage(content=content))
+                try:
+                    converted.append(convert_to_messages([msg])[0])
+                except (NotImplementedError, TypeError, ValueError):
+                    converted.append(HumanMessage(content=msg.get("content", "")))
             else:
                 converted.append(msg)
         return {**raw_input, "messages": converted}

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -67,11 +67,62 @@ def test_normalize_input_none():
 
 
 def test_normalize_input_with_messages():
+    from langchain_core.messages import HumanMessage
+
     from app.gateway.services import normalize_input
 
     result = normalize_input({"messages": [{"role": "user", "content": "hi"}]})
     assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], HumanMessage)
     assert result["messages"][0].content == "hi"
+
+
+def test_normalize_input_preserves_system_messages():
+    from langchain_core.messages import SystemMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({"messages": [{"role": "system", "content": "Use concise answers."}]})
+
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], SystemMessage)
+    assert result["messages"][0].content == "Use concise answers."
+
+
+def test_normalize_input_preserves_assistant_tool_calls():
+    from langchain_core.messages import AIMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input(
+        {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"id": "call-1", "name": "bash", "args": {"cmd": "ls"}}],
+                }
+            ]
+        }
+    )
+
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], AIMessage)
+    assert result["messages"][0].tool_calls == [{"id": "call-1", "name": "bash", "args": {"cmd": "ls"}, "type": "tool_call"}]
+
+
+def test_normalize_input_preserves_tool_messages():
+    from langchain_core.messages import ToolMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input({"messages": [{"role": "tool", "content": "file.txt", "name": "bash", "tool_call_id": "call-1"}]})
+
+    assert len(result["messages"]) == 1
+    assert isinstance(result["messages"][0], ToolMessage)
+    assert result["messages"][0].content == "file.txt"
+    assert result["messages"][0].name == "bash"
+    assert result["messages"][0].tool_call_id == "call-1"
 
 
 def test_normalize_input_passthrough():


### PR DESCRIPTION
## Summary

- Preserve standard LangChain message roles when Gateway normalizes `input.messages`.
- Keep the previous permissive fallback for malformed dict messages.
- Add regression coverage for system messages, assistant tool calls, and tool result messages.

## Why

Gateway previously coerced non-user dict messages into `HumanMessage`, which dropped system prompts, assistant tool calls, and tool result metadata before the agent received the state.

## Validation

- `PYTHONPATH=. python -m uv run pytest tests/test_gateway_services.py -q`
- `python -m uv run ruff check .`
- `python -m uv run ruff format --check .`