### PR TITLE
fix: re-defer promoted tools after each model turn (#2968)

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/deferred_tool_filter_middleware.py
@@ -29,6 +29,10 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
     ToolNode still holds all tools (including deferred) for execution routing,
     but the LLM only sees active tool schemas — deferred tools are discoverable
     via tool_search at runtime.
+
+    After each model call, previously promoted tools are re-deferred so they
+    don't stay bound to the model forever (issue #2968). Only tools promoted
+    during the current tool-execution phase are visible to the next model call.
     """
 
     def _filter_tools(self, request: ModelRequest) -> ModelRequest:
@@ -45,6 +49,21 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
             logger.debug(f"Filtered {len(request.tools) - len(active_tools)} deferred tool schema(s) from model binding")
 
         return request.override(tools=active_tools)
+
+    @staticmethod
+    def _reset_promoted() -> None:
+        """Re-defer tools that were promoted in a previous turn (issue #2968).
+
+        Called AFTER each model call so that promoted tools are only visible
+        for the turn immediately following their promotion. Without this,
+        once promoted a tool's schema stays bound to the model forever,
+        continuously consuming context tokens even when no longer needed.
+        """
+        from deerflow.tools.builtins.tool_search import get_deferred_registry
+
+        registry = get_deferred_registry()
+        if registry:
+            registry.reset_promoted()
 
     def _blocked_tool_message(self, request: ToolCallRequest) -> ToolMessage | None:
         from deerflow.tools.builtins.tool_search import get_deferred_registry
@@ -74,7 +93,9 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], ModelResponse],
     ) -> ModelCallResult:
-        return handler(self._filter_tools(request))
+        result = handler(self._filter_tools(request))
+        self._reset_promoted()
+        return result
 
     @override
     def wrap_tool_call(
@@ -93,7 +114,9 @@ class DeferredToolFilterMiddleware(AgentMiddleware[AgentState]):
         request: ModelRequest,
         handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
     ) -> ModelCallResult:
-        return await handler(self._filter_tools(request))
+        result = await handler(self._filter_tools(request))
+        self._reset_promoted()
+        return result
 
     @override
     async def awrap_tool_call(

--- a/backend/packages/harness/deerflow/tools/builtins/tool_search.py
+++ b/backend/packages/harness/deerflow/tools/builtins/tool_search.py
@@ -37,10 +37,19 @@ class DeferredToolEntry:
 
 
 class DeferredToolRegistry:
-    """Registry of deferred tools, searchable by regex pattern."""
+    """Registry of deferred tools, searchable by regex pattern.
+
+    Tools that have been promoted (via tool_search) are moved from
+    ``_entries`` to ``_promoted`` so that the middleware stops filtering
+    them from model binding.  ``reset_promoted()`` moves all promoted
+    tools back to deferred — called by the middleware after each model
+    turn so that unused promoted tools don't stay visible forever
+    (issue #2968).
+    """
 
     def __init__(self):
         self._entries: list[DeferredToolEntry] = []
+        self._promoted: list[DeferredToolEntry] = []
 
     def register(self, tool: BaseTool) -> None:
         self._entries.append(
@@ -52,19 +61,26 @@ class DeferredToolRegistry:
         )
 
     def promote(self, names: set[str]) -> None:
-        """Remove tools from the deferred registry so they pass through the filter.
+        """Move tools from deferred to promoted so they pass through the filter.
 
         Called after tool_search returns a tool's schema — the LLM now knows
         the full definition, so the DeferredToolFilterMiddleware should stop
-        stripping it from bind_tools on subsequent calls.
+        stripping it from bind_tools on subsequent model calls.
+
+        Promoted tools are tracked in ``_promoted`` (not discarded) so that
+        ``reset_promoted()`` can move them back to deferred after the model
+        turn that uses them.
         """
         if not names:
             return
-        before = len(self._entries)
-        self._entries = [e for e in self._entries if e.name not in names]
-        promoted = before - len(self._entries)
-        if promoted:
-            logger.debug(f"Promoted {promoted} tool(s) from deferred to active: {names}")
+        promoted_entries: list[DeferredToolEntry] = []
+        remaining: list[DeferredToolEntry] = []
+        for e in self._entries:
+            (promoted_entries if e.name in names else remaining).append(e)
+        self._entries = remaining
+        self._promoted.extend(promoted_entries)
+        if promoted_entries:
+            logger.debug(f"Promoted {len(promoted_entries)} tool(s) from deferred to active: {names}")
 
     def search(self, query: str) -> list[BaseTool]:
         """Search deferred tools by regex pattern against name + description.
@@ -107,6 +123,25 @@ class DeferredToolRegistry:
 
         scored.sort(key=lambda x: x[0], reverse=True)
         return [entry.tool for _, entry in scored][:MAX_RESULTS]
+
+    def reset_promoted(self) -> None:
+        """Move all promoted tools back to deferred.
+
+        Called by ``DeferredToolFilterMiddleware`` after each model call so
+        that promoted tools are only visible for one turn.  If the agent
+        needs them again it must call ``tool_search`` once more.
+        """
+        if not self._promoted:
+            return
+        count = len(self._promoted)
+        self._entries.extend(self._promoted)
+        self._promoted.clear()
+        logger.debug(f"Re-deferred {count} previously promoted tool(s)")
+
+    @property
+    def promoted_names(self) -> set[str]:
+        """Names of tools that have been promoted (not deferred, not hidden)."""
+        return {e.name for e in self._promoted}
 
     @property
     def entries(self) -> list[DeferredToolEntry]:

--- a/backend/tests/test_tool_search.py
+++ b/backend/tests/test_tool_search.py
@@ -607,3 +607,139 @@ class TestDeferredToolExecutionGate:
         assert result.tool_call_id == "call-1"
         assert "tool_search" in result.content
         assert "github_create_issue" in result.content
+
+
+# ── Issue #2968: Re-deferral of promoted tools after model call ──
+
+
+class TestPromotedToolReDeferral:
+    """Regression tests for issue #2968.
+
+    Once a tool is promoted via tool_search, its schema should only stay
+    visible for the turn immediately following the promotion.  After that
+    turn's model call completes, the middleware re-defers the tool so it
+    stops consuming context tokens in subsequent turns.
+    """
+
+    def test_promote_tracks_promoted_entries(self, registry):
+        """promote() should move entries to _promoted, not discard them."""
+        registry.promote({"github_create_issue"})
+        assert registry.contains("github_create_issue") is False
+        assert "github_create_issue" not in registry.deferred_names
+        assert "github_create_issue" in registry.promoted_names
+        assert len(registry) == 5  # 6 - 1 promoted
+
+    def test_reset_promoted_moves_all_back_to_deferred(self, registry):
+        """reset_promoted() should re-defer all promoted tools."""
+        registry.promote({"github_create_issue", "slack_send_message"})
+        assert len(registry) == 4
+        assert len(registry.promoted_names) == 2
+
+        registry.reset_promoted()
+
+        assert len(registry) == 6  # all back
+        assert registry.contains("github_create_issue") is True
+        assert registry.contains("slack_send_message") is True
+        assert len(registry.promoted_names) == 0
+
+    def test_reset_promoted_empty_is_noop(self, registry):
+        """reset_promoted() with no promoted tools is a no-op."""
+        registry.reset_promoted()  # should not raise
+        assert len(registry) == 6
+
+    def test_search_finds_re_deferred_tools(self, registry):
+        """After reset_promoted(), re-deferred tools are searchable again."""
+        registry.promote({"github_create_issue"})
+        assert registry.search("select:github_create_issue") == []
+
+        registry.reset_promoted()
+        results = registry.search("select:github_create_issue")
+        assert len(results) == 1
+        assert results[0].name == "github_create_issue"
+
+    def test_filter_strips_re_deferred_tools(self, registry):
+        """After reset_promoted(), re-deferred tools are filtered again."""
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        tool_github = _make_mock_tool("github_create_issue", "Create issue")
+        tool_slack = _make_mock_tool("slack_send_message", "Send msg")
+        tool_builtin = _make_mock_tool("tool_search", "Search tools")
+
+        class FakeRequest:
+            def __init__(self, tools):
+                self.tools = tools
+            def override(self, **kwargs):
+                return FakeRequest(kwargs.get("tools", self.tools))
+
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+
+        # Promote github tool
+        registry.promote({"github_create_issue"})
+
+        # Filter: only github is promoted, slack is deferred
+        request = FakeRequest(tools=[tool_github, tool_slack, tool_builtin])
+        filtered = middleware._filter_tools(request)
+        names = {t.name for t in filtered.tools}
+        assert "github_create_issue" in names  # promoted, passes through
+        assert "slack_send_message" not in names  # deferred, stripped
+        assert "tool_search" in names  # not deferred
+
+        # Re-defer
+        registry.reset_promoted()
+
+        # Filter: github is now deferred again
+        request2 = FakeRequest(tools=[tool_github, tool_slack, tool_builtin])
+        filtered2 = middleware._filter_tools(request2)
+        names2 = {t.name for t in filtered2.tools}
+        assert "github_create_issue" not in names2  # re-deferred, stripped
+        assert "slack_send_message" not in names2
+        assert "tool_search" in names2
+
+    def test_promote_after_reset_preserves_entries(self, registry):
+        """Promoting after a reset still works correctly."""
+        registry.promote({"github_create_issue"})
+        registry.reset_promoted()
+        registry.promote({"slack_send_message"})
+
+        assert registry.contains("github_create_issue") is True  # re-deferred
+        assert registry.contains("slack_send_message") is False  # just promoted
+        assert len(registry) == 5
+        assert registry.promoted_names == {"slack_send_message"}
+
+    def test_wrap_model_call_resets_promoted_after_handler(self, registry):
+        """wrap_model_call should re-defer promoted tools after the handler returns."""
+        from deerflow.agents.middlewares.deferred_tool_filter_middleware import DeferredToolFilterMiddleware
+
+        tool_github = _make_mock_tool("github_create_issue", "Create issue")
+        tool_builtin = _make_mock_tool("tool_search", "Search tools")
+
+        class FakeRequest:
+            def __init__(self, tools):
+                self.tools = tools
+            def override(self, **kwargs):
+                return FakeRequest(kwargs.get("tools", self.tools))
+
+        set_deferred_registry(registry)
+        middleware = DeferredToolFilterMiddleware()
+
+        # Simulate: tool_search already promoted github_create_issue
+        registry.promote({"github_create_issue"})
+        assert "github_create_issue" in registry.promoted_names
+
+        # Model call: the handler runs (model sees github_create_issue),
+        # then _reset_promoted() fires.
+        request = FakeRequest(tools=[tool_github, tool_builtin])
+        handler_calls = 0
+
+        def handler(req):
+            nonlocal handler_calls
+            handler_calls += 1
+            return SimpleNamespace(content="model response")
+
+        middleware.wrap_model_call(request, handler)
+
+        # After wrap_model_call returns, promoted tools should be re-deferred
+        assert handler_calls == 1
+        assert "github_create_issue" not in registry.promoted_names
+        assert registry.contains("github_create_issue") is True


### PR DESCRIPTION
## Problem

Once a tool is promoted from deferred to active via `tool_search`, its schema stays bound to the model for **all** subsequent conversation turns, continuously consuming context tokens even when the tool is no longer needed.

**Root cause:** `DeferredToolRegistry.promote()` permanently discards entries from the deferred list. Since `DeferredToolFilterMiddleware._filter_tools()` only strips tools whose names remain in `deferred_names`, promoted tools pass through the filter forever.

## Fix

### `DeferredToolRegistry` (tool_search.py)
- **Track promoted tools** in a separate `_promoted` list instead of discarding them
- **Add `reset_promoted()`** to move all promoted tools back to deferred state
- **Add `promoted_names`** property for introspection

### `DeferredToolFilterMiddleware` (deferred_tool_filter_middleware.py)
- Call `reset_promoted()` **after each model call** (at the end of `wrap_model_call` / `awrap_model_call`)
- This ensures promoted tools are only visible for the turn immediately following their promotion
- Previously promoted but now-unused tools are automatically re-deferred

### Lifecycle per agent step (after fix):
1. `wrap_model_call` → `_filter_tools` strips deferred tools → model generates response
2. `_reset_promoted()` → moves all promoted tools back to deferred
3. Tool execution phase → `tool_search` promotes needed tools
4. Next `wrap_model_call` → only recently-promoted tools pass through the filter
5. After this model call → `_reset_promoted()` re-defers everything again

## Testing
- Added 7 new regression tests in `TestPromotedToolReDeferral` class:
  - `test_promote_tracks_promoted_entries` — verify promoted entries are tracked, not discarded
  - `test_reset_promoted_moves_all_back_to_deferred` — verify full re-deferral
  - `test_reset_promoted_empty_is_noop` — no-op when nothing promoted
  - `test_search_finds_re_deferred_tools` — re-deferred tools become searchable again
  - `test_filter_strips_re_deferred_tools` — middleware correctly strips re-deferred tools
  - `test_promote_after_reset_preserves_entries` — promote→reset→promote cycle works correctly
  - `test_wrap_model_call_resets_promoted_after_handler` — end-to-end middleware integration test
- All 59 existing tests continue to pass (including #2884 regression tests)

Closes #2968