### PR TITLE
fix(frontend): refresh thread run list after stream so older history loads on active page

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -351,6 +351,15 @@ export function useThreadStream({
           .filter((id): id is string => Boolean(id)),
       );
       void queryClient.invalidateQueries({ queryKey: ["threads", "search"] });
+      // Refresh the thread's run list so useThreadHistory can discover runs
+      // that were created during this streaming session (e.g. runs split by
+      // context summarization). Without this, hasMore stays false and the
+      // user cannot scroll-to-top to load older history on the active page.
+      if (threadIdRef.current) {
+        void queryClient.invalidateQueries({
+          queryKey: ["thread", threadIdRef.current],
+        });
+      }
       if (threadIdRef.current && !isMock) {
         void queryClient.invalidateQueries({
           queryKey: threadTokenUsageQueryKey(threadIdRef.current),


### PR DESCRIPTION
## Problem

Closes #2965

After context summarization fires mid-session, scrolling to the top of an active chat page no longer loads older history. Reopening the conversation works fine, but staying on the same page leaves the older runs inaccessible.

## Root Cause

`useThreadHistory` relies on `useThreadRuns` (query key `["thread", threadId]`) to know which runs exist for the thread. This query is populated once on mount and never invalidated during the session. After a run finishes:

1. `onFinish` invalidates `["threads", "search"]` (sidebar list) but not the per-thread run list
2. `useThreadRuns` returns only the initial (empty or single) run list
3. `findLatestUnloadedRunIndex` sees all known runs as loaded → returns `-1`
4. `hasMore = false` → scroll-to-top trigger is hidden
5. Older runs produced before/during summarization are unreachable until page reload

## Fix

In `onFinish` inside `useThreadStream`, add one `invalidateQueries` call for `["thread", threadId]`:

```ts
if (threadIdRef.current) {
  void queryClient.invalidateQueries({ queryKey: ["thread", threadIdRef.current] });
}
```

After the stream ends, `useThreadRuns` refetches the complete run list. `useThreadHistory` detects unloaded older runs, sets `hasMore` correctly, and the user can scroll-to-top to load them — matching the behaviour when re-opening an existing conversation.

## Validation

- `pnpm typecheck` — clean  
- `pnpm lint` — clean  
- Normal (no-summarization) sessions: one extra runs-list refetch on stream end, negligible overhead  
- Mock sessions: not affected (mock sessions don't trigger `onFinish` with real thread IDs)