### PR TITLE
fix(frontend): add logout reset recovery route

### DIFF
--- a/frontend/src/app/logout-reset/route.ts
+++ b/frontend/src/app/logout-reset/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const response = NextResponse.redirect(new URL("/", request.url));
+
+  response.cookies.set({
+    name: "access_token",
+    value: "",
+    expires: new Date(0),
+    httpOnly: true,
+    maxAge: 0,
+    path: "/",
+    sameSite: "lax",
+    secure: request.nextUrl.protocol === "https:",
+  });
+
+  return response;
+}

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -44,7 +44,7 @@ export default async function WorkspaceLayout({
               Retry
             </Link>
             <Link
-              href="/api/v1/auth/logout"
+              href="/logout-reset"
               className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm"
             >
               Logout &amp; Reset

--- a/frontend/tests/unit/app/logout-reset.route.test.ts
+++ b/frontend/tests/unit/app/logout-reset.route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "vitest";
+
+describe("logout-reset route", () => {
+  test("clears the access_token cookie and redirects to the landing page", async () => {
+    const { NextRequest } = await import("next/server");
+    const { GET } = await import("@/app/logout-reset/route");
+
+    const response = await GET(
+      new NextRequest("http://localhost:2026/logout-reset"),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("http://localhost:2026/");
+
+    const setCookie = response.headers.get("set-cookie");
+    expect(setCookie).toContain("access_token=");
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("Path=/");
+  });
+});


### PR DESCRIPTION
## Summary
- replace the gateway-unavailable fallback logout link with a frontend recovery route
- clear the access_token cookie locally and redirect back to the landing page
- add a unit test covering the redirect and cookie reset behavior

Fixes #3001.

## Testing
- pnpm test -- tests/unit/app/logout-reset.route.test.ts
- pnpm exec eslint src/app/workspace/layout.tsx src/app/logout-reset/route.ts tests/unit/app/logout-reset.route.test.ts
