### PR TITLE
fix(frontend): use POST form for gateway-unavailable logout to fix 405

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -43,12 +43,14 @@ export default async function WorkspaceLayout({
             >
               Retry
             </Link>
-            <Link
-              href="/api/v1/auth/logout"
-              className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm"
-            >
-              Logout &amp; Reset
-            </Link>
+            <form action="/api/v1/auth/logout" method="POST">
+              <button
+                type="submit"
+                className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm"
+              >
+                Logout &amp; Reset
+              </button>
+            </form>
           </div>
         </div>
       );


### PR DESCRIPTION
## Summary

The "Logout & Reset" recovery link in the `gateway_unavailable` fallback screen sends a `GET` to `/api/v1/auth/logout`, but the backend only defines `POST /api/v1/auth/logout`. This returns `405 Method Not Allowed` instead of clearing the session cookie.

- Replace `<Link href="/api/v1/auth/logout">` with `<form action="/api/v1/auth/logout" method="POST">` and a styled `<button type="submit">`
- The endpoint is already CSRF-exempt (`_AUTH_EXEMPT_PATHS` in `csrf_middleware.py`), so a native form POST is safe
- No backend changes required

Fixes #3001

## Test plan

- [ ] Trigger `gateway_unavailable` state (e.g. stop the backend, navigate to `/workspace`)
- [ ] Click "Logout & Reset" — session cookie should be cleared (no 405)
- [ ] Verify `curl -i -X POST http://localhost:2026/api/v1/auth/logout` returns `200 OK` with `set-cookie: access_token=""; Max-Age=0`
- [ ] Verify button appearance is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)