### PR TITLE
fix(2648) :- resolve 401 invalid_signature errors during multi-worker deployments

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -686,6 +686,7 @@ def test_missing_jwt_secret_generates_ephemeral(monkeypatch, caplog):
 
     config_module._auth_config = None
     monkeypatch.delenv("AUTH_JWT_SECRET", raising=False)
+    monkeypatch.setattr("dotenv.load_dotenv", lambda *args, **kwargs: None)
 
     with caplog.at_level(logging.WARNING):
         config = config_module.get_auth_config()

--- a/backend/tests/test_auth_config.py
+++ b/backend/tests/test_auth_config.py
@@ -46,8 +46,9 @@ def test_auth_config_missing_secret_generates_ephemeral(caplog):
     try:
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("AUTH_JWT_SECRET", None)
-            with caplog.at_level(logging.WARNING):
-                config = cfg.get_auth_config()
+            with patch("dotenv.load_dotenv"):
+                with caplog.at_level(logging.WARNING):
+                    config = cfg.get_auth_config()
             assert config.jwt_secret
             assert any("AUTH_JWT_SECRET" in msg for msg in caplog.messages)
     finally:

--- a/backend/tests/test_auth_type_system.py
+++ b/backend/tests/test_auth_type_system.py
@@ -387,10 +387,11 @@ def test_get_auth_config_missing_env_var_generates_ephemeral(caplog):
     try:
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("AUTH_JWT_SECRET", None)
-            with caplog.at_level(logging.WARNING):
-                config = cfg.get_auth_config()
-            assert config.jwt_secret
-            assert any("AUTH_JWT_SECRET" in msg for msg in caplog.messages)
+            with patch("dotenv.load_dotenv"):
+                with caplog.at_level(logging.WARNING):
+                    config = cfg.get_auth_config()
+                assert config.jwt_secret
+                assert any("AUTH_JWT_SECRET" in msg for msg in caplog.messages)
     finally:
         cfg._auth_config = old
 

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -163,6 +163,7 @@ services:
           create_host_path: true
     working_dir: /app
     environment:
+      - AUTH_JWT_SECRET=${AUTH_JWT_SECRET}
       - CI=true
       - DEER_FLOW_PROJECT_ROOT=/app
       - DEER_FLOW_HOME=/app/backend/.deer-flow

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -94,6 +94,7 @@ services:
           create_host_path: true
     working_dir: /app
     environment:
+      - AUTH_JWT_SECRET=${AUTH_JWT_SECRET}
       - CI=true
       - DEER_FLOW_PROJECT_ROOT=/app
       - DEER_FLOW_HOME=/app/backend/.deer-flow

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -127,6 +127,25 @@ if [ -z "$BETTER_AUTH_SECRET" ]; then
     fi
 fi
 
+# ── AUTH_JWT_SECRET ──────────────────────────────────────────────────────────
+# Required by FastAPI for JWT signing. Generated once and persisted so sessions
+# survive container restarts and multiple Uvicorn workers share the same secret.
+
+_jwt_secret_file="$DEER_FLOW_HOME/.auth-jwt-secret"
+if [ -z "$AUTH_JWT_SECRET" ]; then
+    if [ -f "$_jwt_secret_file" ]; then
+        export AUTH_JWT_SECRET
+        AUTH_JWT_SECRET="$(cat "$_jwt_secret_file")"
+        echo -e "${GREEN}✓ AUTH_JWT_SECRET loaded from $_jwt_secret_file${NC}"
+    else
+        export AUTH_JWT_SECRET
+        AUTH_JWT_SECRET="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+        echo "$AUTH_JWT_SECRET" > "$_jwt_secret_file"
+        chmod 600 "$_jwt_secret_file"
+        echo -e "${GREEN}✓ AUTH_JWT_SECRET generated → $_jwt_secret_file${NC}"
+    fi
+fi
+
 # ── detect_sandbox_mode ───────────────────────────────────────────────────────
 
 detect_sandbox_mode() {
@@ -173,6 +192,7 @@ if [ "$CMD" = "down" ]; then
     export DEER_FLOW_DOCKER_SOCKET="${DEER_FLOW_DOCKER_SOCKET:-/var/run/docker.sock}"
     export DEER_FLOW_REPO_ROOT="${DEER_FLOW_REPO_ROOT:-$REPO_ROOT}"
     export BETTER_AUTH_SECRET="${BETTER_AUTH_SECRET:-placeholder}"
+    export AUTH_JWT_SECRET="${AUTH_JWT_SECRET:-placeholder}"
     "${COMPOSE_CMD[@]}" down
     exit 0
 fi

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -220,6 +220,23 @@ start() {
         fi
     fi
 
+    export DEER_FLOW_HOME="${DEER_FLOW_HOME:-$PROJECT_ROOT/backend/.deer-flow}"
+    _jwt_secret_file="$DEER_FLOW_HOME/.auth-jwt-secret"
+    if [ -z "$AUTH_JWT_SECRET" ]; then
+        if [ -f "$_jwt_secret_file" ]; then
+            export AUTH_JWT_SECRET
+            AUTH_JWT_SECRET="$(cat "$_jwt_secret_file")"
+            echo -e "${GREEN}✓ AUTH_JWT_SECRET loaded from $_jwt_secret_file${NC}"
+        else
+            export AUTH_JWT_SECRET
+            AUTH_JWT_SECRET="$(python3 -c 'import secrets; print(secrets.token_urlsafe(32))')"
+            mkdir -p "$DEER_FLOW_HOME"
+            echo "$AUTH_JWT_SECRET" > "$_jwt_secret_file"
+            chmod 600 "$_jwt_secret_file"
+            echo -e "${GREEN}✓ AUTH_JWT_SECRET generated → $_jwt_secret_file${NC}"
+        fi
+    fi
+
     echo "Building and starting containers..."
     cd "$DOCKER_DIR" && $COMPOSE_CMD up --build -d --remove-orphans $services
     echo ""


### PR DESCRIPTION
This PR fixes #2648 

Previously, when the gateway was deployed with `make up`, Uvicorn would spawn multiple worker processes. If `AUTH_JWT_SECRET` wasn't explicitly set in the environment, the `config.py` fallback logic caused each worker to independently generate its own ephemeral secret in memory. This resulted in JWTs signed by one worker being rejected by others (e.g., during UI re-renders or background fetches), throwing a 401 `invalid_signature` error.
This commit resolves the issue by treating `AUTH_JWT_SECRET` exactly like `BETTER_AUTH_SECRET`:
- `scripts/deploy.sh` and `scripts/docker.sh` now check for the secret before Docker starts.
- If missing, it generates a secure token via Python and persists it to `$DEER_FLOW_HOME/.auth-jwt-secret`.
- The secret is then explicitly injected into the gateway container's environment via `docker-compose.yaml` and `docker-compose-dev.yaml`.
This ensures all Uvicorn workers read a single, consistent secret from the environment, completely eliminating random logouts while preserving stateless container behavior.