### PR TITLE
fix(runtime): bound write_file execution-failure observations

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -457,17 +457,18 @@ def _format_write_file_error(
     error: Exception,
     runtime: Runtime | None = None,
     *,
+    message: str | None = None,
     max_chars: int = _DEFAULT_WRITE_FILE_ERROR_MAX_CHARS,
 ) -> str:
     """Return a bounded, sanitized error string for write_file failures."""
-    header = f"Error: Failed to write file '{requested_path}': "
+    header = message or f"Error: Failed to write file '{requested_path}'"
     detail = _sanitize_error(error, runtime)
     if max_chars == 0:
-        return f"{header}{detail}"
-    detail_budget = max_chars - len(header)
+        return f"{header}: {detail}"
+    detail_budget = max_chars - len(header) - 2
     if detail_budget <= 0:
-        return _truncate_write_file_error_detail(f"{header}{detail}", max_chars)
-    return f"{header}{_truncate_write_file_error_detail(detail, detail_budget)}"
+        return _truncate_write_file_error_detail(f"{header}: {detail}", max_chars)
+    return f"{header}: {_truncate_write_file_error_detail(detail, detail_budget)}"
 
 
 def replace_virtual_path(path: str, thread_data: ThreadDataState | None) -> str:
@@ -1564,9 +1565,19 @@ def write_file_tool(
     except SandboxError as e:
         return _format_write_file_error(requested_path, e, runtime)
     except PermissionError as e:
-        return _format_write_file_error(requested_path, e, runtime)
+        return _format_write_file_error(
+            requested_path,
+            e,
+            runtime,
+            message=f"Error: Permission denied writing to file: {requested_path}",
+        )
     except IsADirectoryError as e:
-        return _format_write_file_error(requested_path, e, runtime)
+        return _format_write_file_error(
+            requested_path,
+            e,
+            runtime,
+            message=f"Error: Path is a directory, not a file: {requested_path}",
+        )
     except OSError as e:
         return _format_write_file_error(requested_path, e, runtime)
     except Exception as e:

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -40,6 +40,7 @@ _DEFAULT_GLOB_MAX_RESULTS = 200
 _MAX_GLOB_MAX_RESULTS = 1000
 _DEFAULT_GREP_MAX_RESULTS = 100
 _MAX_GREP_MAX_RESULTS = 500
+_DEFAULT_WRITE_FILE_ERROR_MAX_CHARS = 2000
 _LOCAL_BASH_CWD_COMMANDS = {"cd", "pushd"}
 _LOCAL_BASH_COMMAND_WRAPPERS = {"command", "builtin"}
 _LOCAL_BASH_COMMAND_PREFIX_KEYWORDS = {"!", "{", "case", "do", "elif", "else", "for", "if", "select", "then", "time", "until", "while"}
@@ -431,6 +432,42 @@ def _sanitize_error(error: Exception, runtime: Runtime | None = None) -> str:
         thread_data = get_thread_data(runtime)
         msg = mask_local_paths_in_output(msg, thread_data)
     return msg
+
+
+def _truncate_write_file_error_detail(detail: str, max_chars: int) -> str:
+    """Middle-truncate write_file error details, preserving the head and tail."""
+    if max_chars == 0:
+        return detail
+    if len(detail) <= max_chars:
+        return detail
+    total = len(detail)
+    marker_max_len = len(f"\n... [write_file error truncated: {total} chars skipped] ...\n")
+    kept = max(0, max_chars - marker_max_len)
+    if kept == 0:
+        return detail[:max_chars]
+    head_len = kept // 2
+    tail_len = kept - head_len
+    skipped = total - kept
+    marker = f"\n... [write_file error truncated: {skipped} chars skipped] ...\n"
+    return f"{detail[:head_len]}{marker}{detail[-tail_len:] if tail_len > 0 else ''}"
+
+
+def _format_write_file_error(
+    requested_path: str,
+    error: Exception,
+    runtime: Runtime | None = None,
+    *,
+    max_chars: int = _DEFAULT_WRITE_FILE_ERROR_MAX_CHARS,
+) -> str:
+    """Return a bounded, sanitized error string for write_file failures."""
+    header = f"Error: Failed to write file '{requested_path}': "
+    detail = _sanitize_error(error, runtime)
+    if max_chars == 0:
+        return f"{header}{detail}"
+    detail_budget = max_chars - len(header)
+    if detail_budget <= 0:
+        return _truncate_write_file_error_detail(f"{header}{detail}", max_chars)
+    return f"{header}{_truncate_write_file_error_detail(detail, detail_budget)}"
 
 
 def replace_virtual_path(path: str, thread_data: ThreadDataState | None) -> str:
@@ -1525,15 +1562,15 @@ def write_file_tool(
             sandbox.write_file(path, content, append)
         return "OK"
     except SandboxError as e:
-        return f"Error: {e}"
-    except PermissionError:
-        return f"Error: Permission denied writing to file: {requested_path}"
-    except IsADirectoryError:
-        return f"Error: Path is a directory, not a file: {requested_path}"
+        return _format_write_file_error(requested_path, e, runtime)
+    except PermissionError as e:
+        return _format_write_file_error(requested_path, e, runtime)
+    except IsADirectoryError as e:
+        return _format_write_file_error(requested_path, e, runtime)
     except OSError as e:
-        return f"Error: Failed to write file '{requested_path}': {_sanitize_error(e, runtime)}"
+        return _format_write_file_error(requested_path, e, runtime)
     except Exception as e:
-        return f"Error: Unexpected error writing file: {_sanitize_error(e, runtime)}"
+        return _format_write_file_error(requested_path, e, runtime)
 
 
 @tool("str_replace", parse_docstring=True)

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -457,11 +457,10 @@ def _format_write_file_error(
     error: Exception,
     runtime: Runtime | None = None,
     *,
-    message: str | None = None,
     max_chars: int = _DEFAULT_WRITE_FILE_ERROR_MAX_CHARS,
 ) -> str:
     """Return a bounded, sanitized error string for write_file failures."""
-    header = message or f"Error: Failed to write file '{requested_path}'"
+    header = f"Error: Failed to write file '{requested_path}'"
     detail = _sanitize_error(error, runtime)
     if max_chars == 0:
         return f"{header}: {detail}"
@@ -1564,19 +1563,15 @@ def write_file_tool(
         return "OK"
     except SandboxError as e:
         return _format_write_file_error(requested_path, e, runtime)
-    except PermissionError as e:
-        return _format_write_file_error(
-            requested_path,
-            e,
-            runtime,
-            message=f"Error: Permission denied writing to file: {requested_path}",
+    except PermissionError:
+        return _truncate_write_file_error_detail(
+            f"Error: Permission denied writing to file: {requested_path}",
+            _DEFAULT_WRITE_FILE_ERROR_MAX_CHARS,
         )
-    except IsADirectoryError as e:
-        return _format_write_file_error(
-            requested_path,
-            e,
-            runtime,
-            message=f"Error: Path is a directory, not a file: {requested_path}",
+    except IsADirectoryError:
+        return _truncate_write_file_error_detail(
+            f"Error: Path is a directory, not a file: {requested_path}",
+            _DEFAULT_WRITE_FILE_ERROR_MAX_CHARS,
         )
     except OSError as e:
         return _format_write_file_error(requested_path, e, runtime)

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1549,9 +1549,9 @@ def write_file_tool(
         append: Whether to append content to the end of the file instead of overwriting it. Defaults to false.
     """
     try:
+        requested_path = path
         sandbox = ensure_sandbox_initialized(runtime)
         ensure_thread_directories_exist(runtime)
-        requested_path = path
         if is_local_sandbox(runtime):
             thread_data = get_thread_data(runtime)
             validate_local_tool_path(path, thread_data)

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1235,12 +1235,12 @@ def test_write_file_tool_bounds_large_sandbox_error(monkeypatch) -> None:
     [
         pytest.param(
             PermissionError("permission denied"),
-            "PermissionError: permission denied",
+            "Error: Permission denied writing to file: /mnt/user-data/workspace/output.txt",
             id="permission",
         ),
         pytest.param(
             IsADirectoryError("target is a directory"),
-            "IsADirectoryError: target is a directory",
+            "Error: Path is a directory, not a file: /mnt/user-data/workspace/output.txt",
             id="directory",
         ),
         pytest.param(

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
+from deerflow.sandbox.exceptions import SandboxError
 from deerflow.sandbox.tools import (
     VIRTUAL_PATH_PREFIX,
     _apply_cwd_prefix,
@@ -1138,6 +1139,129 @@ def test_str_replace_and_append_on_same_path_should_preserve_both_updates(monkey
 
     assert failures == []
     assert sandbox.content == "ALPHA\ntail\n"
+
+
+def test_write_file_tool_bounds_large_oserror_and_masks_local_paths(monkeypatch) -> None:
+    class FailingSandbox:
+        id = "sandbox-write-large-oserror"
+
+        def write_file(self, path: str, content: str, append: bool = False) -> None:
+            host_path = f"{_THREAD_DATA['workspace_path']}/nested/output.txt"
+            raise OSError(f"write failed at {host_path}\n{'A' * 12000}\nremote tail marker")
+
+    runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
+    sandbox = FailingSandbox()
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: True)
+    monkeypatch.setattr("deerflow.sandbox.tools.get_thread_data", lambda runtime: _THREAD_DATA)
+    monkeypatch.setattr("deerflow.sandbox.tools.validate_local_tool_path", lambda path, thread_data: None)
+    monkeypatch.setattr(
+        "deerflow.sandbox.tools._resolve_and_validate_user_data_path",
+        lambda path, thread_data: f"{_THREAD_DATA['workspace_path']}/output.txt",
+    )
+
+    result = write_file_tool.func(
+        runtime=runtime,
+        description="写入大文件失败",
+        path="/mnt/user-data/workspace/output.txt",
+        content="report body",
+    )
+
+    assert len(result) <= 2000
+    assert "Error: Failed to write file '/mnt/user-data/workspace/output.txt':" in result
+    assert "/tmp/deer-flow/threads/t1/user-data/workspace" not in result
+    assert "/mnt/user-data/workspace/nested/output.txt" in result
+    assert "remote tail marker" in result
+    assert "[write_file error truncated:" in result
+
+
+def test_write_file_tool_preserves_short_oserror_without_truncation(monkeypatch) -> None:
+    class FailingSandbox:
+        id = "sandbox-write-short-oserror"
+
+        def write_file(self, path: str, content: str, append: bool = False) -> None:
+            raise OSError("disk quota exceeded")
+
+    runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
+    sandbox = FailingSandbox()
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: False)
+
+    result = write_file_tool.func(
+        runtime=runtime,
+        description="写入失败",
+        path="/mnt/user-data/workspace/output.txt",
+        content="tiny payload",
+    )
+
+    assert result == "Error: Failed to write file '/mnt/user-data/workspace/output.txt': OSError: disk quota exceeded"
+    assert "[write_file error truncated:" not in result
+
+
+def test_write_file_tool_bounds_large_sandbox_error(monkeypatch) -> None:
+    class FailingSandbox:
+        id = "sandbox-write-large-sandbox-error"
+
+        def write_file(self, path: str, content: str, append: bool = False) -> None:
+            raise SandboxError(f"remote write rejected {'B' * 12000} final detail")
+
+    runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
+    sandbox = FailingSandbox()
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: False)
+
+    result = write_file_tool.func(
+        runtime=runtime,
+        description="远端写入失败",
+        path="/mnt/user-data/workspace/output.txt",
+        content="tiny payload",
+    )
+
+    assert len(result) <= 2000
+    assert "Error: Failed to write file '/mnt/user-data/workspace/output.txt':" in result
+    assert "SandboxError: remote write rejected" in result
+    assert "final detail" in result
+    assert "[write_file error truncated:" in result
+
+
+@pytest.mark.parametrize(
+    ("raised_error", "expected_fragment"),
+    [
+        pytest.param(PermissionError("permission denied"), "PermissionError: permission denied", id="permission"),
+        pytest.param(IsADirectoryError("target is a directory"), "IsADirectoryError: target is a directory", id="directory"),
+        pytest.param(Exception("remote sandbox timeout"), "Exception: remote sandbox timeout", id="generic"),
+    ],
+)
+def test_write_file_tool_formats_all_other_failure_branches(monkeypatch, raised_error: Exception, expected_fragment: str) -> None:
+    class FailingSandbox:
+        id = "sandbox-write-other-failure"
+
+        def write_file(self, path: str, content: str, append: bool = False) -> None:
+            raise raised_error
+
+    runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
+    sandbox = FailingSandbox()
+
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: False)
+
+    result = write_file_tool.func(
+        runtime=runtime,
+        description="验证错误分支格式化",
+        path="/mnt/user-data/workspace/output.txt",
+        content="tiny payload",
+    )
+
+    assert result.startswith("Error: Failed to write file '/mnt/user-data/workspace/output.txt': ")
+    assert expected_fragment in result
+    assert "[write_file error truncated:" not in result
 
 
 def test_file_operation_lock_memory_cleanup() -> None:

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1280,6 +1280,33 @@ def test_write_file_tool_formats_all_other_failure_branches(
     assert "[write_file error truncated:" not in result
 
 
+def test_write_file_tool_handles_sandbox_init_failure(monkeypatch) -> None:
+    """Regression for #3133 review: SandboxError raised during sandbox
+    initialization (before the local `requested_path` assignment) must still
+    surface as a bounded tool error rather than an UnboundLocalError.
+    """
+
+    def raise_sandbox_error(runtime):
+        raise SandboxError("sandbox missing")
+
+    runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
+    monkeypatch.setattr(
+        "deerflow.sandbox.tools.ensure_sandbox_initialized", raise_sandbox_error
+    )
+    monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: False)
+
+    result = write_file_tool.func(
+        runtime=runtime,
+        description="sandbox 初始化失败",
+        path="/mnt/user-data/workspace/output.txt",
+        content="tiny payload",
+    )
+
+    assert "Error: Failed to write file '/mnt/user-data/workspace/output.txt':" in result
+    assert "SandboxError: sandbox missing" in result
+    assert "[write_file error truncated:" not in result
+
+
 def test_file_operation_lock_memory_cleanup() -> None:
     """Verify that released locks are eventually cleaned up by WeakValueDictionary.
 

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1231,14 +1231,34 @@ def test_write_file_tool_bounds_large_sandbox_error(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("raised_error", "expected_fragment"),
+    ("raised_error", "expected_start", "expected_fragment"),
     [
-        pytest.param(PermissionError("permission denied"), "PermissionError: permission denied", id="permission"),
-        pytest.param(IsADirectoryError("target is a directory"), "IsADirectoryError: target is a directory", id="directory"),
-        pytest.param(Exception("remote sandbox timeout"), "Exception: remote sandbox timeout", id="generic"),
+        pytest.param(
+            PermissionError("permission denied"),
+            "Error: Permission denied writing to file: /mnt/user-data/workspace/output.txt",
+            "PermissionError: permission denied",
+            id="permission",
+        ),
+        pytest.param(
+            IsADirectoryError("target is a directory"),
+            "Error: Path is a directory, not a file: /mnt/user-data/workspace/output.txt",
+            "IsADirectoryError: target is a directory",
+            id="directory",
+        ),
+        pytest.param(
+            Exception("remote sandbox timeout"),
+            "Error: Failed to write file '/mnt/user-data/workspace/output.txt'",
+            "Exception: remote sandbox timeout",
+            id="generic",
+        ),
     ],
 )
-def test_write_file_tool_formats_all_other_failure_branches(monkeypatch, raised_error: Exception, expected_fragment: str) -> None:
+def test_write_file_tool_formats_all_other_failure_branches(
+    monkeypatch,
+    raised_error: Exception,
+    expected_start: str,
+    expected_fragment: str,
+) -> None:
     class FailingSandbox:
         id = "sandbox-write-other-failure"
 
@@ -1259,7 +1279,7 @@ def test_write_file_tool_formats_all_other_failure_branches(monkeypatch, raised_
         content="tiny payload",
     )
 
-    assert result.startswith("Error: Failed to write file '/mnt/user-data/workspace/output.txt': ")
+    assert result.startswith(expected_start)
     assert expected_fragment in result
     assert "[write_file error truncated:" not in result
 

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1290,9 +1290,7 @@ def test_write_file_tool_handles_sandbox_init_failure(monkeypatch) -> None:
         raise SandboxError("sandbox missing")
 
     runtime = SimpleNamespace(state={}, context={"thread_id": "thread-1"}, config={})
-    monkeypatch.setattr(
-        "deerflow.sandbox.tools.ensure_sandbox_initialized", raise_sandbox_error
-    )
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", raise_sandbox_error)
     monkeypatch.setattr("deerflow.sandbox.tools.is_local_sandbox", lambda runtime: False)
 
     result = write_file_tool.func(

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -1231,23 +1231,20 @@ def test_write_file_tool_bounds_large_sandbox_error(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("raised_error", "expected_start", "expected_fragment"),
+    ("raised_error", "expected_fragment"),
     [
         pytest.param(
             PermissionError("permission denied"),
-            "Error: Permission denied writing to file: /mnt/user-data/workspace/output.txt",
             "PermissionError: permission denied",
             id="permission",
         ),
         pytest.param(
             IsADirectoryError("target is a directory"),
-            "Error: Path is a directory, not a file: /mnt/user-data/workspace/output.txt",
             "IsADirectoryError: target is a directory",
             id="directory",
         ),
         pytest.param(
             Exception("remote sandbox timeout"),
-            "Error: Failed to write file '/mnt/user-data/workspace/output.txt'",
             "Exception: remote sandbox timeout",
             id="generic",
         ),
@@ -1256,7 +1253,6 @@ def test_write_file_tool_bounds_large_sandbox_error(monkeypatch) -> None:
 def test_write_file_tool_formats_all_other_failure_branches(
     monkeypatch,
     raised_error: Exception,
-    expected_start: str,
     expected_fragment: str,
 ) -> None:
     class FailingSandbox:
@@ -1279,7 +1275,7 @@ def test_write_file_tool_formats_all_other_failure_branches(
         content="tiny payload",
     )
 
-    assert result.startswith(expected_start)
+    assert "/mnt/user-data/workspace/output.txt" in result
     assert expected_fragment in result
     assert "[write_file error truncated:" not in result
 


### PR DESCRIPTION
## Summary

Related to [#3114 ](https://github.com/bytedance/deer-flow/issues/3114)This PR bounds `write_file` execution-failure observations.

The runtime already truncates tool exceptions that are raised into `ToolErrorHandlingMiddleware`, but `write_file_tool()` currently catches its own exceptions and returns error strings directly. That bypasses the framework-level exception truncation path, so oversized write failures can still feed large observations back into later model context.

This patch adds bounded formatting for that tool-local catch/return path while preserving the current tool contract and local path sanitization behavior.

## Key Decisions

- keep the fix local to `write_file` instead of changing the tool to re-raise into middleware
- preserve `_sanitize_error()` path masking for local sandbox output
- apply bounded formatting across `SandboxError`, `PermissionError`, `IsADirectoryError`, `OSError`, and generic `Exception` paths
- keep this as a containment fix for the execution-failure surface; broader payload/history inflation should be handled separately

## Tests

Ran:

```bash
uv run pytest tests/test_sandbox_tools_security.py -v
```

Added regression coverage for:

- large `OSError` is bounded and still preserves diagnostic context
- local sandbox host paths are still masked
- short `OSError` remains readable and untruncated
- large `SandboxError` is bounded
- `PermissionError`, `IsADirectoryError`, and generic `Exception` all follow the bounded formatting path without regressing short-error readability
