### PR TITLE
fix(frontend): allow unauthenticated access to mock/demo workspace routes

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -13,6 +14,25 @@ export default async function WorkspaceLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   const result = await getServerSideUser();
+
+  // Allow public mock/demo routes (e.g. case-study links with ?mock=true)
+  // through without authentication.  Next.js App Router layouts do not
+  // receive searchParams directly, so middleware.ts injects x-invoke-url.
+  const headersList = await headers();
+  const invokeUrl = headersList.get("x-invoke-url") ?? "";
+  const isMockRequest =
+    invokeUrl !== "" &&
+    new URL(invokeUrl).searchParams.get("mock") === "true";
+  if (
+    isMockRequest &&
+    (result.tag === "unauthenticated" || result.tag === "system_setup_required")
+  ) {
+    return (
+      <AuthProvider initialUser={null}>
+        <WorkspaceContent>{children}</WorkspaceContent>
+      </AuthProvider>
+    );
+  }
 
   switch (result.tag) {
     case "authenticated":

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,17 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+/**
+ * Inject the full request URL as a header so Server Component layouts can
+ * read query parameters (e.g. ?mock=true) that Next.js App Router does not
+ * expose to layout components directly.
+ */
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next();
+  response.headers.set("x-invoke-url", request.nextUrl.toString());
+  return response;
+}
+
+export const config = {
+  matcher: ["/workspace/:path*"],
+};


### PR DESCRIPTION
## Summary

Public Case Study links on the landing page point to `/workspace/chats/[id]?mock=true`. These links are intended to be publicly accessible demos, but the workspace layout's SSR auth guard runs before the page can read the `?mock=true` flag — redirecting unauthenticated visitors to `/login` with a 307 redirect.

**Root cause**: Next.js App Router layout components do not receive `searchParams` (only page components do). `WorkspaceLayout` could not detect `?mock=true` to bypass the auth redirect.

**Fix**:
1. Add `src/middleware.ts` — injects `x-invoke-url` header for `/workspace/*` requests so Server Components can access the full URL including query params
2. In `WorkspaceLayout` — read `x-invoke-url`, check for `mock=true`, and allow unauthenticated requests through by rendering with `AuthProvider(null)` + `WorkspaceContent`. Authenticated users and all non-mock flows are fully unchanged.

## Changes

- `frontend/src/middleware.ts` (new) — lightweight middleware, matcher scoped to `/workspace/:path*` only
- `frontend/src/app/workspace/layout.tsx` — early mock bypass before auth switch

## Test plan

- [ ] Unauthenticated: click a Case Study card on the landing page → mock demo thread should load without redirect to `/login`
- [ ] Unauthenticated: direct visit to `/workspace/chats/7cfa5f8f-a2f8-47ad-acbd-da7137baf990?mock=true` → loads without redirect
- [ ] Authenticated user visiting a mock thread → still works as before (auth result is used normally)
- [ ] Unauthenticated user visiting a non-mock workspace route → still redirects to `/login`

Fixes #3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)