### PR TITLE
fix(skills): add scanner_fail_open to avoid skill-evolution DoS on moderation outage

### DIFF
--- a/backend/packages/harness/deerflow/config/skill_evolution_config.py
+++ b/backend/packages/harness/deerflow/config/skill_evolution_config.py
@@ -12,3 +12,11 @@ class SkillEvolutionConfig(BaseModel):
         default=None,
         description="Optional model name for skill security moderation. Defaults to the primary chat model.",
     )
+    scanner_fail_open: bool = Field(
+        default=False,
+        description=(
+            "When True, non-executable skill content is allowed (with a warning) if the moderation model "
+            "is unavailable. Executable content is always blocked when the scanner cannot run. "
+            "Defaults to False (fail-closed: block all content on scanner unavailability)."
+        ),
+    )

--- a/backend/packages/harness/deerflow/skills/security_scanner.py
+++ b/backend/packages/harness/deerflow/skills/security_scanner.py
@@ -104,6 +104,11 @@ async def scan_skill_content(content: str, *, executable: bool = False, location
 
     if model_responded:
         return ScanResult("block", "Security scan produced unparseable output; manual review required.")
+
+    # Model was unreachable. Respect the fail_open config for non-executable content.
     if executable:
         return ScanResult("block", "Security scan unavailable for executable content; manual review required.")
+    cfg = app_config or get_app_config()
+    if cfg.skill_evolution.scanner_fail_open:
+        return ScanResult("warn", "Security scan unavailable; content allowed by fail-open policy.")
     return ScanResult("block", "Security scan unavailable for skill content; manual review required.")

--- a/backend/tests/test_security_scanner.py
+++ b/backend/tests/test_security_scanner.py
@@ -77,7 +77,7 @@ async def test_scan_skill_content_passes_run_name_to_model(monkeypatch):
 
 @pytest.mark.anyio
 async def test_scan_skill_content_blocks_when_model_unavailable(monkeypatch):
-    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=None))
+    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=None, scanner_fail_open=False))
     monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
     monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
 
@@ -139,3 +139,39 @@ async def test_scan_distinguishes_unparseable_executable(monkeypatch):
     # Even for executable content, unparseable uses the unparseable message
     assert result.decision == "block"
     assert "unparseable" in result.reason
+
+
+# --- scanner_fail_open tests ---
+
+
+def _make_unavailable_env(monkeypatch, *, fail_open: bool):
+    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=None, scanner_fail_open=fail_open))
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", lambda **kwargs: (_ for _ in ()).throw(RuntimeError("model down")))
+
+
+@pytest.mark.anyio
+async def test_fail_closed_blocks_non_executable_when_model_down(monkeypatch):
+    """Default fail-closed: non-executable content is blocked when model unavailable."""
+    _make_unavailable_env(monkeypatch, fail_open=False)
+    result = await scan_skill_content(SKILL_CONTENT, executable=False)
+    assert result.decision == "block"
+    assert "unavailable" in result.reason
+
+
+@pytest.mark.anyio
+async def test_fail_open_warns_non_executable_when_model_down(monkeypatch):
+    """fail_open=True: non-executable content is warned (not blocked) when model unavailable."""
+    _make_unavailable_env(monkeypatch, fail_open=True)
+    result = await scan_skill_content(SKILL_CONTENT, executable=False)
+    assert result.decision == "warn"
+    assert "fail-open" in result.reason
+
+
+@pytest.mark.anyio
+async def test_fail_open_still_blocks_executable_when_model_down(monkeypatch):
+    """fail_open=True still blocks executable content — executable is never allowed without scan."""
+    _make_unavailable_env(monkeypatch, fail_open=True)
+    result = await scan_skill_content(SKILL_CONTENT, executable=True)
+    assert result.decision == "block"
+    assert "unavailable" in result.reason


### PR DESCRIPTION
## Summary

Fixes #3021 — when the security moderation model is unavailable, the scanner blocks **all** skill writes (fail-closed), preventing any skill evolution until the model recovers. This is a DoS risk for deployments using the skill-evolution feature.

**Root cause**: the `except Exception` fallback in `scan_skill_content()` blocks every non-executable skill file the same as executable scripts — a conservative but operationally painful default.

**Fix**: add `skill_evolution.scanner_fail_open: bool = false` to config.

| `scanner_fail_open` | Model up | Model down (non-executable) | Model down (executable) |
|---|---|---|---|
| `false` (default) | normal scan | `block` ← unchanged | `block` |
| `true` | normal scan | `warn` ← new | `block` ← always blocked |

Executable content is **always** blocked when the scanner cannot run, regardless of this flag.

**Change**: `+8` lines across 2 source files, `+38` lines of tests.

## Test plan

- [x] `test_fail_closed_blocks_non_executable_when_model_down` — default behaviour preserved
- [x] `test_fail_open_warns_non_executable_when_model_down` — new warn path
- [x] `test_fail_open_still_blocks_executable_when_model_down` — executable always blocked
- [x] All 20 scanner tests pass
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)