### PR TITLE
fix(config): preserve extra top-level fields when saving extensions_config.json

### DIFF
--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -145,11 +145,12 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
         # Load current config to preserve skills configuration
         current_config = get_extensions_config()
 
-        # Convert request to dict format for JSON serialization
-        config_data = {
-            "mcpServers": {name: server.model_dump() for name, server in request.mcp_servers.items()},
-            "skills": {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()},
-        }
+        # Convert request to dict format for JSON serialization, preserving any
+        # extra top-level fields (e.g. mcpInterceptors) that are not part of
+        # the typed schema but must survive round-trips through the API.
+        config_data = dict(current_config.model_extra or {})
+        config_data["mcpServers"] = {name: server.model_dump() for name, server in request.mcp_servers.items()}
+        config_data["skills"] = {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()}
 
         # Write the configuration to file
         with open(config_path, "w", encoding="utf-8") as f:

--- a/backend/app/gateway/routers/skills.py
+++ b/backend/app/gateway/routers/skills.py
@@ -324,10 +324,9 @@ async def update_skill(skill_name: str, request: SkillUpdateRequest, config: App
         extensions_config = get_extensions_config()
         extensions_config.skills[skill_name] = SkillStateConfig(enabled=request.enabled)
 
-        config_data = {
-            "mcpServers": {name: server.model_dump() for name, server in extensions_config.mcp_servers.items()},
-            "skills": {name: {"enabled": skill_config.enabled} for name, skill_config in extensions_config.skills.items()},
-        }
+        config_data = dict(extensions_config.model_extra or {})
+        config_data["mcpServers"] = {name: server.model_dump() for name, server in extensions_config.mcp_servers.items()}
+        config_data["skills"] = {name: {"enabled": skill_config.enabled} for name, skill_config in extensions_config.skills.items()}
 
         with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config_data, f, indent=2)

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -924,10 +924,9 @@ class DeerFlowClient:
 
         current_config = get_extensions_config()
 
-        config_data = {
-            "mcpServers": mcp_servers,
-            "skills": {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()},
-        }
+        config_data = dict(current_config.model_extra or {})
+        config_data["mcpServers"] = mcp_servers
+        config_data["skills"] = {name: {"enabled": skill.enabled} for name, skill in current_config.skills.items()}
 
         self._atomic_write_json(config_path, config_data)
 
@@ -990,10 +989,9 @@ class DeerFlowClient:
         extensions_config = get_extensions_config()
         extensions_config.skills[name] = SkillStateConfig(enabled=enabled)
 
-        config_data = {
-            "mcpServers": {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()},
-            "skills": {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()},
-        }
+        config_data = dict(extensions_config.model_extra or {})
+        config_data["mcpServers"] = {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()}
+        config_data["skills"] = {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()}
 
         self._atomic_write_json(config_path, config_data)
 

--- a/backend/tests/test_extensions_extra_fields_preserved.py
+++ b/backend/tests/test_extensions_extra_fields_preserved.py
@@ -1,0 +1,160 @@
+"""Verify that extra top-level fields in extensions_config.json (e.g. mcpInterceptors)
+are preserved when MCP server config or skill state is updated via the API or client.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deerflow.config.extensions_config import ExtensionsConfig, McpServerConfig, SkillStateConfig, reset_extensions_config, set_extensions_config
+
+
+@pytest.fixture(autouse=True)
+def _reset_extensions_config():
+    reset_extensions_config()
+    yield
+    reset_extensions_config()
+
+
+def _make_config_with_interceptors(tmp_path: Path) -> tuple[Path, ExtensionsConfig]:
+    """Write an extensions_config.json with an mcpInterceptors extra field and return its path."""
+    data = {
+        "mcpServers": {
+            "github": {
+                "enabled": True,
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@modelcontextprotocol/server-github"],
+                "env": {},
+                "description": "GitHub MCP",
+            }
+        },
+        "skills": {"my-skill": {"enabled": True}},
+        "mcpInterceptors": ["my_pkg.module:builder"],
+    }
+    config_file = tmp_path / "extensions_config.json"
+    config_file.write_text(json.dumps(data, indent=2))
+    cfg = ExtensionsConfig.from_file(str(config_file))
+    set_extensions_config(cfg)
+    return config_file, cfg
+
+
+class TestMcpRouterPreservesExtraFields:
+    @pytest.mark.anyio
+    async def test_update_mcp_config_preserves_mcp_interceptors(self, tmp_path: Path) -> None:
+        config_file, current_cfg = _make_config_with_interceptors(tmp_path)
+
+        from app.gateway.routers.mcp import McpConfigUpdateRequest, McpServerConfigResponse, update_mcp_configuration
+
+        request = McpConfigUpdateRequest(
+            mcp_servers={
+                "github": McpServerConfigResponse(
+                    enabled=False,
+                    type="stdio",
+                    command="npx",
+                    args=["-y", "@modelcontextprotocol/server-github"],
+                )
+            }
+        )
+
+        with (
+            patch("app.gateway.routers.mcp.ExtensionsConfig.resolve_config_path", return_value=config_file),
+            patch("app.gateway.routers.mcp.get_extensions_config", return_value=current_cfg),
+            patch("app.gateway.routers.mcp.reload_extensions_config", return_value=current_cfg),
+        ):
+            await update_mcp_configuration(request)
+
+        saved = json.loads(config_file.read_text())
+        assert "mcpInterceptors" in saved
+        assert saved["mcpInterceptors"] == ["my_pkg.module:builder"]
+
+
+class TestSkillsRouterPreservesExtraFields:
+    @pytest.mark.anyio
+    async def test_update_skill_preserves_mcp_interceptors(self, tmp_path: Path) -> None:
+        config_file, current_cfg = _make_config_with_interceptors(tmp_path)
+
+        from app.gateway.routers.skills import SkillUpdateRequest, update_skill
+
+        skill_mock = MagicMock()
+        skill_mock.name = "my-skill"
+        skill_mock.description = "A skill"
+        skill_mock.license = "MIT"
+        skill_mock.category = "public"
+        skill_mock.enabled = True
+        skill_mock.tools = []
+        skill_mock.content = ""
+
+        mock_storage = MagicMock()
+        mock_storage.load_skills.return_value = [skill_mock]
+
+        with (
+            patch("app.gateway.routers.skills.ExtensionsConfig.resolve_config_path", return_value=config_file),
+            patch("app.gateway.routers.skills.get_extensions_config", return_value=current_cfg),
+            patch("app.gateway.routers.skills.reload_extensions_config", return_value=current_cfg),
+            patch("app.gateway.routers.skills.refresh_skills_system_prompt_cache_async", new_callable=AsyncMock),
+            patch("app.gateway.routers.skills.get_or_new_skill_storage", return_value=mock_storage),
+        ):
+            await update_skill("my-skill", SkillUpdateRequest(enabled=False), config=MagicMock())
+
+        saved = json.loads(config_file.read_text())
+        assert "mcpInterceptors" in saved
+        assert saved["mcpInterceptors"] == ["my_pkg.module:builder"]
+
+
+class TestClientPreservesExtraFields:
+    def test_update_mcp_config_preserves_mcp_interceptors(self, tmp_path: Path) -> None:
+        config_file, current_cfg = _make_config_with_interceptors(tmp_path)
+
+        from deerflow.client import DeerFlowClient
+
+        client = DeerFlowClient.__new__(DeerFlowClient)
+        client._agent = None
+        client._agent_config_key = None
+
+        with (
+            patch("deerflow.client.ExtensionsConfig.resolve_config_path", return_value=config_file),
+            patch("deerflow.client.get_extensions_config", return_value=current_cfg),
+            patch("deerflow.client.reload_extensions_config", return_value=current_cfg),
+        ):
+            client.update_mcp_config({"github": {"enabled": False, "type": "stdio", "command": "npx"}})
+
+        saved = json.loads(config_file.read_text())
+        assert "mcpInterceptors" in saved
+        assert saved["mcpInterceptors"] == ["my_pkg.module:builder"]
+
+    def test_update_skill_preserves_mcp_interceptors(self, tmp_path: Path) -> None:
+        config_file, current_cfg = _make_config_with_interceptors(tmp_path)
+        current_cfg.skills["my-skill"] = SkillStateConfig(enabled=True)
+
+        from deerflow.client import DeerFlowClient
+
+        client = DeerFlowClient.__new__(DeerFlowClient)
+        client._agent = None
+        client._agent_config_key = None
+
+        skill_mock = MagicMock()
+        skill_mock.name = "my-skill"
+        skill_mock.description = "A skill"
+        skill_mock.license = "MIT"
+        skill_mock.category = "public"
+        skill_mock.enabled = False
+
+        mock_storage = MagicMock()
+        mock_storage.load_skills.return_value = [skill_mock]
+
+        with (
+            patch("deerflow.client.ExtensionsConfig.resolve_config_path", return_value=config_file),
+            patch("deerflow.client.get_extensions_config", return_value=current_cfg),
+            patch("deerflow.client.reload_extensions_config", return_value=current_cfg),
+            patch("deerflow.skills.storage.get_or_new_skill_storage", return_value=mock_storage),
+        ):
+            client.update_skill("my-skill", enabled=False)
+
+        saved = json.loads(config_file.read_text())
+        assert "mcpInterceptors" in saved
+        assert saved["mcpInterceptors"] == ["my_pkg.module:builder"]


### PR DESCRIPTION
## Problem

Closes #2886

When a user updates MCP servers or skill states via:
- `PUT /api/mcp/config` (Gateway API)
- `PUT /api/skills/{name}` (Gateway API)
- `DeerFlowClient.update_mcp_config()` (embedded client)
- `DeerFlowClient.update_skill()` (embedded client)

...the write rebuilds `extensions_config.json` from only the typed schema fields (`mcpServers`, `skills`). Any extra top-level key present in the file — such as `mcpInterceptors` — is **silently dropped** on every save.

## Root Cause

All four write paths built `config_data` as a literal dict containing only the two known keys:

```python
config_data = {
    "mcpServers": {...},
    "skills": {...},
}
```

`ExtensionsConfig` is a Pydantic model with `extra="allow"`, so unknown fields like `mcpInterceptors` are stored in `model_extra` — but none of the write paths ever consulted `model_extra`.

## Fix

Seed `config_data` from `model_extra` before overlaying the known fields, so any extra keys survive round-trips through the API:

```python
config_data = dict(current_config.model_extra or {})
config_data["mcpServers"] = {...}
config_data["skills"] = {...}
```

Applied consistently across all four write paths.

## Files Changed

| File | Change |
|------|--------|
| `app/gateway/routers/mcp.py` | `update_mcp_configuration` — seed from `model_extra` |
| `app/gateway/routers/skills.py` | `update_skill` — seed from `model_extra` |
| `packages/harness/deerflow/client.py` | `update_mcp_config` + `update_skill` — seed from `model_extra` |
| `tests/test_extensions_extra_fields_preserved.py` | 4 new tests (one per write path) |

## Tests

Added `tests/test_extensions_extra_fields_preserved.py` — 4 tests, one per write path, each writing an `extensions_config.json` with `mcpInterceptors` and verifying the field survives after an update. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)