### PR TITLE
fix(agents): resolve duplicate todos channel type conflict in TodoMiddleware

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
@@ -25,6 +25,8 @@ from langchain.agents.middleware.types import ModelCallResult, ModelRequest, Mod
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.runtime import Runtime
 
+from deerflow.agents.thread_state import ThreadState
+
 
 def _todos_in_messages(messages: list[Any]) -> bool:
     """Return True if any AIMessage in *messages* contains a write_todos tool call."""
@@ -111,7 +113,17 @@ class TodoMiddleware(TodoListMiddleware):
     history (e.g., after summarization), the model loses awareness of the current
     todo list. This middleware detects that gap in `before_model` / `abefore_model`
     and injects a reminder message so the model can continue tracking progress.
+
+    Overrides ``state_schema`` to use ``ThreadState`` instead of the base class
+    ``PlanningState``.  This keeps a single source of truth for the ``todos``
+    channel: ``ThreadState.todos`` carries the ``merge_todos`` reducer (a
+    ``BinaryOperatorAggregate``), while ``PlanningState.todos`` would declare
+    a ``LastValue`` channel.  When both are present LangGraph raises
+    ``ValueError: Channel 'todos' already exists with a different type``
+    (see #3199).
     """
+
+    state_schema = ThreadState
 
     @override
     def before_model(

--- a/backend/tests/test_todo_middleware.py
+++ b/backend/tests/test_todo_middleware.py
@@ -17,6 +17,7 @@ from deerflow.agents.middlewares.todo_middleware import (
     _reminder_in_messages,
     _todos_in_messages,
 )
+from deerflow.agents.thread_state import ThreadState
 
 
 def _ai_with_write_todos():
@@ -644,3 +645,30 @@ class TestAwrapModelCall:
         injected_messages = request.override.call_args.kwargs["messages"]
         assert injected_messages[-1].name == "todo_completion_reminder"
         handler.assert_awaited_once_with("patched-request")
+
+
+class TestTodoMiddlewareStateSchema:
+    """Regression guard for #3199: TodoMiddleware must use ThreadState as its
+    state_schema so that the ``todos`` channel is defined once (with the
+    ``merge_todos`` reducer) instead of conflicting with PlanningState's
+    ``LastValue`` channel.
+    """
+
+    def test_state_schema_is_thread_state(self):
+        assert TodoMiddleware.state_schema is ThreadState
+
+    def test_no_channel_conflict_when_combined_with_thread_state(self):
+        """Creating an agent graph with TodoMiddleware + ThreadState must not
+        raise ``ValueError: Channel 'todos' already exists with a different type``.
+        """
+        model = _CapturingFakeMessagesListChatModel(
+            responses=[AIMessage(content="done")],
+        )
+        mw = TodoMiddleware()
+        # This would raise ValueError before the fix.
+        graph = create_agent(model=model, tools=[], middleware=[mw])
+        result = graph.invoke(
+            {"messages": [("user", "hello")]},
+            context={"thread_id": "regression-3199", "run_id": "run-1"},
+        )
+        assert result is not None


### PR DESCRIPTION
## Problem

When plan mode is enabled (pro/ultra), sending a chat message fails with:

```
ValueError: Channel 'todos' already exists with a different type
```

This is a regression from #3180, which added a `merge_todos` reducer to `ThreadState.todos` to fix #3123. The reducer is necessary to prevent partial state updates from wiping the todo list after streaming completes.

## Root Cause

`TodoMiddleware` inherits `TodoListMiddleware`, whose `state_schema = PlanningState` declares `todos` as a `LastValue` channel. `ThreadState.todos` uses the `merge_todos` reducer (`BinaryOperatorAggregate`). When LangGraph merges both schemas, it sees two different channel types for `todos` and raises.

## Fix

Override `state_schema = ThreadState` on `TodoMiddleware` so there is a single source of truth for the `todos` channel:

- The `merge_todos` reducer from #3180 is preserved (fixing #3123)
- LangChain's `write_todos` tool and middleware hooks continue to work
- The duplicate channel type conflict is eliminated

## Changes

- `todo_middleware.py`: Add `state_schema = ThreadState` class attribute + import
- `test_todo_middleware.py`: Add `TestTodoMiddlewareStateSchema` regression tests

Fixes #3199