### PR TITLE
fix(frontend): avoid previewing in-progress HTML writes

### DIFF
--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -30,6 +30,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { CodeEditor } from "@/components/workspace/code-editor";
 import { useArtifactContent } from "@/core/artifacts/hooks";
+import { isArtifactPreviewSupported } from "@/core/artifacts/preview";
 import { urlOfArtifact } from "@/core/artifacts/utils";
 import { useI18n } from "@/core/i18n/hooks";
 import { installSkill } from "@/core/skills/api";
@@ -81,8 +82,8 @@ export function ArtifactFileDetail({
     return checkCodeFile(filepath);
   }, [filepath, isWriteFile, isSkillFile]);
   const isSupportPreview = useMemo(() => {
-    return language === "html" || language === "markdown";
-  }, [language]);
+    return isArtifactPreviewSupported({ language, isWriteFile });
+  }, [language, isWriteFile]);
   const { content } = useArtifactContent({
     threadId,
     filepath: filepathFromProps,
@@ -132,7 +133,7 @@ export function ArtifactFileDetail({
               <div className="px-2">{getFileName(filepath)}</div>
             ) : (
               <Select value={filepath} onValueChange={select}>
-                <SelectTrigger className="border-none bg-transparent! shadow-none select-none focus:outline-0 active:outline-0">
+                <SelectTrigger className="bg-transparent! select-none border-none shadow-none focus:outline-0 active:outline-0">
                   <SelectValue placeholder="Select a file" />
                 </SelectTrigger>
                 <SelectContent className="select-none">
@@ -290,7 +291,9 @@ export function ArtifactFilePreview({
       return;
     }
 
-    const blob = new Blob([content ?? ""], { type: "text/html" });
+    const blob = new Blob([content ?? ""], {
+      type: "text/html;charset=utf-8",
+    });
     const url = URL.createObjectURL(blob);
     setHtmlPreviewUrl(url);
 

--- a/frontend/src/core/artifacts/preview.ts
+++ b/frontend/src/core/artifacts/preview.ts
@@ -1,0 +1,17 @@
+export function isArtifactPreviewSupported({
+  language,
+  isWriteFile,
+}: {
+  language: string | undefined;
+  isWriteFile: boolean;
+}) {
+  if (language === "markdown") {
+    return true;
+  }
+
+  if (language === "html") {
+    return !isWriteFile;
+  }
+
+  return false;
+}

--- a/frontend/tests/unit/core/artifacts/preview.test.ts
+++ b/frontend/tests/unit/core/artifacts/preview.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "vitest";
+
+import { isArtifactPreviewSupported } from "@/core/artifacts/preview";
+
+test("allows completed html and markdown artifact previews", () => {
+  expect(
+    isArtifactPreviewSupported({ language: "html", isWriteFile: false }),
+  ).toBe(true);
+  expect(
+    isArtifactPreviewSupported({ language: "markdown", isWriteFile: false }),
+  ).toBe(true);
+});
+
+test("keeps in-progress html writes out of iframe preview", () => {
+  expect(
+    isArtifactPreviewSupported({ language: "html", isWriteFile: true }),
+  ).toBe(false);
+});
+
+test("allows markdown write-file previews", () => {
+  expect(
+    isArtifactPreviewSupported({ language: "markdown", isWriteFile: true }),
+  ).toBe(true);
+});


### PR DESCRIPTION
## Summary

- keep in-progress HTML `write_file` artifacts in code view instead of iframe preview
- keep completed HTML artifacts and markdown previews unchanged
- add a small preview-support helper with regression coverage
- set an explicit UTF-8 MIME type for completed HTML preview blobs

Fixes #3119.

## Testing

- pnpm test --run tests/unit/core/artifacts/preview.test.ts
- pnpm exec prettier --write src/components/workspace/artifacts/artifact-file-detail.tsx src/core/artifacts/preview.ts tests/unit/core/artifacts/preview.test.ts

Note: targeted eslint could not run locally because `pnpm install --frozen-lockfile` stalled on slow registry downloads and did not finish linking all dev dependencies (`@eslint/eslintrc` was unavailable).
