### PR TITLE
feat(models): add MiMo reasoning adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
 
    For vLLM 0.19.0, use `deerflow.models.vllm_provider:VllmChatModel`. For Qwen-style reasoning models, DeerFlow toggles reasoning with `extra_body.chat_template_kwargs.enable_thinking` and preserves vLLM's non-standard `reasoning` field across multi-turn tool-call conversations. Legacy `thinking` configs are normalized automatically for backward compatibility. Reasoning models may also require the server to be started with `--reasoning-parser ...`. If your local vLLM deployment accepts any non-empty API key, you can still set `VLLM_API_KEY` to a placeholder value.
 
+   MiMo reasoning models need `deerflow.models.patched_mimo:PatchedMimoChatModel` instead of plain `langchain_openai:ChatOpenAI`. MiMo returns assistant-side `reasoning_content` and expects that field to be echoed back on later turns when thinking is enabled, so the patched adapter preserves it across multi-turn agent runs.
+
    CLI-backed provider examples:
 
    ```yaml

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -166,6 +166,35 @@ models:
 
 For Gemini accessed **without** thinking (e.g. via OpenRouter where thinking is not activated), the plain `langchain_openai:ChatOpenAI` with `supports_thinking: false` is sufficient and no patch is needed.
 
+MiMo reasoning models need the same kind of provider-specific care. MiMo returns
+assistant-side `reasoning_content` and expects that field to be sent back in
+later turns when thinking is enabled. Use
+`deerflow.models.patched_mimo:PatchedMimoChatModel` so multi-turn agent runs
+preserve that field:
+
+```yaml
+models:
+  - name: mimo-v2-5-pro
+    display_name: MiMo V2.5 Pro
+    use: deerflow.models.patched_mimo:PatchedMimoChatModel
+    model: mimo-v2.5-pro
+    api_key: $MIMO_API_KEY
+    base_url: $MIMO_BASE_URL
+    max_tokens: 4096
+    supports_thinking: true
+    when_thinking_enabled:
+      extra_body:
+        thinking:
+          type: enabled
+    when_thinking_disabled:
+      extra_body:
+        thinking:
+          type: disabled
+```
+
+At the moment, only thinking on/off has been validated for MiMo. DeerFlow does
+not enable `supports_reasoning_effort` for MiMo by default.
+
 ### Tool Groups
 
 Organize tools into logical groups:

--- a/backend/packages/harness/deerflow/models/patched_mimo.py
+++ b/backend/packages/harness/deerflow/models/patched_mimo.py
@@ -1,0 +1,226 @@
+"""Patched ChatOpenAI for MiMo reasoning-mode history round-tripping.
+
+MiMo's OpenAI-compatible thinking mode returns ``reasoning_content`` on
+assistant messages. Standard ``langchain_openai.ChatOpenAI`` ignores that
+provider-specific field when parsing responses, so subsequent turns have
+nothing to send back even if the transport layer tries to preserve it.
+
+This adapter fixes both halves of the protocol:
+
+1. Parse ``reasoning_content`` from full responses and streaming deltas into
+   ``AIMessage.additional_kwargs``.
+2. Re-inject that field into assistant messages when building the next request.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models.base import (
+    _convert_delta_to_message_chunk,
+    _create_usage_metadata,
+)
+
+
+class PatchedMimoChatModel(ChatOpenAI):
+    """ChatOpenAI with MiMo ``reasoning_content`` preservation."""
+
+    def _get_request_payload(
+        self,
+        input_: LanguageModelInput,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict:
+        original_messages = self._convert_input(input_).to_messages()
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+
+        payload_messages = payload.get("messages", [])
+
+        if len(payload_messages) == len(original_messages):
+            for payload_msg, orig_msg in zip(payload_messages, original_messages):
+                if payload_msg.get("role") == "assistant" and isinstance(orig_msg, AIMessage):
+                    _restore_reasoning_content(payload_msg, orig_msg)
+        else:
+            ai_messages = [m for m in original_messages if isinstance(m, AIMessage)]
+            assistant_payloads = [m for m in payload_messages if m.get("role") == "assistant"]
+            for payload_msg, ai_msg in zip(assistant_payloads, ai_messages):
+                _restore_reasoning_content(payload_msg, ai_msg)
+
+        if _thinking_enabled(payload):
+            payload["messages"] = _drop_legacy_messages_missing_reasoning(payload_messages)
+        return payload
+
+    def _convert_chunk_to_generation_chunk(
+        self,
+        chunk: dict,
+        default_chunk_class: type,
+        base_generation_info: dict | None,
+    ) -> ChatGenerationChunk | None:
+        token_usage = chunk.get("usage")
+        choices = chunk.get("choices", []) or chunk.get("chunk", {}).get("choices", [])
+        usage_metadata = _create_usage_metadata(token_usage, chunk.get("service_tier")) if token_usage else None
+
+        if len(choices) == 0:
+            generation_chunk = ChatGenerationChunk(
+                message=default_chunk_class(content="", usage_metadata=usage_metadata),
+                generation_info=base_generation_info,
+            )
+            return generation_chunk
+
+        choice = choices[0]
+        delta = choice.get("delta")
+        if delta is None:
+            return None
+
+        message_chunk = _convert_delta_to_message_chunk(delta, default_chunk_class)
+        generation_info = {**base_generation_info} if base_generation_info else {}
+
+        if finish_reason := choice.get("finish_reason"):
+            generation_info["finish_reason"] = finish_reason
+            if model_name := chunk.get("model"):
+                generation_info["model_name"] = model_name
+            if system_fingerprint := chunk.get("system_fingerprint"):
+                generation_info["system_fingerprint"] = system_fingerprint
+            if service_tier := chunk.get("service_tier"):
+                generation_info["service_tier"] = service_tier
+
+        if logprobs := choice.get("logprobs"):
+            generation_info["logprobs"] = logprobs
+
+        if isinstance(message_chunk, AIMessageChunk):
+            if usage_metadata:
+                message_chunk.usage_metadata = usage_metadata
+            if isinstance(delta.get("reasoning_content"), str) and delta["reasoning_content"].strip():
+                message_chunk = _with_reasoning_content(
+                    message_chunk,
+                    delta["reasoning_content"],
+                    preserve_whitespace=True,
+                )
+
+        message_chunk.response_metadata["model_provider"] = "openai"
+        return ChatGenerationChunk(
+            message=message_chunk,
+            generation_info=generation_info or None,
+        )
+
+    def _create_chat_result(
+        self,
+        response: dict | Any,
+        generation_info: dict | None = None,
+    ) -> ChatResult:
+        result = super()._create_chat_result(response, generation_info)
+        response_dict = response if isinstance(response, dict) else response.model_dump()
+        choices = response_dict.get("choices", [])
+
+        generations: list[ChatGeneration] = []
+        for index, generation in enumerate(result.generations):
+            choice = choices[index] if index < len(choices) else {}
+            message = generation.message
+            if isinstance(message, AIMessage):
+                choice_message = choice.get("message", {}) if isinstance(choice, dict) else {}
+                reasoning_content = choice_message.get("reasoning_content")
+
+                if isinstance(reasoning_content, str) and reasoning_content.strip():
+                    message = _with_reasoning_content(message, reasoning_content)
+                    generation = ChatGeneration(
+                        message=message,
+                        generation_info=generation.generation_info,
+                    )
+
+            generations.append(generation)
+
+        return ChatResult(generations=generations, llm_output=result.llm_output)
+
+
+def _restore_reasoning_content(payload_msg: dict, orig_msg: AIMessage) -> None:
+    reasoning_content = orig_msg.additional_kwargs.get("reasoning_content")
+    if reasoning_content is not None:
+        payload_msg["reasoning_content"] = reasoning_content
+
+
+def _drop_legacy_messages_missing_reasoning(payload_messages: list[dict]) -> list[dict]:
+    """Remove assistant turns that cannot satisfy MiMo's history contract.
+
+    Older persisted threads may contain assistant messages created before this
+    adapter existed, so they have no ``reasoning_content`` to echo back. MiMo
+    rejects the entire request in that case. We prefer dropping those legacy
+    turns over failing the whole conversation.
+    """
+    cleaned: list[dict] = []
+    skipped_tool_call_ids: set[str] = set()
+
+    for message in payload_messages:
+        role = message.get("role")
+
+        if role == "tool":
+            tool_call_id = message.get("tool_call_id")
+            if isinstance(tool_call_id, str) and tool_call_id in skipped_tool_call_ids:
+                continue
+            cleaned.append(message)
+            continue
+
+        if role == "assistant" and not _has_reasoning_content(message):
+            for tool_call in message.get("tool_calls") or []:
+                if isinstance(tool_call, dict):
+                    tool_call_id = tool_call.get("id")
+                    if isinstance(tool_call_id, str) and tool_call_id:
+                        skipped_tool_call_ids.add(tool_call_id)
+            continue
+
+        cleaned.append(message)
+
+    return cleaned
+
+
+def _has_reasoning_content(message: dict) -> bool:
+    reasoning_content = message.get("reasoning_content")
+    return isinstance(reasoning_content, str) and bool(reasoning_content.strip())
+
+
+def _thinking_enabled(payload: dict) -> bool:
+    extra_body = payload.get("extra_body")
+    if not isinstance(extra_body, dict):
+        return False
+
+    thinking = extra_body.get("thinking")
+    if not isinstance(thinking, dict):
+        return False
+
+    return thinking.get("type") == "enabled"
+
+
+def _merge_reasoning(*values: str | None) -> str | None:
+    merged: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        normalized = value.strip()
+        if normalized and normalized not in merged:
+            merged.append(normalized)
+    return "\n\n".join(merged) if merged else None
+
+
+def _with_reasoning_content(
+    message: AIMessage | AIMessageChunk,
+    reasoning: str | None,
+    *,
+    preserve_whitespace: bool = False,
+):
+    if not reasoning:
+        return message
+
+    additional_kwargs = dict(message.additional_kwargs)
+    if preserve_whitespace:
+        existing = additional_kwargs.get("reasoning_content")
+        additional_kwargs["reasoning_content"] = f"{existing}{reasoning}" if isinstance(existing, str) else reasoning
+    else:
+        additional_kwargs["reasoning_content"] = _merge_reasoning(
+            additional_kwargs.get("reasoning_content"),
+            reasoning,
+        )
+    return message.model_copy(update={"additional_kwargs": additional_kwargs})

--- a/backend/tests/test_patched_mimo.py
+++ b/backend/tests/test_patched_mimo.py
@@ -1,0 +1,313 @@
+"""Tests for deerflow.models.patched_mimo.PatchedMimoChatModel.
+
+Covers:
+- response parsing for ``reasoning_content``
+- streaming delta preservation
+- history replay with ``reasoning_content`` restoration
+- legacy-thread compatibility when old assistant turns are incomplete
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+
+
+def _make_model(**kwargs):
+    from deerflow.models.patched_mimo import PatchedMimoChatModel
+
+    return PatchedMimoChatModel(
+        model="mimo-v2.5-pro",
+        api_key="test-key",
+        base_url="https://token-plan-cn.xiaomimimo.com/v1",
+        **kwargs,
+    )
+
+
+def _make_payload_message(role: str, content: str | None = None) -> dict:
+    return {"role": role, "content": content}
+
+
+def test_reasoning_content_injected_into_assistant_message():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    ai = AIMessage(
+        content="hello",
+        additional_kwargs={"reasoning_content": "internal reasoning"},
+    )
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("user", "hi"),
+            _make_payload_message("assistant", "hello"),
+        ]
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, ai])
+            payload = model._get_request_payload([human, ai])
+
+    assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
+    assert assistant_msg["reasoning_content"] == "internal reasoning"
+
+
+def test_no_reasoning_content_plain_assistant_is_dropped_when_thinking_enabled():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    ai = AIMessage(content="hello", additional_kwargs={})
+    followup = HumanMessage(content="continue")
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("user", "hi"),
+            _make_payload_message("assistant", "hello"),
+            _make_payload_message("user", "continue"),
+        ],
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, ai, followup])
+            payload = model._get_request_payload([human, ai, followup])
+
+    assert payload["messages"] == [
+        _make_payload_message("user", "hi"),
+        _make_payload_message("user", "continue"),
+    ]
+
+
+def test_no_reasoning_content_plain_assistant_is_preserved_when_thinking_disabled():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    ai = AIMessage(content="hello", additional_kwargs={})
+    followup = HumanMessage(content="continue")
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("user", "hi"),
+            _make_payload_message("assistant", "hello"),
+            _make_payload_message("user", "continue"),
+        ],
+        "extra_body": {"thinking": {"type": "disabled"}},
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, ai, followup])
+            payload = model._get_request_payload([human, ai, followup])
+
+    assert payload["messages"] == base_payload["messages"]
+
+
+def test_positional_fallback_when_count_differs():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    ai = AIMessage(
+        content="hello",
+        additional_kwargs={"reasoning_content": "carry me forward"},
+    )
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("system", "You are helpful."),
+            _make_payload_message("user", "hi"),
+            _make_payload_message("assistant", "hello"),
+        ]
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, ai])
+            payload = model._get_request_payload([human, ai])
+
+    assistant_msg = next(m for m in payload["messages"] if m["role"] == "assistant")
+    assert assistant_msg["reasoning_content"] == "carry me forward"
+
+
+def test_legacy_assistant_without_reasoning_is_dropped_with_tool_result_when_thinking_enabled():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    legacy_ai = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "get_weather",
+                "args": {"city": "Beijing"},
+                "id": "call_legacy",
+                "type": "tool_call",
+            }
+        ],
+        additional_kwargs={},
+    )
+    followup = HumanMessage(content="continue")
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("user", "hi"),
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_legacy",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Beijing"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_legacy", "content": '{"temp": 20}'},
+            _make_payload_message("user", "continue"),
+        ],
+        "extra_body": {"thinking": {"type": "enabled"}},
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, legacy_ai, followup])
+            payload = model._get_request_payload([human, legacy_ai, followup])
+
+    assert payload["messages"] == [
+        _make_payload_message("user", "hi"),
+        _make_payload_message("user", "continue"),
+    ]
+
+
+def test_legacy_assistant_without_reasoning_is_preserved_when_thinking_disabled():
+    model = _make_model()
+
+    human = HumanMessage(content="hi")
+    legacy_ai = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "get_weather",
+                "args": {"city": "Beijing"},
+                "id": "call_legacy",
+                "type": "tool_call",
+            }
+        ],
+        additional_kwargs={},
+    )
+    followup = HumanMessage(content="continue")
+
+    base_payload = {
+        "messages": [
+            _make_payload_message("user", "hi"),
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_legacy",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Beijing"}',
+                        },
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_legacy", "content": '{"temp": 20}'},
+            _make_payload_message("user", "continue"),
+        ],
+        "extra_body": {"thinking": {"type": "disabled"}},
+    }
+
+    with patch.object(type(model).__bases__[0], "_get_request_payload", return_value=base_payload):
+        with patch.object(model, "_convert_input") as mock_convert:
+            mock_convert.return_value = MagicMock(to_messages=lambda: [human, legacy_ai, followup])
+            payload = model._get_request_payload([human, legacy_ai, followup])
+
+    assert payload["messages"] == base_payload["messages"]
+
+
+def test_create_chat_result_maps_reasoning_content_to_additional_kwargs():
+    model = _make_model()
+    response = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "final answer",
+                    "reasoning_content": "step by step reasoning",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "model": "mimo-v2.5-pro",
+    }
+
+    result = model._create_chat_result(response)
+    message = result.generations[0].message
+
+    assert message.content == "final answer"
+    assert message.additional_kwargs["reasoning_content"] == "step by step reasoning"
+    assert result.generations[0].text == "final answer"
+
+
+def test_convert_chunk_to_generation_chunk_preserves_reasoning_deltas():
+    model = _make_model()
+
+    first = model._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "First, ",
+                    }
+                }
+            ]
+        },
+        AIMessageChunk,
+        {},
+    )
+    second = model._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "",
+                        "reasoning_content": "think carefully.",
+                    }
+                }
+            ]
+        },
+        AIMessageChunk,
+        {},
+    )
+    answer = model._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "content": "final answer",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "model": "mimo-v2.5-pro",
+        },
+        AIMessageChunk,
+        {},
+    )
+
+    assert first is not None
+    assert second is not None
+    assert answer is not None
+
+    combined = first.message + second.message + answer.message
+    assert combined.additional_kwargs["reasoning_content"] == "First, think carefully."
+    assert combined.content == "final answer"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -191,6 +191,26 @@ models:
   #       thinking:
   #         type: disabled
 
+  # Example: MiMo reasoning model (with thinking support)
+  # MiMo requires assistant ``reasoning_content`` to be echoed back on later
+  # turns, so use the patched adapter instead of plain ``ChatOpenAI``.
+  # - name: mimo-v2-5-pro
+  #   display_name: MiMo V2.5 Pro
+  #   use: deerflow.models.patched_mimo:PatchedMimoChatModel
+  #   model: mimo-v2.5-pro
+  #   api_key: $MIMO_API_KEY
+  #   base_url: $MIMO_BASE_URL
+  #   max_tokens: 8192              # Conservative sample value; MiMo supports much larger outputs, so tune this per task
+  #   supports_thinking: true
+  #   when_thinking_enabled:
+  #     extra_body:
+  #       thinking:
+  #         type: enabled
+  #   when_thinking_disabled:
+  #     extra_body:
+  #       thinking:
+  #         type: disabled
+
   # Example: Kimi K2.5 model
   # - name: kimi-k2.5
   #   display_name: Kimi K2.5
@@ -1035,8 +1055,8 @@ run_events:
 #     bot_token: $DISCORD_BOT_TOKEN
 #     allowed_guilds: []              # empty = allow all guilds; can also be a single guild ID
 #     mention_only: false             # If true, only respond when the bot is mentioned
-#     allowed_channels: []              # Optional: channel IDs exempt from mention_only (bot responds without mention)
-#     thread_mode: false               # If true, group a channel conversation into a thread
+#     allowed_channels: []            # Optional: channel IDs exempt from mention_only (bot responds without mention)
+#     thread_mode: false              # If true, group a channel conversation into a thread
 
 # ============================================================================
 # Guardrails Configuration


### PR DESCRIPTION

Closes #2990

## Summary

Add MiMo reasoning-mode support for multi-turn agent conversations.

MiMo returns `reasoning_content` in thinking mode and expects that field to be passed back in later requests. The default OpenAI-compatible adapter does not preserve that field end to end, which can break multi-turn reasoning flows.

## Changes

- add `PatchedMimoChatModel` to preserve MiMo `reasoning_content`
- support both non-streaming responses and streaming deltas
- re-inject `reasoning_content` when replaying assistant history
- add tests for request replay, response parsing, streaming, and legacy-history compatibility
- add a MiMo config example to `config.example.yaml`

## Verification

```bash
cd backend
make format
make lint
uv run pytest tests/test_patched_mimo.py tests/test_patched_deepseek.py tests/test_patched_minimax.py -q
```