### PR TITLE
fix(scripts): kill nginx by command line on macOS and release port 2026 on stop

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -79,9 +79,16 @@ stop_all() {
     pkill -f "next-server" 2>/dev/null || true
     nginx -c "$REPO_ROOT/docker/nginx/nginx.local.conf" -p "$REPO_ROOT" -s quit 2>/dev/null || true
     sleep 1
+    # On macOS nginx changes its process title to "nginx: master pr …", which
+    # can prevent exact-name matches.  Kill by full command line first so our
+    # specific instance is found on both Linux and macOS, then fall back to
+    # name-based kill for any remaining nginx processes.
+    pkill -f "nginx.local.conf" 2>/dev/null || true
     pkill -9 nginx 2>/dev/null || true
-    # Force-kill any survivors still holding the service ports
+    # Force-kill any survivors still holding the service ports, including
+    # nginx's unified proxy port :2026 which was previously omitted.
     _kill_port 8001
+    _kill_port 2026
     _kill_port 3000
     ./scripts/cleanup-containers.sh deer-flow-sandbox 2>/dev/null || true
     echo "✓ All services stopped"


### PR DESCRIPTION
## Summary

Two related bugs in `stop_all()` inside `scripts/serve.sh`:

1. **macOS nginx kill failure** — `pkill -9 nginx` matches on process name. On macOS, nginx changes its process title to `nginx: master pr …` / `nginx: worker pr …` via `setproctitle`, which can prevent exact-name matching. Add `pkill -f "nginx.local.conf"` (full command-line match) *before* the name-based fallback so our specific nginx instance is reliably terminated on both macOS and Linux.

2. **Port 2026 not cleaned up** — `_kill_port` cleaned ports 8001 and 3000 but not 2026 (nginx). A stale nginx listener on `:2026` can survive `make stop`. A subsequent `make dev` then reports `✓ Nginx started on localhost:2026` against the stale process while the newly launched nginx fails to bind — leaving the unified endpoint proxying an older config or returning 502.

## Changes

- `scripts/serve.sh` `stop_all()`:
  - Add `pkill -f "nginx.local.conf" 2>/dev/null || true` before `pkill -9 nginx`
  - Add `_kill_port 2026` to the port cleanup sequence

## Test plan

- [ ] macOS: run `make dev`, then `make stop` — verify port 2026 is released (`lsof -i :2026` shows nothing)
- [ ] macOS: run `make dev` twice without stopping in between — second startup should bind nginx cleanly
- [ ] Linux: verify `make stop` behavior unchanged

Fixes #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)