### PR TITLE
fix(persistence): emit tz-aware timestamps from SQLite-backed stores

### DIFF
--- a/backend/packages/harness/deerflow/persistence/feedback/sql.py
+++ b/backend/packages/harness/deerflow/persistence/feedback/sql.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from deerflow.persistence.feedback.model import FeedbackRow
 from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_iso
 
 
 class FeedbackRepository:
@@ -24,7 +25,8 @@ class FeedbackRepository:
         d = row.to_dict()
         val = d.get("created_at")
         if isinstance(val, datetime):
-            d["created_at"] = val.isoformat()
+            # SQLite drops tzinfo on read; normalize via ``coerce_iso`` so output is always tz-aware.
+            d["created_at"] = coerce_iso(val)
         return d
 
     async def create(

--- a/backend/packages/harness/deerflow/persistence/run/sql.py
+++ b/backend/packages/harness/deerflow/persistence/run/sql.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from deerflow.persistence.run.model import RunRow
 from deerflow.runtime.runs.store.base import RunStore
 from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_iso
 
 
 class RunRepository(RunStore):
@@ -68,11 +69,13 @@ class RunRepository(RunStore):
         # Remap JSON columns to match RunStore interface
         d["metadata"] = d.pop("metadata_json", {})
         d["kwargs"] = d.pop("kwargs_json", {})
-        # Convert datetime to ISO string for consistency with MemoryRunStore
+        # Convert datetime to ISO string for consistency with MemoryRunStore.
+        # SQLite drops tzinfo on read despite ``DateTime(timezone=True)`` —
+        # ``coerce_iso`` normalizes naive datetimes as UTC.
         for key in ("created_at", "updated_at"):
             val = d.get(key)
             if isinstance(val, datetime):
-                d[key] = val.isoformat()
+                d[key] = coerce_iso(val)
         return d
 
     async def put(

--- a/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
+++ b/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
@@ -13,6 +13,7 @@ from deerflow.persistence.json_compat import json_match
 from deerflow.persistence.thread_meta.base import InvalidMetadataFilterError, ThreadMetaStore
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_iso
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,9 @@ class ThreadMetaRepository(ThreadMetaStore):
         for key in ("created_at", "updated_at"):
             val = d.get(key)
             if isinstance(val, datetime):
-                d[key] = val.isoformat()
+                # SQLite drops tzinfo despite ``DateTime(timezone=True)``;
+                # ``coerce_iso`` normalizes naive values as UTC so the wire format always carries tz.
+                d[key] = coerce_iso(val)
         return d
 
     async def create(

--- a/backend/packages/harness/deerflow/runtime/events/store/db.py
+++ b/backend/packages/harness/deerflow/runtime/events/store/db.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.runtime.events.store.base import RunEventStore
 from deerflow.runtime.user_context import AUTO, _AutoSentinel, get_current_user, resolve_user_id
+from deerflow.utils.time import coerce_iso
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,9 @@ class DbRunEventStore(RunEventStore):
         d["metadata"] = d.pop("event_metadata", {})
         val = d.get("created_at")
         if isinstance(val, datetime):
-            d["created_at"] = val.isoformat()
+            # SQLite drops tzinfo on read despite ``DateTime(timezone=True)``;
+            # ``coerce_iso`` normalizes naive datetimes as UTC.
+            d["created_at"] = coerce_iso(val)
         d.pop("id", None)
         # Restore structured content that was JSON-serialized on write.
         raw = d.get("content", "")

--- a/backend/tests/test_persistence_timezone.py
+++ b/backend/tests/test_persistence_timezone.py
@@ -1,0 +1,106 @@
+"""Regression tests for #3120: SQLite-backed stores must emit tz-aware ISO timestamps.
+
+SQLAlchemy's ``DateTime(timezone=True)`` is a no-op on SQLite because the
+backend has no native timezone type, so values read back are naive
+``datetime`` instances. The four SQL ``_row_to_dict`` helpers therefore
+have to normalize through :func:`deerflow.utils.time.coerce_iso` instead
+of calling ``.isoformat()`` directly; otherwise the API ships
+timezone-less strings (e.g. ``"2026-05-20T06:10:22.970977"``) and the
+frontend's ``new Date(...)`` parses them as local time, shifting recent
+threads by the local UTC offset.
+"""
+
+import re
+
+import pytest
+
+_TZ_SUFFIX_RE = re.compile(r"(?:\+\d{2}:\d{2}|Z)$")
+
+
+def _assert_tz_aware(value: str | None, *, context: str) -> None:
+    assert value, f"{context}: expected ISO string, got {value!r}"
+    assert _TZ_SUFFIX_RE.search(value), f"{context}: timestamp lacks tz suffix: {value!r}"
+
+
+async def _init_sqlite(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'tz.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    return get_session_factory()
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+@pytest.mark.anyio
+async def test_thread_meta_emits_tz_aware_timestamps(tmp_path):
+    from deerflow.persistence.thread_meta import ThreadMetaRepository
+
+    repo = ThreadMetaRepository(await _init_sqlite(tmp_path))
+    try:
+        created = await repo.create("t-tz", user_id="u1", display_name="tz")
+        _assert_tz_aware(created["created_at"], context="thread_meta.create.created_at")
+        _assert_tz_aware(created["updated_at"], context="thread_meta.create.updated_at")
+
+        # Second read from DB exercises the same _row_to_dict path on a
+        # value that SQLite has round-tripped (where tzinfo is lost).
+        fetched = await repo.get("t-tz", user_id="u1")
+        _assert_tz_aware(fetched["created_at"], context="thread_meta.get.created_at")
+        _assert_tz_aware(fetched["updated_at"], context="thread_meta.get.updated_at")
+
+        listed = await repo.search(user_id="u1")
+        assert listed, "search must return the created row"
+        _assert_tz_aware(listed[0]["created_at"], context="thread_meta.search.created_at")
+        _assert_tz_aware(listed[0]["updated_at"], context="thread_meta.search.updated_at")
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_run_repository_emits_tz_aware_timestamps(tmp_path):
+    from deerflow.persistence.run import RunRepository
+
+    repo = RunRepository(await _init_sqlite(tmp_path))
+    try:
+        await repo.put("r-tz", thread_id="t-tz", user_id="u1")
+        row = await repo.get("r-tz", user_id="u1")
+        _assert_tz_aware(row["created_at"], context="run.get.created_at")
+        _assert_tz_aware(row["updated_at"], context="run.get.updated_at")
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_feedback_repository_emits_tz_aware_timestamps(tmp_path):
+    from deerflow.persistence.feedback import FeedbackRepository
+
+    repo = FeedbackRepository(await _init_sqlite(tmp_path))
+    try:
+        record = await repo.create(run_id="r-tz", thread_id="t-tz", rating=1, user_id="u1")
+        _assert_tz_aware(record["created_at"], context="feedback.create.created_at")
+    finally:
+        await _cleanup()
+
+
+@pytest.mark.anyio
+async def test_run_event_store_emits_tz_aware_timestamps(tmp_path):
+    from deerflow.runtime.events.store.db import DbRunEventStore
+
+    store = DbRunEventStore(await _init_sqlite(tmp_path))
+    try:
+        await store.put(
+            thread_id="t-tz",
+            run_id="r-tz",
+            event_type="log",
+            category="log",
+            content="hello",
+        )
+        events = await store.list_events("t-tz", "r-tz", user_id=None)
+        assert events, "expected at least one event"
+        _assert_tz_aware(events[0]["created_at"], context="run_event.list.created_at")
+    finally:
+        await _cleanup()


### PR DESCRIPTION
Closes #3120 (one of the items tracked in #3107).

## What's wrong

On the default SQLite backend, `POST /api/threads/search` returns timestamps without a timezone suffix:

```
"created_at": "2026-05-20T06:10:22.970977"
"updated_at": "2026-05-20T06:12:31.333753"
```

`new Date("2026-05-20T06:12:31.333753")` in the browser interprets these as local time, so the chat list shows recent threads as roughly 8h ago in Asia/Shanghai.

## Why

All write paths use `datetime.now(UTC)` and the ORM columns are declared `DateTime(timezone=True)`, so the code looked correct. The catch is SQLite: it has no native timezone type, and SQLAlchemy's `timezone=True` is documented as a no-op there. Values come back from the DB as naive `datetime` instances.

Four `_row_to_dict` helpers then called `.isoformat()` directly on those naive values, emitting timezone-less strings. The downstream `coerce_iso()` call in `threads.py` is a no-op on already-formatted strings, so the missing tz survives all the way to the API response.

PostgreSQL deployments are unaffected — `timestamptz` preserves tzinfo end-to-end.

## Fix

Route the four call sites through the existing `deerflow.utils.time.coerce_iso`, which normalizes naive values as UTC and emits `+00:00`. No data migration: existing SQLite rows read back through the corrected serializer.

Touched four files: `thread_meta/sql.py`, `run/sql.py`, `feedback/sql.py`, `runtime/events/store/db.py`.

## Verification

### Unit test (red without fix, green with fix)

New `backend/tests/test_persistence_timezone.py` exercises all four stores against a temp SQLite. With the fix reverted on one of them:

```
E AssertionError: thread_meta.create.created_at: timestamp lacks tz suffix: '2026-05-21T07:35:04.294061'
FAILED tests/test_persistence_timezone.py::test_thread_meta_emits_tz_aware_timestamps
```

With the fix in place:

```
tests/test_persistence_timezone.py::test_thread_meta_emits_tz_aware_timestamps PASSED
tests/test_persistence_timezone.py::test_run_repository_emits_tz_aware_timestamps PASSED
tests/test_persistence_timezone.py::test_feedback_repository_emits_tz_aware_timestamps PASSED
tests/test_persistence_timezone.py::test_run_event_store_emits_tz_aware_timestamps PASSED
4 passed in 0.21s
```

Broader regression run also clean:

```
pytest -k "thread or run_repo or feedback or run_event or persistence or datetime or timestamp or timezone"
359 passed, 2 skipped, 0 failed
```

### Real Gateway HTTP (same DB row, only code version differs)

Started Gateway against SQLite, logged in, created a thread, then ran `POST /api/threads/search` twice — once with the fix reverted, once with the fix in place — against the **same row** without touching the database.

Before:
```
{"thread_id":"d4d7007a-410c-4802-a491-21f9c7bb7890",
 "created_at":"2026-05-21T07:04:26.213274",
 "updated_at":"2026-05-21T07:04:26.213274", ...}
```

After:
```
{"thread_id":"d4d7007a-410c-4802-a491-21f9c7bb7890",
 "created_at":"2026-05-21T07:04:26.213274+00:00",
 "updated_at":"2026-05-21T07:04:26.213274+00:00", ...}
```

Same row, same request, only the serializer changed.

## Scope

- Default SQLite backend only; PostgreSQL deployments unchanged.
- Reads only — write paths and stored values are untouched, so no migration is needed and the rollout is safe in either direction.
