### PR TITLE
fix(frontend): don't redirect /setup to /login on setup-status errors

### DIFF
--- a/frontend/src/app/(auth)/setup/page.tsx
+++ b/frontend/src/app/(auth)/setup/page.tsx
@@ -37,18 +37,27 @@ export default function SetupPage() {
     } else if (!isAuthenticated) {
       // Check if the system has no users yet
       void fetch("/api/v1/auth/setup-status")
-        .then((r) => r.json())
-        .then((data: { needs_setup?: boolean }) => {
+        .then((r) => {
+          // Only treat a successful 200 response as authoritative.
+          // A non-2xx response must not be interpreted as "setup already
+          // done" — return null to stay on the loading screen so the user
+          // can reload and retry.
+          if (!r.ok) return null;
+          return r.json() as Promise<{ needs_setup?: boolean }>;
+        })
+        .then((data) => {
           if (cancelled) return;
-          if (data.needs_setup) {
+          if (data?.needs_setup) {
             setMode("init_admin");
-          } else {
-            // System already set up and user is not logged in — go to login
+          } else if (data != null) {
+            // Explicit 200 with needs_setup: false — system is initialized
             router.push("/login");
           }
+          // data === null means the check returned a non-2xx status;
+          // stay on the loading screen so the user can reload and retry.
         })
         .catch(() => {
-          if (!cancelled) router.push("/login");
+          // Network error — do not redirect to /login; the user can reload.
         });
     } else {
       // Authenticated but needs_setup is false — already set up


### PR DESCRIPTION
## Summary

The first-boot `/setup` page runs a client-side `useEffect` that calls `GET /api/v1/auth/setup-status` to confirm the system has no admin yet. Previously, any non-`{needs_setup: true}` response — including HTTP errors (5xx, 429) and network failures — was treated as "system already initialized" and triggered a redirect to `/login`, making the setup form unreachable.

**Root cause**: the fetch chain called `r.json()` unconditionally and redirected to `/login` when `data.needs_setup` was not `true` (falsy, undefined, or error body). The `.catch()` handler also redirected on network errors.

**Fix**: check `r.ok` before parsing JSON. Only redirect to `/login` when we receive an explicit `200 OK` with `needs_setup: false`. Non-2xx responses and network errors leave the loading screen visible so the user can reload and retry.

Note: the backend was updated in parallel (cache-based `setup-status` instead of per-IP rate limiting) which reduces the likelihood of non-2xx responses, but this frontend fix is a necessary defensive measure for any transient error.

## Changes

- `frontend/src/app/(auth)/setup/page.tsx` — guard the `setup-status` fetch with `r.ok`; only route to `/login` on confirmed `{needs_setup: false}`; do not redirect on errors

## Test plan

- [ ] First boot: visit `/setup` — admin initialization form should appear
- [ ] Simulate a non-2xx from `setup-status` (e.g. mock the endpoint to return 500) — page should stay on loading, not redirect to `/login`
- [ ] Normal flow after setup: visit `/setup` once admin exists — should redirect to `/login` as before

Fixes #2999

🤖 Generated with [Claude Code](https://claude.com/claude-code)