### PR TITLE
fix(summarization): add nostream tag to suppress stream pollution from summarization LLM calls

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
@@ -110,6 +110,7 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
         **kwargs,
     ) -> None:
         super().__init__(*args, **kwargs)
+        self.model = self.model.with_config(tags=["nostream"])
         self._skills_container_path = skills_container_path or "/mnt/skills"
         self._skill_file_read_tool_names = frozenset(skill_file_read_tool_names or {"read_file", "read", "view", "cat"})
         self._before_summarization_hooks = before_summarization or []

--- a/backend/tests/test_summarization_middleware.py
+++ b/backend/tests/test_summarization_middleware.py
@@ -57,6 +57,7 @@ def _middleware(
 ) -> DeerFlowSummarizationMiddleware:
     model = MagicMock()
     model.invoke.return_value = SimpleNamespace(text="compressed summary")
+    model.with_config.return_value = model
     return DeerFlowSummarizationMiddleware(
         model=model,
         trigger=trigger,
@@ -659,3 +660,22 @@ def test_memory_flush_hook_passes_runtime_user_id(monkeypatch: pytest.MonkeyPatc
 
     queue.add_nowait.assert_called_once()
     assert queue.add_nowait.call_args.kwargs["user_id"] == "alice"
+
+
+def test_model_configured_with_nostream_tag() -> None:
+    """Summarization model gets 'nostream' tag so its tokens are not broadcast to clients."""
+    tagged_model = MagicMock()
+    tagged_model.invoke.return_value = SimpleNamespace(text="compressed summary")
+
+    original_model = MagicMock()
+    original_model.with_config.return_value = tagged_model
+
+    middleware = DeerFlowSummarizationMiddleware(
+        model=original_model,
+        trigger=("messages", 4),
+        keep=("messages", 2),
+        token_counter=len,
+    )
+
+    original_model.with_config.assert_called_once_with(tags=["nostream"])
+    assert middleware.model is tagged_model


### PR DESCRIPTION
## Problem

When summarization is enabled and a delta-streaming model (e.g. DeepSeek V4) is used, every token generated by the summarization LLM call is broadcast through the `messages-tuple` stream to the client. This causes a "ghost AI message" to appear in the frontend mid-conversation, which is confusing and incorrect — the summarization is an internal housekeeping step, not a user-facing response.

## Root Cause

`DeerFlowSummarizationMiddleware` extends LangChain's `SummarizationMiddleware` and holds a reference to the LLM via `self.model`. LangGraph's streaming pipeline emits tokens from every model invocation unless the model is tagged with `"nostream"` (via `langchain_core`'s `with_config(tags=["nostream"])`). The tag was never applied to the summarization model, so its tokens leaked into the stream.

## Fix

Apply the `"nostream"` tag to `self.model` immediately after `super().__init__()` in `DeerFlowSummarizationMiddleware.__init__`:

```python
self.model = self.model.with_config(tags=["nostream"])
```

This is the standard LangGraph opt-out mechanism — it tells the streaming layer to suppress token events from this specific model invocation.

## Tests

- Updated `_middleware` test helper to configure `model.with_config.return_value = model` so existing tests remain stable.
- Added `test_model_configured_with_nostream_tag`: verifies `with_config(tags=["nostream"])` is called during construction and that `middleware.model` holds the tagged instance.
- All 24 existing tests pass unchanged.

## Affected Files

- `backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py` — 1-line fix in `__init__`
- `backend/tests/test_summarization_middleware.py` — updated helper + 1 new test