### PR TITLE
docs(config.example): fix Claude thinking example — add supports_thinking and budget_tokens

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -118,19 +118,25 @@ models:
   # For Docker deployments, use host.docker.internal instead of localhost:
   #   base_url: http://host.docker.internal:11434
 
-  # Example: Anthropic Claude model
-  # - name: claude-3-5-sonnet
-  #   display_name: Claude 3.5 Sonnet
+  # Example: Anthropic Claude model (with extended thinking)
+  # supports_thinking: true is required — without it, DeerFlow silently falls
+  # back to non-thinking mode even when the UI thinking toggle is on.
+  # budget_tokens is required by the Anthropic API when thinking.type=enabled
+  # (no server default; min 1024; must be less than max_tokens).
+  # - name: claude-sonnet-4
+  #   display_name: Claude Sonnet 4
   #   use: langchain_anthropic:ChatAnthropic
-  #   model: claude-3-5-sonnet-20241022
+  #   model: claude-sonnet-4-20250514
   #   api_key: $ANTHROPIC_API_KEY
   #   default_request_timeout: 600.0
   #   max_retries: 2
-  #   max_tokens: 8192
-  #   supports_vision: true  # Enable vision support for view_image tool
+  #   max_tokens: 16000
+  #   supports_vision: true
+  #   supports_thinking: true
   #   when_thinking_enabled:
   #     thinking:
   #       type: enabled
+  #       budget_tokens: 4096   # required; min 1024; must be < max_tokens
   #   when_thinking_disabled:
   #     thinking:
   #       type: disabled


### PR DESCRIPTION
## Summary

The commented Anthropic Claude example in `config.example.yaml` had two silent traps for users:

1. **`supports_thinking: true` was missing.** Without it, `agent.py` silently falls back to non-thinking mode (line 380 logs a warning but does not raise), so a user who copies the block and updates the model name to `claude-sonnet-4` / `claude-opus-4` gets non-thinking behaviour with no obvious error.

2. **`budget_tokens` was absent from `when_thinking_enabled`.** Per the [Anthropic Extended Thinking docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking), `budget_tokens` is required when `thinking.type == "enabled"` — there is no API default. Any user who did add `supports_thinking: true` would immediately hit a runtime API error.

## Changes

- Replace the Claude 3.5 Sonnet example (no thinking) with a Claude Sonnet 4 example that includes:
  - `supports_thinking: true`
  - `budget_tokens: 4096` inside `when_thinking_enabled` with an inline comment explaining the constraint
- Add two short comment lines above the block explaining *why* each field is required.

No code changes — config comments only.

Closes #2336

🤖 Generated with [Claude Code](https://claude.ai/claude-code)