### PR TITLE
fix(sandbox): scope provisioner PVC data by user

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/remote_backend.py
@@ -21,6 +21,8 @@ import logging
 
 import requests
 
+from deerflow.runtime.user_context import get_effective_user_id
+
 from .backend import SandboxBackend
 from .sandbox_info import SandboxInfo
 
@@ -138,6 +140,7 @@ class RemoteSandboxBackend(SandboxBackend):
                 json={
                     "sandbox_id": sandbox_id,
                     "thread_id": thread_id,
+                    "user_id": get_effective_user_id(),
                 },
                 timeout=30,
             )

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -1,11 +1,13 @@
 """Tests for AioSandboxProvider mount helpers."""
 
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from deerflow.config.paths import Paths, join_host_path
+from deerflow.runtime.user_context import reset_current_user, set_current_user
 
 # ── ensure_thread_dirs ───────────────────────────────────────────────────────
 
@@ -136,3 +138,36 @@ def test_discover_or_create_only_unlocks_when_lock_succeeds(tmp_path, monkeypatc
             provider._discover_or_create_with_lock("thread-5", "sandbox-5")
 
     assert unlock_calls == []
+
+
+def test_remote_backend_create_forwards_effective_user_id(monkeypatch):
+    """Provisioner mode must receive user_id so PVC subPath matches user isolation."""
+    remote_mod = importlib.import_module("deerflow.community.aio_sandbox.remote_backend")
+    backend = remote_mod.RemoteSandboxBackend("http://provisioner:8002")
+    token = set_current_user(SimpleNamespace(id="user-7"))
+    posted: dict = {}
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"sandbox_url": "http://sandbox.local"}
+
+    def _post(url, json, timeout):  # noqa: A002 - mirrors requests.post kwarg
+        posted.update({"url": url, "json": json, "timeout": timeout})
+        return _Response()
+
+    monkeypatch.setattr(remote_mod.requests, "post", _post)
+
+    try:
+        backend.create("thread-42", "sandbox-42")
+    finally:
+        reset_current_user(token)
+
+    assert posted["url"] == "http://provisioner:8002/api/sandboxes"
+    assert posted["json"] == {
+        "sandbox_id": "sandbox-42",
+        "thread_id": "thread-42",
+        "user_id": "user-7",
+    }

--- a/backend/tests/test_provisioner_pvc_volumes.py
+++ b/backend/tests/test_provisioner_pvc_volumes.py
@@ -92,12 +92,19 @@ class TestBuildVolumeMounts:
         userdata_mount = mounts[1]
         assert userdata_mount.sub_path is None
 
-    def test_pvc_sets_subpath(self, provisioner_module):
-        """PVC mode should set sub_path to threads/{thread_id}/user-data."""
+    def test_pvc_sets_user_scoped_subpath(self, provisioner_module):
+        """PVC mode should include user_id in the user-data subPath."""
+        provisioner_module.USERDATA_PVC_NAME = "my-pvc"
+        mounts = provisioner_module._build_volume_mounts("thread-42", user_id="user-7")
+        userdata_mount = mounts[1]
+        assert userdata_mount.sub_path == "taichu-claw/users/user-7/threads/thread-42/user-data"
+
+    def test_pvc_defaults_to_default_user_subpath(self, provisioner_module):
+        """Older callers should still land under a stable default user namespace."""
         provisioner_module.USERDATA_PVC_NAME = "my-pvc"
         mounts = provisioner_module._build_volume_mounts("thread-42")
         userdata_mount = mounts[1]
-        assert userdata_mount.sub_path == "threads/thread-42/user-data"
+        assert userdata_mount.sub_path == "taichu-claw/users/default/threads/thread-42/user-data"
 
     def test_skills_mount_read_only(self, provisioner_module):
         """Skills mount should always be read-only."""
@@ -146,13 +153,12 @@ class TestBuildPodVolumes:
         pod = provisioner_module._build_pod("sandbox-1", "thread-1")
         assert len(pod.spec.containers[0].volume_mounts) == 2
 
-    def test_pod_pvc_mode(self, provisioner_module):
-        """Pod should use PVC volumes when PVC names are configured."""
+    def test_pod_pvc_mode_uses_user_scoped_subpath(self, provisioner_module):
+        """Pod should use a user-scoped subPath for PVC user-data."""
         provisioner_module.SKILLS_PVC_NAME = "skills-pvc"
         provisioner_module.USERDATA_PVC_NAME = "userdata-pvc"
-        pod = provisioner_module._build_pod("sandbox-1", "thread-1")
+        pod = provisioner_module._build_pod("sandbox-1", "thread-1", user_id="user-7")
         assert pod.spec.volumes[0].persistent_volume_claim is not None
         assert pod.spec.volumes[1].persistent_volume_claim is not None
-        # subPath should be set on user-data mount
         userdata_mount = pod.spec.containers[0].volume_mounts[1]
-        assert userdata_mount.sub_path == "threads/thread-1/user-data"
+        assert userdata_mount.sub_path == "taichu-claw/users/user-7/threads/thread-1/user-data"

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -37,7 +37,7 @@ services:
       - THREADS_HOST_PATH=${DEER_FLOW_ROOT}/backend/.deer-flow/threads
       # Production: use PVC instead of hostPath to avoid data loss on node failure.
       # When set, hostPath vars above are ignored for the corresponding volume.
-      # USERDATA_PVC_NAME uses subPath (threads/{thread_id}/user-data) automatically.
+      # USERDATA_PVC_NAME uses subPath (users/{user_id}/threads/{thread_id}/user-data) automatically.
       # - SKILLS_PVC_NAME=deer-flow-skills-pvc
       # - USERDATA_PVC_NAME=deer-flow-userdata-pvc
       - KUBECONFIG_PATH=/root/.kube/config

--- a/docker/provisioner/README.md
+++ b/docker/provisioner/README.md
@@ -138,7 +138,7 @@ The provisioner is configured via environment variables (set in [docker-compose-
 | `SKILLS_HOST_PATH` | - | **Host machine** path to skills directory (must be absolute) |
 | `THREADS_HOST_PATH` | - | **Host machine** path to threads data directory (must be absolute) |
 | `SKILLS_PVC_NAME` | empty (use hostPath) | PVC name for skills volume; when set, sandbox Pods use PVC instead of hostPath |
-| `USERDATA_PVC_NAME` | empty (use hostPath) | PVC name for user-data volume; when set, uses PVC with `subPath: threads/{thread_id}/user-data` |
+| `USERDATA_PVC_NAME` | empty (use hostPath) | PVC name for user-data volume; when set, uses PVC with `subPath: taichu-claw/users/{user_id}/threads/{thread_id}/user-data` |
 | `KUBECONFIG_PATH` | `/root/.kube/config` | Path to kubeconfig **inside** the provisioner container |
 | `NODE_HOST` | `host.docker.internal` | Hostname that backend containers use to reach host NodePorts |
 | `K8S_API_SERVER` | (from kubeconfig) | Override K8s API server URL (e.g., `https://host.docker.internal:26443`) |

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -63,6 +63,8 @@ THREADS_HOST_PATH = os.environ.get("THREADS_HOST_PATH", "/.deer-flow/threads")
 SKILLS_PVC_NAME = os.environ.get("SKILLS_PVC_NAME", "")
 USERDATA_PVC_NAME = os.environ.get("USERDATA_PVC_NAME", "")
 SAFE_THREAD_ID_PATTERN = r"^[A-Za-z0-9_\-]+$"
+SAFE_USER_ID_PATTERN = r"^[A-Za-z0-9_\-]+$"
+DEFAULT_USER_ID = "default"
 
 # Path to the kubeconfig *inside* the provisioner container.
 # Typically the host's ~/.kube/config is mounted here.
@@ -101,6 +103,14 @@ def _validate_thread_id(thread_id: str) -> str:
             "Invalid thread_id: only alphanumeric characters, hyphens, and underscores are allowed."
         )
     return thread_id
+
+
+def _validate_user_id(user_id: str) -> str:
+    if not re.match(SAFE_USER_ID_PATTERN, user_id):
+        raise ValueError(
+            "Invalid user_id: only alphanumeric characters, hyphens, and underscores are allowed."
+        )
+    return user_id
 
 
 # ── K8s client setup ────────────────────────────────────────────────────
@@ -221,6 +231,7 @@ app = FastAPI(title="DeerFlow Sandbox Provisioner", lifespan=lifespan)
 class CreateSandboxRequest(BaseModel):
     sandbox_id: str
     thread_id: str = Field(pattern=SAFE_THREAD_ID_PATTERN)
+    user_id: str = Field(default=DEFAULT_USER_ID, pattern=SAFE_USER_ID_PATTERN)
 
 
 class SandboxResponse(BaseModel):
@@ -283,15 +294,17 @@ def _build_volumes(thread_id: str) -> list[k8s_client.V1Volume]:
     return [skills_vol, userdata_vol]
 
 
-def _build_volume_mounts(thread_id: str) -> list[k8s_client.V1VolumeMount]:
+def _build_volume_mounts(thread_id: str, user_id: str = DEFAULT_USER_ID) -> list[k8s_client.V1VolumeMount]:
     """Build volume mount list, using subPath for PVC user-data."""
+    thread_id = _validate_thread_id(thread_id)
+    user_id = _validate_user_id(user_id)
     userdata_mount = k8s_client.V1VolumeMount(
         name="user-data",
         mount_path="/mnt/user-data",
         read_only=False,
     )
     if USERDATA_PVC_NAME:
-        userdata_mount.sub_path = f"threads/{thread_id}/user-data"
+        userdata_mount.sub_path = f"taichu-claw/users/{user_id}/threads/{thread_id}/user-data"
 
     return [
         k8s_client.V1VolumeMount(
@@ -303,9 +316,10 @@ def _build_volume_mounts(thread_id: str) -> list[k8s_client.V1VolumeMount]:
     ]
 
 
-def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
+def _build_pod(sandbox_id: str, thread_id: str, user_id: str = DEFAULT_USER_ID) -> k8s_client.V1Pod:
     """Construct a Pod manifest for a single sandbox."""
     thread_id = _validate_thread_id(thread_id)
+    user_id = _validate_user_id(user_id)
     return k8s_client.V1Pod(
         metadata=k8s_client.V1ObjectMeta(
             name=_pod_name(sandbox_id),
@@ -362,7 +376,7 @@ def _build_pod(sandbox_id: str, thread_id: str) -> k8s_client.V1Pod:
                             "ephemeral-storage": "500Mi",
                         },
                     ),
-                    volume_mounts=_build_volume_mounts(thread_id),
+                    volume_mounts=_build_volume_mounts(thread_id, user_id=user_id),
                     security_context=k8s_client.V1SecurityContext(
                         privileged=False,
                         allow_privilege_escalation=True,
@@ -445,9 +459,10 @@ async def create_sandbox(req: CreateSandboxRequest):
     """
     sandbox_id = req.sandbox_id
     thread_id = req.thread_id
+    user_id = req.user_id
 
     logger.info(
-        f"Received request to create sandbox '{sandbox_id}' for thread '{thread_id}'"
+        f"Received request to create sandbox '{sandbox_id}' for thread '{thread_id}' user '{user_id}'"
     )
 
     # ── Fast path: sandbox already exists ────────────────────────────
@@ -461,7 +476,7 @@ async def create_sandbox(req: CreateSandboxRequest):
 
     # ── Create Pod ───────────────────────────────────────────────────
     try:
-        core_v1.create_namespaced_pod(K8S_NAMESPACE, _build_pod(sandbox_id, thread_id))
+        core_v1.create_namespaced_pod(K8S_NAMESPACE, _build_pod(sandbox_id, thread_id, user_id=user_id))
         logger.info(f"Created Pod {_pod_name(sandbox_id)}")
     except ApiException as exc:
         if exc.status != 409:  # 409 = AlreadyExists


### PR DESCRIPTION
## Summary

Fix provisioner-mode sandbox PVC mounting so user-data subPaths include the effective user id instead of being keyed only by thread id.

## Root Cause

`RemoteSandboxBackend` created provisioner sandboxes with only `sandbox_id` and `thread_id`. When `USERDATA_PVC_NAME` was configured, the provisioner mounted all thread user-data under a thread-only subPath, which could collide across users and bypass the user isolation model used by backend filesystem paths.

## Changes

- Forward the effective user id from `RemoteSandboxBackend` to the provisioner create API.
- Add `user_id` validation and a backwards-compatible default to the provisioner request model.
- Change PVC user-data subPath to `./deer-flow/users/{user_id}/threads/{thread_id}/user-data`.
- Update provisioner docs and regression coverage for user-scoped PVC mounts.

## Tests

- `cd backend && uv run --group dev ruff check packages/harness/deerflow/community/aio_sandbox/remote_backend.py tests/test_aio_sandbox_provider.py tests/test_provisioner_pvc_volumes.py ../docker/provisioner/app.py`
- `cd backend && uv run --group dev pytest tests/test_aio_sandbox_provider.py tests/test_provisioner_pvc_volumes.py -q`
- `git diff --check`
