### PR TITLE
fix(harness): refine ACP session update handling and logging

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -224,7 +224,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                             session_id,
                             update.tool_call_id,
                             update.title,
-                            update.kind,
+                            getattr(update, "kind", None),
                         )
                     elif tool_call_update_cls is not None and isinstance(update, tool_call_update_cls):
                         logger.debug(
@@ -232,7 +232,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                             session_id,
                             update.tool_call_id,
                             getattr(update, "title", None),
-                            update.status,
+                            getattr(update, "status", None),
                         )
                 except Exception:
                     logger.warning("ACP session_update failed [session=%s]", session_id, exc_info=True)

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -1,6 +1,5 @@
 """Built-in tool for invoking external ACP-compatible agents."""
 
-import json
 import logging
 import os
 import shutil
@@ -13,7 +12,6 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger(__name__)
 
 _THOUGHT_PREVIEW_CHARS = 200
-_TOOL_IO_PREVIEW_CHARS = 2000
 _PROMPT_PREVIEW_CHARS = 200
 _RESULT_PREVIEW_CHARS = 1000
 
@@ -22,14 +20,6 @@ def _truncate_preview(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[:limit] + "..."
-
-
-def _format_tool_io(value: object) -> str:
-    try:
-        text = json.dumps(value, ensure_ascii=False, indent=2)
-    except (TypeError, ValueError):
-        text = repr(value)
-    return _truncate_preview(text, _TOOL_IO_PREVIEW_CHARS)
 
 
 class _InvokeACPAgentInput(BaseModel):
@@ -212,54 +202,31 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                 try:
                     from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock, ToolCallStart, ToolCallUpdate
 
-                    content = getattr(update, "content", None)
-                    if isinstance(content, TextContentBlock):
+                    if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
                         if isinstance(update, AgentMessageChunk):
-                            self._chunks.append(content.text)
+                            self._chunks.append(update.content.text)
                         elif isinstance(update, AgentThoughtChunk):
                             logger.debug(
                                 "ACP agent thought [session=%s]: %s",
                                 session_id,
-                                _truncate_preview(content.text, _THOUGHT_PREVIEW_CHARS),
+                                _truncate_preview(update.content.text, _THOUGHT_PREVIEW_CHARS),
                             )
                     elif isinstance(update, ToolCallStart):
                         logger.debug(
-                            "ACP agent tool start [session=%s, title=%s, id=%s, kind=%s]",
+                            "ACP agent tool start [session=%s, id=%s, title=%s, kind=%s]",
                             session_id,
-                            update.title,
                             update.tool_call_id,
+                            update.title,
                             update.kind,
                         )
                     elif isinstance(update, ToolCallUpdate):
-                        title = getattr(update, "title", None)
-                        raw_input = getattr(update, "raw_input", None)
-                        raw_output = getattr(update, "raw_output", None)
-                        if raw_input is not None:
-                            logger.debug(
-                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s] params:\n%s",
-                                session_id,
-                                title,
-                                update.tool_call_id,
-                                update.status,
-                                _format_tool_io(raw_input),
-                            )
-                        if raw_output is not None:
-                            logger.debug(
-                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s] result:\n%s",
-                                session_id,
-                                title,
-                                update.tool_call_id,
-                                update.status,
-                                _format_tool_io(raw_output),
-                            )
-                        if raw_input is None and raw_output is None:
-                            logger.debug(
-                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s]",
-                                session_id,
-                                title,
-                                update.tool_call_id,
-                                update.status,
-                            )
+                        logger.debug(
+                            "ACP agent tool update [session=%s, id=%s, title=%s, status=%s]",
+                            session_id,
+                            update.tool_call_id,
+                            getattr(update, "title", None),
+                            update.status,
+                        )
                 except Exception:
                     logger.warning("ACP session_update failed [session=%s]", session_id, exc_info=True)
 

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -190,13 +190,15 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
             async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
                 try:
-                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock
+                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock, ToolCallStart
 
                     if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
                         if isinstance(update, AgentMessageChunk):
                             self._chunks.append(update.content.text)
                         elif isinstance(update, AgentThoughtChunk):
                             logger.debug("ACP agent thought [session=%s]: %s", session_id, update.content.text)
+                    elif isinstance(update, ToolCallStart):
+                        logger.debug("ACP agent tool call [session=%s, id=%s, kind=%s]: %s", session_id, update.tool_call_id, update.kind, update.title)
                 except Exception:
                     pass
 

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -200,7 +200,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                     elif isinstance(update, ToolCallStart):
                         logger.debug("ACP agent tool call [session=%s, id=%s, kind=%s]: %s", session_id, update.tool_call_id, update.kind, update.title)
                 except Exception:
-                    pass
+                    logger.warning("ACP session_update failed [session=%s]", session_id, exc_info=True)
 
             async def request_permission(self, options, session_id: str, tool_call, **kwargs):  # type: ignore[override]
                 response = _build_permission_response(options, auto_approve=agent_config.auto_approve_permissions)

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -190,10 +190,13 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
             async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
                 try:
-                    from acp.schema import TextContentBlock
+                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock
 
                     if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
-                        self._chunks.append(update.content.text)
+                        if isinstance(update, AgentMessageChunk):
+                            self._chunks.append(update.content.text)
+                        elif isinstance(update, AgentThoughtChunk):
+                            logger.debug("ACP agent thought [session=%s]: %s", session_id, update.content.text)
                 except Exception:
                     pass
 

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -1,5 +1,6 @@
 """Built-in tool for invoking external ACP-compatible agents."""
 
+import json
 import logging
 import os
 import shutil
@@ -10,6 +11,25 @@ from langchain_core.tools import BaseTool, InjectedToolArg, StructuredTool
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
+
+_THOUGHT_PREVIEW_CHARS = 200
+_TOOL_IO_PREVIEW_CHARS = 2000
+_PROMPT_PREVIEW_CHARS = 200
+_RESULT_PREVIEW_CHARS = 1000
+
+
+def _truncate_preview(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "..."
+
+
+def _format_tool_io(value: object) -> str:
+    try:
+        text = json.dumps(value, ensure_ascii=False, indent=2)
+    except (TypeError, ValueError):
+        text = repr(value)
+    return _truncate_preview(text, _TOOL_IO_PREVIEW_CHARS)
 
 
 class _InvokeACPAgentInput(BaseModel):
@@ -164,7 +184,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
     async def _invoke(agent: str, prompt: str, config: Annotated[RunnableConfig, InjectedToolArg] = None) -> str:
         logger.info("Invoking ACP agent %s (prompt length: %d)", agent, len(prompt))
-        logger.debug("Invoking ACP agent %s with prompt: %.200s%s", agent, prompt, "..." if len(prompt) > 200 else "")
+        logger.debug("Invoking ACP agent %s with prompt: %s", agent, _truncate_preview(prompt, _PROMPT_PREVIEW_CHARS))
         if agent not in _agents:
             available = ", ".join(_agents.keys())
             return f"Error: Unknown agent '{agent}'. Available: {available}"
@@ -190,15 +210,56 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
             async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
                 try:
-                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock, ToolCallStart
+                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock, ToolCallStart, ToolCallUpdate
 
-                    if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
+                    content = getattr(update, "content", None)
+                    if isinstance(content, TextContentBlock):
                         if isinstance(update, AgentMessageChunk):
-                            self._chunks.append(update.content.text)
+                            self._chunks.append(content.text)
                         elif isinstance(update, AgentThoughtChunk):
-                            logger.debug("ACP agent thought [session=%s]: %s", session_id, update.content.text)
+                            logger.debug(
+                                "ACP agent thought [session=%s]: %s",
+                                session_id,
+                                _truncate_preview(content.text, _THOUGHT_PREVIEW_CHARS),
+                            )
                     elif isinstance(update, ToolCallStart):
-                        logger.debug("ACP agent tool call [session=%s, id=%s, kind=%s]: %s", session_id, update.tool_call_id, update.kind, update.title)
+                        logger.debug(
+                            "ACP agent tool start [session=%s, title=%s, id=%s, kind=%s]",
+                            session_id,
+                            update.title,
+                            update.tool_call_id,
+                            update.kind,
+                        )
+                    elif isinstance(update, ToolCallUpdate):
+                        title = getattr(update, "title", None)
+                        raw_input = getattr(update, "raw_input", None)
+                        raw_output = getattr(update, "raw_output", None)
+                        if raw_input is not None:
+                            logger.debug(
+                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s] params:\n%s",
+                                session_id,
+                                title,
+                                update.tool_call_id,
+                                update.status,
+                                _format_tool_io(raw_input),
+                            )
+                        if raw_output is not None:
+                            logger.debug(
+                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s] result:\n%s",
+                                session_id,
+                                title,
+                                update.tool_call_id,
+                                update.status,
+                                _format_tool_io(raw_output),
+                            )
+                        if raw_input is None and raw_output is None:
+                            logger.debug(
+                                "ACP agent tool update [session=%s, title=%s, id=%s, status=%s]",
+                                session_id,
+                                title,
+                                update.tool_call_id,
+                                update.status,
+                            )
                 except Exception:
                     logger.warning("ACP session_update failed [session=%s]", session_id, exc_info=True)
 
@@ -247,7 +308,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                     prompt=[text_block(prompt)],
                 )
             result = client.collected_text
-            logger.info("ACP agent '%s' returned %s", agent, result[:1000])
+            logger.info("ACP agent '%s' returned %s", agent, _truncate_preview(result, _RESULT_PREVIEW_CHARS))
             logger.info("ACP agent '%s' returned %d characters", agent, len(result))
             return result or "(no response)"
         except Exception as e:

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+import sys
 from typing import Annotated, Any
 
 from langchain_core.runnables import RunnableConfig
@@ -188,6 +189,13 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         except ImportError:
             return "Error: agent-client-protocol package is not installed. Run `uv sync` to install project dependencies."
 
+        acp_schema = sys.modules.get("acp.schema")
+        agent_message_chunk_cls = getattr(acp_schema, "AgentMessageChunk", None)
+        agent_thought_chunk_cls = getattr(acp_schema, "AgentThoughtChunk", None)
+        text_content_block_cls = getattr(acp_schema, "TextContentBlock", None)
+        tool_call_start_cls = getattr(acp_schema, "ToolCallStart", None)
+        tool_call_update_cls = getattr(acp_schema, "ToolCallUpdate", None)
+
         class _CollectingClient(Client):
             """Minimal ACP Client that collects streamed text from session updates."""
 
@@ -200,18 +208,17 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
 
             async def session_update(self, session_id: str, update, **kwargs) -> None:  # type: ignore[override]
                 try:
-                    from acp.schema import AgentMessageChunk, AgentThoughtChunk, TextContentBlock, ToolCallStart, ToolCallUpdate
-
-                    if hasattr(update, "content") and isinstance(update.content, TextContentBlock):
-                        if isinstance(update, AgentMessageChunk):
-                            self._chunks.append(update.content.text)
-                        elif isinstance(update, AgentThoughtChunk):
+                    content = getattr(update, "content", None)
+                    if text_content_block_cls is not None and isinstance(content, text_content_block_cls):
+                        if agent_message_chunk_cls is not None and isinstance(update, agent_message_chunk_cls):
+                            self._chunks.append(content.text)
+                        elif agent_thought_chunk_cls is not None and isinstance(update, agent_thought_chunk_cls):
                             logger.debug(
                                 "ACP agent thought [session=%s]: %s",
                                 session_id,
-                                _truncate_preview(update.content.text, _THOUGHT_PREVIEW_CHARS),
+                                _truncate_preview(content.text, _THOUGHT_PREVIEW_CHARS),
                             )
-                    elif isinstance(update, ToolCallStart):
+                    elif tool_call_start_cls is not None and isinstance(update, tool_call_start_cls):
                         logger.debug(
                             "ACP agent tool start [session=%s, id=%s, title=%s, kind=%s]",
                             session_id,
@@ -219,7 +226,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
                             update.title,
                             update.kind,
                         )
-                    elif isinstance(update, ToolCallUpdate):
+                    elif tool_call_update_cls is not None and isinstance(update, tool_call_update_cls):
                         logger.debug(
                             "ACP agent tool update [session=%s, id=%s, title=%s, status=%s]",
                             session_id,

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -11,6 +11,7 @@ from deerflow.tools.builtins.invoke_acp_agent_tool import (
     _build_acp_mcp_servers,
     _build_mcp_servers,
     _build_permission_response,
+    _format_tool_io,
     _get_work_dir,
     build_invoke_acp_agent_tool,
 )
@@ -175,7 +176,7 @@ def test_get_work_dir_falls_back_to_global_for_invalid_thread_id(monkeypatch, tm
 
 @pytest.mark.anyio
 async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
-    """ACP agent uses {base_dir}/acp-workspace/ when no thread_id is available (no config)."""
+    """ACP agent uses the global workspace and returns only AgentMessageChunk text."""
     from deerflow.config import paths as paths_module
 
     monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
@@ -218,6 +219,16 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
         async def prompt(self, **kwargs):
             captured["prompt"] = kwargs
             client = captured["client"]
+            thought_chunk = sys.modules["acp.schema"].AgentThoughtChunk()
+            thought_chunk.content = text_content_block("internal thought")
+            await client.session_update("session-1", thought_chunk)
+
+            await client.session_update("session-1", sys.modules["acp.schema"].ToolCallStart())
+
+            user_chunk = sys.modules["acp.schema"].UserMessageChunk()
+            user_chunk.content = text_content_block("user prompt echo")
+            await client.session_update("session-1", user_chunk)
+
             agent_chunk = sys.modules["acp.schema"].AgentMessageChunk()
             agent_chunk.content = text_content_block("ACP result")
             await client.session_update("session-1", agent_chunk)
@@ -257,7 +268,9 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
             Implementation=lambda **kwargs: kwargs,
             AgentMessageChunk=type("AgentMessageChunk", (), {}),
             AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
-            ToolCallStart=type("ToolCallStart", (), {}),
+            ToolCallStart=type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "read file", "kind": "read"}),
+            ToolCallUpdate=type("ToolCallUpdate", (), {}),
+            UserMessageChunk=type("UserMessageChunk", (), {}),
             TextContentBlock=type(
                 "TextContentBlock",
                 (),
@@ -817,9 +830,45 @@ def test_get_available_tools_uses_explicit_app_config_for_acp_agents(monkeypatch
     assert "invoke_acp_agent" in [tool.name for tool in tools]
 
 
+# ---------------------------------------------------------------------------
+# _format_tool_io unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_tool_io_serializes_dict():
+    result = _format_tool_io({"key": "val"})
+    assert '"key"' in result
+    assert '"val"' in result
+
+
+def test_format_tool_io_truncates_long_output():
+    long_obj = {"data": "x" * 3000}
+    result = _format_tool_io(long_obj)
+    assert result.endswith("...")
+    assert len(result) <= 2003  # 2000 chars + "..."
+
+
+def test_format_tool_io_falls_back_to_repr_on_json_error():
+    class Unserializable:
+        pass
+
+    result = _format_tool_io(Unserializable())
+    assert "Unserializable" in result
+
+
+def test_format_tool_io_does_not_append_ellipsis_when_not_truncated():
+    result = _format_tool_io({"key": "val"})
+    assert not result.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# ToolCallUpdate integration test
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.anyio
-async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tmp_path):
-    """Only AgentMessageChunk content is appended; AgentThoughtChunk and UserMessageChunk are filtered out."""
+async def test_session_update_logs_tool_call_update_raw_io(monkeypatch, tmp_path, caplog):
+    """ToolCallUpdate with raw_input/raw_output is logged at DEBUG level."""
     from deerflow.config import paths as paths_module
 
     monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
@@ -831,18 +880,18 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
     TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
     AgentMessageChunk = type("AgentMessageChunk", (), {})
     AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "read file", "kind": "read"})
-    UserMessageChunk = type("UserMessageChunk", (), {})
+    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "search", "kind": "read"})
+    ToolCallUpdate = type(
+        "ToolCallUpdate",
+        (),
+        {"tool_call_id": "tc-1", "title": "search", "status": "completed", "raw_input": {"query": "foo"}, "raw_output": {"result": "bar"}},
+    )
 
     captured: dict[str, object] = {}
 
     class DummyClient:
         def __init__(self) -> None:
             self._chunks: list[str] = []
-
-        @property
-        def collected_text(self) -> str:
-            return "".join(self._chunks)
 
         async def session_update(self, session_id, update, **kwargs):
             pass
@@ -855,20 +904,14 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
             pass
 
         async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s1")
+            return SimpleNamespace(session_id="s2")
 
         async def prompt(self, **kwargs):
             client = captured["client"]
-            thought = AgentThoughtChunk()
-            thought.content = TextContentBlock("internal thought")
-            await client.session_update("s1", thought)
-            await client.session_update("s1", ToolCallStart())
-            user_echo = UserMessageChunk()
-            user_echo.content = TextContentBlock("user prompt echo")
-            await client.session_update("s1", user_echo)
+            await client.session_update("s2", ToolCallUpdate())
             agent_msg = AgentMessageChunk()
-            agent_msg.content = TextContentBlock("actual response")
-            await client.session_update("s1", agent_msg)
+            agent_msg.content = TextContentBlock("done")
+            await client.session_update("s2", agent_msg)
 
     class DummyProcessContext:
         def __init__(self, client, cmd, *args, env=None, cwd):
@@ -905,7 +948,7 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
             AgentMessageChunk=AgentMessageChunk,
             AgentThoughtChunk=AgentThoughtChunk,
             ToolCallStart=ToolCallStart,
-            UserMessageChunk=UserMessageChunk,
+            ToolCallUpdate=ToolCallUpdate,
             TextContentBlock=TextContentBlock,
         ),
     )
@@ -913,9 +956,514 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
     tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
 
     try:
-        result = await tool.coroutine(agent="codex", prompt="Do something")
+        with caplog.at_level("DEBUG"):
+            result = await tool.coroutine(agent="codex", prompt="Search for foo")
     finally:
         sys.modules.pop("acp", None)
         sys.modules.pop("acp.schema", None)
 
-    assert result == "actual response"
+    assert result == "done"
+    messages = [r.message for r in caplog.records]
+    assert any("tool update" in m and "params" in m and "search" in m and "tc-1" in m for m in messages)
+    assert any("tool update" in m and "result" in m and "search" in m and "tc-1" in m for m in messages)
+
+
+# ---------------------------------------------------------------------------
+# Thought logging integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_session_update_logs_thought_chunks_immediately(monkeypatch, tmp_path, caplog):
+    """AgentThoughtChunk text is logged as soon as the chunk arrives."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentMessageChunk = type("AgentMessageChunk", (), {})
+    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-2", "title": "bash", "kind": "exec"})
+    ToolCallUpdate = type("ToolCallUpdate", (), {})
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s3")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            thought = AgentThoughtChunk()
+            thought.content = TextContentBlock("thinking hard")
+            await client.session_update("s3", thought)
+            captured["thought_logged_immediately"] = any("thinking hard" in record.message for record in caplog.records)
+            await client.session_update("s3", ToolCallStart())
+            msg = AgentMessageChunk()
+            msg.content = TextContentBlock("result")
+            await client.session_update("s3", msg)
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=AgentMessageChunk,
+            AgentThoughtChunk=AgentThoughtChunk,
+            ToolCallStart=ToolCallStart,
+            ToolCallUpdate=ToolCallUpdate,
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        with caplog.at_level("DEBUG"):
+            result = await tool.coroutine(agent="codex", prompt="Do it")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == "result"
+    assert captured["thought_logged_immediately"] is True
+    assert any("thinking hard" in r.message for r in caplog.records)
+    tool_call_messages = [r.message for r in caplog.records if "ACP agent tool start" in r.message]
+    assert tool_call_messages
+    assert tool_call_messages[0].index("bash") < tool_call_messages[0].index("tc-2")
+
+
+@pytest.mark.anyio
+async def test_session_update_logs_truncated_thought_with_ellipsis(monkeypatch, tmp_path, caplog):
+    """Long thought chunks include an ellipsis when truncated for logging."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentMessageChunk = type("AgentMessageChunk", (), {})
+    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+    ToolCallStart = type("ToolCallStart", (), {})
+    ToolCallUpdate = type("ToolCallUpdate", (), {})
+
+    captured: dict[str, object] = {}
+    long_thought = "x" * 250
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s3b")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            thought = AgentThoughtChunk()
+            thought.content = TextContentBlock(long_thought)
+            await client.session_update("s3b", thought)
+            msg = AgentMessageChunk()
+            msg.content = TextContentBlock("result")
+            await client.session_update("s3b", msg)
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=AgentMessageChunk,
+            AgentThoughtChunk=AgentThoughtChunk,
+            ToolCallStart=ToolCallStart,
+            ToolCallUpdate=ToolCallUpdate,
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        with caplog.at_level("DEBUG"):
+            result = await tool.coroutine(agent="codex", prompt="Do it")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == "result"
+    thought_messages = [r.message for r in caplog.records if "ACP agent thought" in r.message]
+    assert thought_messages
+    assert thought_messages[0].endswith("...")
+
+
+@pytest.mark.anyio
+async def test_session_update_logs_tool_call_update_status_only(monkeypatch, tmp_path, caplog):
+    """ToolCallUpdate with neither raw_input nor raw_output logs the status line."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentMessageChunk = type("AgentMessageChunk", (), {})
+    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+    ToolCallStart = type("ToolCallStart", (), {})
+    ToolCallUpdate = type(
+        "ToolCallUpdate",
+        (),
+        {"tool_call_id": "tc-3", "status": "in_progress", "title": "bash"},
+    )
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s4")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            await client.session_update("s4", ToolCallUpdate())
+            msg = AgentMessageChunk()
+            msg.content = TextContentBlock("done")
+            await client.session_update("s4", msg)
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=AgentMessageChunk,
+            AgentThoughtChunk=AgentThoughtChunk,
+            ToolCallStart=ToolCallStart,
+            ToolCallUpdate=ToolCallUpdate,
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        with caplog.at_level("DEBUG"):
+            result = await tool.coroutine(agent="codex", prompt="Run bash")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == "done"
+    assert any("tool update" in r.message and "status" in r.message and "tc-3" in r.message and "in_progress" in r.message for r in caplog.records)
+    tool_status_messages = [r.message for r in caplog.records if "ACP agent tool update" in r.message and "status" in r.message]
+    assert tool_status_messages
+    assert tool_status_messages[0].index("bash") < tool_status_messages[0].index("tc-3")
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_logs_thought_on_prompt_failure(monkeypatch, tmp_path, caplog):
+    """Thought text is still logged when prompt execution later fails."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s5")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            thought = AgentThoughtChunk()
+            thought.content = TextContentBlock("partial failure thought")
+            await client.session_update("s5", thought)
+            raise RuntimeError("prompt failed")
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=type("AgentMessageChunk", (), {}),
+            AgentThoughtChunk=AgentThoughtChunk,
+            ToolCallStart=type("ToolCallStart", (), {}),
+            ToolCallUpdate=type("ToolCallUpdate", (), {}),
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        with caplog.at_level("DEBUG"):
+            result = await tool.coroutine(agent="codex", prompt="Fail")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == "Error invoking ACP agent 'codex': prompt failed"
+    assert any("partial failure thought" in r.message for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_invoke_acp_agent_logs_truncated_result_with_ellipsis(monkeypatch, tmp_path, caplog):
+    """Long final responses include an ellipsis in the info preview log."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentMessageChunk = type("AgentMessageChunk", (), {})
+    long_result = "r" * 1200
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s6")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            msg = AgentMessageChunk()
+            msg.content = TextContentBlock(long_result)
+            await client.session_update("s6", msg)
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=AgentMessageChunk,
+            AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
+            ToolCallStart=type("ToolCallStart", (), {}),
+            ToolCallUpdate=type("ToolCallUpdate", (), {}),
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        with caplog.at_level("INFO"):
+            result = await tool.coroutine(agent="codex", prompt="Do it")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == long_result
+    return_messages = [r.message for r in caplog.records if "ACP agent 'codex' returned " in r.message]
+    assert return_messages
+    assert any(message.endswith("...") for message in return_messages if "characters" not in message)

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -218,10 +218,9 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
         async def prompt(self, **kwargs):
             captured["prompt"] = kwargs
             client = captured["client"]
-            await client.session_update(
-                "session-1",
-                SimpleNamespace(content=text_content_block("ACP result")),
-            )
+            agent_chunk = sys.modules["acp.schema"].AgentMessageChunk()
+            agent_chunk.content = text_content_block("ACP result")
+            await client.session_update("session-1", agent_chunk)
 
     class DummyProcessContext:
         def __init__(self, client, cmd, *args, cwd):
@@ -256,6 +255,8 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
         SimpleNamespace(
             ClientCapabilities=lambda: {"supports": []},
             Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=type("AgentMessageChunk", (), {}),
+            AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
             TextContentBlock=type(
                 "TextContentBlock",
                 (),
@@ -813,3 +814,104 @@ def test_get_available_tools_uses_explicit_app_config_for_acp_agents(monkeypatch
 
     assert captured["agents"] is explicit_agents
     assert "invoke_acp_agent" in [tool.name for tool in tools]
+
+
+@pytest.mark.anyio
+async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tmp_path):
+    """Only AgentMessageChunk content is appended; AgentThoughtChunk and UserMessageChunk are filtered out."""
+    from deerflow.config import paths as paths_module
+
+    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
+    monkeypatch.setattr(
+        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
+        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
+    )
+
+    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
+    AgentMessageChunk = type("AgentMessageChunk", (), {})
+    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+    UserMessageChunk = type("UserMessageChunk", (), {})
+
+    captured: dict[str, object] = {}
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self._chunks: list[str] = []
+
+        @property
+        def collected_text(self) -> str:
+            return "".join(self._chunks)
+
+        async def session_update(self, session_id, update, **kwargs):
+            pass
+
+        async def request_permission(self, options, session_id, tool_call, **kwargs):
+            raise AssertionError("should not be called")
+
+    class DummyConn:
+        async def initialize(self, **kwargs):
+            pass
+
+        async def new_session(self, **kwargs):
+            return SimpleNamespace(session_id="s1")
+
+        async def prompt(self, **kwargs):
+            client = captured["client"]
+            thought = AgentThoughtChunk()
+            thought.content = TextContentBlock("internal thought")
+            await client.session_update("s1", thought)
+            user_echo = UserMessageChunk()
+            user_echo.content = TextContentBlock("user prompt echo")
+            await client.session_update("s1", user_echo)
+            agent_msg = AgentMessageChunk()
+            agent_msg.content = TextContentBlock("actual response")
+            await client.session_update("s1", agent_msg)
+
+    class DummyProcessContext:
+        def __init__(self, client, cmd, *args, env=None, cwd):
+            captured["client"] = client
+
+        async def __aenter__(self):
+            return DummyConn(), object()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummyRequestError(Exception):
+        @staticmethod
+        def method_not_found(method):
+            return DummyRequestError(method)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "acp",
+        SimpleNamespace(
+            PROTOCOL_VERSION="2026-03-24",
+            Client=DummyClient,
+            RequestError=DummyRequestError,
+            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
+            text_block=lambda text: {"type": "text", "text": text},
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "acp.schema",
+        SimpleNamespace(
+            ClientCapabilities=lambda: {},
+            Implementation=lambda **kwargs: kwargs,
+            AgentMessageChunk=AgentMessageChunk,
+            AgentThoughtChunk=AgentThoughtChunk,
+            UserMessageChunk=UserMessageChunk,
+            TextContentBlock=TextContentBlock,
+        ),
+    )
+
+    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
+
+    try:
+        result = await tool.coroutine(agent="codex", prompt="Do something")
+    finally:
+        sys.modules.pop("acp", None)
+        sys.modules.pop("acp.schema", None)
+
+    assert result == "actual response"

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -257,6 +257,7 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
             Implementation=lambda **kwargs: kwargs,
             AgentMessageChunk=type("AgentMessageChunk", (), {}),
             AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
+            ToolCallStart=type("ToolCallStart", (), {}),
             TextContentBlock=type(
                 "TextContentBlock",
                 (),
@@ -830,6 +831,7 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
     TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
     AgentMessageChunk = type("AgentMessageChunk", (), {})
     AgentThoughtChunk = type("AgentThoughtChunk", (), {})
+    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "read file", "kind": "read"})
     UserMessageChunk = type("UserMessageChunk", (), {})
 
     captured: dict[str, object] = {}
@@ -860,6 +862,7 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
             thought = AgentThoughtChunk()
             thought.content = TextContentBlock("internal thought")
             await client.session_update("s1", thought)
+            await client.session_update("s1", ToolCallStart())
             user_echo = UserMessageChunk()
             user_echo.content = TextContentBlock("user prompt echo")
             await client.session_update("s1", user_echo)
@@ -901,6 +904,7 @@ async def test_session_update_collects_only_agent_message_chunks(monkeypatch, tm
             Implementation=lambda **kwargs: kwargs,
             AgentMessageChunk=AgentMessageChunk,
             AgentThoughtChunk=AgentThoughtChunk,
+            ToolCallStart=ToolCallStart,
             UserMessageChunk=UserMessageChunk,
             TextContentBlock=TextContentBlock,
         ),

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -181,7 +181,7 @@ def test_get_work_dir_falls_back_to_global_for_invalid_thread_id(monkeypatch, tm
 
 @pytest.mark.anyio
 async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
-    """ACP agent uses the global workspace and returns only AgentMessageChunk text."""
+    """ACP agent uses the fixed global ACP workspace when thread_id is absent."""
     from deerflow.config import paths as paths_module
 
     monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))

--- a/backend/tests/test_invoke_acp_agent_tool.py
+++ b/backend/tests/test_invoke_acp_agent_tool.py
@@ -11,11 +11,16 @@ from deerflow.tools.builtins.invoke_acp_agent_tool import (
     _build_acp_mcp_servers,
     _build_mcp_servers,
     _build_permission_response,
-    _format_tool_io,
     _get_work_dir,
     build_invoke_acp_agent_tool,
 )
 from deerflow.tools.tools import get_available_tools
+
+
+class _DummyRequestError(Exception):
+    @staticmethod
+    def method_not_found(method):
+        return _DummyRequestError(method)
 
 
 def test_build_mcp_servers_filters_disabled_and_maps_transports():
@@ -223,8 +228,6 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
             thought_chunk.content = text_content_block("internal thought")
             await client.session_update("session-1", thought_chunk)
 
-            await client.session_update("session-1", sys.modules["acp.schema"].ToolCallStart())
-
             user_chunk = sys.modules["acp.schema"].UserMessageChunk()
             user_chunk.content = text_content_block("user prompt echo")
             await client.session_update("session-1", user_chunk)
@@ -244,18 +247,13 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method: str):
-            return DummyRequestError(method)
-
     monkeypatch.setitem(
         sys.modules,
         "acp",
         SimpleNamespace(
             PROTOCOL_VERSION="2026-03-24",
             Client=DummyClient,
-            RequestError=DummyRequestError,
+            RequestError=_DummyRequestError,
             spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, cwd=cwd),
             text_block=lambda text: {"type": "text", "text": text},
         ),
@@ -268,7 +266,7 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
             Implementation=lambda **kwargs: kwargs,
             AgentMessageChunk=type("AgentMessageChunk", (), {}),
             AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
-            ToolCallStart=type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "read file", "kind": "read"}),
+            ToolCallStart=type("ToolCallStart", (), {}),
             ToolCallUpdate=type("ToolCallUpdate", (), {}),
             UserMessageChunk=type("UserMessageChunk", (), {}),
             TextContentBlock=type(
@@ -293,14 +291,10 @@ async def test_invoke_acp_agent_uses_fixed_acp_workspace(monkeypatch, tmp_path):
         }
     )
 
-    try:
-        result = await tool.coroutine(
-            agent="codex",
-            prompt="Implement the fix",
-        )
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
+    result = await tool.coroutine(
+        agent="codex",
+        prompt="Implement the fix",
+    )
 
     assert result == "ACP result"
     assert captured["spawn"] == {"cmd": "codex-acp", "args": ["--json"], "cwd": expected_cwd}
@@ -374,18 +368,13 @@ async def test_invoke_acp_agent_uses_per_thread_workspace_when_thread_id_in_conf
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
     monkeypatch.setitem(
         sys.modules,
         "acp",
         SimpleNamespace(
             PROTOCOL_VERSION="2026-03-24",
             Client=DummyClient,
-            RequestError=DummyRequestError,
+            RequestError=_DummyRequestError,
             spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, cwd=cwd),
             text_block=lambda text: {"type": "text", "text": text},
         ),
@@ -405,15 +394,11 @@ async def test_invoke_acp_agent_uses_per_thread_workspace_when_thread_id_in_conf
 
     tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
 
-    try:
-        await tool.coroutine(
-            agent="codex",
-            prompt="Do something",
-            config={"configurable": {"thread_id": thread_id}},
-        )
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
+    await tool.coroutine(
+        agent="codex",
+        prompt="Do something",
+        config={"configurable": {"thread_id": thread_id}},
+    )
 
     assert captured["cwd"] == expected_cwd
 
@@ -466,18 +451,13 @@ async def test_invoke_acp_agent_passes_env_to_spawn(monkeypatch, tmp_path):
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
     monkeypatch.setitem(
         sys.modules,
         "acp",
         SimpleNamespace(
             PROTOCOL_VERSION="2026-03-24",
             Client=DummyClient,
-            RequestError=DummyRequestError,
+            RequestError=_DummyRequestError,
             spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
             text_block=lambda text: {"type": "text", "text": text},
         ),
@@ -502,11 +482,7 @@ async def test_invoke_acp_agent_passes_env_to_spawn(monkeypatch, tmp_path):
         }
     )
 
-    try:
-        await tool.coroutine(agent="codex", prompt="Do something")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
+    await tool.coroutine(agent="codex", prompt="Do something")
 
     assert captured["env"] == {"OPENAI_API_KEY": "sk-from-env", "FOO": "bar"}
 
@@ -559,18 +535,13 @@ async def test_invoke_acp_agent_skips_invalid_mcp_servers(monkeypatch, tmp_path,
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
     monkeypatch.setitem(
         sys.modules,
         "acp",
         SimpleNamespace(
             PROTOCOL_VERSION="2026-03-24",
             Client=DummyClient,
-            RequestError=DummyRequestError,
+            RequestError=_DummyRequestError,
             spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
             text_block=lambda text: {"type": "text", "text": text},
         ),
@@ -588,11 +559,7 @@ async def test_invoke_acp_agent_skips_invalid_mcp_servers(monkeypatch, tmp_path,
     tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
     caplog.set_level("WARNING")
 
-    try:
-        await tool.coroutine(agent="codex", prompt="Do something")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
+    await tool.coroutine(agent="codex", prompt="Do something")
 
     assert captured["new_session"]["mcp_servers"] == []
     assert "continuing without MCP servers" in caplog.text
@@ -646,18 +613,13 @@ async def test_invoke_acp_agent_passes_none_env_when_not_configured(monkeypatch,
         async def __aexit__(self, exc_type, exc, tb):
             return False
 
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
     monkeypatch.setitem(
         sys.modules,
         "acp",
         SimpleNamespace(
             PROTOCOL_VERSION="2026-03-24",
             Client=DummyClient,
-            RequestError=DummyRequestError,
+            RequestError=_DummyRequestError,
             spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
             text_block=lambda text: {"type": "text", "text": text},
         ),
@@ -674,11 +636,7 @@ async def test_invoke_acp_agent_passes_none_env_when_not_configured(monkeypatch,
 
     tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
 
-    try:
-        await tool.coroutine(agent="codex", prompt="Do something")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
+    await tool.coroutine(agent="codex", prompt="Do something")
 
     assert captured["env"] is None
 
@@ -828,642 +786,3 @@ def test_get_available_tools_uses_explicit_app_config_for_acp_agents(monkeypatch
 
     assert captured["agents"] is explicit_agents
     assert "invoke_acp_agent" in [tool.name for tool in tools]
-
-
-# ---------------------------------------------------------------------------
-# _format_tool_io unit tests
-# ---------------------------------------------------------------------------
-
-
-def test_format_tool_io_serializes_dict():
-    result = _format_tool_io({"key": "val"})
-    assert '"key"' in result
-    assert '"val"' in result
-
-
-def test_format_tool_io_truncates_long_output():
-    long_obj = {"data": "x" * 3000}
-    result = _format_tool_io(long_obj)
-    assert result.endswith("...")
-    assert len(result) <= 2003  # 2000 chars + "..."
-
-
-def test_format_tool_io_falls_back_to_repr_on_json_error():
-    class Unserializable:
-        pass
-
-    result = _format_tool_io(Unserializable())
-    assert "Unserializable" in result
-
-
-def test_format_tool_io_does_not_append_ellipsis_when_not_truncated():
-    result = _format_tool_io({"key": "val"})
-    assert not result.endswith("...")
-
-
-# ---------------------------------------------------------------------------
-# ToolCallUpdate integration test
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_session_update_logs_tool_call_update_raw_io(monkeypatch, tmp_path, caplog):
-    """ToolCallUpdate with raw_input/raw_output is logged at DEBUG level."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentMessageChunk = type("AgentMessageChunk", (), {})
-    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-1", "title": "search", "kind": "read"})
-    ToolCallUpdate = type(
-        "ToolCallUpdate",
-        (),
-        {"tool_call_id": "tc-1", "title": "search", "status": "completed", "raw_input": {"query": "foo"}, "raw_output": {"result": "bar"}},
-    )
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s2")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            await client.session_update("s2", ToolCallUpdate())
-            agent_msg = AgentMessageChunk()
-            agent_msg.content = TextContentBlock("done")
-            await client.session_update("s2", agent_msg)
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=AgentMessageChunk,
-            AgentThoughtChunk=AgentThoughtChunk,
-            ToolCallStart=ToolCallStart,
-            ToolCallUpdate=ToolCallUpdate,
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("DEBUG"):
-            result = await tool.coroutine(agent="codex", prompt="Search for foo")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == "done"
-    messages = [r.message for r in caplog.records]
-    assert any("tool update" in m and "params" in m and "search" in m and "tc-1" in m for m in messages)
-    assert any("tool update" in m and "result" in m and "search" in m and "tc-1" in m for m in messages)
-
-
-# ---------------------------------------------------------------------------
-# Thought logging integration tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.anyio
-async def test_session_update_logs_thought_chunks_immediately(monkeypatch, tmp_path, caplog):
-    """AgentThoughtChunk text is logged as soon as the chunk arrives."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentMessageChunk = type("AgentMessageChunk", (), {})
-    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-    ToolCallStart = type("ToolCallStart", (), {"tool_call_id": "tc-2", "title": "bash", "kind": "exec"})
-    ToolCallUpdate = type("ToolCallUpdate", (), {})
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s3")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            thought = AgentThoughtChunk()
-            thought.content = TextContentBlock("thinking hard")
-            await client.session_update("s3", thought)
-            captured["thought_logged_immediately"] = any("thinking hard" in record.message for record in caplog.records)
-            await client.session_update("s3", ToolCallStart())
-            msg = AgentMessageChunk()
-            msg.content = TextContentBlock("result")
-            await client.session_update("s3", msg)
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=AgentMessageChunk,
-            AgentThoughtChunk=AgentThoughtChunk,
-            ToolCallStart=ToolCallStart,
-            ToolCallUpdate=ToolCallUpdate,
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("DEBUG"):
-            result = await tool.coroutine(agent="codex", prompt="Do it")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == "result"
-    assert captured["thought_logged_immediately"] is True
-    assert any("thinking hard" in r.message for r in caplog.records)
-    tool_call_messages = [r.message for r in caplog.records if "ACP agent tool start" in r.message]
-    assert tool_call_messages
-    assert tool_call_messages[0].index("bash") < tool_call_messages[0].index("tc-2")
-
-
-@pytest.mark.anyio
-async def test_session_update_logs_truncated_thought_with_ellipsis(monkeypatch, tmp_path, caplog):
-    """Long thought chunks include an ellipsis when truncated for logging."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentMessageChunk = type("AgentMessageChunk", (), {})
-    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-    ToolCallStart = type("ToolCallStart", (), {})
-    ToolCallUpdate = type("ToolCallUpdate", (), {})
-
-    captured: dict[str, object] = {}
-    long_thought = "x" * 250
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s3b")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            thought = AgentThoughtChunk()
-            thought.content = TextContentBlock(long_thought)
-            await client.session_update("s3b", thought)
-            msg = AgentMessageChunk()
-            msg.content = TextContentBlock("result")
-            await client.session_update("s3b", msg)
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=AgentMessageChunk,
-            AgentThoughtChunk=AgentThoughtChunk,
-            ToolCallStart=ToolCallStart,
-            ToolCallUpdate=ToolCallUpdate,
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("DEBUG"):
-            result = await tool.coroutine(agent="codex", prompt="Do it")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == "result"
-    thought_messages = [r.message for r in caplog.records if "ACP agent thought" in r.message]
-    assert thought_messages
-    assert thought_messages[0].endswith("...")
-
-
-@pytest.mark.anyio
-async def test_session_update_logs_tool_call_update_status_only(monkeypatch, tmp_path, caplog):
-    """ToolCallUpdate with neither raw_input nor raw_output logs the status line."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentMessageChunk = type("AgentMessageChunk", (), {})
-    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-    ToolCallStart = type("ToolCallStart", (), {})
-    ToolCallUpdate = type(
-        "ToolCallUpdate",
-        (),
-        {"tool_call_id": "tc-3", "status": "in_progress", "title": "bash"},
-    )
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s4")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            await client.session_update("s4", ToolCallUpdate())
-            msg = AgentMessageChunk()
-            msg.content = TextContentBlock("done")
-            await client.session_update("s4", msg)
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=AgentMessageChunk,
-            AgentThoughtChunk=AgentThoughtChunk,
-            ToolCallStart=ToolCallStart,
-            ToolCallUpdate=ToolCallUpdate,
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("DEBUG"):
-            result = await tool.coroutine(agent="codex", prompt="Run bash")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == "done"
-    assert any("tool update" in r.message and "status" in r.message and "tc-3" in r.message and "in_progress" in r.message for r in caplog.records)
-    tool_status_messages = [r.message for r in caplog.records if "ACP agent tool update" in r.message and "status" in r.message]
-    assert tool_status_messages
-    assert tool_status_messages[0].index("bash") < tool_status_messages[0].index("tc-3")
-
-
-@pytest.mark.anyio
-async def test_invoke_acp_agent_logs_thought_on_prompt_failure(monkeypatch, tmp_path, caplog):
-    """Thought text is still logged when prompt execution later fails."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentThoughtChunk = type("AgentThoughtChunk", (), {})
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s5")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            thought = AgentThoughtChunk()
-            thought.content = TextContentBlock("partial failure thought")
-            await client.session_update("s5", thought)
-            raise RuntimeError("prompt failed")
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=type("AgentMessageChunk", (), {}),
-            AgentThoughtChunk=AgentThoughtChunk,
-            ToolCallStart=type("ToolCallStart", (), {}),
-            ToolCallUpdate=type("ToolCallUpdate", (), {}),
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("DEBUG"):
-            result = await tool.coroutine(agent="codex", prompt="Fail")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == "Error invoking ACP agent 'codex': prompt failed"
-    assert any("partial failure thought" in r.message for r in caplog.records)
-
-
-@pytest.mark.anyio
-async def test_invoke_acp_agent_logs_truncated_result_with_ellipsis(monkeypatch, tmp_path, caplog):
-    """Long final responses include an ellipsis in the info preview log."""
-    from deerflow.config import paths as paths_module
-
-    monkeypatch.setattr(paths_module, "get_paths", lambda: paths_module.Paths(base_dir=tmp_path))
-    monkeypatch.setattr(
-        "deerflow.config.extensions_config.ExtensionsConfig.from_file",
-        classmethod(lambda cls: ExtensionsConfig(mcp_servers={}, skills={})),
-    )
-
-    TextContentBlock = type("TextContentBlock", (), {"__init__": lambda self, text: setattr(self, "text", text)})
-    AgentMessageChunk = type("AgentMessageChunk", (), {})
-    long_result = "r" * 1200
-
-    captured: dict[str, object] = {}
-
-    class DummyClient:
-        def __init__(self) -> None:
-            self._chunks: list[str] = []
-
-        async def session_update(self, session_id, update, **kwargs):
-            pass
-
-        async def request_permission(self, options, session_id, tool_call, **kwargs):
-            raise AssertionError("should not be called")
-
-    class DummyConn:
-        async def initialize(self, **kwargs):
-            pass
-
-        async def new_session(self, **kwargs):
-            return SimpleNamespace(session_id="s6")
-
-        async def prompt(self, **kwargs):
-            client = captured["client"]
-            msg = AgentMessageChunk()
-            msg.content = TextContentBlock(long_result)
-            await client.session_update("s6", msg)
-
-    class DummyProcessContext:
-        def __init__(self, client, cmd, *args, env=None, cwd):
-            captured["client"] = client
-
-        async def __aenter__(self):
-            return DummyConn(), object()
-
-        async def __aexit__(self, exc_type, exc, tb):
-            return False
-
-    class DummyRequestError(Exception):
-        @staticmethod
-        def method_not_found(method):
-            return DummyRequestError(method)
-
-    monkeypatch.setitem(
-        sys.modules,
-        "acp",
-        SimpleNamespace(
-            PROTOCOL_VERSION="2026-03-24",
-            Client=DummyClient,
-            RequestError=DummyRequestError,
-            spawn_agent_process=lambda client, cmd, *args, env=None, cwd: DummyProcessContext(client, cmd, *args, env=env, cwd=cwd),
-            text_block=lambda text: {"type": "text", "text": text},
-        ),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "acp.schema",
-        SimpleNamespace(
-            ClientCapabilities=lambda: {},
-            Implementation=lambda **kwargs: kwargs,
-            AgentMessageChunk=AgentMessageChunk,
-            AgentThoughtChunk=type("AgentThoughtChunk", (), {}),
-            ToolCallStart=type("ToolCallStart", (), {}),
-            ToolCallUpdate=type("ToolCallUpdate", (), {}),
-            TextContentBlock=TextContentBlock,
-        ),
-    )
-
-    tool = build_invoke_acp_agent_tool({"codex": ACPAgentConfig(command="codex-acp", description="Codex CLI")})
-
-    try:
-        with caplog.at_level("INFO"):
-            result = await tool.coroutine(agent="codex", prompt="Do it")
-    finally:
-        sys.modules.pop("acp", None)
-        sys.modules.pop("acp.schema", None)
-
-    assert result == long_result
-    return_messages = [r.message for r in caplog.records if "ACP agent 'codex' returned " in r.message]
-    assert return_messages
-    assert any(message.endswith("...") for message in return_messages if "characters" not in message)


### PR DESCRIPTION
## Summary

Aligns `invoke_acp_agent` with the design in Refs #1296 and #1302: `session_update` now returns only `AgentMessageChunk` text as the tool result. Thought and tool lifecycle updates are treated as logs, not tool output.

## Changes

- Dispatch `session_update` by ACP update type: append only `AgentMessageChunk` text to `collected_text`; ignore non-agent text chunks such as `UserMessageChunk`
- Keep `AgentThoughtChunk`, `ToolCallStart`, and `ToolCallUpdate` as logging-only paths (no impact on returned message)
- Log `session_update` parse failures at `warning` level with exception info instead of silently swallowing them
- Keep ACP test coverage focused on behavior that affects results (message aggregation, workspace/env wiring, tool registration) and remove debug-log-detail assertions