### PR TITLE
feat(models): add llama.cpp local model configuration example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -329,6 +329,34 @@ models:
   #       chat_template_kwargs:
   #         enable_thinking: true
 
+  # Example: llama.cpp (local model inference)
+  # llama.cpp provides local LLM inference with OpenAI-compatible API.
+  # See: https://github.com/ggerganov/llama.cpp
+  #
+  # Start llama.cpp server:
+  #   ./llama-server --model ./qwen3.6-35b-a3b.gguf --port 8080 --host 0.0.0.0
+  #
+  # - name: llama-qwen3.6
+  #   display_name: Qwen3.6 35B (llama.cpp)
+  #   use: langchain_openai:ChatOpenAI
+  #   model: qwen3.6-35b-a3b  # Use model name from GGUF filename or server --model alias
+  #   base_url: http://localhost:8080/v1
+  #   # api_key: $LLAMACPP_API_KEY  # Optional: langchain_openai requires api_key, but llama.cpp local server doesn't. Set env var to any non-empty value (e.g. "dummy").
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 4096
+  #   temperature: 0.7
+  #   supports_thinking: false
+  #   supports_vision: false
+  #
+  # For Docker deployments, use host.docker.internal instead of localhost:
+  #   base_url: http://host.docker.internal:8080/v1
+  #
+  # Note: llama.cpp also supports advanced features like:
+  # - --ctx-size <N> for custom context size
+  # - --n-gpu-layers <N> to offload layers to GPU
+  # - --metrics for monitoring endpoint
+
 
   # Example: Qwen3-Coder deployed on MindIE Engine
   # - name: Qwen3_Coder_480B_MindIE


### PR DESCRIPTION
## Summary
Add llama.cpp local LLM inference configuration example to `config.example.yaml`

## What
Added commented configuration example for llama.cpp local model server:
- Uses OpenAI-compatible API via `langchain_openai:ChatOpenAI`
- Default port: 8080 (llama.cpp standard)
- Example uses Qwen3.6 35B model as referenced in the issue

## Why
Issue #2931 requests configuration example for llama.cpp local deployment. Users deploying local models via llama.cpp can now easily configure DeerFlow without manually writing configuration.

## How
Configuration follows existing OpenAI-compatible pattern:
- `base_url: http://localhost:8080/v1`
- `api_key` is optional (commented with explanation)
- Includes Docker deployment note (`host.docker.internal`)
- Documents server startup command and advanced options

## Test plan
- [x] Configuration follows existing patterns in `config.example.yaml`
- [x] All required fields documented (name, display_name, use, model, base_url)
- [x] api_key handling properly explained
- [x] Docker deployment note included

## Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated (config.example.yaml)

Fixes #2931