### PR TITLE
fix(runtime): keep todo completion reminders out of user-visible messages

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
@@ -7,17 +7,20 @@ reminder message so the model still knows about the outstanding todo list.
 
 Additionally, this middleware prevents the agent from exiting the loop while
 there are still incomplete todo items. When the model produces a final response
-(no tool calls) but todos are not yet complete, the middleware injects a reminder
-and jumps back to the model node to force continued engagement.
+(no tool calls) but todos are not yet complete, the middleware queues a
+transient reminder for the next model request and jumps back to the model node
+to force continued engagement.
 """
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
+from threading import Lock
 from typing import Any, override
 
 from langchain.agents.middleware import TodoListMiddleware
 from langchain.agents.middleware.todo import PlanningState, Todo
-from langchain.agents.middleware.types import hook_config
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse, hook_config
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.runtime import Runtime
 
@@ -63,6 +66,53 @@ class TodoMiddleware(TodoListMiddleware):
     todo list. This middleware detects that gap in `before_model` / `abefore_model`
     and injects a reminder message so the model can continue tracking progress.
     """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._completion_reminder_lock = Lock()
+        self._pending_completion_reminders: dict[str, HumanMessage] = {}
+        self._completion_reminder_counts: dict[str, int] = {}
+
+    @staticmethod
+    def _thread_id(runtime: Runtime) -> str:
+        context = getattr(runtime, "context", None) or {}
+        return str(context.get("thread_id") or "__default__")
+
+    def _clear_completion_reminder_state(self, thread_id: str) -> None:
+        with self._completion_reminder_lock:
+            self._pending_completion_reminders.pop(thread_id, None)
+            self._completion_reminder_counts.pop(thread_id, None)
+
+    def _queue_completion_reminder(self, thread_id: str, reminder: HumanMessage) -> None:
+        with self._completion_reminder_lock:
+            self._pending_completion_reminders[thread_id] = reminder
+            self._completion_reminder_counts[thread_id] = self._completion_reminder_counts.get(thread_id, 0) + 1
+
+    def _completion_reminder_count_for_thread(self, thread_id: str) -> int:
+        with self._completion_reminder_lock:
+            return self._completion_reminder_counts.get(thread_id, 0)
+
+    def _pop_pending_completion_reminder(self, thread_id: str) -> HumanMessage | None:
+        with self._completion_reminder_lock:
+            return self._pending_completion_reminders.pop(thread_id, None)
+
+    def before_agent(self, state: PlanningState, runtime: Runtime) -> dict[str, Any] | None:
+        """Clear stale completion reminders at run start."""
+        self._clear_completion_reminder_state(self._thread_id(runtime))
+        return None
+
+    def after_agent(self, state: PlanningState, runtime: Runtime) -> dict[str, Any] | None:
+        """Clear queued completion reminders at run end."""
+        self._clear_completion_reminder_state(self._thread_id(runtime))
+        return None
+
+    async def abefore_agent(self, state: PlanningState, runtime: Runtime) -> dict[str, Any] | None:
+        """Async version of before_agent."""
+        return self.before_agent(state, runtime)
+
+    async def aafter_agent(self, state: PlanningState, runtime: Runtime) -> dict[str, Any] | None:
+        """Async version of after_agent."""
+        return self.after_agent(state, runtime)
 
     @override
     def before_model(
@@ -125,7 +175,7 @@ class TodoMiddleware(TodoListMiddleware):
 
         In addition to the base class check for parallel ``write_todos`` calls,
         this override intercepts model responses that have no tool calls while
-        there are still incomplete todo items. It injects a reminder
+        there are still incomplete todo items. It queues a transient reminder
         ``HumanMessage`` and jumps back to the model node so the agent
         continues working through the todo list.
 
@@ -137,22 +187,31 @@ class TodoMiddleware(TodoListMiddleware):
         if base_result is not None:
             return base_result
 
+        thread_id = self._thread_id(runtime)
+
         # 2. Only intervene when the agent wants to exit (no tool calls).
         messages = state.get("messages") or []
         last_ai = next((m for m in reversed(messages) if isinstance(m, AIMessage)), None)
         if not last_ai or last_ai.tool_calls:
             return None
+        if getattr(last_ai, "invalid_tool_calls", None):
+            return {"jump_to": "model"}
 
         # 3. Allow exit when all todos are completed or there are no todos.
         todos: list[Todo] = state.get("todos") or []  # type: ignore[assignment]
         if not todos or all(t.get("status") == "completed" for t in todos):
+            self._clear_completion_reminder_state(thread_id)
             return None
 
         # 4. Enforce a reminder cap to prevent infinite re-engagement loops.
-        if _completion_reminder_count(messages) >= self._MAX_COMPLETION_REMINDERS:
+        persisted_count = _completion_reminder_count(messages)
+        transient_count = self._completion_reminder_count_for_thread(thread_id)
+        if max(persisted_count, transient_count) >= self._MAX_COMPLETION_REMINDERS:
             return None
 
-        # 5. Inject a reminder and force the agent back to the model.
+        # 5. Queue a transient reminder and force the agent back to the model.
+        # The reminder is injected in wrap_model_call so it is visible to the
+        # model but never persisted or streamed as a normal conversation message.
         incomplete = [t for t in todos if t.get("status") != "completed"]
         incomplete_text = "\n".join(f"- [{t.get('status', 'pending')}] {t.get('content', '')}" for t in incomplete)
         reminder = HumanMessage(
@@ -166,7 +225,32 @@ class TodoMiddleware(TodoListMiddleware):
                 "</system_reminder>"
             ),
         )
-        return {"jump_to": "model", "messages": [reminder]}
+        self._queue_completion_reminder(thread_id, reminder)
+        return {"jump_to": "model"}
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        thread_id = self._thread_id(request.runtime)
+        reminder = self._pop_pending_completion_reminder(thread_id)
+        if reminder is not None:
+            request = request.override(messages=[*request.messages, reminder])
+        return handler(request)
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        thread_id = self._thread_id(request.runtime)
+        reminder = self._pop_pending_completion_reminder(thread_id)
+        if reminder is not None:
+            request = request.override(messages=[*request.messages, reminder])
+        return await handler(request)
 
     @override
     @hook_config(can_jump_to=["model"])

--- a/backend/tests/test_todo_middleware.py
+++ b/backend/tests/test_todo_middleware.py
@@ -22,10 +22,23 @@ def _reminder_msg():
     return HumanMessage(name="todo_reminder", content="reminder")
 
 
-def _make_runtime():
+def _make_runtime(thread_id="test-thread"):
     runtime = MagicMock()
-    runtime.context = {"thread_id": "test-thread"}
+    runtime.context = {"thread_id": thread_id}
     return runtime
+
+
+class _FakeModelRequest:
+    def __init__(self, messages, runtime=None):
+        self.messages = messages
+        self.runtime = runtime or _make_runtime()
+
+    def override(self, **kwargs):
+        request = _FakeModelRequest(
+            messages=kwargs.get("messages", self.messages),
+            runtime=kwargs.get("runtime", self.runtime),
+        )
+        return request
 
 
 def _sample_todos():
@@ -237,15 +250,24 @@ class TestAfterModel:
 
     def test_injects_reminder_and_jumps_to_model_when_incomplete(self):
         mw = TodoMiddleware()
+        runtime = _make_runtime()
         state = {
             "messages": [HumanMessage(content="hi"), _ai_no_tool_calls()],
             "todos": _incomplete_todos(),
         }
-        result = mw.after_model(state, _make_runtime())
+        result = mw.after_model(state, runtime)
         assert result is not None
         assert result["jump_to"] == "model"
-        assert len(result["messages"]) == 1
-        reminder = result["messages"][0]
+        assert "messages" not in result
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        assert mw.wrap_model_call(_FakeModelRequest(state["messages"], runtime), handler) == "ok"
+        reminder = captured["messages"][-1]
         assert isinstance(reminder, HumanMessage)
         assert reminder.name == "todo_completion_reminder"
         assert "Step 2" in reminder.content
@@ -253,12 +275,22 @@ class TestAfterModel:
 
     def test_reminder_lists_only_incomplete_items(self):
         mw = TodoMiddleware()
+        runtime = _make_runtime()
         state = {
             "messages": [_ai_no_tool_calls()],
             "todos": _incomplete_todos(),
         }
-        result = mw.after_model(state, _make_runtime())
-        content = result["messages"][0].content
+        result = mw.after_model(state, runtime)
+        assert result == {"jump_to": "model"}
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(state["messages"], runtime), handler)
+        content = captured["messages"][-1].content
         assert "Step 1" not in content  # completed — should not appear
         assert "Step 2" in content
         assert "Step 3" in content
@@ -287,16 +319,162 @@ class TestAfterModel:
         result = mw.after_model(state, _make_runtime())
         assert result is not None
         assert result["jump_to"] == "model"
+        assert "messages" not in result
+
+    def test_wrap_model_call_does_not_persist_transient_reminder(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        messages = [HumanMessage(content="hi"), _ai_no_tool_calls()]
+        state = {"messages": messages, "todos": _incomplete_todos()}
+
+        result = mw.after_model(state, runtime)
+        assert result == {"jump_to": "model"}
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(messages, runtime), handler)
+
+        assert captured["messages"][:-1] == messages
+        assert captured["messages"][-1].name == "todo_completion_reminder"
+        assert messages == state["messages"]
+
+    def test_transient_reminder_cap_does_not_depend_on_persisted_messages(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        messages = [_ai_no_tool_calls()]
+        state = {"messages": messages, "todos": _incomplete_todos()}
+
+        def handler(request):
+            return request.messages
+
+        assert mw.after_model(state, runtime) == {"jump_to": "model"}
+        assert mw.wrap_model_call(_FakeModelRequest(messages, runtime), handler)[-1].name == "todo_completion_reminder"
+
+        assert mw.after_model(state, runtime) == {"jump_to": "model"}
+        assert mw.wrap_model_call(_FakeModelRequest(messages, runtime), handler)[-1].name == "todo_completion_reminder"
+
+        assert mw.after_model(state, runtime) is None
+
+    def test_before_agent_clears_pending_completion_reminder(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        messages = [_ai_no_tool_calls()]
+        state = {"messages": messages, "todos": _incomplete_todos()}
+
+        assert mw.after_model(state, runtime) == {"jump_to": "model"}
+        assert mw.before_agent(state, runtime) is None
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(messages, runtime), handler)
+        assert captured["messages"] == messages
+
+    def test_after_agent_clears_pending_completion_reminder(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        messages = [_ai_no_tool_calls()]
+        state = {"messages": messages, "todos": _incomplete_todos()}
+
+        assert mw.after_model(state, runtime) == {"jump_to": "model"}
+        assert mw.after_agent(state, runtime) is None
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(messages, runtime), handler)
+        assert captured["messages"] == messages
+
+    def test_pending_completion_reminders_are_thread_scoped(self):
+        mw = TodoMiddleware()
+        runtime_a = _make_runtime("thread-a")
+        runtime_b = _make_runtime("thread-b")
+        messages = [_ai_no_tool_calls()]
+        state = {"messages": messages, "todos": _incomplete_todos()}
+
+        assert mw.after_model(state, runtime_a) == {"jump_to": "model"}
+
+        captured_b = {}
+
+        def handler_b(request):
+            captured_b["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(messages, runtime_b), handler_b)
+        assert captured_b["messages"] == messages
+
+        captured_a = {}
+
+        def handler_a(request):
+            captured_a["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(messages, runtime_a), handler_a)
+        assert captured_a["messages"][-1].name == "todo_completion_reminder"
+
+    def test_invalid_tool_calls_jump_without_completion_reminder(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        ai_message = AIMessage(
+            content="",
+            invalid_tool_calls=[{"id": "bad-call", "name": "write_todos", "args": "", "error": "bad json"}],
+        )
+        state = {
+            "messages": [ai_message],
+            "todos": _incomplete_todos(),
+        }
+
+        assert mw.after_model(state, runtime) == {"jump_to": "model"}
+
+        captured = {}
+
+        def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        mw.wrap_model_call(_FakeModelRequest(state["messages"], runtime), handler)
+        assert captured["messages"] == state["messages"]
 
 
 class TestAafterModel:
     def test_delegates_to_sync(self):
         mw = TodoMiddleware()
+        runtime = _make_runtime()
         state = {
             "messages": [_ai_no_tool_calls()],
             "todos": _incomplete_todos(),
         }
-        result = asyncio.run(mw.aafter_model(state, _make_runtime()))
+        result = asyncio.run(mw.aafter_model(state, runtime))
         assert result is not None
         assert result["jump_to"] == "model"
-        assert result["messages"][0].name == "todo_completion_reminder"
+        assert "messages" not in result
+
+    def test_awrap_model_call_injects_pending_reminder(self):
+        mw = TodoMiddleware()
+        runtime = _make_runtime()
+        messages = [_ai_no_tool_calls()]
+        state = {
+            "messages": messages,
+            "todos": _incomplete_todos(),
+        }
+        asyncio.run(mw.aafter_model(state, runtime))
+
+        captured = {}
+
+        async def handler(request):
+            captured["messages"] = request.messages
+            return "ok"
+
+        result = asyncio.run(mw.awrap_model_call(_FakeModelRequest(messages, runtime), handler))
+        assert result == "ok"
+        assert captured["messages"][-1].name == "todo_completion_reminder"

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -53,10 +53,6 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
       continue;
     }
 
-    if (message.name === "todo_reminder") {
-      continue;
-    }
-
     if (message.type === "human") {
       groups.push({ id: message.id, type: "human", messages: [message] });
       continue;
@@ -369,7 +365,9 @@ export function isHiddenFromUIMessage(message: Message) {
   return (
     message.additional_kwargs?.hide_from_ui === true ||
     message.name === "summary" ||
-    message.name === "loop_warning"
+    message.name === "loop_warning" ||
+    message.name === "todo_reminder" ||
+    message.name === "todo_completion_reminder"
   );
 }
 

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -63,3 +63,34 @@ test("aggregates token usage messages once per assistant turn", () => {
     ),
   ).toEqual([null, null, ["ai-1", "ai-2"], null, ["ai-3"]]);
 });
+
+test("hides internal todo reminder messages from UI groups", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Start",
+    },
+    {
+      id: "todo-reminder",
+      type: "human",
+      name: "todo_reminder",
+      content: "<system_reminder>hidden</system_reminder>",
+    },
+    {
+      id: "todo-completion-reminder",
+      type: "human",
+      name: "todo_completion_reminder",
+      content: "<system_reminder>also hidden</system_reminder>",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "Visible answer",
+    },
+  ] as Message[];
+
+  const groups = getMessageGroups(messages);
+
+  expect(groups.map((group) => group.id)).toEqual(["human-1", "ai-1"]);
+});


### PR DESCRIPTION
Fixes #2892.

## Summary

This changes todo completion reminders from persistent graph messages into transient model-call injections.

Previously, `TodoMiddleware.after_model()` returned a `HumanMessage(name="todo_completion_reminder")` in the graph `messages` update. That made an internal `<system_reminder>` eligible for persistence, streaming, replay, and user-visible IM/chat rendering.

Now `after_model()` only queues a per-thread reminder intent and jumps back to the model. The reminder is appended only to the next model request via `wrap_model_call()` / `awrap_model_call()`, without mutating the original message list or writing it to graph state.

This PR focuses on `todo_completion_reminder`, which is emitted from `after_model()` during premature-exit prevention. The existing `todo_reminder` context-loss reminder is left unchanged.

## What Changed

- Queue todo completion reminders as transient middleware state instead of returning them in `messages`
- Inject pending reminders only into the next model request
- Scope pending reminders and reminder counts by resolved thread/run context
- Preserve the max-reminder cap without relying on persisted reminder messages
- Clear pending reminder state at agent start/end
- Avoid triggering completion reminders for `invalid_tool_calls`
- Hide `todo_completion_reminder` in the frontend as a defensive fallback

## Why

Todo completion reminders are framework control text. They should be visible to the model, but they should not become durable conversation history or user-visible chat messages.

This keeps the boundary explicit:

```text
model-visible control signal
≠
persistent graph message
≠
user-visible transcript / IMMessage
```

## Safety / Correctness

- Pending reminders are scoped by resolved thread/run context
- Reminder counts are tracked separately from persisted messages
- `before_agent()` / `after_agent()` clear pending state
- `wrap_model_call()` uses `request.override(messages=[*request.messages, reminder])` instead of mutating the original list
- Sync and async model-call paths are both covered
- Frontend filtering is only defense-in-depth, not the primary fix

## Tests

- `PYTHONPATH=. uv run pytest tests/test_todo_middleware.py -q`
- `PYTHONPATH=. uv run ruff check packages/harness/deerflow/agents/middlewares/todo_middleware.py tests/test_todo_middleware.py`
- `PYTHONPATH=. uv run ruff format --check packages/harness/deerflow/agents/middlewares/todo_middleware.py tests/test_todo_middleware.py`
- `corepack pnpm test tests/unit/core/messages/utils.test.ts`
- `git diff --check`

## Reviewer Notes

The important behavioral change is that `after_model()` no longer returns:

```python
{"jump_to": "model", "messages": [reminder]}
```

It now returns only:

```python
{"jump_to": "model"}
```

The reminder is model-visible only during the next model call.
