### PR TITLE
feat(models): add Zhipu GLM model configuration examples

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -236,6 +236,70 @@ models:
   #       thinking:
   #         type: disabled
 
+  # Example: 智谱 GLM 模型 (Zhipu AI)
+  # 智谱开放平台：https://open.bigmodel.cn/
+  # 文档：https://docs.bigmodel.cn/
+  #
+  # 通用端点配置：
+  # - name: glm-5.1
+  #   display_name: GLM-5.1
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-5.1
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #   temperature: 0.7
+  #   supports_thinking: true
+  #   supports_vision: false
+  #   when_thinking_enabled:
+  #     extra_body:
+  #       thinking:
+  #         type: enabled
+  #   when_thinking_disabled:
+  #     extra_body:
+  #       thinking:
+  #         type: disabled
+  #
+  # 多模态视觉模型 (GLM-4.6V)：
+  # - name: glm-4.6v
+  #   display_name: GLM-4.6V (Vision)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-4.6v
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #   supports_thinking: false
+  #   supports_vision: true
+  #
+  # 长上下文模型 (GLM-4-Long, 128K context)：
+  # - name: glm-4-long
+  #   display_name: GLM-4 Long (128K)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-4-long
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 32768
+  #   supports_thinking: false
+  #   supports_vision: false
+  #
+  # Coding 专用端点 (仅限 Coding 场景)：
+  # - name: glm-5.1-coding
+  #   display_name: GLM-5.1 (Coding)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: glm-5.1
+  #   api_key: $ZHIPU_API_KEY
+  #   base_url: https://open.bigmodel.cn/api/coding/paas/v4
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #   supports_thinking: true
+
   # Example: MiniMax (OpenAI-compatible) - International Edition
   # MiniMax provides high-performance models with 204K context window
   # Docs: https://platform.minimax.io/docs/api-reference/text-openai-api


### PR DESCRIPTION
## Summary
- Add Zhipu AI (智谱) GLM series model configuration examples to `config.example.yaml`
- Support for general-purpose, vision, long-context, and coding-specific models

## What
Added commented configuration examples for 4 Zhipu GLM models:
- `glm-5.1`: General flagship model with deep thinking support
- `glm-4.6v`: Multimodal vision model for image understanding
- `glm-4-long`: Long context model (128K tokens)
- `glm-5.1-coding`: Coding-specific endpoint

## Why
Zhipu AI is a leading Chinese LLM provider with OpenAI-compatible API. Users can now easily configure GLM models in DeerFlow without manually writing configuration.

## How
- Uses `langchain_openai:ChatOpenAI` (OpenAI-compatible)
- Base URL: `https://open.bigmodel.cn/api/paas/v4` (general) or `/api/coding/paas/v4` (coding)
- Environment variable: `$ZHIPU_API_KEY`
- Follows existing configuration patterns (similar to Novita AI, MiniMax)

## Test plan
- [x] Configuration follows existing patterns in `config.example.yaml`
- [x] All required fields documented (name, display_name, use, model, api_key, base_url)
- [x] Thinking mode configuration included for applicable models
- [x] Vision support flag correctly set for multimodal model

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (config.example.yaml)