### PR TITLE
fix(gateway): avoid stale AppConfig in request and run paths

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -163,8 +163,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     # Load config and check necessary environment variables at startup
     try:
-        app.state.config = get_app_config()
-        apply_logging_level(app.state.config.log_level)
+        startup_config = get_app_config()
+        apply_logging_level(startup_config.log_level)
         logger.info("Configuration loaded successfully")
     except Exception as e:
         error_msg = f"Failed to load configuration during gateway startup: {e}"
@@ -185,7 +185,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         try:
             from app.channels.service import start_channel_service
 
-            channel_service = await start_channel_service(app.state.config)
+            channel_service = await start_channel_service(startup_config)
             logger.info("Channel service started: %s", channel_service.get_status())
         except Exception:
             logger.exception("No IM channels configured or channel service failed to start")

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -3,6 +3,11 @@
 **Getters** (used by routers): raise 503 when a required dependency is
 missing, except ``get_store`` which returns ``None``.
 
+``AppConfig`` is intentionally *not* cached on ``app.state``. Routers and
+the run path resolve it through :func:`deerflow.config.get_app_config`,
+which performs mtime-based hot reload, so edits to ``config.yaml`` take
+effect on the next request without a process restart.
+
 Initialization is handled directly in ``app.py`` via :class:`AsyncExitStack`.
 """
 
@@ -15,6 +20,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 from fastapi import FastAPI, HTTPException, Request
 from langgraph.types import Checkpointer
 
+from deerflow.config import get_app_config
 from deerflow.config.app_config import AppConfig
 from deerflow.persistence.feedback import FeedbackRepository
 from deerflow.runtime import RunContext, RunManager, StreamBridge
@@ -31,11 +37,16 @@ T = TypeVar("T")
 
 
 def get_config(request: Request) -> AppConfig:
-    """Return the app-scoped ``AppConfig`` stored on ``app.state``."""
-    config = getattr(request.app.state, "config", None)
-    if config is None:
-        raise HTTPException(status_code=503, detail="Configuration not available")
-    return config
+    """Return the live :class:`AppConfig`, honouring mtime-based hot reload.
+
+    ``request`` is accepted for FastAPI ``Depends`` compatibility but is
+    intentionally unused — config no longer lives on ``app.state``.
+    """
+    del request
+    try:
+        return get_app_config()
+    except Exception as exc:  # config not loaded / yaml unreadable
+        raise HTTPException(status_code=503, detail="Configuration not available") from exc
 
 
 @asynccontextmanager
@@ -53,9 +64,10 @@ async def langgraph_runtime(app: FastAPI) -> AsyncGenerator[None, None]:
     from deerflow.runtime.events.store import make_run_event_store
 
     async with AsyncExitStack() as stack:
-        config = getattr(app.state, "config", None)
-        if config is None:
-            raise RuntimeError("langgraph_runtime() requires app.state.config to be initialized")
+        try:
+            config = get_app_config()
+        except Exception as exc:
+            raise RuntimeError("langgraph_runtime() could not load AppConfig") from exc
 
         app.state.stream_bridge = await stack.enter_async_context(make_stream_bridge(config))
 

--- a/backend/tests/test_gateway_config_hot_reload.py
+++ b/backend/tests/test_gateway_config_hot_reload.py
@@ -1,0 +1,126 @@
+"""End-to-end regression for #3112 — gateway config hot reload.
+
+Validates that ``get_config`` and ``get_run_context`` both reflect a live
+``config.yaml`` edit on the next request, without restarting the
+gateway process. The test exercises the same chain that broke before the
+fix:
+
+    config.yaml mtime changes
+        → deerflow.config.get_app_config() reloads (mtime-based)
+        → app.gateway.deps.get_config(request) returns the new instance
+        → app.gateway.deps.get_run_context(request).app_config is the new instance
+
+If any link reverts to a startup-time snapshot, the second request below
+will see the old ``log_level`` / ``model.max_tokens`` and the assertion
+fails.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.gateway.deps import get_config, get_run_context
+from deerflow.config import app_config as app_config_module
+from deerflow.config.app_config import AppConfig
+
+
+def _write_config(path: Path, *, log_level: str, max_tokens: int) -> None:
+    payload = {
+        "log_level": log_level,
+        "models": [
+            {
+                "name": "test-model",
+                "use": "langchain_openai:ChatOpenAI",
+                "model": "gpt-4o-mini",
+                "max_tokens": max_tokens,
+            }
+        ],
+        "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+    }
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+
+@pytest.fixture
+def hot_reload_config(tmp_path, monkeypatch):
+    """Write a temporary config.yaml and point AppConfig resolution at it.
+
+    Resets the AppConfig singleton before and after the test so the
+    cached state of other tests does not leak.
+    """
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path, log_level="info", max_tokens=8192)
+
+    # Force AppConfig.resolve_config_path() to return our temp file.
+    monkeypatch.setattr(AppConfig, "resolve_config_path", classmethod(lambda cls, p=None: config_path))
+
+    # Clear any AppConfig singleton populated by an earlier test.
+    app_config_module.reset_app_config()
+    yield config_path
+    app_config_module.reset_app_config()
+
+
+def test_get_config_reflects_yaml_edit(hot_reload_config):
+    """Editing config.yaml must change the next ``Depends(get_config)`` result."""
+    app = FastAPI()
+
+    @app.get("/log-level")
+    def log_level(cfg: AppConfig = Depends(get_config)):
+        return {"level": cfg.log_level}
+
+    @app.get("/max-tokens")
+    def max_tokens(cfg: AppConfig = Depends(get_config)):
+        model = cfg.get_model_config("test-model")
+        return {"max_tokens": getattr(model, "max_tokens", None)}
+
+    client = TestClient(app)
+
+    assert client.get("/log-level").json() == {"level": "info"}
+    assert client.get("/max-tokens").json() == {"max_tokens": 8192}
+
+    # Bump mtime so AppConfig's mtime-based reload triggers. ``time.sleep``
+    # is necessary because some filesystems only honour second-level mtime
+    # resolution; touching twice in the same second would be a no-op.
+    time.sleep(1.1)
+    _write_config(hot_reload_config, log_level="debug", max_tokens=384000)
+
+    assert client.get("/log-level").json() == {"level": "debug"}
+    assert client.get("/max-tokens").json() == {"max_tokens": 384000}
+
+
+def test_get_run_context_app_config_reflects_yaml_edit(hot_reload_config):
+    """``RunContext.app_config`` must follow the live AppConfig too.
+
+    This is the path the agent worker uses; without it the lead-agent
+    factory and SummarizationMiddleware would receive a stale snapshot
+    even after ``get_config`` was fixed.
+    """
+    app = FastAPI()
+
+    # ``get_run_context`` requires several other singletons (checkpointer,
+    # store, etc.) on app.state. Stub them with sentinel objects so the
+    # dependency wiring runs to completion; the assertions below only
+    # care about ``ctx.app_config``.
+    sentinel = object()
+    app.state.checkpointer = sentinel
+    app.state.store = sentinel
+    app.state.run_event_store = sentinel
+    app.state.thread_store = sentinel
+
+    @app.get("/run-context-max-tokens")
+    def probe(ctx=Depends(get_run_context)):
+        model = ctx.app_config.get_model_config("test-model")
+        return {"max_tokens": getattr(model, "max_tokens", None)}
+
+    client = TestClient(app)
+    assert client.get("/run-context-max-tokens").json() == {"max_tokens": 8192}
+
+    time.sleep(1.1)
+    _write_config(hot_reload_config, log_level="info", max_tokens=384000)
+
+    assert client.get("/run-context-max-tokens").json() == {"max_tokens": 384000}

--- a/backend/tests/test_gateway_deps_config.py
+++ b/backend/tests/test_gateway_deps_config.py
@@ -1,3 +1,12 @@
+"""Regression tests for ``app.gateway.deps.get_config``.
+
+These tests verify that ``get_config`` returns the live ``AppConfig``
+resolved through ``deerflow.config.get_app_config`` rather than a
+startup-time snapshot stored on ``app.state``. This is the contract
+required to fix issue #3112: edits to ``config.yaml`` must take effect
+on the next request without a process restart.
+"""
+
 from __future__ import annotations
 
 from fastapi import Depends, FastAPI
@@ -8,11 +17,12 @@ from deerflow.config.app_config import AppConfig
 from deerflow.config.sandbox_config import SandboxConfig
 
 
-def test_get_config_returns_app_state_config():
-    """get_config should return the exact AppConfig stored on app.state."""
-    app = FastAPI()
+def test_get_config_returns_live_app_config(monkeypatch):
+    """``get_config`` should return whatever ``get_app_config()`` resolves to."""
     config = AppConfig(sandbox=SandboxConfig(use="test"))
-    app.state.config = config
+    monkeypatch.setattr("app.gateway.deps.get_app_config", lambda: config)
+
+    app = FastAPI()
 
     @app.get("/probe")
     def probe(cfg: AppConfig = Depends(get_config)):
@@ -25,10 +35,20 @@ def test_get_config_returns_app_state_config():
     assert response.json() == {"same_identity": True, "log_level": "info"}
 
 
-def test_get_config_reads_updated_app_state():
-    """Swapping app.state.config should be visible to the dependency."""
+def test_get_config_picks_up_reload(monkeypatch):
+    """A subsequent ``get_app_config()`` reload must be visible to the dependency.
+
+    This is the regression for #3112: if ``get_config`` cached the first
+    AppConfig instance, edits to ``config.yaml`` would never reach
+    routers nor the run path.
+    """
+    initial = AppConfig(sandbox=SandboxConfig(use="test"), log_level="info")
+    reloaded = AppConfig(sandbox=SandboxConfig(use="test"), log_level="debug")
+
+    state = {"current": initial}
+    monkeypatch.setattr("app.gateway.deps.get_app_config", lambda: state["current"])
+
     app = FastAPI()
-    app.state.config = AppConfig(sandbox=SandboxConfig(use="test"), log_level="info")
 
     @app.get("/log-level")
     def log_level(cfg: AppConfig = Depends(get_config)):
@@ -37,5 +57,26 @@ def test_get_config_reads_updated_app_state():
     client = TestClient(app)
     assert client.get("/log-level").json() == {"level": "info"}
 
-    app.state.config = app.state.config.model_copy(update={"log_level": "debug"})
+    # Simulate ``get_app_config()`` reloading after an mtime change.
+    state["current"] = reloaded
     assert client.get("/log-level").json() == {"level": "debug"}
+
+
+def test_get_config_503_when_config_unavailable(monkeypatch):
+    """If config loading fails, surface a 503 rather than a 500."""
+
+    def _raise():
+        raise FileNotFoundError("config.yaml not found")
+
+    monkeypatch.setattr("app.gateway.deps.get_app_config", _raise)
+
+    app = FastAPI()
+
+    @app.get("/probe")
+    def probe(cfg: AppConfig = Depends(get_config)):  # pragma: no cover - unreachable
+        return cfg.log_level
+
+    client = TestClient(app)
+    response = client.get("/probe")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Configuration not available"}

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -37,8 +37,10 @@ def _make_skill(name: str, *, enabled: bool) -> Skill:
 
 
 def _make_test_app(config) -> FastAPI:
+    from app.gateway.deps import get_config
+
     app = FastAPI()
-    app.state.config = config
+    app.dependency_overrides[get_config] = lambda: config
     app.include_router(skills_router.router)
     return app
 

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -627,10 +627,12 @@ def test_upload_limits_endpoint_reads_uploads_config():
 
 
 def test_upload_limits_endpoint_requires_thread_access():
+    from app.gateway.deps import get_config
+
     cfg = MagicMock()
     cfg.uploads = {}
     app = make_authed_test_app(owner_check_passes=False)
-    app.state.config = cfg
+    app.dependency_overrides[get_config] = lambda: cfg
     app.include_router(uploads.router)
 
     with TestClient(app) as client:


### PR DESCRIPTION
## Summary

Fixes #3112.

This removes the gateway startup `app.state.config` snapshot from request/run config resolution. Routers and new run contexts now resolve `AppConfig` through `get_app_config()`, so mtime-based `config.yaml` reloads are visible on the next request without restarting the gateway.

## Root Cause

The gateway loaded `AppConfig` once during lifespan startup and stored it on `app.state.config`.

That startup snapshot was then reused by:

- FastAPI dependencies such as `get_config()`
- `get_run_context()`
- new agent runs via `RunContext.app_config`

As a result, global `get_app_config()` could reload the updated file, but the main gateway request/run path still forwarded the stale startup snapshot.

## Changes

- Stop storing `AppConfig` on `app.state.config`.
- Make `get_config()` return the live `get_app_config()` value.
- Make `langgraph_runtime()` load its startup infrastructure config directly from `get_app_config()`.
- Keep startup-only consumers, such as channel service initialization, on the explicit `startup_config` snapshot.
- Update router tests to override the `get_config` dependency instead of mutating `app.state.config`.
- Add regression coverage for `get_config()` and `get_run_context()` observing `config.yaml` edits.

## Scope Boundaries

This PR does not make every config section hot-reloadable.

Still startup/restart-bound by design:

- channels service configuration
- database/checkpointer/store configuration
- stream bridge
- run event store
- run manager / in-flight runs

Related to #3103: this may address the stale-config part of updated `summarization` settings not reaching new runs. It does not address separate summarization issues such as custom-model `fraction` profile requirements, approximate token counting, or explicit input-token caps.
