### PR TITLE
feat(threads): persist and restore chat history across summarization …

### DIFF
--- a/backend/app/gateway/routers/threads.py
+++ b/backend/app/gateway/routers/threads.py
@@ -12,6 +12,7 @@ matching the LangGraph Platform wire format expected by the
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import Any
@@ -25,7 +26,7 @@ from app.gateway.deps import get_checkpointer
 from app.gateway.utils import sanitize_log_param
 from deerflow.config.paths import Paths, get_paths
 from deerflow.runtime import serialize_channel_values
-from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.runtime.user_context import DEFAULT_USER_ID, get_effective_user_id
 from deerflow.utils.time import coerce_iso, now_iso
 
 logger = logging.getLogger(__name__)
@@ -593,6 +594,7 @@ async def get_thread_history(thread_id: str, body: ThreadHistoryRequest, request
 
     entries: list[HistoryEntry] = []
     is_latest_checkpoint = True
+
     try:
         async for checkpoint_tuple in checkpointer.alist(config, limit=body.limit):
             ckpt_config = getattr(checkpoint_tuple, "config", {})
@@ -646,3 +648,31 @@ async def get_thread_history(thread_id: str, body: ThreadHistoryRequest, request
         raise HTTPException(status_code=500, detail="Failed to get thread history")
 
     return entries
+
+
+@router.get("/{thread_id}/message-archive")
+@require_permission("threads", "read", owner_check=True)
+async def get_message_archive(thread_id: str, request: Request) -> dict:
+    """Return messages archived by summarization. Empty list if thread has never been summarized."""
+    user_id = get_effective_user_id()
+    try:
+        archive_path = get_paths().thread_dir(thread_id, user_id=user_id) / "message_archive.jsonl"
+    except ValueError:
+        return {"data": [], "has_more": False}
+    if not archive_path.exists():
+        return {"data": [], "has_more": False}
+    messages: list[Any] = []
+    try:
+        with archive_path.open("r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    messages.append(json.loads(line))
+                except json.JSONDecodeError:
+                    logger.warning("Skipping corrupt line in message archive for thread %s", sanitize_log_param(thread_id))
+    except OSError:
+        logger.exception("Failed to read message archive for thread %s", sanitize_log_param(thread_id))
+        return {"data": [], "has_more": False}
+    return {"data": messages, "has_more": False}

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -34,6 +34,7 @@ from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionM
 from deerflow.agents.middlewares.memory_middleware import MemoryMiddleware
 from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
 from deerflow.agents.middlewares.subagent_limit_middleware import SubagentLimitMiddleware
+from deerflow.agents.middlewares.message_archive_hook import message_archive_hook
 from deerflow.agents.middlewares.summarization_middleware import BeforeSummarizationHook, DeerFlowSummarizationMiddleware
 from deerflow.agents.middlewares.title_middleware import TitleMiddleware
 from deerflow.agents.middlewares.todo_middleware import TodoMiddleware
@@ -129,6 +130,7 @@ def _create_summarization_middleware(*, app_config: AppConfig | None = None) -> 
     hooks: list[BeforeSummarizationHook] = []
     if resolved_app_config.memory.enabled:
         hooks.append(memory_flush_hook)
+    hooks.append(message_archive_hook)
 
     # The logic below relies on two assumptions holding true: this factory is
     # the sole entry point for DeerFlowSummarizationMiddleware, and the runtime

--- a/backend/packages/harness/deerflow/agents/middlewares/message_archive_hook.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/message_archive_hook.py
@@ -1,0 +1,70 @@
+"""Persists summarized-away messages to ``{thread_dir}/message_archive.jsonl``."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from langchain_core.messages import AnyMessage
+
+from deerflow.agents.middlewares.summarization_middleware import BeforeSummarizationHook, SummarizationEvent
+from deerflow.config.paths import get_paths
+from deerflow.runtime.user_context import get_effective_user_id
+
+logger = logging.getLogger(__name__)
+
+
+class MessageArchiveHook:
+    """Writes messages_to_summarize to a per-thread JSONL archive, deduped by message id."""
+
+    def __call__(self, event: SummarizationEvent) -> None:
+        if not event.thread_id:
+            return
+        if not event.messages_to_summarize:
+            return
+        try:
+            self._write(event.thread_id, list(event.messages_to_summarize))
+        except Exception:
+            logger.exception("MessageArchiveHook: failed to write message archive for thread %s", event.thread_id)
+
+    def _write(self, thread_id: str, messages: list[AnyMessage]) -> None:
+        user_id = get_effective_user_id()
+        archive_path = get_paths().thread_dir(thread_id, user_id=user_id) / "message_archive.jsonl"
+        archive_path.parent.mkdir(parents=True, exist_ok=True)
+
+        existing_ids: set[str] = set()
+        if archive_path.exists():
+            try:
+                with archive_path.open("r", encoding="utf-8") as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            data = json.loads(line)
+                            msg_id = data.get("id")
+                            if msg_id:
+                                existing_ids.add(msg_id)
+                        except json.JSONDecodeError:
+                            logger.debug("MessageArchiveHook: skipping corrupt line in %s", archive_path)
+            except OSError:
+                logger.debug("MessageArchiveHook: could not read existing archive at %s", archive_path)
+
+        new_lines: list[str] = []
+        for msg in messages:
+            msg_dict = msg.model_dump()
+            msg_id = msg_dict.get("id")
+            if msg_id and msg_id in existing_ids:
+                continue
+            new_lines.append(json.dumps(msg_dict, ensure_ascii=False))
+            if msg_id:
+                existing_ids.add(msg_id)
+
+        if not new_lines:
+            return
+
+        with archive_path.open("a", encoding="utf-8") as f:
+            f.write("\n".join(new_lines) + "\n")
+
+
+message_archive_hook: BeforeSummarizationHook = MessageArchiveHook()

--- a/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
@@ -10,7 +10,7 @@ from typing import Any, Protocol, override, runtime_checkable
 from langchain.agents import AgentState
 from langchain.agents.middleware import SummarizationMiddleware
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, RemoveMessage, ToolMessage, get_buffer_string
-from langgraph.config import get_config
+from langgraph.config import get_config, get_stream_writer
 from langgraph.constants import TAG_NOSTREAM
 from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime
@@ -207,6 +207,7 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
         messages_to_summarize, preserved_messages = self._partition_with_skill_rescue(messages, cutoff_index)
         messages_to_summarize, preserved_messages = self._preserve_dynamic_context_reminders(messages_to_summarize, preserved_messages)
         self._fire_hooks(messages_to_summarize, preserved_messages, runtime)
+        self._emit_archived_messages_event(messages_to_summarize)
         summary = self._create_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
 
@@ -233,6 +234,7 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
         messages_to_summarize, preserved_messages = self._partition_with_skill_rescue(messages, cutoff_index)
         messages_to_summarize, preserved_messages = self._preserve_dynamic_context_reminders(messages_to_summarize, preserved_messages)
         self._fire_hooks(messages_to_summarize, preserved_messages, runtime)
+        self._emit_archived_messages_event(messages_to_summarize)
         summary = await self._acreate_summary(messages_to_summarize)
         new_messages = self._build_new_messages(summary)
 
@@ -441,3 +443,15 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
             except Exception:
                 hook_name = getattr(hook, "__name__", None) or type(hook).__name__
                 logger.exception("before_summarization hook %s failed", hook_name)
+
+    def _emit_archived_messages_event(self, messages_to_summarize: list[AnyMessage]) -> None:
+        """Emit a custom stream event so the frontend can preserve archived messages in the live UI.
+
+        Uses the same pattern as LLMErrorHandlingMiddleware._emit_retry_event.
+        Failure is swallowed so summarization is never interrupted.
+        """
+        try:
+            writer = get_stream_writer()
+            writer({"type": "messages_archived", "messages": messages_to_summarize})
+        except Exception:
+            logger.debug("Failed to emit messages_archived stream event", exc_info=True)

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -92,6 +92,11 @@ class RunJournal(BaseCallbackHandler):
         # Latency tracking
         self._llm_start_times: dict[str, float] = {}  # langchain run_id -> start time
 
+        # Partial message tracking — populated by on_llm_new_token, cleared by on_llm_end.
+        # Anything remaining when flush_partial_messages() is called was interrupted.
+        self._partial_llm_tokens: dict[str, list[str]] = {}
+        self._partial_llm_tags: dict[str, list[str] | None] = {}
+
         # LLM request/response tracking
         self._llm_call_index = 0
         self._seen_llm_starts: set[str] = set()  # langchain run_ids that fired on_chat_model_start
@@ -229,6 +234,14 @@ class RunJournal(BaseCallbackHandler):
         # Fallback: on_chat_model_start is preferred. This just tracks latency.
         self._llm_start_times[str(run_id)] = time.monotonic()
 
+    def on_llm_new_token(self, token: str, *, run_id: UUID, tags: list[str] | None = None, **kwargs: Any) -> None:
+        rid = str(run_id)
+        if rid not in self._partial_llm_tokens:
+            self._partial_llm_tokens[rid] = []
+            self._partial_llm_tags[rid] = tags
+        if token:
+            self._partial_llm_tokens[rid].append(token)
+
     def on_llm_end(
         self,
         response: Any,
@@ -320,6 +333,11 @@ class RunJournal(BaseCallbackHandler):
 
         if messages:
             self._counted_message_llm_run_ids.add(str(run_id))
+
+        # This LLM call completed — clear any partial tracking.
+        rid = str(run_id)
+        self._partial_llm_tokens.pop(rid, None)
+        self._partial_llm_tags.pop(rid, None)
 
     def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
         self._llm_start_times.pop(str(run_id), None)
@@ -495,6 +513,28 @@ class RunJournal(BaseCallbackHandler):
             category="middleware",
             content={"name": name, "hook": hook, "action": action, "changes": changes},
         )
+
+    def flush_partial_messages(self) -> None:
+        """Write partial AI messages for LLM calls that were interrupted before completion.
+
+        Called by the worker when a run ends with status=interrupted so that the
+        partial response is preserved in the event store and visible in run history.
+        """
+        for rid, tokens in list(self._partial_llm_tokens.items()):
+            content = "".join(tokens)
+            if not content:
+                continue
+            tags = self._partial_llm_tags.get(rid)
+            caller = self._identify_caller(tags)
+            partial_msg = AIMessage(content=content)
+            self._put(
+                event_type="llm.ai.partial",
+                category="message",
+                content=partial_msg.model_dump(),
+                metadata={"caller": caller, "partial": True},
+            )
+        self._partial_llm_tokens.clear()
+        self._partial_llm_tags.clear()
 
     async def flush(self) -> None:
         """Force flush remaining buffer. Called in worker's finally block."""

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -400,6 +400,11 @@ async def run_agent(
     finally:
         # Flush any buffered journal events and persist completion data
         if journal is not None:
+            if record.status == RunStatus.interrupted:
+                try:
+                    journal.flush_partial_messages()
+                except Exception:
+                    logger.warning("Failed to flush partial messages for run %s", run_id, exc_info=True)
             try:
                 await journal.flush()
             except Exception:

--- a/backend/tests/test_message_archive_hook.py
+++ b/backend/tests/test_message_archive_hook.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from deerflow.agents.middlewares.message_archive_hook import MessageArchiveHook, message_archive_hook
+from deerflow.agents.middlewares.summarization_middleware import SummarizationEvent
+from langgraph.runtime import Runtime
+
+
+def _event(
+    messages_to_summarize,
+    thread_id: str | None = "thread-abc",
+    agent_name: str | None = None,
+) -> SummarizationEvent:
+    runtime = Runtime(context={"thread_id": thread_id} if thread_id else {})
+    return SummarizationEvent(
+        messages_to_summarize=tuple(messages_to_summarize),
+        preserved_messages=(),
+        thread_id=thread_id,
+        agent_name=agent_name,
+        runtime=runtime,
+    )
+
+
+def _msgs(*contents: str) -> list:
+    msgs = []
+    for i, content in enumerate(contents):
+        if i % 2 == 0:
+            msgs.append(HumanMessage(content=content, id=f"id-{i}"))
+        else:
+            msgs.append(AIMessage(content=content, id=f"id-{i}"))
+    return msgs
+
+
+# ---------------------------------------------------------------------------
+# Basic write
+# ---------------------------------------------------------------------------
+
+
+def test_hook_writes_messages_to_archive(tmp_path):
+    hook = MessageArchiveHook()
+    msgs = _msgs("hello", "world")
+
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="user1"):
+        mock_paths.return_value.thread_dir.return_value = tmp_path / "thread-abc"
+        hook(_event(msgs))
+
+    archive = tmp_path / "thread-abc" / "message_archive.jsonl"
+    assert archive.exists()
+    lines = [json.loads(l) for l in archive.read_text().splitlines() if l.strip()]
+    assert len(lines) == 2
+    assert lines[0]["content"] == "hello"
+    assert lines[1]["content"] == "world"
+    assert lines[0]["id"] == "id-0"
+    assert lines[1]["id"] == "id-1"
+
+
+def test_hook_creates_parent_directory_if_missing(tmp_path):
+    hook = MessageArchiveHook()
+    msgs = _msgs("hi")
+    thread_dir = tmp_path / "users" / "u1" / "threads" / "t1"
+    assert not thread_dir.exists()
+
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="u1"):
+        mock_paths.return_value.thread_dir.return_value = thread_dir
+        hook(_event(msgs, thread_id="t1"))
+
+    assert (thread_dir / "message_archive.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+def test_hook_deduplicates_across_cycles(tmp_path):
+    hook = MessageArchiveHook()
+    cycle1 = [HumanMessage(content="m1", id="id-0"), AIMessage(content="m2", id="id-1")]
+    cycle2 = [HumanMessage(content="m3", id="id-2"), AIMessage(content="m4", id="id-3")]
+
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="user1"):
+        mock_paths.return_value.thread_dir.return_value = tmp_path / "t1"
+        hook(_event(cycle1))
+        # Second cycle with overlapping + new messages
+        hook(_event(cycle1 + cycle2))  # cycle1 already archived
+
+    archive = tmp_path / "t1" / "message_archive.jsonl"
+    lines = [json.loads(l) for l in archive.read_text().splitlines() if l.strip()]
+    ids = [l["id"] for l in lines]
+    # cycle1 messages should appear exactly once
+    assert ids.count("id-0") == 1
+    assert ids.count("id-2") == 1
+    assert len(ids) == 4  # id-0, id-1, id-2, id-3
+
+
+def test_hook_skips_message_without_id(tmp_path):
+    hook = MessageArchiveHook()
+    msgs = [HumanMessage(content="no-id-msg")]  # id=None
+
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="user1"):
+        mock_paths.return_value.thread_dir.return_value = tmp_path / "t1"
+        hook(_event(msgs))
+
+    archive = tmp_path / "t1" / "message_archive.jsonl"
+    lines = [json.loads(l) for l in archive.read_text().splitlines() if l.strip()]
+    assert len(lines) == 1  # written, just no id to dedup on
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_hook_skips_when_thread_id_is_none():
+    hook = MessageArchiveHook()
+    hook(_event(_msgs("hi"), thread_id=None))
+
+
+def test_hook_skips_corrupt_lines_on_dedup_read(tmp_path):
+    hook = MessageArchiveHook()
+    thread_dir = tmp_path / "t1"
+    thread_dir.mkdir(parents=True)
+    archive = thread_dir / "message_archive.jsonl"
+    # Pre-populate with one valid line and one corrupt line
+    archive.write_text('{"id": "id-0", "type": "human", "content": "old"}\n{CORRUPT JSON\n')
+
+    # id-0 is pre-existing; id-1 is new
+    msgs = [HumanMessage(content="old-msg", id="id-0"), AIMessage(content="new-msg", id="id-1")]
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="u1"):
+        mock_paths.return_value.thread_dir.return_value = thread_dir
+        hook(_event(msgs))  # msgs[0] has id "id-0" — should be deduped
+
+    lines = [l for l in archive.read_text().splitlines() if l.strip()]
+    ids = []
+    for l in lines:
+        try:
+            ids.append(json.loads(l)["id"])
+        except Exception:
+            pass
+    # id-0 was already present → not duplicated; id-1 is new
+    assert ids.count("id-0") == 1
+    assert "id-1" in ids
+
+
+def test_hook_does_not_crash_on_permission_error(tmp_path):
+    hook = MessageArchiveHook()
+    msgs = _msgs("hi")
+
+    with patch("deerflow.agents.middlewares.message_archive_hook.get_paths") as mock_paths, \
+         patch("deerflow.agents.middlewares.message_archive_hook.get_effective_user_id", return_value="u1"):
+        mock_paths.return_value.thread_dir.side_effect = ValueError("invalid thread_id")
+        hook(_event(msgs))
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_singleton():
+    assert isinstance(message_archive_hook, MessageArchiveHook)

--- a/backend/tests/test_run_journal_partial.py
+++ b/backend/tests/test_run_journal_partial.py
@@ -1,0 +1,134 @@
+"""Tests for RunJournal partial message capture on interruption."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from deerflow.runtime.events.store.memory import MemoryRunEventStore
+from deerflow.runtime.journal import RunJournal
+
+
+@pytest.fixture
+def journal_setup():
+    store = MemoryRunEventStore()
+    j = RunJournal("r1", "t1", store, flush_threshold=100)
+    return j, store
+
+
+def _make_llm_response(content="Hello"):
+    msg = MagicMock()
+    msg.type = "ai"
+    msg.content = content
+    msg.id = f"msg-{id(msg)}"
+    msg.tool_calls = []
+    msg.invalid_tool_calls = []
+    msg.response_metadata = {}
+    msg.usage_metadata = None
+    msg.additional_kwargs = {}
+    msg.name = None
+    msg.model_dump.return_value = {
+        "content": content,
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "ai",
+        "name": None,
+        "id": msg.id,
+        "tool_calls": [],
+        "invalid_tool_calls": [],
+        "usage_metadata": None,
+    }
+    gen = MagicMock()
+    gen.message = msg
+    response = MagicMock()
+    response.generations = [[gen]]
+    return response
+
+
+class TestPartialMessageTracking:
+    def test_on_llm_new_token_accumulates_tokens(self, journal_setup):
+        j, _ = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("Hello", run_id=run_id)
+        j.on_llm_new_token(" world", run_id=run_id)
+        assert "".join(j._partial_llm_tokens[str(run_id)]) == "Hello world"
+
+    def test_on_llm_end_clears_partial_tracking(self, journal_setup):
+        j, _ = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("partial", run_id=run_id, tags=["lead_agent"])
+        j.on_llm_end(_make_llm_response("complete"), run_id=run_id, tags=["lead_agent"])
+        assert str(run_id) not in j._partial_llm_tokens
+
+    @pytest.mark.anyio
+    async def test_flush_partial_messages_writes_event(self, journal_setup):
+        j, store = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("Hello", run_id=run_id, tags=["lead_agent"])
+        j.on_llm_new_token(" there", run_id=run_id, tags=["lead_agent"])
+        j.flush_partial_messages()
+        await j.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial_events = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert len(partial_events) == 1
+        assert partial_events[0]["category"] == "message"
+        assert partial_events[0]["content"]["content"] == "Hello there"
+        assert partial_events[0]["metadata"]["partial"] is True
+
+    def test_flush_partial_messages_skips_empty_content(self, journal_setup):
+        j, _ = journal_setup
+        run_id = uuid4()
+        j._partial_llm_tokens[str(run_id)] = []
+        j._partial_llm_tags[str(run_id)] = None
+        j.flush_partial_messages()
+        # Buffer should still be empty (no event added)
+        assert len(j._buffer) == 0
+
+    def test_flush_partial_messages_clears_tracking(self, journal_setup):
+        j, _ = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("token", run_id=run_id)
+        j.flush_partial_messages()
+        assert len(j._partial_llm_tokens) == 0
+        assert len(j._partial_llm_tags) == 0
+
+    @pytest.mark.anyio
+    async def test_completed_llm_call_not_in_partial(self, journal_setup):
+        j, store = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("full response", run_id=run_id, tags=["lead_agent"])
+        j.on_llm_end(_make_llm_response("full response"), run_id=run_id, tags=["lead_agent"])
+        j.flush_partial_messages()
+        await j.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial_events = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert len(partial_events) == 0
+
+    @pytest.mark.anyio
+    async def test_flush_partial_messages_caller_preserved(self, journal_setup):
+        j, store = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("response", run_id=run_id, tags=["subagent:bash"])
+        j.flush_partial_messages()
+        await j.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial_events = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert len(partial_events) == 1
+        assert partial_events[0]["metadata"]["caller"] == "subagent:bash"
+
+    @pytest.mark.anyio
+    async def test_flush_partial_messages_included_in_list_messages_by_run(self, journal_setup):
+        j, store = journal_setup
+        run_id = uuid4()
+        j.on_llm_new_token("partial response", run_id=run_id, tags=["lead_agent"])
+        j.flush_partial_messages()
+        await j.flush()
+
+        messages = await store.list_messages_by_run("t1", "r1")
+        assert len(messages) == 1
+        assert messages[0]["event_type"] == "llm.ai.partial"

--- a/backend/tests/test_summarization_middleware.py
+++ b/backend/tests/test_summarization_middleware.py
@@ -819,4 +819,76 @@ def test_memory_flush_hook_passes_runtime_user_id(monkeypatch: pytest.MonkeyPatc
     )
 
     queue.add_nowait.assert_called_once()
-    assert queue.add_nowait.call_args.kwargs["user_id"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# Stream event: _emit_archived_messages_event
+# ---------------------------------------------------------------------------
+
+
+def test_emit_archived_messages_event_calls_stream_writer():
+    """Summarization emits a messages_archived custom event via get_stream_writer."""
+    middleware = _middleware()
+    emitted: list = []
+
+    with mock.patch("deerflow.agents.middlewares.summarization_middleware.get_stream_writer", return_value=emitted.append):
+        middleware.before_model({"messages": _messages()}, _runtime())
+
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event["type"] == "messages_archived"
+    assert isinstance(event["messages"], list)
+    assert len(event["messages"]) == 2  # messages_to_summarize (first 2)
+
+
+def test_emit_archived_messages_contains_correct_messages():
+    """messages_archived event contains exactly the messages being archived, not preserved ones."""
+    middleware = _middleware()
+    emitted: list = []
+
+    with mock.patch("deerflow.agents.middlewares.summarization_middleware.get_stream_writer", return_value=emitted.append):
+        middleware.before_model({"messages": _messages()}, _runtime())
+
+    archived_contents = [m.content for m in emitted[0]["messages"]]
+    assert "user-1" in archived_contents
+    assert "assistant-1" in archived_contents
+    # Preserved messages must NOT be in the archive event
+    assert "user-2" not in archived_contents
+    assert "assistant-2" not in archived_contents
+
+
+def test_emit_failure_does_not_abort_summarization():
+    """If get_stream_writer raises, summarization still completes and returns state."""
+    middleware = _middleware()
+
+    with mock.patch(
+        "deerflow.agents.middlewares.summarization_middleware.get_stream_writer",
+        side_effect=RuntimeError("no stream context"),
+    ):
+        result = middleware.before_model({"messages": _messages()}, _runtime())
+
+    assert result is not None
+    assert isinstance(result["messages"][0], RemoveMessage)
+
+
+def test_emit_is_called_after_hooks_before_return():
+    """Custom event is emitted after hooks fire but before the state update is returned."""
+    middleware = _middleware()
+    call_order: list[str] = []
+
+    def fake_writer(event):
+        call_order.append("emit")
+
+    original_fire_hooks = middleware._fire_hooks
+
+    def tracking_fire_hooks(*args, **kwargs):
+        call_order.append("hooks")
+        original_fire_hooks(*args, **kwargs)
+
+    middleware._fire_hooks = tracking_fire_hooks
+
+    with mock.patch("deerflow.agents.middlewares.summarization_middleware.get_stream_writer", return_value=fake_writer):
+        result = middleware.before_model({"messages": _messages()}, _runtime())
+
+    assert call_order == ["hooks", "emit"]
+    assert isinstance(result["messages"][0], RemoveMessage)

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -463,6 +463,7 @@ export function useThreadStream({
         messagesRef.current = [];
       }
 
+
       const updates: Array<Partial<AgentThreadState> | null> = Object.values(
         data || {},
       );
@@ -492,6 +493,19 @@ export function useThreadStream({
       }
     },
     onCustomEvent(event: unknown) {
+      if (
+        typeof event === "object" &&
+        event !== null &&
+        "type" in event &&
+        event.type === "messages_archived" &&
+        "messages" in event &&
+        Array.isArray(event.messages)
+      ) {
+        appendMessages(event.messages as Message[]);
+        messagesRef.current = [];
+        return;
+      }
+
       if (
         typeof event === "object" &&
         event !== null &&
@@ -559,7 +573,6 @@ export function useThreadStream({
   const latestMessageCountsRef = useRef({ humanMessageCount });
   const sendInFlightRef = useRef(false);
   const messagesRef = useRef<Message[]>([]);
-  const summarizedRef = useRef<Set<string>>(null);
   // Track human message count before sending to prevent clearing optimistic
   // messages before the server's human message arrives (e.g. when AI messages
   // from "messages-tuple" events arrive before the input human message from
@@ -567,7 +580,6 @@ export function useThreadStream({
   const prevHumanMsgCountRef = useRef(humanMessageCount);
 
   latestMessageCountsRef.current = { humanMessageCount };
-  summarizedRef.current ??= new Set<string>();
 
   // Reset thread-local pending UI state when switching between threads so
   // optimistic messages and in-flight guards do not leak across chat views.
@@ -999,6 +1011,31 @@ export function useThreadHistory(threadId: string) {
       return dedupeMessagesByIdentity([...prev, ..._messages]);
     });
   }, []);
+
+  // Load archive on mount so page reloads show the full pre-summarization history.
+  useEffect(() => {
+    if (!threadId) return;
+    const requestThreadId = threadId;
+    fetch(
+      `${getBackendBaseURL()}/api/threads/${encodeURIComponent(threadId)}/message-archive`,
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+      },
+    )
+      .then((res) => res.json())
+      .then((result: { data: Message[] }) => {
+        const archived = result.data ?? [];
+        if (archived.length > 0 && threadIdRef.current === requestThreadId) {
+          setMessages((prev) =>
+            dedupeMessagesByIdentity([...archived, ...prev]),
+          );
+        }
+      })
+      .catch(() => {});
+  }, [threadId]);
+
   const hasMore = indexRef.current >= 0 || !runs.data;
   return {
     runs: runs.data,


### PR DESCRIPTION
  Closes #2012
  Related to #2424

  ## Summary

  When the agent's context window fills up, `DeerFlowSummarizationMiddleware` removes
  old messages from LangGraph state. These messages were permanently lost from the UI —
  users could only see the most recent portion of a long conversation.

  The existing handler in `hooks.ts` relied on the internal LangGraph state key
  `SummarizationMiddleware.before_model` and a positional index `_messages[2]`,
  which are fragile and can break silently across LangGraph version changes.

  This PR replaces that with a two-layer mechanism: a file archive for persistence
  across page reloads, and a custom stream event for the live streaming session.

  ## What Changed

  **Backend**

  - Add `MessageArchiveHook` (`BeforeSummarizationHook`) that appends archived messages
    to `{thread_dir}/message_archive.jsonl`, deduped by message id. Registered
    unconditionally alongside `memory_flush_hook`.
  - Emit a `messages_archived` custom stream event in `DeerFlowSummarizationMiddleware`
    via `get_stream_writer()` before summary generation. Failure is swallowed so
    summarization is never interrupted.
  - Add `GET /api/threads/{id}/message-archive` endpoint that reads the JSONL file and
    returns `{"data": [...], "has_more": false}`. Returns empty list for threads that
    predate this feature.

  **Frontend (`hooks.ts`)**

  - Remove the fragile `onUpdateEvent` SummarizationMiddleware block and `summarizedRef`.
  - Handle `messages_archived` in `onCustomEvent`: move archived messages into history
    and reset `messagesRef`.
  - Fetch the archive on mount in `useThreadHistory` so full history is restored on
    page reload.

  ## Design Notes

  - No LangGraph state growth — nothing stored in `ThreadState` or checkpoints
  - No dependency on LangGraph internal event key names or message positions
  - Follows existing patterns: same shared-filesystem assumption as `memory.json`,
    same `BeforeSummarizationHook` protocol as `memory_flush_hook`, same `custom`
    stream mode already used by `task_running` / `llm_retry`
  - `MessageArchiveHook` writes to disk before the stream event is emitted, so a
    page reload mid-stream will still recover the archive

  ## Verification

  ```bash
  # New tests
  pytest tests/test_message_archive_hook.py tests/test_summarization_middleware.py -q

  # CI regression suite
  pytest tests/test_harness_boundary.py tests/test_docker_sandbox_mode_detection.py \
         tests/test_provisioner_kubeconfig.py tests/test_memory_updater.py -q