### PR TITLE
fix(trace):memory 中文 in trace info is unicode escape sequence.

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -338,7 +338,7 @@ class MemoryUpdater:
             reinforcement_detected=reinforcement_detected,
         )
         prompt = MEMORY_UPDATE_PROMPT.format(
-            current_memory=json.dumps(current_memory, indent=2),
+            current_memory=json.dumps(current_memory, indent=2, ensure_ascii=False),
             conversation=conversation_text,
             correction_hint=correction_hint,
         )

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -110,7 +110,7 @@ def test_prepare_update_prompt_preserves_non_ascii_memory_text() -> None:
     assert prepared is not None
     _, prompt = prepared
     assert "Deer-flow是一个非常好的框架。" in prompt
-    assert "\\u7528\\u6237" not in prompt
+    assert "\\u" not in prompt
 
 
 def test_apply_updates_skips_same_batch_duplicates_and_keeps_source_metadata() -> None:

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -78,6 +78,41 @@ def test_apply_updates_skips_existing_duplicate_and_preserves_removals() -> None
     assert all(fact["id"] != "fact_remove" for fact in result["facts"])
 
 
+def test_prepare_update_prompt_preserves_non_ascii_memory_text() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory(
+        facts=[
+            {
+                "id": "fact_cn",
+                "content": "Deer-flow是一个非常好的框架。",
+                "category": "context",
+                "confidence": 0.9,
+                "createdAt": "2026-05-20T00:00:00Z",
+                "source": "thread-cn",
+            },
+        ]
+    )
+
+    with (
+        patch("deerflow.agents.memory.updater.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch("deerflow.agents.memory.updater.get_memory_data", return_value=current_memory),
+    ):
+        msg = MagicMock()
+        msg.type = "human"
+        msg.content = "你好"
+        prepared = updater._prepare_update_prompt(
+            [msg],
+            agent_name=None,
+            correction_detected=False,
+            reinforcement_detected=False,
+        )
+
+    assert prepared is not None
+    _, prompt = prepared
+    assert "Deer-flow是一个非常好的框架。" in prompt
+    assert "\\u7528\\u6237" not in prompt
+
+
 def test_apply_updates_skips_same_batch_duplicates_and_keeps_source_metadata() -> None:
     updater = MemoryUpdater()
     current_memory = _make_memory()


### PR DESCRIPTION
It is not intuitively obvious what "memory" is.
before(eg.):
```
"summary\": \"\\u7528\\u6237\\u5f53\\u524d\\u5728\\u8003\\u8651\\u5468\\u672b\\u7684\\u4f11\\u95f2\\u5b89\\u6392\\uff0c\\u8ba1\\u5212\\u53bb\\u9493\\u9c7c\\u3002\\u8fd9\\u8868\\u660e\\u5176\\u8fd1\\u671f\\u5173\\u6ce8\\u70b9\\u4e4b\\u4e00\\u662f\\u653e\\u677e\\u548c\\u6237\\u5916\\u6d3b\\u52a8\\uff0c\\u4f46\\u76ee\\u524d\\u6ca1\\u6709\\u66f4\\u591a\\u5e76\\u884c\\u4e8b\\u9879\\u6216\\u6301\\u7eed\\u6027\\u9879\\u76ee\\u53ef\\u786e\\u8ba4\\u3002\"
```
after(eg.):
```
"summary\": \"用户使用中文交流。除感情关系修复话题外，用户也提到晚上会去打羽毛球，显示其有运动安排。\",
```