### PR TITLE
fix: preserve decorated route body signatures

### DIFF
--- a/backend/app/gateway/authz.py
+++ b/backend/app/gateway/authz.py
@@ -33,7 +33,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, get_type_hints
 
 from fastapi import HTTPException, Request
 
@@ -119,6 +119,28 @@ _ALL_PERMISSIONS: list[str] = [
 ]
 
 
+def _resolved_route_signature(func: Callable[..., Any]) -> inspect.Signature:
+    """Return the wrapped route signature with postponed annotations resolved."""
+    signature = inspect.signature(func)
+    try:
+        hints = get_type_hints(
+            func,
+            globalns=getattr(func, "__globals__", None),
+            include_extras=True,
+        )
+    except Exception:
+        return signature
+
+    parameters = [
+        parameter.replace(annotation=hints.get(name, parameter.annotation))
+        for name, parameter in signature.parameters.items()
+    ]
+    return signature.replace(
+        parameters=parameters,
+        return_annotation=hints.get("return", signature.return_annotation),
+    )
+
+
 def _make_test_request_stub() -> Any:
     """Create a minimal request-like object for direct unit calls.
 
@@ -191,6 +213,7 @@ def require_auth[**P, T](func: Callable[P, T]) -> Callable[P, T]:
 
         return await func(*args, **kwargs)
 
+    wrapper.__signature__ = _resolved_route_signature(func)  # type: ignore[attr-defined]
     return wrapper
 
 
@@ -296,6 +319,7 @@ def require_permission(
 
             return await func(*args, **kwargs)
 
+        wrapper.__signature__ = _resolved_route_signature(func)  # type: ignore[attr-defined]
         return wrapper
 
     return decorator

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -8,6 +8,7 @@ import bcrypt
 import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from app.gateway.auth import create_access_token, decode_token, hash_password, verify_password
 from app.gateway.auth.models import User
@@ -19,6 +20,10 @@ from app.gateway.authz import (
     require_auth,
     require_permission,
 )
+
+
+class DeferredBodyRequest(BaseModel):
+    value: str
 
 # ── Password Hashing ────────────────────────────────────────────────────────
 
@@ -278,6 +283,25 @@ def test_require_permission_denies_wrong_permission():
             response = client.get("/test")
             assert response.status_code == 403
             assert "Permission denied" in response.json()["detail"]
+
+
+def test_require_permission_preserves_deferred_body_param_for_fastapi():
+    """Decorated routes should keep string-annotated Pydantic bodies as bodies."""
+    from fastapi import Request
+
+    app = FastAPI()
+
+    @app.post("/test")
+    @require_permission("threads", "write")
+    async def endpoint(body: "DeferredBodyRequest", request: Request):
+        return {"value": body.value}
+
+    route = next(route for route in app.routes if getattr(route, "path", "") == "/test")
+
+    assert [(param.name, param.type_) for param in route.dependant.body_params] == [
+        ("body", DeferredBodyRequest),
+    ]
+    assert "body" not in {param.name for param in route.dependant.query_params}
 
 
 # ── Weak JWT secret warning ──────────────────────────────────────────────────


### PR DESCRIPTION
## What
- Resolve postponed route annotations before exposing decorated endpoint signatures to FastAPI.
- Preserve Pydantic body models on routes wrapped by `require_auth` / `require_permission`.
- Add a regression test for a string-annotated body parameter wrapped by `require_permission`.

## Why
Decorated routes in modules using postponed annotations can expose unresolved string annotations through the wrapper signature. FastAPI then sees parameters such as `body: "RunCreateRequest"` as unresolved `ForwardRef`s and can register them as query parameters instead of request bodies, causing valid JSON POST requests to fail validation.

This affects authenticated/authorized endpoints such as:
- `POST /api/threads/{thread_id}/runs`
- `POST /api/threads/{thread_id}/runs/stream`
- `POST /api/threads/{thread_id}/runs/wait`
- `POST /api/threads/{thread_id}/state`

## How
- Use `typing.get_type_hints()` with the original route function globals to resolve postponed annotations.
- Build a replacement `inspect.Signature` with resolved parameter and return annotations.
- Assign the resolved signature to auth decorator wrappers so FastAPI inspects the original resolved route contract.

## Testing
- `PYTHONPATH=.;packages/harness python -m pytest tests/test_auth.py::test_require_permission_preserves_deferred_body_param_for_fastapi -q` -> passed
- `PYTHONPATH=.;packages/harness python -m pytest tests/test_auth.py -q` -> 54 passed
- `PYTHONPATH=.;packages/harness python -m pytest tests/test_runtime_lifecycle_e2e.py -q` -> 4 passed, 1 failed: existing unrelated `test_cancel_interrupt_stops_running_background_run` assertion on the fake controller cancellation event. The cancel endpoint returned 204 and logs show the run was marked interrupted/cancelled.
- Route introspection confirms the affected POST routes now register `RunCreateRequest` / `ThreadStateUpdateRequest` as body params with no `body` query param.
- `git diff --check` -> passed

Not run locally because these tools are unavailable in this environment: `uv run pytest`, `make lint`, `make format`, `python -m ruff`.