### PR TITLE
fix(frontend): surface backend detail when agent name check fails

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -150,16 +150,20 @@ export default function NewAgentPage() {
         err instanceof AgentNameCheckError &&
         err.reason === "request_failed"
       ) {
-        // Surface the backend-provided detail (e.g. validation error) instead
-        // of swallowing it into the generic fallback. Wrap it in a localised
-        // prefix so zh-CN users don't see a bare English string next to the
-        // surrounding Chinese UI. Falls back to the generic fallback when
-        // detail is empty.
+        // Surface the backend-provided detail (e.g. validation error) when
+        // one is present, wrapped in a localised prefix so zh-CN users
+        // don't see a bare English string next to the surrounding Chinese
+        // UI. Falls back to the generic localised fallback when the backend
+        // sent no detail — `err.message` is unreliable for this branch
+        // because `checkAgentName` substitutes a generated fallback string
+        // ("Failed to check agent name: ${statusText}") when `detail` is
+        // missing, so testing `err.message` would always be truthy and the
+        // generated fallback would leak through.
         setNameError(
-          err.message
+          err.detail
             ? t.agents.nameStepCheckErrorWithDetail.replace(
                 "{detail}",
-                err.message,
+                err.detail,
               )
             : t.agents.nameStepCheckError,
         );

--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -151,9 +151,18 @@ export default function NewAgentPage() {
         err.reason === "request_failed"
       ) {
         // Surface the backend-provided detail (e.g. validation error) instead
-        // of swallowing it into the generic fallback. The detail is already
-        // carried as `err.message` by `checkAgentName` in core/agents/api.ts.
-        setNameError(err.message || t.agents.nameStepCheckError);
+        // of swallowing it into the generic fallback. Wrap it in a localised
+        // prefix so zh-CN users don't see a bare English string next to the
+        // surrounding Chinese UI. Falls back to the generic fallback when
+        // detail is empty.
+        setNameError(
+          err.message
+            ? t.agents.nameStepCheckErrorWithDetail.replace(
+                "{detail}",
+                err.message,
+              )
+            : t.agents.nameStepCheckError,
+        );
       } else {
         setNameError(t.agents.nameStepCheckError);
       }
@@ -180,6 +189,7 @@ export default function NewAgentPage() {
     t.agents.nameStepNetworkError,
     t.agents.nameStepBootstrapMessage,
     t.agents.nameStepCheckError,
+    t.agents.nameStepCheckErrorWithDetail,
     t.agents.nameStepInvalidError,
     threadId,
   ]);

--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -146,6 +146,14 @@ export default function NewAgentPage() {
         err.reason === "backend_unreachable"
       ) {
         setNameError(t.agents.nameStepNetworkError);
+      } else if (
+        err instanceof AgentNameCheckError &&
+        err.reason === "request_failed"
+      ) {
+        // Surface the backend-provided detail (e.g. validation error) instead
+        // of swallowing it into the generic fallback. The detail is already
+        // carried as `err.message` by `checkAgentName` in core/agents/api.ts.
+        setNameError(err.message || t.agents.nameStepCheckError);
       } else {
         setNameError(t.agents.nameStepCheckError);
       }

--- a/frontend/src/core/agents/api.ts
+++ b/frontend/src/core/agents/api.ts
@@ -9,6 +9,15 @@ export class AgentNameCheckError extends Error {
   constructor(
     message: string,
     public readonly reason: "backend_unreachable" | "request_failed",
+    /**
+     * Raw backend `detail` string when the failure came from a backend
+     * response carrying one. `null` when no detail was provided (e.g.
+     * network-layer failure, empty response body, unparseable body) — in
+     * which case `message` is a generated fallback like "Failed to check
+     * agent name: Bad Gateway" and the UI should prefer its own localized
+     * fallback instead of surfacing the generated string.
+     */
+    public readonly detail: string | null = null,
   ) {
     super(message);
     this.name = "AgentNameCheckError";
@@ -104,9 +113,11 @@ export async function checkAgentName(
         "backend_unreachable",
       );
     }
+    const backendDetail = typeof err.detail === "string" ? err.detail : null;
     throw new AgentNameCheckError(
-      err.detail ?? `Failed to check agent name: ${res.statusText}`,
+      backendDetail ?? `Failed to check agent name: ${res.statusText}`,
       "request_failed",
+      backendDetail,
     );
   }
   return res.json() as Promise<{ available: boolean; name: string }>;

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -204,6 +204,7 @@ export const enUS: Translations = {
     nameStepNetworkError:
       "Network request failed — check your network or backend connection",
     nameStepCheckError: "Could not verify name availability — please try again",
+    nameStepCheckErrorWithDetail: "Name check failed: {detail}",
     nameStepApiDisabledError:
       "Custom agent management is not enabled on this server. Please contact your administrator.",
     nameStepBootstrapMessage:

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -141,6 +141,7 @@ export interface Translations {
     nameStepAlreadyExistsError: string;
     nameStepNetworkError: string;
     nameStepCheckError: string;
+    nameStepCheckErrorWithDetail: string;
     nameStepApiDisabledError: string;
     nameStepBootstrapMessage: string;
     save: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -192,6 +192,7 @@ export const zhCN: Translations = {
     nameStepAlreadyExistsError: "已存在同名智能体",
     nameStepNetworkError: "网络请求失败，请检查网络或后端连接",
     nameStepCheckError: "无法验证名称可用性，请稍后重试",
+    nameStepCheckErrorWithDetail: "名称校验失败：{detail}",
     nameStepApiDisabledError:
       "服务器未开启自定义智能体管理功能，请联系管理员。",
     nameStepBootstrapMessage:

--- a/frontend/tests/unit/core/agents/api.test.ts
+++ b/frontend/tests/unit/core/agents/api.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for the error-classification behaviour of `checkAgentName`.
+ *
+ * Issue #3041: when the backend returns 422 with a validation detail (e.g.
+ * "Invalid agent name 'deal agent'. Must match ^[A-Za-z0-9-]+$..."), the UI
+ * used to swallow that detail into a generic "Could not verify name
+ * availability" fallback because the page-level catch block only handled
+ * `reason === "backend_unreachable"`. The fix carries the detail through as
+ * `AgentNameCheckError.message`; these tests pin the contract so a future
+ * refactor doesn't silently drop the detail again.
+ */
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/core/api/fetcher", () => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock("@/core/config", () => ({
+  getBackendBaseURL: () => "",
+}));
+
+import { AgentsApiDisabledError, checkAgentName } from "@/core/agents/api";
+import { fetch as fetcher } from "@/core/api/fetcher";
+
+const mockedFetch = vi.mocked(fetcher);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("checkAgentName", () => {
+  test("returns availability payload on 200", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse(200, { available: true, name: "dealagent" }),
+    );
+    const result = await checkAgentName("dealagent");
+    expect(result).toEqual({ available: true, name: "dealagent" });
+  });
+
+  test("treats network-layer fetch rejection as backend_unreachable", async () => {
+    mockedFetch.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    await expect(checkAgentName("dealagent")).rejects.toMatchObject({
+      name: "AgentNameCheckError",
+      reason: "backend_unreachable",
+    });
+  });
+
+  test.each([502, 503, 504])(
+    "treats HTTP %i as backend_unreachable",
+    async (status) => {
+      mockedFetch.mockResolvedValueOnce(
+        jsonResponse(status, { detail: "Bad Gateway" }),
+      );
+      await expect(checkAgentName("dealagent")).rejects.toMatchObject({
+        name: "AgentNameCheckError",
+        reason: "backend_unreachable",
+      });
+    },
+  );
+
+  test("recognises agents_api disabled detail and throws AgentsApiDisabledError", async () => {
+    const detail =
+      "Custom-agent management API is disabled. Set agents_api.enabled=true to expose agent and user-profile routes over HTTP.";
+    mockedFetch.mockResolvedValueOnce(jsonResponse(403, { detail }));
+    await expect(checkAgentName("dealagent")).rejects.toBeInstanceOf(
+      AgentsApiDisabledError,
+    );
+  });
+
+  test("carries backend 422 detail through AgentNameCheckError.message (issue #3041)", async () => {
+    // This is the exact response shape produced by `_validate_agent_name`
+    // when the user submits a name with disallowed characters — e.g. a
+    // trailing space, a dot, a Chinese character, or invisible whitespace
+    // pasted in from another window.
+    const detail =
+      "Invalid agent name 'deal agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).";
+    mockedFetch.mockResolvedValueOnce(jsonResponse(422, { detail }));
+
+    await expect(checkAgentName("deal agent")).rejects.toMatchObject({
+      name: "AgentNameCheckError",
+      reason: "request_failed",
+      // The full detail must be preserved verbatim so the page-level catch
+      // can surface it to the user instead of falling back to a generic
+      // "Could not verify name availability — please try again".
+      message: detail,
+    });
+  });
+
+  test("falls back to statusText when backend returns no detail", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      new Response("", { status: 500, statusText: "Internal Server Error" }),
+    );
+    await expect(checkAgentName("dealagent")).rejects.toMatchObject({
+      name: "AgentNameCheckError",
+      reason: "request_failed",
+      message: expect.stringContaining("Internal Server Error"),
+    });
+  });
+
+  test("does not misclassify a 422 with unrelated detail as agents_api disabled", async () => {
+    // Defence-in-depth: the disabled detector matches on the substring
+    // "agents_api.enabled", so a 422 whose detail accidentally contains
+    // the same substring would be misclassified. The validation detail
+    // produced by `_validate_agent_name` never contains it; this test
+    // simply asserts that "Invalid agent name ..." stays in the
+    // request_failed branch, which is where the page now surfaces it.
+    const detail = "Invalid agent name 'deal.agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).";
+    mockedFetch.mockResolvedValueOnce(jsonResponse(422, { detail }));
+    await expect(checkAgentName("deal.agent")).rejects.not.toBeInstanceOf(
+      AgentsApiDisabledError,
+    );
+  });
+});

--- a/frontend/tests/unit/core/agents/api.test.ts
+++ b/frontend/tests/unit/core/agents/api.test.ts
@@ -1,13 +1,20 @@
 /**
  * Tests for the error-classification behaviour of `checkAgentName`.
  *
- * Issue #3041: when the backend returns 422 with a validation detail (e.g.
- * "Invalid agent name 'deal agent'. Must match ^[A-Za-z0-9-]+$..."), the UI
- * used to swallow that detail into a generic "Could not verify name
- * availability" fallback because the page-level catch block only handled
- * `reason === "backend_unreachable"`. The fix carries the detail through as
- * `AgentNameCheckError.message`; these tests pin the contract so a future
- * refactor doesn't silently drop the detail again.
+ * Issue #3041: when the backend returns a non-200 response (e.g. a 500 with
+ * a database error, a 422 from misbehaving routing, or any other 4xx/5xx
+ * not in the 502/503/504 set), the UI used to swallow the backend detail
+ * into a generic "Could not verify name availability" fallback because the
+ * page-level catch block only handled `reason === "backend_unreachable"`.
+ *
+ * The fix carries the raw backend detail as `AgentNameCheckError.detail`
+ * (distinct from `message`, which always has a non-empty value because
+ * `checkAgentName` substitutes a generated fallback when the backend sent
+ * no detail). The UI uses `detail` to decide whether to surface a real
+ * backend string or fall back to the localised "could not verify" copy.
+ *
+ * These tests pin both halves of the contract so a future refactor doesn't
+ * silently drop the detail or leak the generated fallback into the UI.
  */
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -74,7 +81,7 @@ describe("checkAgentName", () => {
     );
   });
 
-  test("carries backend 422 detail through AgentNameCheckError.message (issue #3041)", async () => {
+  test("carries backend 422 detail through AgentNameCheckError.detail (issue #3041)", async () => {
     // This is the exact response shape produced by `_validate_agent_name`
     // when the user submits a name with disallowed characters — e.g. a
     // trailing space, a dot, a Chinese character, or invisible whitespace
@@ -86,21 +93,42 @@ describe("checkAgentName", () => {
     await expect(checkAgentName("deal agent")).rejects.toMatchObject({
       name: "AgentNameCheckError",
       reason: "request_failed",
-      // The full detail must be preserved verbatim so the page-level catch
-      // can surface it to the user instead of falling back to a generic
-      // "Could not verify name availability — please try again".
+      // The full detail is preserved on both `detail` (for the UI to
+      // recognise "real backend detail vs generated fallback") and
+      // `message` (for stack traces / logs).
+      detail,
       message: detail,
     });
   });
 
-  test("falls back to statusText when backend returns no detail", async () => {
+  test("falls back to statusText in message but leaves detail null when backend returns no detail", async () => {
+    // The fallback message must NOT mask the absence of a real backend
+    // detail — the page-level catch relies on `detail === null` to choose
+    // the localised generic fallback rather than rendering the bare
+    // "Failed to check agent name: Internal Server Error" string.
     mockedFetch.mockResolvedValueOnce(
       new Response("", { status: 500, statusText: "Internal Server Error" }),
     );
     await expect(checkAgentName("dealagent")).rejects.toMatchObject({
       name: "AgentNameCheckError",
       reason: "request_failed",
+      detail: null,
       message: expect.stringContaining("Internal Server Error"),
+    });
+  });
+
+  test("treats non-string detail as null (defence against future schema drift)", async () => {
+    // If the backend ever returns `{detail: {code, message}}` (the shape
+    // used by auth errors today) on this endpoint, we must not surface a
+    // `[object Object]` string. `detail` should fall back to null so the
+    // page uses its localised fallback.
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse(500, { detail: { code: "x", message: "y" } }),
+    );
+    await expect(checkAgentName("dealagent")).rejects.toMatchObject({
+      name: "AgentNameCheckError",
+      reason: "request_failed",
+      detail: null,
     });
   });
 
@@ -111,7 +139,8 @@ describe("checkAgentName", () => {
     // produced by `_validate_agent_name` never contains it; this test
     // simply asserts that "Invalid agent name ..." stays in the
     // request_failed branch, which is where the page now surfaces it.
-    const detail = "Invalid agent name 'deal.agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).";
+    const detail =
+      "Invalid agent name 'deal.agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).";
     mockedFetch.mockResolvedValueOnce(jsonResponse(422, { detail }));
     await expect(checkAgentName("deal.agent")).rejects.not.toBeInstanceOf(
       AgentsApiDisabledError,


### PR DESCRIPTION
## Summary

Closes #3041.

The reporter saw \"Could not verify name availability — please try again\" when entering an agent name on `/workspace/agents/new`. That string is the **generic fallback** of the page's catch block: anything that isn't `AgentsApiDisabledError` or `AgentNameCheckError{reason: \"backend_unreachable\"}` gets swallowed into it. The reason matters less than the fact that the backend already shipped a precise detail to the client and the UI threw it away.

## Reproduction (logged in, against `main`)

```
$ curl -b \"access_token=...\" 'http://localhost:2026/api/agents/check?name=deal%20agent'
HTTP/1.1 422 Unprocessable Entity
{\"detail\":\"Invalid agent name 'deal agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).\"}

$ curl -b \"access_token=...\" 'http://localhost:2026/api/agents/check?name=%E4%B8%AD%E6%96%87'
HTTP/1.1 422 Unprocessable Entity
{\"detail\":\"Invalid agent name '中文'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).\"}

$ curl -b \"access_token=...\" 'http://localhost:2026/api/agents/check?name=deal.agent'
HTTP/1.1 422 Unprocessable Entity
{\"detail\":\"Invalid agent name 'deal.agent'. Must match ^[A-Za-z0-9-]+$ (letters, digits, and hyphens only).\"}
```

Every one of these surfaces in the UI as the same useless \"Could not verify name availability — please try again\". The reporter most likely typed a name that *looked like* `dealagent` but had a trailing space, an invisible character pasted in from another window, or similar — exactly the kind of thing a precise validation message would have caught instantly.

## Root cause

`checkAgentName` in `frontend/src/core/agents/api.ts` already constructs `AgentNameCheckError(err.detail ?? statusText, \"request_failed\")` — so the detail is carried as `err.message`. The page-level catch block in `frontend/src/app/workspace/agents/new/page.tsx:141-152` never reads it:

```typescript
} else if (
  err instanceof AgentNameCheckError &&
  err.reason === \"backend_unreachable\"
) {
  setNameError(t.agents.nameStepNetworkError);
} else {
  setNameError(t.agents.nameStepCheckError);   // <-- request_failed falls through here
}
```

## Change

Add the missing `request_failed` branch, surface `err.message`, fall back to the existing i18n string only when the detail is empty. Four-line UI change, no i18n updates needed because the backend message is already user-actionable.

```typescript
} else if (
  err instanceof AgentNameCheckError &&
  err.reason === \"request_failed\"
) {
  setNameError(err.message || t.agents.nameStepCheckError);
}
```

## Tests

New `frontend/tests/unit/core/agents/api.test.ts` (9 cases) pins the contract so a future refactor doesn't quietly drop the detail again. Covers:

- 200 success returns the availability payload
- network-layer fetch rejection → `backend_unreachable`
- HTTP 502 / 503 / 504 → `backend_unreachable`
- 403 with `agents_api.enabled` detail → `AgentsApiDisabledError`
- **422 validation detail carried verbatim as `AgentNameCheckError.message`** (the issue-specific regression)
- empty detail falls back to statusText
- a 422 with unrelated detail is not misclassified as `AgentsApiDisabledError`

```
$ pnpm exec vitest run tests/unit/core/agents/api.test.ts --reporter=verbose
Test Files  1 passed (1)
     Tests  9 passed (9)
$ pnpm test
Test Files  15 passed (15)
     Tests  61 passed (61)
$ pnpm exec tsc --noEmit
EXIT=0
$ pnpm exec eslint src/app/workspace/agents/new/page.tsx tests/unit/core/agents/api.test.ts
(clean)
```

## Out of scope (deliberate)

- **Backend validation detail i18n** — `_validate_agent_name` raises a plain English string. Translating it is a separate effort. The current PR lets users see the English detail (which is actionable on its own — \"Must match ^[A-Za-z0-9-]+$\" doesn't need translation) instead of the useless generic fallback.
- **`isAgentsApiDisabledDetail` substring matching** — `core/agents/api.ts:25-27` matches on the literal substring `\"agents_api.enabled\"`. This is fragile to backend wording changes. A typed error code on the backend would be safer, but that's a cross-cutting refactor and out of scope here.
- **`/api/agents/{name}` catching every unknown subpath** — FastAPI routes `/api/agents/nonexistent_path` to the `{name}` parameter and returns 422 \"Invalid agent name 'nonexistent_path'...\". Surprising but harmless once the frontend surfaces the detail, since users will see the literal name and realise it isn't what they typed. Worth a separate route order fix but out of scope.

<img width="1594" height="886" alt="image" src="https://github.com/user-attachments/assets/9564ca8a-d35f-4251-8b12-afa30a1282c2" />
<img width="1456" height="876" alt="image" src="https://github.com/user-attachments/assets/d1ad0329-dafe-416a-bb52-389d2a069709" />

## Test plan

- [x] `pnpm test` (vitest)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint`
- [x] Reproduced 422 paths against a real running backend (logged in via `/setup` → `/initialize`) and verified the bare API behaviour matches what unit tests mock
- [ ] CI green