### PR TITLE
fix: allow public mock chat views

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,3 +1,6 @@
+import fs from "fs";
+import path from "path";
+
 import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -5,6 +8,7 @@ import { redirect } from "next/navigation";
 import { AuthProvider } from "@/core/auth/AuthProvider";
 import { getServerSideUser } from "@/core/auth/server";
 import { assertNever } from "@/core/auth/types";
+import { getPublicMockChatThreadId } from "@/core/public-mock-chat";
 import {
   DEERFLOW_REQUEST_PATHNAME_HEADER,
   DEERFLOW_REQUEST_SEARCH_HEADER,
@@ -14,29 +18,28 @@ import { WorkspaceContent } from "./workspace-content";
 
 export const dynamic = "force-dynamic";
 
-function isPublicMockChatRequest(
-  pathname: string | null,
-  search: string | null,
-) {
-  if (!pathname?.startsWith("/workspace/chats/")) {
-    return false;
-  }
-  if (pathname === "/workspace/chats/new") {
-    return false;
-  }
-  return new URLSearchParams(search ?? "").get("mock") === "true";
+function hasPublicDemoThread(threadId: string) {
+  return fs.existsSync(
+    path.join(
+      process.cwd(),
+      "public",
+      "demo",
+      "threads",
+      threadId,
+      "thread.json",
+    ),
+  );
 }
 
 export default async function WorkspaceLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const requestHeaders = await headers();
-  if (
-    isPublicMockChatRequest(
-      requestHeaders.get(DEERFLOW_REQUEST_PATHNAME_HEADER),
-      requestHeaders.get(DEERFLOW_REQUEST_SEARCH_HEADER),
-    )
-  ) {
+  const publicMockThreadId = getPublicMockChatThreadId(
+    requestHeaders.get(DEERFLOW_REQUEST_PATHNAME_HEADER),
+    requestHeaders.get(DEERFLOW_REQUEST_SEARCH_HEADER),
+  );
+  if (publicMockThreadId && hasPublicDemoThread(publicMockThreadId)) {
     return (
       <AuthProvider initialUser={null}>
         <WorkspaceContent>{children}</WorkspaceContent>

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -14,7 +14,10 @@ import { WorkspaceContent } from "./workspace-content";
 
 export const dynamic = "force-dynamic";
 
-function isPublicMockChatRequest(pathname: string | null, search: string | null) {
+function isPublicMockChatRequest(
+  pathname: string | null,
+  search: string | null,
+) {
   if (!pathname?.startsWith("/workspace/chats/")) {
     return false;
   }

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,17 +1,46 @@
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { AuthProvider } from "@/core/auth/AuthProvider";
 import { getServerSideUser } from "@/core/auth/server";
 import { assertNever } from "@/core/auth/types";
+import {
+  DEERFLOW_REQUEST_PATHNAME_HEADER,
+  DEERFLOW_REQUEST_SEARCH_HEADER,
+} from "@/core/request-headers";
 
 import { WorkspaceContent } from "./workspace-content";
 
 export const dynamic = "force-dynamic";
 
+function isPublicMockChatRequest(pathname: string | null, search: string | null) {
+  if (!pathname?.startsWith("/workspace/chats/")) {
+    return false;
+  }
+  if (pathname === "/workspace/chats/new") {
+    return false;
+  }
+  return new URLSearchParams(search ?? "").get("mock") === "true";
+}
+
 export default async function WorkspaceLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
+  const requestHeaders = await headers();
+  if (
+    isPublicMockChatRequest(
+      requestHeaders.get(DEERFLOW_REQUEST_PATHNAME_HEADER),
+      requestHeaders.get(DEERFLOW_REQUEST_SEARCH_HEADER),
+    )
+  ) {
+    return (
+      <AuthProvider initialUser={null}>
+        <WorkspaceContent>{children}</WorkspaceContent>
+      </AuthProvider>
+    );
+  }
+
   const result = await getServerSideUser();
 
   switch (result.tag) {

--- a/frontend/src/core/public-mock-chat.ts
+++ b/frontend/src/core/public-mock-chat.ts
@@ -1,0 +1,16 @@
+const PUBLIC_MOCK_CHAT_PATH_PATTERN =
+  /^\/workspace\/chats\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+export function getPublicMockChatThreadId(
+  pathname: string | null,
+  search: string | null,
+) {
+  const match = pathname?.match(PUBLIC_MOCK_CHAT_PATH_PATTERN);
+  if (!match) {
+    return null;
+  }
+  if (new URLSearchParams(search ?? "").get("mock") !== "true") {
+    return null;
+  }
+  return match[1] ?? null;
+}

--- a/frontend/src/core/request-headers.ts
+++ b/frontend/src/core/request-headers.ts
@@ -1,0 +1,2 @@
+export const DEERFLOW_REQUEST_PATHNAME_HEADER = "x-deerflow-request-pathname";
+export const DEERFLOW_REQUEST_SEARCH_HEADER = "x-deerflow-request-search";

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,25 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import {
+  DEERFLOW_REQUEST_PATHNAME_HEADER,
+  DEERFLOW_REQUEST_SEARCH_HEADER,
+} from "@/core/request-headers";
+
+export function middleware(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set(
+    DEERFLOW_REQUEST_PATHNAME_HEADER,
+    request.nextUrl.pathname,
+  );
+  requestHeaders.set(DEERFLOW_REQUEST_SEARCH_HEADER, request.nextUrl.search);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+export const config = {
+  matcher: ["/workspace/:path*"],
+};

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -5,7 +5,7 @@ import {
   DEERFLOW_REQUEST_SEARCH_HEADER,
 } from "@/core/request-headers";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set(
     DEERFLOW_REQUEST_PATHNAME_HEADER,

--- a/frontend/tests/unit/core/public-mock-chat.test.ts
+++ b/frontend/tests/unit/core/public-mock-chat.test.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "vitest";
+
+import { getPublicMockChatThreadId } from "@/core/public-mock-chat";
+
+const THREAD_ID = "7cfa5f8f-a2f8-47ad-acbd-da7137baf990";
+
+test("recognizes public mock chat requests", () => {
+  expect(
+    getPublicMockChatThreadId(`/workspace/chats/${THREAD_ID}`, "?mock=true"),
+  ).toBe(THREAD_ID);
+});
+
+test("does not treat protected workspace routes as public mock chats", () => {
+  expect(getPublicMockChatThreadId("/workspace/chats/new", "?mock=true")).toBe(
+    null,
+  );
+  expect(getPublicMockChatThreadId("/workspace/chats", "?mock=true")).toBe(
+    null,
+  );
+  expect(
+    getPublicMockChatThreadId(
+      `/workspace/chats/${THREAD_ID}/artifacts`,
+      "?mock=true",
+    ),
+  ).toBe(null);
+  expect(
+    getPublicMockChatThreadId(
+      `/workspace/agents/researcher/chats/${THREAD_ID}`,
+      "?mock=true",
+    ),
+  ).toBe(null);
+});
+
+test("requires explicit mock mode and a UUID thread id", () => {
+  expect(getPublicMockChatThreadId(`/workspace/chats/${THREAD_ID}`, "")).toBe(
+    null,
+  );
+  expect(
+    getPublicMockChatThreadId(`/workspace/chats/${THREAD_ID}`, "?mock=false"),
+  ).toBe(null);
+  expect(
+    getPublicMockChatThreadId("/workspace/chats/not-a-uuid", "?mock=true"),
+  ).toBe(null);
+  expect(
+    getPublicMockChatThreadId("/workspace/chats/..%2Fsecret", "?mock=true"),
+  ).toBe(null);
+});


### PR DESCRIPTION
## Summary
- propagate workspace pathname/search through the Next 16 `proxy.ts` hook
- allow unauthenticated public mock chat rendering only for single-segment UUID demo threads with `mock=true`
- keep `/workspace/chats/new`, nested workspace routes, non-demo thread ids, and non-mock requests protected
- add unit coverage for public mock route classification

Fixes #3000

## Tests
- `pnpm format`
- `pnpm exec eslint src/app/workspace/layout.tsx src/core/request-headers.ts src/core/public-mock-chat.ts src/proxy.ts tests/unit/core/public-mock-chat.test.ts`
- `pnpm exec vitest run tests/unit/core/public-mock-chat.test.ts`
- `pnpm run typecheck`
