### PR TITLE
fix(runtime): recover legacy checkpoint threads for cleanup

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -124,13 +124,12 @@ async def _ensure_admin_user(app: FastAPI) -> None:
     # ``threads_meta`` does not. Without a metadata row these threads are
     # invisible in /threads/search and cannot pass strict delete owner checks.
     try:
-        from app.gateway.checkpoint_maintenance import migrate_app_checkpoint_threads_to_thread_meta
+        from app.gateway.checkpoint_maintenance import schedule_app_checkpoint_thread_migration
 
-        migrated = await migrate_app_checkpoint_threads_to_thread_meta(app, admin_id)
-        if migrated:
-            logger.info("Migrated %d legacy checkpoint thread(s) to admin thread metadata", migrated)
+        if schedule_app_checkpoint_thread_migration(app, admin_id):
+            logger.info("Scheduled legacy checkpoint thread migration")
     except Exception:
-        logger.exception("Legacy checkpoint thread migration failed (non-fatal)")
+        logger.exception("Could not schedule legacy checkpoint thread migration (non-fatal)")
 
 
 async def _iter_store_items(store, namespace, *, page_size: int = 500):

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -119,6 +119,19 @@ async def _ensure_admin_user(app: FastAPI) -> None:
         except Exception:
             logger.exception("LangGraph thread migration failed (non-fatal)")
 
+    # Checkpointer-only legacy thread migration — non-fatal.
+    # This covers upgrades where LangGraph checkpoint data exists but
+    # ``threads_meta`` does not. Without a metadata row these threads are
+    # invisible in /threads/search and cannot pass strict delete owner checks.
+    try:
+        from app.gateway.checkpoint_maintenance import migrate_app_checkpoint_threads_to_thread_meta
+
+        migrated = await migrate_app_checkpoint_threads_to_thread_meta(app, admin_id)
+        if migrated:
+            logger.info("Migrated %d legacy checkpoint thread(s) to admin thread metadata", migrated)
+    except Exception:
+        logger.exception("Legacy checkpoint thread migration failed (non-fatal)")
+
 
 async def _iter_store_items(store, namespace, *, page_size: int = 500):
     """Paginated async iterator over a LangGraph store namespace.

--- a/backend/app/gateway/checkpoint_maintenance.py
+++ b/backend/app/gateway/checkpoint_maintenance.py
@@ -108,8 +108,11 @@ async def migrate_checkpoint_threads_to_thread_meta(
     Older DeerFlow installs could have valid LangGraph checkpoints without a
     corresponding ``threads_meta`` row. After search moved to ThreadMetaStore,
     those threads became invisible to the normal thread list and also failed
-    strict destructive owner checks. Assigning these legacy rows to the first
-    admin mirrors the existing no-auth-to-auth orphan migration.
+    strict destructive owner checks.
+
+    Assigning these legacy rows to the first admin mirrors the existing
+    no-auth-to-auth orphan migration. It is an ownership-recovery fallback for
+    pre-auth single-owner installs, not a multi-tenant ownership audit tool.
     """
     conn = _sqlite_saver_connection(checkpointer)
     if conn is None:
@@ -179,12 +182,16 @@ async def compact_sqlite_checkpointer(
     checkpointer: Any,
     *,
     min_reclaimable_bytes: int = 64 * 1024 * 1024,
+    min_reclaimable_ratio: float = 0.10,
+    max_database_bytes: int = 2 * 1024 * 1024 * 1024,
 ) -> bool:
     """Best-effort SQLite compaction after checkpoint deletes.
 
     LangGraph's SQLite saver deletes checkpoint rows, but SQLite keeps the file
     size until a VACUUM. Running this only when the active saver exposes a
-    SQLite connection keeps postgres/memory backends as no-ops.
+    SQLite connection keeps postgres/memory backends as no-ops. Automatic
+    compaction is intentionally conservative because VACUUM rewrites the whole
+    database; large stores should use the explicit maintenance CLI instead.
     """
     conn = _sqlite_saver_connection(checkpointer)
     if conn is None:
@@ -198,8 +205,16 @@ async def compact_sqlite_checkpointer(
         await conn.commit()
         await _execute("PRAGMA wal_checkpoint(TRUNCATE)")
         page_size = await _pragma_int(conn, "PRAGMA page_size")
+        page_count = await _pragma_int(conn, "PRAGMA page_count")
         freelist_count = await _pragma_int(conn, "PRAGMA freelist_count")
-        if page_size * freelist_count < min_reclaimable_bytes:
+        reclaimable_bytes = page_size * freelist_count
+        database_bytes = page_size * page_count
+        reclaimable_ratio = freelist_count / page_count if page_count else 0
+        if reclaimable_bytes < min_reclaimable_bytes:
+            return False
+        if reclaimable_ratio < min_reclaimable_ratio:
+            return False
+        if database_bytes > max_database_bytes:
             return False
         await _execute("VACUUM")
         await conn.commit()

--- a/backend/app/gateway/checkpoint_maintenance.py
+++ b/backend/app/gateway/checkpoint_maintenance.py
@@ -1,0 +1,127 @@
+"""Maintenance helpers for LangGraph checkpoint storage.
+
+These helpers intentionally live outside the router layer so startup
+migrations and request handlers can share the same SQLite-specific
+checkpointer maintenance behavior without depending on FastAPI.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def _sqlite_checkpoint_thread_ids(checkpointer: Any) -> list[str]:
+    """Return checkpoint thread IDs using the SQLite saver connection when available.
+
+    The public LangGraph checkpointer API can list checkpoints, but doing so
+    deserializes checkpoint payloads. For migration/cleanup we only need the
+    distinct thread IDs, so use the SQLite connection directly when the active
+    saver exposes one.
+    """
+    conn = getattr(checkpointer, "conn", None)
+    if conn is None:
+        return []
+
+    setup = getattr(checkpointer, "setup", None)
+    if setup is not None:
+        result = setup()
+        if inspect.isawaitable(result):
+            await result
+
+    lock = getattr(checkpointer, "lock", None)
+    if lock is None:
+        async with conn.execute("SELECT DISTINCT thread_id FROM checkpoints ORDER BY thread_id") as cur:
+            return [str(row[0]) async for row in cur]
+
+    async with lock:
+        async with conn.execute("SELECT DISTINCT thread_id FROM checkpoints ORDER BY thread_id") as cur:
+            return [str(row[0]) async for row in cur]
+
+
+async def migrate_checkpoint_threads_to_thread_meta(
+    checkpointer: Any,
+    thread_store: Any,
+    admin_user_id: str,
+) -> int:
+    """Create missing thread_meta rows for legacy checkpoint-only threads.
+
+    Older DeerFlow installs could have valid LangGraph checkpoints without a
+    corresponding ``threads_meta`` row. After search moved to ThreadMetaStore,
+    those threads became invisible to the normal thread list and also failed
+    strict destructive owner checks. Assigning these legacy rows to the first
+    admin mirrors the existing no-auth-to-auth orphan migration.
+    """
+    migrated = 0
+    for thread_id in await _sqlite_checkpoint_thread_ids(checkpointer):
+        existing = await thread_store.get(thread_id, user_id=None)
+        if existing is not None:
+            continue
+        try:
+            await thread_store.create(
+                thread_id,
+                user_id=admin_user_id,
+                metadata={"migrated_from": "legacy_checkpointer"},
+            )
+            migrated += 1
+        except Exception:
+            logger.debug("Could not create thread_meta for legacy checkpoint thread %s", thread_id, exc_info=True)
+    return migrated
+
+
+async def migrate_app_checkpoint_threads_to_thread_meta(app: Any, admin_user_id: str) -> int:
+    """Migrate app-scoped legacy checkpoint threads when runtime state exists."""
+    checkpointer = getattr(app.state, "checkpointer", None)
+    thread_store = getattr(app.state, "thread_store", None)
+    if checkpointer is None or thread_store is None:
+        return 0
+    return await migrate_checkpoint_threads_to_thread_meta(checkpointer, thread_store, admin_user_id)
+
+
+async def _pragma_int(conn: Any, statement: str) -> int:
+    async with conn.execute(statement) as cur:
+        row = await cur.fetchone()
+    return int(row[0])
+
+
+async def compact_sqlite_checkpointer(
+    checkpointer: Any,
+    *,
+    min_reclaimable_bytes: int = 64 * 1024 * 1024,
+) -> bool:
+    """Best-effort SQLite compaction after checkpoint deletes.
+
+    LangGraph's SQLite saver deletes checkpoint rows, but SQLite keeps the file
+    size until a VACUUM. Running this only when the active saver exposes a
+    SQLite connection keeps postgres/memory backends as no-ops.
+    """
+    conn = getattr(checkpointer, "conn", None)
+    if conn is None:
+        return False
+
+    async def _execute(statement: str) -> None:
+        async with conn.execute(statement) as cur:
+            await cur.fetchall()
+
+    async def _compact_if_worthwhile() -> bool:
+        await conn.commit()
+        await _execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        page_size = await _pragma_int(conn, "PRAGMA page_size")
+        freelist_count = await _pragma_int(conn, "PRAGMA freelist_count")
+        if page_size * freelist_count < min_reclaimable_bytes:
+            return False
+        await _execute("VACUUM")
+        await conn.commit()
+        await _execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        await conn.commit()
+        return True
+
+    lock = getattr(checkpointer, "lock", None)
+    if lock is None:
+        return await _compact_if_worthwhile()
+
+    async with lock:
+        return await _compact_if_worthwhile()

--- a/backend/app/gateway/checkpoint_maintenance.py
+++ b/backend/app/gateway/checkpoint_maintenance.py
@@ -7,11 +7,71 @@ checkpointer maintenance behavior without depending on FastAPI.
 
 from __future__ import annotations
 
+import asyncio
+import hashlib
 import inspect
 import logging
+from pathlib import Path
 from typing import Any
 
+from deerflow.config.runtime_paths import runtime_home
+
 logger = logging.getLogger(__name__)
+
+_MIGRATION_TASK_STATE_ATTR = "checkpoint_thread_migration_task"
+
+
+def _sqlite_saver_connection(checkpointer: Any) -> Any | None:
+    """Return the aiosqlite connection only for LangGraph SQLite savers."""
+    saver_type = type(checkpointer)
+    type_name = saver_type.__name__.lower()
+    module_name = saver_type.__module__.lower()
+    if "sqlite" not in type_name or "langgraph.checkpoint.sqlite" not in module_name:
+        return None
+
+    conn = getattr(checkpointer, "conn", None)
+    if conn is None or not hasattr(conn, "execute") or not hasattr(conn, "commit"):
+        return None
+    return conn
+
+
+async def _ensure_checkpointer_setup(checkpointer: Any) -> None:
+    setup = getattr(checkpointer, "setup", None)
+    if setup is None:
+        return
+    result = setup()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _row_value(row: Any, index: int, key: str) -> Any:
+    try:
+        return row[key]
+    except (IndexError, KeyError, TypeError):
+        return row[index]
+
+
+async def _sqlite_database_path(conn: Any) -> str | None:
+    async with conn.execute("PRAGMA database_list") as cur:
+        rows = await cur.fetchall()
+    for row in rows:
+        if _row_value(row, 1, "name") == "main":
+            value = str(_row_value(row, 2, "file") or "")
+            return value or None
+    return None
+
+
+async def _checkpoint_thread_migration_marker_path(conn: Any) -> Path | None:
+    db_path = await _sqlite_database_path(conn)
+    if not db_path:
+        return None
+    digest = hashlib.sha256(str(Path(db_path).expanduser().resolve()).encode()).hexdigest()[:16]
+    return runtime_home() / "maintenance" / f"checkpoint-thread-meta-migration-{digest}.done"
+
+
+def _write_migration_marker(marker_path: Path) -> None:
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("completed\n", encoding="utf-8")
 
 
 async def _sqlite_checkpoint_thread_ids(checkpointer: Any) -> list[str]:
@@ -22,15 +82,11 @@ async def _sqlite_checkpoint_thread_ids(checkpointer: Any) -> list[str]:
     distinct thread IDs, so use the SQLite connection directly when the active
     saver exposes one.
     """
-    conn = getattr(checkpointer, "conn", None)
+    conn = _sqlite_saver_connection(checkpointer)
     if conn is None:
         return []
 
-    setup = getattr(checkpointer, "setup", None)
-    if setup is not None:
-        result = setup()
-        if inspect.isawaitable(result):
-            await result
+    await _ensure_checkpointer_setup(checkpointer)
 
     lock = getattr(checkpointer, "lock", None)
     if lock is None:
@@ -55,7 +111,17 @@ async def migrate_checkpoint_threads_to_thread_meta(
     strict destructive owner checks. Assigning these legacy rows to the first
     admin mirrors the existing no-auth-to-auth orphan migration.
     """
+    conn = _sqlite_saver_connection(checkpointer)
+    if conn is None:
+        return 0
+
+    await _ensure_checkpointer_setup(checkpointer)
+    marker_path = await _checkpoint_thread_migration_marker_path(conn)
+    if marker_path is not None and marker_path.exists():
+        return 0
+
     migrated = 0
+    failed = False
     for thread_id in await _sqlite_checkpoint_thread_ids(checkpointer):
         existing = await thread_store.get(thread_id, user_id=None)
         if existing is not None:
@@ -68,7 +134,10 @@ async def migrate_checkpoint_threads_to_thread_meta(
             )
             migrated += 1
         except Exception:
+            failed = True
             logger.debug("Could not create thread_meta for legacy checkpoint thread %s", thread_id, exc_info=True)
+    if marker_path is not None and not failed:
+        _write_migration_marker(marker_path)
     return migrated
 
 
@@ -79,6 +148,25 @@ async def migrate_app_checkpoint_threads_to_thread_meta(app: Any, admin_user_id:
     if checkpointer is None or thread_store is None:
         return 0
     return await migrate_checkpoint_threads_to_thread_meta(checkpointer, thread_store, admin_user_id)
+
+
+def schedule_app_checkpoint_thread_migration(app: Any, admin_user_id: str) -> bool:
+    """Schedule legacy checkpoint thread migration without blocking startup/setup."""
+    existing_task = getattr(app.state, _MIGRATION_TASK_STATE_ATTR, None)
+    if existing_task is not None and not existing_task.done():
+        return False
+
+    async def _run() -> None:
+        try:
+            migrated = await migrate_app_checkpoint_threads_to_thread_meta(app, admin_user_id)
+            if migrated:
+                logger.info("Migrated %d legacy checkpoint thread(s) to admin thread metadata", migrated)
+        except Exception:
+            logger.exception("Legacy checkpoint thread migration failed (non-fatal)")
+
+    task = asyncio.create_task(_run(), name="deerflow-checkpoint-thread-migration")
+    setattr(app.state, _MIGRATION_TASK_STATE_ATTR, task)
+    return True
 
 
 async def _pragma_int(conn: Any, statement: str) -> int:
@@ -98,7 +186,7 @@ async def compact_sqlite_checkpointer(
     size until a VACUUM. Running this only when the active saver exposes a
     SQLite connection keeps postgres/memory backends as no-ops.
     """
-    conn = getattr(checkpointer, "conn", None)
+    conn = _sqlite_saver_connection(checkpointer)
     if conn is None:
         return False
 

--- a/backend/app/gateway/routers/auth.py
+++ b/backend/app/gateway/routers/auth.py
@@ -455,6 +455,15 @@ async def initialize_admin(request: Request, response: Response, body: Initializ
     token = create_access_token(str(user.id), token_version=user.token_version)
     _set_session_cookie(response, token, request)
 
+    try:
+        from app.gateway.checkpoint_maintenance import migrate_app_checkpoint_threads_to_thread_meta
+
+        migrated = await migrate_app_checkpoint_threads_to_thread_meta(request.app, str(user.id))
+        if migrated:
+            logger.info("Migrated %d legacy checkpoint thread(s) after first admin setup", migrated)
+    except Exception:
+        logger.exception("Legacy checkpoint thread migration after first admin setup failed (non-fatal)")
+
     return UserResponse(id=str(user.id), email=user.email, system_role=user.system_role)
 
 

--- a/backend/app/gateway/routers/auth.py
+++ b/backend/app/gateway/routers/auth.py
@@ -456,13 +456,12 @@ async def initialize_admin(request: Request, response: Response, body: Initializ
     _set_session_cookie(response, token, request)
 
     try:
-        from app.gateway.checkpoint_maintenance import migrate_app_checkpoint_threads_to_thread_meta
+        from app.gateway.checkpoint_maintenance import schedule_app_checkpoint_thread_migration
 
-        migrated = await migrate_app_checkpoint_threads_to_thread_meta(request.app, str(user.id))
-        if migrated:
-            logger.info("Migrated %d legacy checkpoint thread(s) after first admin setup", migrated)
+        if schedule_app_checkpoint_thread_migration(request.app, str(user.id)):
+            logger.info("Scheduled legacy checkpoint thread migration after first admin setup")
     except Exception:
-        logger.exception("Legacy checkpoint thread migration after first admin setup failed (non-fatal)")
+        logger.exception("Could not schedule legacy checkpoint thread migration after first admin setup (non-fatal)")
 
     return UserResponse(id=str(user.id), email=user.email, system_role=user.system_role)
 

--- a/backend/app/gateway/routers/threads.py
+++ b/backend/app/gateway/routers/threads.py
@@ -231,6 +231,13 @@ async def delete_thread_data(thread_id: str, request: Request) -> ThreadDeleteRe
                 await checkpointer.adelete_thread(thread_id)
         except Exception:
             logger.debug("Could not delete checkpoints for thread %s (not critical)", sanitize_log_param(thread_id))
+        else:
+            try:
+                from app.gateway.checkpoint_maintenance import compact_sqlite_checkpointer
+
+                await compact_sqlite_checkpointer(checkpointer)
+            except Exception:
+                logger.debug("Could not compact checkpoint storage after deleting thread %s (not critical)", sanitize_log_param(thread_id))
 
     # Remove thread_meta row (best-effort) — required for sqlite backend
     # so the deleted thread no longer appears in /threads/search.

--- a/backend/tests/test_checkpoint_maintenance.py
+++ b/backend/tests/test_checkpoint_maintenance.py
@@ -5,6 +5,7 @@ from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.store.memory import InMemoryStore
 
+from app.gateway import checkpoint_maintenance
 from app.gateway.checkpoint_maintenance import (
     compact_sqlite_checkpointer,
     migrate_checkpoint_threads_to_thread_meta,
@@ -47,6 +48,65 @@ async def test_migrate_checkpoint_threads_to_thread_meta_assigns_missing_rows_to
     assert legacy["metadata"] == {"migrated_from": "legacy_checkpointer"}
     assert existing is not None
     assert existing["user_id"] == "existing-owner"
+
+
+@pytest.mark.anyio
+async def test_migrate_checkpoint_threads_skips_non_sqlite_saver_with_conn():
+    class FakeConn:
+        async def execute(self, _statement):
+            raise AssertionError("non-sqlite saver connection should not be queried")
+
+        async def commit(self):
+            raise AssertionError("non-sqlite saver connection should not be committed")
+
+    class FakeSaver:
+        conn = FakeConn()
+
+    thread_store = MemoryThreadMetaStore(InMemoryStore())
+
+    migrated = await migrate_checkpoint_threads_to_thread_meta(
+        FakeSaver(),
+        thread_store,
+        "admin-user-id",
+    )
+
+    assert migrated == 0
+
+
+@pytest.mark.anyio
+async def test_migrate_checkpoint_threads_uses_completion_marker(tmp_path, monkeypatch):
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path / "runtime-home"))
+    thread_store = MemoryThreadMetaStore(InMemoryStore())
+
+    async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+        await saver.setup()
+        await saver.aput(
+            {"configurable": {"thread_id": "legacy-thread", "checkpoint_ns": ""}},
+            empty_checkpoint(),
+            {"step": -1, "source": "input", "writes": None, "parents": {}},
+            {},
+        )
+
+        migrated = await migrate_checkpoint_threads_to_thread_meta(
+            saver,
+            thread_store,
+            "admin-user-id",
+        )
+
+        assert migrated == 1
+
+        async def fail_if_scanned(_checkpointer):
+            raise AssertionError("completed migration should not rescan checkpoints")
+
+        monkeypatch.setattr(checkpoint_maintenance, "_sqlite_checkpoint_thread_ids", fail_if_scanned)
+
+        migrated_again = await checkpoint_maintenance.migrate_checkpoint_threads_to_thread_meta(
+            saver,
+            thread_store,
+            "admin-user-id",
+        )
+
+    assert migrated_again == 0
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_checkpoint_maintenance.py
+++ b/backend/tests/test_checkpoint_maintenance.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+from langgraph.checkpoint.base import empty_checkpoint
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from langgraph.store.memory import InMemoryStore
+
+from app.gateway.checkpoint_maintenance import (
+    compact_sqlite_checkpointer,
+    migrate_checkpoint_threads_to_thread_meta,
+)
+from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
+
+
+async def _pragma_int(conn, statement: str) -> int:
+    async with conn.execute(statement) as cur:
+        row = await cur.fetchone()
+    return int(row[0])
+
+
+@pytest.mark.anyio
+async def test_migrate_checkpoint_threads_to_thread_meta_assigns_missing_rows_to_admin(tmp_path):
+    thread_store = MemoryThreadMetaStore(InMemoryStore())
+    await thread_store.create("existing-thread", user_id="existing-owner")
+
+    async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+        await saver.setup()
+        for thread_id in ("legacy-thread", "existing-thread"):
+            await saver.aput(
+                {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}},
+                empty_checkpoint(),
+                {"step": -1, "source": "input", "writes": None, "parents": {}},
+                {},
+            )
+
+        migrated = await migrate_checkpoint_threads_to_thread_meta(
+            saver,
+            thread_store,
+            "admin-user-id",
+        )
+
+    assert migrated == 1
+    legacy = await thread_store.get("legacy-thread", user_id=None)
+    existing = await thread_store.get("existing-thread", user_id=None)
+    assert legacy is not None
+    assert legacy["user_id"] == "admin-user-id"
+    assert legacy["metadata"] == {"migrated_from": "legacy_checkpointer"}
+    assert existing is not None
+    assert existing["user_id"] == "existing-owner"
+
+
+@pytest.mark.anyio
+async def test_compact_sqlite_checkpointer_reclaims_deleted_pages(tmp_path):
+    async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+        await saver.setup()
+        async with saver.lock:
+            for idx in range(100):
+                await saver.conn.execute(
+                    """
+                    INSERT INTO checkpoints (
+                        thread_id,
+                        checkpoint_ns,
+                        checkpoint_id,
+                        parent_checkpoint_id,
+                        type,
+                        checkpoint,
+                        metadata
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    ("fat-thread", "", f"{idx:04d}", None, "json", b"x" * 8192, b"{}"),
+                )
+            await saver.conn.commit()
+
+        await saver.adelete_thread("fat-thread")
+        assert await _pragma_int(saver.conn, "PRAGMA freelist_count") > 0
+
+        compacted = await compact_sqlite_checkpointer(saver, min_reclaimable_bytes=1)
+
+        assert compacted is True
+        assert await _pragma_int(saver.conn, "PRAGMA freelist_count") == 0
+
+
+@pytest.mark.anyio
+async def test_compact_sqlite_checkpointer_skips_small_deletes_by_default(tmp_path):
+    async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+        await saver.setup()
+        await saver.aput(
+            {"configurable": {"thread_id": "small-thread", "checkpoint_ns": ""}},
+            empty_checkpoint(),
+            {"step": -1, "source": "input", "writes": None, "parents": {}},
+            {},
+        )
+        await saver.adelete_thread("small-thread")
+
+        compacted = await compact_sqlite_checkpointer(saver)
+
+        assert compacted is False

--- a/backend/tests/test_checkpoint_maintenance.py
+++ b/backend/tests/test_checkpoint_maintenance.py
@@ -156,3 +156,40 @@ async def test_compact_sqlite_checkpointer_skips_small_deletes_by_default(tmp_pa
         compacted = await compact_sqlite_checkpointer(saver)
 
         assert compacted is False
+
+
+@pytest.mark.anyio
+async def test_compact_sqlite_checkpointer_skips_when_database_exceeds_auto_limit(tmp_path):
+    async with AsyncSqliteSaver.from_conn_string(str(tmp_path / "checkpoints.db")) as saver:
+        await saver.setup()
+        async with saver.lock:
+            for idx in range(10):
+                await saver.conn.execute(
+                    """
+                    INSERT INTO checkpoints (
+                        thread_id,
+                        checkpoint_ns,
+                        checkpoint_id,
+                        parent_checkpoint_id,
+                        type,
+                        checkpoint,
+                        metadata
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    ("large-thread", "", f"{idx:04d}", None, "json", b"x" * 8192, b"{}"),
+                )
+            await saver.conn.commit()
+
+        await saver.adelete_thread("large-thread")
+        assert await _pragma_int(saver.conn, "PRAGMA freelist_count") > 0
+
+        compacted = await compact_sqlite_checkpointer(
+            saver,
+            min_reclaimable_bytes=1,
+            min_reclaimable_ratio=0,
+            max_database_bytes=1,
+        )
+
+        assert compacted is False
+        assert await _pragma_int(saver.conn, "PRAGMA freelist_count") > 0

--- a/backend/tests/test_initialize_admin.py
+++ b/backend/tests/test_initialize_admin.py
@@ -7,6 +7,7 @@ and public accessibility (no auth cookie required).
 
 import asyncio
 import os
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -73,6 +74,18 @@ def test_initialize_creates_admin_and_sets_cookie(client):
     assert data["email"] == "admin@example.com"
     assert data["system_role"] == "admin"
     assert "access_token" in resp.cookies
+
+
+def test_initialize_migrates_legacy_checkpoint_threads_for_new_admin(client):
+    """First-admin setup should recover legacy checkpoint-only threads immediately."""
+    with patch(
+        "app.gateway.checkpoint_maintenance.migrate_app_checkpoint_threads_to_thread_meta",
+        new=AsyncMock(return_value=2),
+    ) as migrate:
+        resp = client.post("/api/v1/auth/initialize", json=_init_payload())
+
+    assert resp.status_code == 201
+    migrate.assert_awaited_once_with(client.app, resp.json()["id"])
 
 
 def test_initialize_needs_setup_false(client):

--- a/backend/tests/test_initialize_admin.py
+++ b/backend/tests/test_initialize_admin.py
@@ -7,7 +7,7 @@ and public accessibility (no auth cookie required).
 
 import asyncio
 import os
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -77,15 +77,15 @@ def test_initialize_creates_admin_and_sets_cookie(client):
 
 
 def test_initialize_migrates_legacy_checkpoint_threads_for_new_admin(client):
-    """First-admin setup should recover legacy checkpoint-only threads immediately."""
+    """First-admin setup should schedule checkpoint-only thread recovery."""
     with patch(
-        "app.gateway.checkpoint_maintenance.migrate_app_checkpoint_threads_to_thread_meta",
-        new=AsyncMock(return_value=2),
-    ) as migrate:
+        "app.gateway.checkpoint_maintenance.schedule_app_checkpoint_thread_migration",
+        return_value=True,
+    ) as schedule:
         resp = client.post("/api/v1/auth/initialize", json=_init_payload())
 
     assert resp.status_code == 201
-    migrate.assert_awaited_once_with(client.app, resp.json()["id"])
+    schedule.assert_called_once_with(client.app, resp.json()["id"])
 
 
 def test_initialize_needs_setup_false(client):


### PR DESCRIPTION
## What

Recover legacy checkpoint-only threads so they can be managed through the normal thread lifecycle again.

This PR adds a small checkpoint maintenance helper and wires it into two safe lifecycle points:

- During startup, when an admin already exists, create missing `threads_meta` rows for threads that still exist only in the active checkpoint store.
- During first-admin setup, run the same migration so first-boot installs with legacy checkpoints become manageable immediately after `/setup`.
- After an explicit `DELETE /api/threads/{thread_id}`, compact SQLite checkpoint storage when enough space is reclaimable.

## Why

After thread search moved to `ThreadMetaStore`, older installs can have valid LangGraph checkpoint state without corresponding `threads_meta` rows. Those threads may be resumable at the checkpointer layer but invisible through `/threads/search`, which also makes cleanup hard to discover and perform safely.

There is a second SQLite-specific issue: deleting checkpoint rows does not necessarily return disk space to the filesystem. A `VACUUM` plus WAL checkpoint is needed after explicit deletion to actually reclaim disk.

This is part of the broader checkpoint lifecycle issue discussed in #3011.

## Scope and safety

This PR deliberately does **not** add automatic checkpoint pruning or retention cleanup.

The intended boundary is:

- make legacy checkpoint-only threads visible/manageable again,
- reclaim SQLite disk space only after an explicit thread delete,
- leave broader retention policy, storage observability, and large-payload externalization for follow-up work.

That keeps the change focused on manageability and explicit cleanup rather than opaque background data deletion.

## Testing

- `cd backend && make lint`
- `cd backend && uv run pytest tests/test_checkpoint_maintenance.py tests/test_initialize_admin.py tests/test_ensure_admin.py tests/test_threads_router.py tests/test_gateway_lifespan_shutdown.py tests/test_gateway_runtime_cleanup.py -q`
- `cd backend && PYTHONPATH=. uv run pytest tests/ -q`
