### PR TITLE
chore(runtime): warn on legacy checkpointer precedence

### DIFF
--- a/backend/packages/harness/deerflow/runtime/checkpointer/async_provider.py
+++ b/backend/packages/harness/deerflow/runtime/checkpointer/async_provider.py
@@ -29,6 +29,7 @@ from deerflow.runtime.checkpointer.provider import (
     POSTGRES_CONN_REQUIRED,
     POSTGRES_INSTALL,
     SQLITE_INSTALL,
+    warn_legacy_checkpointer_precedence,
 )
 from deerflow.runtime.store._sqlite_utils import ensure_sqlite_parent_dir, resolve_sqlite_conn_str
 
@@ -143,6 +144,7 @@ async def make_checkpointer(app_config: AppConfig | None = None) -> AsyncIterato
 
     # Legacy: standalone checkpointer config takes precedence
     if app_config.checkpointer is not None:
+        warn_legacy_checkpointer_precedence(app_config)
         async with _async_checkpointer(app_config.checkpointer) as saver:
             yield saver
             return

--- a/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
+++ b/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Iterator
+from typing import Any
 
 from langgraph.types import Checkpointer
 
@@ -40,6 +41,41 @@ POSTGRES_INSTALL = (
     "langgraph-checkpoint-postgres is required for the PostgreSQL checkpointer. Install the package extra with: pip install 'deerflow-harness[postgres]' (or use: uv sync --all-packages --extra postgres when developing locally)"
 )
 POSTGRES_CONN_REQUIRED = "checkpointer.connection_string is required for the postgres backend"
+
+
+def _storage_target_label(config: Any) -> str:
+    backend = getattr(config, "backend", None)
+    if backend == "sqlite":
+        return f"sqlite:{getattr(config, 'sqlite_path', '<unknown>')}"
+    if backend == "postgres":
+        return "postgres:<configured>"
+    return str(backend or "<unknown>")
+
+
+def _checkpointer_target_label(config: CheckpointerConfig) -> str:
+    if config.type == "sqlite":
+        return f"sqlite:{config.connection_string or 'store.db'}"
+    if config.type == "postgres":
+        return "postgres:<configured>"
+    return config.type
+
+
+def warn_legacy_checkpointer_precedence(app_config: Any) -> None:
+    """Warn when legacy checkpointer config overrides unified database storage."""
+    checkpointer_config = getattr(app_config, "checkpointer", None)
+    database_config = getattr(app_config, "database", None)
+    database_backend = getattr(database_config, "backend", None)
+    if checkpointer_config is None or database_config is None or database_backend in (None, "memory"):
+        return
+
+    logger.warning(
+        "Legacy checkpointer config is present and takes precedence over database config for LangGraph state persistence. "
+        "Checkpoint state will use legacy checkpointer target %s instead of database target %s. "
+        "Remove the legacy checkpointer section to use the unified database config for checkpoint storage.",
+        _checkpointer_target_label(checkpointer_config),
+        _storage_target_label(database_config),
+    )
+
 
 # ---------------------------------------------------------------------------
 # Sync factory
@@ -142,6 +178,9 @@ def get_checkpointer() -> Checkpointer:
         _checkpointer = InMemorySaver()
         return _checkpointer
 
+    if _app_config is not None:
+        warn_legacy_checkpointer_precedence(_app_config)
+
     _checkpointer_ctx = _sync_checkpointer_cm(config)
     _checkpointer = _checkpointer_ctx.__enter__()
 
@@ -189,6 +228,8 @@ def checkpointer_context() -> Iterator[Checkpointer]:
 
         yield InMemorySaver()
         return
+
+    warn_legacy_checkpointer_precedence(config)
 
     with _sync_checkpointer_cm(config.checkpointer) as saver:
         yield saver

--- a/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
+++ b/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
@@ -77,6 +77,48 @@ def warn_legacy_checkpointer_precedence(app_config: Any) -> None:
     )
 
 
+@contextlib.contextmanager
+def _sync_checkpointer_from_database(db_config: Any) -> Iterator[Checkpointer]:
+    """Construct a sync checkpointer from unified DatabaseConfig."""
+    if db_config.backend == "memory":
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        logger.info("Checkpointer: using InMemorySaver (database.backend=memory)")
+        yield InMemorySaver()
+        return
+
+    if db_config.backend == "sqlite":
+        try:
+            from langgraph.checkpoint.sqlite import SqliteSaver
+        except ImportError as exc:
+            raise ImportError(SQLITE_INSTALL) from exc
+
+        conn_str = db_config.checkpointer_sqlite_path
+        ensure_sqlite_parent_dir(conn_str)
+        with SqliteSaver.from_conn_string(conn_str) as saver:
+            saver.setup()
+            logger.info("Checkpointer: using SqliteSaver from database config (%s)", conn_str)
+            yield saver
+        return
+
+    if db_config.backend == "postgres":
+        try:
+            from langgraph.checkpoint.postgres import PostgresSaver
+        except ImportError as exc:
+            raise ImportError(POSTGRES_INSTALL) from exc
+
+        if not db_config.postgres_url:
+            raise ValueError("database.postgres_url is required for the postgres backend")
+
+        with PostgresSaver.from_conn_string(db_config.postgres_url) as saver:
+            saver.setup()
+            logger.info("Checkpointer: using PostgresSaver from database config")
+            yield saver
+        return
+
+    raise ValueError(f"Unknown database backend: {db_config.backend!r}")
+
+
 # ---------------------------------------------------------------------------
 # Sync factory
 # ---------------------------------------------------------------------------
@@ -155,31 +197,42 @@ def get_checkpointer() -> Checkpointer:
     # Ensure app config is loaded before checking checkpointer config
     # This prevents returning InMemorySaver when config.yaml actually has a checkpointer section
     # but hasn't been loaded yet
-    from deerflow.config.app_config import _app_config
     from deerflow.config.checkpointer_config import get_checkpointer_config
 
+    app_config = None
     config = get_checkpointer_config()
 
-    if config is None and _app_config is None:
+    if config is None:
         # Only load app config lazily when neither the app config nor an explicit
         # checkpointer config has been initialized yet. This keeps tests that
         # intentionally set the global checkpointer config isolated from any
         # ambient config.yaml on disk.
         try:
-            get_app_config()
+            app_config = get_app_config()
         except FileNotFoundError:
             # In test environments without config.yaml, this is expected.
             pass
         config = get_checkpointer_config()
     if config is None:
+        db_config = getattr(app_config, "database", None)
+        if db_config is not None and db_config.backend != "memory":
+            _checkpointer_ctx = _sync_checkpointer_from_database(db_config)
+            _checkpointer = _checkpointer_ctx.__enter__()
+            return _checkpointer
+
         from langgraph.checkpoint.memory import InMemorySaver
 
         logger.info("Checkpointer: using InMemorySaver (in-process, not persistent)")
         _checkpointer = InMemorySaver()
         return _checkpointer
 
-    if _app_config is not None:
-        warn_legacy_checkpointer_precedence(_app_config)
+    if app_config is None:
+        import deerflow.config.app_config as app_config_module
+
+        app_config = app_config_module._app_config
+
+    if app_config is not None:
+        warn_legacy_checkpointer_precedence(app_config)
 
     _checkpointer_ctx = _sync_checkpointer_cm(config)
     _checkpointer = _checkpointer_ctx.__enter__()
@@ -222,14 +275,20 @@ def checkpointer_context() -> Iterator[Checkpointer]:
     Yields an ``InMemorySaver`` when no checkpointer is configured in *config.yaml*.
     """
 
-    config = get_app_config()
-    if config.checkpointer is None:
+    app_config = get_app_config()
+    if app_config.checkpointer is None:
+        db_config = getattr(app_config, "database", None)
+        if db_config is not None and db_config.backend != "memory":
+            with _sync_checkpointer_from_database(db_config) as saver:
+                yield saver
+            return
+
         from langgraph.checkpoint.memory import InMemorySaver
 
         yield InMemorySaver()
         return
 
-    warn_legacy_checkpointer_precedence(config)
+    warn_legacy_checkpointer_precedence(app_config)
 
-    with _sync_checkpointer_cm(config.checkpointer) as saver:
+    with _sync_checkpointer_cm(app_config.checkpointer) as saver:
         yield saver

--- a/backend/tests/test_checkpointer.py
+++ b/backend/tests/test_checkpointer.py
@@ -109,6 +109,28 @@ class TestLegacyCheckpointerPrecedenceWarning:
 
         assert "Legacy checkpointer config is present" not in caplog.text
 
+    def test_warning_redacts_postgres_targets(self, caplog):
+        from deerflow.runtime.checkpointer.provider import warn_legacy_checkpointer_precedence
+
+        app_config = MagicMock()
+        app_config.checkpointer = CheckpointerConfig(
+            type="postgres",
+            connection_string="postgresql://legacy_user:legacy_pass@example.test/deerflow",
+        )
+        app_config.database = DatabaseConfig(
+            backend="postgres",
+            postgres_url="postgresql://database_user:database_pass@example.test/deerflow",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="deerflow.runtime.checkpointer.provider"):
+            warn_legacy_checkpointer_precedence(app_config)
+
+        assert "postgres:<configured>" in caplog.text
+        assert "legacy_user" not in caplog.text
+        assert "legacy_pass" not in caplog.text
+        assert "database_user" not in caplog.text
+        assert "database_pass" not in caplog.text
+
     @pytest.mark.anyio
     async def test_async_make_checkpointer_warns_when_legacy_overrides_database(self, caplog):
         from langgraph.checkpoint.memory import InMemorySaver
@@ -331,6 +353,89 @@ class TestGetCheckpointer:
         assert cp is mock_saver_instance
         mock_saver_cls.from_conn_string.assert_called_once_with("postgresql://localhost/db")
         mock_saver_instance.setup.assert_called_once()
+
+    def test_get_checkpointer_uses_database_when_legacy_checkpointer_absent(self, tmp_path):
+        """Sync singleton should mirror async provider database fallback."""
+        app_config = MagicMock()
+        app_config.checkpointer = None
+        app_config.database = DatabaseConfig(backend="sqlite", sqlite_dir=str(tmp_path))
+
+        mock_saver_instance = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_saver_instance)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        mock_saver_cls = MagicMock()
+        mock_saver_cls.from_conn_string = MagicMock(return_value=mock_cm)
+
+        mock_module = MagicMock()
+        mock_module.SqliteSaver = mock_saver_cls
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch.dict(sys.modules, {"langgraph.checkpoint.sqlite": mock_module}),
+            patch("deerflow.runtime.checkpointer.provider.ensure_sqlite_parent_dir") as mock_ensure,
+        ):
+            cp = get_checkpointer()
+
+        expected_path = str(tmp_path / "deerflow.db")
+        assert cp is mock_saver_instance
+        mock_ensure.assert_called_once_with(expected_path)
+        mock_saver_cls.from_conn_string.assert_called_once_with(expected_path)
+        mock_saver_instance.setup.assert_called_once()
+
+    def test_checkpointer_context_uses_database_when_legacy_checkpointer_absent(self, tmp_path):
+        """One-shot sync context should not fall back to memory when database is configured."""
+        from deerflow.runtime.checkpointer.provider import checkpointer_context
+
+        app_config = MagicMock()
+        app_config.checkpointer = None
+        app_config.database = DatabaseConfig(backend="sqlite", sqlite_dir=str(tmp_path))
+
+        mock_saver_instance = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.__enter__ = MagicMock(return_value=mock_saver_instance)
+        mock_cm.__exit__ = MagicMock(return_value=False)
+
+        mock_saver_cls = MagicMock()
+        mock_saver_cls.from_conn_string = MagicMock(return_value=mock_cm)
+
+        mock_module = MagicMock()
+        mock_module.SqliteSaver = mock_saver_cls
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch.dict(sys.modules, {"langgraph.checkpoint.sqlite": mock_module}),
+            patch("deerflow.runtime.checkpointer.provider.ensure_sqlite_parent_dir") as mock_ensure,
+        ):
+            with checkpointer_context() as cp:
+                assert cp is mock_saver_instance
+
+        expected_path = str(tmp_path / "deerflow.db")
+        mock_ensure.assert_called_once_with(expected_path)
+        mock_saver_cls.from_conn_string.assert_called_once_with(expected_path)
+        mock_saver_instance.setup.assert_called_once()
+
+    def test_get_checkpointer_warns_after_lazy_app_config_load(self, caplog):
+        """The warning should use the app config returned by lazy loading."""
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        app_config = MagicMock()
+        app_config.checkpointer = CheckpointerConfig(type="memory")
+        app_config.database = DatabaseConfig(backend="sqlite", sqlite_dir=".deer-flow/data")
+
+        def load_config():
+            set_checkpointer_config(app_config.checkpointer)
+            return app_config
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", side_effect=load_config),
+            caplog.at_level(logging.WARNING, logger="deerflow.runtime.checkpointer.provider"),
+        ):
+            cp = get_checkpointer()
+
+        assert isinstance(cp, InMemorySaver)
+        assert "Legacy checkpointer config is present" in caplog.text
 
 
 class TestAsyncCheckpointer:

--- a/backend/tests/test_checkpointer.py
+++ b/backend/tests/test_checkpointer.py
@@ -1,5 +1,6 @@
 """Unit tests for checkpointer config, packaging metadata, and factories."""
 
+import logging
 import sys
 import tomllib
 from pathlib import Path
@@ -14,6 +15,7 @@ from deerflow.config.checkpointer_config import (
     load_checkpointer_config_from_dict,
     set_checkpointer_config,
 )
+from deerflow.config.database_config import DatabaseConfig
 from deerflow.runtime.checkpointer import get_checkpointer, reset_checkpointer
 from deerflow.runtime.checkpointer.provider import POSTGRES_INSTALL
 from deerflow.runtime.store.provider import POSTGRES_STORE_INSTALL
@@ -78,6 +80,50 @@ class TestCheckpointerConfig:
         assert "Optional for sqlite" in description
         assert "defaults to 'store.db'" in description
         assert "Required for postgres" in description
+
+
+class TestLegacyCheckpointerPrecedenceWarning:
+    def test_warning_includes_legacy_and_database_targets(self, caplog):
+        from deerflow.runtime.checkpointer.provider import warn_legacy_checkpointer_precedence
+
+        app_config = MagicMock()
+        app_config.checkpointer = CheckpointerConfig(type="sqlite", connection_string="checkpoints.db")
+        app_config.database = DatabaseConfig(backend="sqlite", sqlite_dir=".deer-flow/data")
+
+        with caplog.at_level(logging.WARNING, logger="deerflow.runtime.checkpointer.provider"):
+            warn_legacy_checkpointer_precedence(app_config)
+
+        assert "Legacy checkpointer config is present" in caplog.text
+        assert "sqlite:checkpoints.db" in caplog.text
+        assert "deerflow.db" in caplog.text
+
+    def test_warning_is_skipped_for_memory_database_backend(self, caplog):
+        from deerflow.runtime.checkpointer.provider import warn_legacy_checkpointer_precedence
+
+        app_config = MagicMock()
+        app_config.checkpointer = CheckpointerConfig(type="memory")
+        app_config.database = DatabaseConfig(backend="memory")
+
+        with caplog.at_level(logging.WARNING, logger="deerflow.runtime.checkpointer.provider"):
+            warn_legacy_checkpointer_precedence(app_config)
+
+        assert "Legacy checkpointer config is present" not in caplog.text
+
+    @pytest.mark.anyio
+    async def test_async_make_checkpointer_warns_when_legacy_overrides_database(self, caplog):
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        from deerflow.runtime.checkpointer.async_provider import make_checkpointer
+
+        app_config = MagicMock()
+        app_config.checkpointer = CheckpointerConfig(type="memory")
+        app_config.database = DatabaseConfig(backend="sqlite", sqlite_dir=".deer-flow/data")
+
+        with caplog.at_level(logging.WARNING, logger="deerflow.runtime.checkpointer.provider"):
+            async with make_checkpointer(app_config) as checkpointer:
+                assert isinstance(checkpointer, InMemorySaver)
+
+        assert "Legacy checkpointer config is present" in caplog.text
 
 
 class TestHarnessPackaging:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -843,6 +843,10 @@ skill_evolution:
 #
 # If both `checkpointer` and `database` are present, `checkpointer`
 # takes precedence for LangGraph state persistence only.
+# This is intentional for backward compatibility, but upgraded installs can
+# accidentally keep writing checkpoints to the legacy database. Remove the
+# `checkpointer` section when you want checkpoint state to use the unified
+# `database` backend below.
 #
 # checkpointer:
 #   type: sqlite


### PR DESCRIPTION
## What

Add a runtime warning when legacy `checkpointer:` config is present alongside unified `database:` config.

The warning states that legacy checkpointer config takes precedence for LangGraph checkpoint state and reports both the legacy target and the database target. This also documents the upgrade caveat in `config.example.yaml`.

## Why

`checkpointer:` precedence is intentionally backward compatible, but upgraded installs can keep writing checkpoint state to the legacy DB even after `database:` is present. That makes the active checkpoint store easy to miss when diagnosing checkpoint growth.

This is a small visibility guard for the broader checkpoint lifecycle gap tracked in #3011.

## How

- Add `warn_legacy_checkpointer_precedence()` in the sync checkpointer provider.
- Reuse it from async gateway and sync checkpointer paths.
- Skip the warning when the unified database backend is `memory`.
- Redact PostgreSQL targets as `<configured>` while showing SQLite targets.

## Testing

- `cd backend && uv run pytest tests/test_checkpointer.py -q`
- `cd backend && make format`
- `cd backend && make lint`
- `cd backend && make test`
