### PR TITLE
fix(runtime): roll back in-memory run record when store persistence fails

### DIFF
--- a/backend/packages/harness/deerflow/runtime/runs/manager.py
+++ b/backend/packages/harness/deerflow/runtime/runs/manager.py
@@ -54,23 +54,20 @@ class RunManager:
         self._store = store
 
     async def _persist_to_store(self, record: RunRecord) -> None:
-        """Best-effort persist run record to backing store."""
+        """Persist a new run record to the backing store. Raises on failure."""
         if self._store is None:
             return
-        try:
-            await self._store.put(
-                record.run_id,
-                thread_id=record.thread_id,
-                assistant_id=record.assistant_id,
-                status=record.status.value,
-                multitask_strategy=record.multitask_strategy,
-                metadata=record.metadata or {},
-                kwargs=record.kwargs or {},
-                created_at=record.created_at,
-                model_name=record.model_name,
-            )
-        except Exception:
-            logger.warning("Failed to persist run %s to store", record.run_id, exc_info=True)
+        await self._store.put(
+            record.run_id,
+            thread_id=record.thread_id,
+            assistant_id=record.assistant_id,
+            status=record.status.value,
+            multitask_strategy=record.multitask_strategy,
+            metadata=record.metadata or {},
+            kwargs=record.kwargs or {},
+            created_at=record.created_at,
+            model_name=record.model_name,
+        )
 
     async def _persist_status(self, run_id: str, status: RunStatus, *, error: str | None = None) -> None:
         """Best-effort persist a status transition to the backing store."""
@@ -139,7 +136,13 @@ class RunManager:
         )
         async with self._lock:
             self._runs[run_id] = record
-        await self._persist_to_store(record)
+        try:
+            await self._persist_to_store(record)
+        except Exception:
+            async with self._lock:
+                self._runs.pop(run_id, None)
+            logger.warning("Failed to persist run %s; rolled back in-memory record", run_id, exc_info=True)
+            raise
         logger.info("Run created: run_id=%s thread_id=%s", run_id, thread_id)
         return record
 
@@ -344,7 +347,13 @@ class RunManager:
 
         for interrupted_run_id in interrupted_run_ids:
             await self._persist_status(interrupted_run_id, RunStatus.interrupted)
-        await self._persist_to_store(record)
+        try:
+            await self._persist_to_store(record)
+        except Exception:
+            async with self._lock:
+                self._runs.pop(run_id, None)
+            logger.warning("Failed to persist run %s; rolled back in-memory record", run_id, exc_info=True)
+            raise
         logger.info("Run created: run_id=%s thread_id=%s", run_id, thread_id)
         return record
 

--- a/backend/tests/test_run_manager.py
+++ b/backend/tests/test_run_manager.py
@@ -509,3 +509,65 @@ async def test_list_by_thread_falls_back_to_store_with_user_filter():
 
     runs = await mgr.list_by_thread("thread-1", user_id="user-1")
     assert [r.run_id for r in runs] == ["run-1"]
+
+
+# ---------------------------------------------------------------------------
+# Rollback on store failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_create_rolls_back_in_memory_record_on_store_failure():
+    """create() must roll back the in-memory record when the store raises."""
+    from unittest.mock import AsyncMock
+
+    store = MemoryRunStore()
+    store.put = AsyncMock(side_effect=RuntimeError("db down"))
+    mgr = RunManager(store=store)
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await mgr.create("thread-1")
+
+    assert await mgr.get("thread-1") is None
+    assert len(mgr._runs) == 0
+
+
+@pytest.mark.anyio
+async def test_create_or_reject_rolls_back_in_memory_record_on_store_failure():
+    """create_or_reject() must roll back the in-memory record when the store raises."""
+    from unittest.mock import AsyncMock
+
+    store = MemoryRunStore()
+    store.put = AsyncMock(side_effect=RuntimeError("db down"))
+    mgr = RunManager(store=store)
+
+    with pytest.raises(RuntimeError, match="db down"):
+        await mgr.create_or_reject("thread-1")
+
+    assert len(mgr._runs) == 0
+
+
+@pytest.mark.anyio
+async def test_create_succeeds_and_persists_when_store_is_healthy():
+    """create() must register the run both in memory and in the store on success."""
+    store = MemoryRunStore()
+    mgr = RunManager(store=store)
+
+    record = await mgr.create("thread-1")
+
+    assert await mgr.get(record.run_id) is not None
+    store_rows = await store.list_by_thread("thread-1")
+    assert any(r["run_id"] == record.run_id for r in store_rows)
+
+
+@pytest.mark.anyio
+async def test_create_or_reject_succeeds_and_persists_when_store_is_healthy():
+    """create_or_reject() must register the run both in memory and in the store."""
+    store = MemoryRunStore()
+    mgr = RunManager(store=store)
+
+    record = await mgr.create_or_reject("thread-1")
+
+    assert await mgr.get(record.run_id) is not None
+    store_rows = await store.list_by_thread("thread-1")
+    assert any(r["run_id"] == record.run_id for r in store_rows)


### PR DESCRIPTION
## Summary

- `RunManager.create()` and `create_or_reject()` both add the new run to `_runs` under the lock, then call `_persist_to_store` **after** releasing the lock
- `_persist_to_store` previously caught all exceptions and logged a warning — so a store failure left `_runs` containing the run record while the backing store had nothing
- On the next process restart, that run is unrecoverable (can't be hydrated from the store), and callers received no error signal

**Fix:** `_persist_to_store` now propagates exceptions. Both callers wrap the call in a try/except that re-acquires the lock, removes the record from `_runs`, logs a warning, then re-raises — keeping in-memory state and the persistent store consistent.

Closes #3020

## Test plan

- [ ] `test_create_rolls_back_in_memory_record_on_store_failure` — `create()` raises and leaves `_runs` empty
- [ ] `test_create_or_reject_rolls_back_in_memory_record_on_store_failure` — same for `create_or_reject()`
- [ ] `test_create_succeeds_and_persists_when_store_is_healthy` — happy path still writes to both memory and store
- [ ] `test_create_or_reject_succeeds_and_persists_when_store_is_healthy` — same for `create_or_reject()`
- [ ] All 36 `test_run_manager.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)