### PR TITLE
fix(frontend): hide assistant copy while streaming

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -64,6 +64,7 @@ export default function AgentChatPage() {
 
   const {
     thread,
+    pendingStreamMessages,
     pendingUsageMessages,
     sendMessage,
     isUploading,
@@ -182,6 +183,7 @@ export default function AgentChatPage() {
                 className={cn("size-full", !isWelcomeMode && "pt-10")}
                 threadId={threadId}
                 thread={thread}
+                pendingStreamMessages={pendingStreamMessages}
                 paddingBottom={MESSAGE_LIST_DEFAULT_PADDING_BOTTOM}
                 hasMoreHistory={hasMoreHistory}
                 loadMoreHistory={loadMoreHistory}

--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -86,7 +86,7 @@ export default function NewAgentPage() {
 
   const threadId = useMemo(() => uuid(), []);
 
-  const { thread, sendMessage } = useThreadStream({
+  const { thread, pendingStreamMessages, sendMessage } = useThreadStream({
     threadId: undefined,
     context: {
       mode: "flash",
@@ -343,6 +343,7 @@ export default function NewAgentPage() {
                 className={cn("size-full", showSaveHint ? "pt-4" : "pt-10")}
                 threadId={threadId}
                 thread={thread}
+                pendingStreamMessages={pendingStreamMessages}
               />
             </div>
 

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -67,6 +67,7 @@ export default function ChatPage() {
 
   const {
     thread,
+    pendingStreamMessages,
     pendingUsageMessages,
     sendMessage,
     isUploading,
@@ -163,6 +164,7 @@ export default function ChatPage() {
                 className={cn("size-full", !isWelcomeMode && "pt-10")}
                 threadId={threadId}
                 thread={thread}
+                pendingStreamMessages={pendingStreamMessages}
                 paddingBottom={MESSAGE_LIST_DEFAULT_PADDING_BOTTOM}
                 hasMoreHistory={hasMoreHistory}
                 loadMoreHistory={loadMoreHistory}

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -16,13 +16,15 @@ import {
 import {
   extractContentFromMessage,
   extractPresentFilesFromMessage,
-  extractReasoningContentFromMessage,
   extractTextFromMessage,
+  getCurrentStreamingAssistantMessage,
+  getAssistantTurnCopyData,
   getAssistantTurnUsageMessages,
   getMessageGroups,
   hasContent,
   hasPresentFiles,
   hasReasoning,
+  isCurrentStreamingAssistantTurn,
 } from "@/core/messages/utils";
 import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
 import type { Subtask } from "@/core/tasks";
@@ -157,6 +159,7 @@ export function MessageList({
   className,
   threadId,
   thread,
+  pendingStreamMessages = [],
   paddingBottom = MESSAGE_LIST_DEFAULT_PADDING_BOTTOM,
   tokenUsageInlineMode = "off",
   hasMoreHistory,
@@ -166,6 +169,7 @@ export function MessageList({
   className?: string;
   threadId: string;
   thread: BaseStream<AgentThreadState>;
+  pendingStreamMessages?: Message[];
   paddingBottom?: number;
   tokenUsageInlineMode?: TokenUsageInlineMode;
   hasMoreHistory?: boolean;
@@ -179,31 +183,34 @@ export function MessageList({
   const groupedMessages = getMessageGroups(messages);
   const turnUsageMessagesByGroupIndex =
     getAssistantTurnUsageMessages(groupedMessages);
+  const currentStreamingAssistantMessage = useMemo(
+    () =>
+      getCurrentStreamingAssistantMessage(messages, thread.isLoading, {
+        pendingStreamMessages,
+      }),
+    [messages, pendingStreamMessages, thread.isLoading],
+  );
   const tokenDebugSteps = useMemo(
     () => buildTokenDebugSteps(messages, t),
     [messages, t],
   );
 
-  const renderAssistantCopyButton = useCallback((messages: Message[]) => {
-    const clipboardData = [...messages]
-      .reverse()
-      .filter((message) => message.type === "ai")
-      .map((message) => {
-        const content = extractContentFromMessage(message);
-        return content ?? extractReasoningContentFromMessage(message) ?? "";
-      })
-      .find((content) => content.length > 0);
+  const renderAssistantCopyButton = useCallback(
+    (messages: Message[], isStreaming: boolean) => {
+      const clipboardData = getAssistantTurnCopyData(messages, { isStreaming });
 
-    if (!clipboardData) {
-      return null;
-    }
+      if (!clipboardData) {
+        return null;
+      }
 
-    return (
-      <div className="mt-2 flex justify-start opacity-0 transition-opacity delay-200 duration-300 group-hover/assistant-turn:opacity-100">
-        <CopyButton clipboardData={clipboardData} />
-      </div>
-    );
-  }, []);
+      return (
+        <div className="mt-2 flex justify-start opacity-0 transition-opacity delay-200 duration-300 group-hover/assistant-turn:opacity-100">
+          <CopyButton clipboardData={clipboardData} />
+        </div>
+      );
+    },
+    [],
+  );
 
   const renderTokenUsage = useCallback(
     ({
@@ -293,7 +300,13 @@ export function MessageList({
                   turnUsageMessages,
                 })}
                 {group.type === "assistant" &&
-                  renderAssistantCopyButton(group.messages)}
+                  renderAssistantCopyButton(
+                    group.messages,
+                    isCurrentStreamingAssistantTurn(
+                      group.messages,
+                      currentStreamingAssistantMessage,
+                    ),
+                  )}
               </div>
             );
           } else if (group.type === "assistant:clarification") {

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -170,6 +170,84 @@ export function getAssistantTurnUsageMessages(groups: MessageGroup[]) {
   return usageMessagesByGroupIndex;
 }
 
+function isSameMessage(left: Message, right: Message) {
+  if (
+    typeof left.id === "string" &&
+    left.id.length > 0 &&
+    typeof right.id === "string" &&
+    right.id.length > 0
+  ) {
+    return left.id === right.id;
+  }
+
+  return left === right;
+}
+
+export function isCurrentStreamingAssistantTurn(
+  groupMessages: Message[],
+  currentStreamingAssistantMessage: Message | null,
+) {
+  if (!currentStreamingAssistantMessage) {
+    return false;
+  }
+
+  return groupMessages.some((message) =>
+    isSameMessage(message, currentStreamingAssistantMessage),
+  );
+}
+
+export function getCurrentStreamingAssistantMessage(
+  _messages: Message[],
+  isStreaming: boolean,
+  { pendingStreamMessages = [] }: { pendingStreamMessages?: Message[] } = {},
+) {
+  if (!isStreaming) {
+    return null;
+  }
+
+  return getLatestStreamingAssistantMessage(pendingStreamMessages);
+}
+
+function getLatestStreamingAssistantMessage(messages: Message[]) {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+
+    if (!message) {
+      continue;
+    }
+
+    if (isHiddenFromUIMessage(message)) {
+      continue;
+    }
+
+    if (message.type === "ai") {
+      return message;
+    }
+  }
+
+  return null;
+}
+
+export function getAssistantTurnCopyData(
+  messages: Message[],
+  { isStreaming = false }: { isStreaming?: boolean } = {},
+) {
+  if (isStreaming) {
+    return null;
+  }
+
+  return (
+    [...messages]
+      .reverse()
+      .filter((message) => message.type === "ai")
+      .map((message) => {
+        const content = extractContentFromMessage(message);
+        return content ?? extractReasoningContentFromMessage(message) ?? "";
+      })
+      .find((content) => content.length > 0) ?? null
+  );
+}
+
 export function extractTextFromMessage(message: Message) {
   if (typeof message.content === "string") {
     return (

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -63,6 +63,122 @@ function messageIdentity(message: Message): string | undefined {
   return undefined;
 }
 
+export type MessageBaseline = {
+  fingerprintCounts: Map<string, number>;
+};
+
+const MESSAGE_SNAPSHOT = Symbol("message-snapshot");
+
+type MessageSnapshot = {
+  readonly [MESSAGE_SNAPSHOT]: true;
+  message: Message;
+  fingerprint: string;
+};
+
+type MessageSource = Message[] | MessageSnapshot[];
+
+type StreamMetadataLookup = (
+  message: Message,
+  index: number,
+) => { streamMetadata?: Record<string, unknown> } | undefined;
+
+function stableSerialize(value: unknown): string {
+  const seen = new WeakSet<object>();
+
+  return (
+    JSON.stringify(value, (_key, currentValue: unknown) => {
+      if (
+        !currentValue ||
+        typeof currentValue !== "object" ||
+        currentValue instanceof Date
+      ) {
+        return currentValue;
+      }
+
+      if (seen.has(currentValue)) {
+        return "[Circular]";
+      }
+      seen.add(currentValue);
+
+      if (Array.isArray(currentValue)) {
+        return currentValue;
+      }
+
+      return Object.keys(currentValue)
+        .sort()
+        .reduce<Record<string, unknown>>((normalized, key) => {
+          normalized[key] = (currentValue as Record<string, unknown>)[key];
+          return normalized;
+        }, {});
+    }) ?? ""
+  );
+}
+
+function messageFingerprint(message: Message): string {
+  const fingerprint = {
+    identity: messageIdentity(message),
+    type: message.type,
+    content: message.content,
+    name: message.name,
+    additional_kwargs: message.additional_kwargs,
+    tool_call_id: "tool_call_id" in message ? message.tool_call_id : undefined,
+    status: "status" in message ? message.status : undefined,
+    tool_calls: message.type === "ai" ? message.tool_calls : undefined,
+    invalid_tool_calls:
+      message.type === "ai" ? message.invalid_tool_calls : undefined,
+  };
+
+  return stableSerialize(fingerprint);
+}
+
+function createMessageSnapshots(messages: Message[]): MessageSnapshot[] {
+  return messages.map((message) => ({
+    [MESSAGE_SNAPSHOT]: true,
+    message,
+    fingerprint: messageFingerprint(message),
+  }));
+}
+
+function isMessageSnapshot(
+  value: Message | MessageSnapshot,
+): value is MessageSnapshot {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    MESSAGE_SNAPSHOT in value &&
+    value[MESSAGE_SNAPSHOT] === true
+  );
+}
+
+function toMessageSnapshots(source: MessageSource): MessageSnapshot[] {
+  const firstItem = source[0];
+  if (firstItem && isMessageSnapshot(firstItem)) {
+    return source as MessageSnapshot[];
+  }
+  return createMessageSnapshots(source as Message[]);
+}
+
+function toMessages(source: MessageSource): Message[] {
+  const firstItem = source[0];
+  if (firstItem && isMessageSnapshot(firstItem)) {
+    return (source as MessageSnapshot[]).map(({ message }) => message);
+  }
+  return source as Message[];
+}
+
+export function createMessageBaseline(source: MessageSource): MessageBaseline {
+  const fingerprintCounts = new Map<string, number>();
+
+  for (const { fingerprint } of toMessageSnapshots(source)) {
+    fingerprintCounts.set(
+      fingerprint,
+      (fingerprintCounts.get(fingerprint) ?? 0) + 1,
+    );
+  }
+
+  return { fingerprintCounts };
+}
+
 function dedupeMessagesByIdentity(messages: Message[]): Message[] {
   const lastIndexByIdentity = new Map<string, number>();
 
@@ -103,7 +219,7 @@ export function mergeMessages(
 
   // The overlap is a contiguous suffix of historyMessages (newest history == oldest thread).
   // Scan from the end: shrink cutoff while messages are already in thread, stop as soon as
-  // we hit one that isn't — everything before that point is non-overlapping.
+  // we hit one that isn't; everything before that point is non-overlapping.
   let cutoff = historyMessages.length;
   for (let i = historyMessages.length - 1; i >= 0; i--) {
     const msg = historyMessages[i];
@@ -125,14 +241,65 @@ export function mergeMessages(
   ]);
 }
 
-function getMessagesAfterBaseline(
-  messages: Message[],
-  baselineMessageIds: ReadonlySet<string>,
+export function getMessagesAfterBaseline(
+  source: MessageSource,
+  baseline: MessageBaseline,
 ): Message[] {
-  return messages.filter((message) => {
-    const id = messageIdentity(message);
-    return !id || !baselineMessageIds.has(id);
+  const remainingBaselineCounts = new Map(baseline.fingerprintCounts);
+
+  return toMessageSnapshots(source).flatMap(({ message, fingerprint }) => {
+    const remainingCount = remainingBaselineCounts.get(fingerprint) ?? 0;
+
+    if (remainingCount > 0) {
+      if (remainingCount === 1) {
+        remainingBaselineCounts.delete(fingerprint);
+      } else {
+        remainingBaselineCounts.set(fingerprint, remainingCount - 1);
+      }
+      return [];
+    }
+
+    return [message];
   });
+}
+
+export function getPendingStreamMessages(
+  source: MessageSource,
+  {
+    isLoading,
+    baseline,
+    baselineInitialized,
+    getMessagesMetadata,
+  }: {
+    isLoading: boolean;
+    baseline: MessageBaseline;
+    baselineInitialized: boolean;
+    getMessagesMetadata?: StreamMetadataLookup;
+  },
+): Message[] {
+  if (!isLoading) {
+    return [];
+  }
+
+  const pendingMessages = baselineInitialized
+    ? getMessagesAfterBaseline(source, baseline)
+    : [];
+  const pendingMessageRefs = new Set(pendingMessages);
+  const messages = toMessages(source);
+
+  messages.forEach((message, index) => {
+    if (
+      message.type === "ai" &&
+      getMessagesMetadata?.(message, index)?.streamMetadata
+    ) {
+      if (!pendingMessageRefs.has(message)) {
+        pendingMessages.push(message);
+        pendingMessageRefs.add(message);
+      }
+    }
+  });
+
+  return pendingMessages;
 }
 
 function getStreamErrorMessage(error: unknown): string {
@@ -174,7 +341,14 @@ export function useThreadStream({
   // and to allow access to the current thread id in onUpdateEvent
   const threadIdRef = useRef<string | null>(threadId ?? null);
   const startedRef = useRef(false);
-  const pendingUsageBaselineMessageIdsRef = useRef<Set<string>>(new Set());
+  const pendingUsageBaselineRef = useRef<MessageBaseline>(
+    createMessageBaseline([]),
+  );
+  const pendingUsageBaselineInitializedRef = useRef(false);
+  const pendingStreamBaselineRef = useRef<MessageBaseline>(
+    createMessageBaseline([]),
+  );
+  const pendingStreamBaselineInitializedRef = useRef(false);
   const listeners = useRef({
     onSend,
     onStart,
@@ -332,11 +506,14 @@ export function useThreadStream({
     onError(error) {
       setOptimisticMessages([]);
       toast.error(getStreamErrorMessage(error));
-      pendingUsageBaselineMessageIdsRef.current = new Set(
-        messagesRef.current
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
+      pendingUsageBaselineRef.current = createMessageBaseline(
+        messagesRef.current,
       );
+      pendingUsageBaselineInitializedRef.current = true;
+      pendingStreamBaselineRef.current = createMessageBaseline(
+        messagesRef.current,
+      );
+      pendingStreamBaselineInitializedRef.current = true;
       if (threadIdRef.current && !isMock) {
         void queryClient.invalidateQueries({
           queryKey: threadTokenUsageQueryKey(threadIdRef.current),
@@ -345,11 +522,14 @@ export function useThreadStream({
     },
     onFinish(state) {
       listeners.current.onFinish?.(state.values);
-      pendingUsageBaselineMessageIdsRef.current = new Set(
-        messagesRef.current
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
+      pendingUsageBaselineRef.current = createMessageBaseline(
+        messagesRef.current,
       );
+      pendingUsageBaselineInitializedRef.current = true;
+      pendingStreamBaselineRef.current = createMessageBaseline(
+        messagesRef.current,
+      );
+      pendingStreamBaselineInitializedRef.current = true;
       void queryClient.invalidateQueries({ queryKey: ["threads", "search"] });
       if (threadIdRef.current && !isMock) {
         void queryClient.invalidateQueries({
@@ -383,11 +563,10 @@ export function useThreadStream({
   useEffect(() => {
     startedRef.current = false;
     sendInFlightRef.current = false;
-    pendingUsageBaselineMessageIdsRef.current = new Set(
-      messagesRef.current
-        .map(messageIdentity)
-        .filter((id): id is string => Boolean(id)),
-    );
+    pendingUsageBaselineRef.current = createMessageBaseline([]);
+    pendingUsageBaselineInitializedRef.current = false;
+    pendingStreamBaselineRef.current = createMessageBaseline([]);
+    pendingStreamBaselineInitializedRef.current = false;
     prevHumanMsgCountRef.current =
       latestMessageCountsRef.current.humanMessageCount;
   }, [threadId]);
@@ -396,16 +575,34 @@ export function useThreadStream({
   // from another client, or page reload mid-stream), snapshot the current
   // messages so only *new* messages are treated as "pending" for token usage.
   useEffect(() => {
-    if (
-      thread.isLoading &&
-      pendingUsageBaselineMessageIdsRef.current.size === 0
-    ) {
-      pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
-      );
+    if (thread.isLoading && !pendingUsageBaselineInitializedRef.current) {
+      pendingUsageBaselineRef.current = createMessageBaseline(thread.messages);
+      pendingUsageBaselineInitializedRef.current = true;
+      return;
     }
+
+    if (!thread.isLoading) {
+      pendingUsageBaselineInitializedRef.current = false;
+    }
+  }, [thread.isLoading, thread.messages]);
+
+  // For copy-button visibility, keep a separate current-stream baseline. A
+  // local send initializes this explicitly, even for empty new threads. Runs
+  // observed without a local send baseline snapshot the current messages first
+  // so historical answers do not become the active stream.
+  useEffect(() => {
+    if (thread.isLoading) {
+      if (!pendingStreamBaselineInitializedRef.current) {
+        pendingStreamBaselineRef.current = createMessageBaseline(
+          thread.messages,
+        );
+        pendingStreamBaselineInitializedRef.current = true;
+      }
+      return;
+    }
+
+    pendingStreamBaselineRef.current = createMessageBaseline(thread.messages);
+    pendingStreamBaselineInitializedRef.current = false;
   }, [thread.isLoading, thread.messages]);
 
   // Clear optimistic when server messages arrive.
@@ -442,11 +639,10 @@ export function useThreadStream({
       // Capture the current human message count before showing optimistic
       // messages so we can wait for the server's copy of the user input.
       prevHumanMsgCountRef.current = humanMessageCount;
-      pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
-          .map(messageIdentity)
-          .filter((id): id is string => Boolean(id)),
-      );
+      pendingUsageBaselineRef.current = createMessageBaseline(thread.messages);
+      pendingUsageBaselineInitializedRef.current = true;
+      pendingStreamBaselineRef.current = createMessageBaseline(thread.messages);
+      pendingStreamBaselineInitializedRef.current = true;
 
       // Build optimistic files list with uploading status
       const optimisticFiles: FileInMessage[] = (message.files ?? []).map(
@@ -632,12 +828,26 @@ export function useThreadStream({
     thread.messages,
     optimisticMessages,
   );
-  const pendingUsageMessages = thread.isLoading
-    ? getMessagesAfterBaseline(
-        thread.messages,
-        pendingUsageBaselineMessageIdsRef.current,
-      )
-    : [];
+  const needsPendingMessageDiff =
+    thread.isLoading &&
+    (pendingStreamBaselineInitializedRef.current ||
+      pendingUsageBaselineInitializedRef.current);
+  const pendingMessageSource = needsPendingMessageDiff
+    ? createMessageSnapshots(thread.messages)
+    : thread.messages;
+  const pendingStreamMessages = getPendingStreamMessages(pendingMessageSource, {
+    isLoading: thread.isLoading,
+    baseline: pendingStreamBaselineRef.current,
+    baselineInitialized: pendingStreamBaselineInitializedRef.current,
+    getMessagesMetadata: thread.getMessagesMetadata,
+  });
+  const pendingUsageMessages =
+    needsPendingMessageDiff && pendingUsageBaselineInitializedRef.current
+      ? getMessagesAfterBaseline(
+          pendingMessageSource,
+          pendingUsageBaselineRef.current,
+        )
+      : [];
 
   // Merge history, live stream, and optimistic messages for display
   // History messages may overlap with thread.messages; thread.messages take precedence
@@ -648,6 +858,7 @@ export function useThreadStream({
 
   return {
     thread: mergedThread,
+    pendingStreamMessages,
     pendingUsageMessages,
     sendMessage,
     isUploading,

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -2,8 +2,11 @@ import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
 import {
+  getAssistantTurnCopyData,
   getAssistantTurnUsageMessages,
+  getCurrentStreamingAssistantMessage,
   getMessageGroups,
+  isCurrentStreamingAssistantTurn,
 } from "@/core/messages/utils";
 
 test("aggregates token usage messages once per assistant turn", () => {
@@ -96,4 +99,394 @@ test("hides internal todo reminder messages from message groups", () => {
   expect(
     groups.flatMap((group) => group.messages).map((message) => message.id),
   ).toEqual(["human-1", "ai-1"]);
+});
+
+test("hides assistant turn copy data while that turn is still streaming", () => {
+  const messages = [
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "Partial answer",
+    },
+  ] as Message[];
+
+  expect(getAssistantTurnCopyData(messages)).toBe("Partial answer");
+  expect(getAssistantTurnCopyData(messages, { isStreaming: true })).toBeNull();
+});
+
+test("marks only the latest visible AI turn as streaming", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "human-2",
+      type: "human",
+      content: "Continue",
+    },
+    {
+      id: "ai-2",
+      type: "ai",
+      content: "Still generating",
+    },
+  ] as Message[];
+
+  const assistantGroups = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+  const pendingStreamMessages = messages.slice(2);
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[0]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages,
+      }),
+    ),
+  ).toBe(false);
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[1]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages,
+      }),
+    ),
+  ).toBe(true);
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[1]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, false, {
+        pendingStreamMessages,
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("does not mark the previous assistant turn as streaming while waiting for a new answer", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "human-2",
+      type: "human",
+      content: "Continue",
+    },
+  ] as Message[];
+
+  const [assistantGroup] = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroup?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [messages[2]!],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("does not mark the previous assistant turn as streaming after a hidden human message", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "human-hidden",
+      type: "human",
+      content: "Save this agent",
+      additional_kwargs: { hide_from_ui: true },
+    },
+  ] as Message[];
+
+  const [assistantGroup] = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroup?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [messages[2]!],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("does not fall back to a completed assistant turn when no pending AI has arrived", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+  ] as Message[];
+
+  const [assistantGroup] = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroup?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("marks a streaming AI message before an optimistic human message", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "ai-2",
+      type: "ai",
+      content: "Still generating",
+    },
+    {
+      id: "opt-human-1",
+      type: "human",
+      content: "Continue",
+    },
+  ] as Message[];
+
+  const assistantGroups = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[0]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [messages[2]!],
+      }),
+    ),
+  ).toBe(false);
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[1]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [messages[2]!],
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("does not mark the previous assistant turn as streaming after an optimistic human message", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "opt-human-1",
+      type: "human",
+      content: "Continue",
+    },
+  ] as Message[];
+
+  const [assistantGroup] = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroup?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [],
+      }),
+    ),
+  ).toBe(false);
+});
+
+test("keeps the pending AI streaming when the server human arrives after it", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "ai-2",
+      type: "ai",
+      content: "Still generating",
+    },
+    {
+      id: "opt-human-1",
+      type: "human",
+      content: "Continue",
+    },
+  ] as Message[];
+
+  const assistantGroups = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[1]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [
+          messages[2]!,
+          {
+            id: "human-2",
+            type: "human",
+            content: "Continue",
+          } as Message,
+        ],
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("keeps the pending AI streaming when a hidden human arrives after it", () => {
+  const messages = [
+    {
+      id: "human-1",
+      type: "human",
+      content: "Hello",
+    },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "First answer",
+    },
+    {
+      id: "ai-2",
+      type: "ai",
+      content: "Still generating",
+    },
+    {
+      id: "opt-human-1",
+      type: "human",
+      content: "Continue",
+    },
+  ] as Message[];
+
+  const assistantGroups = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      assistantGroups[1]?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: [
+          messages[2]!,
+          {
+            id: "human-hidden",
+            type: "human",
+            content: "Save this agent",
+            additional_kwargs: { hide_from_ui: true },
+          } as Message,
+        ],
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("ignores hidden AI messages when finding the streaming assistant turn", () => {
+  const messages = [
+    {
+      id: "ai-visible",
+      type: "ai",
+      content: "Visible answer",
+    },
+    {
+      id: "ai-hidden",
+      type: "ai",
+      content: "Hidden control update",
+      additional_kwargs: { hide_from_ui: true },
+    },
+  ] as Message[];
+
+  const [visibleGroup] = getMessageGroups(messages).filter(
+    (group) => group.type === "assistant",
+  );
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      visibleGroup?.messages ?? [],
+      getCurrentStreamingAssistantMessage(messages, true, {
+        pendingStreamMessages: messages,
+      }),
+    ),
+  ).toBe(true);
+});
+
+test("matches id-less streaming AI messages by object identity", () => {
+  const streamingAi = {
+    type: "ai",
+    content: "Still generating",
+  } as Message;
+  const copiedStreamingAi = {
+    type: "ai",
+    content: "Still generating",
+  } as Message;
+
+  expect(
+    isCurrentStreamingAssistantTurn(
+      [streamingAi],
+      getCurrentStreamingAssistantMessage([streamingAi], true, {
+        pendingStreamMessages: [streamingAi],
+      }),
+    ),
+  ).toBe(true);
+  expect(
+    isCurrentStreamingAssistantTurn(
+      [copiedStreamingAi],
+      getCurrentStreamingAssistantMessage([streamingAi], true, {
+        pendingStreamMessages: [streamingAi],
+      }),
+    ),
+  ).toBe(false);
 });

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -1,7 +1,12 @@
 import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
-import { mergeMessages } from "@/core/threads/hooks";
+import {
+  createMessageBaseline,
+  getMessagesAfterBaseline,
+  getPendingStreamMessages,
+  mergeMessages,
+} from "@/core/threads/hooks";
 
 test("mergeMessages removes duplicate messages already present in history", () => {
   const human = {
@@ -61,4 +66,166 @@ test("mergeMessages deduplicates tool messages by tool_call_id", () => {
   } as Message;
 
   expect(mergeMessages([oldTool], [liveTool], [])).toEqual([liveTool]);
+});
+
+test("getMessagesAfterBaseline treats an empty baseline as initialized", () => {
+  const firstAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "First answer",
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline([firstAi], createMessageBaseline([])),
+  ).toEqual([firstAi]);
+});
+
+test("getMessagesAfterBaseline includes same-id streaming message updates", () => {
+  const baselineAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Partial",
+  } as Message;
+  const updatedAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Partial answer",
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline([updatedAi], createMessageBaseline([baselineAi])),
+  ).toEqual([updatedAi]);
+});
+
+test("getMessagesAfterBaseline ignores same-id metadata-only changes", () => {
+  const baselineAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Completed answer",
+    response_metadata: { finish_reason: "stop" },
+  } as Message;
+  const updatedMetadataAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Completed answer",
+    response_metadata: { finish_reason: "stop", model_name: "gpt-4o" },
+    usage_metadata: {
+      input_tokens: 1,
+      output_tokens: 2,
+      total_tokens: 3,
+    },
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline(
+      [updatedMetadataAi],
+      createMessageBaseline([baselineAi]),
+    ),
+  ).toEqual([]);
+});
+
+test("getMessagesAfterBaseline excludes unchanged same-id historical messages", () => {
+  const baselineAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Completed answer",
+  } as Message;
+  const unchangedAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Completed answer",
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline(
+      [unchangedAi],
+      createMessageBaseline([baselineAi]),
+    ),
+  ).toEqual([]);
+});
+
+test("getMessagesAfterBaseline excludes rebuilt id-less historical messages", () => {
+  const historicalAi = {
+    type: "ai",
+    content: "Completed answer",
+  } as Message;
+  const rebuiltHistoricalAi = {
+    type: "ai",
+    content: "Completed answer",
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline(
+      [rebuiltHistoricalAi],
+      createMessageBaseline([historicalAi]),
+    ),
+  ).toEqual([]);
+});
+
+test("getMessagesAfterBaseline preserves duplicate messages beyond the baseline count", () => {
+  const firstAi = {
+    type: "ai",
+    content: "Duplicate",
+  } as Message;
+  const rebuiltFirstAi = {
+    type: "ai",
+    content: "Duplicate",
+  } as Message;
+  const secondAi = {
+    type: "ai",
+    content: "Duplicate",
+  } as Message;
+
+  expect(
+    getMessagesAfterBaseline(
+      [rebuiltFirstAi, secondAi],
+      createMessageBaseline([firstAi]),
+    ),
+  ).toEqual([secondAi]);
+});
+
+test("getMessagesAfterBaseline does not treat raw message fields as snapshots", () => {
+  const messageWithSnapshotLikeFields = {
+    id: "ai-1",
+    type: "ai",
+    content: "Visible answer",
+    message: {
+      id: "nested-ai",
+      type: "ai",
+      content: "Nested object",
+    },
+    fingerprint: "backend-field",
+  } as unknown as Message;
+
+  expect(
+    getMessagesAfterBaseline(
+      [messageWithSnapshotLikeFields],
+      createMessageBaseline([]),
+    ),
+  ).toEqual([messageWithSnapshotLikeFields]);
+});
+
+test("getPendingStreamMessages includes SDK streaming metadata without a local baseline", () => {
+  const historicalAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "Completed answer",
+  } as Message;
+  const streamingAi = {
+    id: "ai-2",
+    type: "ai",
+    content: "Partial",
+  } as Message;
+
+  expect(
+    getPendingStreamMessages([historicalAi, streamingAi], {
+      isLoading: true,
+      baseline: createMessageBaseline([]),
+      baselineInitialized: false,
+      getMessagesMetadata: (message) =>
+        message === streamingAi
+          ? { streamMetadata: { langgraph_node: "agent" } }
+          : undefined,
+    }),
+  ).toEqual([streamingAi]);
 });


### PR DESCRIPTION
## 问题原因

assistant 消息仍在生成时，当前回答的 hover 操作区会提前显示复制按钮，用户可能复制到未完成内容。

## 修改内容

为 assistant turn 增加当前 streaming 判定，并在当前回答仍在生成时隐藏复制按钮；历史已完成回答仍保留复制能力，并补充相关单元测试。





## 测试

- 前端：`pnpm format`、`pnpm lint`、`pnpm typecheck`、`pnpm build`、`pnpm test`、`pnpm exec playwright test` 通过。

## 关联 issue

关联 #2995