### PR TITLE
fix(frontend): resolve login page flickering and resize observer loop.

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -130,7 +130,7 @@ export default function LoginPage() {
   const actualTheme = theme === "system" ? resolvedTheme : theme;
 
   return (
-    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden">
+    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-x-hidden overflow-y-auto">
       <FlickeringGrid
         className="absolute inset-0 z-0 mask-[url(/images/deer.svg)] mask-size-[100vw] mask-center mask-no-repeat md:mask-size-[72vh]"
         squareSize={4}

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -130,7 +130,7 @@ export default function LoginPage() {
   const actualTheme = theme === "system" ? resolvedTheme : theme;
 
   return (
-    <div className="bg-background flex min-h-screen items-center justify-center">
+    <div className="bg-background relative flex min-h-screen items-center justify-center overflow-hidden">
       <FlickeringGrid
         className="absolute inset-0 z-0 mask-[url(/images/deer.svg)] mask-size-[100vw] mask-center mask-no-repeat md:mask-size-[72vh]"
         squareSize={4}

--- a/frontend/src/components/ui/flickering-grid.tsx
+++ b/frontend/src/components/ui/flickering-grid.tsx
@@ -186,12 +186,12 @@ export const FlickeringGrid: React.FC<FlickeringGridProps> = ({
   return (
     <div
       ref={containerRef}
-      className={cn(`h-full w-full ${className}`)}
+      className={cn("h-full w-full overflow-hidden", className)}
       {...props}
     >
       <canvas
         ref={canvasRef}
-        className="pointer-events-none"
+        className="pointer-events-none block"
         style={{
           width: canvasSize.width,
           height: canvasSize.height,


### PR DESCRIPTION
## Description
This PR fixes a layout thrashing bug.When the login page is zoomed in to the point where scrollbars appear, this bug causes the page to continuously flicker and zoom.

**Solution:**
1. Set the `<canvas>` inside `FlickeringGrid` to `block` to remove inline descender spacing.
2. Added `overflow-hidden` to the `FlickeringGrid` wrapper to clip any fractional pixel rendering overflow.
3. Added `relative` and `overflow-hidden` to the `login/page.tsx` wrapper to ensure the absolute grid is properly scoped and doesn't affect the document body.