### PR TITLE
fix(gateway): preserve message additional_kwargs in normalize_input (#3132)

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -84,17 +84,28 @@ def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
     ``name``, and non-human roles (ai/system/tool) survive unchanged.  An earlier
     hand-rolled version only forwarded ``content`` and collapsed every role to
     ``HumanMessage``, which silently stripped frontend-supplied attachments.
+
+    Malformed message dicts (missing ``role``/``type``/``content``, unsupported
+    role, etc.) raise ``HTTPException(400)`` with the offending index, instead
+    of bubbling up as a 500.  The gateway is a system boundary, so per-entry
+    validation errors are the right shape for clients to retry against.
     """
     if raw_input is None:
         return {}
     messages = raw_input.get("messages")
     if messages and isinstance(messages, list):
         converted: list[Any] = []
-        for msg in messages:
+        for index, msg in enumerate(messages):
             if isinstance(msg, BaseMessage):
                 converted.append(msg)
             elif isinstance(msg, dict):
-                converted.extend(convert_to_messages([msg]))
+                try:
+                    converted.extend(convert_to_messages([msg]))
+                except (ValueError, TypeError, NotImplementedError) as exc:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Invalid message at input.messages[{index}]: {exc}",
+                    ) from exc
             else:
                 converted.append(msg)
         return {**raw_input, "messages": converted}

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -15,7 +15,8 @@ from collections.abc import Mapping
 from typing import Any
 
 from fastapi import HTTPException, Request
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import BaseMessage
+from langchain_core.messages.utils import convert_to_messages
 
 from app.gateway.deps import get_run_context, get_run_manager, get_stream_bridge
 from app.gateway.utils import sanitize_log_param
@@ -76,21 +77,24 @@ def normalize_stream_modes(raw: list[str] | str | None) -> list[str]:
 
 
 def normalize_input(raw_input: dict[str, Any] | None) -> dict[str, Any]:
-    """Convert LangGraph Platform input format to LangChain state dict."""
+    """Convert LangGraph Platform input format to LangChain state dict.
+
+    Delegates dict→message coercion to ``langchain_core.messages.utils.convert_to_messages``
+    so that ``additional_kwargs`` (e.g. uploaded-file metadata — gh #3132), ``id``,
+    ``name``, and non-human roles (ai/system/tool) survive unchanged.  An earlier
+    hand-rolled version only forwarded ``content`` and collapsed every role to
+    ``HumanMessage``, which silently stripped frontend-supplied attachments.
+    """
     if raw_input is None:
         return {}
     messages = raw_input.get("messages")
     if messages and isinstance(messages, list):
-        converted = []
+        converted: list[Any] = []
         for msg in messages:
-            if isinstance(msg, dict):
-                role = msg.get("role", msg.get("type", "user"))
-                content = msg.get("content", "")
-                if role in ("user", "human"):
-                    converted.append(HumanMessage(content=content))
-                else:
-                    # TODO: handle other message types (system, ai, tool)
-                    converted.append(HumanMessage(content=content))
+            if isinstance(msg, BaseMessage):
+                converted.append(msg)
+            elif isinstance(msg, dict):
+                converted.extend(convert_to_messages([msg]))
             else:
                 converted.append(msg)
         return {**raw_input, "messages": converted}

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -81,6 +81,75 @@ def test_normalize_input_passthrough():
     assert result == {"custom_key": "value"}
 
 
+def test_normalize_input_preserves_additional_kwargs_and_id():
+    """Regression: gh #3132 — frontend ships uploaded-file metadata in
+    additional_kwargs.files (and a client-side message id).  The gateway must
+    not strip them before the graph runs, otherwise UploadsMiddleware reports
+    "(empty)" for new uploads and the frontend message loses its file chip.
+    """
+    from langchain_core.messages import HumanMessage
+
+    from app.gateway.services import normalize_input
+
+    files = [{"filename": "a.csv", "size": 100, "path": "/mnt/user-data/uploads/a.csv", "status": "uploaded"}]
+    result = normalize_input(
+        {
+            "messages": [
+                {
+                    "type": "human",
+                    "id": "client-msg-1",
+                    "name": "user-input",
+                    "content": [{"type": "text", "text": "clean it"}],
+                    "additional_kwargs": {"files": files, "custom": "keep-me"},
+                }
+            ]
+        }
+    )
+    assert len(result["messages"]) == 1
+    msg = result["messages"][0]
+    assert isinstance(msg, HumanMessage)
+    assert msg.id == "client-msg-1"
+    assert msg.name == "user-input"
+    assert msg.content == [{"type": "text", "text": "clean it"}]
+    assert msg.additional_kwargs == {"files": files, "custom": "keep-me"}
+
+
+def test_normalize_input_passes_through_basemessage_instances():
+    from langchain_core.messages import HumanMessage
+
+    from app.gateway.services import normalize_input
+
+    msg = HumanMessage(content="hello", id="m-1", additional_kwargs={"files": [{"filename": "x"}]})
+    result = normalize_input({"messages": [msg]})
+    assert result["messages"][0] is msg
+
+
+def test_normalize_input_handles_non_human_roles():
+    """The previous implementation collapsed every role to HumanMessage with a
+    `# TODO: handle other message types` comment.  Resuming a thread with prior
+    AI/tool messages would silently rewrite them as human turns — corrupting
+    the conversation.  Use langchain's standard conversion so ai/system/tool
+    roles round-trip correctly.
+    """
+    from langchain_core.messages import AIMessage, SystemMessage, ToolMessage
+
+    from app.gateway.services import normalize_input
+
+    result = normalize_input(
+        {
+            "messages": [
+                {"role": "system", "content": "sys"},
+                {"role": "ai", "content": "hi", "id": "ai-1"},
+                {"role": "tool", "content": "result", "tool_call_id": "call-1"},
+            ]
+        }
+    )
+    types = [type(m) for m in result["messages"]]
+    assert types == [SystemMessage, AIMessage, ToolMessage]
+    assert result["messages"][1].id == "ai-1"
+    assert result["messages"][2].tool_call_id == "call-1"
+
+
 def test_build_run_config_basic():
     from app.gateway.services import build_run_config
 

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -124,6 +124,25 @@ def test_normalize_input_passes_through_basemessage_instances():
     assert result["messages"][0] is msg
 
 
+def test_normalize_input_rejects_malformed_message_with_400():
+    """Boundary validation: ``convert_to_messages`` raises ``ValueError`` when a
+    message dict is missing ``role``/``type``/``content``.  ``normalize_input``
+    runs inside the gateway HTTP boundary, so a malformed payload should surface
+    as a 400 referencing the offending entry — not bubble up as a 500.
+
+    Raised after the Copilot review on PR #3136.
+    """
+    import pytest
+    from fastapi import HTTPException
+
+    from app.gateway.services import normalize_input
+
+    with pytest.raises(HTTPException) as excinfo:
+        normalize_input({"messages": [{"role": "human", "content": "ok"}, {"oops": "no role here"}]})
+    assert excinfo.value.status_code == 400
+    assert "input.messages[1]" in excinfo.value.detail
+
+
 def test_normalize_input_handles_non_human_roles():
     """The previous implementation collapsed every role to HumanMessage with a
     `# TODO: handle other message types` comment.  Resuming a thread with prior


### PR DESCRIPTION
Closes #3132.

## Problem

Uploaded files render as a chip on the user message while uploading, then vanish the instant the run finishes. Same bug also makes the agent see `<uploaded_files> ... (empty)` for the current turn and lump the just-uploaded file under "previous messages".

## Root cause

`backend/app/gateway/services.py::normalize_input` was a hand-rolled dict→`BaseMessage` coercion (introduced with the LangGraph-compatible runtime in #1403, with a `# TODO: handle other message types` on the only branch that handled non-human roles). For every dict the gateway received it built `HumanMessage(content=content)` and threw away `additional_kwargs`, `id`, and `name`. Once the optimistic-UI PR (#967) started shipping uploaded-file metadata in `additional_kwargs.files`, that data hit the gateway and was wiped before the graph ever ran.

Downstream consequences observed on a real run:

- `UploadsMiddleware._files_from_kwargs` returned `None`, so the just-uploaded file fell through to the historical scan and the model saw `(empty)` for the current turn.
- The final `__user` message stored by `DynamicContextMiddleware` had `additional_kwargs={"run_id": ..., "timestamp": ...}` (set by `ThreadDataMiddleware`) but **no `files`**, so the frontend's `RichFilesList` had nothing to render after optimistic state cleared.
- The dropped `id` also meant the optimistic message and the server-side message couldn't be deduplicated by id (the `humanMessageCount` heuristic in `useThreadStream` was masking this).

This is purely a backend bug — the frontend submission (`frontend/src/core/threads/hooks.ts:566-611`) correctly puts `files` into `additional_kwargs`, and the screen capture and `/api/langgraph/threads/{tid}/state` payload both confirm the data is stripped at the gateway boundary, not downstream.

## Fix

Hand the dict→message conversion over to `langchain_core.messages.utils.convert_to_messages`. It already handles `additional_kwargs`, `id`, `name`, `response_metadata`, and the full `human`/`ai`/`system`/`tool` role set, and is what LangGraph itself uses everywhere else. `BaseMessage` instances pass through untouched. The `# TODO: handle other message types` is gone for the same reason.

## Validation

- `make lint` — clean
- `uv run pytest backend/tests/test_gateway_services.py` — 36 passed (33 existing + 3 new regression cases covering `additional_kwargs.files` + `id` preservation, `BaseMessage` passthrough, and ai/system/tool role handling)
- Adjacent files that import `services` or touch the upload pipeline: `test_sse_format.py`, `test_runtime_lifecycle_e2e.py`, `test_setup_agent_e2e_user_isolation.py`, `test_update_agent_e2e_user_isolation.py`, `test_uploads_middleware_core_logic.py` — 94 passed in total
- Manual reproduction: created a thread, uploaded `reproduce.txt`, submitted a turn, hit `/api/langgraph/threads/{tid}/state`. Before: `__user` message `additional_kwargs={run_id, timestamp}`, content `in this message: (empty)`. After: `additional_kwargs.files=[{filename, size, path, status}]`, content `in this message: - reproduce.txt`.

## Notes for reviewers

- No frontend changes. The frontend's `additional_kwargs.files` write path is untouched.
- The replacement is a drop-in: existing `test_normalize_input_with_messages` (only-content case) still passes.
- The fix also unblocks any future feature that wants to ship custom fields through `additional_kwargs` (e.g. citation metadata, tool hints) over the LangGraph-compat endpoint.

Here is fix Evidence:
<img width="1730" height="1274" alt="969dff4949d592452093c7f79aa8747d" src="https://github.com/user-attachments/assets/5060be6d-18ad-4481-8cfa-7032ea5353fa" />

