### PR TITLE
fix(frontend): dedupe merged thread messages

### DIFF
--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -62,3 +62,32 @@ test("mergeMessages deduplicates tool messages by tool_call_id", () => {
 
   expect(mergeMessages([oldTool], [liveTool], [])).toEqual([liveTool]);
 });
+
+test("mergeMessages preserves messages without an identity", () => {
+  const first = {
+    type: "ai",
+    content: "first anonymous",
+  } as Message;
+  const second = {
+    type: "ai",
+    content: "second anonymous",
+  } as Message;
+
+  expect(mergeMessages([], [first, second], [])).toEqual([first, second]);
+});
+
+test("mergeMessages keeps message ids distinct from tool call ids", () => {
+  const ai = {
+    id: "shared-id",
+    type: "ai",
+    content: "assistant message",
+  } as Message;
+  const tool = {
+    id: "tool-message-id",
+    type: "tool",
+    tool_call_id: "shared-id",
+    content: "tool result",
+  } as Message;
+
+  expect(mergeMessages([], [ai, tool], [])).toEqual([ai, tool]);
+});


### PR DESCRIPTION
## Summary

- move thread message merge/identity helpers into a small pure utility module
- tail-dedupe merged history/live/optimistic messages by message id or tool_call_id, keeping the latest snapshot
- preserve anonymous messages without an identity
- add unit coverage for history overlap and duplicate live-stream snapshots

Fixes #2961.

## Tests

- `cd frontend && pnpm test tests/unit/core/threads/messages.test.ts`
- `cd frontend && pnpm typecheck --pretty false`
- `cd frontend && pnpm format --check src/core/threads/hooks.ts src/core/threads/messages.ts tests/unit/core/threads/messages.test.ts`
- `git diff --check`
