### PR TITLE
fix(docker): strip nginx IPv6 listen line when extra args follow port

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -74,7 +74,7 @@ services:
       - |
         set -e
         cp /etc/nginx/nginx.conf.template /etc/nginx/nginx.conf
-        test -e /proc/net/if_inet6 || sed -i '/^[[:space:]]*listen[[:space:]]\+\[::\]:2026;/d' /etc/nginx/nginx.conf
+        test -e /proc/net/if_inet6 || sed -i '/^[[:space:]]*listen[[:space:]]\+\[::\]:2026/d' /etc/nginx/nginx.conf
         exec nginx -g 'daemon off;'
     depends_on:
       - frontend

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -74,7 +74,7 @@ services:
       - |
         set -e
         cp /etc/nginx/nginx.conf.template /etc/nginx/nginx.conf
-        test -e /proc/net/if_inet6 || sed -i '/^[[:space:]]*listen[[:space:]]\+\[::\]:2026/d' /etc/nginx/nginx.conf
+        test -e /proc/net/if_inet6 || sed -i '/^[[:space:]]*listen[[:space:]]\+\[::\]:2026\([[:space:]]\|;\)/d' /etc/nginx/nginx.conf
         exec nginx -g 'daemon off;'
     depends_on:
       - frontend


### PR DESCRIPTION
## Problem

On Docker Desktop (Windows/WSL2), `/proc/net/if_inet6` is absent inside the
nginx container, so the existing guard in `docker/docker-compose-dev.yaml`
runs the strip-sed. But the sed pattern `\[::\]:2026;` anchors on the
trailing semicolon, while the actual line in `docker/nginx/nginx.conf` is:

```nginx
listen [::]:2026 default_server;
```

The sed silently no-ops, nginx tries `socket(AF_INET6,...)` — which Docker
Desktop refuses on Windows by default — and the container crash-loops:

```
2026/05/12 22:08:41 [emerg] 1#1: socket() [::]:2026 failed
(97: Address family not supported by protocol)
```

## Fix

Drop the `;` anchor so the sed matches any `listen [::]:2026 ...;` form,
including the current `default_server` arg or future additions.

## Behavior on other platforms

- **Linux hosts**: `/proc/net/if_inet6` exists, the guard short-circuits, sed never runs. No change.
- **macOS Docker Desktop**: `/proc/net/if_inet6` likewise exists in containers. No change.
- **Windows Docker Desktop / WSL2**: `/proc/net/if_inet6` is absent, sed now correctly strips the IPv6 listen directive, and nginx starts.

## Repro environment

- Windows 11 Pro 26200
- Docker Desktop 29.3.1 (WSL2 backend, default install — no IPv6 in bridge network)
- DeerFlow `main` @ e9deb6c2

Without this patch: `make docker-init && make docker-start` builds successfully, then the `deer-flow-nginx` container enters `Restarting (1)` with the `socket() [::]:2026 failed` error in `docker logs`.

With this patch: `docker logs deer-flow-nginx` is clean; `curl http://localhost:2026/` returns HTTP 200; UI loads.

## Test plan

- [x] Verified that on Windows Docker Desktop the nginx container starts cleanly and serves at `http://localhost:2026`
- [x] Verified that `/proc/net/if_inet6` check returns missing on `nginx:alpine` containers in this environment
- [x] Visually confirmed the sed pattern no longer requires a trailing `;` after the port
- [ ] (Reviewers) Sanity check on Linux that the guard still short-circuits and no behavioral change occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)