### PR TITLE
fix(journal): preserve partial AI response on run interruption (#3036)

### DIFF
--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -92,6 +92,10 @@ class RunJournal(BaseCallbackHandler):
         # Latency tracking
         self._llm_start_times: dict[str, float] = {}  # langchain run_id -> start time
 
+        # Message IDs that completed normally via on_llm_end.
+        # Used by record_partial_ai_message() to avoid duplicating already-recorded messages.
+        self._completed_message_ids: set[str] = set()
+
         # LLM request/response tracking
         self._llm_call_index = 0
         self._seen_llm_starts: set[str] = set()  # langchain run_ids that fired on_chat_model_start
@@ -320,6 +324,10 @@ class RunJournal(BaseCallbackHandler):
 
         if messages:
             self._counted_message_llm_run_ids.add(str(run_id))
+            for message in messages:
+                msg_id = getattr(message, "id", None)
+                if msg_id:
+                    self._completed_message_ids.add(msg_id)
 
     def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
         self._llm_start_times.pop(str(run_id), None)
@@ -494,6 +502,25 @@ class RunJournal(BaseCallbackHandler):
             event_type=f"middleware:{tag}",
             category="middleware",
             content={"name": name, "hook": hook, "action": action, "changes": changes},
+        )
+
+    def record_partial_ai_message(self, msg_id: str | None, content: str, *, caller: str = "lead_agent") -> None:
+        """Write a partial AI message for a run that was interrupted before the LLM finished.
+
+        Skips silently if content is empty or if msg_id was already recorded as a
+        completed message by on_llm_end (prevents double-writing on the rare race
+        where the LLM finishes just as abort is detected).
+        """
+        if not content:
+            return
+        if msg_id and msg_id in self._completed_message_ids:
+            return
+        partial_msg = AIMessage(content=content, id=msg_id) if msg_id else AIMessage(content=content)
+        self._put(
+            event_type="llm.ai.partial",
+            category="message",
+            content=partial_msg.model_dump(),
+            metadata={"caller": caller, "partial": True},
         )
 
     async def flush(self) -> None:

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -153,6 +153,7 @@ async def run_agent(
     llm_error_fallback_message: str | None = None
 
     journal = None
+    partial_ai_content: dict[str, list[str]] = {}
 
     # Track whether "events" was requested but skipped
     if "events" in requested_modes:
@@ -305,6 +306,11 @@ async def run_agent(
 
         logger.info("Run %s: streaming with modes %s (requested: %s)", run_id, lg_modes, requested_modes)
 
+        # Accumulate AIMessageChunk content per message-id for partial-response capture.
+        # Only populated when "messages" mode is in the stream — the same path that feeds
+        # the SSE bridge, so the IDs here are identical to what the frontend already saw.
+        partial_ai_content: dict[str, list[str]] = {}
+
         # 7. Stream using graph.astream
         if len(lg_modes) == 1 and not stream_subgraphs:
             # Single mode, no subgraphs: astream yields raw chunks
@@ -314,6 +320,7 @@ async def run_agent(
                     logger.info("Run %s abort requested — stopping", run_id)
                     break
                 llm_error_fallback_message = llm_error_fallback_message or _extract_llm_error_fallback_message(chunk)
+                _accumulate_ai_chunk(single_mode, chunk, partial_ai_content)
                 sse_event = _lg_mode_to_sse_event(single_mode)
                 await bridge.publish(run_id, sse_event, serialize(chunk, mode=single_mode))
         else:
@@ -333,6 +340,7 @@ async def run_agent(
                     continue
 
                 llm_error_fallback_message = llm_error_fallback_message or _extract_llm_error_fallback_message(chunk)
+                _accumulate_ai_chunk(mode, chunk, partial_ai_content)
                 sse_event = _lg_mode_to_sse_event(mode)
                 await bridge.publish(run_id, sse_event, serialize(chunk, mode=mode))
 
@@ -400,6 +408,12 @@ async def run_agent(
     finally:
         # Flush any buffered journal events and persist completion data
         if journal is not None:
+            if record.status == RunStatus.interrupted and partial_ai_content:
+                try:
+                    for msg_id, tokens in partial_ai_content.items():
+                        journal.record_partial_ai_message(msg_id, "".join(tokens))
+                except Exception:
+                    logger.warning("Failed to record partial AI messages for run %s", run_id, exc_info=True)
             try:
                 await journal.flush()
             except Exception:
@@ -549,6 +563,30 @@ async def _rollback_to_pre_run_checkpoint(
 def _new_checkpoint_marker() -> dict[str, str]:
     marker = empty_checkpoint()
     return {"id": marker["id"], "ts": marker["ts"]}
+
+
+def _accumulate_ai_chunk(mode: str, chunk: Any, target: dict[str, list[str]]) -> None:
+    """Extract text from an AIMessageChunk and append it to *target* keyed by message id.
+
+    Only operates on "messages" mode events — the same events published to the SSE
+    bridge, so the message ids here match exactly what the frontend already received.
+    No-ops for all other modes or chunk types.
+    """
+    if mode != "messages":
+        return
+    if not isinstance(chunk, tuple) or len(chunk) != 2:
+        return
+    from langchain_core.messages import AIMessageChunk
+
+    msg_chunk, _ = chunk
+    if not isinstance(msg_chunk, AIMessageChunk):
+        return
+    msg_id = msg_chunk.id
+    if not msg_id:
+        return
+    content = msg_chunk.content if isinstance(msg_chunk.content, str) else ""
+    if content:
+        target.setdefault(msg_id, []).append(content)
 
 
 def _lg_mode_to_sse_event(mode: str) -> str:

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -306,11 +306,6 @@ async def run_agent(
 
         logger.info("Run %s: streaming with modes %s (requested: %s)", run_id, lg_modes, requested_modes)
 
-        # Accumulate AIMessageChunk content per message-id for partial-response capture.
-        # Only populated when "messages" mode is in the stream — the same path that feeds
-        # the SSE bridge, so the IDs here are identical to what the frontend already saw.
-        partial_ai_content: dict[str, list[str]] = {}
-
         # 7. Stream using graph.astream
         if len(lg_modes) == 1 and not stream_subgraphs:
             # Single mode, no subgraphs: astream yields raw chunks

--- a/backend/tests/test_run_journal_partial.py
+++ b/backend/tests/test_run_journal_partial.py
@@ -1,0 +1,218 @@
+"""Tests for partial AI message capture on run interruption.
+
+Covers:
+- RunJournal.record_partial_ai_message: skips empty, skips completed, preserves ID
+- RunJournal._completed_message_ids tracking via on_llm_end
+- _accumulate_ai_chunk helper in worker module
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from langchain_core.messages import AIMessageChunk
+
+from deerflow.runtime.events.store.memory import MemoryRunEventStore
+from deerflow.runtime.journal import RunJournal
+from deerflow.runtime.runs.worker import _accumulate_ai_chunk
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def store():
+    return MemoryRunEventStore()
+
+
+@pytest.fixture
+def journal(store):
+    return RunJournal("r1", "t1", store, flush_threshold=100)
+
+
+def _make_llm_response(content="Hello", msg_id: str | None = None):
+    msg = MagicMock()
+    msg.type = "ai"
+    msg.content = content
+    msg.id = msg_id or f"msg-{id(msg)}"
+    msg.tool_calls = []
+    msg.invalid_tool_calls = []
+    msg.response_metadata = {}
+    msg.usage_metadata = None
+    msg.additional_kwargs = {}
+    msg.name = None
+    msg.model_dump.return_value = {
+        "content": content,
+        "additional_kwargs": {},
+        "response_metadata": {},
+        "type": "ai",
+        "name": None,
+        "id": msg.id,
+        "tool_calls": [],
+        "invalid_tool_calls": [],
+        "usage_metadata": None,
+    }
+    gen = MagicMock()
+    gen.message = msg
+    response = MagicMock()
+    response.generations = [[gen]]
+    return response, msg.id
+
+
+# ---------------------------------------------------------------------------
+# record_partial_ai_message
+# ---------------------------------------------------------------------------
+
+
+class TestRecordPartialAiMessage:
+    @pytest.mark.anyio
+    async def test_writes_llm_ai_partial_event(self, journal, store):
+        journal.record_partial_ai_message("msg-abc", "Hello world")
+        await journal.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert len(partial) == 1
+        assert partial[0]["category"] == "message"
+        assert partial[0]["content"]["content"] == "Hello world"
+        assert partial[0]["metadata"]["partial"] is True
+
+    @pytest.mark.anyio
+    async def test_preserves_message_id(self, journal, store):
+        journal.record_partial_ai_message("msg-xyz", "partial text")
+        await journal.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert partial[0]["content"]["id"] == "msg-xyz"
+
+    @pytest.mark.anyio
+    async def test_skips_empty_content(self, journal, store):
+        journal.record_partial_ai_message("msg-abc", "")
+        await journal.flush()
+
+        events = await store.list_events("t1", "r1")
+        assert not any(e["event_type"] == "llm.ai.partial" for e in events)
+
+    @pytest.mark.anyio
+    async def test_skips_completed_message(self, journal, store):
+        """If on_llm_end already recorded this message, record_partial must not duplicate it."""
+        response, msg_id = _make_llm_response("complete response", msg_id="msg-done")
+        journal.on_llm_end(response, run_id=uuid4(), tags=["lead_agent"])
+
+        journal.record_partial_ai_message("msg-done", "partial text")
+        await journal.flush()
+
+        events = await store.list_events("t1", "r1")
+        assert not any(e["event_type"] == "llm.ai.partial" for e in events)
+
+    @pytest.mark.anyio
+    async def test_writes_when_msg_id_is_none(self, journal, store):
+        """No ID available (unusual) — should still write the content."""
+        journal.record_partial_ai_message(None, "content without id")
+        await journal.flush()
+
+        events = await store.list_events("t1", "r1")
+        partial = [e for e in events if e["event_type"] == "llm.ai.partial"]
+        assert len(partial) == 1
+
+    @pytest.mark.anyio
+    async def test_included_in_list_messages_by_run(self, journal, store):
+        journal.record_partial_ai_message("msg-abc", "partial")
+        await journal.flush()
+
+        messages = await store.list_messages_by_run("t1", "r1")
+        assert len(messages) == 1
+        assert messages[0]["event_type"] == "llm.ai.partial"
+
+    def test_caller_default_is_lead_agent(self, journal):
+        journal.record_partial_ai_message("msg-abc", "hello")
+        assert journal._buffer[0]["metadata"]["caller"] == "lead_agent"
+
+    def test_caller_can_be_overridden(self, journal):
+        journal.record_partial_ai_message("msg-abc", "hello", caller="subagent:bash")
+        assert journal._buffer[0]["metadata"]["caller"] == "subagent:bash"
+
+
+# ---------------------------------------------------------------------------
+# _completed_message_ids tracking via on_llm_end
+# ---------------------------------------------------------------------------
+
+
+class TestCompletedMessageIdTracking:
+    def test_on_llm_end_records_completed_message_id(self, journal):
+        response, msg_id = _make_llm_response(msg_id="msg-complete")
+        journal.on_llm_end(response, run_id=uuid4(), tags=["lead_agent"])
+        assert "msg-complete" in journal._completed_message_ids
+
+    def test_multiple_llm_ends_accumulate_ids(self, journal):
+        r1, id1 = _make_llm_response(msg_id="msg-1")
+        r2, id2 = _make_llm_response(msg_id="msg-2")
+        journal.on_llm_end(r1, run_id=uuid4(), tags=["lead_agent"])
+        journal.on_llm_end(r2, run_id=uuid4(), tags=["lead_agent"])
+        assert "msg-1" in journal._completed_message_ids
+        assert "msg-2" in journal._completed_message_ids
+
+    def test_message_with_no_id_does_not_crash(self, journal):
+        response, _ = _make_llm_response(msg_id=None)
+        response.generations[0][0].message.id = None
+        # Should not raise
+        journal.on_llm_end(response, run_id=uuid4(), tags=["lead_agent"])
+
+
+# ---------------------------------------------------------------------------
+# _accumulate_ai_chunk worker helper
+# ---------------------------------------------------------------------------
+
+
+class TestAccumulateAiChunk:
+    def _make_chunk(self, content: str, msg_id: str) -> tuple:
+        chunk = AIMessageChunk(content=content, id=msg_id)
+        return (chunk, {"langgraph_node": "agent"})
+
+    def test_accumulates_text_for_message_id(self):
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("messages", self._make_chunk("Hello", "msg-1"), target)
+        _accumulate_ai_chunk("messages", self._make_chunk(" world", "msg-1"), target)
+        assert "".join(target["msg-1"]) == "Hello world"
+
+    def test_ignores_non_messages_mode(self):
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("values", {"messages": []}, target)
+        _accumulate_ai_chunk("updates", {}, target)
+        assert target == {}
+
+    def test_ignores_non_tuple_chunk(self):
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("messages", AIMessageChunk(content="x", id="msg-1"), target)
+        assert target == {}
+
+    def test_ignores_non_ai_message_chunk(self):
+        from langchain_core.messages import HumanMessage
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("messages", (HumanMessage(content="hi"), {}), target)
+        assert target == {}
+
+    def test_ignores_chunk_without_id(self):
+        target: dict[str, list[str]] = {}
+        chunk = AIMessageChunk(content="hello")
+        chunk.id = None
+        _accumulate_ai_chunk("messages", (chunk, {}), target)
+        assert target == {}
+
+    def test_ignores_empty_content(self):
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("messages", self._make_chunk("", "msg-1"), target)
+        assert target == {}
+
+    def test_multiple_messages_tracked_separately(self):
+        target: dict[str, list[str]] = {}
+        _accumulate_ai_chunk("messages", self._make_chunk("A", "msg-1"), target)
+        _accumulate_ai_chunk("messages", self._make_chunk("B", "msg-2"), target)
+        _accumulate_ai_chunk("messages", self._make_chunk("C", "msg-1"), target)
+        assert "".join(target["msg-1"]) == "AC"
+        assert "".join(target["msg-2"]) == "B"

--- a/backend/tests/test_run_journal_partial.py
+++ b/backend/tests/test_run_journal_partial.py
@@ -18,7 +18,6 @@ from deerflow.runtime.events.store.memory import MemoryRunEventStore
 from deerflow.runtime.journal import RunJournal
 from deerflow.runtime.runs.worker import _accumulate_ai_chunk
 
-
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

  Fixes #3036.

  When a user clicks "Stop" mid-generation, `on_llm_end` never fires for
  the in-progress LLM call. `RunJournal` records nothing. After a page
  refresh the partial response is gone.

  ## Root Cause

  The worker stream loop already receives every `(AIMessageChunk, metadata)`
  tuple emitted by LangGraph's `StreamMessagesHandler` — it uses these to
  publish SSE events to the browser. But no code was preserving those chunks
  for the journal on early exit.

  ## Solution

  **Worker (`runs/worker.py`)**
  - Accumulates `AIMessageChunk` content in `partial_ai_content: dict[str, list[str]]`
    keyed by the LangChain-assigned stable message ID.
  - In the `finally` block, when `record.status == RunStatus.interrupted`, calls
    `journal.record_partial_ai_message()` for each accumulated message.
  - New helper `_accumulate_ai_chunk` handles all filtering edge cases.

  **Journal (`runtime/journal.py`)**
  - Adds `_completed_message_ids: set[str]` populated by `on_llm_end` to prevent
    double-writing messages that completed normally just before abort.
  - New `record_partial_ai_message(msg_id, content, *, caller)` writes a
    `llm.ai.partial` event with `category="message"` so it's returned by
    `list_messages_by_run`.

  **Frontend** — no changes needed. `hooks.ts` already calls
  `GET /api/threads/{id}/runs/{rid}/messages` on history load; partial events
  are included automatically. `dedupeMessagesByIdentity` prevents duplicates
  on live sessions.

  ## Tests

  `backend/tests/test_run_journal_partial.py` — 18 new unit tests, all pass:
  - `TestRecordPartialAiMessage` (8): event written, ID preserved, empty skipped,
    completed-ID skipped, None-ID handled, returned by list_messages_by_run, caller override
  - `TestCompletedMessageIdTracking` (3): IDs accumulated, no-ID doesn't crash
  - `TestAccumulateAiChunk` (7): accumulates by ID, filters all edge cases