### PR TITLE
fix(sandbox): fall back to ambient config in is_host_bash_allowed when config lacks .sandbox

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/security.py
+++ b/backend/packages/harness/deerflow/sandbox/security.py
@@ -33,11 +33,20 @@ def uses_local_sandbox_provider(config=None) -> bool:
 
 
 def is_host_bash_allowed(config=None) -> bool:
-    """Return whether host bash execution is explicitly allowed."""
+    """Return whether host bash execution is explicitly allowed.
+
+    When *config* lacks a ``.sandbox`` attribute (e.g. a ``SubagentsAppConfig``
+    slice), fall back to the ambient ``get_app_config()`` so callers never need
+    to guard the call with ``hasattr(config, "sandbox")`` checks.
+    """
     if config is None:
         config = get_app_config()
 
     sandbox_cfg = getattr(config, "sandbox", None)
+    if sandbox_cfg is None:
+        # Config is a narrow slice (no .sandbox) — retry with the full app config.
+        config = get_app_config()
+        sandbox_cfg = getattr(config, "sandbox", None)
     if sandbox_cfg is None:
         return False
     if not uses_local_sandbox_provider(config):

--- a/backend/packages/harness/deerflow/subagents/registry.py
+++ b/backend/packages/harness/deerflow/subagents/registry.py
@@ -155,7 +155,7 @@ def get_available_subagent_names(*, app_config: Any | None = None) -> list[str]:
     """
     names = get_subagent_names(app_config=app_config)
     try:
-        host_bash_allowed = is_host_bash_allowed(app_config) if hasattr(app_config, "sandbox") else is_host_bash_allowed()
+        host_bash_allowed = is_host_bash_allowed(app_config)
     except Exception:
         logger.debug("Could not determine host bash availability; exposing all subagents")
         return names

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -35,7 +35,7 @@ def _token_usage_cache_enabled(app_config: "AppConfig | None") -> bool:
     if app_config is None:
         try:
             app_config = get_app_config()
-        except FileNotFoundError:
+        except (FileNotFoundError, RuntimeError):
             return False
     return bool(getattr(getattr(app_config, "token_usage", None), "enabled", False))
 
@@ -211,10 +211,10 @@ async def task_tool(
     """
     runtime_app_config = _get_runtime_app_config(runtime)
     cache_token_usage = _token_usage_cache_enabled(runtime_app_config)
-    available_subagent_names = get_available_subagent_names(app_config=runtime_app_config) if runtime_app_config is not None else get_available_subagent_names()
+    available_subagent_names = get_available_subagent_names(app_config=runtime_app_config)
 
     # Get subagent configuration
-    config = get_subagent_config(subagent_type, app_config=runtime_app_config) if runtime_app_config is not None else get_subagent_config(subagent_type)
+    config = get_subagent_config(subagent_type, app_config=runtime_app_config)
     if config is None:
         available = ", ".join(available_subagent_names)
         return f"Error: Unknown subagent type '{subagent_type}'. Available: {available}"

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -219,7 +219,7 @@ async def task_tool(
         available = ", ".join(available_subagent_names)
         return f"Error: Unknown subagent type '{subagent_type}'. Available: {available}"
     if subagent_type == "bash":
-        host_bash_allowed = is_host_bash_allowed(runtime_app_config) if runtime_app_config is not None else is_host_bash_allowed()
+        host_bash_allowed = is_host_bash_allowed(runtime_app_config)
         if not host_bash_allowed:
             return f"Error: {LOCAL_BASH_SUBAGENT_DISABLED_MESSAGE}"
 

--- a/backend/tests/test_local_bash_tool_loading.py
+++ b/backend/tests/test_local_bash_tool_loading.py
@@ -82,6 +82,9 @@ def test_get_available_tools_keeps_bash_for_aio_sandbox(monkeypatch):
     assert "ls" in names
 
 
-def test_is_host_bash_allowed_defaults_false_when_sandbox_missing():
+def test_is_host_bash_allowed_defaults_false_when_sandbox_missing(monkeypatch):
+    # When both the passed config and the ambient config have no .sandbox, return False.
+    from deerflow.sandbox import security as _security_mod
+    monkeypatch.setattr(_security_mod, "get_app_config", lambda: SimpleNamespace())
     assert is_host_bash_allowed(SimpleNamespace()) is False
     assert is_host_bash_allowed(SimpleNamespace(sandbox=None)) is False

--- a/backend/tests/test_subagent_skills_config.py
+++ b/backend/tests/test_subagent_skills_config.py
@@ -377,7 +377,8 @@ class TestRegistryCustomAgentLookup:
         _reset_subagents_config()
         assert get_subagent_config("nonexistent") is None
 
-    def test_get_available_subagent_names_falls_back_when_subagents_app_config_lacks_sandbox(self, monkeypatch):
+    def test_get_available_subagent_names_passes_config_to_is_host_bash_allowed(self, monkeypatch):
+        """is_host_bash_allowed now always receives the app_config; fallback is internal."""
         from deerflow.subagents import registry as registry_module
         from deerflow.subagents.registry import get_available_subagent_names
 
@@ -389,9 +390,11 @@ class TestRegistryCustomAgentLookup:
 
         monkeypatch.setattr(registry_module, "is_host_bash_allowed", fake_is_host_bash_allowed)
 
-        get_available_subagent_names(app_config=SubagentsAppConfig())
+        sub_cfg = SubagentsAppConfig()
+        get_available_subagent_names(app_config=sub_cfg)
 
-        assert captured["args"] == ()
+        assert len(captured["args"]) == 1
+        assert captured["args"][0] is sub_cfg
 
     def test_builtin_takes_priority_over_custom(self):
         """If a custom agent has the same name as a builtin, builtin wins."""

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -1035,7 +1035,7 @@ def test_task_tool_returns_cancelled_message(monkeypatch):
         "SubagentExecutor",
         type("DummyExecutor", (), {"__init__": lambda self, **kwargs: None, "execute_async": lambda self, prompt, task_id=None: task_id}),
     )
-    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: config)
+    monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _, *, app_config=None: config)
 
     monkeypatch.setattr(task_tool_module, "get_background_task_result", lambda _: next(responses))
     monkeypatch.setattr(task_tool_module, "get_stream_writer", lambda: events.append)


### PR DESCRIPTION
## Summary

- `is_host_bash_allowed(config)` returned `False` unconditionally when the passed config had no `.sandbox` attribute (e.g. `SubagentsAppConfig`)
- Both call sites in `task_tool.py` and `registry.py` worked around this with `hasattr(config, "sandbox")` guards that fell back to `is_host_bash_allowed()` (no-arg call) — but this pattern is fragile and easy to get wrong at new call sites
- Result: any code path that received a narrow config slice would silently disable the bash subagent even when the real `AppConfig` permits it

**Fix:** When `config.sandbox` is absent, `is_host_bash_allowed` now retries with `get_app_config()` internally before returning `False`. Both call sites are simplified to unconditionally pass the config.

Closes #2687 (item 1 of the deferred follow-ups)

## Test plan

- [ ] Updated `test_is_host_bash_allowed_defaults_false_when_sandbox_missing` to mock the ambient `get_app_config` so the test still validates `False` when both passed and ambient configs have no sandbox
- [ ] Updated `test_get_available_subagent_names_passes_config_to_is_host_bash_allowed` to assert the config is always passed through (no more no-arg fallback at the call site)
- [ ] `PYTHONPATH=. uv run pytest tests/test_local_bash_tool_loading.py tests/test_subagent_skills_config.py` — 47 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)