### PR TITLE
fix(token-usage): make thread totals reliable across active and interrupted runs

### DIFF
--- a/backend/packages/harness/deerflow/persistence/run/sql.py
+++ b/backend/packages/harness/deerflow/persistence/run/sql.py
@@ -15,7 +15,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from deerflow.persistence.run.model import RunRow
-from deerflow.runtime.runs.store.base import RunStore
+from deerflow.runtime.runs.store.base import TOKEN_USAGE_ACTIVE_STATUSES, TOKEN_USAGE_TERMINAL_STATUSES, RunStore
 from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
 from deerflow.utils.time import coerce_iso
 
@@ -302,8 +302,8 @@ class RunRepository(RunStore):
 
     async def aggregate_tokens_by_thread(self, thread_id: str, *, include_active: bool = False) -> dict[str, Any]:
         """Aggregate token usage via a single SQL GROUP BY query."""
-        statuses = ("success", "error", "running") if include_active else ("success", "error")
-        _completed = RunRow.status.in_(statuses)
+        statuses = TOKEN_USAGE_ACTIVE_STATUSES if include_active else TOKEN_USAGE_TERMINAL_STATUSES
+        _eligible_status = RunRow.status.in_(statuses)
         _thread = RunRow.thread_id == thread_id
         model_name = func.coalesce(RunRow.model_name, "unknown")
 
@@ -318,7 +318,7 @@ class RunRepository(RunStore):
                 func.coalesce(func.sum(RunRow.subagent_tokens), 0).label("subagent"),
                 func.coalesce(func.sum(RunRow.middleware_tokens), 0).label("middleware"),
             )
-            .where(_thread, _completed)
+            .where(_thread, _eligible_status)
             .group_by(model_name)
         )
 

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -48,6 +48,7 @@ class RunJournal(BaseCallbackHandler):
         flush_threshold: int = 20,
         progress_reporter: Callable[[dict], Awaitable[None]] | None = None,
         progress_flush_interval: float = 5.0,
+        progress_loop: asyncio.AbstractEventLoop | None = None,
     ):
         super().__init__()
         self.run_id = run_id
@@ -57,6 +58,12 @@ class RunJournal(BaseCallbackHandler):
         self._flush_threshold = flush_threshold
         self._progress_reporter = progress_reporter
         self._progress_flush_interval = progress_flush_interval
+        if progress_loop is None:
+            try:
+                progress_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                progress_loop = None
+        self._progress_loop = progress_loop
 
         # Write buffer
         self._buffer: list[dict] = []
@@ -508,6 +515,10 @@ class RunJournal(BaseCallbackHandler):
         """Best-effort throttled progress snapshot for active run visibility."""
         if self._progress_reporter is None:
             return
+        if not self._run_on_progress_loop(self._schedule_progress_flush_on_loop):
+            self._progress_dirty = True
+
+    def _schedule_progress_flush_on_loop(self) -> None:
         now = time.monotonic()
         elapsed = now - self._last_progress_flush
         if elapsed < self._progress_flush_interval:
@@ -517,23 +528,45 @@ class RunJournal(BaseCallbackHandler):
         if self._pending_progress_task is not None and not self._pending_progress_task.done():
             self._progress_dirty = True
             return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return
+        loop = asyncio.get_running_loop()
         self._progress_dirty = False
         self._pending_progress_task = loop.create_task(self._flush_progress_async(snapshot=self.get_completion_data()))
 
     def _schedule_delayed_progress_flush(self, delay: float) -> None:
+        if self._progress_reporter is None:
+            return
+        self._run_on_progress_loop(lambda: self._schedule_delayed_progress_flush_on_loop(delay))
+
+    def _schedule_delayed_progress_flush_on_loop(self, delay: float) -> None:
         if self._pending_progress_task is not None and not self._pending_progress_task.done():
             return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return
+        loop = asyncio.get_running_loop()
         delay = max(0.0, delay)
         self._pending_progress_delayed = delay > 0
         self._pending_progress_task = loop.create_task(self._flush_progress_async(delay=delay))
+
+    def _run_on_progress_loop(self, callback: Callable[[], None]) -> bool:
+        loop = self._progress_loop
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if loop is not None and loop.is_closed():
+            self._progress_loop = None
+            loop = None
+        if loop is None:
+            loop = running_loop
+            self._progress_loop = loop
+        if loop is None or loop.is_closed():
+            return False
+        if running_loop is loop:
+            callback()
+            return True
+        try:
+            loop.call_soon_threadsafe(callback)
+        except RuntimeError:
+            return False
+        return True
 
     async def _flush_progress_async(self, *, snapshot: dict | None = None, delay: float = 0.0) -> None:
         if self._progress_reporter is None:

--- a/backend/packages/harness/deerflow/runtime/runs/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/runs/store/base.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 import abc
 from typing import Any
 
+TOKEN_USAGE_TERMINAL_STATUSES = ("success", "error", "interrupted")
+TOKEN_USAGE_ACTIVE_STATUSES = (*TOKEN_USAGE_TERMINAL_STATUSES, "running")
+
 
 class RunStore(abc.ABC):
     @abc.abstractmethod
@@ -133,7 +136,11 @@ class RunStore(abc.ABC):
 
     @abc.abstractmethod
     async def aggregate_tokens_by_thread(self, thread_id: str, *, include_active: bool = False) -> dict[str, Any]:
-        """Aggregate token usage for completed runs in a thread.
+        """Aggregate token usage for terminal runs in a thread.
+
+        Terminal usage includes ``success``, ``error``, and ``interrupted``
+        runs because interrupted runs can still persist consumed token counts.
+        Set ``include_active`` to also include running progress snapshots.
 
         Returns a dict with keys: total_tokens, total_input_tokens,
         total_output_tokens, total_runs, by_model (model_name → {tokens, runs}),

--- a/backend/packages/harness/deerflow/runtime/runs/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/runs/store/memory.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
-from deerflow.runtime.runs.store.base import RunStore
+from deerflow.runtime.runs.store.base import TOKEN_USAGE_ACTIVE_STATUSES, TOKEN_USAGE_TERMINAL_STATUSES, RunStore
 
 
 class MemoryRunStore(RunStore):
@@ -106,23 +106,23 @@ class MemoryRunStore(RunStore):
         return results
 
     async def aggregate_tokens_by_thread(self, thread_id: str, *, include_active: bool = False) -> dict[str, Any]:
-        statuses = ("success", "error", "running") if include_active else ("success", "error")
-        completed = [r for r in self._runs.values() if r["thread_id"] == thread_id and r.get("status") in statuses]
+        statuses = TOKEN_USAGE_ACTIVE_STATUSES if include_active else TOKEN_USAGE_TERMINAL_STATUSES
+        included_runs = [r for r in self._runs.values() if r["thread_id"] == thread_id and r.get("status") in statuses]
         by_model: dict[str, dict] = {}
-        for r in completed:
+        for r in included_runs:
             model = r.get("model_name") or "unknown"
             entry = by_model.setdefault(model, {"tokens": 0, "runs": 0})
             entry["tokens"] += r.get("total_tokens", 0)
             entry["runs"] += 1
         return {
-            "total_tokens": sum(r.get("total_tokens", 0) for r in completed),
-            "total_input_tokens": sum(r.get("total_input_tokens", 0) for r in completed),
-            "total_output_tokens": sum(r.get("total_output_tokens", 0) for r in completed),
-            "total_runs": len(completed),
+            "total_tokens": sum(r.get("total_tokens", 0) for r in included_runs),
+            "total_input_tokens": sum(r.get("total_input_tokens", 0) for r in included_runs),
+            "total_output_tokens": sum(r.get("total_output_tokens", 0) for r in included_runs),
+            "total_runs": len(included_runs),
             "by_model": by_model,
             "by_caller": {
-                "lead_agent": sum(r.get("lead_agent_tokens", 0) for r in completed),
-                "subagent": sum(r.get("subagent_tokens", 0) for r in completed),
-                "middleware": sum(r.get("middleware_tokens", 0) for r in completed),
+                "lead_agent": sum(r.get("lead_agent_tokens", 0) for r in included_runs),
+                "subagent": sum(r.get("subagent_tokens", 0) for r in included_runs),
+                "middleware": sum(r.get("middleware_tokens", 0) for r in included_runs),
             },
         }

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -176,6 +176,7 @@ async def run_agent(
                 event_store=event_store,
                 track_token_usage=getattr(run_events_config, "track_token_usage", True),
                 progress_reporter=lambda snapshot: run_manager.update_run_progress(run_id, **snapshot),
+                progress_loop=asyncio.get_running_loop(),
             )
 
         # 1. Mark running

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -742,6 +742,42 @@ class TestProgressSnapshots:
         assert snapshots[-1]["last_ai_message"] == "Answer"
 
     @pytest.mark.anyio
+    async def test_callback_thread_reports_progress_snapshot_on_journal_loop(self):
+        snapshots: list[dict] = []
+        progress_seen = asyncio.Event()
+
+        async def reporter(snapshot: dict) -> None:
+            snapshots.append(snapshot)
+            if snapshot["total_tokens"] == 15:
+                progress_seen.set()
+
+        store = MemoryRunEventStore()
+        j = RunJournal(
+            "r1",
+            "t1",
+            store,
+            flush_threshold=100,
+            progress_reporter=reporter,
+            progress_flush_interval=0,
+            progress_loop=asyncio.get_running_loop(),
+        )
+        usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+        await asyncio.to_thread(
+            j.on_llm_end,
+            _make_llm_response("Answer", usage=usage),
+            run_id=uuid4(),
+            parent_run_id=None,
+            tags=["lead_agent"],
+        )
+        await asyncio.wait_for(progress_seen.wait(), timeout=1.0)
+        await j.flush()
+
+        assert snapshots[-1]["total_tokens"] == 15
+        assert snapshots[-1]["llm_call_count"] == 1
+        assert snapshots[-1]["last_ai_message"] == "Answer"
+
+    @pytest.mark.anyio
     async def test_throttled_progress_flush_emits_trailing_snapshot(self):
         snapshots: list[dict] = []
         trailing_seen = asyncio.Event()

--- a/backend/tests/test_run_repository.py
+++ b/backend/tests/test_run_repository.py
@@ -11,6 +11,7 @@ from sqlalchemy.dialects import postgresql
 from deerflow.persistence.run import RunRepository
 from deerflow.runtime import RunManager, RunStatus
 from deerflow.runtime.runs.store.base import RunStore
+from deerflow.runtime.runs.store.memory import MemoryRunStore
 
 
 async def _make_repo(tmp_path):
@@ -64,6 +65,30 @@ async def test_update_run_progress_defaults_to_noop_for_custom_store():
     store = _CustomRunStoreWithoutProgress()
 
     await store.update_run_progress("r1", total_tokens=1)
+
+
+@pytest.mark.anyio
+async def test_memory_run_store_aggregate_tokens_counts_terminal_runs():
+    store = MemoryRunStore()
+    await store.put("success-run", thread_id="t1", status="running")
+    await store.update_run_completion("success-run", status="success", total_tokens=100, lead_agent_tokens=100)
+    await store.put("interrupted-run", thread_id="t1", status="running")
+    await store.update_run_completion("interrupted-run", status="interrupted", total_tokens=40, middleware_tokens=40)
+    await store.put("running-run", thread_id="t1", status="running")
+    await store.update_run_progress("running-run", total_tokens=25, subagent_tokens=25)
+
+    without_active = await store.aggregate_tokens_by_thread("t1")
+    with_active = await store.aggregate_tokens_by_thread("t1", include_active=True)
+
+    assert without_active["total_tokens"] == 140
+    assert without_active["total_runs"] == 2
+    assert with_active["total_tokens"] == 165
+    assert with_active["total_runs"] == 3
+    assert with_active["by_caller"] == {
+        "lead_agent": 100,
+        "subagent": 25,
+        "middleware": 40,
+    }
 
 
 class TestRunRepository:
@@ -316,7 +341,7 @@ class TestRunRepository:
         await _cleanup()
 
     @pytest.mark.anyio
-    async def test_aggregate_tokens_by_thread_counts_completed_runs_only(self, tmp_path):
+    async def test_aggregate_tokens_by_thread_counts_terminal_runs(self, tmp_path):
         repo = await _make_repo(tmp_path)
         await repo.put("success-run", thread_id="t1", status="running")
         await repo.update_run_completion(
@@ -339,6 +364,17 @@ class TestRunRepository:
             lead_agent_tokens=40,
             subagent_tokens=10,
         )
+        await repo.put("interrupted-run", thread_id="t1", status="running")
+        await repo.update_run_completion(
+            "interrupted-run",
+            status="interrupted",
+            total_input_tokens=11,
+            total_output_tokens=9,
+            total_tokens=20,
+            lead_agent_tokens=12,
+            subagent_tokens=3,
+            middleware_tokens=5,
+        )
         await repo.put("running-run", thread_id="t1", status="running")
         await repo.update_run_completion(
             "running-run",
@@ -358,15 +394,15 @@ class TestRunRepository:
 
         agg = await repo.aggregate_tokens_by_thread("t1")
 
-        assert agg["total_tokens"] == 150
-        assert agg["total_input_tokens"] == 90
-        assert agg["total_output_tokens"] == 60
-        assert agg["total_runs"] == 2
-        assert agg["by_model"] == {"unknown": {"tokens": 150, "runs": 2}}
+        assert agg["total_tokens"] == 170
+        assert agg["total_input_tokens"] == 101
+        assert agg["total_output_tokens"] == 69
+        assert agg["total_runs"] == 3
+        assert agg["by_model"] == {"unknown": {"tokens": 170, "runs": 3}}
         assert agg["by_caller"] == {
-            "lead_agent": 120,
-            "subagent": 25,
-            "middleware": 5,
+            "lead_agent": 132,
+            "subagent": 28,
+            "middleware": 10,
         }
         await _cleanup()
 
@@ -375,20 +411,22 @@ class TestRunRepository:
         repo = await _make_repo(tmp_path)
         await repo.put("success-run", thread_id="t1", status="running")
         await repo.update_run_completion("success-run", status="success", total_tokens=100, lead_agent_tokens=100)
+        await repo.put("interrupted-run", thread_id="t1", status="running")
+        await repo.update_run_completion("interrupted-run", status="interrupted", total_tokens=40, middleware_tokens=40)
         await repo.put("running-run", thread_id="t1", status="running")
         await repo.update_run_progress("running-run", total_tokens=25, lead_agent_tokens=20, subagent_tokens=5)
 
         without_active = await repo.aggregate_tokens_by_thread("t1")
         with_active = await repo.aggregate_tokens_by_thread("t1", include_active=True)
 
-        assert without_active["total_tokens"] == 100
-        assert without_active["total_runs"] == 1
-        assert with_active["total_tokens"] == 125
-        assert with_active["total_runs"] == 2
+        assert without_active["total_tokens"] == 140
+        assert without_active["total_runs"] == 2
+        assert with_active["total_tokens"] == 165
+        assert with_active["total_runs"] == 3
         assert with_active["by_caller"] == {
             "lead_agent": 120,
             "subagent": 5,
-            "middleware": 0,
+            "middleware": 40,
         }
         await _cleanup()
 

--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -163,6 +163,7 @@ export default function AgentChatPage() {
               <TokenUsageIndicator
                 threadId={isNewThread ? undefined : threadId}
                 backendUsage={backendTokenUsage}
+                backendIncludesActive
                 enabled={tokenUsageEnabled}
                 messages={thread.messages}
                 pendingMessages={pendingUsageMessages}

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -145,6 +145,7 @@ export default function ChatPage() {
               <TokenUsageIndicator
                 threadId={isNewThread ? undefined : threadId}
                 backendUsage={backendTokenUsage}
+                backendIncludesActive
                 enabled={tokenUsageEnabled}
                 messages={thread.messages}
                 pendingMessages={pendingUsageMessages}

--- a/frontend/src/components/workspace/token-usage-indicator.tsx
+++ b/frontend/src/components/workspace/token-usage-indicator.tsx
@@ -2,7 +2,7 @@
 
 import type { Message } from "@langchain/langgraph-sdk";
 import { ChevronDownIcon, CoinsIcon } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -17,6 +17,7 @@ import {
 import { useI18n } from "@/core/i18n/hooks";
 import {
   formatTokenCount,
+  selectNonDecreasingTokenUsage,
   selectHeaderTokenUsage,
   type TokenUsage,
 } from "@/core/messages/usage";
@@ -60,6 +61,20 @@ export function TokenUsageIndicator({
       }),
     [backendUsage, messages, pendingMessages, threadId],
   );
+  const [displayedUsage, setDisplayedUsage] = useState<TokenUsage | null>(
+    usage,
+  );
+  const displayedUsageThreadIdRef = useRef(threadId);
+  useEffect(() => {
+    if (displayedUsageThreadIdRef.current !== threadId) {
+      displayedUsageThreadIdRef.current = threadId;
+      setDisplayedUsage(usage);
+      return;
+    }
+    setDisplayedUsage((previous) =>
+      selectNonDecreasingTokenUsage(usage, previous),
+    );
+  }, [threadId, usage]);
   const preset = getTokenUsageViewPreset(preferences);
 
   if (!enabled) {
@@ -81,8 +96,8 @@ export function TokenUsageIndicator({
           <span>{t.tokenUsage.label}</span>
           <span className="font-mono">
             {preferences.headerTotal
-              ? usage
-                ? formatTokenCount(usage.totalTokens)
+              ? displayedUsage
+                ? formatTokenCount(displayedUsage.totalTokens)
                 : "-"
               : t.tokenUsage.presets[presetKeyToTranslationKey(preset)]}
           </span>
@@ -92,25 +107,25 @@ export function TokenUsageIndicator({
       <DropdownMenuContent side="bottom" align="end" className="w-80">
         <DropdownMenuLabel>{t.tokenUsage.title}</DropdownMenuLabel>
         <div className="px-2 py-1 text-xs">
-          {usage ? (
+          {displayedUsage ? (
             <div className="space-y-1">
               <div className="flex justify-between gap-4">
                 <span>{t.tokenUsage.input}</span>
                 <span className="font-mono">
-                  {formatTokenCount(usage.inputTokens)}
+                  {formatTokenCount(displayedUsage.inputTokens)}
                 </span>
               </div>
               <div className="flex justify-between gap-4">
                 <span>{t.tokenUsage.output}</span>
                 <span className="font-mono">
-                  {formatTokenCount(usage.outputTokens)}
+                  {formatTokenCount(displayedUsage.outputTokens)}
                 </span>
               </div>
               <div className="border-t pt-1">
                 <div className="flex justify-between gap-4">
                   <span>{t.tokenUsage.total}</span>
                   <span className="font-mono font-medium">
-                    {formatTokenCount(usage.totalTokens)}
+                    {formatTokenCount(displayedUsage.totalTokens)}
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/workspace/token-usage-indicator.tsx
+++ b/frontend/src/components/workspace/token-usage-indicator.tsx
@@ -34,6 +34,7 @@ interface TokenUsageIndicatorProps {
   messages: Message[];
   pendingMessages?: Message[];
   backendUsage?: TokenUsage | null;
+  backendIncludesActive?: boolean;
   enabled?: boolean;
   preferences: TokenUsagePreferences;
   onPreferencesChange: (preferences: TokenUsagePreferences) => void;
@@ -45,6 +46,7 @@ export function TokenUsageIndicator({
   messages,
   pendingMessages,
   backendUsage,
+  backendIncludesActive = false,
   enabled = false,
   preferences,
   onPreferencesChange,
@@ -56,10 +58,11 @@ export function TokenUsageIndicator({
     () =>
       selectHeaderTokenUsage({
         backendUsage: threadId ? backendUsage : null,
+        backendIncludesActive,
         messages,
         pendingMessages,
       }),
-    [backendUsage, messages, pendingMessages, threadId],
+    [backendIncludesActive, backendUsage, messages, pendingMessages, threadId],
   );
   const [displayedUsage, setDisplayedUsage] = useState<TokenUsage | null>(
     usage,

--- a/frontend/src/core/messages/usage.ts
+++ b/frontend/src/core/messages/usage.ts
@@ -99,6 +99,19 @@ export function selectHeaderTokenUsage({
   return accumulateUsage(messages);
 }
 
+export function selectNonDecreasingTokenUsage(
+  currentUsage: TokenUsage | null,
+  previousUsage: TokenUsage | null,
+): TokenUsage | null {
+  if (!currentUsage) {
+    return previousUsage;
+  }
+  if (!previousUsage || currentUsage.totalTokens >= previousUsage.totalTokens) {
+    return currentUsage;
+  }
+  return previousUsage;
+}
+
 /**
  * Format a token count for display: 1234 -> "1,234", 12345 -> "12.3K"
  */

--- a/frontend/src/core/messages/usage.ts
+++ b/frontend/src/core/messages/usage.ts
@@ -85,14 +85,19 @@ export function addUsage(base: TokenUsage, delta: TokenUsage): TokenUsage {
 
 export function selectHeaderTokenUsage({
   backendUsage,
+  backendIncludesActive = false,
   messages,
   pendingMessages = [],
 }: {
   backendUsage?: TokenUsage | null;
+  backendIncludesActive?: boolean;
   messages: Message[];
   pendingMessages?: Message[];
 }): TokenUsage | null {
   if (hasNonZeroUsage(backendUsage)) {
+    if (backendIncludesActive) {
+      return backendUsage;
+    }
     const pendingUsage = accumulateUsage(pendingMessages);
     return pendingUsage ? addUsage(backendUsage, pendingUsage) : backendUsage;
   }

--- a/frontend/src/core/threads/api.ts
+++ b/frontend/src/core/threads/api.ts
@@ -7,7 +7,7 @@ export async function fetchThreadTokenUsage(
   threadId: string,
 ): Promise<ThreadTokenUsageResponse | null> {
   const response = await fetchWithAuth(
-    `${getBackendBaseURL()}/api/threads/${encodeURIComponent(threadId)}/token-usage`,
+    `${getBackendBaseURL()}/api/threads/${encodeURIComponent(threadId)}/token-usage?include_active=true`,
     {
       method: "GET",
     },

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -175,6 +175,9 @@ export function useThreadStream({
   const threadIdRef = useRef<string | null>(threadId ?? null);
   const startedRef = useRef(false);
   const pendingUsageBaselineMessageIdsRef = useRef<Set<string>>(new Set());
+  const tokenUsageRefreshTimersRef = useRef<ReturnType<typeof setTimeout>[]>(
+    [],
+  );
   const listeners = useRef({
     onSend,
     onStart,
@@ -218,6 +221,40 @@ export function useThreadStream({
 
   const queryClient = useQueryClient();
   const updateSubtask = useUpdateSubtask();
+
+  const clearThreadTokenUsageRefreshTimers = useCallback(() => {
+    tokenUsageRefreshTimersRef.current.forEach((timer) => clearTimeout(timer));
+    tokenUsageRefreshTimersRef.current = [];
+  }, []);
+
+  const refreshThreadTokenUsage = useCallback(
+    (targetThreadId: string | null | undefined) => {
+      if (!targetThreadId || isMock) {
+        return;
+      }
+
+      clearThreadTokenUsageRefreshTimers();
+      const queryKey = threadTokenUsageQueryKey(targetThreadId);
+      const refresh = () => {
+        void queryClient.invalidateQueries({ queryKey });
+      };
+
+      refresh();
+      // The SDK can call onFinish as soon as the final state event arrives,
+      // while the worker is still flushing final run counters to SQL.
+      for (const delayMs of [1_000, 3_000]) {
+        tokenUsageRefreshTimersRef.current.push(setTimeout(refresh, delayMs));
+      }
+    },
+    [clearThreadTokenUsageRefreshTimers, isMock, queryClient],
+  );
+
+  useEffect(
+    () => () => {
+      clearThreadTokenUsageRefreshTimers();
+    },
+    [clearThreadTokenUsageRefreshTimers, threadId],
+  );
 
   const thread = useStream<AgentThreadState>({
     client: getAPIClient(isMock),
@@ -337,11 +374,7 @@ export function useThreadStream({
           .map(messageIdentity)
           .filter((id): id is string => Boolean(id)),
       );
-      if (threadIdRef.current && !isMock) {
-        void queryClient.invalidateQueries({
-          queryKey: threadTokenUsageQueryKey(threadIdRef.current),
-        });
-      }
+      refreshThreadTokenUsage(threadIdRef.current);
     },
     onFinish(state) {
       listeners.current.onFinish?.(state.values);
@@ -351,11 +384,7 @@ export function useThreadStream({
           .filter((id): id is string => Boolean(id)),
       );
       void queryClient.invalidateQueries({ queryKey: ["threads", "search"] });
-      if (threadIdRef.current && !isMock) {
-        void queryClient.invalidateQueries({
-          queryKey: threadTokenUsageQueryKey(threadIdRef.current),
-        });
-      }
+      refreshThreadTokenUsage(threadIdRef.current);
     },
   });
 
@@ -880,7 +909,7 @@ export function useThreadTokenUsage(
     },
     enabled: enabled && Boolean(threadId),
     retry: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/frontend/tests/unit/core/messages/usage.test.ts
+++ b/frontend/tests/unit/core/messages/usage.test.ts
@@ -135,6 +135,36 @@ test("adds current in-flight message usage to backend header totals", () => {
   });
 });
 
+test("does not double count pending usage when backend totals include active runs", () => {
+  const completedMessages = [
+    {
+      id: "ai-completed",
+      type: "ai",
+      content: "Completed answer",
+      usage_metadata: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+    },
+    {
+      id: "ai-pending",
+      type: "ai",
+      content: "Streaming answer",
+      usage_metadata: { input_tokens: 4, output_tokens: 6, total_tokens: 10 },
+    },
+  ] as Message[];
+
+  expect(
+    selectHeaderTokenUsage({
+      backendUsage: { inputTokens: 104, outputTokens: 56, totalTokens: 160 },
+      backendIncludesActive: true,
+      messages: completedMessages,
+      pendingMessages: [completedMessages[1]!],
+    }),
+  ).toEqual({
+    inputTokens: 104,
+    outputTokens: 56,
+    totalTokens: 160,
+  });
+});
+
 test("falls back to visible messages when backend usage is unavailable or zero", () => {
   const messages = [
     {

--- a/frontend/tests/unit/core/messages/usage.test.ts
+++ b/frontend/tests/unit/core/messages/usage.test.ts
@@ -1,7 +1,11 @@
 import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
-import { accumulateUsage, selectHeaderTokenUsage } from "@/core/messages/usage";
+import {
+  accumulateUsage,
+  selectHeaderTokenUsage,
+  selectNonDecreasingTokenUsage,
+} from "@/core/messages/usage";
 import {
   getAssistantTurnUsageMessages,
   getMessageGroups,
@@ -160,5 +164,31 @@ test("falls back to visible messages when backend usage is unavailable or zero",
     inputTokens: 10,
     outputTokens: 5,
     totalTokens: 15,
+  });
+});
+
+test("keeps header usage from decreasing on stale refreshes", () => {
+  const previous = {
+    inputTokens: 200_000,
+    outputTokens: 5_000,
+    totalTokens: 205_000,
+  };
+
+  expect(
+    selectNonDecreasingTokenUsage(
+      { inputTokens: 144_300, outputTokens: 2_824, totalTokens: 147_124 },
+      previous,
+    ),
+  ).toBe(previous);
+
+  expect(
+    selectNonDecreasingTokenUsage(
+      { inputTokens: 319_488, outputTokens: 5_425, totalTokens: 324_913 },
+      previous,
+    ),
+  ).toEqual({
+    inputTokens: 319_488,
+    outputTokens: 5_425,
+    totalTokens: 324_913,
   });
 });

--- a/frontend/tests/unit/core/threads/api.test.ts
+++ b/frontend/tests/unit/core/threads/api.test.ts
@@ -36,7 +36,9 @@ test("fetchThreadTokenUsage uses shared auth fetch without JSON GET headers", as
   });
 
   expect(fetchWithAuth).toHaveBeenCalledWith(
-    expect.stringContaining("/api/threads/thread-1/token-usage"),
+    expect.stringContaining(
+      "/api/threads/thread-1/token-usage?include_active=true",
+    ),
     {
       method: "GET",
     },


### PR DESCRIPTION
# fix(token-usage): make thread totals reliable across active and interrupted runs

## What

This PR fixes three thread token usage consistency gaps:

- Backend token aggregation now counts persisted `interrupted` runs as terminal usage.
- Frontend token usage display now avoids same-thread regressions while final usage is refetched after stream completion.
- Active run token progress is now persisted even when LangChain invokes callbacks from a worker thread, and the frontend thread total requests those active snapshots.

Related to #2874.

## Why

Interrupted runs can still contain persisted token counters for LLM calls that already happened. From the user perspective, those tokens were consumed and should be part of the thread-level total.

Previously, `/api/threads/{thread_id}/token-usage` counted:

```text
success, error
```

and with `include_active=true`:

```text
success, error, running
```

That omitted persisted `interrupted` usage.

Separately, after stream completion, the frontend invalidated token usage once. If that refresh landed before final counters settled, or if the header fell back to visible-message usage, the displayed total could move backward.

There was also a longer-running active-run gap. `RunJournal` only scheduled active progress writes through `asyncio.get_running_loop()` in the callback thread. When LangChain invoked `on_llm_end` from a thread without a running event loop, token counters accumulated in memory and final completion persistence worked, but the active run row stayed at zero until completion. During long runs, `/token-usage?include_active=true` therefore still undercounted.

## How

Backend:

- Add shared token usage status sets:
  - terminal: `success`, `error`, `interrupted`
  - active-inclusive: terminal statuses plus `running`
- Use those status sets in both SQL and memory run stores.
- Update the `RunStore.aggregate_tokens_by_thread` contract from "completed" to "terminal" runs.
- Capture the worker event loop in `RunJournal` and schedule progress flushes back onto it with `call_soon_threadsafe` when callbacks run off-loop.
- Add tests covering both SQL and memory aggregation behavior.
- Add a regression test for `on_llm_end` invoked through `asyncio.to_thread(...)`, proving active progress snapshots are still reported.

Frontend:

- Request `/api/threads/{thread_id}/token-usage?include_active=true` for thread totals.
- Mark backend totals as active-inclusive in `TokenUsageIndicator`, so visible pending message usage is not double-counted.
- Revalidate thread token usage on stream finish/error immediately and again after short delays.
- Refetch token usage on window focus.
- Keep displayed token usage non-decreasing within the same thread.
- Reset the displayed usage guard when switching threads.
- Add a unit test for stale refreshes that should not reduce the displayed header total.

## Testing

Backend contribution checks run locally:

```bash
uv run ruff check .
uv run ruff format --check .
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -q
```

Result: `3634 passed, 16 skipped, 12 warnings`.

Frontend contribution checks run locally:

```bash
cd frontend
pnpm format
pnpm lint
pnpm test
pnpm typecheck
```

Results:

- unit tests: `18 files passed`, `87 tests passed`
- format/lint/typecheck: passed

E2E check:

```bash
pnpm exec playwright test --config playwright.local-3100.config.ts
```

Result: `16 passed`.

The first local `pnpm test:e2e` attempt reused an existing long-running `localhost:3000` Next server that was not started with `DEER_FLOW_AUTH_DISABLED=1`, so the app redirected `/workspace` to `/setup`. I reran E2E with a temporary isolated Playwright config on port `3100` and removed that local config after the run.

Manual local verification after restart:

```json
{
  "thread_id": "redacted",
  "total_tokens": 3075422,
  "total_input_tokens": 2925690,
  "total_output_tokens": 149732,
  "total_runs": 10
}
```

This matched the SQL terminal-run sum:

```text
success     total=2757325
interrupted total=318097
combined    total=3075422
```

## Notes

This PR intentionally keeps the token source of truth in persisted run rows. It does not derive product totals from logs or checkpoints. The active-run path now makes those persisted rows update during the run, while terminal aggregation continues to use stored run counters.

PR #2925 also touches frontend token usage models for cache token fields. This change is semantically independent, but it may need a small rebase if #2925 lands first.
