### PR TITLE
fix(packaging): declare requests as direct deerflow-harness dependency

### DIFF
--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "markitdown[all,xlsx]>=0.0.1a2",
     "pydantic>=2.12.5",
     "pyyaml>=6.0.3",
+    "requests>=2.28.0",
     "readabilipy>=0.3.0",
     "tavily-python>=0.7.17",
     "firecrawl-py>=1.15.0",

--- a/backend/tests/test_checkpointer.py
+++ b/backend/tests/test_checkpointer.py
@@ -101,6 +101,12 @@ class TestHarnessPackaging:
         optional_dependencies = data["project"]["optional-dependencies"]
         assert optional_dependencies["postgres"] == ["deerflow-harness[postgres]"]
 
+    def test_pyproject_declares_requests_dependency(self):
+        pyproject_path = Path(__file__).resolve().parents[1] / "packages" / "harness" / "pyproject.toml"
+        data = tomllib.loads(pyproject_path.read_text())
+        deps = data["project"]["dependencies"]
+        assert any(d.startswith("requests") for d in deps), "requests must be a direct harness dependency"
+
     def test_postgres_missing_dependency_messages_recommend_package_extra(self):
         assert "deerflow-harness[postgres]" in POSTGRES_INSTALL
         assert "deerflow-harness[postgres]" in POSTGRES_STORE_INSTALL


### PR DESCRIPTION
## Summary

`deerflow-harness` imports `requests` in three places but the package is not listed as a direct dependency in `pyproject.toml`. A standalone install can fail at runtime with `ModuleNotFoundError` when those code paths are reached.

## Affected files

| File | Usage |
|------|-------|
| `community/aio_sandbox/backend.py` | `requests.get()` in `wait_for_sandbox_ready()` |
| `community/aio_sandbox/remote_backend.py` | provisioner HTTP API calls |
| `community/infoquest/infoquest_client.py` | InfoQuest search/fetch API calls |

The import currently works in the monorepo because another package happens to pull in `requests` transitively, masking the missing declaration.

## Fix

Add `requests>=2.28.0` to `[project].dependencies` in `backend/packages/harness/pyproject.toml`.

## Test

Added `TestHarnessPackaging::test_pyproject_declares_requests_dependency` alongside the existing `test_pyproject_declares_postgres_extra` — reads `pyproject.toml` via `tomllib` and asserts that at least one dependency starts with `"requests"`.

Closes #2551

🤖 Generated with [Claude Code](https://claude.ai/claude-code)