### PR TITLE
fix(deploy): fall back to python/openssl when python3 is absent for secret generation

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -120,12 +120,15 @@ if [ -z "$BETTER_AUTH_SECRET" ]; then
         echo -e "${GREEN}✓ BETTER_AUTH_SECRET loaded from $_secret_file${NC}"
     else
         export BETTER_AUTH_SECRET
-        if command -v python3 > /dev/null 2>&1; then
-            BETTER_AUTH_SECRET="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
-        elif command -v python > /dev/null 2>&1; then
-            BETTER_AUTH_SECRET="$(python -c 'import secrets; print(secrets.token_hex(32))')"
-        elif command -v openssl > /dev/null 2>&1; then
-            BETTER_AUTH_SECRET="$(openssl rand -hex 32)"
+        if command -v python3 > /dev/null 2>&1 && \
+            BETTER_AUTH_SECRET="$(python3 -c 'import sys; sys.version_info >= (3, 6) or sys.exit(1); import secrets; print(secrets.token_hex(32))' 2>/dev/null)"; then
+            true
+        elif command -v python > /dev/null 2>&1 && \
+            BETTER_AUTH_SECRET="$(python -c 'import sys; sys.version_info >= (3, 6) or sys.exit(1); import secrets; print(secrets.token_hex(32))' 2>/dev/null)"; then
+            true
+        elif command -v openssl > /dev/null 2>&1 && \
+            BETTER_AUTH_SECRET="$(openssl rand -hex 32)"; then
+            true
         else
             echo -e "${RED}✗ Cannot generate BETTER_AUTH_SECRET: python3, python, and openssl are all unavailable.${NC}" >&2
             echo -e "${RED}  Set BETTER_AUTH_SECRET manually before running make up.${NC}" >&2

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -120,7 +120,17 @@ if [ -z "$BETTER_AUTH_SECRET" ]; then
         echo -e "${GREEN}✓ BETTER_AUTH_SECRET loaded from $_secret_file${NC}"
     else
         export BETTER_AUTH_SECRET
-        BETTER_AUTH_SECRET="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+        if command -v python3 > /dev/null 2>&1; then
+            BETTER_AUTH_SECRET="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+        elif command -v python > /dev/null 2>&1; then
+            BETTER_AUTH_SECRET="$(python -c 'import secrets; print(secrets.token_hex(32))')"
+        elif command -v openssl > /dev/null 2>&1; then
+            BETTER_AUTH_SECRET="$(openssl rand -hex 32)"
+        else
+            echo -e "${RED}✗ Cannot generate BETTER_AUTH_SECRET: python3, python, and openssl are all unavailable.${NC}" >&2
+            echo -e "${RED}  Set BETTER_AUTH_SECRET manually before running make up.${NC}" >&2
+            exit 1
+        fi
         echo "$BETTER_AUTH_SECRET" > "$_secret_file"
         chmod 600 "$_secret_file"
         echo -e "${GREEN}✓ BETTER_AUTH_SECRET generated → $_secret_file${NC}"


### PR DESCRIPTION
## Summary

- `deploy.sh` generates `BETTER_AUTH_SECRET` with a bare `python3` call
- On systems where only `python` is on `PATH` (some Alpine containers, Windows environments), or where neither Python variant is present, this exits with code 49 and crashes `make up` with a cryptic `recipe for target 'up' failed` message

**Fix:** try `python3` first, then `python`, then `openssl rand -hex 32`. If all three are unavailable, print a clear error message instructing the user to set `BETTER_AUTH_SECRET` manually.

Closes #2922

## Test plan

- [ ] Systems with `python3`: behaviour unchanged
- [ ] Systems with only `python` (no `python3`): secret generated successfully
- [ ] Systems with only `openssl` (no Python): secret generated via `openssl rand -hex 32`
- [ ] Systems with none of the above: clear error message + non-zero exit instead of cryptic recipe failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)