### PR TITLE
fix(subagents): preserve user id in child runtime context

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -405,6 +405,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
             "subagent_enabled": subagent_enabled,
             "tool_groups": agent_config.tool_groups if agent_config else None,
             "available_skills": sorted(available_skills) if available_skills is not None else None,
+            "user_id": cfg.get("user_id"),
         }
     )
 

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -278,6 +278,7 @@ class SubagentExecutor:
         sandbox_state: SandboxState | None = None,
         thread_data: ThreadDataState | None = None,
         thread_id: str | None = None,
+        user_id: str | None = None,
         trace_id: str | None = None,
     ):
         """Initialize the executor.
@@ -292,6 +293,7 @@ class SubagentExecutor:
             sandbox_state: Sandbox state from parent agent.
             thread_data: Thread data from parent agent.
             thread_id: Thread ID for sandbox operations.
+            user_id: Authenticated user ID from the parent runtime.
             trace_id: Trace ID from parent for distributed tracing.
         """
         self.config = config
@@ -307,6 +309,7 @@ class SubagentExecutor:
         self.sandbox_state = sandbox_state
         self.thread_data = thread_data
         self.thread_id = thread_id
+        self.user_id = user_id
         # Generate trace_id if not provided (for top-level calls)
         self.trace_id = trace_id or str(uuid.uuid4())[:8]
 
@@ -492,6 +495,8 @@ class SubagentExecutor:
             if self.thread_id:
                 run_config["configurable"] = {"thread_id": self.thread_id}
                 context["thread_id"] = self.thread_id
+            if self.user_id:
+                context["user_id"] = self.user_id
             if self.app_config is not None:
                 context["app_config"] = self.app_config
 

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -155,6 +155,28 @@ def _get_runtime_app_config(runtime: Any) -> "AppConfig | None":
     return None
 
 
+def _get_user_id_from_runtime(runtime: Any) -> str | None:
+    """Return the authenticated user ID carried by the parent runtime."""
+    if runtime is None:
+        return None
+
+    context = getattr(runtime, "context", None)
+    if isinstance(context, dict):
+        user_id = context.get("user_id")
+        if isinstance(user_id, str) and user_id:
+            return user_id
+
+    config = getattr(runtime, "config", None)
+    if isinstance(config, dict):
+        metadata = config.get("metadata", {})
+        if isinstance(metadata, dict):
+            user_id = metadata.get("user_id")
+            if isinstance(user_id, str) and user_id:
+                return user_id
+
+    return None
+
+
 def _merge_skill_allowlists(parent: list[str] | None, child: list[str] | None) -> list[str] | None:
     """Return the effective subagent skill allowlist under the parent policy."""
     if parent is None:
@@ -234,6 +256,7 @@ async def task_tool(
     sandbox_state = None
     thread_data = None
     thread_id = None
+    user_id = None
     parent_model = None
     trace_id = None
     metadata: dict = {}
@@ -242,6 +265,7 @@ async def task_tool(
         sandbox_state = runtime.state.get("sandbox")
         thread_data = runtime.state.get("thread_data")
         thread_id = runtime.context.get("thread_id") if runtime.context else None
+        user_id = _get_user_id_from_runtime(runtime)
         if thread_id is None:
             thread_id = runtime.config.get("configurable", {}).get("thread_id")
 
@@ -288,6 +312,7 @@ async def task_tool(
         "sandbox_state": sandbox_state,
         "thread_data": thread_data,
         "thread_id": thread_id,
+        "user_id": user_id,
         "trace_id": trace_id,
     }
     if resolved_app_config is not None:

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -490,6 +490,35 @@ class TestAsyncExecutionPath:
         assert result.completed_at is not None
 
     @pytest.mark.anyio
+    async def test_aexecute_passes_user_id_to_child_runtime_context(self, classes, base_config, msg):
+        """Subagent tools should see the same authenticated user as the parent run."""
+        SubagentExecutor = classes["SubagentExecutor"]
+        SubagentStatus = classes["SubagentStatus"]
+
+        captured_context: dict | None = None
+
+        async def capturing_astream(_state, **kwargs):
+            nonlocal captured_context
+            captured_context = kwargs.get("context")
+            yield {"messages": [msg.ai("done", "msg-user-context")]}
+
+        mock_agent = MagicMock()
+        mock_agent.astream = capturing_astream
+
+        executor = SubagentExecutor(
+            config=base_config,
+            tools=[],
+            thread_id="test-thread",
+            user_id="user-42",
+        )
+
+        with patch.object(executor, "_create_agent", return_value=mock_agent):
+            result = await executor._aexecute("Task")
+
+        assert result.status == SubagentStatus.COMPLETED
+        assert captured_context == {"thread_id": "test-thread", "user_id": "user-42"}
+
+    @pytest.mark.anyio
     async def test_aexecute_collects_ai_messages(self, classes, base_config, mock_agent, msg):
         """Test that AI messages are collected during streaming."""
         SubagentExecutor = classes["SubagentExecutor"]

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -24,11 +24,16 @@ class FakeSubagentStatus(Enum):
     TIMED_OUT = "timed_out"
 
 
-def _make_runtime(*, app_config=None) -> SimpleNamespace:
+def _make_runtime(*, app_config=None, user_id: str | None = None, user_id_in_metadata: str | None = None) -> SimpleNamespace:
     # Minimal ToolRuntime-like object; task_tool only reads these three attributes.
     context = {"thread_id": "thread-1"}
     if app_config is not None:
         context["app_config"] = app_config
+    if user_id is not None:
+        context["user_id"] = user_id
+    metadata = {"model_name": "ark-model", "trace_id": "trace-1"}
+    if user_id_in_metadata is not None:
+        metadata["user_id"] = user_id_in_metadata
     return SimpleNamespace(
         state={
             "sandbox": {"sandbox_id": "local"},
@@ -39,7 +44,7 @@ def _make_runtime(*, app_config=None) -> SimpleNamespace:
             },
         },
         context=context,
-        config={"metadata": {"model_name": "ark-model", "trace_id": "trace-1"}},
+        config={"metadata": metadata},
     )
 
 
@@ -88,6 +93,18 @@ class _DummyScheduledTask:
         return None
 
 
+def test_get_user_id_from_runtime_prefers_context_over_metadata():
+    runtime = _make_runtime(user_id="context-user", user_id_in_metadata="metadata-user")
+
+    assert task_tool_module._get_user_id_from_runtime(runtime) == "context-user"
+
+
+def test_get_user_id_from_runtime_falls_back_to_metadata():
+    runtime = _make_runtime(user_id_in_metadata="metadata-user")
+
+    assert task_tool_module._get_user_id_from_runtime(runtime) == "metadata-user"
+
+
 def test_task_tool_returns_error_for_unknown_subagent(monkeypatch):
     monkeypatch.setattr(task_tool_module, "get_subagent_config", lambda _: None)
     monkeypatch.setattr(task_tool_module, "get_available_subagent_names", lambda: ["general-purpose"])
@@ -121,7 +138,7 @@ def test_task_tool_rejects_bash_subagent_when_host_bash_disabled(monkeypatch):
 def test_task_tool_threads_runtime_app_config_to_subagent_dependencies(monkeypatch):
     app_config = object()
     config = _make_subagent_config(name="bash")
-    runtime = _make_runtime(app_config=app_config)
+    runtime = _make_runtime(app_config=app_config, user_id="user-42")
     events = []
     captured = {}
 
@@ -177,6 +194,7 @@ def test_task_tool_threads_runtime_app_config_to_subagent_dependencies(monkeypat
     assert captured["bash_gate_app_config"] is app_config
     assert captured["tools_kwargs"]["app_config"] is app_config
     assert captured["executor_kwargs"]["app_config"] is app_config
+    assert captured["executor_kwargs"]["user_id"] == "user-42"
     assert captured["executor_kwargs"]["tools"] == ["tool-a"]
 
 


### PR DESCRIPTION
## Summary
- carry the authenticated `user_id` from the lead-agent runtime metadata into `task` subagent execution
- pass `user_id` through `SubagentExecutor` into the child agent runtime context so runtime-scoped tools do not fall back to `default`
- add focused regression coverage for context/metadata extraction and child runtime propagation

## Verification
- `uv run ruff format packages/harness/deerflow/agents/lead_agent/agent.py packages/harness/deerflow/subagents/executor.py packages/harness/deerflow/tools/builtins/task_tool.py tests/test_task_tool_core_logic.py tests/test_subagent_executor.py`
- `uv run ruff check packages/harness/deerflow/agents/lead_agent/agent.py packages/harness/deerflow/subagents/executor.py packages/harness/deerflow/tools/builtins/task_tool.py tests/test_task_tool_core_logic.py tests/test_subagent_executor.py`
- `uv run pytest tests/test_task_tool_core_logic.py tests/test_subagent_executor.py -q` — 78 passed

Part of #3102
