### PR TITLE
fix: recover legacy checkpoint-only threads after auth migration

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -119,6 +119,15 @@ async def _ensure_admin_user(app: FastAPI) -> None:
         except Exception:
             logger.exception("LangGraph thread migration failed (non-fatal)")
 
+    try:
+        from app.gateway.checkpoint_maintenance import migrate_app_checkpoint_threads_to_thread_meta
+
+        migrated = await migrate_app_checkpoint_threads_to_thread_meta(app, admin_id)
+        if migrated:
+            logger.info("Migrated %d legacy checkpoint thread(s) to admin thread metadata", migrated)
+    except Exception:
+        logger.exception("Legacy checkpoint thread migration failed (non-fatal)")
+
 
 async def _iter_store_items(store, namespace, *, page_size: int = 500):
     """Paginated async iterator over a LangGraph store namespace.

--- a/backend/app/gateway/checkpoint_maintenance.py
+++ b/backend/app/gateway/checkpoint_maintenance.py
@@ -1,0 +1,242 @@
+"""Maintenance helpers for LangGraph checkpoint storage."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import inspect
+import logging
+import shutil
+from pathlib import Path
+from typing import Any
+
+from deerflow.config.paths import Paths, get_paths
+from deerflow.config.runtime_paths import runtime_home
+
+logger = logging.getLogger(__name__)
+
+_MIGRATION_TASK_STATE_ATTR = "checkpoint_thread_migration_task"
+
+
+def _sqlite_saver_connection(checkpointer: Any) -> Any | None:
+    """Return the aiosqlite connection only for LangGraph SQLite savers."""
+    saver_type = type(checkpointer)
+    type_name = saver_type.__name__.lower()
+    module_name = saver_type.__module__.lower()
+    if "sqlite" not in type_name or "langgraph.checkpoint.sqlite" not in module_name:
+        return None
+
+    conn = getattr(checkpointer, "conn", None)
+    if conn is None or not hasattr(conn, "execute") or not hasattr(conn, "commit"):
+        return None
+    return conn
+
+
+async def _ensure_checkpointer_setup(checkpointer: Any) -> None:
+    setup = getattr(checkpointer, "setup", None)
+    if setup is None:
+        return
+    result = setup()
+    if inspect.isawaitable(result):
+        await result
+
+
+def _row_value(row: Any, index: int, key: str) -> Any:
+    try:
+        return row[key]
+    except (IndexError, KeyError, TypeError):
+        return row[index]
+
+
+async def _sqlite_database_path(conn: Any) -> str | None:
+    async with conn.execute("PRAGMA database_list") as cur:
+        rows = await cur.fetchall()
+    for row in rows:
+        if _row_value(row, 1, "name") == "main":
+            value = str(_row_value(row, 2, "file") or "")
+            return value or None
+    return None
+
+
+async def _checkpoint_thread_migration_marker_path(conn: Any) -> Path | None:
+    db_path = await _sqlite_database_path(conn)
+    if not db_path:
+        return None
+    digest = hashlib.sha256(str(Path(db_path).expanduser().resolve()).encode()).hexdigest()[:16]
+    return runtime_home() / "maintenance" / f"checkpoint-thread-meta-migration-{digest}.done"
+
+
+def _write_migration_marker(marker_path: Path) -> None:
+    marker_path.parent.mkdir(parents=True, exist_ok=True)
+    marker_path.write_text("completed\n", encoding="utf-8")
+
+
+async def _sqlite_checkpoint_thread_ids(checkpointer: Any) -> list[str]:
+    """Return distinct checkpoint thread IDs from a LangGraph SQLite saver."""
+    conn = _sqlite_saver_connection(checkpointer)
+    if conn is None:
+        return []
+
+    await _ensure_checkpointer_setup(checkpointer)
+
+    lock = getattr(checkpointer, "lock", None)
+    if lock is None:
+        async with conn.execute("SELECT DISTINCT thread_id FROM checkpoints ORDER BY thread_id") as cur:
+            return [str(row[0]) async for row in cur]
+
+    async with lock:
+        async with conn.execute("SELECT DISTINCT thread_id FROM checkpoints ORDER BY thread_id") as cur:
+            return [str(row[0]) async for row in cur]
+
+
+async def _checkpoint_title(checkpointer: Any, thread_id: str) -> str | None:
+    aget_tuple = getattr(checkpointer, "aget_tuple", None)
+    if aget_tuple is None:
+        return None
+    try:
+        checkpoint_tuple = await aget_tuple({"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}})
+    except Exception:
+        logger.debug("Could not read checkpoint title for legacy thread %s", thread_id, exc_info=True)
+        return None
+    if checkpoint_tuple is None:
+        return None
+
+    checkpoint = getattr(checkpoint_tuple, "checkpoint", {}) or {}
+    title = checkpoint.get("channel_values", {}).get("title")
+    if isinstance(title, str) and title.strip():
+        return title
+    return None
+
+
+def _copy_legacy_thread_dir(paths: Paths, thread_id: str, user_id: str) -> bool:
+    """Copy legacy thread data into the user-scoped layout without overwrites."""
+    legacy_dir = paths.thread_dir(thread_id)
+    if not legacy_dir.exists():
+        return False
+
+    target_dir = paths.thread_dir(thread_id, user_id=user_id)
+    if not target_dir.exists():
+        shutil.copytree(legacy_dir, target_dir)
+        paths.ensure_thread_dirs(thread_id, user_id=user_id)
+        return True
+
+    copied = False
+    for source in legacy_dir.rglob("*"):
+        relative = source.relative_to(legacy_dir)
+        target = target_dir / relative
+        if source.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if target.exists():
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+        copied = True
+
+    paths.ensure_thread_dirs(thread_id, user_id=user_id)
+    return copied
+
+
+async def _migrate_checkpoint_thread_ids(
+    checkpointer: Any,
+    thread_store: Any,
+    admin_user_id: str,
+    thread_ids: list[str],
+    *,
+    paths: Paths | None = None,
+) -> tuple[int, bool]:
+    paths = paths or get_paths()
+    migrated = 0
+    failed = False
+
+    for thread_id in thread_ids:
+        try:
+            existing = await thread_store.get(thread_id, user_id=None)
+        except Exception:
+            failed = True
+            logger.debug("Could not read thread_meta for legacy checkpoint thread %s", thread_id, exc_info=True)
+            continue
+
+        try:
+            if existing is None:
+                await thread_store.create(
+                    thread_id,
+                    user_id=admin_user_id,
+                    display_name=await _checkpoint_title(checkpointer, thread_id),
+                    metadata={"migrated_from": "legacy_checkpointer"},
+                )
+                migrated += 1
+
+            owner_id = admin_user_id if existing is None else existing.get("user_id")
+            if owner_id == admin_user_id:
+                _copy_legacy_thread_dir(paths, thread_id, admin_user_id)
+        except Exception:
+            failed = True
+            logger.debug("Could not migrate legacy checkpoint thread %s", thread_id, exc_info=True)
+
+    return migrated, failed
+
+
+async def migrate_checkpoint_threads_to_thread_meta(
+    checkpointer: Any,
+    thread_store: Any,
+    admin_user_id: str,
+) -> int:
+    """Create missing thread_meta rows for legacy SQLite checkpoint threads.
+
+    Older DeerFlow installs could have valid LangGraph checkpoints and legacy
+    ``threads/<thread_id>/user-data`` files without a corresponding
+    ``threads_meta`` row. After thread search moved to ``ThreadMetaStore`` and
+    artifacts became user-scoped, those threads disappeared from the UI and
+    their artifact links resolved under the wrong directory.
+
+    Assigning recovered rows to the first admin mirrors the existing no-auth to
+    auth orphan migration for pre-auth single-user installs.
+    """
+    conn = _sqlite_saver_connection(checkpointer)
+    if conn is None:
+        return 0
+
+    await _ensure_checkpointer_setup(checkpointer)
+    marker_path = await _checkpoint_thread_migration_marker_path(conn)
+    if marker_path is not None and marker_path.exists():
+        return 0
+
+    migrated, failed = await _migrate_checkpoint_thread_ids(
+        checkpointer,
+        thread_store,
+        admin_user_id,
+        await _sqlite_checkpoint_thread_ids(checkpointer),
+    )
+
+    if marker_path is not None and not failed:
+        _write_migration_marker(marker_path)
+    return migrated
+
+
+async def migrate_app_checkpoint_threads_to_thread_meta(app: Any, admin_user_id: str) -> int:
+    """Migrate app-scoped legacy checkpoint threads when runtime state exists."""
+    checkpointer = getattr(app.state, "checkpointer", None)
+    thread_store = getattr(app.state, "thread_store", None)
+    if checkpointer is None or thread_store is None:
+        return 0
+    return await migrate_checkpoint_threads_to_thread_meta(checkpointer, thread_store, admin_user_id)
+
+
+def schedule_app_checkpoint_thread_migration(app: Any, admin_user_id: str) -> bool:
+    """Schedule legacy checkpoint thread migration without blocking setup."""
+    existing_task = getattr(app.state, _MIGRATION_TASK_STATE_ATTR, None)
+    if existing_task is not None and not existing_task.done():
+        return False
+
+    async def _run() -> None:
+        try:
+            migrated = await migrate_app_checkpoint_threads_to_thread_meta(app, admin_user_id)
+            if migrated:
+                logger.info("Migrated %d legacy checkpoint thread(s) to admin thread metadata", migrated)
+        except Exception:
+            logger.exception("Legacy checkpoint thread migration failed (non-fatal)")
+
+    task = asyncio.create_task(_run(), name="deerflow-checkpoint-thread-migration")
+    setattr(app.state, _MIGRATION_TASK_STATE_ATTR, task)
+    return True

--- a/backend/app/gateway/routers/auth.py
+++ b/backend/app/gateway/routers/auth.py
@@ -489,6 +489,13 @@ async def initialize_admin(request: Request, response: Response, body: Initializ
     token = create_access_token(str(user.id), token_version=user.token_version)
     _set_session_cookie(response, token, request)
 
+    try:
+        from app.gateway.checkpoint_maintenance import schedule_app_checkpoint_thread_migration
+
+        schedule_app_checkpoint_thread_migration(request.app, str(user.id))
+    except Exception:
+        logger.exception("Failed to schedule legacy checkpoint thread migration after setup")
+
     return UserResponse(id=str(user.id), email=user.email, system_role=user.system_role)
 
 

--- a/backend/tests/test_checkpoint_thread_maintenance.py
+++ b/backend/tests/test_checkpoint_thread_maintenance.py
@@ -1,0 +1,149 @@
+"""Tests for legacy checkpoint thread maintenance."""
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from fastapi import Response
+
+os.environ.setdefault("AUTH_JWT_SECRET", "test-secret-key-checkpoint-maintenance-min-32")
+
+from app.gateway.auth.config import AuthConfig, set_auth_config
+from app.gateway.auth.models import User
+from deerflow.config.paths import Paths
+
+_JWT_SECRET = "test-secret-key-checkpoint-maintenance-min-32"
+
+
+def test_migrate_checkpoint_thread_ids_creates_meta_with_title_and_copies_legacy_files(tmp_path):
+    """A checkpoint-only legacy thread becomes visible and keeps artifacts readable."""
+    from app.gateway.checkpoint_maintenance import _migrate_checkpoint_thread_ids
+
+    paths = Paths(tmp_path)
+    legacy_outputs = paths.sandbox_outputs_dir("thread-1")
+    legacy_outputs.mkdir(parents=True)
+    (legacy_outputs / "report.md").write_text("legacy artifact", encoding="utf-8")
+
+    checkpointer = SimpleNamespace(aget_tuple=AsyncMock(return_value=SimpleNamespace(checkpoint={"channel_values": {"title": "Legacy Report"}})))
+    thread_store = AsyncMock()
+    thread_store.get = AsyncMock(return_value=None)
+    created: list[dict] = []
+
+    async def _create(thread_id, **kwargs):
+        created.append({"thread_id": thread_id, **kwargs})
+        return {"thread_id": thread_id, **kwargs}
+
+    thread_store.create = AsyncMock(side_effect=_create)
+
+    migrated, failed = asyncio.run(
+        _migrate_checkpoint_thread_ids(
+            checkpointer,
+            thread_store,
+            "admin-1",
+            ["thread-1"],
+            paths=paths,
+        )
+    )
+
+    assert migrated == 1
+    assert failed is False
+    assert created == [
+        {
+            "thread_id": "thread-1",
+            "user_id": "admin-1",
+            "display_name": "Legacy Report",
+            "metadata": {"migrated_from": "legacy_checkpointer"},
+        }
+    ]
+    user_artifact = paths.sandbox_outputs_dir("thread-1", user_id="admin-1") / "report.md"
+    assert user_artifact.read_text(encoding="utf-8") == "legacy artifact"
+
+
+def test_migrate_checkpoint_thread_ids_does_not_copy_other_users_existing_thread(tmp_path):
+    """Existing owned rows are not reassigned or copied into the admin layout."""
+    from app.gateway.checkpoint_maintenance import _migrate_checkpoint_thread_ids
+
+    paths = Paths(tmp_path)
+    legacy_outputs = paths.sandbox_outputs_dir("thread-2")
+    legacy_outputs.mkdir(parents=True)
+    (legacy_outputs / "report.md").write_text("legacy artifact", encoding="utf-8")
+
+    checkpointer = SimpleNamespace(aget_tuple=AsyncMock())
+    thread_store = AsyncMock()
+    thread_store.get = AsyncMock(return_value={"thread_id": "thread-2", "user_id": "other-user"})
+    thread_store.create = AsyncMock()
+
+    migrated, failed = asyncio.run(
+        _migrate_checkpoint_thread_ids(
+            checkpointer,
+            thread_store,
+            "admin-1",
+            ["thread-2"],
+            paths=paths,
+        )
+    )
+
+    assert migrated == 0
+    assert failed is False
+    thread_store.create.assert_not_called()
+    assert not (paths.sandbox_outputs_dir("thread-2", user_id="admin-1") / "report.md").exists()
+
+
+def test_schedule_app_checkpoint_thread_migration_debounces_running_task():
+    """Setup can schedule migration once without blocking the response path."""
+    import app.gateway.checkpoint_maintenance as maintenance
+
+    calls: list[str] = []
+
+    async def _migrate(_app, admin_user_id):
+        calls.append(admin_user_id)
+        await asyncio.sleep(0)
+        return 0
+
+    async def _run():
+        app = SimpleNamespace(state=SimpleNamespace())
+        with patch.object(maintenance, "migrate_app_checkpoint_threads_to_thread_meta", side_effect=_migrate):
+            assert maintenance.schedule_app_checkpoint_thread_migration(app, "admin-1") is True
+            assert maintenance.schedule_app_checkpoint_thread_migration(app, "admin-1") is False
+            await app.state.checkpoint_thread_migration_task
+
+    asyncio.run(_run())
+    assert calls == ["admin-1"]
+
+
+def test_initialize_admin_schedules_checkpoint_thread_migration_after_first_setup():
+    """First admin creation kicks off legacy checkpoint recovery immediately."""
+    from app.gateway.routers.auth import InitializeAdminRequest, initialize_admin
+
+    set_auth_config(AuthConfig(jwt_secret=_JWT_SECRET))
+    user = User(
+        id=uuid4(),
+        email="admin@example.com",
+        password_hash="hash",
+        system_role="admin",
+        needs_setup=False,
+    )
+    provider = AsyncMock()
+    provider.count_admin_users = AsyncMock(return_value=0)
+    provider.create_user = AsyncMock(return_value=user)
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace()),
+        headers={},
+        url=SimpleNamespace(scheme="http"),
+    )
+
+    async def _run():
+        with patch("app.gateway.routers.auth.get_local_provider", return_value=provider):
+            with patch("app.gateway.checkpoint_maintenance.schedule_app_checkpoint_thread_migration") as schedule:
+                result = await initialize_admin(
+                    request,
+                    Response(),
+                    InitializeAdminRequest(email="admin@example.com", password="StrongPass123!"),
+                )
+
+        assert result.id == str(user.id)
+        schedule.assert_called_once_with(request.app, str(user.id))
+
+    asyncio.run(_run())

--- a/backend/tests/test_ensure_admin.py
+++ b/backend/tests/test_ensure_admin.py
@@ -119,6 +119,29 @@ def test_admin_exists_triggers_migration():
     store.asearch.assert_called_once()
 
 
+def test_admin_exists_triggers_checkpoint_thread_migration():
+    """Admin exists and admin row found → checkpoint-only threads are recovered."""
+    from uuid import uuid4
+
+    admin_row = MagicMock()
+    admin_row.id = uuid4()
+
+    provider = _make_provider(admin_count=1)
+    sf = _make_session_factory(admin_row=admin_row)
+    store = AsyncMock()
+    store.asearch = AsyncMock(return_value=[])
+    app = _make_app_stub(store=store)
+
+    with patch("app.gateway.deps.get_local_provider", return_value=provider):
+        with patch("deerflow.persistence.engine.get_session_factory", return_value=sf):
+            with patch("app.gateway.checkpoint_maintenance.migrate_app_checkpoint_threads_to_thread_meta", AsyncMock(return_value=2)) as migrate:
+                from app.gateway.app import _ensure_admin_user
+
+                asyncio.run(_ensure_admin_user(app))
+
+    migrate.assert_awaited_once_with(app, str(admin_row.id))
+
+
 def test_admin_exists_no_admin_row_skips_migration():
     """Admin count > 0 but DB row missing (edge case) → skip migration gracefully."""
     provider = _make_provider(admin_count=2)


### PR DESCRIPTION
## What

Recover legacy SQLite checkpoint threads that predate `threads_meta` during the auth/user-isolation upgrade path.

This adds a gateway maintenance helper that:

- scans distinct thread IDs from the LangGraph SQLite checkpointer
- creates missing `threads_meta` rows assigned to the first admin
- preserves checkpoint titles as `display_name` when available
- copies legacy `threads/<thread_id>/user-data` files into the user-scoped thread layout without overwriting existing files
- runs on startup when an admin already exists
- schedules the same recovery immediately after first admin setup

## Why

Older DeerFlow installs can have valid checkpoints without corresponding `threads_meta` rows. Since `/threads/search` is backed by `ThreadMetaStore`, those threads disappear from the frontend thread list after upgrading. If artifacts still live in the legacy thread directory, user-scoped artifact resolution can also miss them.

Fixes #3186

## How

The migration is SQLite-specific and best-effort:

- non-SQLite checkpointers no-op
- failures are logged as non-fatal
- existing thread metadata is not reassigned
- existing user-scoped files are not overwritten
- a per-checkpointer marker avoids rerunning a completed migration repeatedly

## Testing

- `cd backend && make lint`
- `cd backend && uv run pytest tests/test_checkpoint_thread_maintenance.py tests/test_ensure_admin.py -q`
- `cd backend && make test`
