### PR TITLE
fix(runtime): add user_id param to list_messages across all RunEventStore backends

### DIFF
--- a/backend/packages/harness/deerflow/runtime/events/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/events/store/base.py
@@ -55,6 +55,7 @@ class RunEventStore(abc.ABC):
         limit: int = 50,
         before_seq: int | None = None,
         after_seq: int | None = None,
+        user_id: str | None = None,
     ) -> list[dict]:
         """Return displayable messages (category=message) for a thread, ordered by seq ascending.
 
@@ -62,6 +63,11 @@ class RunEventStore(abc.ABC):
         - before_seq: return the last ``limit`` records with seq < before_seq (ascending)
         - after_seq: return the first ``limit`` records with seq > after_seq (ascending)
         - neither: return the latest ``limit`` records (ascending)
+
+        ``user_id`` is an optional ownership filter.  Implementations that
+        support per-user isolation (e.g. the DB backend) SHOULD filter by it.
+        Lightweight backends (memory, JSONL) accept the parameter for interface
+        consistency but rely on thread-scoped isolation instead.
         """
 
     @abc.abstractmethod

--- a/backend/packages/harness/deerflow/runtime/events/store/jsonl.py
+++ b/backend/packages/harness/deerflow/runtime/events/store/jsonl.py
@@ -162,7 +162,13 @@ class JsonlRunEventStore(RunEventStore):
             results.append(record)
         return results
 
-    async def list_messages(self, thread_id, *, limit=50, before_seq=None, after_seq=None):
+    async def list_messages(self, thread_id, *, limit=50, before_seq=None, after_seq=None, user_id=None):
+        if user_id is not None:
+            logger.warning(
+                "user_id=%r passed to JsonlRunEventStore.list_messages; "
+                "this backend relies on thread-scoped isolation and does not enforce per-user filtering.",
+                user_id,
+            )
         all_events = await asyncio.to_thread(self._read_thread_events, thread_id)
         messages = [e for e in all_events if e.get("category") == "message"]
 

--- a/backend/packages/harness/deerflow/runtime/events/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/events/store/memory.py
@@ -75,7 +75,7 @@ class MemoryRunEventStore(RunEventStore):
             results.append(record)
         return results
 
-    async def list_messages(self, thread_id, *, limit=50, before_seq=None, after_seq=None):
+    async def list_messages(self, thread_id, *, limit=50, before_seq=None, after_seq=None, user_id=None):
         all_events = self._events.get(thread_id, [])
         messages = [e for e in all_events if e["category"] == "message"]
 


### PR DESCRIPTION
## Summary

- `RunEventStore.list_messages()` had no `user_id` parameter in the abstract interface, while the DB backend already supported per-user filtering internally.
- This inconsistency made it impossible for callers to pass ownership context through the interface contract.
- Memory and JSONL backends now accept `user_id=None` for interface consistency, documented as relying on thread-scoped isolation rather than per-row filtering.

## Changes

- `store/base.py` — add `user_id: str | None = None` to the abstract `list_messages()` signature with docstring update
- `store/memory.py` — accept `user_id` parameter (ignored, thread-scoped)
- `store/jsonl.py` — accept `user_id` parameter (ignored, thread-scoped)
- DB store already has `user_id` support — no change needed

## Test plan

- [ ] All existing event store tests pass: `pytest -k "event_store or run_event or jsonl"` (59 tests)
- [ ] No callers broken — signature change is fully backward-compatible (new param has a default)

Closes #2814

🤖 Generated with [Claude Code](https://claude.com/claude-code)