### PR TITLE
fix(harness): handle AsyncCallbackManager in _find_usage_recorder

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -108,6 +108,12 @@ def _find_usage_recorder(runtime: Any) -> Any | None:
     callbacks = config.get("callbacks", [])
     if not callbacks:
         return None
+    # LangChain may pass a CallbackManager object rather than a plain list;
+    # extract the concrete handler list so the for-loop below never raises TypeError.
+    if hasattr(callbacks, "handlers"):
+        callbacks = callbacks.handlers
+    if not isinstance(callbacks, (list, tuple)):
+        return None
     for cb in callbacks:
         if hasattr(cb, "record_external_llm_usage_records"):
             return cb

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -1285,3 +1285,60 @@ def test_subagent_usage_cache_is_cleared_when_polling_raises(monkeypatch):
         )
 
     assert task_tool_module.pop_cached_subagent_usage("tc-error") is None
+
+
+class TestFindUsageRecorder:
+    """_find_usage_recorder must not crash when callbacks is a CallbackManager."""
+
+    _fn = staticmethod(task_tool_module._find_usage_recorder)
+
+    def _make_runtime(self, callbacks):
+        return SimpleNamespace(config={"callbacks": callbacks})
+
+    def _recorder(self):
+        # SimpleNamespace so hasattr only returns True for explicitly set attributes.
+        return SimpleNamespace(record_external_llm_usage_records=MagicMock())
+
+    def _plain_handler(self):
+        # No record_external_llm_usage_records attribute → hasattr returns False.
+        return SimpleNamespace()
+
+    def test_returns_none_when_runtime_is_none(self):
+        assert self._fn(None) is None
+
+    def test_returns_none_when_config_not_dict(self):
+        runtime = SimpleNamespace(config="not-a-dict")
+        assert self._fn(runtime) is None
+
+    def test_returns_none_when_callbacks_empty_list(self):
+        assert self._fn(self._make_runtime([])) is None
+
+    def test_finds_recorder_in_plain_list(self):
+        recorder = self._recorder()
+        runtime = self._make_runtime([self._plain_handler(), recorder, self._plain_handler()])
+        assert self._fn(runtime) is recorder
+
+    def test_returns_none_when_no_matching_handler_in_plain_list(self):
+        runtime = self._make_runtime([self._plain_handler(), self._plain_handler()])
+        assert self._fn(runtime) is None
+
+    def test_finds_recorder_when_callbacks_is_callback_manager(self):
+        """LangChain AsyncCallbackManager has .handlers; must not raise TypeError."""
+        recorder = self._recorder()
+        manager = SimpleNamespace(handlers=[self._plain_handler(), recorder])
+        runtime = self._make_runtime(manager)
+        assert self._fn(runtime) is recorder
+
+    def test_returns_none_when_callback_manager_handlers_empty(self):
+        manager = SimpleNamespace(handlers=[])
+        runtime = self._make_runtime(manager)
+        assert self._fn(runtime) is None
+
+    def test_returns_none_when_callbacks_is_non_iterable_object(self):
+        """A non-list, non-manager object must not raise — return None instead."""
+
+        class _Opaque:
+            pass
+
+        runtime = self._make_runtime(_Opaque())
+        assert self._fn(runtime) is None


### PR DESCRIPTION
## Summary

- `_find_usage_recorder` in `task_tool.py` iterates `runtime.config["callbacks"]` with a bare `for` loop
- LangChain's `AsyncCallbackManager` is not directly iterable — it exposes its handlers via a `.handlers` list attribute
- This caused a `TypeError` whenever a `CallbackManager` was passed instead of a plain list, silently breaking usage recording for all subagent task calls

**Fix:** extract `.handlers` when the callbacks object has that attribute, and add an `isinstance` guard to return `None` gracefully for any other non-iterable.

Closes #2950

## Test plan

- [ ] `TestFindUsageRecorder` (8 new tests in `test_task_tool_core_logic.py`) covers: `None` runtime, non-dict config, empty list, recorder found in plain list, no matching handler, `CallbackManager` with `.handlers`, empty `.handlers`, opaque non-iterable object
- [ ] `PYTHONPATH=. uv run pytest tests/test_task_tool_core_logic.py::TestFindUsageRecorder -v` — all 8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)