### PR TITLE
fix: keep setup status idempotent

### DIFF
--- a/backend/app/gateway/routers/auth.py
+++ b/backend/app/gateway/routers/auth.py
@@ -382,37 +382,9 @@ async def get_me(request: Request):
     return UserResponse(id=str(user.id), email=user.email, system_role=user.system_role, needs_setup=user.needs_setup)
 
 
-_SETUP_STATUS_COOLDOWN: dict[str, float] = {}
-_SETUP_STATUS_COOLDOWN_SECONDS = 60
-_MAX_TRACKED_SETUP_STATUS_IPS = 10000
-
-
 @router.get("/setup-status")
-async def setup_status(request: Request):
+async def setup_status():
     """Check if an admin account exists. Returns needs_setup=True when no admin exists."""
-    client_ip = _get_client_ip(request)
-    now = time.time()
-    last_check = _SETUP_STATUS_COOLDOWN.get(client_ip, 0)
-    elapsed = now - last_check
-    if elapsed < _SETUP_STATUS_COOLDOWN_SECONDS:
-        retry_after = max(1, int(_SETUP_STATUS_COOLDOWN_SECONDS - elapsed))
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail="Setup status check is rate limited",
-            headers={"Retry-After": str(retry_after)},
-        )
-    # Evict stale entries when dict grows too large to bound memory usage.
-    if len(_SETUP_STATUS_COOLDOWN) >= _MAX_TRACKED_SETUP_STATUS_IPS:
-        cutoff = now - _SETUP_STATUS_COOLDOWN_SECONDS
-        stale = [k for k, t in _SETUP_STATUS_COOLDOWN.items() if t < cutoff]
-        for k in stale:
-            del _SETUP_STATUS_COOLDOWN[k]
-        # If still too large after evicting expired entries, remove oldest half.
-        if len(_SETUP_STATUS_COOLDOWN) >= _MAX_TRACKED_SETUP_STATUS_IPS:
-            by_time = sorted(_SETUP_STATUS_COOLDOWN.items(), key=lambda kv: kv[1])
-            for k, _ in by_time[: len(by_time) // 2]:
-                del _SETUP_STATUS_COOLDOWN[k]
-    _SETUP_STATUS_COOLDOWN[client_ip] = now
     admin_count = await get_local_provider().count_admin_users()
     return {"needs_setup": admin_count == 0}
 

--- a/backend/app/gateway/routers/auth.py
+++ b/backend/app/gateway/routers/auth.py
@@ -1,5 +1,6 @@
 """Authentication endpoints."""
 
+import asyncio
 import logging
 import os
 import time
@@ -389,6 +390,9 @@ async def setup_status():
     return {"needs_setup": admin_count == 0}
 
 
+_initialize_admin_lock = asyncio.Lock()
+
+
 class InitializeAdminRequest(BaseModel):
     """Request model for first-boot admin account creation."""
 
@@ -408,21 +412,22 @@ async def initialize_admin(request: Request, response: Response, body: Initializ
     On success, the admin account is created with ``needs_setup=False`` and
     the session cookie is set.
     """
-    admin_count = await get_local_provider().count_admin_users()
-    if admin_count > 0:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=AuthErrorResponse(code=AuthErrorCode.SYSTEM_ALREADY_INITIALIZED, message="System already initialized").model_dump(),
-        )
+    async with _initialize_admin_lock:
+        admin_count = await get_local_provider().count_admin_users()
+        if admin_count > 0:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=AuthErrorResponse(code=AuthErrorCode.SYSTEM_ALREADY_INITIALIZED, message="System already initialized").model_dump(),
+            )
 
-    try:
-        user = await get_local_provider().create_user(email=body.email, password=body.password, system_role="admin", needs_setup=False)
-    except ValueError:
-        # DB unique-constraint race: another concurrent request beat us.
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=AuthErrorResponse(code=AuthErrorCode.SYSTEM_ALREADY_INITIALIZED, message="System already initialized").model_dump(),
-        )
+        try:
+            user = await get_local_provider().create_user(email=body.email, password=body.password, system_role="admin", needs_setup=False)
+        except ValueError:
+            # Duplicate email during first-boot initialization maps to the same public conflict.
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=AuthErrorResponse(code=AuthErrorCode.SYSTEM_ALREADY_INITIALIZED, message="System already initialized").model_dump(),
+            )
 
     token = create_access_token(str(user.id), token_version=user.token_version)
     _set_session_cookie(response, token, request)

--- a/backend/packages/harness/deerflow/persistence/user/model.py
+++ b/backend/packages/harness/deerflow/persistence/user/model.py
@@ -55,5 +55,13 @@ class UserRow(Base):
             "oauth_id",
             unique=True,
             sqlite_where=text("oauth_provider IS NOT NULL AND oauth_id IS NOT NULL"),
+            postgresql_where=text("oauth_provider IS NOT NULL AND oauth_id IS NOT NULL"),
+        ),
+        Index(
+            "idx_users_single_admin",
+            "system_role",
+            unique=True,
+            sqlite_where=text("system_role = 'admin'"),
+            postgresql_where=text("system_role = 'admin'"),
         ),
     )

--- a/backend/tests/test_initialize_admin.py
+++ b/backend/tests/test_initialize_admin.py
@@ -22,7 +22,6 @@ _TEST_SECRET = "test-secret-key-initialize-admin-min-32"
 def _setup_auth(tmp_path):
     """Fresh SQLite engine + auth config per test."""
     from app.gateway import deps
-    from app.gateway.routers.auth import _SETUP_STATUS_COOLDOWN
     from deerflow.persistence.engine import close_engine, init_engine
 
     set_auth_config(AuthConfig(jwt_secret=_TEST_SECRET))
@@ -30,13 +29,11 @@ def _setup_auth(tmp_path):
     asyncio.run(init_engine("sqlite", url=url, sqlite_dir=str(tmp_path)))
     deps._cached_local_provider = None
     deps._cached_repo = None
-    _SETUP_STATUS_COOLDOWN.clear()
     try:
         yield
     finally:
         deps._cached_local_provider = None
         deps._cached_repo = None
-        _SETUP_STATUS_COOLDOWN.clear()
         asyncio.run(close_engine())
 
 
@@ -168,15 +165,12 @@ def test_setup_status_false_when_only_regular_user_exists(client):
     assert resp.json()["needs_setup"] is True
 
 
-def test_setup_status_rate_limited_on_second_call(client):
-    """Second /setup-status call within the cooldown window returns 429 with Retry-After."""
-    # First call succeeds.
+def test_setup_status_allows_repeated_checks(client):
+    """Repeated /setup-status calls stay idempotent for first-boot browser flows."""
     resp1 = client.get("/api/v1/auth/setup-status")
     assert resp1.status_code == 200
+    assert resp1.json()["needs_setup"] is True
 
-    # Immediate second call is rate-limited.
     resp2 = client.get("/api/v1/auth/setup-status")
-    assert resp2.status_code == 429
-    assert "Retry-After" in resp2.headers
-    retry_after = int(resp2.headers["Retry-After"])
-    assert 1 <= retry_after <= 60
+    assert resp2.status_code == 200
+    assert resp2.json()["needs_setup"] is True

--- a/backend/tests/test_initialize_admin.py
+++ b/backend/tests/test_initialize_admin.py
@@ -8,6 +8,7 @@ and public accessibility (no auth cookie required).
 import asyncio
 import os
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -95,6 +96,49 @@ def test_initialize_rejected_when_admin_exists(client):
     assert body["detail"]["code"] == "system_already_initialized"
 
 
+def test_initialize_concurrent_requests_create_single_admin(client):
+    """Concurrent first-boot initialization requests cannot create two admins."""
+
+    async def _post_concurrently():
+        transport = httpx.ASGITransport(app=client.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as async_client:
+            return await asyncio.gather(
+                async_client.post(
+                    "/api/v1/auth/initialize",
+                    json=_init_payload(email="admin1@example.com"),
+                ),
+                async_client.post(
+                    "/api/v1/auth/initialize",
+                    json=_init_payload(email="admin2@example.com"),
+                ),
+            )
+
+    responses = asyncio.run(_post_concurrently())
+
+    assert sorted(response.status_code for response in responses) == [201, 409]
+    conflict = next(response for response in responses if response.status_code == 409)
+    assert conflict.json()["detail"]["code"] == "system_already_initialized"
+
+    from app.gateway.deps import get_local_provider
+
+    assert asyncio.run(get_local_provider().count_admin_users()) == 1
+
+
+def test_user_table_rejects_second_admin_directly(client):
+    """The database constraint backs up /initialize against cross-worker races."""
+
+    async def _create_admins():
+        from app.gateway.deps import get_local_provider
+
+        provider = get_local_provider()
+        await provider.create_user(email="admin1@example.com", password="Str0ng!Pass99", system_role="admin")
+        with pytest.raises(ValueError):
+            await provider.create_user(email="admin2@example.com", password="Str0ng!Pass99", system_role="admin")
+        return await provider.count_admin_users()
+
+    assert asyncio.run(_create_admins()) == 1
+
+
 def test_initialize_register_does_not_block_initialization(client):
     """/register creating a user before /initialize doesn't block admin creation."""
     # Register a regular user first
@@ -157,7 +201,7 @@ def test_setup_status_after_initialization(client):
     assert resp.json()["needs_setup"] is False
 
 
-def test_setup_status_false_when_only_regular_user_exists(client):
+def test_setup_status_true_when_only_regular_user_exists(client):
     """setup-status returns needs_setup=True even when regular users exist (no admin)."""
     client.post("/api/v1/auth/register", json={"email": "regular@example.com", "password": "Tr0ub4dor3a"})
     resp = client.get("/api/v1/auth/setup-status")
@@ -174,3 +218,7 @@ def test_setup_status_allows_repeated_checks(client):
     resp2 = client.get("/api/v1/auth/setup-status")
     assert resp2.status_code == 200
     assert resp2.json()["needs_setup"] is True
+
+    resp3 = client.get("/api/v1/auth/setup-status")
+    assert resp3.status_code == 200
+    assert resp3.json()["needs_setup"] is True


### PR DESCRIPTION
## Summary
- remove the per-IP cooldown from `/api/v1/auth/setup-status`
- keep setup status checks idempotent for first-boot browser flows
- serialize first-admin initialization and add a DB-level single-admin guard for fresh databases
- expand initialize-admin tests for repeated setup checks and concurrent initialization

Fixes #2999

## Tests
- `uv run ruff check app/gateway/routers/auth.py packages/harness/deerflow/persistence/user/model.py tests/test_initialize_admin.py`
- `uv run pytest tests/test_initialize_admin.py`
