### PR TITLE
feat(context): support client context capabilities

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -39,7 +39,7 @@ class RunCreateRequest(BaseModel):
     command: dict[str, Any] | None = Field(default=None, description="LangGraph Command")
     metadata: dict[str, Any] | None = Field(default=None, description="Run metadata")
     config: dict[str, Any] | None = Field(default=None, description="RunnableConfig overrides")
-    context: dict[str, Any] | None = Field(default=None, description="DeerFlow context overrides (model_name, thinking_enabled, etc.)")
+    context: dict[str, Any] | None = Field(default=None, description="DeerFlow context overrides (model_name, thinking_enabled, etc.). May include client capabilities under context.client.")
     webhook: str | None = Field(default=None, description="Completion callback URL")
     checkpoint_id: str | None = Field(default=None, description="Resume from checkpoint")
     checkpoint: dict[str, Any] | None = Field(default=None, description="Full checkpoint object")

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -32,6 +32,7 @@ from deerflow.runtime import (
     UnsupportedStrategyError,
     run_agent,
 )
+from deerflow.runtime.client_context import sanitize_client_context
 from deerflow.runtime.runs.naming import resolve_root_run_name
 
 logger = logging.getLogger(__name__)
@@ -125,9 +126,22 @@ def merge_run_context_overrides(config: dict[str, Any], context: Mapping[str, An
     """Merge whitelisted keys from ``body.context`` into both ``config['configurable']``
     and ``config['context']`` so they are visible to legacy configurable readers and
     to LangGraph ``ToolRuntime.context`` consumers (e.g. the ``setup_agent`` tool —
-    see issue #2677)."""
+    see issue #2677).
+
+    Client capability context is runtime-only: it is sanitized and copied into
+    ``config['context']['client']`` but never into ``configurable``.
+    """
+    existing_runtime_context = config.get("context")
+    if isinstance(existing_runtime_context, dict) and "client" in existing_runtime_context:
+        existing_client_context = sanitize_client_context(existing_runtime_context.get("client"))
+        if existing_client_context is None:
+            existing_runtime_context.pop("client", None)
+        else:
+            existing_runtime_context["client"] = existing_client_context
+
     if not context:
         return
+
     configurable = config.setdefault("configurable", {})
     runtime_context = config.setdefault("context", {})
     for key in _CONTEXT_CONFIGURABLE_KEYS:
@@ -136,6 +150,10 @@ def merge_run_context_overrides(config: dict[str, Any], context: Mapping[str, An
                 configurable.setdefault(key, context[key])
             if isinstance(runtime_context, dict):
                 runtime_context.setdefault(key, context[key])
+
+    client_context = sanitize_client_context(context.get("client"))
+    if client_context is not None and isinstance(runtime_context, dict):
+        runtime_context.setdefault("client", client_context)
 
 
 def inject_authenticated_user_context(config: dict[str, Any], request: Request) -> None:

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -115,6 +115,42 @@ nested subagent graphs.
 - `thinking_enabled` (boolean): Enable extended thinking for supported models
 - `is_plan_mode` (boolean): Enable TodoList middleware for task tracking
 
+**Client Context:**
+
+Clients may describe their output capabilities under top-level `context.client`.
+The gateway keeps only the prompt-relevant, non-sensitive fields (`name`,
+`capabilities`, and `preferences`) and places the sanitized value in the run
+runtime context. The agent may also receive a compact hidden
+`<client_context>` reminder so skills can choose an output shape that fits the
+calling client.
+
+```json
+{
+  "input": {
+    "messages": [
+      {
+        "role": "user",
+        "content": "Analyze this dataset"
+      }
+    ]
+  },
+  "context": {
+    "client": {
+      "name": "custom-analytics-frontend",
+      "capabilities": {
+        "artifacts": true,
+        "csv_download": true,
+        "charts": true
+      },
+      "preferences": {
+        "csv": "present",
+        "chart": "present"
+      }
+    }
+  }
+}
+```
+
 **Response:** Server-Sent Events (SSE) stream
 
 ```

--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -24,8 +24,13 @@ Reminder format:
 Date-update format:
 
     <system-reminder>
+    <client_context>...</client_context>
+
     <current_date>2026-05-09, Saturday</current_date>
     </system-reminder>
+
+If no client context is active during a date update, the ``<client_context>``
+block is omitted.
 """
 
 from __future__ import annotations
@@ -162,9 +167,10 @@ class DynamicContextMiddleware(AgentMiddleware):
 
     def _build_date_update_reminder(self, client_context: str | None = None) -> str:
         current_date = datetime.now().strftime("%Y-%m-%d, %A")
-        lines = ["<system-reminder>", f"<current_date>{current_date}</current_date>"]
+        lines = ["<system-reminder>"]
         if client_context:
-            lines.extend(["", client_context])
+            lines.extend([client_context, ""])
+        lines.append(f"<current_date>{current_date}</current_date>")
         lines.append("</system-reminder>")
         return "\n".join(lines)
 

--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -1,10 +1,10 @@
-"""Middleware to inject dynamic context (memory, current date) as a system-reminder.
+"""Middleware to inject dynamic context (memory, client context, current date) as a system-reminder.
 
 The system prompt is kept fully static for maximum prefix-cache reuse across users
 and sessions.  The current date is always injected.  Per-user memory is also injected
-when ``memory.injection_enabled`` is True in the app config.  Both are delivered once
-per conversation as a dedicated <system-reminder> HumanMessage inserted before the
-first user message (frozen-snapshot pattern).
+when ``memory.injection_enabled`` is True in the app config.  Sanitized client
+capabilities are injected when present in ``runtime.context["client"]``. These are
+delivered as dedicated <system-reminder> HumanMessages inserted before user messages.
 
 When a conversation spans midnight the middleware detects the date change and injects
 a lightweight date-update reminder as a separate HumanMessage before the current turn.
@@ -15,6 +15,8 @@ Reminder format:
 
     <system-reminder>
     <memory>...</memory>
+
+    <client_context>...</client_context>
 
     <current_date>2026-05-08, Friday</current_date>
     </system-reminder>
@@ -31,12 +33,15 @@ from __future__ import annotations
 import logging
 import re
 import uuid
+from collections.abc import Mapping
 from datetime import datetime
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
 from langgraph.runtime import Runtime
+
+from deerflow.runtime.client_context import render_client_context_for_prompt, render_empty_client_context_for_prompt
 
 if TYPE_CHECKING:
     from deerflow.config.app_config import AppConfig
@@ -44,6 +49,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _DATE_RE = re.compile(r"<current_date>([^<]+)</current_date>")
+_CLIENT_CONTEXT_RE = re.compile(r"<client_context>.*?</client_context>", re.DOTALL)
 _DYNAMIC_CONTEXT_REMINDER_KEY = "dynamic_context_reminder"
 _SUMMARY_MESSAGE_NAME = "summary"
 
@@ -52,6 +58,12 @@ def _extract_date(content: str) -> str | None:
     """Return the first <current_date> value found in *content*, or None."""
     m = _DATE_RE.search(content)
     return m.group(1) if m else None
+
+
+def _extract_client_context(content: str) -> str | None:
+    """Return the first rendered <client_context> block found in *content*."""
+    m = _CLIENT_CONTEXT_RE.search(content)
+    return m.group(0).strip() if m else None
 
 
 def is_dynamic_context_reminder(message: object) -> bool:
@@ -69,7 +81,20 @@ def _last_injected_date(messages: list) -> str | None:
     for msg in reversed(messages):
         if is_dynamic_context_reminder(msg):
             content_str = msg.content if isinstance(msg.content, str) else str(msg.content)
-            return _extract_date(content_str)
+            date = _extract_date(content_str)
+            if date:
+                return date
+    return None
+
+
+def _last_injected_client_context(messages: list) -> str | None:
+    """Return the most recently injected client-context block, if any."""
+    for msg in reversed(messages):
+        if is_dynamic_context_reminder(msg):
+            content_str = msg.content if isinstance(msg.content, str) else str(msg.content)
+            client_context = _extract_client_context(content_str)
+            if client_context:
+                return client_context
     return None
 
 
@@ -78,13 +103,26 @@ def _is_user_injection_target(message: object) -> bool:
     return isinstance(message, HumanMessage) and not is_dynamic_context_reminder(message) and message.name != _SUMMARY_MESSAGE_NAME
 
 
+def _runtime_context(runtime: Runtime) -> Mapping[str, Any] | None:
+    context = getattr(runtime, "context", None)
+    return context if isinstance(context, Mapping) else None
+
+
+def _runtime_client_context(runtime: Runtime) -> str | None:
+    context = _runtime_context(runtime)
+    if context is None:
+        return None
+    return render_client_context_for_prompt(context.get("client"))
+
+
 class DynamicContextMiddleware(AgentMiddleware):
-    """Inject memory and current date into HumanMessages as a <system-reminder>.
+    """Inject memory, client context, and current date into hidden reminders.
 
     First turn
     ----------
-    Prepends a full system-reminder (memory + date) to the first HumanMessage and
-    persists it (same message ID).  The first message is then frozen for the whole
+    Prepends a full system-reminder (memory + client context + date) to the
+    first HumanMessage and persists it (same message ID).  The first message is
+    then frozen for the whole
     session — its content never changes again, so the prefix cache can hit on every
     subsequent turn.
 
@@ -101,32 +139,37 @@ class DynamicContextMiddleware(AgentMiddleware):
         self._agent_name = agent_name
         self._app_config = app_config
 
-    def _build_full_reminder(self) -> str:
+    def _build_full_reminder(self, runtime: Runtime) -> str:
         from deerflow.agents.lead_agent.prompt import _get_memory_context
 
         # Memory injection is gated by injection_enabled; date is always included.
         injection_enabled = self._app_config.memory.injection_enabled if self._app_config else True
         memory_context = _get_memory_context(self._agent_name, app_config=self._app_config) if injection_enabled else ""
+        client_context = _runtime_client_context(runtime)
         current_date = datetime.now().strftime("%Y-%m-%d, %A")
 
         lines: list[str] = ["<system-reminder>"]
         if memory_context:
             lines.append(memory_context.strip())
             lines.append("")  # blank line separating memory from date
+        if client_context:
+            lines.append(client_context)
+            lines.append("")
         lines.append(f"<current_date>{current_date}</current_date>")
         lines.append("</system-reminder>")
 
         return "\n".join(lines)
 
-    def _build_date_update_reminder(self) -> str:
+    def _build_date_update_reminder(self, client_context: str | None = None) -> str:
         current_date = datetime.now().strftime("%Y-%m-%d, %A")
-        return "\n".join(
-            [
-                "<system-reminder>",
-                f"<current_date>{current_date}</current_date>",
-                "</system-reminder>",
-            ]
-        )
+        lines = ["<system-reminder>", f"<current_date>{current_date}</current_date>"]
+        if client_context:
+            lines.extend(["", client_context])
+        lines.append("</system-reminder>")
+        return "\n".join(lines)
+
+    def _build_client_context_update_reminder(self, client_context: str) -> str:
+        return "\n".join(["<system-reminder>", client_context, "</system-reminder>"])
 
     @staticmethod
     def _make_reminder_and_user_messages(original: HumanMessage, reminder_content: str) -> tuple[HumanMessage, HumanMessage]:
@@ -153,18 +196,23 @@ class DynamicContextMiddleware(AgentMiddleware):
         )
         return reminder_msg, user_msg
 
-    def _inject(self, state) -> dict | None:
+    def _inject(self, state, runtime: Runtime) -> dict | None:
         messages = list(state.get("messages", []))
         if not messages:
             return None
 
         current_date = datetime.now().strftime("%Y-%m-%d, %A")
         last_date = _last_injected_date(messages)
+        last_client_context = _last_injected_client_context(messages)
+        current_client_context = _runtime_client_context(runtime)
+        if last_client_context is not None and current_client_context is None:
+            current_client_context = render_empty_client_context_for_prompt()
         logger.debug(
-            "DynamicContextMiddleware._inject: msg_count=%d last_date=%r current_date=%r",
+            "DynamicContextMiddleware._inject: msg_count=%d last_date=%r current_date=%r has_client_context=%s",
             len(messages),
             last_date,
             current_date,
+            bool(current_client_context),
         )
 
         if last_date is None:
@@ -172,17 +220,26 @@ class DynamicContextMiddleware(AgentMiddleware):
             first_idx = next((i for i, m in enumerate(messages) if _is_user_injection_target(m)), None)
             if first_idx is None:
                 return None
-            full_reminder = self._build_full_reminder()
+            full_reminder = self._build_full_reminder(runtime)
             logger.info(
-                "DynamicContextMiddleware: injecting full reminder (len=%d, has_memory=%s) into first HumanMessage id=%r",
+                "DynamicContextMiddleware: injecting full reminder (len=%d, has_memory=%s, has_client_context=%s) into first HumanMessage id=%r",
                 len(full_reminder),
                 "<memory>" in full_reminder,
+                "<client_context>" in full_reminder,
                 messages[first_idx].id,
             )
             reminder_msg, user_msg = self._make_reminder_and_user_messages(messages[first_idx], full_reminder)
             return {"messages": [reminder_msg, user_msg]}
 
         if last_date == current_date:
+            if current_client_context is not None and current_client_context != last_client_context:
+                last_human_idx = next((i for i in reversed(range(len(messages))) if _is_user_injection_target(messages[i])), None)
+                if last_human_idx is None:
+                    return None
+                reminder_msg, user_msg = self._make_reminder_and_user_messages(messages[last_human_idx], self._build_client_context_update_reminder(current_client_context))
+                logger.info("DynamicContextMiddleware: injected client-context update before current turn")
+                return {"messages": [reminder_msg, user_msg]}
+
             # ── Same day: nothing to do ──────────────────────────────────────────
             return None
 
@@ -191,14 +248,14 @@ class DynamicContextMiddleware(AgentMiddleware):
         if last_human_idx is None:
             return None
 
-        reminder_msg, user_msg = self._make_reminder_and_user_messages(messages[last_human_idx], self._build_date_update_reminder())
+        reminder_msg, user_msg = self._make_reminder_and_user_messages(messages[last_human_idx], self._build_date_update_reminder(current_client_context))
         logger.info("DynamicContextMiddleware: midnight crossing detected — injected date update before current turn")
         return {"messages": [reminder_msg, user_msg]}
 
     @override
     def before_agent(self, state, runtime: Runtime) -> dict | None:
-        return self._inject(state)
+        return self._inject(state, runtime)
 
     @override
     async def abefore_agent(self, state, runtime: Runtime) -> dict | None:
-        return self._inject(state)
+        return self._inject(state, runtime)

--- a/backend/packages/harness/deerflow/runtime/client_context.py
+++ b/backend/packages/harness/deerflow/runtime/client_context.py
@@ -1,0 +1,147 @@
+"""Helpers for request-level client context.
+
+The HTTP API accepts a broad ``context`` object for compatibility with
+LangGraph SDK clients.  Only a small, explicit subset of client-provided data
+should be preserved for runtime use or rendered into model-visible reminders.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections.abc import Mapping
+from html import escape
+from typing import Any
+
+_CLIENT_CONTEXT_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
+_MAX_CLIENT_CONTEXT_ITEMS = 32
+_MAX_CLIENT_NAME_LENGTH = 80
+_MAX_CLIENT_VALUE_LENGTH = 200
+
+_PROMPT_EMPTY_CLIENT_CONTEXT = "<client_context>not provided</client_context>"
+
+
+def _clean_key(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    key = value.strip()
+    if not key or not _CLIENT_CONTEXT_KEY_RE.fullmatch(key):
+        return None
+    return key
+
+
+def _clean_text(value: Any, *, max_length: int = _MAX_CLIENT_VALUE_LENGTH) -> str | None:
+    if not isinstance(value, str):
+        return None
+    # Collapse all whitespace so client-provided values cannot introduce
+    # prompt structure by adding line breaks or tags across lines.
+    text = " ".join(value.split())
+    if not text:
+        return None
+    if len(text) > max_length:
+        text = text[:max_length]
+    return text
+
+
+def _clean_preference_value(value: Any) -> str | int | float | bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, str):
+        return _clean_text(value)
+    return None
+
+
+def sanitize_client_context(raw_client: Any) -> dict[str, Any] | None:
+    """Return the safe subset of ``context.client`` for runtime use.
+
+    Accepted prompt-visible fields:
+    - ``name``: short client identifier
+    - ``capabilities``: mapping of capability name to boolean support flag
+    - ``preferences``: mapping of preference name to a scalar value
+
+    Unknown keys and nested structures are intentionally dropped.
+    """
+
+    if not isinstance(raw_client, Mapping):
+        return None
+
+    client: dict[str, Any] = {}
+
+    name = _clean_text(raw_client.get("name"), max_length=_MAX_CLIENT_NAME_LENGTH)
+    if name:
+        client["name"] = name
+
+    raw_capabilities = raw_client.get("capabilities")
+    if isinstance(raw_capabilities, Mapping):
+        capabilities: dict[str, bool] = {}
+        for raw_key, raw_value in list(raw_capabilities.items())[:_MAX_CLIENT_CONTEXT_ITEMS]:
+            key = _clean_key(raw_key)
+            if key is None or not isinstance(raw_value, bool):
+                continue
+            capabilities[key] = raw_value
+        if capabilities:
+            client["capabilities"] = dict(sorted(capabilities.items()))
+
+    raw_preferences = raw_client.get("preferences")
+    if isinstance(raw_preferences, Mapping):
+        preferences: dict[str, str | int | float | bool] = {}
+        for raw_key, raw_value in list(raw_preferences.items())[:_MAX_CLIENT_CONTEXT_ITEMS]:
+            key = _clean_key(raw_key)
+            value = _clean_preference_value(raw_value)
+            if key is None or value is None:
+                continue
+            preferences[key] = value
+        if preferences:
+            client["preferences"] = dict(sorted(preferences.items()))
+
+    return client or None
+
+
+def _format_prompt_value(value: str | int | float | bool) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return escape(value, quote=False)
+    return str(value)
+
+
+def render_client_context_for_prompt(raw_client: Any) -> str | None:
+    """Render safe client context as a compact model-visible reminder block."""
+
+    client = sanitize_client_context(raw_client)
+    if not client:
+        return None
+
+    lines = ["<client_context>"]
+
+    name = client.get("name")
+    if isinstance(name, str):
+        lines.append(f"name: {escape(name, quote=False)}")
+
+    capabilities = client.get("capabilities")
+    if isinstance(capabilities, Mapping):
+        enabled = sorted(key for key, enabled in capabilities.items() if enabled is True)
+        disabled = sorted(key for key, enabled in capabilities.items() if enabled is False)
+        if enabled:
+            lines.append(f"capabilities: {', '.join(enabled)}")
+        if disabled:
+            lines.append(f"unsupported_capabilities: {', '.join(disabled)}")
+
+    preferences = client.get("preferences")
+    if isinstance(preferences, Mapping):
+        rendered = [f"{key}={_format_prompt_value(value)}" for key, value in preferences.items() if isinstance(value, (str, int, float, bool))]
+        if rendered:
+            lines.append(f"preferences: {'; '.join(rendered)}")
+
+    lines.append("</client_context>")
+    return "\n".join(lines)
+
+
+def render_empty_client_context_for_prompt() -> str:
+    """Render an explicit reminder that no client context is active."""
+
+    return _PROMPT_EMPTY_CLIENT_CONTEXT

--- a/backend/packages/harness/deerflow/runtime/client_context.py
+++ b/backend/packages/harness/deerflow/runtime/client_context.py
@@ -11,6 +11,7 @@ import math
 import re
 from collections.abc import Mapping
 from html import escape
+from itertools import islice
 from typing import Any
 
 _CLIENT_CONTEXT_KEY_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,63}$")
@@ -78,7 +79,7 @@ def sanitize_client_context(raw_client: Any) -> dict[str, Any] | None:
     raw_capabilities = raw_client.get("capabilities")
     if isinstance(raw_capabilities, Mapping):
         capabilities: dict[str, bool] = {}
-        for raw_key, raw_value in list(raw_capabilities.items())[:_MAX_CLIENT_CONTEXT_ITEMS]:
+        for raw_key, raw_value in islice(raw_capabilities.items(), _MAX_CLIENT_CONTEXT_ITEMS):
             key = _clean_key(raw_key)
             if key is None or not isinstance(raw_value, bool):
                 continue
@@ -89,7 +90,7 @@ def sanitize_client_context(raw_client: Any) -> dict[str, Any] | None:
     raw_preferences = raw_client.get("preferences")
     if isinstance(raw_preferences, Mapping):
         preferences: dict[str, str | int | float | bool] = {}
-        for raw_key, raw_value in list(raw_preferences.items())[:_MAX_CLIENT_CONTEXT_ITEMS]:
+        for raw_key, raw_value in islice(raw_preferences.items(), _MAX_CLIENT_CONTEXT_ITEMS):
             key = _clean_key(raw_key)
             value = _clean_preference_value(raw_value)
             if key is None or value is None:

--- a/backend/tests/test_client_context.py
+++ b/backend/tests/test_client_context.py
@@ -39,6 +39,19 @@ def test_sanitize_client_context_keeps_only_prompt_relevant_fields():
     }
 
 
+def test_sanitize_client_context_limits_capabilities_and_preferences():
+    client = sanitize_client_context(
+        {
+            "capabilities": {f"cap_{i:02d}": True for i in range(40)},
+            "preferences": {f"pref_{i:02d}": "present" for i in range(40)},
+        }
+    )
+
+    assert client is not None
+    assert list(client["capabilities"]) == [f"cap_{i:02d}" for i in range(32)]
+    assert list(client["preferences"]) == [f"pref_{i:02d}" for i in range(32)]
+
+
 def test_render_client_context_for_prompt_escapes_and_formats():
     rendered = render_client_context_for_prompt(
         {

--- a/backend/tests/test_client_context.py
+++ b/backend/tests/test_client_context.py
@@ -1,0 +1,71 @@
+from deerflow.runtime.client_context import (
+    render_client_context_for_prompt,
+    sanitize_client_context,
+)
+
+
+def test_sanitize_client_context_keeps_only_prompt_relevant_fields():
+    client = sanitize_client_context(
+        {
+            "name": "custom-analytics-frontend",
+            "access_token": "secret",
+            "capabilities": {
+                "artifacts": True,
+                "csv_download": True,
+                "charts": False,
+                "bad key": True,
+                "string_bool": "true",
+            },
+            "preferences": {
+                "csv": "present",
+                "chart": "present",
+                "nested": {"drop": True},
+                "empty": "",
+            },
+        }
+    )
+
+    assert client == {
+        "name": "custom-analytics-frontend",
+        "capabilities": {
+            "artifacts": True,
+            "charts": False,
+            "csv_download": True,
+        },
+        "preferences": {
+            "chart": "present",
+            "csv": "present",
+        },
+    }
+
+
+def test_render_client_context_for_prompt_escapes_and_formats():
+    rendered = render_client_context_for_prompt(
+        {
+            "name": "analytics <frontend>",
+            "capabilities": {
+                "artifacts": True,
+                "images": False,
+            },
+            "preferences": {
+                "csv": "present <download>",
+                "concise": True,
+            },
+        }
+    )
+
+    assert rendered == "\n".join(
+        [
+            "<client_context>",
+            "name: analytics &lt;frontend&gt;",
+            "capabilities: artifacts",
+            "unsupported_capabilities: images",
+            "preferences: concise=true; csv=present &lt;download&gt;",
+            "</client_context>",
+        ]
+    )
+
+
+def test_render_client_context_for_prompt_returns_none_when_no_safe_fields():
+    assert render_client_context_for_prompt({"access_token": "secret"}) is None
+    assert render_client_context_for_prompt("bad-client-context") is None

--- a/backend/tests/test_dynamic_context_middleware.py
+++ b/backend/tests/test_dynamic_context_middleware.py
@@ -21,8 +21,8 @@ def _make_middleware(**kwargs) -> DynamicContextMiddleware:
     return DynamicContextMiddleware(**kwargs)
 
 
-def _fake_runtime():
-    return SimpleNamespace(context={})
+def _fake_runtime(context=None):
+    return SimpleNamespace(context=context or {})
 
 
 def _reminder_msg(content: str, msg_id: str) -> HumanMessage:
@@ -84,6 +84,94 @@ def test_memory_included_when_present():
     assert "User prefers Python." in reminder_content
     assert "<current_date>2026-05-08, Friday</current_date>" in reminder_content
     assert result["messages"][1].content == "Hi"
+
+
+def test_client_context_included_when_present():
+    mw = _make_middleware()
+    state = {"messages": [HumanMessage(content="Show me the data", id="msg-1")]}
+    runtime = _fake_runtime(
+        {
+            "client": {
+                "name": "custom-analytics-frontend",
+                "access_token": "secret",
+                "capabilities": {
+                    "artifacts": True,
+                    "csv_download": True,
+                    "images": False,
+                },
+                "preferences": {
+                    "csv": "present",
+                },
+            }
+        }
+    )
+
+    with mock.patch("deerflow.agents.lead_agent.prompt._get_memory_context", return_value=""), mock.patch("deerflow.agents.middlewares.dynamic_context_middleware.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "2026-05-08, Friday"
+        result = mw.before_agent(state, runtime)
+
+    reminder_content = result["messages"][0].content
+    assert "<client_context>" in reminder_content
+    assert "name: custom-analytics-frontend" in reminder_content
+    assert "capabilities: artifacts, csv_download" in reminder_content
+    assert "unsupported_capabilities: images" in reminder_content
+    assert "preferences: csv=present" in reminder_content
+    assert "access_token" not in reminder_content
+
+
+def test_client_context_update_injected_when_context_changes_same_day():
+    mw = _make_middleware()
+    reminder_content = "<system-reminder>\n<current_date>2026-05-08, Friday</current_date>\n</system-reminder>"
+    state = {
+        "messages": [
+            _reminder_msg(reminder_content, "msg-1"),
+            HumanMessage(content="Hello", id="msg-1__user"),
+            AIMessage(content="Hi there"),
+            HumanMessage(content="Follow-up", id="msg-2"),
+        ]
+    }
+    runtime = _fake_runtime({"client": {"name": "analytics-ui", "capabilities": {"csv_download": True}}})
+
+    with mock.patch("deerflow.agents.middlewares.dynamic_context_middleware.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "2026-05-08, Friday"
+        result = mw.before_agent(state, runtime)
+
+    assert result is not None
+    reminder = result["messages"][0]
+    assert reminder.id == "msg-2"
+    assert "<current_date>" not in reminder.content
+    assert "<client_context>" in reminder.content
+    assert "name: analytics-ui" in reminder.content
+    assert result["messages"][1].content == "Follow-up"
+
+
+def test_client_context_cleared_when_runtime_omits_previous_context():
+    mw = _make_middleware()
+    reminder_content = "\n".join(
+        [
+            "<system-reminder>",
+            "<client_context>",
+            "name: analytics-ui",
+            "</client_context>",
+            "<current_date>2026-05-08, Friday</current_date>",
+            "</system-reminder>",
+        ]
+    )
+    state = {
+        "messages": [
+            _reminder_msg(reminder_content, "msg-1"),
+            HumanMessage(content="Hello", id="msg-1__user"),
+            AIMessage(content="Hi there"),
+            HumanMessage(content="Follow-up", id="msg-2"),
+        ]
+    }
+
+    with mock.patch("deerflow.agents.middlewares.dynamic_context_middleware.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "2026-05-08, Friday"
+        result = mw.before_agent(state, _fake_runtime())
+
+    assert result is not None
+    assert "<client_context>not provided</client_context>" in result["messages"][0].content
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_dynamic_context_middleware.py
+++ b/backend/tests/test_dynamic_context_middleware.py
@@ -117,6 +117,7 @@ def test_client_context_included_when_present():
     assert "unsupported_capabilities: images" in reminder_content
     assert "preferences: csv=present" in reminder_content
     assert "access_token" not in reminder_content
+    assert reminder_content.index("<client_context>") < reminder_content.index("<current_date>")
 
 
 def test_client_context_update_injected_when_context_changes_same_day():
@@ -377,6 +378,28 @@ def test_midnight_crossing_injects_date_update_as_separate_message():
     # Original user text appended with derived ID
     assert msgs[1].id == "msg-2__user"
     assert msgs[1].content == "Good morning"
+
+
+def test_midnight_crossing_keeps_client_context_before_date_update():
+    mw = _make_middleware()
+    reminder_content = "<system-reminder>\n<current_date>2026-05-08, Friday</current_date>\n</system-reminder>"
+    state = {
+        "messages": [
+            _reminder_msg(reminder_content, "msg-1"),
+            HumanMessage(content="Hello", id="msg-1__user"),
+            AIMessage(content="Response"),
+            HumanMessage(content="Good morning", id="msg-2"),
+        ]
+    }
+    runtime = _fake_runtime({"client": {"name": "analytics-ui", "capabilities": {"charts": True}}})
+
+    with mock.patch("deerflow.agents.middlewares.dynamic_context_middleware.datetime") as mock_dt:
+        mock_dt.now.return_value.strftime.return_value = "2026-05-09, Saturday"
+        result = mw.before_agent(state, runtime)
+
+    content = result["messages"][0].content
+    assert "name: analytics-ui" in content
+    assert content.index("<client_context>") < content.index("<current_date>")
 
 
 def test_midnight_crossing_id_swap():

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -281,6 +281,68 @@ def test_merge_run_context_overrides_propagates_to_runtime_context():
     assert "thread_id" not in config["context"]
 
 
+def test_merge_run_context_overrides_propagates_sanitized_client_context_to_runtime_only():
+    """``context.client`` should be available to runtime consumers, not legacy configurable readers."""
+    from app.gateway.services import build_run_config, merge_run_context_overrides
+
+    config = build_run_config("thread-1", None, None)
+    merge_run_context_overrides(
+        config,
+        {
+            "client": {
+                "name": "custom-analytics-frontend",
+                "access_token": "must-not-propagate",
+                "capabilities": {
+                    "artifacts": True,
+                    "csv_download": True,
+                    "charts": False,
+                    "bad key": True,
+                    "coerced": "true",
+                },
+                "preferences": {
+                    "csv": "present",
+                    "chart": "skip",
+                    "nested": {"bad": "value"},
+                },
+            }
+        },
+    )
+
+    assert config["context"]["client"] == {
+        "name": "custom-analytics-frontend",
+        "capabilities": {
+            "artifacts": True,
+            "charts": False,
+            "csv_download": True,
+        },
+        "preferences": {
+            "chart": "skip",
+            "csv": "present",
+        },
+    }
+    assert "client" not in config["configurable"]
+
+
+def test_merge_run_context_overrides_preserves_explicit_config_context_client():
+    """Explicit ``config.context.client`` wins over top-level ``context.client``."""
+    from app.gateway.services import build_run_config, merge_run_context_overrides
+
+    config = build_run_config(
+        "thread-1",
+        {"context": {"client": {"name": "config-client", "capabilities": {"artifacts": False}}}},
+        None,
+    )
+    merge_run_context_overrides(
+        config,
+        {"client": {"name": "body-client", "capabilities": {"artifacts": True}}},
+    )
+
+    assert config["context"]["client"] == {
+        "name": "config-client",
+        "capabilities": {"artifacts": False},
+    }
+
+
 def test_merge_run_context_overrides_noop_for_empty_context():
     from app.gateway.services import build_run_config, merge_run_context_overrides
 

--- a/backend/tests/test_runtime_lifecycle_e2e.py
+++ b/backend/tests/test_runtime_lifecycle_e2e.py
@@ -57,6 +57,7 @@ class _RunController:
     def __init__(self) -> None:
         self.started = threading.Event()
         self.checkpoint_written = threading.Event()
+        self.blocked = threading.Event()
         self.cancelled = threading.Event()
         self.release = threading.Event()
         self.instances: list[_ScriptedAgent] = []
@@ -109,6 +110,7 @@ class _ScriptedAgent:
         yield _stream_item_for_mode(stream_mode, state)
 
         if self.block_after_first_chunk:
+            self.controller.blocked.set()
             try:
                 while not self.controller.release.is_set():
                     await asyncio.sleep(0.05)
@@ -560,6 +562,7 @@ def test_cancel_interrupt_stops_running_background_run(isolated_app):
         assert created.status_code == 200, created.text
         run_id = created.json()["run_id"]
         assert controller.started.wait(5), "fake agent never started"
+        assert controller.blocked.wait(5), "fake agent never entered its cancellable wait"
 
         cancelled = client.post(
             f"/api/threads/{thread_id}/runs/{run_id}/cancel?wait=true&action=interrupt",
@@ -665,6 +668,7 @@ def test_cancel_rollback_restores_pre_run_checkpoint(isolated_app):
         assert created.status_code == 200, created.text
         run_id = created.json()["run_id"]
         assert controller.checkpoint_written.wait(5), "fake agent did not write in-run checkpoint"
+        assert controller.blocked.wait(5), "fake agent never entered its cancellable wait"
 
         during = client.get(f"/api/threads/{thread_id}/state")
         assert during.status_code == 200, during.text

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -9,6 +9,12 @@ export interface AgentThreadState extends Record<string, unknown> {
   todos?: Todo[];
 }
 
+export interface AgentClientContext {
+  name?: string;
+  capabilities?: Record<string, boolean>;
+  preferences?: Record<string, string | number | boolean>;
+}
+
 export interface AgentThreadContext extends Record<string, unknown> {
   thread_id: string;
   model_name: string | undefined;
@@ -17,6 +23,7 @@ export interface AgentThreadContext extends Record<string, unknown> {
   subagent_enabled: boolean;
   reasoning_effort?: "minimal" | "low" | "medium" | "high";
   agent_name?: string;
+  client?: AgentClientContext;
 }
 
 export interface AgentThread extends Thread<AgentThreadState> {


### PR DESCRIPTION
## 概要

这个 PR 增加了一个轻量的 `context.client` 机制，使自定义前端可以把客户端能力和偏好传入 DeerFlow runtime。

目标是让 agent 和 skill 能够根据当前请求来源的客户端做出更合适的输出决策，例如判断是否支持 artifact、CSV 下载、图表，或者是否只能返回纯文本结果。

## 改动

- 增加 `context.client` 的安全裁剪和 prompt 渲染 helper
- 将 gateway run request 中经过安全裁剪的 `context.client` 转发到 `runtime.context`
- 将简洁的隐藏 client context reminder 注入到 agent 的动态上下文中
- 为前端 thread context 增加 client context 类型定义
- 补充 `context.client` 的请求格式文档
- 增加针对安全裁剪、gateway 转发、动态上下文注入的回归测试

## 示例

```json
{
  "context": {
    "client": {
      "name": "custom-analytics-frontend",
      "capabilities": {
        "artifacts": true,
        "csv_download": true,
        "charts": true
      },
      "preferences": {
        "csv": "present",
        "chart": "present"
      }
    }
  }
}
```
Closes #3105