### PR TITLE
fix: post logout reset action

### DIFF
--- a/frontend/src/app/logout-reset/route.ts
+++ b/frontend/src/app/logout-reset/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+const ACCESS_TOKEN_COOKIE = "access_token";
+const CSRF_COOKIE = "csrf_token";
+
+function firstHeaderValue(value: string | null): string | null {
+  if (!value) return null;
+  const first = value.split(",", 1)[0]?.trim();
+  return first === undefined || first.length === 0 ? null : first;
+}
+
+function normalizeOrigin(value: string): string | null {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function getRequestOrigin(request: NextRequest): string {
+  const protocol =
+    firstHeaderValue(request.headers.get("x-forwarded-proto")) ??
+    request.nextUrl.protocol.replace(/:$/, "");
+  const host =
+    firstHeaderValue(request.headers.get("x-forwarded-host")) ??
+    firstHeaderValue(request.headers.get("host")) ??
+    request.nextUrl.host;
+
+  return normalizeOrigin(`${protocol}://${host}`) ?? request.nextUrl.origin;
+}
+
+function isAllowedOrigin(request: NextRequest): boolean {
+  const origin = request.headers.get("origin");
+  if (!origin) return true;
+
+  const normalizedOrigin = normalizeOrigin(origin);
+  return (
+    normalizedOrigin !== null && normalizedOrigin === getRequestOrigin(request)
+  );
+}
+
+export async function POST(request: NextRequest) {
+  if (!isAllowedOrigin(request)) {
+    return NextResponse.json(
+      { detail: "Cross-site auth request denied." },
+      { status: 403 },
+    );
+  }
+
+  // This frontend route intentionally avoids /api/* so nginx can still reach
+  // it when the gateway is unavailable and cannot return its own Set-Cookie.
+  const response = NextResponse.json({ message: "Successfully logged out" });
+  response.cookies.delete(ACCESS_TOKEN_COOKIE);
+  response.cookies.delete(CSRF_COOKIE);
+  return response;
+}

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from "@/core/auth/AuthProvider";
 import { getServerSideUser } from "@/core/auth/server";
 import { assertNever } from "@/core/auth/types";
 
+import { LogoutResetButton } from "./logout-reset-button";
 import { WorkspaceContent } from "./workspace-content";
 
 export const dynamic = "force-dynamic";
@@ -43,12 +44,7 @@ export default async function WorkspaceLayout({
             >
               Retry
             </Link>
-            <Link
-              href="/api/v1/auth/logout"
-              className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm"
-            >
-              Logout &amp; Reset
-            </Link>
+            <LogoutResetButton />
           </div>
         </div>
       );

--- a/frontend/src/app/workspace/logout-reset-button.tsx
+++ b/frontend/src/app/workspace/logout-reset-button.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useState } from "react";
+
+export function LogoutResetButton() {
+  const [isResetting, setIsResetting] = useState(false);
+
+  const handleLogoutReset = async () => {
+    setIsResetting(true);
+    try {
+      await fetch("/api/v1/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } finally {
+      window.location.href = "/";
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={isResetting}
+      onClick={handleLogoutReset}
+      className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm disabled:pointer-events-none disabled:opacity-50"
+    >
+      {isResetting ? "Resetting..." : "Logout & Reset"}
+    </button>
+  );
+}

--- a/frontend/src/app/workspace/logout-reset-button.tsx
+++ b/frontend/src/app/workspace/logout-reset-button.tsx
@@ -2,29 +2,39 @@
 
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 export function LogoutResetButton() {
   const [isResetting, setIsResetting] = useState(false);
 
   const handleLogoutReset = async () => {
+    if (isResetting) return;
+
     setIsResetting(true);
     try {
-      await fetch("/api/v1/auth/logout", {
+      const response = await fetch("/logout-reset", {
         method: "POST",
         credentials: "include",
       });
+      if (!response.ok) {
+        console.error("Logout reset request failed:", response.status);
+      }
+    } catch (err) {
+      console.error("Logout reset request failed:", err);
     } finally {
       window.location.href = "/";
     }
   };
 
   return (
-    <button
+    <Button
       type="button"
+      variant="outline"
       disabled={isResetting}
       onClick={handleLogoutReset}
-      className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm disabled:pointer-events-none disabled:opacity-50"
+      className="text-muted-foreground min-w-32"
     >
       {isResetting ? "Resetting..." : "Logout & Reset"}
-    </button>
+    </Button>
   );
 }

--- a/frontend/tests/unit/app/logout-reset-route.test.ts
+++ b/frontend/tests/unit/app/logout-reset-route.test.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { describe, expect, test } from "vitest";
+
+import { POST } from "@/app/logout-reset/route";
+
+function createLogoutRequest(
+  origin?: string,
+  extraHeaders: HeadersInit = {},
+): NextRequest {
+  const headers = new Headers();
+  for (const [key, value] of new Headers(extraHeaders)) {
+    headers.set(key, value);
+  }
+  if (origin) {
+    headers.set("origin", origin);
+  }
+
+  return new NextRequest("http://localhost:3000/logout-reset", {
+    method: "POST",
+    headers,
+  });
+}
+
+describe("POST /logout-reset", () => {
+  test("clears auth cookies for same-origin requests", async () => {
+    const response = await POST(createLogoutRequest("http://localhost:3000"));
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("access_token=");
+    expect(setCookie).toContain("csrf_token=");
+    expect(setCookie).toContain("Expires=Thu, 01 Jan 1970 00:00:00 GMT");
+  });
+
+  test("allows same-origin requests behind a forwarded HTTPS proxy", async () => {
+    const response = await POST(
+      createLogoutRequest("https://app.example.com", {
+        host: "internal-frontend:3000",
+        "x-forwarded-host": "app.example.com",
+        "x-forwarded-proto": "https",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  test("rejects cross-site logout requests", async () => {
+    const response = await POST(createLogoutRequest("https://evil.example"));
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the gateway-unavailable logout reset GET link with a client-side button
- POST to a frontend `/logout-reset` route so the reset still works when nginx cannot reach the gateway
- clear stale auth and CSRF cookies with same-origin origin checks
- add unit coverage for cookie clearing and cross-site rejection

Fixes #3001

## Tests
- `pnpm format`
- `pnpm exec eslint src/app/workspace/layout.tsx src/app/workspace/logout-reset-button.tsx src/app/logout-reset/route.ts tests/unit/app/logout-reset-route.test.ts`
- `pnpm exec vitest run tests/unit/app/logout-reset-route.test.ts`
- `pnpm run typecheck`
