### PR TITLE
fix(gateway): preserve uploaded file metadata in normalize_input

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -85,11 +85,17 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
             if isinstance(msg, dict):
                 role = msg.get("role", msg.get("type", "user"))
                 content = msg.get("content", "")
+                additional_kwargs = msg.get("additional_kwargs")
+                message_kwargs: dict[str, Any] = {}
+                if isinstance(additional_kwargs, dict):
+                    files = additional_kwargs.get("files")
+                    if isinstance(files, list) and files:
+                        message_kwargs["additional_kwargs"] = {"files": files}
                 if role in ("user", "human"):
-                    converted.append(HumanMessage(content=content))
+                    converted.append(HumanMessage(content=content, **message_kwargs))
                 else:
                     # TODO: handle other message types (system, ai, tool)
-                    converted.append(HumanMessage(content=content))
+                    converted.append(HumanMessage(content=content, **message_kwargs))
             else:
                 converted.append(msg)
         return {**raw_input, "messages": converted}

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -74,6 +74,42 @@ def test_normalize_input_with_messages():
     assert result["messages"][0].content == "hi"
 
 
+def test_normalize_input_preserves_files_additional_kwargs():
+    from app.gateway.services import normalize_input
+
+    result = normalize_input(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "hi",
+                    "additional_kwargs": {
+                        "files": [
+                            {
+                                "filename": "report.pdf",
+                                "size": 123,
+                                "path": "/mnt/user-data/uploads/report.pdf",
+                                "status": "uploaded",
+                            }
+                        ],
+                        "tool_calls": [{"name": "get_weather"}],
+                    },
+                }
+            ]
+        }
+    )
+    assert result["messages"][0].additional_kwargs == {
+        "files": [
+            {
+                "filename": "report.pdf",
+                "size": 123,
+                "path": "/mnt/user-data/uploads/report.pdf",
+                "status": "uploaded",
+            }
+        ]
+    }
+
+
 def test_normalize_input_passthrough():
     from app.gateway.services import normalize_input
 


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Gateway LangGraph compatibility layer where frontend-provided uploaded file metadata in `input.messages[*].additional_kwargs.files` was dropped during `normalize_input()`.

As a result, the backend could not reliably detect newly uploaded files from the current human message, which could cause uploaded files to disappear from the message area while a task was running. #2208 #2880

## Changes

- Preserve `additional_kwargs.files` when converting incoming message dicts into `HumanMessage`
- Restrict the passthrough to a whitelist of allowed keys
- Only keep `files` for now to avoid major changes to the processing logic.If other fields also need to be retained, this can be achieved in a similar way, such as tool_calls.
- Add regression tests to verify:
  - uploaded file metadata is preserved
  - non-`files` keys in `additional_kwargs` are dropped
 
## Why

The frontend already submits uploaded file metadata in the run payload, but the Gateway's `normalize_input()` only forwarded `content` and ignored `additional_kwargs`.

