### PR TITLE
feat(config): support user MCP settings merge

### DIFF
--- a/backend/packages/harness/deerflow/config/extensions_config.py
+++ b/backend/packages/harness/deerflow/config/extensions_config.py
@@ -1,5 +1,6 @@
 """Unified extensions configuration for MCP servers and skills."""
 
+import copy
 import json
 import os
 from pathlib import Path
@@ -7,7 +8,17 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from deerflow.config.runtime_paths import existing_project_file
+from deerflow.config.runtime_paths import existing_project_file, runtime_home
+
+USER_MCP_SETTINGS_FILENAME = "mcp_settings.json"
+
+
+def _validate_user_id_for_path(user_id: str) -> str:
+    """Validate a user id before using it as a path segment."""
+    normalized = user_id.strip()
+    if not normalized or normalized in {".", ".."} or "/" in normalized or "\\" in normalized or "\x00" in normalized:
+        raise ValueError(f"Invalid user_id {user_id!r}: user ids used in paths cannot be empty or contain path separators.")
+    return normalized
 
 
 class McpOAuthConfig(BaseModel):
@@ -69,6 +80,44 @@ class ExtensionsConfig(BaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
     @classmethod
+    def user_mcp_settings_path(cls, user_id: str) -> Path:
+        """Return the user-level MCP settings path for a user id.
+
+        The file is intentionally separate from the global `extensions_config.json`
+        so future call sites can load per-user MCP settings without changing the
+        existing global configuration behavior.
+        """
+        safe_user_id = _validate_user_id_for_path(user_id)
+        return runtime_home() / "users" / safe_user_id / USER_MCP_SETTINGS_FILENAME
+
+    @classmethod
+    def resolve_user_mcp_settings_path(cls, user_id: str | None = None, user_config_path: str | None = None) -> Path | None:
+        """Resolve an existing user-level MCP settings file.
+
+        Args:
+            user_id: User id whose settings should be loaded from
+                     `{runtime_home}/users/{user_id}/mcp_settings.json`.
+            user_config_path: Optional explicit settings file path, mainly useful
+                              for tests and future API call sites.
+
+        Returns:
+            Path to an existing user MCP settings file, or None if no user file
+            should be loaded.
+        """
+        if user_config_path:
+            path = Path(user_config_path)
+            if not path.exists():
+                raise FileNotFoundError(f"User MCP settings file specified by param `user_config_path` not found at {path}")
+            return path
+        if user_id is None:
+            return None
+
+        path = cls.user_mcp_settings_path(user_id)
+        if path.is_file():
+            return path
+        return None
+
+    @classmethod
     def resolve_config_path(cls, config_path: str | None = None) -> Path | None:
         """Resolve the extensions config file path.
 
@@ -122,13 +171,15 @@ class ExtensionsConfig(BaseModel):
             return None
 
     @classmethod
-    def from_file(cls, config_path: str | None = None) -> "ExtensionsConfig":
+    def from_file(cls, config_path: str | None = None, *, user_id: str | None = None, user_config_path: str | None = None) -> "ExtensionsConfig":
         """Load extensions config from JSON file.
 
         See `resolve_config_path` for more details.
 
         Args:
             config_path: Path to the extensions config file.
+            user_id: Optional user id used to load and merge user-level MCP settings.
+            user_config_path: Optional explicit user MCP settings file path.
 
         Returns:
             ExtensionsConfig: The loaded config, or empty config if file not found.
@@ -136,17 +187,64 @@ class ExtensionsConfig(BaseModel):
         resolved_path = cls.resolve_config_path(config_path)
         if resolved_path is None:
             # Return empty config if extensions config file is not found
-            return cls(mcp_servers={}, skills={})
+            config_data: dict[str, Any] = {"mcpServers": {}, "skills": {}}
+        else:
+            config_data = cls._load_config_data(resolved_path, description="Extensions config file")
+
+        resolved_user_path = cls.resolve_user_mcp_settings_path(user_id=user_id, user_config_path=user_config_path)
+        if resolved_user_path is not None:
+            user_config_data = cls._load_config_data(resolved_user_path, description="User MCP settings file")
+            config_data = cls.merge_user_mcp_settings_data(config_data, user_config_data)
 
         try:
-            with open(resolved_path, encoding="utf-8") as f:
-                config_data = json.load(f)
             cls.resolve_env_variables(config_data)
             return cls.model_validate(config_data)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Extensions config file at {resolved_path} is not valid JSON: {e}") from e
         except Exception as e:
-            raise RuntimeError(f"Failed to load extensions config from {resolved_path}: {e}") from e
+            source = resolved_path or "empty extensions config"
+            raise RuntimeError(f"Failed to load extensions config from {source}: {e}") from e
+
+    @classmethod
+    def _load_config_data(cls, path: Path, *, description: str) -> dict[str, Any]:
+        """Load raw JSON config data from a file."""
+        try:
+            with open(path, encoding="utf-8") as f:
+                config_data = json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"{description} at {path} is not valid JSON: {e}") from e
+
+        if not isinstance(config_data, dict):
+            raise ValueError(f"{description} at {path} must contain a JSON object")
+        return config_data
+
+    @classmethod
+    def merge_user_mcp_settings_data(cls, base_config: dict[str, Any], user_config: dict[str, Any]) -> dict[str, Any]:
+        """Merge user-level MCP server settings into a global extensions config.
+
+        Only `mcpServers` is merged from the user config. Global skills and other
+        extension-level fields remain owned by the global config. For an MCP
+        server with the same name, user-provided fields override the global server
+        fields while unspecified fields are inherited from the global server.
+        """
+        merged = copy.deepcopy(base_config)
+        base_servers_raw = merged.get("mcpServers")
+        user_servers_raw = user_config.get("mcpServers")
+        base_servers = copy.deepcopy(base_servers_raw) if base_servers_raw is not None else {}
+        user_servers = user_servers_raw if user_servers_raw is not None else {}
+
+        if not isinstance(base_servers, dict):
+            raise ValueError("Global extensions config field `mcpServers` must be an object")
+        if not isinstance(user_servers, dict):
+            raise ValueError("User MCP settings field `mcpServers` must be an object")
+
+        for server_name, user_server in user_servers.items():
+            base_server = base_servers.get(server_name)
+            if isinstance(base_server, dict) and isinstance(user_server, dict):
+                base_servers[server_name] = {**base_server, **copy.deepcopy(user_server)}
+            else:
+                base_servers[server_name] = copy.deepcopy(user_server)
+
+        merged["mcpServers"] = base_servers
+        return merged
 
     @classmethod
     def resolve_env_variables(cls, config: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_extensions_config_user_mcp.py
+++ b/backend/tests/test_extensions_config_user_mcp.py
@@ -1,0 +1,180 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from deerflow.config.extensions_config import ExtensionsConfig
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_user_mcp_settings_path_resolves_under_runtime_home(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path / "state"))
+
+    assert ExtensionsConfig.user_mcp_settings_path("user-1") == tmp_path / "state" / "users" / "user-1" / "mcp_settings.json"
+
+
+@pytest.mark.parametrize("user_id", ["", "   ", ".", "..", "../other", "nested/user", "nested\\user"])
+def test_user_mcp_settings_path_rejects_unsafe_user_ids(user_id: str):
+    with pytest.raises(ValueError, match="Invalid user_id"):
+        ExtensionsConfig.user_mcp_settings_path(user_id)
+
+
+def test_from_file_keeps_existing_behavior_without_user_id(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path / "state"))
+    global_config = tmp_path / "extensions_config.json"
+    user_config = tmp_path / "state" / "users" / "user-1" / "mcp_settings.json"
+
+    _write_json(
+        global_config,
+        {
+            "mcpServers": {
+                "global-server": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "global-command",
+                }
+            },
+            "skills": {"global-skill": {"enabled": True}},
+        },
+    )
+    _write_json(
+        user_config,
+        {
+            "mcpServers": {
+                "user-server": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "user-command",
+                }
+            }
+        },
+    )
+
+    config = ExtensionsConfig.from_file(str(global_config))
+
+    assert set(config.mcp_servers) == {"global-server"}
+    assert set(config.skills) == {"global-skill"}
+
+
+def test_from_file_merges_user_mcp_settings_from_user_id(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path / "state"))
+    global_config = tmp_path / "extensions_config.json"
+    user_config = tmp_path / "state" / "users" / "user-1" / "mcp_settings.json"
+
+    _write_json(
+        global_config,
+        {
+            "mcpServers": {
+                "shared": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "global-command",
+                    "args": ["global"],
+                    "description": "Global server",
+                }
+            },
+            "skills": {"global-skill": {"enabled": True}},
+        },
+    )
+    _write_json(
+        user_config,
+        {
+            "mcpServers": {
+                "shared": {
+                    "enabled": False,
+                    "args": ["user"],
+                },
+                "user-only": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "user-command",
+                },
+            },
+            "skills": {"ignored-user-skill": {"enabled": True}},
+        },
+    )
+
+    config = ExtensionsConfig.from_file(str(global_config), user_id="user-1")
+
+    assert set(config.mcp_servers) == {"shared", "user-only"}
+    assert config.mcp_servers["shared"].enabled is False
+    assert config.mcp_servers["shared"].command == "global-command"
+    assert config.mcp_servers["shared"].args == ["user"]
+    assert config.mcp_servers["shared"].description == "Global server"
+    assert config.mcp_servers["user-only"].command == "user-command"
+    assert set(config.skills) == {"global-skill"}
+
+
+def test_from_file_merges_user_mcp_settings_from_explicit_path(tmp_path: Path):
+    global_config = tmp_path / "extensions_config.json"
+    user_config = tmp_path / "custom-user-mcp.json"
+
+    _write_json(global_config, {"mcpServers": {}, "skills": {}})
+    _write_json(
+        user_config,
+        {
+            "mcpServers": {
+                "user-only": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "user-command",
+                }
+            }
+        },
+    )
+
+    config = ExtensionsConfig.from_file(str(global_config), user_config_path=str(user_config))
+
+    assert set(config.mcp_servers) == {"user-only"}
+
+
+def test_from_file_supports_user_mcp_settings_without_global_config(tmp_path: Path):
+    user_config = tmp_path / "user-mcp.json"
+    _write_json(
+        user_config,
+        {
+            "mcpServers": {
+                "user-only": {
+                    "enabled": True,
+                    "type": "stdio",
+                    "command": "user-command",
+                }
+            }
+        },
+    )
+
+    config = ExtensionsConfig.from_file(user_config_path=str(user_config))
+
+    assert set(config.mcp_servers) == {"user-only"}
+    assert config.skills == {}
+
+
+def test_from_file_rejects_invalid_user_mcp_settings_json(tmp_path: Path):
+    global_config = tmp_path / "extensions_config.json"
+    user_config = tmp_path / "bad-user-mcp.json"
+
+    _write_json(global_config, {"mcpServers": {}, "skills": {}})
+    user_config.write_text("{", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="User MCP settings file .* is not valid JSON"):
+        ExtensionsConfig.from_file(str(global_config), user_config_path=str(user_config))
+
+
+def test_from_file_rejects_non_object_user_mcp_settings(tmp_path: Path):
+    global_config = tmp_path / "extensions_config.json"
+    user_config = tmp_path / "bad-user-mcp.json"
+
+    _write_json(global_config, {"mcpServers": {}, "skills": {}})
+    user_config.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        ExtensionsConfig.from_file(str(global_config), user_config_path=str(user_config))
+
+
+def test_merge_user_mcp_settings_rejects_non_object_mcp_servers():
+    with pytest.raises(ValueError, match="User MCP settings field `mcpServers` must be an object"):
+        ExtensionsConfig.merge_user_mcp_settings_data({"mcpServers": {}, "skills": {}}, {"mcpServers": []})


### PR DESCRIPTION
## Summary

Refs #2949.

This is the first small PR for user-level MCP settings support. It only adds the configuration-layer foundation and intentionally does not change the current default MCP loading behavior yet.

### Multi-stage plan

1. Add backend config support for reading and merging user-level `mcp_settings.json`.
2. Wire user context into MCP tool loading and make the MCP tools cache user-aware to avoid cross-user config reuse.
3. Add user-level MCP config GET/PUT APIs.
4. Add a Settings UI for editing user-level MCP config.

### This PR

- Adds `ExtensionsConfig.user_mcp_settings_path(user_id)` for `.deer-flow/users/<user_id>/mcp_settings.json`.
- Adds optional `user_id` / `user_config_path` arguments to `ExtensionsConfig.from_file()`.
- Merges only the user config `mcpServers` into the global config.
- Keeps global `skills` and other extension-level fields owned by the global config.
- Uses field-level overlay for same-name MCP servers, so a user can override selected fields without restating the whole global server config.
- Preserves existing behavior when no `user_id` or `user_config_path` is passed.

## Tests

- `uv run pytest tests/test_extensions_config_user_mcp.py tests/test_runtime_paths.py`
- `uvx ruff check .`
- `uvx ruff format --check .`