### PR TITLE
fix(frontend): exclude values stream mode to reduce SSE payload by ~75%

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -587,6 +587,7 @@ export function useThreadStream({
             threadId: threadId,
             streamSubgraphs: true,
             streamResumable: true,
+            streamMode: ["messages-tuple", "updates", "custom"],
             config: {
               recursion_limit: 1000,
             },

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -371,8 +371,8 @@ export function useThreadStream({
   const summarizedRef = useRef<Set<string>>(null);
   // Track human message count before sending to prevent clearing optimistic
   // messages before the server's human message arrives (e.g. when AI messages
-  // from "messages-tuple" events arrive before the input human message from
-  // "values" events).
+  // from "messages-tuple" events arrive before the input human message in the
+  // same stream).
   const prevHumanMsgCountRef = useRef(humanMessageCount);
 
   latestMessageCountsRef.current = { humanMessageCount };
@@ -411,8 +411,8 @@ export function useThreadStream({
   // Clear optimistic when server messages arrive.
   // For messages with a human optimistic message, wait until the server's
   // human message has arrived to avoid clearing before the input message
-  // appears in the stream (the input message may arrive via "values" events
-  // after individual "messages-tuple" events for AI messages).
+  // appears in the stream (AI messages-tuple events can arrive before the
+  // human messages-tuple event).
   const optimisticMessageCount = optimisticMessages.length;
   const hasHumanOptimistic = optimisticMessages.some((m) => m.type === "human");
   useEffect(() => {

--- a/frontend/tests/e2e/utils/mock-api.ts
+++ b/frontend/tests/e2e/utils/mock-api.ts
@@ -262,7 +262,7 @@ export function mockLangGraphAPI(page: Page, options?: MockAPIOptions) {
 
 /**
  * Build a minimal SSE stream that the LangGraph SDK can parse.
- * The stream returns a single AI message: "Hello from DeerFlow!".
+ * The stream emits a human echo and a single AI message: "Hello from DeerFlow!".
  */
 export function handleRunStream(route: Route) {
   const events = [
@@ -273,7 +273,11 @@ export function handleRunStream(route: Route) {
     {
       event: "messages",
       data: [
-        { type: "human", id: "msg-human-1", content: [{ type: "text", text: "Hello" }] },
+        {
+          type: "human",
+          id: "msg-human-1",
+          content: [{ type: "text", text: "Hello" }],
+        },
         { langgraph_node: "lead_agent" },
       ],
     },

--- a/frontend/tests/e2e/utils/mock-api.ts
+++ b/frontend/tests/e2e/utils/mock-api.ts
@@ -271,21 +271,18 @@ export function handleRunStream(route: Route) {
       data: { run_id: MOCK_RUN_ID, thread_id: MOCK_THREAD_ID },
     },
     {
-      event: "values",
-      data: {
-        messages: [
-          {
-            type: "human",
-            id: "msg-human-1",
-            content: [{ type: "text", text: "Hello" }],
-          },
-          {
-            type: "ai",
-            id: "msg-ai-1",
-            content: "Hello from DeerFlow!",
-          },
-        ],
-      },
+      event: "messages",
+      data: [
+        { type: "human", id: "msg-human-1", content: [{ type: "text", text: "Hello" }] },
+        { langgraph_node: "lead_agent" },
+      ],
+    },
+    {
+      event: "messages",
+      data: [
+        { type: "ai", id: "msg-ai-1", content: "Hello from DeerFlow!" },
+        { langgraph_node: "lead_agent" },
+      ],
     },
     { event: "end", data: {} },
   ];


### PR DESCRIPTION
## Summary

Closes #2981.

The chat SSE stream was implicitly subscribing to all stream modes, including `values`, which retransmits the **complete message history** as a full state snapshot after every graph step. On a long-running task this accounted for ~74% of transferred bytes.

- **Before:** `values` + `messages-tuple` + `updates` + `custom` — ~6.56 MB per long task
- **After:** `messages-tuple` + `updates` + `custom` only — ~1.64 MB (**~75% reduction**)

`messages-tuple` already delivers every message token-by-token in real time, making the full-snapshot `values` events redundant for the chat UI.

## Changes

| File | Change |
|------|--------|
| `frontend/src/core/threads/hooks.ts` | Add `streamMode: ["messages-tuple", "updates", "custom"]` to `thread.submit()` options |
| `frontend/tests/e2e/utils/mock-api.ts` | Replace `values` snapshot event with individual `messages`-format events (messages-tuple wire format) so E2E mocks match the new subscription |

## Test plan

- [x] `pnpm typecheck` — no errors
- [x] `pnpm test` — 52/52 unit tests pass
- [ ] Manual: send a long-running task in the chat UI and confirm messages still stream correctly
- [ ] Manual: check browser Network tab to confirm `values` events are no longer present in the SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)