### PR TITLE
config: raise default summarization trigger before v2.0-m1

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -799,7 +799,7 @@ summarization:
   # Summarization runs when ANY threshold is met (OR logic)
   # You can specify a single trigger or a list of triggers
   trigger:
-    # Trigger when token count reaches 15564
+    # Trigger when token count reaches 32000
     - type: tokens
       value: 32000
     # Uncomment to also trigger when message count reaches 50

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -801,7 +801,7 @@ summarization:
   trigger:
     # Trigger when token count reaches 15564
     - type: tokens
-      value: 15564
+      value: 32000
     # Uncomment to also trigger when message count reaches 50
     # - type: messages
     #   value: 50

--- a/frontend/src/content/en/harness/middlewares.mdx
+++ b/frontend/src/content/en/harness/middlewares.mdx
@@ -162,7 +162,7 @@ summarization:
   # Trigger conditions — summarization runs when ANY threshold is met
   trigger:
     - type: tokens # trigger when context exceeds N tokens
-      value: 15564
+      value: 32000
     # - type: messages  # trigger when there are more than N messages
     #   value: 50
     # - type: fraction  # trigger when context exceeds X% of model max

--- a/frontend/src/content/zh/harness/middlewares.mdx
+++ b/frontend/src/content/zh/harness/middlewares.mdx
@@ -154,7 +154,7 @@ summarization:
   # 触发条件——满足任意一个条件时运行摘要
   trigger:
     - type: tokens # 当上下文超过 N 个 token 时触发
-      value: 15564
+      value: 32000
     # - type: messages  # 当消息数超过 N 时触发
     #   value: 50
     # - type: fraction  # 当上下文达到模型最大输入的 X% 时触发


### PR DESCRIPTION
## Summary

- raise the release-facing summarization token trigger example from `15564` to `32000`
- keep the `config.example.yaml` comment and English/Chinese middleware docs aligned with that default

## Why

The current `15564` trigger sits inside the normal working range for tool-heavy research/report runs. Those runs can cross the trigger repeatedly as search results and recent tool payloads accumulate, causing repeated `DeerFlowSummarizationMiddleware` work and avoidable latency before the agent continues.

For v2.0-m1, this is the smallest config-facing change that suppresses frequent summarization for most users while deeper trigger/retention observability and policy work remain follow-up items.

Fixes #3173

## Validation

- `git diff --check`
- `pnpm exec prettier --check src/content/en/harness/middlewares.mdx src/content/zh/harness/middlewares.mdx`
- frontend pre-commit check during commit: `eslint . --ext .ts,.tsx && tsc --noEmit`
