### PR TITLE
fix(config): expand $VAR tokens inside list values in MCP env resolver

### DIFF
--- a/backend/packages/harness/deerflow/config/extensions_config.py
+++ b/backend/packages/harness/deerflow/config/extensions_config.py
@@ -149,6 +149,29 @@ class ExtensionsConfig(BaseModel):
             raise RuntimeError(f"Failed to load extensions config from {resolved_path}: {e}") from e
 
     @classmethod
+    def _resolve_value(cls, value: Any) -> Any:
+        """Resolve a single config value, recursing into dicts and lists.
+
+        - ``str`` starting with ``$`` → resolved via :func:`os.getenv`; unknown
+          variables become the empty string (same policy as the top-level loop).
+        - ``dict`` → recursed via :meth:`resolve_env_variables`.
+        - ``list`` → each element resolved recursively via this method.
+        - All other types are returned unchanged.
+        """
+        if isinstance(value, str):
+            if value.startswith("$"):
+                env_value = os.getenv(value[1:])
+                # Unresolved placeholder → empty string so downstream consumers
+                # (e.g. MCP servers) don't receive the literal "$VAR" token.
+                return env_value if env_value is not None else ""
+            return value
+        if isinstance(value, dict):
+            return cls.resolve_env_variables(value)
+        if isinstance(value, list):
+            return [cls._resolve_value(item) for item in value]
+        return value
+
+    @classmethod
     def resolve_env_variables(cls, config: dict[str, Any]) -> dict[str, Any]:
         """Recursively resolve environment variables in the config.
 
@@ -161,22 +184,7 @@ class ExtensionsConfig(BaseModel):
             The config with environment variables resolved.
         """
         for key, value in config.items():
-            if isinstance(value, str):
-                if value.startswith("$"):
-                    env_value = os.getenv(value[1:])
-                    if env_value is None:
-                        # Unresolved placeholder — store empty string so downstream
-                        # consumers (e.g. MCP servers) don't receive the literal "$VAR"
-                        # token as an actual environment value.
-                        config[key] = ""
-                    else:
-                        config[key] = env_value
-                else:
-                    config[key] = value
-            elif isinstance(value, dict):
-                config[key] = cls.resolve_env_variables(value)
-            elif isinstance(value, list):
-                config[key] = [cls.resolve_env_variables(item) if isinstance(item, dict) else item for item in value]
+            config[key] = cls._resolve_value(value)
         return config
 
     def get_enabled_mcp_servers(self) -> dict[str, McpServerConfig]:

--- a/backend/tests/test_extensions_config_env_resolution.py
+++ b/backend/tests/test_extensions_config_env_resolution.py
@@ -1,0 +1,60 @@
+"""Tests for ExtensionsConfig.resolve_env_variables — list-value expansion."""
+
+import pytest
+
+from deerflow.config.extensions_config import ExtensionsConfig
+
+
+@pytest.fixture(autouse=True)
+def _set_test_env(monkeypatch):
+    monkeypatch.setenv("TEST_TOKEN", "resolved-token")
+    monkeypatch.setenv("TEST_HOST", "example.com")
+
+
+def test_string_in_list_expanded():
+    config = {"args": ["--token", "$TEST_TOKEN"]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["args"] == ["--token", "resolved-token"]
+
+
+def test_plain_string_in_list_unchanged():
+    config = {"args": ["--verbose", "--no-cache"]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["args"] == ["--verbose", "--no-cache"]
+
+
+def test_missing_env_var_in_list_becomes_empty_string(monkeypatch):
+    monkeypatch.delenv("DOES_NOT_EXIST", raising=False)
+    config = {"args": ["--key", "$DOES_NOT_EXIST"]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["args"] == ["--key", ""]
+
+
+def test_dict_inside_list_still_recursed():
+    config = {"items": [{"header": "$TEST_TOKEN"}, {"plain": "value"}]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["items"] == [{"header": "resolved-token"}, {"plain": "value"}]
+
+
+def test_top_level_string_value_expanded():
+    config = {"api_key": "$TEST_TOKEN"}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["api_key"] == "resolved-token"
+
+
+def test_nested_dict_string_expanded():
+    config = {"auth": {"token": "$TEST_TOKEN", "host": "$TEST_HOST"}}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["auth"] == {"token": "resolved-token", "host": "example.com"}
+
+
+def test_mixed_list_with_multiple_vars():
+    config = {"args": ["--host", "$TEST_HOST", "--token", "$TEST_TOKEN", "--debug"]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["args"] == ["--host", "example.com", "--token", "resolved-token", "--debug"]
+
+
+def test_non_string_scalars_in_list_unchanged():
+    config = {"ports": [8080, 9090, True]}
+    result = ExtensionsConfig.resolve_env_variables(config)
+    assert result["ports"] == [8080, 9090, True]


### PR DESCRIPTION
## Summary

`ExtensionsConfig.resolve_env_variables` recursed into dict values and nested dicts inside lists, but left string elements inside lists unexpanded.

An MCP server configured with `args` like `["--token", "$API_TOKEN"]` would receive the literal `"$API_TOKEN"` string instead of the resolved environment variable value, causing startup failures or incorrect runtime behaviour.

## Root cause

`extensions_config.py` line 179 (before this fix):

```python
elif isinstance(value, list):
    config[key] = [cls.resolve_env_variables(item) if isinstance(item, dict) else item for item in value]
```

String items in lists fell through the `else item` branch — no `$VAR` expansion.

## Fix

Extract a private `_resolve_value(cls, value: Any) -> Any` classmethod that handles `str` / `dict` / `list` / scalar uniformly, and use it in both the top-level key loop and list expansion. Existing behaviour for top-level strings and nested dicts is preserved.

## Tests

8 new unit tests in `tests/test_extensions_config_env_resolution.py`:

- `$VAR` in `args` list → resolved to env value
- plain strings in list → unchanged
- missing env var in list → empty string (same policy as top-level)
- dict inside list → still recursed (regression guard)
- top-level string → still resolved (regression guard)
- nested dict → still resolved (regression guard)
- mixed list with multiple vars → all expanded
- non-string scalars in list → unchanged

Closes #2544

🤖 Generated with [Claude Code](https://claude.ai/claude-code)