### PR TITLE
fix(task_tool): unwrap CallbackManager before scanning for usage recorder

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -99,7 +99,13 @@ def _schedule_deferred_subagent_cleanup(task_id: str, trace_id: str, max_polls: 
 
 
 def _find_usage_recorder(runtime: Any) -> Any | None:
-    """Find a callback handler with ``record_external_llm_usage_records`` in the runtime config."""
+    """Find a callback handler with ``record_external_llm_usage_records`` in the runtime config.
+
+    The ``callbacks`` entry in a LangChain RunnableConfig may be either a plain list
+    of handlers or a ``BaseCallbackManager``/``AsyncCallbackManager`` instance (when
+    LangChain has merged callbacks from multiple sources). The manager object is not
+    directly iterable, so we unwrap it via ``.handlers`` before scanning.
+    """
     if runtime is None:
         return None
     config = getattr(runtime, "config", None)
@@ -108,6 +114,8 @@ def _find_usage_recorder(runtime: Any) -> Any | None:
     callbacks = config.get("callbacks", [])
     if not callbacks:
         return None
+    if hasattr(callbacks, "handlers"):
+        callbacks = callbacks.handlers
     for cb in callbacks:
         if hasattr(cb, "record_external_llm_usage_records"):
             return cb

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -1285,3 +1285,78 @@ def test_subagent_usage_cache_is_cleared_when_polling_raises(monkeypatch):
         )
 
     assert task_tool_module.pop_cached_subagent_usage("tc-error") is None
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for _find_usage_recorder (bug #2026-05-14):
+# AsyncCallbackManager is not directly iterable, but LangChain sometimes
+# returns one in config["callbacks"] instead of a plain list. Iterating it
+# crashes with TypeError, which propagates out of _report_subagent_usage and
+# leaves the lead agent in a permanently-hung state.
+# ---------------------------------------------------------------------------
+
+
+class _RecorderHandler:
+    """Stand-in for a usage-recording callback handler."""
+
+    def record_external_llm_usage_records(self, records):  # pragma: no cover - never called in unit
+        return None
+
+
+class _UnrelatedHandler:
+    """Stand-in for any other LangChain callback handler."""
+
+
+class _FakeCallbackManager:
+    """Minimal stand-in for ``AsyncCallbackManager`` / ``BaseCallbackManager``.
+
+    The real classes are NOT directly iterable; consumers must read ``.handlers``.
+    """
+
+    def __init__(self, handlers):
+        self.handlers = handlers
+
+    def __iter__(self):
+        raise TypeError("'AsyncCallbackManager' object is not iterable")
+
+
+def _runtime_with_callbacks(callbacks):
+    return SimpleNamespace(config={"callbacks": callbacks})
+
+
+def test_find_usage_recorder_accepts_plain_list():
+    """Original code path: callbacks is already a list."""
+    recorder = _RecorderHandler()
+    runtime = _runtime_with_callbacks([_UnrelatedHandler(), recorder])
+
+    found = task_tool_module._find_usage_recorder(runtime)
+
+    assert found is recorder
+
+
+def test_find_usage_recorder_unwraps_callback_manager():
+    """Regression: a CallbackManager-like object must be unwrapped via .handlers
+    instead of iterated directly, otherwise the lookup raises TypeError and
+    the lead agent hangs after each subagent completes."""
+    recorder = _RecorderHandler()
+    manager = _FakeCallbackManager([_UnrelatedHandler(), recorder])
+    runtime = _runtime_with_callbacks(manager)
+
+    found = task_tool_module._find_usage_recorder(runtime)
+
+    assert found is recorder
+
+
+def test_find_usage_recorder_returns_none_when_no_recorder_present():
+    """If no handler exposes record_external_llm_usage_records, return None
+    cleanly — both for list and manager shapes."""
+    assert task_tool_module._find_usage_recorder(_runtime_with_callbacks([_UnrelatedHandler()])) is None
+    assert task_tool_module._find_usage_recorder(_runtime_with_callbacks(_FakeCallbackManager([_UnrelatedHandler()]))) is None
+
+
+def test_find_usage_recorder_handles_missing_or_empty_config():
+    """Defensive branches: no runtime / no config dict / no callbacks key / empty."""
+    assert task_tool_module._find_usage_recorder(None) is None
+    assert task_tool_module._find_usage_recorder(SimpleNamespace(config=None)) is None
+    assert task_tool_module._find_usage_recorder(SimpleNamespace(config={})) is None
+    assert task_tool_module._find_usage_recorder(_runtime_with_callbacks([])) is None


### PR DESCRIPTION
## Summary

`_find_usage_recorder` in `task_tool.py` assumed `config[\"callbacks\"]` was a plain list of handlers, but LangChain sometimes returns a `BaseCallbackManager` / `AsyncCallbackManager` instance when callbacks are merged from multiple sources. These manager objects are **not directly iterable**, so the original `for cb in callbacks` raised `TypeError: 'AsyncCallbackManager' object is not iterable` once a subagent completed. The exception propagated out of `_report_subagent_usage`, was caught by `tool_error_handling_middleware` as a failed tool execution, but the lead agent never received the subagent result back as a `ToolMessage` — leaving the run permanently stuck in "Running subtask".

## Reproduction

Observed deterministically on Ultra mode runs (subagent_enabled=true) once a `task()` subagent reached `COMPLETED` status. Triggered with multiple model providers (verified with Mistral Large and Qwen 27B via Ollama).

## Traceback

```
ERROR - Tool execution failed (async): name=task id=<tc-id>
Traceback (most recent call last):
  File "/app/backend/packages/harness/deerflow/tools/builtins/task_tool.py", line 316, in task_tool
    _report_subagent_usage(runtime, result)
  File "/app/backend/packages/harness/deerflow/tools/builtins/task_tool.py", line 105, in _report_subagent_usage
    journal = _find_usage_recorder(runtime)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/backend/packages/harness/deerflow/tools/builtins/task_tool.py", line 89, in _find_usage_recorder
    for cb in callbacks:
              ^^^^^^^^^
TypeError: 'AsyncCallbackManager' object is not iterable
```

## Fix

Detect the manager shape via `hasattr(callbacks, \"handlers\")` and unwrap to the underlying list before iterating. The fix preserves the original list-based code path unchanged — `hasattr` returns `False` for plain lists, so existing behavior is unaffected.

\`\`\`python
if hasattr(callbacks, \"handlers\"):
    callbacks = callbacks.handlers
for cb in callbacks:
    ...
\`\`\`

## Tests

Adds 4 regression tests in `test_task_tool_core_logic.py`:

| Test | Purpose |
|---|---|
| `test_find_usage_recorder_accepts_plain_list` | Existing list code path still works |
| `test_find_usage_recorder_unwraps_callback_manager` | **Bug regression** — fails pre-fix with TypeError |
| `test_find_usage_recorder_returns_none_when_no_recorder_present` | Negative case across both shapes |
| `test_find_usage_recorder_handles_missing_or_empty_config` | Defensive branches (None runtime, no config, empty callbacks) |

A minimal `_FakeCallbackManager` stand-in is used (its `__iter__` raises `TypeError` with the exact production message) so the regression test fails the same way the real bug manifests.

## Risk assessment

- **Scope**: single function `_find_usage_recorder`, ~5 LOC added
- **Backward compat**: 100% — existing list path is unchanged
- **Coverage**: 26/26 tests pass in `test_task_tool_core_logic.py` (22 existing + 4 new)

## Test plan
- [x] Unit tests pass (`pytest tests/test_task_tool_core_logic.py`)
- [x] Verified in a real Ultra mode run after deploying: subagents complete cleanly, lead agent integrates results, run finishes properly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)