### PR TITLE
[codex] support slash skill activation

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -20,6 +20,8 @@ from app.channels.store import ChannelStore
 from app.gateway.csrf_middleware import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, generate_csrf_token
 from app.gateway.internal_auth import create_internal_auth_headers
 from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.storage import get_or_new_skill_storage
 
 logger = logging.getLogger(__name__)
 
@@ -351,6 +353,21 @@ def _format_artifact_text(artifacts: list[str]) -> str:
 
 
 _OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
+
+
+def _is_enabled_slash_skill_command(text: str) -> bool:
+    if parse_slash_skill_reference(text) is None:
+        return False
+    try:
+        storage = get_or_new_skill_storage()
+        return resolve_slash_skill(
+            text,
+            storage.load_skills(enabled_only=True),
+            container_base_path=storage.get_container_root(),
+        ) is not None
+    except Exception:
+        logger.exception("[Manager] failed to resolve slash skill command")
+        return False
 
 
 def _resolve_attachments(thread_id: str, artifacts: list[str]) -> list[ResolvedAttachment]:
@@ -984,8 +1001,15 @@ class ChannelManager:
                 "/status — Show current thread info\n"
                 "/models — List available models\n"
                 "/memory — Show memory status\n"
+                "/<skill-name> <task> — Activate an enabled skill for one turn\n"
                 "/help — Show this help"
             )
+        elif await asyncio.to_thread(_is_enabled_slash_skill_command, text):
+            from dataclasses import replace as _dc_replace
+
+            chat_msg = _dc_replace(msg, msg_type=InboundMessageType.CHAT)
+            await self._handle_chat(chat_msg)
+            return
         else:
             available = " | ".join(sorted(KNOWN_CHANNEL_COMMANDS))
             reply = f"Unknown command: /{command}. Available commands: {available}"

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -19,6 +19,7 @@ from app.channels.message_bus import InboundMessage, InboundMessageType, Message
 from app.channels.store import ChannelStore
 from app.gateway.csrf_middleware import CSRF_COOKIE_NAME, CSRF_HEADER_NAME, generate_csrf_token
 from app.gateway.internal_auth import create_internal_auth_headers
+from deerflow.config.agents_config import load_agent_config
 from deerflow.runtime.user_context import get_effective_user_id
 from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
@@ -355,7 +356,7 @@ def _format_artifact_text(artifacts: list[str]) -> str:
 _OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
 
 
-def _is_enabled_slash_skill_command(text: str) -> bool:
+def _is_enabled_slash_skill_command(text: str, available_skills: set[str] | None = None) -> bool:
     if parse_slash_skill_reference(text) is None:
         return False
     try:
@@ -364,6 +365,7 @@ def _is_enabled_slash_skill_command(text: str) -> bool:
             resolve_slash_skill(
                 text,
                 storage.load_skills(enabled_only=True),
+                available_skills=available_skills,
                 container_base_path=storage.get_container_root(),
             )
             is not None
@@ -650,6 +652,21 @@ class ChannelManager:
             assistant_id = DEFAULT_ASSISTANT_ID
 
         return assistant_id, run_config, run_context
+
+    def _resolve_available_skill_names(self, msg: InboundMessage) -> set[str] | None:
+        thread_id = self.store.get_thread_id(msg.channel_name, msg.chat_id, topic_id=msg.topic_id) or ""
+        _, _, run_context = self._resolve_run_params(msg, thread_id)
+        if run_context.get("is_bootstrap"):
+            return {"bootstrap"}
+
+        agent_name = run_context.get("agent_name")
+        if not isinstance(agent_name, str) or not agent_name.strip():
+            return None
+
+        agent_config = load_agent_config(_normalize_custom_agent_name(agent_name))
+        if agent_config and agent_config.skills is not None:
+            return set(agent_config.skills)
+        return None
 
     # -- LangGraph SDK client (lazy) ----------------------------------------
 
@@ -1007,7 +1024,7 @@ class ChannelManager:
                 "/<skill-name> <task> — Activate an enabled skill for one turn\n"
                 "/help — Show this help"
             )
-        elif await asyncio.to_thread(_is_enabled_slash_skill_command, text):
+        elif await asyncio.to_thread(lambda: _is_enabled_slash_skill_command(text, self._resolve_available_skill_names(msg))):
             from dataclasses import replace as _dc_replace
 
             chat_msg = _dc_replace(msg, msg_type=InboundMessageType.CHAT)

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -360,11 +360,14 @@ def _is_enabled_slash_skill_command(text: str) -> bool:
         return False
     try:
         storage = get_or_new_skill_storage()
-        return resolve_slash_skill(
-            text,
-            storage.load_skills(enabled_only=True),
-            container_base_path=storage.get_container_root(),
-        ) is not None
+        return (
+            resolve_slash_skill(
+                text,
+                storage.load_skills(enabled_only=True),
+                container_base_path=storage.get_container_root(),
+            )
+            is not None
+        )
     except Exception:
         logger.exception("[Manager] failed to resolve slash skill command")
         return False

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -23,6 +23,7 @@ from deerflow.config.agents_config import load_agent_config
 from deerflow.runtime.user_context import get_effective_user_id
 from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
+from deerflow.skills.storage.skill_storage import SkillStorage
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,10 @@ register_inbound_file_reader("wechat", _read_wechat_inbound_file)
 
 class InvalidChannelSessionConfigError(ValueError):
     """Raised when IM channel session overrides contain invalid agent config."""
+
+
+class SlashSkillCommandResolutionError(RuntimeError):
+    """Raised when IM slash-skill command resolution cannot complete safely."""
 
 
 def _is_thread_busy_error(exc: BaseException | None) -> bool:
@@ -356,23 +361,27 @@ def _format_artifact_text(artifacts: list[str]) -> str:
 _OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
 
 
-def _is_enabled_slash_skill_command(text: str, available_skills: set[str] | None = None) -> bool:
+def _is_enabled_slash_skill_command(
+    text: str,
+    available_skills: set[str] | None = None,
+    storage: SkillStorage | None = None,
+) -> bool:
     if parse_slash_skill_reference(text) is None:
         return False
     try:
-        storage = get_or_new_skill_storage()
+        resolved_storage = storage or get_or_new_skill_storage()
         return (
             resolve_slash_skill(
                 text,
-                storage.load_skills(enabled_only=True),
+                resolved_storage.load_skills(enabled_only=False),
                 available_skills=available_skills,
-                container_base_path=storage.get_container_root(),
+                container_base_path=resolved_storage.get_container_root(),
             )
             is not None
         )
-    except Exception:
+    except Exception as exc:
         logger.exception("[Manager] failed to resolve slash skill command")
-        return False
+        raise SlashSkillCommandResolutionError("Failed to resolve slash skill command. Please check the skill configuration.") from exc
 
 
 def _resolve_attachments(thread_id: str, artifacts: list[str]) -> list[ResolvedAttachment]:
@@ -589,6 +598,7 @@ class ChannelManager:
         self._default_session = _as_dict(default_session)
         self._channel_sessions = dict(channel_sessions or {})
         self._client = None  # lazy init — langgraph_sdk async client
+        self._skill_storage: SkillStorage | None = None
         self._csrf_token = generate_csrf_token()
         self._semaphore: asyncio.Semaphore | None = None
         self._running = False
@@ -685,6 +695,11 @@ class ChannelManager:
             )
         return self._client
 
+    def _get_skill_storage(self) -> SkillStorage:
+        if self._skill_storage is None:
+            self._skill_storage = get_or_new_skill_storage()
+        return self._skill_storage
+
     # -- lifecycle ---------------------------------------------------------
 
     async def start(self) -> None:
@@ -749,6 +764,14 @@ class ChannelManager:
             except InvalidChannelSessionConfigError as exc:
                 logger.warning(
                     "Invalid channel session config for %s (chat=%s): %s",
+                    msg.channel_name,
+                    msg.chat_id,
+                    exc,
+                )
+                await self._send_error(msg, str(exc))
+            except SlashSkillCommandResolutionError as exc:
+                logger.warning(
+                    "Slash skill command resolution failed for %s (chat=%s): %s",
                     msg.channel_name,
                     msg.chat_id,
                     exc,
@@ -1024,7 +1047,13 @@ class ChannelManager:
                 "/<skill-name> <task> — Activate an enabled skill for one turn\n"
                 "/help — Show this help"
             )
-        elif await asyncio.to_thread(lambda: _is_enabled_slash_skill_command(text, self._resolve_available_skill_names(msg))):
+        elif await asyncio.to_thread(
+            lambda: _is_enabled_slash_skill_command(
+                text,
+                self._resolve_available_skill_names(msg),
+                self._get_skill_storage(),
+            )
+        ):
             from dataclasses import replace as _dc_replace
 
             chat_msg = _dc_replace(msg, msg_type=InboundMessageType.CHAT)

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -364,12 +364,12 @@ _OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
 def _is_enabled_slash_skill_command(
     text: str,
     available_skills: set[str] | None = None,
-    storage: SkillStorage | None = None,
+    storage: SkillStorage | Callable[[], SkillStorage] | None = None,
 ) -> bool:
     if parse_slash_skill_reference(text) is None:
         return False
     try:
-        resolved_storage = storage or get_or_new_skill_storage()
+        resolved_storage = storage() if callable(storage) else storage or get_or_new_skill_storage()
         return (
             resolve_slash_skill(
                 text,
@@ -1051,7 +1051,7 @@ class ChannelManager:
             lambda: _is_enabled_slash_skill_command(
                 text,
                 self._resolve_available_skill_names(msg),
-                self._get_skill_storage(),
+                self._get_skill_storage,
             )
         ):
             from dataclasses import replace as _dc_replace

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -462,7 +462,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
             subagent_enabled=subagent_enabled,
             max_concurrent_subagents=max_concurrent_subagents,
             agent_name=agent_name,
-            available_skills=set(agent_config.skills) if agent_config and agent_config.skills is not None else None,
+            available_skills=available_skills,
             app_config=resolved_app_config,
         ),
         state_schema=ThreadState,

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -25,6 +25,8 @@ from deerflow.skills.types import Skill
 
 logger = logging.getLogger(__name__)
 
+_BOOTSTRAP_SKILL_NAMES = {"bootstrap"}
+
 
 def _get_runtime_config(config: RunnableConfig) -> dict:
     """Merge legacy configurable options with LangGraph runtime context."""
@@ -328,7 +330,7 @@ def _build_middlewares(
 
 def _available_skill_names(agent_config, is_bootstrap: bool) -> set[str] | None:
     if is_bootstrap:
-        return {"bootstrap"}
+        return set(_BOOTSTRAP_SKILL_NAMES)
     if agent_config and agent_config.skills is not None:
         return set(agent_config.skills)
     return None
@@ -420,6 +422,8 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
 
     if is_bootstrap:
         # Special bootstrap agent with minimal prompt for initial custom agent creation flow
+        # Keep the bootstrap skill set intentionally narrow so agent creation
+        # remains deterministic before the custom agent's own config exists.
         tools = get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled, app_config=resolved_app_config) + [setup_agent]
         return create_agent(
             model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, app_config=resolved_app_config),
@@ -427,13 +431,13 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
             middleware=_build_middlewares(
                 config,
                 model_name=model_name,
-                available_skills=set(["bootstrap"]),
+                available_skills=set(_BOOTSTRAP_SKILL_NAMES),
                 app_config=resolved_app_config,
             ),
             system_prompt=apply_prompt_template(
                 subagent_enabled=subagent_enabled,
                 max_concurrent_subagents=max_concurrent_subagents,
-                available_skills=set(["bootstrap"]),
+                available_skills=set(_BOOTSTRAP_SKILL_NAMES),
                 app_config=resolved_app_config,
             ),
             state_schema=ThreadState,

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -243,6 +243,7 @@ def _build_middlewares(
     agent_name: str | None = None,
     custom_middlewares: list[AgentMiddleware] | None = None,
     *,
+    available_skills: set[str] | None = None,
     app_config: AppConfig | None = None,
 ):
     """Build middleware chain based on runtime configuration.
@@ -263,6 +264,13 @@ def _build_middlewares(
     from deerflow.agents.middlewares.dynamic_context_middleware import DynamicContextMiddleware
 
     middlewares.append(DynamicContextMiddleware(agent_name=agent_name, app_config=resolved_app_config))
+
+    # Deterministically load a full SKILL.md when the user starts the turn with
+    # /skill-name. This keeps the base system prompt metadata-only while giving
+    # explicit user activation priority over model-side relevance guessing.
+    from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware
+
+    middlewares.append(SkillActivationMiddleware(available_skills=available_skills, app_config=resolved_app_config))
 
     # Add summarization middleware if enabled
     summarization_middleware = _create_summarization_middleware(app_config=resolved_app_config)
@@ -416,7 +424,12 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
         return create_agent(
             model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, app_config=resolved_app_config),
             tools=filter_tools_by_skill_allowed_tools(tools, skills_for_tool_policy),
-            middleware=_build_middlewares(config, model_name=model_name, app_config=resolved_app_config),
+            middleware=_build_middlewares(
+                config,
+                model_name=model_name,
+                available_skills=set(["bootstrap"]),
+                app_config=resolved_app_config,
+            ),
             system_prompt=apply_prompt_template(
                 subagent_enabled=subagent_enabled,
                 max_concurrent_subagents=max_concurrent_subagents,
@@ -434,7 +447,13 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     return create_agent(
         model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort, app_config=resolved_app_config),
         tools=filter_tools_by_skill_allowed_tools(tools + extra_tools, skills_for_tool_policy),
-        middleware=_build_middlewares(config, model_name=model_name, agent_name=agent_name, app_config=resolved_app_config),
+        middleware=_build_middlewares(
+            config,
+            model_name=model_name,
+            agent_name=agent_name,
+            available_skills=available_skills,
+            app_config=resolved_app_config,
+        ),
         system_prompt=apply_prompt_template(
             subagent_enabled=subagent_enabled,
             max_concurrent_subagents=max_concurrent_subagents,

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -616,6 +616,11 @@ You have access to skills that provide optimized workflows for specific tasks. E
 4. Load referenced resources only when needed during execution
 5. Follow the skill's instructions precisely
 
+**Explicit Slash Skill Activation:**
+- If the user starts a request with `/<skill-name>`, that skill was explicitly requested for the current turn.
+- Follow the activated skill before choosing a general workflow.
+- The system may inject the activated skill content directly; if it does not, load the matching skill file with `read_file` before acting.
+
 **Skills are located at:** {container_base_path}
 {skill_evolution_section}
 {skills_list}

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -619,7 +619,7 @@ You have access to skills that provide optimized workflows for specific tasks. E
 **Explicit Slash Skill Activation:**
 - If the user starts a request with `/<skill-name>`, that skill was explicitly requested for the current turn.
 - Follow the activated skill before choosing a general workflow.
-- The system may inject the activated skill content directly; if it does not, load the matching skill file with `read_file` before acting.
+- The runtime injects the activated skill content for explicit slash activations; do not call `read_file` for that SKILL.md again unless the injected skill references supporting resources you need.
 
 **Skills are located at:** {container_base_path}
 {skill_evolution_section}

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import html
 import logging
 import uuid
 from collections.abc import Awaitable, Callable
@@ -15,9 +16,10 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
 from langchain_core.messages import AIMessage, HumanMessage
 
-from deerflow.skills.slash import get_original_user_content_text, parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
 from deerflow.skills.types import SKILL_MD_FILE
+from deerflow.utils.messages import get_original_user_content_text
 
 if TYPE_CHECKING:
     from deerflow.config.app_config import AppConfig
@@ -97,6 +99,14 @@ class SkillActivationMiddleware(AgentMiddleware):
 
         storage = self._storage()
         skills = storage.load_skills(enabled_only=False)
+        skill = next((candidate for candidate in skills if candidate.name == reference.name), None)
+        if skill is None:
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` is not installed.")
+        if not skill.enabled:
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` is installed but disabled. Enable it before using slash activation.")
+        if self._available_skills is not None and reference.name not in self._available_skills:
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` is not available for this agent.")
+
         resolved = resolve_slash_skill(
             text,
             skills,
@@ -104,7 +114,7 @@ class SkillActivationMiddleware(AgentMiddleware):
             container_base_path=storage.get_container_root(),
         )
         if resolved is None:
-            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` is not enabled or is not available for this agent.")
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` could not be resolved.")
 
         try:
             skill_content = self._read_skill_content(resolved.skill.skill_file, storage.get_skills_root_path())
@@ -127,19 +137,25 @@ class SkillActivationMiddleware(AgentMiddleware):
     @staticmethod
     def _build_activation_reminder(activation: _Activation) -> str:
         user_request = activation.remaining_text or ("No additional task text was provided after the slash skill command. Ask the user what they want to do with this skill if the next step is unclear.")
+        escaped_user_request = html.escape(user_request, quote=False)
+        escaped_skill_content = html.escape(activation.skill_content, quote=False)
+        escaped_skill_name = html.escape(activation.skill_name, quote=True)
+        escaped_category = html.escape(activation.category, quote=True)
+        escaped_path = html.escape(activation.container_file_path, quote=True)
+        escaped_content_hash = html.escape(activation.content_hash, quote=True)
         return f"""<slash_skill_activation>
 The user explicitly activated the `{activation.skill_name}` skill for this turn.
 Treat the task text as:
 <user_request>
-{user_request}
+{escaped_user_request}
 </user_request>
 
 Follow this skill before choosing a general workflow. Load supporting resources from the same skill directory only when needed.
 
-<skill name="{activation.skill_name}" category="{activation.category}" path="{activation.container_file_path}" sha256="{activation.content_hash}">
------ BEGIN SKILL.md -----
-{activation.skill_content}
------ END SKILL.md -----
+<skill name="{escaped_skill_name}" category="{escaped_category}" path="{escaped_path}" sha256="{escaped_content_hash}">
+<skill_content encoding="xml-escaped">
+{escaped_skill_content}
+</skill_content>
 </skill>
 </slash_skill_activation>"""
 

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,7 +13,7 @@ from typing import TYPE_CHECKING, override
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.skills.slash import get_original_user_content_text, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SLASH_SKILL_ACTIVATION_KEY = "slash_skill_activation"
 _SUMMARY_MESSAGE_NAME = "summary"
 
 
@@ -40,6 +42,10 @@ class _Activation:
 class _ActivationResolution:
     activation: _Activation | None = None
     failure_message: str | None = None
+
+
+def is_slash_skill_activation_reminder(message: object) -> bool:
+    return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_SLASH_SKILL_ACTIVATION_KEY))
 
 
 def _is_user_activation_target(message: object) -> bool:
@@ -170,31 +176,31 @@ Follow this skill before choosing a general workflow. Load supporting resources 
             activation.category,
             activation.content_hash[:12],
         )
-        system_message = self._append_activation_to_system_message(
-            request.system_message,
-            self._build_activation_reminder(activation),
-        )
-        return request.override(system_message=system_message)
+        activation_msg = self._make_activation_message(target, self._build_activation_reminder(activation))
+        messages = list(request.messages)
+        target_index = self._find_target_index(messages, target)
+        messages.insert(target_index, activation_msg)
+        return request.override(messages=messages)
 
     @staticmethod
-    def _append_activation_to_system_message(system_message: SystemMessage | None, activation_content: str) -> SystemMessage:
-        if system_message is None:
-            return SystemMessage(content=activation_content)
-
-        if isinstance(system_message.content, str):
-            content = f"{system_message.content}\n\n{activation_content}"
-        elif isinstance(system_message.content, list):
-            content = [*system_message.content, {"type": "text", "text": f"\n\n{activation_content}"}]
-        else:
-            content = f"{system_message.content}\n\n{activation_content}"
-
-        return SystemMessage(
-            content=content,
-            id=system_message.id,
-            name=system_message.name,
-            additional_kwargs=system_message.additional_kwargs,
-            response_metadata=system_message.response_metadata,
+    def _make_activation_message(target: HumanMessage, activation_content: str) -> HumanMessage:
+        stable_id = target.id or str(uuid.uuid4())
+        return HumanMessage(
+            content=activation_content,
+            id=f"{stable_id}__slash_activation",
+            additional_kwargs={
+                "hide_from_ui": True,
+                _SLASH_SKILL_ACTIVATION_KEY: True,
+            },
         )
+
+    @staticmethod
+    def _find_target_index(messages: list, target: HumanMessage) -> int:
+        for idx, message in enumerate(messages):
+            if message is target:
+                return idx
+        logger.warning("SkillActivationMiddleware target message was not found in request messages; appending activation at the end")
+        return len(messages)
 
     @override
     def wrap_model_call(

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -14,7 +14,7 @@ from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
 
-from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.slash import get_original_user_content_text, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
 from deerflow.skills.types import SKILL_MD_FILE
 
@@ -156,7 +156,7 @@ Follow this skill before choosing a general workflow. Load supporting resources 
         if target is None:
             return None
 
-        content = target.content if isinstance(target.content, str) else str(target.content)
+        content = get_original_user_content_text(target.content, target.additional_kwargs)
         activation = self._resolve_activation(content)
         if activation is None:
             return None

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -1,0 +1,182 @@
+"""Middleware for explicit slash skill activation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, override
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
+
+from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.storage import get_or_new_skill_storage
+from deerflow.skills.types import SKILL_MD_FILE
+
+if TYPE_CHECKING:
+    from deerflow.config.app_config import AppConfig
+
+logger = logging.getLogger(__name__)
+
+_SLASH_SKILL_ACTIVATION_KEY = "slash_skill_activation"
+_SLASH_SKILL_PROCESSED_KEY = "slash_skill_activation_processed"
+_SUMMARY_MESSAGE_NAME = "summary"
+
+
+@dataclass(frozen=True, slots=True)
+class _Activation:
+    skill_name: str
+    category: str
+    container_file_path: str
+    skill_content: str
+    content_hash: str
+    remaining_text: str
+
+
+def is_slash_skill_activation_reminder(message: object) -> bool:
+    return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_SLASH_SKILL_ACTIVATION_KEY))
+
+
+def _is_user_activation_target(message: object) -> bool:
+    if not isinstance(message, HumanMessage):
+        return False
+    if message.name == _SUMMARY_MESSAGE_NAME:
+        return False
+    if message.additional_kwargs.get("hide_from_ui"):
+        return False
+    return not bool(message.additional_kwargs.get(_SLASH_SKILL_PROCESSED_KEY))
+
+
+class SkillActivationMiddleware(AgentMiddleware):
+    """Inject full SKILL.md content when the user explicitly types /skill-name."""
+
+    def __init__(
+        self,
+        *,
+        available_skills: set[str] | None = None,
+        app_config: AppConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self._available_skills = set(available_skills) if available_skills is not None else None
+        self._app_config = app_config
+
+    def _storage(self):
+        if self._app_config is not None:
+            return get_or_new_skill_storage(app_config=self._app_config)
+        return get_or_new_skill_storage()
+
+    @staticmethod
+    def _read_skill_content(skill_file: Path) -> str:
+        if skill_file.name != SKILL_MD_FILE:
+            raise ValueError(f"Expected {SKILL_MD_FILE}, got {skill_file.name}")
+        return skill_file.read_text(encoding="utf-8")
+
+    def _resolve_activation(self, text: str) -> _Activation | None:
+        if parse_slash_skill_reference(text) is None:
+            return None
+
+        storage = self._storage()
+        skills = storage.load_skills(enabled_only=True)
+        resolved = resolve_slash_skill(
+            text,
+            skills,
+            available_skills=self._available_skills,
+            container_base_path=storage.get_container_root(),
+        )
+        if resolved is None:
+            return None
+
+        try:
+            skill_content = self._read_skill_content(resolved.skill.skill_file)
+        except OSError:
+            logger.exception("Failed to read slash-activated skill %s", resolved.skill.name)
+            return None
+
+        content_hash = hashlib.sha256(skill_content.encode("utf-8")).hexdigest()
+        return _Activation(
+            skill_name=resolved.skill.name,
+            category=str(resolved.skill.category),
+            container_file_path=resolved.container_file_path,
+            skill_content=skill_content,
+            content_hash=content_hash,
+            remaining_text=resolved.remaining_text,
+        )
+
+    @staticmethod
+    def _build_activation_reminder(activation: _Activation) -> str:
+        user_request = activation.remaining_text or (
+            "No additional task text was provided after the slash skill command. "
+            "Ask the user what they want to do with this skill if the next step is unclear."
+        )
+        return f"""<slash_skill_activation>
+The user explicitly activated the `{activation.skill_name}` skill for this turn.
+Treat the task text as:
+<user_request>
+{user_request}
+</user_request>
+
+Follow this skill before choosing a general workflow. Load supporting resources from the same skill directory only when needed.
+
+<skill name="{activation.skill_name}" category="{activation.category}" path="{activation.container_file_path}" sha256="{activation.content_hash}">
+----- BEGIN SKILL.md -----
+{activation.skill_content}
+----- END SKILL.md -----
+</skill>
+</slash_skill_activation>"""
+
+    @staticmethod
+    def _make_activation_and_user_messages(original: HumanMessage, activation_content: str) -> tuple[HumanMessage, HumanMessage]:
+        stable_id = original.id or str(uuid.uuid4())
+        activation_msg = HumanMessage(
+            content=activation_content,
+            id=stable_id,
+            additional_kwargs={
+                "hide_from_ui": True,
+                _SLASH_SKILL_ACTIVATION_KEY: True,
+            },
+        )
+        user_kwargs = dict(original.additional_kwargs)
+        user_kwargs[_SLASH_SKILL_PROCESSED_KEY] = True
+        user_msg = HumanMessage(
+            content=original.content,
+            id=f"{stable_id}__slash_user",
+            name=original.name,
+            additional_kwargs=user_kwargs,
+        )
+        return activation_msg, user_msg
+
+    def _inject(self, state) -> dict | None:
+        messages = list(state.get("messages", []))
+        if not messages:
+            return None
+
+        target = next((msg for msg in reversed(messages) if _is_user_activation_target(msg)), None)
+        if target is None:
+            return None
+
+        content = target.content if isinstance(target.content, str) else str(target.content)
+        activation = self._resolve_activation(content)
+        if activation is None:
+            return None
+
+        logger.info(
+            "SkillActivationMiddleware: activating slash skill %s category=%s hash=%s",
+            activation.skill_name,
+            activation.category,
+            activation.content_hash[:12],
+        )
+        activation_msg, user_msg = self._make_activation_and_user_messages(target, self._build_activation_reminder(activation))
+        return {"messages": [activation_msg, user_msg]}
+
+    @override
+    def before_agent(self, state, runtime: Runtime) -> dict | None:
+        return self._inject(state)
+
+    @override
+    async def abefore_agent(self, state, runtime: Runtime) -> dict | None:
+        return await asyncio.to_thread(self._inject, state)

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -6,13 +6,14 @@ import asyncio
 import hashlib
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import HumanMessage
-from langgraph.runtime import Runtime
+from langchain.agents.middleware.types import ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.skills.slash import get_original_user_content_text, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
@@ -24,7 +25,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SLASH_SKILL_ACTIVATION_KEY = "slash_skill_activation"
-_SLASH_SKILL_PROCESSED_KEY = "slash_skill_activation_processed"
 _SUMMARY_MESSAGE_NAME = "summary"
 
 
@@ -38,6 +38,12 @@ class _Activation:
     remaining_text: str
 
 
+@dataclass(frozen=True, slots=True)
+class _ActivationResolution:
+    activation: _Activation | None = None
+    failure_message: str | None = None
+
+
 def is_slash_skill_activation_reminder(message: object) -> bool:
     return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_SLASH_SKILL_ACTIVATION_KEY))
 
@@ -49,7 +55,7 @@ def _is_user_activation_target(message: object) -> bool:
         return False
     if message.additional_kwargs.get("hide_from_ui"):
         return False
-    return not bool(message.additional_kwargs.get(_SLASH_SKILL_PROCESSED_KEY))
+    return True
 
 
 class SkillActivationMiddleware(AgentMiddleware):
@@ -71,13 +77,22 @@ class SkillActivationMiddleware(AgentMiddleware):
         return get_or_new_skill_storage()
 
     @staticmethod
-    def _read_skill_content(skill_file: Path) -> str:
+    def _read_skill_content(skill_file: Path, skills_root: Path) -> str:
         if skill_file.name != SKILL_MD_FILE:
             raise ValueError(f"Expected {SKILL_MD_FILE}, got {skill_file.name}")
-        return skill_file.read_text(encoding="utf-8")
+        resolved_root = skills_root.resolve()
+        resolved_file = skill_file.resolve()
+        try:
+            resolved_file.relative_to(resolved_root)
+        except ValueError as exc:
+            raise ValueError("Resolved skill file must stay within the configured skills root.") from exc
+        if not resolved_file.is_file():
+            raise FileNotFoundError(resolved_file)
+        return resolved_file.read_text(encoding="utf-8")
 
-    def _resolve_activation(self, text: str) -> _Activation | None:
-        if parse_slash_skill_reference(text) is None:
+    def _resolve_activation(self, text: str) -> _ActivationResolution | None:
+        reference = parse_slash_skill_reference(text)
+        if reference is None:
             return None
 
         storage = self._storage()
@@ -89,22 +104,24 @@ class SkillActivationMiddleware(AgentMiddleware):
             container_base_path=storage.get_container_root(),
         )
         if resolved is None:
-            return None
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` is not enabled or is not available for this agent.")
 
         try:
-            skill_content = self._read_skill_content(resolved.skill.skill_file)
-        except OSError:
+            skill_content = self._read_skill_content(resolved.skill.skill_file, storage.get_skills_root_path())
+        except (OSError, ValueError):
             logger.exception("Failed to read slash-activated skill %s", resolved.skill.name)
-            return None
+            return _ActivationResolution(failure_message=f"Skill `/{reference.name}` could not be loaded safely. Please check the skill installation.")
 
         content_hash = hashlib.sha256(skill_content.encode("utf-8")).hexdigest()
-        return _Activation(
-            skill_name=resolved.skill.name,
-            category=str(resolved.skill.category),
-            container_file_path=resolved.container_file_path,
-            skill_content=skill_content,
-            content_hash=content_hash,
-            remaining_text=resolved.remaining_text,
+        return _ActivationResolution(
+            activation=_Activation(
+                skill_name=resolved.skill.name,
+                category=str(resolved.skill.category),
+                container_file_path=resolved.container_file_path,
+                skill_content=skill_content,
+                content_hash=content_hash,
+                remaining_text=resolved.remaining_text,
+            )
         )
 
     @staticmethod
@@ -127,28 +144,18 @@ Follow this skill before choosing a general workflow. Load supporting resources 
 </slash_skill_activation>"""
 
     @staticmethod
-    def _make_activation_and_user_messages(original: HumanMessage, activation_content: str) -> tuple[HumanMessage, HumanMessage]:
-        stable_id = original.id or str(uuid.uuid4())
-        activation_msg = HumanMessage(
+    def _make_activation_message(target: HumanMessage, activation_content: str) -> HumanMessage:
+        stable_id = target.id or str(uuid.uuid4())
+        return HumanMessage(
             content=activation_content,
-            id=stable_id,
+            id=f"{stable_id}__slash_activation",
             additional_kwargs={
                 "hide_from_ui": True,
                 _SLASH_SKILL_ACTIVATION_KEY: True,
             },
         )
-        user_kwargs = dict(original.additional_kwargs)
-        user_kwargs[_SLASH_SKILL_PROCESSED_KEY] = True
-        user_msg = HumanMessage(
-            content=original.content,
-            id=f"{stable_id}__slash_user",
-            name=original.name,
-            additional_kwargs=user_kwargs,
-        )
-        return activation_msg, user_msg
 
-    def _inject(self, state) -> dict | None:
-        messages = list(state.get("messages", []))
+    def _find_activation_target(self, messages: list) -> tuple[HumanMessage, _ActivationResolution] | None:
         if not messages:
             return None
 
@@ -157,7 +164,21 @@ Follow this skill before choosing a general workflow. Load supporting resources 
             return None
 
         content = get_original_user_content_text(target.content, target.additional_kwargs)
-        activation = self._resolve_activation(content)
+        resolution = self._resolve_activation(content)
+        if resolution is None:
+            return None
+        return target, resolution
+
+    def _prepare_model_request(self, request: ModelRequest) -> ModelRequest | AIMessage | None:
+        target_and_resolution = self._find_activation_target(list(request.messages))
+        if target_and_resolution is None:
+            return None
+
+        target, resolution = target_and_resolution
+        if resolution.failure_message:
+            return AIMessage(content=resolution.failure_message)
+
+        activation = resolution.activation
         if activation is None:
             return None
 
@@ -167,13 +188,34 @@ Follow this skill before choosing a general workflow. Load supporting resources 
             activation.category,
             activation.content_hash[:12],
         )
-        activation_msg, user_msg = self._make_activation_and_user_messages(target, self._build_activation_reminder(activation))
-        return {"messages": [activation_msg, user_msg]}
+        activation_msg = self._make_activation_message(target, self._build_activation_reminder(activation))
+        messages = list(request.messages)
+        target_index = next((idx for idx, msg in enumerate(messages) if msg is target), len(messages))
+        messages.insert(target_index, activation_msg)
+        return request.override(messages=messages)
 
     @override
-    def before_agent(self, state, runtime: Runtime) -> dict | None:
-        return self._inject(state)
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse | AIMessage:
+        prepared = self._prepare_model_request(request)
+        if prepared is None:
+            return handler(request)
+        if isinstance(prepared, AIMessage):
+            return prepared
+        return handler(prepared)
 
     @override
-    async def abefore_agent(self, state, runtime: Runtime) -> dict | None:
-        return await asyncio.to_thread(self._inject, state)
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse | AIMessage:
+        prepared = await asyncio.to_thread(self._prepare_model_request, request)
+        if prepared is None:
+            return await handler(request)
+        if isinstance(prepared, AIMessage):
+            return prepared
+        return await handler(prepared)

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
-import uuid
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,7 +12,7 @@ from typing import TYPE_CHECKING, override
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from deerflow.skills.slash import get_original_user_content_text, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.storage import get_or_new_skill_storage
@@ -24,7 +23,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_SLASH_SKILL_ACTIVATION_KEY = "slash_skill_activation"
 _SUMMARY_MESSAGE_NAME = "summary"
 
 
@@ -42,10 +40,6 @@ class _Activation:
 class _ActivationResolution:
     activation: _Activation | None = None
     failure_message: str | None = None
-
-
-def is_slash_skill_activation_reminder(message: object) -> bool:
-    return isinstance(message, HumanMessage) and bool(message.additional_kwargs.get(_SLASH_SKILL_ACTIVATION_KEY))
 
 
 def _is_user_activation_target(message: object) -> bool:
@@ -96,7 +90,7 @@ class SkillActivationMiddleware(AgentMiddleware):
             return None
 
         storage = self._storage()
-        skills = storage.load_skills(enabled_only=True)
+        skills = storage.load_skills(enabled_only=False)
         resolved = resolve_slash_skill(
             text,
             skills,
@@ -143,18 +137,6 @@ Follow this skill before choosing a general workflow. Load supporting resources 
 </skill>
 </slash_skill_activation>"""
 
-    @staticmethod
-    def _make_activation_message(target: HumanMessage, activation_content: str) -> HumanMessage:
-        stable_id = target.id or str(uuid.uuid4())
-        return HumanMessage(
-            content=activation_content,
-            id=f"{stable_id}__slash_activation",
-            additional_kwargs={
-                "hide_from_ui": True,
-                _SLASH_SKILL_ACTIVATION_KEY: True,
-            },
-        )
-
     def _find_activation_target(self, messages: list) -> tuple[HumanMessage, _ActivationResolution] | None:
         if not messages:
             return None
@@ -188,11 +170,31 @@ Follow this skill before choosing a general workflow. Load supporting resources 
             activation.category,
             activation.content_hash[:12],
         )
-        activation_msg = self._make_activation_message(target, self._build_activation_reminder(activation))
-        messages = list(request.messages)
-        target_index = next((idx for idx, msg in enumerate(messages) if msg is target), len(messages))
-        messages.insert(target_index, activation_msg)
-        return request.override(messages=messages)
+        system_message = self._append_activation_to_system_message(
+            request.system_message,
+            self._build_activation_reminder(activation),
+        )
+        return request.override(system_message=system_message)
+
+    @staticmethod
+    def _append_activation_to_system_message(system_message: SystemMessage | None, activation_content: str) -> SystemMessage:
+        if system_message is None:
+            return SystemMessage(content=activation_content)
+
+        if isinstance(system_message.content, str):
+            content = f"{system_message.content}\n\n{activation_content}"
+        elif isinstance(system_message.content, list):
+            content = [*system_message.content, {"type": "text", "text": f"\n\n{activation_content}"}]
+        else:
+            content = f"{system_message.content}\n\n{activation_content}"
+
+        return SystemMessage(
+            content=content,
+            id=system_message.id,
+            name=system_message.name,
+            additional_kwargs=system_message.additional_kwargs,
+            response_metadata=system_message.response_metadata,
+        )
 
     @override
     def wrap_model_call(

--- a/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py
@@ -109,10 +109,7 @@ class SkillActivationMiddleware(AgentMiddleware):
 
     @staticmethod
     def _build_activation_reminder(activation: _Activation) -> str:
-        user_request = activation.remaining_text or (
-            "No additional task text was provided after the slash skill command. "
-            "Ask the user what they want to do with this skill if the next step is unclear."
-        )
+        user_request = activation.remaining_text or ("No additional task text was provided after the slash skill command. Ask the user what they want to do with this skill if the next step is unclear.")
         return f"""<slash_skill_activation>
 The user explicitly activated the `{activation.skill_name}` skill for this turn.
 Treat the task text as:

--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -11,6 +11,7 @@ from langgraph.runtime import Runtime
 
 from deerflow.config.paths import Paths, get_paths
 from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, message_content_to_text
 from deerflow.utils.file_conversion import extract_outline
 
 logger = logging.getLogger(__name__)
@@ -264,6 +265,8 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
 
         # Extract original content - handle both string and list formats
         original_content = last_message.content
+        additional_kwargs = dict(last_message.additional_kwargs or {})
+        additional_kwargs.setdefault(ORIGINAL_USER_CONTENT_KEY, message_content_to_text(original_content))
         if isinstance(original_content, str):
             # Simple case: string content, just prepend files message
             updated_content = f"{files_message}\n\n{original_content}"
@@ -284,7 +287,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
             content=updated_content,
             id=last_message.id,
             name=last_message.name,
-            additional_kwargs=last_message.additional_kwargs,
+            additional_kwargs=additional_kwargs,
         )
 
         messages[last_message_index] = updated_message

--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -11,8 +11,8 @@ from langgraph.runtime import Runtime
 
 from deerflow.config.paths import Paths, get_paths
 from deerflow.runtime.user_context import get_effective_user_id
-from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, message_content_to_text
 from deerflow.utils.file_conversion import extract_outline
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY, message_content_to_text
 
 logger = logging.getLogger(__name__)
 

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -230,7 +230,13 @@ class DeerFlowClient:
         kwargs: dict[str, Any] = {
             "model": create_chat_model(name=model_name, thinking_enabled=thinking_enabled),
             "tools": self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled),
-            "middleware": _build_middlewares(config, model_name=model_name, agent_name=self._agent_name, custom_middlewares=self._middlewares),
+            "middleware": _build_middlewares(
+                config,
+                model_name=model_name,
+                agent_name=self._agent_name,
+                available_skills=self._available_skills,
+                custom_middlewares=self._middlewares,
+            ),
             "system_prompt": apply_prompt_template(
                 subagent_enabled=subagent_enabled,
                 max_concurrent_subagents=max_concurrent_subagents,

--- a/backend/packages/harness/deerflow/skills/slash.py
+++ b/backend/packages/harness/deerflow/skills/slash.py
@@ -1,13 +1,9 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
 
 from deerflow.skills.types import Skill
-
-ORIGINAL_USER_CONTENT_KEY = "original_user_content"
 
 _SLASH_SKILL_RE = re.compile(r"^\s*/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$|[^\x00-\x7F])")
 
@@ -33,29 +29,6 @@ def parse_slash_skill_reference(text: str) -> SlashSkillReference | None:
         name=match.group(1),
         remaining_text=text[match.end() :].lstrip(),
     )
-
-
-def message_content_to_text(content: Any) -> str:
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, str):
-                parts.append(item)
-            elif isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "\n".join(part for part in parts if part)
-    return str(content)
-
-
-def get_original_user_content_text(content: Any, additional_kwargs: Mapping[str, Any] | None) -> str:
-    original_content = (additional_kwargs or {}).get(ORIGINAL_USER_CONTENT_KEY)
-    if isinstance(original_content, str):
-        return original_content
-    return message_content_to_text(content)
 
 
 def resolve_slash_skill(

--- a/backend/packages/harness/deerflow/skills/slash.py
+++ b/backend/packages/harness/deerflow/skills/slash.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from deerflow.skills.types import Skill
+
+_SLASH_SKILL_RE = re.compile(r"^\s*/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+|$)")
+
+
+@dataclass(frozen=True, slots=True)
+class SlashSkillReference:
+    name: str
+    remaining_text: str
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedSlashSkill:
+    skill: Skill
+    remaining_text: str
+    container_file_path: str
+
+
+def parse_slash_skill_reference(text: str) -> SlashSkillReference | None:
+    match = _SLASH_SKILL_RE.match(text)
+    if not match:
+        return None
+    return SlashSkillReference(
+        name=match.group(1),
+        remaining_text=text[match.end() :].lstrip(),
+    )
+
+
+def resolve_slash_skill(
+    text: str,
+    skills: list[Skill],
+    *,
+    available_skills: set[str] | None = None,
+    container_base_path: str = "/mnt/skills",
+) -> ResolvedSlashSkill | None:
+    reference = parse_slash_skill_reference(text)
+    if reference is None:
+        return None
+    if available_skills is not None and reference.name not in available_skills:
+        return None
+
+    skill = next((candidate for candidate in skills if candidate.name == reference.name), None)
+    if skill is None:
+        return None
+
+    return ResolvedSlashSkill(
+        skill=skill,
+        remaining_text=reference.remaining_text,
+        container_file_path=skill.get_container_file_path(container_base_path),
+    )

--- a/backend/packages/harness/deerflow/skills/slash.py
+++ b/backend/packages/harness/deerflow/skills/slash.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
+from typing import Any
 
 from deerflow.skills.types import Skill
 
-_SLASH_SKILL_RE = re.compile(r"^\s*/([a-z0-9]+(?:-[a-z0-9]+)*)(?:\s+|$)")
+ORIGINAL_USER_CONTENT_KEY = "original_user_content"
+
+_SLASH_SKILL_RE = re.compile(r"^\s*/([a-z0-9]+(?:-[a-z0-9]+)*)(?=\s|$|[^\x00-\x7F])")
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,6 +33,29 @@ def parse_slash_skill_reference(text: str) -> SlashSkillReference | None:
         name=match.group(1),
         remaining_text=text[match.end() :].lstrip(),
     )
+
+
+def message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)
+
+
+def get_original_user_content_text(content: Any, additional_kwargs: Mapping[str, Any] | None) -> str:
+    original_content = (additional_kwargs or {}).get(ORIGINAL_USER_CONTENT_KEY)
+    if isinstance(original_content, str):
+        return original_content
+    return message_content_to_text(content)
 
 
 def resolve_slash_skill(

--- a/backend/packages/harness/deerflow/skills/slash.py
+++ b/backend/packages/harness/deerflow/skills/slash.py
@@ -71,7 +71,7 @@ def resolve_slash_skill(
     if available_skills is not None and reference.name not in available_skills:
         return None
 
-    skill = next((candidate for candidate in skills if candidate.name == reference.name), None)
+    skill = next((candidate for candidate in skills if candidate.name == reference.name and candidate.enabled), None)
     if skill is None:
         return None
 

--- a/backend/packages/harness/deerflow/utils/messages.py
+++ b/backend/packages/harness/deerflow/utils/messages.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+ORIGINAL_USER_CONTENT_KEY = "original_user_content"
+
+
+def message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(part for part in parts if part)
+    return str(content)
+
+
+def get_original_user_content_text(content: Any, additional_kwargs: Mapping[str, Any] | None) -> str:
+    original_content = (additional_kwargs or {}).get(ORIGINAL_USER_CONTENT_KEY)
+    if isinstance(original_content, str):
+        return original_content
+    return message_content_to_text(content)

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1169,6 +1169,45 @@ class TestChannelManager:
 
         _run(go())
 
+    def test_handle_command_slash_skill_routes_to_chat(self, monkeypatch):
+        from app.channels.manager import ChannelManager
+
+        monkeypatch.setattr("app.channels.manager._is_enabled_slash_skill_command", lambda text: text.startswith("/data-analysis"))
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+
+            mock_client = _make_mock_langgraph_client()
+            manager._client = mock_client
+
+            outbound_received = []
+
+            async def capture_outbound(msg):
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="test",
+                chat_id="chat1",
+                user_id="user1",
+                text="/data-analysis analyze uploads/foo.csv",
+                msg_type=InboundMessageType.COMMAND,
+            )
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: len(outbound_received) >= 1)
+            await manager.stop()
+
+            mock_client.runs.wait.assert_called_once()
+            call_args = mock_client.runs.wait.call_args
+            assert call_args[1]["input"]["messages"][0]["content"] == "/data-analysis analyze uploads/foo.csv"
+            assert outbound_received[0].text == "Hello from agent!"
+
+        _run(go())
+
     def test_handle_command_new(self):
         from app.channels.manager import ChannelManager
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1172,7 +1172,10 @@ class TestChannelManager:
     def test_handle_command_slash_skill_routes_to_chat(self, monkeypatch):
         from app.channels.manager import ChannelManager
 
-        monkeypatch.setattr("app.channels.manager._is_enabled_slash_skill_command", lambda text: text.startswith("/data-analysis"))
+        monkeypatch.setattr(
+            "app.channels.manager._is_enabled_slash_skill_command",
+            lambda text, available_skills=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
+        )
 
         async def go():
             bus = MessageBus()
@@ -1205,6 +1208,51 @@ class TestChannelManager:
             call_args = mock_client.runs.wait.call_args
             assert call_args[1]["input"]["messages"][0]["content"] == "/data-analysis analyze uploads/foo.csv"
             assert outbound_received[0].text == "Hello from agent!"
+
+        _run(go())
+
+    def test_handle_command_slash_skill_respects_custom_agent_skill_whitelist(self, monkeypatch):
+        from app.channels.manager import ChannelManager
+
+        monkeypatch.setattr(
+            "app.channels.manager._is_enabled_slash_skill_command",
+            lambda text, available_skills=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
+        )
+        monkeypatch.setattr("app.channels.manager.load_agent_config", lambda name: SimpleNamespace(skills=["frontend-design"]))
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(
+                bus=bus,
+                store=store,
+                default_session={"assistant_id": "analyst-agent"},
+            )
+
+            mock_client = _make_mock_langgraph_client()
+            manager._client = mock_client
+
+            outbound_received = []
+
+            async def capture_outbound(msg):
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="test",
+                chat_id="chat1",
+                user_id="user1",
+                text="/data-analysis analyze uploads/foo.csv",
+                msg_type=InboundMessageType.COMMAND,
+            )
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: len(outbound_received) >= 1)
+            await manager.stop()
+
+            mock_client.runs.wait.assert_not_called()
+            assert outbound_received[0].text.startswith("Unknown command: /data-analysis.")
 
         _run(go())
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1174,7 +1174,7 @@ class TestChannelManager:
 
         monkeypatch.setattr(
             "app.channels.manager._is_enabled_slash_skill_command",
-            lambda text, available_skills=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
+            lambda text, available_skills=None, storage=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
         )
 
         async def go():
@@ -1216,7 +1216,7 @@ class TestChannelManager:
 
         monkeypatch.setattr(
             "app.channels.manager._is_enabled_slash_skill_command",
-            lambda text, available_skills=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
+            lambda text, available_skills=None, storage=None: text.startswith("/data-analysis") and (available_skills is None or "data-analysis" in available_skills),
         )
         monkeypatch.setattr("app.channels.manager.load_agent_config", lambda name: SimpleNamespace(skills=["frontend-design"]))
 
@@ -1253,6 +1253,46 @@ class TestChannelManager:
 
             mock_client.runs.wait.assert_not_called()
             assert outbound_received[0].text.startswith("Unknown command: /data-analysis.")
+
+        _run(go())
+
+    def test_handle_command_slash_skill_resolution_error_is_reported(self, monkeypatch):
+        from app.channels.manager import ChannelManager, SlashSkillCommandResolutionError
+
+        def fail_resolution(text, available_skills=None, storage=None):
+            raise SlashSkillCommandResolutionError("Failed to resolve slash skill command. Please check the skill configuration.")
+
+        monkeypatch.setattr("app.channels.manager._is_enabled_slash_skill_command", fail_resolution)
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+
+            mock_client = _make_mock_langgraph_client()
+            manager._client = mock_client
+
+            outbound_received = []
+
+            async def capture_outbound(msg):
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="test",
+                chat_id="chat1",
+                user_id="user1",
+                text="/data-analysis analyze uploads/foo.csv",
+                msg_type=InboundMessageType.COMMAND,
+            )
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: len(outbound_received) >= 1)
+            await manager.stop()
+
+            mock_client.runs.wait.assert_not_called()
+            assert outbound_received[0].text == "Failed to resolve slash skill command. Please check the skill configuration."
 
         _run(go())
 

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -6,8 +7,9 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
 from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware, is_slash_skill_activation_reminder
-from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.types import Skill, SkillCategory
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
 
 
 def _make_skill(tmp_path: Path, name: str, content: str = "skill body") -> Skill:
@@ -111,6 +113,32 @@ def test_skill_activation_middleware_injects_hidden_human_context_for_model_call
     assert request.state["messages"] == [original]
 
 
+def test_skill_activation_middleware_async_injects_hidden_human_context_for_model_call(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(content="/data-analysis analyze uploads/foo.csv", id="msg-1")
+    request = _make_model_request([original])
+    captured = {}
+
+    async def handler(model_request: ModelRequest):
+        captured["messages"] = model_request.messages
+        return AIMessage(content="ok")
+
+    result = asyncio.run(middleware.awrap_model_call(request, handler))
+
+    assert isinstance(result, AIMessage)
+    assert result.content == "ok"
+    activation_msg, user_msg = captured["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert activation_msg.additional_kwargs["hide_from_ui"] is True
+    assert "Use pandas." in activation_msg.content
+    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
+    assert user_msg.content == original.content
+    assert request.state["messages"] == [original]
+
+
 def test_skill_activation_middleware_uses_original_user_content_when_uploads_are_injected(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
     monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
@@ -152,7 +180,65 @@ def test_skill_activation_middleware_returns_clear_error_for_disallowed_skill(mo
     result = middleware.wrap_model_call(_make_model_request([original]), handler)
 
     assert isinstance(result, AIMessage)
-    assert "not enabled or is not available" in result.content
+    assert "not available for this agent" in result.content
+
+
+def test_skill_activation_middleware_returns_clear_error_for_missing_skill(monkeypatch, tmp_path):
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, []))
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(content="/data-analysis run")
+
+    def handler(model_request: ModelRequest):
+        raise AssertionError("handler should not be called for missing slash skills")
+
+    result = middleware.wrap_model_call(_make_model_request([original]), handler)
+
+    assert isinstance(result, AIMessage)
+    assert "not installed" in result.content
+
+
+def test_skill_activation_middleware_returns_clear_error_for_disabled_skill(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis")
+    skill.enabled = False
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(content="/data-analysis run")
+
+    def handler(model_request: ModelRequest):
+        raise AssertionError("handler should not be called for disabled slash skills")
+
+    result = middleware.wrap_model_call(_make_model_request([original]), handler)
+
+    assert isinstance(result, AIMessage)
+    assert "installed but disabled" in result.content
+
+
+def test_skill_activation_middleware_escapes_activation_content(monkeypatch, tmp_path):
+    skill = _make_skill(
+        tmp_path,
+        "data-analysis",
+        content="# Data Analysis\nUse <xml> & avoid </skill> collisions.\n----- END SKILL.md -----",
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(content="/data-analysis analyze </user_request>")
+    captured = {}
+
+    def handler(model_request: ModelRequest):
+        captured["messages"] = model_request.messages
+        return AIMessage(content="ok")
+
+    result = middleware.wrap_model_call(_make_model_request([original]), handler)
+
+    assert isinstance(result, AIMessage)
+    activation_msg = captured["messages"][0]
+    assert '<skill_content encoding="xml-escaped">' in activation_msg.content
+    assert "analyze &lt;/user_request&gt;" in activation_msg.content
+    assert "Use &lt;xml&gt; &amp; avoid &lt;/skill&gt; collisions." in activation_msg.content
+    assert "----- BEGIN SKILL.md -----" not in activation_msg.content
 
 
 def test_skill_activation_middleware_rejects_skill_file_outside_skills_root(monkeypatch, tmp_path):

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from langchain_core.messages import HumanMessage
+
+from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
+from deerflow.agents.middlewares.skill_activation_middleware import (
+    _SLASH_SKILL_PROCESSED_KEY,
+    SkillActivationMiddleware,
+    is_slash_skill_activation_reminder,
+)
+from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.types import Skill, SkillCategory
+
+
+def _make_skill(tmp_path: Path, name: str, content: str = "skill body") -> Skill:
+    skill_dir = tmp_path / name
+    skill_dir.mkdir()
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text(content, encoding="utf-8")
+    return Skill(
+        name=name,
+        description=f"Description for {name}",
+        license="MIT",
+        skill_dir=skill_dir,
+        skill_file=skill_file,
+        relative_path=Path(name),
+        category=SkillCategory.CUSTOM,
+        enabled=True,
+    )
+
+
+def test_parse_slash_skill_reference_extracts_name_and_remaining_text():
+    parsed = parse_slash_skill_reference("  /data-analysis analyze uploads/foo.csv")
+
+    assert parsed is not None
+    assert parsed.name == "data-analysis"
+    assert parsed.remaining_text == "analyze uploads/foo.csv"
+
+
+def test_parse_slash_skill_reference_rejects_invalid_names():
+    assert parse_slash_skill_reference("/DataAnalysis run") is None
+    assert parse_slash_skill_reference("/data_analysis run") is None
+    assert parse_slash_skill_reference("please use /data-analysis") is None
+
+
+def test_resolve_slash_skill_respects_available_skill_whitelist(tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis")
+
+    assert resolve_slash_skill("/data-analysis run", [skill], available_skills=set()) is None
+
+    resolved = resolve_slash_skill("/data-analysis run", [skill], available_skills={"data-analysis"})
+    assert resolved is not None
+    assert resolved.skill.name == "data-analysis"
+    assert resolved.remaining_text == "run"
+    assert resolved.container_file_path == "/mnt/skills/custom/data-analysis/SKILL.md"
+
+
+def test_skill_activation_middleware_injects_hidden_skill_context(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
+    storage = SimpleNamespace(
+        load_skills=lambda *, enabled_only: [skill],
+        get_container_root=lambda: "/mnt/skills",
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(content="/data-analysis analyze uploads/foo.csv", id="msg-1")
+
+    update = middleware.before_agent({"messages": [original]}, runtime=None)
+
+    assert update is not None
+    activation_msg, user_msg = update["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert activation_msg.additional_kwargs["hide_from_ui"] is True
+    assert "Use pandas." in activation_msg.content
+    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
+    assert user_msg.content == original.content
+    assert user_msg.additional_kwargs[_SLASH_SKILL_PROCESSED_KEY] is True
+
+
+def test_skill_activation_middleware_skips_already_processed_user_message(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis")
+    storage = SimpleNamespace(
+        load_skills=lambda *, enabled_only: [skill],
+        get_container_root=lambda: "/mnt/skills",
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+
+    middleware = SkillActivationMiddleware()
+    processed = HumanMessage(
+        content="/data-analysis run",
+        id="msg-1__slash_user",
+        additional_kwargs={_SLASH_SKILL_PROCESSED_KEY: True},
+    )
+
+    assert middleware.before_agent({"messages": [processed]}, runtime=None) is None
+
+
+def test_skill_activation_middleware_respects_agent_skill_whitelist(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis")
+    storage = SimpleNamespace(
+        load_skills=lambda *, enabled_only: [skill],
+        get_container_root=lambda: "/mnt/skills",
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+
+    middleware = SkillActivationMiddleware(available_skills={"frontend-design"})
+
+    assert middleware.before_agent({"messages": [HumanMessage(content="/data-analysis run")]}, runtime=None) is None

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -2,13 +2,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from langchain.agents.middleware.types import ModelRequest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 
 from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
-from deerflow.agents.middlewares.skill_activation_middleware import (
-    SkillActivationMiddleware,
-    is_slash_skill_activation_reminder,
-)
+from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware
 from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.types import Skill, SkillCategory
 
@@ -38,10 +35,11 @@ def _make_storage(tmp_path: Path, skills: list[Skill]):
     )
 
 
-def _make_model_request(messages: list[HumanMessage]) -> ModelRequest:
+def _make_model_request(messages: list[HumanMessage], system_message: SystemMessage | None = None) -> ModelRequest:
     return ModelRequest(
         model=object(),
         messages=messages,
+        system_message=system_message,
         state={"messages": list(messages)},
         runtime=None,
     )
@@ -88,29 +86,30 @@ def test_resolve_slash_skill_rejects_disabled_skills(tmp_path):
     assert resolve_slash_skill("/data-analysis run", [skill]) is None
 
 
-def test_skill_activation_middleware_injects_hidden_skill_context_for_model_call(monkeypatch, tmp_path):
+def test_skill_activation_middleware_injects_skill_context_into_system_message(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
     monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
 
     middleware = SkillActivationMiddleware()
     original = HumanMessage(content="/data-analysis analyze uploads/foo.csv", id="msg-1")
-    request = _make_model_request([original])
+    request = _make_model_request([original], system_message=SystemMessage(content="Base system prompt."))
     captured = {}
 
     def handler(model_request: ModelRequest):
         captured["messages"] = model_request.messages
+        captured["system_message"] = model_request.system_message
         return AIMessage(content="ok")
 
     result = middleware.wrap_model_call(request, handler)
 
     assert isinstance(result, AIMessage)
     assert result.content == "ok"
-    activation_msg, user_msg = captured["messages"]
-    assert is_slash_skill_activation_reminder(activation_msg)
-    assert activation_msg.additional_kwargs["hide_from_ui"] is True
-    assert "Use pandas." in activation_msg.content
-    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
-    assert user_msg.content == original.content
+    assert captured["messages"] == [original]
+    system_message = captured["system_message"]
+    assert isinstance(system_message, SystemMessage)
+    assert system_message.content.startswith("Base system prompt.")
+    assert "Use pandas." in system_message.content
+    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in system_message.content
     assert request.state["messages"] == [original]
 
 
@@ -128,18 +127,19 @@ def test_skill_activation_middleware_uses_original_user_content_when_uploads_are
 
     def handler(model_request: ModelRequest):
         captured["messages"] = model_request.messages
+        captured["system_message"] = model_request.system_message
         return AIMessage(content="ok")
 
     result = middleware.wrap_model_call(_make_model_request([original]), handler)
 
     assert isinstance(result, AIMessage)
     assert result.content == "ok"
-    activation_msg, user_msg = captured["messages"]
-    assert is_slash_skill_activation_reminder(activation_msg)
-    assert "Use pandas." in activation_msg.content
-    assert "<user_request>\n分析这个文档\n</user_request>" in activation_msg.content
-    assert user_msg.content == original.content
-    assert user_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
+    assert captured["messages"] == [original]
+    system_message = captured["system_message"]
+    assert isinstance(system_message, SystemMessage)
+    assert "Use pandas." in system_message.content
+    assert "<user_request>\n分析这个文档\n</user_request>" in system_message.content
+    assert original.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
 
 
 def test_skill_activation_middleware_returns_clear_error_for_disallowed_skill(monkeypatch, tmp_path):

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -9,7 +9,7 @@ from deerflow.agents.middlewares.skill_activation_middleware import (
     SkillActivationMiddleware,
     is_slash_skill_activation_reminder,
 )
-from deerflow.skills.slash import parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.types import Skill, SkillCategory
 
 
@@ -36,6 +36,14 @@ def test_parse_slash_skill_reference_extracts_name_and_remaining_text():
     assert parsed is not None
     assert parsed.name == "data-analysis"
     assert parsed.remaining_text == "analyze uploads/foo.csv"
+
+
+def test_parse_slash_skill_reference_accepts_cjk_text_without_space():
+    parsed = parse_slash_skill_reference("/data-analysis分析这个文档")
+
+    assert parsed is not None
+    assert parsed.name == "data-analysis"
+    assert parsed.remaining_text == "分析这个文档"
 
 
 def test_parse_slash_skill_reference_rejects_invalid_names():
@@ -76,6 +84,33 @@ def test_skill_activation_middleware_injects_hidden_skill_context(monkeypatch, t
     assert "Use pandas." in activation_msg.content
     assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
     assert user_msg.content == original.content
+    assert user_msg.additional_kwargs[_SLASH_SKILL_PROCESSED_KEY] is True
+
+
+def test_skill_activation_middleware_uses_original_user_content_when_uploads_are_injected(monkeypatch, tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
+    storage = SimpleNamespace(
+        load_skills=lambda *, enabled_only: [skill],
+        get_container_root=lambda: "/mnt/skills",
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+
+    middleware = SkillActivationMiddleware()
+    original = HumanMessage(
+        content="<uploaded_files>\n- report.pdf\n</uploaded_files>\n\n/data-analysis分析这个文档",
+        id="msg-1",
+        additional_kwargs={ORIGINAL_USER_CONTENT_KEY: "/data-analysis分析这个文档"},
+    )
+
+    update = middleware.before_agent({"messages": [original]}, runtime=None)
+
+    assert update is not None
+    activation_msg, user_msg = update["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert "Use pandas." in activation_msg.content
+    assert "<user_request>\n分析这个文档\n</user_request>" in activation_msg.content
+    assert user_msg.content == original.content
+    assert user_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
     assert user_msg.additional_kwargs[_SLASH_SKILL_PROCESSED_KEY] is True
 
 

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -2,10 +2,10 @@ from pathlib import Path
 from types import SimpleNamespace
 
 from langchain.agents.middleware.types import ModelRequest
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
-from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware
+from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware, is_slash_skill_activation_reminder
 from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY, parse_slash_skill_reference, resolve_slash_skill
 from deerflow.skills.types import Skill, SkillCategory
 
@@ -35,11 +35,10 @@ def _make_storage(tmp_path: Path, skills: list[Skill]):
     )
 
 
-def _make_model_request(messages: list[HumanMessage], system_message: SystemMessage | None = None) -> ModelRequest:
+def _make_model_request(messages: list[HumanMessage]) -> ModelRequest:
     return ModelRequest(
         model=object(),
         messages=messages,
-        system_message=system_message,
         state={"messages": list(messages)},
         runtime=None,
     )
@@ -86,30 +85,29 @@ def test_resolve_slash_skill_rejects_disabled_skills(tmp_path):
     assert resolve_slash_skill("/data-analysis run", [skill]) is None
 
 
-def test_skill_activation_middleware_injects_skill_context_into_system_message(monkeypatch, tmp_path):
+def test_skill_activation_middleware_injects_hidden_human_context_for_model_call(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
     monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
 
     middleware = SkillActivationMiddleware()
     original = HumanMessage(content="/data-analysis analyze uploads/foo.csv", id="msg-1")
-    request = _make_model_request([original], system_message=SystemMessage(content="Base system prompt."))
+    request = _make_model_request([original])
     captured = {}
 
     def handler(model_request: ModelRequest):
         captured["messages"] = model_request.messages
-        captured["system_message"] = model_request.system_message
         return AIMessage(content="ok")
 
     result = middleware.wrap_model_call(request, handler)
 
     assert isinstance(result, AIMessage)
     assert result.content == "ok"
-    assert captured["messages"] == [original]
-    system_message = captured["system_message"]
-    assert isinstance(system_message, SystemMessage)
-    assert system_message.content.startswith("Base system prompt.")
-    assert "Use pandas." in system_message.content
-    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in system_message.content
+    activation_msg, user_msg = captured["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert activation_msg.additional_kwargs["hide_from_ui"] is True
+    assert "Use pandas." in activation_msg.content
+    assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
+    assert user_msg.content == original.content
     assert request.state["messages"] == [original]
 
 
@@ -127,19 +125,18 @@ def test_skill_activation_middleware_uses_original_user_content_when_uploads_are
 
     def handler(model_request: ModelRequest):
         captured["messages"] = model_request.messages
-        captured["system_message"] = model_request.system_message
         return AIMessage(content="ok")
 
     result = middleware.wrap_model_call(_make_model_request([original]), handler)
 
     assert isinstance(result, AIMessage)
     assert result.content == "ok"
-    assert captured["messages"] == [original]
-    system_message = captured["system_message"]
-    assert isinstance(system_message, SystemMessage)
-    assert "Use pandas." in system_message.content
-    assert "<user_request>\n分析这个文档\n</user_request>" in system_message.content
-    assert original.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
+    activation_msg, user_msg = captured["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert "Use pandas." in activation_msg.content
+    assert "<user_request>\n分析这个文档\n</user_request>" in activation_msg.content
+    assert user_msg.content == original.content
+    assert user_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
 
 
 def test_skill_activation_middleware_returns_clear_error_for_disallowed_skill(monkeypatch, tmp_path):

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 from types import SimpleNamespace
 
-from langchain_core.messages import HumanMessage
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
 from deerflow.agents.middlewares.skill_activation_middleware import (
-    _SLASH_SKILL_PROCESSED_KEY,
     SkillActivationMiddleware,
     is_slash_skill_activation_reminder,
 )
@@ -27,6 +27,23 @@ def _make_skill(tmp_path: Path, name: str, content: str = "skill body") -> Skill
         relative_path=Path(name),
         category=SkillCategory.CUSTOM,
         enabled=True,
+    )
+
+
+def _make_storage(tmp_path: Path, skills: list[Skill]):
+    return SimpleNamespace(
+        load_skills=lambda *, enabled_only: [skill for skill in skills if skill.enabled] if enabled_only else skills,
+        get_container_root=lambda: "/mnt/skills",
+        get_skills_root_path=lambda: tmp_path,
+    )
+
+
+def _make_model_request(messages: list[HumanMessage]) -> ModelRequest:
+    return ModelRequest(
+        model=object(),
+        messages=messages,
+        state={"messages": list(messages)},
+        runtime=None,
     )
 
 
@@ -64,36 +81,42 @@ def test_resolve_slash_skill_respects_available_skill_whitelist(tmp_path):
     assert resolved.container_file_path == "/mnt/skills/custom/data-analysis/SKILL.md"
 
 
-def test_skill_activation_middleware_injects_hidden_skill_context(monkeypatch, tmp_path):
+def test_resolve_slash_skill_rejects_disabled_skills(tmp_path):
+    skill = _make_skill(tmp_path, "data-analysis")
+    skill.enabled = False
+
+    assert resolve_slash_skill("/data-analysis run", [skill]) is None
+
+
+def test_skill_activation_middleware_injects_hidden_skill_context_for_model_call(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
-    storage = SimpleNamespace(
-        load_skills=lambda *, enabled_only: [skill],
-        get_container_root=lambda: "/mnt/skills",
-    )
-    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
 
     middleware = SkillActivationMiddleware()
     original = HumanMessage(content="/data-analysis analyze uploads/foo.csv", id="msg-1")
+    request = _make_model_request([original])
+    captured = {}
 
-    update = middleware.before_agent({"messages": [original]}, runtime=None)
+    def handler(model_request: ModelRequest):
+        captured["messages"] = model_request.messages
+        return AIMessage(content="ok")
 
-    assert update is not None
-    activation_msg, user_msg = update["messages"]
+    result = middleware.wrap_model_call(request, handler)
+
+    assert isinstance(result, AIMessage)
+    assert result.content == "ok"
+    activation_msg, user_msg = captured["messages"]
     assert is_slash_skill_activation_reminder(activation_msg)
     assert activation_msg.additional_kwargs["hide_from_ui"] is True
     assert "Use pandas." in activation_msg.content
     assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
     assert user_msg.content == original.content
-    assert user_msg.additional_kwargs[_SLASH_SKILL_PROCESSED_KEY] is True
+    assert request.state["messages"] == [original]
 
 
 def test_skill_activation_middleware_uses_original_user_content_when_uploads_are_injected(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis", content="# Data Analysis\nUse pandas.")
-    storage = SimpleNamespace(
-        load_skills=lambda *, enabled_only: [skill],
-        get_container_root=lambda: "/mnt/skills",
-    )
-    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
 
     middleware = SkillActivationMiddleware()
     original = HumanMessage(
@@ -101,45 +124,67 @@ def test_skill_activation_middleware_uses_original_user_content_when_uploads_are
         id="msg-1",
         additional_kwargs={ORIGINAL_USER_CONTENT_KEY: "/data-analysis分析这个文档"},
     )
+    captured = {}
 
-    update = middleware.before_agent({"messages": [original]}, runtime=None)
+    def handler(model_request: ModelRequest):
+        captured["messages"] = model_request.messages
+        return AIMessage(content="ok")
 
-    assert update is not None
-    activation_msg, user_msg = update["messages"]
+    result = middleware.wrap_model_call(_make_model_request([original]), handler)
+
+    assert isinstance(result, AIMessage)
+    assert result.content == "ok"
+    activation_msg, user_msg = captured["messages"]
     assert is_slash_skill_activation_reminder(activation_msg)
     assert "Use pandas." in activation_msg.content
     assert "<user_request>\n分析这个文档\n</user_request>" in activation_msg.content
     assert user_msg.content == original.content
     assert user_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
-    assert user_msg.additional_kwargs[_SLASH_SKILL_PROCESSED_KEY] is True
 
 
-def test_skill_activation_middleware_skips_already_processed_user_message(monkeypatch, tmp_path):
+def test_skill_activation_middleware_returns_clear_error_for_disallowed_skill(monkeypatch, tmp_path):
     skill = _make_skill(tmp_path, "data-analysis")
-    storage = SimpleNamespace(
-        load_skills=lambda *, enabled_only: [skill],
-        get_container_root=lambda: "/mnt/skills",
-    )
-    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
-
-    middleware = SkillActivationMiddleware()
-    processed = HumanMessage(
-        content="/data-analysis run",
-        id="msg-1__slash_user",
-        additional_kwargs={_SLASH_SKILL_PROCESSED_KEY: True},
-    )
-
-    assert middleware.before_agent({"messages": [processed]}, runtime=None) is None
-
-
-def test_skill_activation_middleware_respects_agent_skill_whitelist(monkeypatch, tmp_path):
-    skill = _make_skill(tmp_path, "data-analysis")
-    storage = SimpleNamespace(
-        load_skills=lambda *, enabled_only: [skill],
-        get_container_root=lambda: "/mnt/skills",
-    )
-    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: storage)
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(tmp_path, [skill]))
 
     middleware = SkillActivationMiddleware(available_skills={"frontend-design"})
+    original = HumanMessage(content="/data-analysis run")
 
-    assert middleware.before_agent({"messages": [HumanMessage(content="/data-analysis run")]}, runtime=None) is None
+    def handler(model_request: ModelRequest):
+        raise AssertionError("handler should not be called for invalid slash skills")
+
+    result = middleware.wrap_model_call(_make_model_request([original]), handler)
+
+    assert isinstance(result, AIMessage)
+    assert "not enabled or is not available" in result.content
+
+
+def test_skill_activation_middleware_rejects_skill_file_outside_skills_root(monkeypatch, tmp_path):
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "custom" / "data-analysis"
+    skill_dir.mkdir(parents=True)
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "SKILL.md"
+    outside_file.write_text("# Leaked\nDo not read me.", encoding="utf-8")
+    (skill_dir / "SKILL.md").symlink_to(outside_file)
+    skill = Skill(
+        name="data-analysis",
+        description="Description for data-analysis",
+        license="MIT",
+        skill_dir=skill_dir,
+        skill_file=skill_dir / "SKILL.md",
+        relative_path=Path("data-analysis"),
+        category=SkillCategory.CUSTOM,
+        enabled=True,
+    )
+    monkeypatch.setattr(middleware_module, "get_or_new_skill_storage", lambda **kwargs: _make_storage(skills_root, [skill]))
+
+    middleware = SkillActivationMiddleware()
+
+    def handler(model_request: ModelRequest):
+        raise AssertionError("handler should not be called when SKILL.md fails safety checks")
+
+    result = middleware.wrap_model_call(_make_model_request([HumanMessage(content="/data-analysis run")]), handler)
+
+    assert isinstance(result, AIMessage)
+    assert "could not be loaded safely" in result.content

--- a/backend/tests/test_uploads_middleware_core_logic.py
+++ b/backend/tests/test_uploads_middleware_core_logic.py
@@ -14,7 +14,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.agents.middlewares.uploads_middleware import UploadsMiddleware
 from deerflow.config.paths import Paths
-from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
 
 THREAD_ID = "thread-abc123"
 

--- a/backend/tests/test_uploads_middleware_core_logic.py
+++ b/backend/tests/test_uploads_middleware_core_logic.py
@@ -14,6 +14,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.agents.middlewares.uploads_middleware import UploadsMiddleware
 from deerflow.config.paths import Paths
+from deerflow.skills.slash import ORIGINAL_USER_CONTENT_KEY
 
 THREAD_ID = "thread-abc123"
 
@@ -277,6 +278,37 @@ class TestBeforeAgent:
         updated_kwargs = result["messages"][-1].additional_kwargs
         assert updated_kwargs.get("files") == files_meta
         assert updated_kwargs.get("element") == "task"
+
+    def test_preserves_original_user_content_before_upload_context(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"pdf")
+
+        msg = _human(
+            "/data-analysis分析这个文档",
+            files=[{"filename": "report.pdf", "size": 3, "path": "/mnt/user-data/uploads/report.pdf"}],
+        )
+        result = mw.before_agent(self._state(msg), _runtime())
+
+        assert result is not None
+        updated_msg = result["messages"][-1]
+        assert updated_msg.content.startswith("<uploaded_files>")
+        assert updated_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis分析这个文档"
+
+    def test_preserves_existing_original_user_content_marker(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"pdf")
+
+        msg = _human(
+            "<uploaded_files>\nold\n</uploaded_files>\n\n/data-analysis run",
+            files=[{"filename": "report.pdf", "size": 3, "path": "/mnt/user-data/uploads/report.pdf"}],
+            **{ORIGINAL_USER_CONTENT_KEY: "/data-analysis run"},
+        )
+        result = mw.before_agent(self._state(msg), _runtime())
+
+        assert result is not None
+        assert result["messages"][-1].additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "/data-analysis run"
 
     def test_uploaded_files_returned_in_state_update(self, tmp_path):
         mw = _middleware(tmp_path)


### PR DESCRIPTION
> Follow-up hardening and latest-main integration are continued in #3466.

## Summary

Implements the MVP for slash skill activation from RFC #3017.

This PR keeps DeerFlow's base skill prompt progressive-disclosure friendly: startup/reload still exposes skill metadata only, while an explicit `/skill-name ...` request deterministically injects that skill's full `SKILL.md` into the current turn as hidden context.

## Changes

- Add `deerflow.skills.slash` for slash skill parsing and enabled/whitelisted skill resolution.
- Add `SkillActivationMiddleware` to inject full `SKILL.md` content when the latest user message starts with `/skill-name`.
- Wire slash activation into the lead-agent runtime and embedded `DeerFlowClient`, preserving custom-agent skill whitelists.
- Update skill prompt guidance to document explicit slash activation.
- Let IM channel commands fall back to chat handling when an unknown slash command matches an enabled skill.
- Add unit coverage for resolver behavior, middleware injection, whitelist enforcement, processed-message deduping, and channel fallback.

## Notes

- Slash activation is current-turn only and does not mutate thread or agent skill config.
- Existing control commands such as `/new`, `/help`, and `/bootstrap` retain precedence.
- Disabled skills are not loaded because activation resolution reads `load_skills(enabled_only=True)`.
- `allowed-tools` policy is not bypassed; tool filtering remains based on the current runtime-visible skill set.

## Validation

- `uv run ruff check packages/harness/deerflow/skills/slash.py packages/harness/deerflow/agents/middlewares/skill_activation_middleware.py packages/harness/deerflow/agents/lead_agent/agent.py packages/harness/deerflow/client.py app/channels/manager.py tests/test_slash_skills.py tests/test_channels.py`
- `uv run pytest -q tests/test_slash_skills.py`
- `uv run pytest -q tests/test_channels.py -k 'slash_skill or command_help or command_new or command_bootstrap'`
- `uv run pytest -q tests/test_lead_agent_prompt.py tests/test_subagent_skills_config.py`
- `uv run pytest -q tests/test_skills_custom_router.py tests/test_skills_installer.py tests/test_skills_bundled.py`
- `uv run pytest -q tests/test_client.py -k 'SkillsManagement or ScenarioSkillInstallAndUse or InstallSkillSecurity'`
- `uv run pytest -q` => 3392 passed, 19 skipped

Refs #3017
