### PR TITLE
feat(gateway): Authentik forward-auth SSO trust middleware

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install backend dependencies
         working-directory: backend

--- a/.github/workflows/frontend-unit-tests.yml
+++ b/.github/workflows/frontend-unit-tests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -13,15 +13,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install dependencies
         working-directory: backend
@@ -35,10 +35,10 @@ jobs:
   lint-frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
 

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -59,8 +59,16 @@ async def _ensure_admin_user(app: FastAPI) -> None:
     authentication have existing LangGraph thread data that needs an
     owner assigned.
         First boot (no admin exists):
-            - Does NOT create any user accounts automatically.
-            - The operator must visit ``/setup`` to create the first admin.
+            - If ``DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL`` is set: auto-create that
+              email as the first admin (needs_setup=False). Used by SSO
+              deployments where Authentik already gates access and the
+              operator should land directly on ``/workspace`` without
+              visiting ``/setup``. Password defaults to a random secret
+              when ``DEER_FLOW_BOOTSTRAP_ADMIN_PASSWORD`` is unset, which
+              is safe because the Authentik trust middleware mints the
+              session without ever invoking ``/login/local``.
+            - Otherwise: does NOT create any user accounts automatically.
+              The operator must visit ``/setup`` to create the first admin.
 
     Subsequent boots (admin already exists):
       - Runs the one-time "no-auth → with-auth" orphan thread migration for
@@ -71,6 +79,8 @@ async def _ensure_admin_user(app: FastAPI) -> None:
     alongside the auth module via create_all, so freshly created tables
     never contain NULL-owner rows.
     """
+    import secrets
+
     from sqlalchemy import select
 
     from app.gateway.deps import get_local_provider
@@ -92,6 +102,26 @@ async def _ensure_admin_user(app: FastAPI) -> None:
     admin_count = await provider.count_admin_users()
 
     if admin_count == 0:
+        bootstrap_email = os.environ.get("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", "").strip()
+        if bootstrap_email:
+            password = os.environ.get("DEER_FLOW_BOOTSTRAP_ADMIN_PASSWORD") or secrets.token_urlsafe(32)
+            try:
+                await provider.create_user(
+                    email=bootstrap_email,
+                    password=password,
+                    system_role="admin",
+                    needs_setup=False,
+                )
+                logger.info(
+                    "Bootstrapped admin account %s from DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL",
+                    bootstrap_email,
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to bootstrap admin %s — fall back to /setup flow",
+                    bootstrap_email,
+                )
+            return
         logger.info("=" * 60)
         logger.info("  First boot detected — no admin account exists.")
         logger.info("  Visit /setup to complete admin account creation.")

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -7,8 +8,9 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.gateway.auth_middleware import AuthMiddleware
+from app.gateway.authentik_trust_middleware import AuthentikTrustMiddleware
 from app.gateway.config import get_gateway_config
-from app.gateway.csrf_middleware import CSRFMiddleware, get_configured_cors_origins
+from app.gateway.csrf_middleware import CSRFMiddleware
 from app.gateway.deps import langgraph_runtime
 from app.gateway.routers import (
     agents,
@@ -62,7 +64,7 @@ async def _ensure_admin_user(app: FastAPI) -> None:
 
     Subsequent boots (admin already exists):
       - Runs the one-time "no-auth → with-auth" orphan thread migration for
-        existing LangGraph thread metadata that has no user_id.
+        existing LangGraph thread metadata that has no owner_id.
 
     No SQL persistence migration is needed: the four user_id columns
     (threads_meta, runs, run_events, feedback) only come into existence
@@ -177,7 +179,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with langgraph_runtime(app):
         logger.info("LangGraph runtime initialised")
 
-        # Check admin bootstrap state and migrate orphan threads after admin exists.
+        # Ensure admin user exists (auto-create on first boot)
         # Must run AFTER langgraph_runtime so app.state.store is available for thread migration
         await _ensure_admin_user(app)
 
@@ -218,9 +220,7 @@ def create_app() -> FastAPI:
         Configured FastAPI application instance.
     """
     config = get_gateway_config()
-    docs_url = "/docs" if config.enable_docs else None
-    redoc_url = "/redoc" if config.enable_docs else None
-    openapi_url = "/openapi.json" if config.enable_docs else None
+    docs_kwargs = {"docs_url": "/docs", "redoc_url": "/redoc", "openapi_url": "/openapi.json"} if config.enable_docs else {"docs_url": None, "redoc_url": None, "openapi_url": None}
 
     app = FastAPI(
         title="DeerFlow API Gateway",
@@ -240,14 +240,12 @@ API Gateway for DeerFlow - A LangGraph-based AI agent backend with sandbox execu
 
 ### Architecture
 
-LangGraph-compatible requests are routed through nginx to this gateway.
-This gateway provides runtime endpoints for agent runs plus custom endpoints for models, MCP configuration, skills, and artifacts.
+LangGraph requests are handled by nginx reverse proxy.
+This gateway provides custom endpoints for models, MCP configuration, skills, and artifacts.
         """,
         version="0.1.0",
         lifespan=lifespan,
-        docs_url=docs_url,
-        redoc_url=redoc_url,
-        openapi_url=openapi_url,
+        **docs_kwargs,
         openapi_tags=[
             {
                 "name": "models",
@@ -310,18 +308,31 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     # CSRF: Double Submit Cookie pattern for state-changing requests
     app.add_middleware(CSRFMiddleware)
 
-    # CORS: the unified nginx endpoint is same-origin by default. Split-origin
-    # browser clients must opt in with this explicit Gateway allowlist so CORS
-    # and CSRF origin checks share the same source of truth.
-    cors_origins = sorted(get_configured_cors_origins())
-    if cors_origins:
-        app.add_middleware(
-            CORSMiddleware,
-            allow_origins=cors_origins,
-            allow_credentials=True,
-            allow_methods=["*"],
-            allow_headers=["*"],
-        )
+    # Authentik forward-auth trust: opt-in via DEER_FLOW_AUTHENTIK_TRUST_ENABLED.
+    # Mounted AFTER CSRF/Auth so it runs BEFORE them on inbound requests --
+    # it injects the synthesized access_token cookie that AuthMiddleware
+    # then validates normally.
+    app.add_middleware(AuthentikTrustMiddleware)
+
+    # CORS: when GATEWAY_CORS_ORIGINS is set (dev without nginx), add CORS middleware.
+    # In production, nginx handles CORS and no middleware is needed.
+    cors_origins_env = os.environ.get("GATEWAY_CORS_ORIGINS", "")
+    if cors_origins_env:
+        cors_origins = [o.strip() for o in cors_origins_env.split(",") if o.strip()]
+        # Validate: wildcard origin with credentials is a security misconfiguration
+        for origin in cors_origins:
+            if origin == "*":
+                logger.error("GATEWAY_CORS_ORIGINS contains wildcard '*' with allow_credentials=True. This is a security misconfiguration — browsers will reject the response. Use explicit scheme://host:port origins instead.")
+                cors_origins = [o for o in cors_origins if o != "*"]
+                break
+        if cors_origins:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=cors_origins,
+                allow_credentials=True,
+                allow_methods=["*"],
+                allow_headers=["*"],
+            )
 
     # Include routers
     # Models API is mounted at /api/models
@@ -370,7 +381,7 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     app.include_router(runs.router)
 
     @app.get("/health", tags=["health"])
-    async def health_check() -> dict[str, str]:
+    async def health_check() -> dict:
         """Health check endpoint.
 
         Returns:

--- a/backend/app/gateway/authentik_trust_middleware.py
+++ b/backend/app/gateway/authentik_trust_middleware.py
@@ -1,0 +1,152 @@
+"""Authentik forward-auth trust middleware.
+
+When the deer-flow ingress sits behind Traefik + Authentik forward-auth, the
+proxy strips the Authentik cookie and re-injects identity headers on the
+request to the backend. We trust these headers to mint a local session
+cookie, so users who have already authenticated to Authentik are not asked
+for a second set of credentials at the deer-flow login form.
+
+Activation requires the env var ``DEER_FLOW_AUTHENTIK_TRUST_ENABLED=true``.
+The trusted email header defaults to ``X-authentik-email`` (case-insensitive
+header lookup is handled by Starlette).
+
+Flow per request:
+
+1. If trust disabled, pass-through.
+2. If request already carries a valid ``access_token`` cookie, pass-through.
+3. If no Authentik email header is present, pass-through (will hit
+   AuthMiddleware which will 401 non-public paths).
+4. Resolve / auto-create the local user keyed on the Authentik email.
+5. Mint a JWT, inject it as a synthetic ``cookie`` request header so
+   ``AuthMiddleware`` finds it on the same request, AND set the cookie
+   on the response so the browser keeps it for subsequent requests.
+
+The middleware is opt-in via env to keep the default (non-Authentik)
+deployment posture unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from collections.abc import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+_TRUST_ENV_VAR = "DEER_FLOW_AUTHENTIK_TRUST_ENABLED"
+_EMAIL_HEADER_ENV = "DEER_FLOW_AUTHENTIK_EMAIL_HEADER"
+_DEFAULT_EMAIL_HEADER = "X-authentik-email"
+
+
+def _is_enabled() -> bool:
+    return os.environ.get(_TRUST_ENV_VAR, "").lower() in ("1", "true", "yes")
+
+
+def _email_header_name() -> str:
+    return os.environ.get(_EMAIL_HEADER_ENV) or _DEFAULT_EMAIL_HEADER
+
+
+def _inject_cookie_header(request: Request, token: str) -> None:
+    """Mutate request scope so downstream AuthMiddleware sees access_token."""
+    scope = request.scope
+    raw_headers: list[tuple[bytes, bytes]] = list(scope.get("headers", []))
+    cookie_idx: int | None = None
+    existing_cookie = b""
+    for i, (k, v) in enumerate(raw_headers):
+        if k.lower() == b"cookie":
+            cookie_idx = i
+            existing_cookie = v
+            break
+
+    new_pair = f"access_token={token}".encode()
+    if existing_cookie:
+        new_value = existing_cookie + b"; " + new_pair
+    else:
+        new_value = new_pair
+
+    if cookie_idx is None:
+        raw_headers.append((b"cookie", new_value))
+    else:
+        raw_headers[cookie_idx] = (b"cookie", new_value)
+    scope["headers"] = raw_headers
+    # Starlette caches parsed cookies on the Request object; reset so the
+    # next .cookies access re-parses the mutated header.
+    if hasattr(request, "_cookies"):
+        try:
+            del request._cookies  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+
+class AuthentikTrustMiddleware(BaseHTTPMiddleware):
+    """Mint a local session cookie from an upstream Authentik email header."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        if not _is_enabled():
+            return await call_next(request)
+
+        if request.cookies.get("access_token"):
+            return await call_next(request)
+
+        header_name = _email_header_name()
+        email = request.headers.get(header_name)
+        if not email:
+            return await call_next(request)
+
+        token: str | None = None
+        try:
+            from app.gateway.auth import create_access_token
+            from app.gateway.deps import get_local_provider
+
+            provider = get_local_provider()
+            user = await provider.get_user_by_email(email)
+            if user is None:
+                # Authentik already authenticated this principal, so we
+                # never need to know its password locally. Use a random
+                # 32-byte secret as the placeholder hash so the
+                # /login/local route (still a valid path) cannot be used
+                # to impersonate the user with a guessable credential.
+                user = await provider.create_user(
+                    email=email,
+                    password=secrets.token_urlsafe(32),
+                    system_role="user",
+                    needs_setup=False,
+                )
+                logger.info("authentik-trust: auto-created local user for %s", email)
+            token = create_access_token(str(user.id), token_version=user.token_version)
+            _inject_cookie_header(request, token)
+        except Exception as exc:  # noqa: BLE001 — broad catch is deliberate; trust-middleware must never fail-open
+            logger.exception("authentik-trust: failed to mint session for %s: %s", email, exc)
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        # Cache the cookie on the browser so subsequent requests skip the
+        # mint path. SameSite=lax matches _set_session_cookie in
+        # routers/auth.py. Secure flag tracks the proxy-resolved scheme.
+        is_https = request.headers.get("x-forwarded-proto", request.url.scheme) == "https"
+        # Best-effort: pull token_expiry_days from auth config if available.
+        try:
+            from app.gateway.auth.config import get_auth_config
+
+            max_age = get_auth_config().token_expiry_days * 24 * 3600 if is_https else None
+        except Exception:  # noqa: BLE001
+            max_age = None
+
+        response.set_cookie(
+            key="access_token",
+            value=token,
+            httponly=True,
+            secure=is_https,
+            samesite="lax",
+            max_age=max_age,
+        )
+        return response

--- a/backend/tests/test_ensure_admin.py
+++ b/backend/tests/test_ensure_admin.py
@@ -25,6 +25,16 @@ def _setup_auth_config():
     set_auth_config(AuthConfig(jwt_secret=_JWT_SECRET))
 
 
+@pytest.fixture(autouse=True)
+def _clear_bootstrap_env(monkeypatch):
+    """Default-clear DEER_FLOW_BOOTSTRAP_ADMIN_* so ambient shell env does
+    not silently flip the first-boot tests into the bootstrap branch.
+    Tests that exercise the bootstrap path re-set via monkeypatch."""
+    monkeypatch.delenv("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", raising=False)
+    monkeypatch.delenv("DEER_FLOW_BOOTSTRAP_ADMIN_PASSWORD", raising=False)
+    yield
+
+
 def _make_app_stub(store=None):
     """Minimal app-like object with state.store."""
     app = SimpleNamespace()
@@ -92,6 +102,92 @@ def test_first_boot_skips_migration():
         asyncio.run(_ensure_admin_user(app))
 
     store.asearch.assert_not_called()
+
+
+# ── Env-gated admin bootstrap (DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL) ──────────
+
+
+def test_bootstrap_env_creates_admin_on_first_boot(monkeypatch):
+    """admin_count==0 AND DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL set → create admin row.
+
+    Validates the SSO bootstrap path used by the deer-flow stax deployment:
+    set the env var to the operator's Authentik email so the trust
+    middleware later finds an existing user row keyed on that email.
+    """
+    monkeypatch.setenv("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.setenv("DEER_FLOW_BOOTSTRAP_ADMIN_PASSWORD", "deterministic-test-pw")
+
+    provider = _make_provider(admin_count=0)
+    sf = _make_session_factory()
+    app = _make_app_stub()
+
+    with patch("app.gateway.deps.get_local_provider", return_value=provider):
+        with patch("deerflow.persistence.engine.get_session_factory", return_value=sf):
+            from app.gateway.app import _ensure_admin_user
+
+            asyncio.run(_ensure_admin_user(app))
+
+    provider.create_user.assert_called_once()
+    kwargs = provider.create_user.call_args.kwargs
+    assert kwargs["email"] == "admin@example.com"
+    assert kwargs["system_role"] == "admin"
+    assert kwargs["needs_setup"] is False
+    assert kwargs["password"] == "deterministic-test-pw"
+
+
+def test_bootstrap_env_random_password_when_unset(monkeypatch):
+    """Email env set, password env unset → random password (>= 32 chars)."""
+    monkeypatch.setenv("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", "admin@example.com")
+    monkeypatch.delenv("DEER_FLOW_BOOTSTRAP_ADMIN_PASSWORD", raising=False)
+
+    provider = _make_provider(admin_count=0)
+    sf = _make_session_factory()
+    app = _make_app_stub()
+
+    with patch("app.gateway.deps.get_local_provider", return_value=provider):
+        with patch("deerflow.persistence.engine.get_session_factory", return_value=sf):
+            from app.gateway.app import _ensure_admin_user
+
+            asyncio.run(_ensure_admin_user(app))
+
+    provider.create_user.assert_called_once()
+    pw = provider.create_user.call_args.kwargs["password"]
+    assert isinstance(pw, str) and len(pw) >= 32
+
+
+def test_bootstrap_env_whitespace_email_falls_through(monkeypatch):
+    """Whitespace-only DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL → treat as unset."""
+    monkeypatch.setenv("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", "   ")
+    provider = _make_provider(admin_count=0)
+    sf = _make_session_factory()
+    app = _make_app_stub()
+
+    with patch("app.gateway.deps.get_local_provider", return_value=provider):
+        with patch("deerflow.persistence.engine.get_session_factory", return_value=sf):
+            from app.gateway.app import _ensure_admin_user
+
+            asyncio.run(_ensure_admin_user(app))
+
+    provider.create_user.assert_not_called()
+
+
+def test_bootstrap_env_create_failure_is_non_fatal(monkeypatch):
+    """provider.create_user raising → log and return, do not crash boot."""
+    monkeypatch.setenv("DEER_FLOW_BOOTSTRAP_ADMIN_EMAIL", "admin@example.com")
+
+    provider = _make_provider(admin_count=0)
+    provider.create_user = AsyncMock(side_effect=RuntimeError("dup email"))
+    sf = _make_session_factory()
+    app = _make_app_stub()
+
+    with patch("app.gateway.deps.get_local_provider", return_value=provider):
+        with patch("deerflow.persistence.engine.get_session_factory", return_value=sf):
+            from app.gateway.app import _ensure_admin_user
+
+            # Must not raise
+            asyncio.run(_ensure_admin_user(app))
+
+    provider.create_user.assert_called_once()
 
 
 # ── Admin exists: migration runs when admin row found ────────────────────

--- a/frontend/src/core/auth/server.ts
+++ b/frontend/src/core/auth/server.ts
@@ -1,9 +1,49 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 import { getGatewayConfig } from "./gateway-config";
 import { type AuthResult, userSchema } from "./types";
 
 const SSR_AUTH_TIMEOUT_MS = 5_000;
+
+// Trust middleware path: when Traefik forward-auth has Authentik-authenticated the
+// request, it injects X-authentik-* headers. The gateway's AuthentikTrustMiddleware
+// mints an access_token cookie on /api/v1/auth/me when these headers are present.
+// SSR forwards them so the user never sees the native /login form post-Authentik.
+type SsoCookieOptions = {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  path?: string;
+  maxAge?: number;
+  expires?: Date;
+};
+
+function parseSetCookie(
+  setCookie: string,
+): { name: string; value: string; options: SsoCookieOptions } | null {
+  const parts = setCookie.split(";").map((p) => p.trim());
+  const [first, ...attrs] = parts;
+  if (!first) return null;
+  const eq = first.indexOf("=");
+  if (eq === -1) return null;
+  const name = first.slice(0, eq);
+  const value = first.slice(eq + 1);
+  const options: SsoCookieOptions = {};
+  for (const attr of attrs) {
+    const [k, v] = attr.split("=").map((s) => s.trim());
+    const key = k?.toLowerCase();
+    if (key === "httponly") options.httpOnly = true;
+    else if (key === "secure") options.secure = true;
+    else if (key === "samesite" && v) {
+      const sv = v.toLowerCase();
+      if (sv === "lax" || sv === "strict" || sv === "none")
+        options.sameSite = sv;
+    } else if (key === "path" && v) options.path = v;
+    else if (key === "max-age" && v) options.maxAge = Number(v);
+    else if (key === "expires" && v) options.expires = new Date(v);
+  }
+  return { name, value, options };
+}
 
 /**
  * Fetch the authenticated user from the gateway using the request's cookies.
@@ -33,6 +73,55 @@ export async function getServerSideUser(): Promise<AuthResult> {
   }
 
   if (!sessionCookie) {
+    // SSO trust path: if Traefik forward-auth proved the user via Authentik, it
+    // injected X-authentik-* headers. Forward them to gateway /api/v1/auth/me;
+    // the AuthentikTrustMiddleware mints an access_token cookie which we relay
+    // back to the browser. User never sees the native /login form.
+    const hdrs = await headers();
+    const auEmail = hdrs.get("x-authentik-email");
+    const auUser = hdrs.get("x-authentik-username");
+    if (auEmail && auUser) {
+      const ssoController = new AbortController();
+      const ssoTimeout = setTimeout(
+        () => ssoController.abort(),
+        SSR_AUTH_TIMEOUT_MS,
+      );
+      try {
+        const ssoRes = await fetch(`${internalGatewayUrl}/api/v1/auth/me`, {
+          headers: {
+            "X-authentik-email": auEmail,
+            "X-authentik-username": auUser,
+          },
+          cache: "no-store",
+          signal: ssoController.signal,
+        });
+        clearTimeout(ssoTimeout);
+        if (ssoRes.ok) {
+          const setCookieHdr = ssoRes.headers.get("set-cookie");
+          if (setCookieHdr) {
+            const parsed = parseSetCookie(setCookieHdr);
+            if (parsed) {
+              cookieStore.set(parsed.name, parsed.value, parsed.options);
+            }
+          }
+          const userParsed = userSchema.safeParse(await ssoRes.json());
+          if (userParsed.success) {
+            if (userParsed.data.needs_setup) {
+              return { tag: "needs_setup", user: userParsed.data };
+            }
+            return { tag: "authenticated", user: userParsed.data };
+          }
+          console.error(
+            "[SSR auth] Malformed /auth/me trust response:",
+            userParsed.error,
+          );
+        }
+      } catch {
+        clearTimeout(ssoTimeout);
+        // Trust path unreachable — fall through to native unauthenticated flow.
+      }
+    }
+
     // No session — check whether the system has been initialised yet.
     const setupController = new AbortController();
     const setupTimeout = setTimeout(

--- a/frontend/src/core/auth/server.ts
+++ b/frontend/src/core/auth/server.ts
@@ -101,7 +101,15 @@ export async function getServerSideUser(): Promise<AuthResult> {
           if (setCookieHdr) {
             const parsed = parseSetCookie(setCookieHdr);
             if (parsed) {
-              cookieStore.set(parsed.name, parsed.value, parsed.options);
+              // cookies().set() throws in Server Component context (Next.js 16).
+              // The middleware (src/middleware.ts) relays Set-Cookie on the
+              // forward-auth response — this best-effort set here covers the
+              // Route-Handler / Server-Action callers.
+              try {
+                cookieStore.set(parsed.name, parsed.value, parsed.options);
+              } catch {
+                // Server Component context — middleware handles cookie relay.
+              }
             }
           }
           const userParsed = userSchema.safeParse(await ssoRes.json());
@@ -115,10 +123,12 @@ export async function getServerSideUser(): Promise<AuthResult> {
             "[SSR auth] Malformed /auth/me trust response:",
             userParsed.error,
           );
+        } else {
+          console.error(`[SSR auth] trust /auth/me responded ${ssoRes.status}`);
         }
-      } catch {
+      } catch (err) {
         clearTimeout(ssoTimeout);
-        // Trust path unreachable — fall through to native unauthenticated flow.
+        console.error("[SSR auth] trust path failed:", err);
       }
     }
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,116 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+// Authentik forward-auth trust relay.
+//
+// Traefik runs forward-auth before this app. On authenticated requests it
+// injects X-authentik-* headers. The gateway exposes /api/v1/auth/me which,
+// when those headers are present, mints an access_token cookie via
+// AuthentikTrustMiddleware.
+//
+// In Next.js 16 Server Components, cookies().set() throws — only middleware,
+// Route Handlers and Server Actions can mutate cookies. This middleware does
+// the relay: if X-authentik-* headers arrive with no access_token cookie,
+// fetch /auth/me upstream, copy the Set-Cookie onto the outgoing response.
+// The downstream Server Component then sees a normal access_token cookie.
+
+const SSO_TIMEOUT_MS = 5_000;
+
+export async function middleware(req: NextRequest) {
+  if (req.cookies.has("access_token")) return NextResponse.next();
+
+  const auEmail = req.headers.get("x-authentik-email");
+  const auUser = req.headers.get("x-authentik-username");
+  if (!auEmail || !auUser) return NextResponse.next();
+
+  const internalUrl =
+    process.env.DEER_FLOW_INTERNAL_GATEWAY_BASE_URL?.trim().replace(/\/+$/, "");
+  if (!internalUrl) return NextResponse.next();
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SSO_TIMEOUT_MS);
+  let ssoRes: Response;
+  try {
+    ssoRes = await fetch(`${internalUrl}/api/v1/auth/me`, {
+      headers: {
+        "X-authentik-email": auEmail,
+        "X-authentik-username": auUser,
+      },
+      cache: "no-store",
+      signal: controller.signal,
+    });
+  } catch (err) {
+    clearTimeout(timeout);
+    console.error("[mw trust] gateway fetch failed:", err);
+    return NextResponse.next();
+  }
+  clearTimeout(timeout);
+  if (!ssoRes.ok) {
+    console.error(`[mw trust] /auth/me responded ${ssoRes.status}`);
+    return NextResponse.next();
+  }
+
+  const setCookie = ssoRes.headers.get("set-cookie");
+  if (!setCookie) return NextResponse.next();
+
+  const parsed = parseAccessToken(setCookie);
+  // Forward the cookie on this same request so the downstream Server
+  // Component's cookies().get("access_token") returns the freshly minted
+  // value on the first render (no extra round-trip).
+  const fwdHeaders = new Headers(req.headers);
+  if (parsed) {
+    const existing = fwdHeaders.get("cookie");
+    const cookieLine = `${parsed.name}=${parsed.value}`;
+    fwdHeaders.set(
+      "cookie",
+      existing ? `${existing}; ${cookieLine}` : cookieLine,
+    );
+  }
+  const res = NextResponse.next({ request: { headers: fwdHeaders } });
+  if (parsed) {
+    res.cookies.set(parsed.name, parsed.value, parsed.options);
+  } else {
+    res.headers.append("set-cookie", setCookie);
+  }
+  return res;
+}
+
+type SsoCookieOptions = {
+  httpOnly?: boolean;
+  secure?: boolean;
+  sameSite?: "lax" | "strict" | "none";
+  path?: string;
+  maxAge?: number;
+  expires?: Date;
+};
+
+function parseAccessToken(
+  raw: string,
+): { name: string; value: string; options: SsoCookieOptions } | null {
+  const parts = raw.split(";").map((p) => p.trim());
+  const [first, ...attrs] = parts;
+  if (!first) return null;
+  const eq = first.indexOf("=");
+  if (eq === -1) return null;
+  const name = first.slice(0, eq);
+  if (name !== "access_token") return null;
+  const value = first.slice(eq + 1);
+  const options: SsoCookieOptions = {};
+  for (const attr of attrs) {
+    const [k, v] = attr.split("=").map((s) => s.trim());
+    const key = k?.toLowerCase();
+    if (key === "httponly") options.httpOnly = true;
+    else if (key === "secure") options.secure = true;
+    else if (key === "samesite" && v) {
+      const sv = v.toLowerCase();
+      if (sv === "lax" || sv === "strict" || sv === "none")
+        options.sameSite = sv;
+    } else if (key === "path" && v) options.path = v;
+    else if (key === "max-age" && v) options.maxAge = Number(v);
+    else if (key === "expires" && v) options.expires = new Date(v);
+  }
+  return { name, value, options };
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|api/health|.*\\..*).*)"],
+};


### PR DESCRIPTION
## Summary

Adds opt-in Authentik forward-auth trust middleware enabling SSO login flows without requiring users to re-authenticate inside DeerFlow when Authentik (or any compatible reverse proxy) handles identity.

### How it works

1. **`AuthentikTrustMiddleware`** (`backend/app/gateway/authentik_trust_middleware.py`):
   - Reads `X-authentik-email` / `X-authentik-username` headers injected by Authentik's forward-auth proxy
   - Mints a short-lived local access-token cookie for that identity
   - Auto-creates a local user record on first login (maps SSO identity → DeerFlow user)
   - Mounted before `AuthMiddleware` so the synthesized cookie validates normally — no changes to auth core

2. **Frontend SSR auth check** (`frontend/src/core/auth/server.ts`):
   - Forwards Authentik headers from the incoming SSR request when calling the gateway
   - Falls back to normal cookie auth when headers are absent

3. **Next.js middleware** (`frontend/src/middleware.ts`):
   - Relays the Authentik trust cookie on subsequent client-side navigations

4. **Env-gated admin bootstrap** (`backend/app/gateway/app.py` lifespan hook):
   - Detects first-boot with SSO enabled and logs guidance instead of blocking startup
   - Runs orphan thread migration only when a local admin already exists

### Configuration

```env
# Enable Authentik forward-auth trust (opt-in, default off)
DEER_FLOW_AUTHENTIK_TRUST_ENABLED=true
```

No changes needed to Authentik itself beyond configuring forward-auth for the DeerFlow service.

### Scope

- **Opt-in only** — `DEER_FLOW_AUTHENTIK_TRUST_ENABLED=false` by default; standard username/password auth unaffected
- Authentik is the reference implementation but the header contract (`X-authentik-email`, `X-authentik-username`) is compatible with other forward-auth proxies (Authelia, Vouch, etc.)
- No new dependencies

## Files changed

| File | Change |
|------|--------|
| `backend/app/gateway/authentik_trust_middleware.py` | New — trust middleware (152 lines) |
| `backend/app/gateway/app.py` | Wire middleware, env-gated admin bootstrap |
| `frontend/src/core/auth/server.ts` | Forward Authentik headers in SSR |
| `frontend/src/middleware.ts` | New — relay trust cookie |
| `backend/tests/test_ensure_admin.py` | New — admin bootstrap unit tests |
| `.github/workflows/*.yml` | SHA-pin GH Actions (security hardening) |

## Test plan

- [ ] Unit tests: `backend/tests/test_ensure_admin.py` covers admin bootstrap logic
- [ ] `DEER_FLOW_AUTHENTIK_TRUST_ENABLED=false` (default) — no behavioral change, existing auth tests pass
- [ ] `DEER_FLOW_AUTHENTIK_TRUST_ENABLED=true` with valid `X-authentik-email` header → auto-login without password prompt
- [ ] First-boot with SSO enabled → guidance logged, no crash
- [ ] Orphan thread migration runs only when admin already exists