### PR TITLE
chore(windows): add PYTHONIOENCODING and PYTHONUTF8 to backend Makefile targets

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,13 +2,13 @@ install:
 	uv sync
 
 dev:
-	PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload
 
 gateway:
-	PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001
 
 test:
-	PYTHONPATH=. uv run pytest tests/ -v
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -v
 
 lint:
 	uvx ruff check .


### PR DESCRIPTION
## Summary

`langgraph-api` emits `→` and `⚠️` characters in version-check log lines. On Windows with `cp1252` as the default stream encoding, each such line throws a `UnicodeEncodeError` inside the logging handler, littering startup output with tracebacks (though the server still boots).

\#1550 already fixed this for `scripts/check.py` via `stream.reconfigure()`. The backend `Makefile` `dev` / `gateway` / `test` targets launch Python subprocesses via `uv run` without any encoding override, so the fix didn't cover them.

## Fix

Prepend `PYTHONIOENCODING=utf-8 PYTHONUTF8=1` to the `dev`, `gateway`, and `test` targets. Both variables are no-ops on Linux/macOS where UTF-8 is already the default encoding.

## Before / After

```makefile
# before
dev:
    PYTHONPATH=. uv run uvicorn ...

# after
dev:
    PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn ...
```

Closes #2337

🤖 Generated with [Claude Code](https://claude.ai/claude-code)