### PR TITLE
fix(middleware): make tool-call transcript validity explicit

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
@@ -8,6 +8,11 @@ This middleware intercepts the model call to detect and patch such gaps by
 inserting synthetic ToolMessages with an error indicator immediately after the
 AIMessage that made the tool calls, ensuring correct message ordering.
 
+The final normalization step delegates to
+:func:`~deerflow.agents.middlewares.tool_call_transcript.normalize_tool_call_transcript`
+which is a standalone, pure-function validator/normalizer with its own regression
+tests (see ``tests/test_tool_call_transcript.py``, issue #3029).
+
 Note: Uses wrap_model_call instead of before_model to ensure patches are inserted
 at the correct positions (immediately after each dangling AIMessage), not appended
 to the end of the message list as before_model + add_messages reducer would do.
@@ -108,56 +113,54 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
 
         This normalizes model-bound causal order before provider serialization while
         preserving already-valid transcripts unchanged.
+
+        Uses the standalone :func:`normalize_tool_call_transcript` as the final
+        normalization pass, with middleware-specific synthetic content for invalid
+        tool calls.
         """
-        tool_messages_by_id: dict[str, ToolMessage] = {}
-        for msg in messages:
-            if isinstance(msg, ToolMessage):
-                tool_messages_by_id.setdefault(msg.tool_call_id, msg)
+        from deerflow.agents.middlewares.tool_call_transcript import normalize_tool_call_transcript
 
-        tool_call_ids: set[str] = set()
-        for msg in messages:
-            if getattr(msg, "type", None) != "ai":
-                continue
-            for tc in self._message_tool_calls(msg):
-                tc_id = tc.get("id")
-                if tc_id:
-                    tool_call_ids.add(tc_id)
+        # First pass: use the standalone normalizer for structural repair.
+        # It handles grouping, adjacency, and inserts generic synthetic messages
+        # for missing results.
+        result = normalize_tool_call_transcript(messages)
 
-        patched: list = []
-        consumed_tool_msg_ids: set[str] = set()
-        patch_count = 0
-        for msg in messages:
-            if isinstance(msg, ToolMessage) and msg.tool_call_id in tool_call_ids:
-                continue
-
-            patched.append(msg)
-            if getattr(msg, "type", None) != "ai":
-                continue
-
-            for tc in self._message_tool_calls(msg):
-                tc_id = tc.get("id")
-                if not tc_id or tc_id in consumed_tool_msg_ids:
-                    continue
-
-                existing_tool_msg = tool_messages_by_id.get(tc_id)
-                if existing_tool_msg is not None:
-                    patched.append(existing_tool_msg)
-                    consumed_tool_msg_ids.add(tc_id)
-                else:
-                    patched.append(
-                        ToolMessage(
-                            content=self._synthetic_tool_message_content(tc),
-                            tool_call_id=tc_id,
-                            name=tc.get("name", "unknown"),
-                            status="error",
-                        )
-                    )
-                    consumed_tool_msg_ids.add(tc_id)
-                    patch_count += 1
-
-        if patched == messages:
+        if result is messages:
             return None
 
+        # Second pass: replace generic synthetic messages with middleware-specific
+        # content for invalid tool calls (better error messages).
+        patched: list = []
+        for msg in result:
+            if (
+                isinstance(msg, ToolMessage)
+                and getattr(msg, "status", None) == "error"
+                and msg.content == "[Tool call was interrupted and did not return a result.]"
+            ):
+                # Check if this corresponds to an invalid tool call from a preceding AI.
+                # Find the AI message that owns this tool_call_id.
+                for candidate in result:
+                    if getattr(candidate, "type", None) != "ai":
+                        continue
+                    for tc in self._message_tool_calls(candidate):
+                        if tc.get("id") == msg.tool_call_id and tc.get("invalid"):
+                            msg = ToolMessage(
+                                content=self._synthetic_tool_message_content(tc),
+                                tool_call_id=msg.tool_call_id,
+                                name=msg.name,
+                                status="error",
+                            )
+                            break
+                    else:
+                        continue
+                    break
+            patched.append(msg)
+
+        patch_count = sum(
+            1
+            for m in patched
+            if isinstance(m, ToolMessage) and getattr(m, "status", None) == "error"
+        )
         if patch_count:
             logger.warning(f"Injecting {patch_count} placeholder ToolMessage(s) for dangling tool calls")
         return patched

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_call_transcript.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_call_transcript.py
@@ -1,0 +1,271 @@
+"""Standalone validator and normalizer for tool-call transcript validity.
+
+Ensures that before a model invocation, the provider-visible transcript satisfies
+the tool-call protocol:
+
+  - Every AIMessage with ``tool_calls`` must be immediately followed by
+    ToolMessages for each tool_call ID.
+  - No non-tool messages between an AIMessage(tool_calls) and its ToolMessages.
+  - Every ToolMessage must have a matching preceding AIMessage(tool_call with
+    same ID).
+  - Multiple tool calls from one AIMessage → multiple ToolMessages in the same
+    block.
+
+These are pure functions — no state, no side effects — making them straightforward
+to test and safe to call from any middleware.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Literal
+
+from langchain_core.messages import AIMessage, BaseMessage, ToolMessage
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+ViolationKind = Literal[
+    "missing_tool_result",
+    "non_adjacent_tool_result",
+    "orphan_tool_message",
+    "non_tool_between_ai_and_tool",
+]
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A single tool-call transcript rule violation."""
+
+    kind: ViolationKind
+    index: int  # position in the original message list
+    detail: str = ""
+
+    def __str__(self) -> str:
+        return f"Violation(kind={self.kind!r}, index={self.index}, detail={self.detail!r})"
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a message list against the tool-call protocol."""
+
+    is_valid: bool
+    violations: list[Violation] = field(default_factory=list)
+
+
+def _collect_ai_tool_call_ids(msg: BaseMessage) -> set[str]:
+    """Return all tool_call IDs declared on an AIMessage (including invalid)."""
+    if getattr(msg, "type", None) != "ai":
+        return set()
+    ids: set[str] = set()
+    for tc in getattr(msg, "tool_calls", None) or []:
+        tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+        if tc_id:
+            ids.add(tc_id)
+    for raw_tc in (getattr(msg, "additional_kwargs", None) or {}).get("tool_calls") or []:
+        if isinstance(raw_tc, dict):
+            tc_id = raw_tc.get("id")
+            if tc_id:
+                ids.add(tc_id)
+    for itc in getattr(msg, "invalid_tool_calls", None) or []:
+        if isinstance(itc, dict):
+            tc_id = itc.get("id")
+            if tc_id:
+                ids.add(tc_id)
+    return ids
+
+
+def validate_tool_call_transcript(messages: list[BaseMessage]) -> ValidationResult:
+    """Validate *messages* against the tool-call protocol.
+
+    Returns a :class:`ValidationResult` with ``is_valid=True`` when the
+    transcript satisfies all rules, and a list of :class:`Violation` objects
+    otherwise.
+    """
+    violations: list[Violation] = []
+
+    # Build a map of tool_call_id → index of the AIMessage that declared it.
+    tool_call_to_ai_idx: dict[str, int] = {}
+    for i, msg in enumerate(messages):
+        for tc_id in _collect_ai_tool_call_ids(msg):
+            tool_call_to_ai_idx[tc_id] = i
+
+    # Track which tool_call_ids have been satisfied (ToolMessage seen after AI).
+    satisfied: set[str] = set()
+    # For each AI message with tool_calls, track if we've started seeing
+    # ToolMessages for it — if so, any non-ToolMessage before all are
+    # satisfied is a non_tool_between violation.
+    ai_started_tool_block: set[int] = set()
+
+    seen_tool_msg_ids: set[str] = set()
+
+    for i, msg in enumerate(messages):
+        if isinstance(msg, ToolMessage):
+            tc_id = msg.tool_call_id
+            seen_tool_msg_ids.add(tc_id)
+
+            if tc_id not in tool_call_to_ai_idx:
+                violations.append(Violation(
+                    kind="orphan_tool_message",
+                    index=i,
+                    detail=f"ToolMessage with tool_call_id={tc_id!r} has no matching AIMessage",
+                ))
+                continue
+
+            ai_idx = tool_call_to_ai_idx[tc_id]
+            # Check adjacency: the ToolMessage must follow the AIMessage with no
+            # non-tool messages in between.
+            if ai_idx not in ai_started_tool_block:
+                # First tool result for this AI — check nothing non-tool between
+                # ai_idx and here.
+                for j in range(ai_idx + 1, i):
+                    if not isinstance(messages[j], ToolMessage):
+                        violations.append(Violation(
+                            kind="non_adjacent_tool_result",
+                            index=i,
+                            detail=f"ToolMessage for tool_call_id={tc_id!r} is non-adjacent to AIMessage at index {ai_idx}",
+                        ))
+                        break
+                ai_started_tool_block.add(ai_idx)
+
+            satisfied.add(tc_id)
+
+        elif getattr(msg, "type", None) == "ai":
+            tc_ids = _collect_ai_tool_call_ids(msg)
+            if tc_ids:
+                # Check if this AI turn's previous tool block is incomplete.
+                pass  # handled below after full scan
+
+    # Check for missing tool results.
+    for tc_id, ai_idx in tool_call_to_ai_idx.items():
+        if tc_id not in satisfied:
+            violations.append(Violation(
+                kind="missing_tool_result",
+                index=ai_idx,
+                detail=f"AIMessage at index {ai_idx} has tool_call_id={tc_id!r} with no ToolMessage",
+            ))
+
+    # Check for non-tool messages between AI(tool_calls) and its ToolMessages.
+    for i, msg in enumerate(messages):
+        if getattr(msg, "type", None) != "ai":
+            continue
+        tc_ids = _collect_ai_tool_call_ids(msg)
+        if not tc_ids:
+            continue
+        # Scan forward: once we see the AI msg, all following msgs must be
+        # ToolMessages until all its tool_call_ids are satisfied.
+        pending = set(tc_ids)
+        j = i + 1
+        while j < len(messages) and pending:
+            m = messages[j]
+            if isinstance(m, ToolMessage):
+                pending.discard(m.tool_call_id)
+            else:
+                # Non-tool message while we still have pending tool results.
+                if pending:
+                    violations.append(Violation(
+                        kind="non_tool_between_ai_and_tool",
+                        index=j,
+                        detail=f"Non-tool message at index {j} interrupts tool results for AIMessage at index {i}",
+                    ))
+                    break
+            j += 1
+
+    is_valid = len(violations) == 0
+    return ValidationResult(is_valid=is_valid, violations=violations)
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def normalize_tool_call_transcript(
+    messages: list[BaseMessage],
+    *,
+    synthetic_content: str = "[Tool call was interrupted and did not return a result.]",
+) -> list[BaseMessage]:
+    """Normalize *messages* to satisfy the tool-call protocol.
+
+    Repair logic:
+
+    - **Missing tool result** → insert a synthetic error ToolMessage.
+    - **Non-adjacent tool result** → move to correct position (immediately
+      after the owning AIMessage).
+    - **Orphan ToolMessage** (no matching AIMessage tool_call) → preserved
+      in its original relative position among non-tool messages.
+    - **Non-tool messages between AIMessage(tool_calls) and ToolMessages** →
+      moved after the ToolMessage block.
+    - **Multiple AI tool-call turns** → each result stays grouped with its
+      own AI turn, preserving order between turns.
+
+    Returns a new list.  The input is not mutated.
+    """
+    # Collect all tool_call_ids declared by AI messages.
+    tool_call_ids: set[str] = set()
+    for msg in messages:
+        for tc_id in _collect_ai_tool_call_ids(msg):
+            tool_call_ids.add(tc_id)
+
+    # Index existing ToolMessages by their tool_call_id (first occurrence wins).
+    tool_messages_by_id: dict[str, ToolMessage] = {}
+    for msg in messages:
+        if isinstance(msg, ToolMessage) and msg.tool_call_id not in tool_messages_by_id:
+            tool_messages_by_id[msg.tool_call_id] = msg
+
+    # Walk through messages, grouping ToolMessages right after their AI turn.
+    result: list[BaseMessage] = []
+    consumed_tool_msg_ids: set[str] = set()
+    synthetic_count = 0
+
+    for msg in messages:
+        # Skip ToolMessages here — they'll be placed right after their AI msg.
+        if isinstance(msg, ToolMessage) and msg.tool_call_id in tool_call_ids:
+            continue
+
+        result.append(msg)
+
+        if getattr(msg, "type", None) != "ai":
+            continue
+
+        tc_ids = _collect_ai_tool_call_ids(msg)
+        if not tc_ids:
+            continue
+
+        # Place ToolMessages for this AI turn right here.
+        for tc_id in tc_ids:
+            if not tc_id:
+                continue
+            if tc_id in consumed_tool_msg_ids:
+                continue
+
+            existing = tool_messages_by_id.get(tc_id)
+            if existing is not None:
+                result.append(existing)
+                consumed_tool_msg_ids.add(tc_id)
+            else:
+                # Insert synthetic error ToolMessage.
+                result.append(ToolMessage(
+                    content=synthetic_content,
+                    tool_call_id=tc_id,
+                    name="unknown",
+                    status="error",
+                ))
+                consumed_tool_msg_ids.add(tc_id)
+                synthetic_count += 1
+
+    if synthetic_count:
+        logger.warning(
+            "normalize_tool_call_transcript: injected %d synthetic ToolMessage(s)",
+            synthetic_count,
+        )
+
+    # If nothing changed, return the original list object to signal no-op.
+    if len(result) == len(messages) and all(a is b for a, b in zip(result, messages)):
+        return messages
+
+    return result

--- a/backend/tests/test_tool_call_transcript.py
+++ b/backend/tests/test_tool_call_transcript.py
@@ -1,0 +1,357 @@
+"""Regression tests for tool-call transcript validation and normalization.
+
+Covers the failure modes described in Issue #3029:
+  - missing tool result
+  - non-adjacent tool result
+  - multiple tool results after one AI tool-call turn
+  - multiple AI tool-call turns — each result stays with its own AI turn
+  - orphan ToolMessage
+  - middleware inserts non-tool messages between AIMessage(tool_calls) and ToolMessages
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, SystemMessage, ToolMessage
+
+from deerflow.agents.middlewares.tool_call_transcript import (
+    Violation,
+    ValidationResult,
+    normalize_tool_call_transcript,
+    validate_tool_call_transcript,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ai(tool_calls: list[dict] | None = None, **kw) -> AIMessage:
+    return AIMessage(content="", tool_calls=tool_calls or [], **kw)
+
+
+def _tc(name: str = "bash", tc_id: str = "call_1") -> dict:
+    return {"name": name, "id": tc_id, "args": {}}
+
+
+def _tool(tc_id: str, name: str = "test_tool", content: str = "result") -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=tc_id, name=name)
+
+
+# ===========================================================================
+# Validation tests
+# ===========================================================================
+
+
+class TestValidateToolCallTranscript:
+    """Tests for validate_tool_call_transcript (pure detection, no repair)."""
+
+    def test_empty_messages_is_valid(self):
+        r = validate_tool_call_transcript([])
+        assert r.is_valid
+        assert r.violations == []
+
+    def test_no_ai_messages_is_valid(self):
+        r = validate_tool_call_transcript([HumanMessage(content="hi")])
+        assert r.is_valid
+
+    def test_ai_without_tool_calls_is_valid(self):
+        r = validate_tool_call_transcript([AIMessage(content="hello")])
+        assert r.is_valid
+
+    def test_all_tool_calls_responded_is_valid(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            _tool("c1", "bash"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert r.is_valid
+
+    def test_missing_tool_result(self):
+        msgs = [_ai([_tc("bash", "c1")])]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "missing_tool_result" in kinds
+
+    def test_non_adjacent_tool_result(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="interruption"),
+            _tool("c1", "bash"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "non_adjacent_tool_result" in kinds
+
+    def test_non_tool_between_ai_and_tool(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="interruption"),
+            _tool("c1", "bash"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "non_tool_between_ai_and_tool" in kinds
+
+    def test_orphan_tool_message(self):
+        msgs = [
+            HumanMessage(content="hi"),
+            _tool("orphan_id", "orphan"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "orphan_tool_message" in kinds
+
+    def test_multiple_tool_calls_all_responded_is_valid(self):
+        msgs = [
+            _ai([_tc("bash", "c1"), _tc("read", "c2")]),
+            _tool("c1", "bash"),
+            _tool("c2", "read"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert r.is_valid
+
+    def test_multiple_ai_turns_each_valid(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            _tool("c1", "bash"),
+            HumanMessage(content="next"),
+            _ai([_tc("read", "c2")]),
+            _tool("c2", "read"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert r.is_valid
+
+    def test_multiple_ai_turns_one_missing_result(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            _tool("c1", "bash"),
+            HumanMessage(content="next"),
+            _ai([_tc("read", "c2")]),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "missing_tool_result" in kinds
+
+    def test_middleware_inserts_system_message_between_ai_and_tool(self):
+        """Simulates middleware injecting a SystemMessage between tool call and result."""
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            SystemMessage(content="middleware note"),
+            _tool("c1", "bash"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert not r.is_valid
+        kinds = {v.kind for v in r.violations}
+        assert "non_tool_between_ai_and_tool" in kinds
+
+
+# ===========================================================================
+# Normalization tests
+# ===========================================================================
+
+
+class TestNormalizeToolCallTranscript:
+    """Tests for normalize_tool_call_transcript (repair)."""
+
+    def test_valid_transcript_unchanged(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            _tool("c1", "bash"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # Should return same object when nothing to fix.
+        assert result is msgs
+
+    def test_empty_returns_empty(self):
+        result = normalize_tool_call_transcript([])
+        assert result == []
+
+    def test_no_ai_returns_same(self):
+        msgs = [HumanMessage(content="hi")]
+        result = normalize_tool_call_transcript(msgs)
+        assert result is msgs
+
+    def test_missing_tool_result_inserts_synthetic(self):
+        msgs = [_ai([_tc("bash", "c1")])]
+        result = normalize_tool_call_transcript(msgs)
+        assert len(result) == 2
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        assert result[1].status == "error"
+
+    def test_missing_tool_result_custom_content(self):
+        msgs = [_ai([_tc("bash", "c1")])]
+        result = normalize_tool_call_transcript(msgs, synthetic_content="custom error")
+        assert result[1].content == "custom error"
+
+    def test_non_adjacent_tool_result_moved(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="interruption"),
+            _tool("c1", "bash"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # ToolMessage should be right after AIMessage, before HumanMessage.
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        assert isinstance(result[2], HumanMessage)
+
+    def test_multiple_tool_results_grouped_after_one_ai_turn(self):
+        msgs = [
+            _ai([_tc("bash", "c1"), _tc("read", "c2")]),
+            HumanMessage(content="interruption"),
+            _tool("c2", "read"),
+            _tool("c1", "bash"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # Both ToolMessages right after AIMessage, then HumanMessage.
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert isinstance(result[2], ToolMessage)
+        assert {result[1].tool_call_id, result[2].tool_call_id} == {"c1", "c2"}
+        assert isinstance(result[3], HumanMessage)
+
+    def test_multiple_ai_turns_each_result_stays_with_own_turn(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="interruption"),
+            _ai([_tc("read", "c2")]),
+            _tool("c1", "bash"),
+            _tool("c2", "read"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # Turn 1: AI + ToolMessage for c1
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        # Then HumanMessage
+        assert isinstance(result[2], HumanMessage)
+        # Turn 2: AI + ToolMessage for c2
+        assert isinstance(result[3], AIMessage)
+        assert isinstance(result[4], ToolMessage)
+        assert result[4].tool_call_id == "c2"
+
+    def test_orphan_tool_message_preserved(self):
+        orphan = _tool("orphan_id", "orphan")
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            orphan,
+            HumanMessage(content="interruption"),
+            _tool("c1", "bash"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # c1 tool message should be right after AI.
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        # Orphan should still be present.
+        assert orphan in result
+
+    def test_middleware_inserts_non_tool_between_ai_and_tool(self):
+        """Simulates middleware inserting SystemMessage between tool call and result."""
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            SystemMessage(content="middleware note"),
+            _tool("c1", "bash"),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        assert isinstance(result[2], SystemMessage)
+
+    def test_mixed_responded_and_missing(self):
+        msgs = [
+            _ai([_tc("bash", "c1"), _tc("read", "c2")]),
+            _tool("c1", "bash"),
+            # c2 is missing
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        tool_msgs = [m for m in result if isinstance(m, ToolMessage)]
+        assert len(tool_msgs) == 2
+        synthetic = [m for m in tool_msgs if getattr(m, "status", None) == "error"]
+        assert len(synthetic) == 1
+        assert synthetic[0].tool_call_id == "c2"
+
+    def test_multiple_missing_results(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="next"),
+            _ai([_tc("read", "c2"), _tc("write", "c3")]),
+        ]
+        result = normalize_tool_call_transcript(msgs)
+        # First AI: synthetic for c1
+        # HumanMessage
+        # Second AI: synthetics for c2, c3
+        assert isinstance(result[0], AIMessage)
+        assert isinstance(result[1], ToolMessage)
+        assert result[1].tool_call_id == "c1"
+        assert isinstance(result[2], HumanMessage)
+        assert isinstance(result[3], AIMessage)
+        assert isinstance(result[4], ToolMessage)
+        assert result[4].tool_call_id == "c2"
+        assert isinstance(result[5], ToolMessage)
+        assert result[5].tool_call_id == "c3"
+
+    def test_no_mutation_of_input(self):
+        original = [
+            _ai([_tc("bash", "c1")]),
+            HumanMessage(content="interruption"),
+            _tool("c1", "bash"),
+        ]
+        import copy
+        snapshot = copy.deepcopy(original)
+        normalize_tool_call_transcript(original)
+        assert original == snapshot
+
+
+# ===========================================================================
+# Round-trip: validate → normalize → validate
+# ===========================================================================
+
+
+class TestRoundTrip:
+    """Verify that normalizing an invalid transcript makes it valid."""
+
+    @pytest.mark.parametrize(
+        "msgs",
+        [
+            # missing result
+            [_ai([_tc("bash", "c1")])],
+            # non-adjacent
+            [_ai([_tc("bash", "c1")]), HumanMessage(content="x"), _tool("c1")],
+            # middleware injection
+            [_ai([_tc("bash", "c1")]), SystemMessage(content="note"), _tool("c1")],
+            # multiple missing
+            [_ai([_tc("bash", "c1")]), _ai([_tc("read", "c2")])],
+        ],
+        ids=["missing", "non-adjacent", "middleware-injection", "multiple-missing"],
+    )
+    def test_normalize_fixes_violations(self, msgs):
+        r1 = validate_tool_call_transcript(msgs)
+        assert not r1.is_valid, f"Expected invalid, got valid: {r1.violations}"
+
+        fixed = normalize_tool_call_transcript(msgs)
+        r2 = validate_tool_call_transcript(fixed)
+        assert r2.is_valid, f"Still invalid after normalization: {r2.violations}"
+
+    def test_already_valid_stays_valid(self):
+        msgs = [
+            _ai([_tc("bash", "c1")]),
+            _tool("c1", "bash"),
+            HumanMessage(content="next"),
+        ]
+        r = validate_tool_call_transcript(msgs)
+        assert r.is_valid
+        fixed = normalize_tool_call_transcript(msgs)
+        assert fixed is msgs  # no-op returns same object
+        r2 = validate_tool_call_transcript(fixed)
+        assert r2.is_valid


### PR DESCRIPTION
Addresses #3029

## Problem

PR #2939 fixed one case of invalid tool-call transcripts being sent to LLM providers, but the broader invariant was not enforced as a standalone, testable contract. Middleware, summarization, interruptions, history replay, and repair logic can all mutate message order, and a transcript can look logically complete inside LangChain state while being invalid for the provider.

## Changes

### New: `tool_call_transcript.py` — standalone validator/normalizer

**`validate_tool_call_transcript(messages)`** — pure function that checks a message list against the tool-call protocol:
- Every AIMessage with `tool_calls` must be followed immediately by ToolMessages for each tool_call ID
- No non-tool messages between an AIMessage(tool_calls) and its ToolMessages
- Every ToolMessage must have a matching preceding AIMessage
- Returns `ValidationResult` with `is_valid` and detailed `Violation` objects

**`normalize_tool_call_transcript(messages)`** — pure function that repairs violations:
- Missing tool result → insert synthetic error ToolMessage
- Non-adjacent tool result → move to correct position
- Orphan ToolMessage → preserved in relative position
- Non-tool messages between AI and ToolMessages → moved after the ToolMessage block
- Multiple AI turns → each result stays grouped with its own AI turn
- Returns same list object when no changes needed (no-op signal)

### Refactored: `DanglingToolCallMiddleware`

Now delegates to `normalize_tool_call_transcript()` as its final normalization pass, then enriches synthetic messages with middleware-specific error content for invalid tool calls. This makes the standalone normalizer the single source of truth for transcript structure.

### Tests: `test_tool_call_transcript.py`

Comprehensive regression tests covering all failure modes:
- Missing tool result
- Non-adjacent tool result
- Multiple tool results after one AI tool-call turn
- Multiple AI tool-call turns — each result stays with its own AI turn
- Orphan ToolMessage
- Middleware inserts non-tool messages between AIMessage(tool_calls) and ToolMessages
- Round-trip: validate → normalize → validate (parametrized)