### PR TITLE
docs: clarify LangGraph compatibility entrypoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -242,6 +242,10 @@ backend/
 └── Dockerfile                  # Container build
 ```
 
+`langgraph.json` is not the default service entrypoint.  The scripts and Docker
+deployments run the Gateway embedded runtime; the file is kept for LangGraph
+tooling, Studio, or direct LangGraph Server compatibility.
+
 ---
 
 ## Configuration

--- a/backend/app/gateway/langgraph_auth.py
+++ b/backend/app/gateway/langgraph_auth.py
@@ -1,8 +1,12 @@
-"""LangGraph Server auth handler — shares JWT logic with Gateway.
+"""LangGraph compatibility auth handler — shares JWT logic with Gateway.
 
-Loaded by LangGraph Server via langgraph.json ``auth.path``.
-Reuses the same ``decode_token`` / ``get_auth_config`` as Gateway,
-so both modes validate tokens with the same secret and rules.
+The default DeerFlow runtime is embedded in the FastAPI Gateway; scripts and
+Docker deployments do not load this module.  It is retained for LangGraph
+tooling, Studio, or direct LangGraph Server compatibility through
+``langgraph.json``'s ``auth.path``.
+
+When that compatibility path is used, this module reuses the same JWT and CSRF
+rules as Gateway so both modes validate sessions consistently.
 
 Two layers:
   1. @auth.authenticate — validates JWT cookie, extracts user_id,

--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -63,7 +63,8 @@ The agent runtime is embedded in the FastAPI Gateway and built on LangGraph for 
 - Tool execution orchestration
 - SSE streaming for real-time responses
 
-**Graph registry**: `langgraph.json` remains available for tooling and Studio compatibility.
+**Graph registry**: `langgraph.json` remains available for tooling, Studio, or direct LangGraph Server compatibility.
+It is not the default service entrypoint; scripts and Docker deployments run the Gateway embedded runtime.
 
 ```json
 {


### PR DESCRIPTION
## Summary

Follow-up to #2868.

Clarify the remaining LangGraph compatibility entrypoints now that the default runtime topology is Gateway embedded runtime.

The default deployment path is:

```text
Nginx /api/langgraph/* -> Gateway /api/* -> in-process LangGraph agent runtime
```

`backend/langgraph.json` and `backend/app/gateway/langgraph_auth.py` are still useful for LangGraph tooling, Studio, or direct LangGraph Server compatibility, but they are not the default scripts/Docker service entrypoint.

## Changes

- Update `backend/app/gateway/langgraph_auth.py` module docstring to clarify that it is loaded only by the LangGraph compatibility path declared in `backend/langgraph.json`.
- Add a short note in `backend/README.md` explaining that `backend/langgraph.json` is retained for tooling/Studio/direct LangGraph Server compatibility.
- Add a matching note in `backend/docs/ARCHITECTURE.md` near the graph registry section to reduce confusion between the default Gateway runtime and compatibility entrypoints.

## Verification

- `git diff --check`

Documentation/comment-only change. No runtime behavior changed.