### PR TITLE
fix(threads): prevent stream clear when creating new thread mid-stream

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -213,7 +213,11 @@ export function useThreadStream({
       listeners.current.onStart?.(_threadId, _runId);
       startedRef.current = true;
     }
-    setOnStreamThreadId(_threadId);
+    // Do NOT set onStreamThreadId here — the parent's onStart callback already
+    // calls setThreadId + setIsNewThread, which triggers a re-render with the
+    // new threadId prop.  Updating onStreamThreadId mid-stream would change the
+    // threadId passed to useStreamLGP, causing its internal useEffect to call
+    // stream.clear() and abort the active SSE connection.
   }, []);
 
   const queryClient = useQueryClient();


### PR DESCRIPTION
 ## Summary

  Fixes a bug where AI output is deleted and regenerated mid-stream with token counts reset.
 Reproduced with DeepSeek V4 API in pro mode. The root cause is a race condition in the LangGraph SDK's threadId   handling that can affect any model when streaming to a new thread, but the longer thinking cycles in pro mode make it much more likely to trigger.
  When submitting to a new thread, `handleStreamStart` was calling `setOnStreamThreadId` with the
  newly created thread ID. This changed the `threadId` prop passed to `useStreamLGP`, causing its
  internal `useEffect` to detect a threadId change and call `stream.clear()`, which:

  1. Aborted the active SSE connection
  2. Cleared all accumulated messages
  3. Reset isLoading

  The reconnect mechanism then rejoined the stream, but all previously received chunks were lost,
  causing output to appear deleted and regenerated from scratch.

  ## Root Cause

  `useStreamLGP` uses the `threadId` option as a signal to switch threads. Any change triggers
  `stream.clear()`. For new threads, the threadId starts as `null` and was being updated to the
  real ID mid-stream via the `onCreated` callback.

  ## Fix

  Remove `setOnStreamThreadId` from `handleStreamStart`. The parent's `onStart` callback already
  calls `setThreadId + setIsNewThread`, which triggers a re-render with the new threadId prop.
  This update goes through React's effect queue rather than firing synchronously from the
  `onCreated` callback, avoiding the `stream.clear()` race condition.

  ## Test Plan

  1. Start a new thread in "pro" mode
  2. Send a message
  3. Verify output streams continuously without deleting and regenerating