### PR TITLE
fix(sandbox): close AioSandbox HTTP client on release and destroy

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
@@ -4,6 +4,7 @@ import shlex
 import threading
 import uuid
 
+import httpx
 from agent_sandbox import Sandbox as AioSandboxClient
 
 from deerflow.sandbox.sandbox import Sandbox
@@ -32,9 +33,18 @@ class AioSandbox(Sandbox):
         """
         super().__init__(id)
         self._base_url = base_url
-        self._client = AioSandboxClient(base_url=base_url, timeout=600)
+        # Own the httpx client so we can close it explicitly on teardown.
+        self._http_client = httpx.Client(timeout=600)
+        self._client = AioSandboxClient(base_url=base_url, timeout=600, httpx_client=self._http_client)
         self._home_dir = home_dir
         self._lock = threading.Lock()
+
+    def close(self) -> None:
+        """Close the underlying HTTP client and release its connection-pool resources."""
+        try:
+            self._http_client.close()
+        except Exception:
+            logger.debug("Error closing AioSandbox HTTP client for %s", self.id, exc_info=True)
 
     @property
     def base_url(self) -> str:

--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -633,8 +633,9 @@ class AioSandboxProvider(SandboxProvider):
         info = None
         thread_ids_to_remove: list[str] = []
 
+        sandbox = None
         with self._lock:
-            self._sandboxes.pop(sandbox_id, None)
+            sandbox = self._sandboxes.pop(sandbox_id, None)
             info = self._sandbox_infos.pop(sandbox_id, None)
             thread_ids_to_remove = [tid for tid, sid in self._thread_sandboxes.items() if sid == sandbox_id]
             for tid in thread_ids_to_remove:
@@ -643,6 +644,12 @@ class AioSandboxProvider(SandboxProvider):
             # Park in warm pool — container keeps running
             if info and sandbox_id not in self._warm_pool:
                 self._warm_pool[sandbox_id] = (info, time.time())
+
+        if sandbox is not None:
+            try:
+                sandbox.close()
+            except Exception:
+                logger.warning("Error closing AioSandbox client for %s during release", sandbox_id, exc_info=True)
 
         logger.info(f"Released sandbox {sandbox_id} to warm pool (container still running)")
 
@@ -655,11 +662,12 @@ class AioSandboxProvider(SandboxProvider):
         Args:
             sandbox_id: The ID of the sandbox to destroy.
         """
+        sandbox = None
         info = None
         thread_ids_to_remove: list[str] = []
 
         with self._lock:
-            self._sandboxes.pop(sandbox_id, None)
+            sandbox = self._sandboxes.pop(sandbox_id, None)
             info = self._sandbox_infos.pop(sandbox_id, None)
             thread_ids_to_remove = [tid for tid, sid in self._thread_sandboxes.items() if sid == sandbox_id]
             for tid in thread_ids_to_remove:
@@ -670,6 +678,12 @@ class AioSandboxProvider(SandboxProvider):
                 info, _ = self._warm_pool.pop(sandbox_id)
             else:
                 self._warm_pool.pop(sandbox_id, None)
+
+        if sandbox is not None:
+            try:
+                sandbox.close()
+            except Exception:
+                logger.warning("Error closing AioSandbox client for %s during destroy", sandbox_id, exc_info=True)
 
         if info:
             self._backend.destroy(info)

--- a/backend/tests/test_aio_sandbox.py
+++ b/backend/tests/test_aio_sandbox.py
@@ -1,4 +1,4 @@
-"""Tests for AioSandbox concurrent command serialization (#1433)."""
+"""Tests for AioSandbox concurrent command serialization (#1433) and teardown (#2872)."""
 
 import threading
 from types import SimpleNamespace
@@ -9,8 +9,9 @@ import pytest
 
 @pytest.fixture()
 def sandbox():
-    """Create an AioSandbox with a mocked client."""
-    with patch("deerflow.community.aio_sandbox.aio_sandbox.AioSandboxClient"):
+    """Create an AioSandbox with a mocked AioSandboxClient and httpx.Client."""
+    with patch("deerflow.community.aio_sandbox.aio_sandbox.AioSandboxClient"), patch("deerflow.community.aio_sandbox.aio_sandbox.httpx") as mock_httpx:
+        mock_httpx.Client.return_value = MagicMock()
         from deerflow.community.aio_sandbox.aio_sandbox import AioSandbox
 
         sb = AioSandbox(id="test-sandbox", base_url="http://localhost:8080")
@@ -233,3 +234,58 @@ class TestConcurrentFileWrites:
             thread.join()
 
         assert storage["content"] in {"seed\nA\nB\n", "seed\nB\nA\n"}
+
+
+class TestClientTeardown:
+    """AioSandbox.close() must close the owned httpx.Client (issue #2872)."""
+
+    def test_close_calls_http_client_close(self, sandbox):
+        sandbox.close()
+        sandbox._http_client.close.assert_called_once()
+
+    def test_close_is_idempotent_when_client_raises(self, sandbox):
+        sandbox._http_client.close.side_effect = RuntimeError("already closed")
+        sandbox.close()  # must not propagate
+
+    def test_provider_release_closes_sandbox_client(self):
+        """release() must close the AioSandbox client before moving to warm pool."""
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+
+        mock_sandbox = MagicMock()
+        provider = aio_mod.AioSandboxProvider.__new__(aio_mod.AioSandboxProvider)
+        provider._lock = __import__("threading").Lock()
+        provider._sandboxes = {"sid-1": mock_sandbox}
+        provider._sandbox_infos = {"sid-1": MagicMock()}
+        provider._thread_sandboxes = {"t-1": "sid-1"}
+        provider._last_activity = {"sid-1": 0.0}
+        provider._warm_pool = {}
+
+        provider.release("sid-1")
+
+        mock_sandbox.close.assert_called_once()
+
+    def test_provider_destroy_closes_sandbox_client(self):
+        """destroy() must close the AioSandbox client before tearing down the container."""
+        import importlib
+        from unittest.mock import MagicMock
+
+        aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+
+        mock_sandbox = MagicMock()
+        mock_backend = MagicMock()
+        provider = aio_mod.AioSandboxProvider.__new__(aio_mod.AioSandboxProvider)
+        provider._lock = __import__("threading").Lock()
+        provider._sandboxes = {"sid-2": mock_sandbox}
+        provider._sandbox_infos = {"sid-2": MagicMock()}
+        provider._thread_sandboxes = {}
+        provider._last_activity = {"sid-2": 0.0}
+        provider._warm_pool = {}
+        provider._backend = mock_backend
+
+        provider.destroy("sid-2")
+
+        mock_sandbox.close.assert_called_once()
+        mock_backend.destroy.assert_called_once()


### PR DESCRIPTION
## Problem

Closes #2872

`AioSandbox.__init__` creates an `httpx.Client` internally (via `AioSandboxClient`) but never closes it. Provider teardown paths (`release()`, `destroy()`, `shutdown()`) clear the in-memory dict and stop the container, but the connection pool owned by each `AioSandbox` instance is never explicitly shut down.

## Root Cause

`AioSandboxClient` owns its httpx client unless an external one is passed in. Because `AioSandbox` never passed one, every `AioSandbox` instance held a connection pool that survived as long as the Python object — which could be indefinitely if the GC didn't collect it promptly.

## Fix

- **`AioSandbox.__init__`**: create an explicit `httpx.Client(timeout=600)` and pass it to `AioSandboxClient`, so we control its lifecycle.
- **`AioSandbox.close()`**: new method that calls `self._http_client.close()`, swallowing exceptions so teardown paths stay robust.
- **`AioSandboxProvider.release()`**: store the popped `AioSandbox` and call `sandbox.close()` after the lock is released.
- **`AioSandboxProvider.destroy()`**: same — close the client before delegating container cleanup to the backend.

`shutdown()` already calls `destroy()` for active sandboxes, so it picks up the fix transitively. Warm-pool items only store `SandboxInfo` (no `AioSandbox` instance), so no change is needed there.

## Tests

Four new tests in `TestClientTeardown`:
- `close()` calls `httpx_client.close()`
- `close()` swallows exceptions (idempotent)
- `release()` calls `sandbox.close()`
- `destroy()` calls `sandbox.close()` then `backend.destroy()`

All 13 tests pass.