### PR TITLE
fix(frontend): Normalize API timestamps as UTC

### DIFF
--- a/frontend/src/core/utils/datetime.ts
+++ b/frontend/src/core/utils/datetime.ts
@@ -4,6 +4,21 @@ import { enUS as dateFnsEnUS, zhCN as dateFnsZhCN } from "date-fns/locale";
 import { detectLocale, type Locale } from "@/core/i18n";
 import { getLocaleFromCookie } from "@/core/i18n/cookies";
 
+const TIMEZONE_PATTERN = /(Z|[+-]\d{2}:?\d{2})$/i;
+
+export function normalizeApiDate(date: Date | string | number): Date | string | number {
+  if (typeof date !== "string") {
+    return date;
+  }
+
+  const trimmed = date.trim();
+  if (!trimmed || TIMEZONE_PATTERN.test(trimmed)) {
+    return date;
+  }
+
+  return new Date(`${trimmed}Z`);
+}
+
 function getDateFnsLocale(locale: Locale) {
   switch (locale) {
     case "zh-CN":
@@ -20,7 +35,7 @@ export function formatTimeAgo(date: Date | string | number, locale?: Locale) {
     (getLocaleFromCookie() as Locale | null) ??
     // Fallback when cookie is missing (or on first render)
     detectLocale();
-  return formatDistanceToNow(date, {
+  return formatDistanceToNow(normalizeApiDate(date), {
     addSuffix: true,
     locale: getDateFnsLocale(effectiveLocale),
   });

--- a/frontend/tests/unit/datetime.test.ts
+++ b/frontend/tests/unit/datetime.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("@/core/i18n", () => ({
+  detectLocale: () => "en-US",
+}));
+
+vi.mock("@/core/i18n/cookies", () => ({
+  getLocaleFromCookie: () => null,
+}));
+
+import { normalizeApiDate } from "@/core/utils/datetime";
+
+describe("normalizeApiDate", () => {
+  test("treats timezone-less API timestamps as UTC", () => {
+    const normalized = normalizeApiDate("2026-05-20T06:12:31.333753");
+
+    expect(normalized).toBeInstanceOf(Date);
+    expect((normalized as Date).toISOString()).toBe("2026-05-20T06:12:31.333Z");
+  });
+
+  test("preserves timezone-aware strings", () => {
+    const timestamp = "2026-05-20T06:12:31.333753Z";
+
+    expect(normalizeApiDate(timestamp)).toBe(timestamp);
+  });
+
+  test("preserves non-string date inputs", () => {
+    const date = new Date("2026-05-20T06:12:31.333Z");
+
+    expect(normalizeApiDate(date)).toBe(date);
+    expect(normalizeApiDate(1779257551333)).toBe(1779257551333);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3120.

Chat history API timestamps can arrive without an explicit timezone suffix, for example `2026-05-20T06:12:31.333753`. Browsers parse those strings as local time, so users in timezones such as Asia/Shanghai see shifted relative times.

This PR normalizes timezone-less API timestamp strings as UTC before passing them to `formatDistanceToNow`, while preserving timezone-aware strings and existing `Date`/number inputs.

## Verification

- `pnpm test tests/unit/datetime.test.ts`
- `pnpm typecheck`
- `git diff --check`
