### PR TITLE
Fix type check for 'thinking' in message content

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -248,7 +248,7 @@ export function extractReasoningContentFromMessage(message: Message) {
   }
   if (Array.isArray(message.content)) {
     const part = message.content[0];
-  if (part && typeof part === "object" && "thinking" in part) {
+    if (part && typeof part === "object" && "thinking" in part) {
       return part.thinking as string;
     }
   }

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -248,7 +248,7 @@ export function extractReasoningContentFromMessage(message: Message) {
   }
   if (Array.isArray(message.content)) {
     const part = message.content[0];
-    if (part && "thinking" in part) {
+  if (part && typeof part === "object" && "thinking" in part) {
       return part.thinking as string;
     }
   }


### PR DESCRIPTION
When Gemini via Vertex AI returns content as a string inside an array, the in operator throws TypeError because it can't be used on primitives.