### PR TITLE
fix(runtime): persist resolved model name to DB even when not explicitly provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ config.yaml.bak
 /frontend/playwright-report/
 .gstack/
 .worktrees
+
+# Agent plans
+.agents/plans/

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -234,12 +234,14 @@ async def run_agent(
         # _resolve_model_name in agent.py may return the default model if the
         # requested name is not in the allowlist — this update ensures the
         # persisted model_name reflects the actual model used.
-        if record.model_name is not None:
-            resolved = getattr(agent, "metadata", {}) or {}
-            if isinstance(resolved, dict):
-                effective = resolved.get("model_name")
-                if effective and effective != record.model_name:
-                    await run_manager.update_model_name(record.run_id, effective)
+        # NOTE: Removed the "record.model_name is not None" guard so that runs
+        # created without an explicit model_name (which leaves it as None) still
+        # get their resolved effective model persisted to the database.
+        resolved = getattr(agent, "metadata", {}) or {}
+        if isinstance(resolved, dict):
+            effective = resolved.get("model_name")
+            if effective:
+                await run_manager.update_model_name(record.run_id, effective)
 
         # 4. Attach checkpointer and store
         if checkpointer is not None:


### PR DESCRIPTION
## Summary

Fixes the `model_name` column in the `runs` database table being permanently empty. When a user starts a run without specifying a `model_name` in the request context, the agent resolves an effective model at runtime, but this was never persisted to the database due to a guard condition that skipped the update entirely when `record.model_name` was `None`.

## Changes

**File:** `backend/packages/harness/deerflow/runtime/runs/worker.py` (lines 237–242)

- Removed the `"record.model_name is not None"` early-exit guard
- The code now always resolves the effective model name from agent metadata and persists it to the DB when available
- When `model_name` was already set at creation time, behavior is unchanged (same or different effective model gets written)
- When `model_name` was never set (the bug case), the resolved default model is now correctly persisted

## Test Plan

- [x] All 64 tests in `tests/test_run_manager.py` pass (including `test_model_name_create_or_reject`, `test_model_name_default_is_none`)
- [x] Python syntax check via ruff: clean
- Manual verification: start a run without explicit `model_name`, query the DB to confirm it's populated

## Related Issues

Closes #3109