### PR TITLE
feat(setup): prompt for thinking support

### DIFF
--- a/backend/tests/test_setup_wizard.py
+++ b/backend/tests/test_setup_wizard.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import yaml
 from wizard.providers import LLM_PROVIDERS, SEARCH_PROVIDERS, WEB_FETCH_PROVIDERS
+from wizard.steps import llm as llm_step
 from wizard.steps import search as search_step
 from wizard.writer import (
     build_minimal_config,
@@ -57,6 +58,58 @@ class TestProviders:
     def test_at_least_one_free_web_fetch_provider(self):
         free = [provider for provider in WEB_FETCH_PROVIDERS if provider.env_var is None]
         assert free, "Expected at least one free (no-key) web fetch provider"
+
+
+class TestLLMStep:
+    def test_other_openai_compatible_prompts_for_thinking_support(self, monkeypatch):
+        provider_index = next(i for i, provider in enumerate(LLM_PROVIDERS) if provider.name == "other")
+
+        monkeypatch.setattr(llm_step, "print_header", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(llm_step, "print_info", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(llm_step, "print_success", lambda *_args, **_kwargs: None)
+
+        choices = iter([provider_index])
+        text_answers = iter(["https://example.com/v1", "custom-reasoner"])
+        prompts: list[str] = []
+
+        monkeypatch.setattr(llm_step, "ask_choice", lambda *_args, **_kwargs: next(choices))
+        monkeypatch.setattr(llm_step, "ask_text", lambda *_args, **_kwargs: next(text_answers))
+        monkeypatch.setattr(llm_step, "ask_secret", lambda _prompt: "test-key")
+
+        def fake_yes_no(prompt, default=True):
+            prompts.append(prompt)
+            return True
+
+        monkeypatch.setattr(llm_step, "ask_yes_no", fake_yes_no)
+
+        result = llm_step.run_llm_step()
+
+        assert result.provider.name == "other"
+        assert result.model_name == "custom-reasoner"
+        assert result.base_url == "https://example.com/v1"
+        assert result.extra_model_config == {"supports_thinking": True}
+        assert prompts == ["Does this model support thinking/reasoning mode?"]
+
+    def test_provider_default_thinking_metadata_skips_capability_prompt(self, monkeypatch):
+        provider_index = next(i for i, provider in enumerate(LLM_PROVIDERS) if provider.name == "vllm")
+
+        monkeypatch.setattr(llm_step, "print_header", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(llm_step, "print_info", lambda *_args, **_kwargs: None)
+        monkeypatch.setattr(llm_step, "print_success", lambda *_args, **_kwargs: None)
+
+        choices = iter([provider_index, 0])
+        monkeypatch.setattr(llm_step, "ask_choice", lambda *_args, **_kwargs: next(choices))
+        monkeypatch.setattr(llm_step, "ask_secret", lambda _prompt: "test-key")
+
+        def fail_yes_no(*_args, **_kwargs):
+            raise AssertionError("thinking support is already declared by the provider")
+
+        monkeypatch.setattr(llm_step, "ask_yes_no", fail_yes_no)
+
+        result = llm_step.run_llm_step()
+
+        assert result.provider.name == "vllm"
+        assert result.extra_model_config is None
 
 
 class TestBuildMinimalConfig:
@@ -128,6 +181,18 @@ class TestBuildMinimalConfig:
         assert model["max_retries"] == 2
         assert model["max_tokens"] == 8192
         assert model["temperature"] == 0.7
+
+    def test_model_capability_metadata_is_written(self):
+        content = build_minimal_config(
+            provider_use="langchain_openai:ChatOpenAI",
+            model_name="custom-reasoner",
+            display_name="Other OpenAI-compatible",
+            api_key_field="api_key",
+            env_var="OPENAI_API_KEY",
+            extra_model_config={"supports_thinking": True},
+        )
+        data = yaml.safe_load(content)
+        assert data["models"][0]["supports_thinking"] is True
 
     def test_web_fetch_tool_included(self):
         content = build_minimal_config(

--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -85,7 +85,11 @@ def main() -> int:
             display_name=f"{llm.provider.display_name} / {llm.model_name}",
             api_key_field=llm.provider.api_key_field,
             env_var=llm.provider.env_var,
-            extra_model_config=llm.provider.extra_config or None,
+            extra_model_config={
+                **llm.provider.extra_config,
+                **(llm.extra_model_config or {}),
+            }
+            or None,
             base_url=llm.base_url,
             search_use=search_provider.use if search_provider else None,
             search_tool_name=search_provider.tool_name if search_provider else "web_search",

--- a/scripts/wizard/steps/llm.py
+++ b/scripts/wizard/steps/llm.py
@@ -9,6 +9,7 @@ from wizard.ui import (
     ask_choice,
     ask_secret,
     ask_text,
+    ask_yes_no,
     print_header,
     print_info,
     print_success,
@@ -21,6 +22,26 @@ class LLMStepResult:
     model_name: str
     api_key: str | None
     base_url: str | None = None
+    extra_model_config: dict | None = None
+
+
+def _should_prompt_for_thinking_support(provider: LLMProvider) -> bool:
+    """Return whether setup needs user-provided thinking capability metadata."""
+    if provider.extra_config.get("supports_thinking") is not None:
+        return False
+    return provider.use == "langchain_openai:ChatOpenAI" and provider.name in {"openrouter", "other"}
+
+
+def _ask_capability_metadata(provider: LLMProvider) -> dict:
+    extra_model_config: dict = {}
+    if _should_prompt_for_thinking_support(provider):
+        print_header("Model capabilities")
+        supports_thinking = ask_yes_no(
+            "Does this model support thinking/reasoning mode?",
+            default=False,
+        )
+        extra_model_config["supports_thinking"] = supports_thinking
+    return extra_model_config
 
 
 def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
@@ -48,7 +69,9 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
         print_header(f"{step_label} · Connection details")
         base_url = ask_text("Base URL (e.g. https://api.openai.com/v1)", required=True)
         model_name = ask_text("Model name", default=provider.default_model)
-    elif provider.auth_hint:
+    extra_model_config = _ask_capability_metadata(provider)
+
+    if provider.auth_hint:
         print_header(f"{step_label} · Authentication")
         print_info(provider.auth_hint)
         api_key = None
@@ -57,6 +80,7 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
             model_name=model_name,
             api_key=api_key,
             base_url=base_url,
+            extra_model_config=extra_model_config or None,
         )
 
     print_header(f"{step_label} · Enter your API Key")
@@ -73,4 +97,5 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
         model_name=model_name,
         api_key=api_key,
         base_url=base_url,
+        extra_model_config=extra_model_config or None,
     )


### PR DESCRIPTION
## Summary
- Prompt OpenAI-compatible setup choices for whether the selected model supports thinking/reasoning mode when the provider does not already declare that metadata.
- Thread the per-run setup answer into generated model config so config.yaml includes supports_thinking.
- Add setup wizard regression coverage for prompting and config emission.

Fixes #3162

## Validation
- uv run pytest tests/test_setup_wizard.py
- uv run ruff check ..\\scripts\\setup_wizard.py ..\\scripts\\wizard\\steps\\llm.py tests\\test_setup_wizard.py