### PR TITLE
fix(frontend): show filename for presented artifacts missing from thr…

### DIFF
--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -76,6 +76,13 @@ export function ArtifactFileDetail({
     }
     return filepathFromProps;
   }, [filepathFromProps, isWriteFile]);
+  const artifactOptions = useMemo(() => {
+    const list = artifacts ?? [];
+    if (list.includes(filepath)) {
+      return list;
+    }
+    return [filepath, ...list];
+  }, [artifacts, filepath]);
   const isSkillFile = useMemo(() => {
     return filepath.endsWith(".skill");
   }, [filepath]);
@@ -167,9 +174,9 @@ export function ArtifactFileDetail({
                 </SelectTrigger>
                 <SelectContent className="select-none">
                   <SelectGroup>
-                    {(artifacts ?? []).map((filepath) => (
-                      <SelectItem key={filepath} value={filepath}>
-                        {getFileName(filepath)}
+                    {artifactOptions.map((option) => (
+                      <SelectItem key={option} value={option}>
+                        {getFileName(option)}
                       </SelectItem>
                     ))}
                   </SelectGroup>

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -5,10 +5,12 @@ import { mockLangGraphAPI } from "./utils/mock-api";
 const ARTIFACT_PATH = "/artifact-fixtures/report.html";
 const MARKDOWN_ARTIFACT_PATH = "/artifact-fixtures/report.md";
 const JSON_ARTIFACT_PATH = "/artifact-fixtures/report.json";
+const PRESENTED_ARTIFACT_PATH = "/mnt/user-data/outputs/presented-report.md";
 const IN_PROGRESS_THREAD_ID = "00000000-0000-0000-0000-000000003119";
 const COMPLETE_THREAD_ID = "00000000-0000-0000-0000-000000003120";
 const MARKDOWN_THREAD_ID = "00000000-0000-0000-0000-000000003121";
 const JSON_THREAD_ID = "00000000-0000-0000-0000-000000003122";
+const PRESENTED_THREAD_ID = "00000000-0000-0000-0000-000000003123";
 
 function writeFileMessages({
   path = ARTIFACT_PATH,
@@ -54,6 +56,30 @@ function writeFileMessages({
   }
 
   return messages;
+}
+
+function presentFilesMessages() {
+  return [
+    {
+      type: "human",
+      id: "msg-human-present-file",
+      content: [{ type: "text", text: "Create a markdown report" }],
+    },
+    {
+      type: "ai",
+      id: "msg-ai-present-file",
+      content: "The report has been written. Now let me present the file.",
+      tool_calls: [
+        {
+          id: "present-file-artifact",
+          name: "present_files",
+          args: {
+            filepaths: [PRESENTED_ARTIFACT_PATH],
+          },
+        },
+      ],
+    },
+  ];
 }
 
 test.describe("Artifact preview stability", () => {
@@ -170,5 +196,46 @@ test.describe("Artifact preview stability", () => {
     await expect(
       artifactsPanel.getByText('"中文字段": "测试内容"'),
     ).toBeVisible();
+  });
+
+  test("shows the title for a presented artifact missing from thread artifacts", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: PRESENTED_THREAD_ID,
+          title: "Presented artifact title fallback",
+          messages: presentFilesMessages(),
+          artifacts: [],
+        },
+      ],
+    });
+    await page.route(
+      `**/api/threads/${PRESENTED_THREAD_ID}/artifacts/mnt/user-data/outputs/presented-report.md`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/markdown",
+          body: "# Presented Report\n\nGenerated content",
+        }),
+    );
+
+    await page.goto(`/workspace/chats/${PRESENTED_THREAD_ID}`);
+
+    // The file card in the message list shows the basename only.
+    await expect(page.getByText("presented-report.md")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByText("presented-report.md").first().click();
+
+    const artifactsPanel = page.locator("#artifacts");
+
+    // 1. Header title should fall back to the current filepath even though
+    //    thread.values.artifacts is empty.
+    await expect(artifactsPanel.getByText("presented-report.md")).toBeVisible();
+
+    // 2. Preview content should still render correctly.
+    await expect(artifactsPanel.getByText("Presented Report")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3192. The artifact preview header shows an empty filename after an AI run completes, even though the preview body renders correctly.

## Root cause

The artifact preview header is driven by a Radix UI `<Select>` whose `<SelectValue>` renders the label of the `<SelectItem>` matching the current `value`. The option list was built solely from `artifacts` in `ArtifactsContext`, which is only synced from `thread.values.artifacts` in `chat-box.tsx`:

> `setArtifacts(thread.values.artifacts);`

Artifacts surfaced via the message-layer `present_files` tool call are **never** written back to `thread.values.artifacts`. So when such a file becomes the selected artifact, its filepath has no matching `<SelectItem>`; Radix silently renders an empty trigger and the header filename appears blank, even though the preview body still loads correctly via the `/artifacts/...` route.

The existing TODO comment in `chat-box.tsx` already acknowledges that "artifacts auto discovering is not work now". This PR addresses the user-visible symptom without depending on that future work.

## Fix

In `artifact-file-detail.tsx`, compute `artifactOptions` as a defensive union of `artifacts` and the current `filepath`: if `filepath` is missing from `artifacts`, prepend it so a matching `<SelectItem>` always exists for `<SelectValue>` to render.

```tsx
const artifactOptions = useMemo(() => {
  const list = artifacts ?? [];
  if (list.includes(filepath)) return list;
  return [filepath, ...list];
}, [artifacts, filepath]);
```

Then render `artifactOptions` (instead of `artifacts`) inside `<SelectContent>`.

This keeps the header label in sync with the active file without:

- changing `ArtifactsContext` semantics,
- coupling the UI to a future auto-discovery mechanism,
- altering behavior for the common case where the artifact is already in `thread.values.artifacts`.

## Testing

### New e2e coverage

Added a case in `tests/e2e/artifact-preview.spec.ts`:

`"shows the title for a presented artifact missing from thread artifacts"`

It mocks a thread where:

- `thread.values.artifacts = []`
- the only artifact reference comes from a `present_files` tool call

and asserts both the header filename and the preview content render after the user clicks the file in the message list. The test **fails on `main`** and **passes with this fix**.

### Full validation

All checks run locally per `CONTRIBUTING.md`:

| Check | Command | Result |
|---|---|---|
| Format | `pnpm format:write` | clean |
| Lint | `pnpm lint` | 0 errors |
| Unit tests | `pnpm test` | 111 / 111 passed |
| E2E tests | `pnpm exec playwright test` | 21 / 21 passed |

## Scope

- No backend changes
- No `ArtifactsContext` API changes
- No styling changes
- One UI component fix + one e2e test