### PR TITLE
fix(frontend): allow mock=true demo URLs through workspace auth guard

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,3 +1,4 @@
+import { headers } from "next/headers";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 
@@ -12,6 +13,14 @@ export const dynamic = "force-dynamic";
 export default async function WorkspaceLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
+  // Allow ?mock=true demo URLs through without authentication. The middleware
+  // at src/middleware.ts sets x-mock on the request so layouts can read it
+  // via headers() (layouts do not receive searchParams in App Router).
+  const headersList = await headers();
+  if (headersList.get("x-mock") === "true") {
+    return <WorkspaceContent>{children}</WorkspaceContent>;
+  }
+
   const result = await getServerSideUser();
 
   switch (result.tag) {

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,20 @@
+import { type NextRequest, NextResponse } from "next/server";
+
+/**
+ * Propagate ?mock=true from the URL into a request header so that server
+ * components (e.g. workspace/layout.tsx) can skip the auth redirect for
+ * public demo pages without needing access to searchParams, which layouts
+ * do not receive in Next.js App Router.
+ */
+export function middleware(request: NextRequest) {
+  if (request.nextUrl.searchParams.get("mock") !== "true") {
+    return NextResponse.next();
+  }
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-mock", "true");
+  return NextResponse.next({ request: { headers: requestHeaders } });
+}
+
+export const config = {
+  matcher: ["/workspace/:path*"],
+};


### PR DESCRIPTION
## Problem

Closes #3000

Public Case Studies landing page links to mock demo chat URLs such as:
```
/workspace/chats/7cfa5f8f-a2f8-47ad-acbd-da7137baf990?mock=true
```

The `workspace/layout.tsx` server component runs a full auth check for every `/workspace/*` route and redirects unauthenticated visitors to `/login` **before** the page can read `?mock=true`. This makes the public demos completely unreachable for anonymous users.

## Root Cause

Next.js App Router layouts receive `children` and `params` but **not** `searchParams`, so the layout cannot read `?mock=true` directly to skip the auth redirect.

## Fix

Two small files changed:

**`src/middleware.ts`** (new) — Next.js middleware that runs before the layout. When `?mock=true` is present, it clones the request headers and injects `x-mock: true`, which server components can read via `headers()` from `next/headers`.

**`src/app/workspace/layout.tsx`** — Added an early-return path before `getServerSideUser()`:
```ts
const headersList = await headers();
if (headersList.get("x-mock") === "true") {
  return <WorkspaceContent>{children}</WorkspaceContent>;
}
```

The chat page already handles mock mode via `useThreadChat().isMock` (switching to the read-only mock API client). This change simply lets the request reach the page.

## Validation

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- Normal authenticated workspace routes are completely unaffected (middleware is a no-op when `mock` param is absent)