### PR TITLE
fix(tools): normalize returned error messages

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -2,7 +2,8 @@
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import override
+from dataclasses import replace
+from typing import Any, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
@@ -16,6 +17,37 @@ from deerflow.config.app_config import AppConfig
 logger = logging.getLogger(__name__)
 
 _MISSING_TOOL_CALL_ID = "missing_tool_call_id"
+_ERROR_PREFIX = "Error:"
+
+
+def _classify_tool_error(text: str) -> dict[str, Any]:
+    """Classify a tool-returned ``Error:`` string without parsing display text downstream."""
+    normalized = text.lower()
+    if any(token in normalized for token in ("401", "unauthorized", "authentication", "invalid api key", "api key")):
+        return {"error_type": "auth", "retryable": False, "recoverable_by_model": False}
+    if any(token in normalized for token in ("429", "rate limit", "rate limited", "timeout", "timed out", "connection", "network", "temporarily", "unavailable")):
+        return {"error_type": "transient", "retryable": True, "recoverable_by_model": False}
+    if any(token in normalized for token in ("not configured", "not installed", "missing required", "disabled", "configuration")):
+        return {"error_type": "config", "retryable": False, "recoverable_by_model": False}
+    if any(token in normalized for token in ("permission denied", "access denied", "path traversal", "not allowed", "forbidden")):
+        return {"error_type": "permission", "retryable": False, "recoverable_by_model": True}
+    if any(token in normalized for token in ("no results found", "no content found", "no images found")):
+        return {"error_type": "no_results", "retryable": False, "recoverable_by_model": True}
+    if any(token in normalized for token in ("not found", "no such file", "does not exist")):
+        return {"error_type": "not_found", "retryable": False, "recoverable_by_model": True}
+    if "unexpected" in normalized:
+        return {"error_type": "internal", "retryable": False, "recoverable_by_model": False}
+    return {"error_type": "unknown", "retryable": False, "recoverable_by_model": True}
+
+
+def _normalizable_error_text(message: ToolMessage) -> str | None:
+    content = message.content
+    if not isinstance(content, str):
+        return None
+    text = content.strip()
+    if not text.startswith(_ERROR_PREFIX):
+        return None
+    return text
 
 
 class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
@@ -36,6 +68,47 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
             status="error",
         )
 
+    def _normalize_tool_message(self, message: ToolMessage) -> ToolMessage:
+        text = _normalizable_error_text(message)
+        if text is None:
+            return message
+
+        additional_kwargs = dict(message.additional_kwargs or {})
+        additional_kwargs.setdefault(
+            "deerflow_tool_error",
+            {
+                "source": "tool_return",
+                **_classify_tool_error(text),
+            },
+        )
+        return message.model_copy(
+            update={
+                "status": "error",
+                "additional_kwargs": additional_kwargs,
+            }
+        )
+
+    def _normalize_tool_result(self, result: ToolMessage | Command) -> ToolMessage | Command:
+        if isinstance(result, ToolMessage):
+            return self._normalize_tool_message(result)
+        if not isinstance(result.update, dict):
+            return result
+
+        messages = result.update.get("messages")
+        if not isinstance(messages, list):
+            return result
+
+        normalized_messages = [
+            self._normalize_tool_message(message) if isinstance(message, ToolMessage) else message
+            for message in messages
+        ]
+        if normalized_messages == messages:
+            return result
+
+        update = dict(result.update)
+        update["messages"] = normalized_messages
+        return replace(result, update=update)
+
     @override
     def wrap_tool_call(
         self,
@@ -43,7 +116,7 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         handler: Callable[[ToolCallRequest], ToolMessage | Command],
     ) -> ToolMessage | Command:
         try:
-            return handler(request)
+            return self._normalize_tool_result(handler(request))
         except GraphBubbleUp:
             # Preserve LangGraph control-flow signals (interrupt/pause/resume).
             raise
@@ -58,7 +131,7 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
     ) -> ToolMessage | Command:
         try:
-            return await handler(request)
+            return self._normalize_tool_result(await handler(request))
         except GraphBubbleUp:
             # Preserve LangGraph control-flow signals (interrupt/pause/resume).
             raise

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -4,6 +4,7 @@ from types import ModuleType, SimpleNamespace
 import pytest
 from langchain_core.messages import ToolMessage
 from langgraph.errors import GraphInterrupt
+from langgraph.types import Command
 
 from deerflow.agents.middlewares.tool_error_handling_middleware import (
     ToolErrorHandlingMiddleware,
@@ -169,6 +170,72 @@ def test_wrap_tool_call_returns_error_tool_message_on_exception():
     assert result.status == "error"
     assert "Tool 'web_search' failed" in result.text
     assert "network down" in result.text
+
+
+def test_wrap_tool_call_normalizes_returned_error_string():
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="web_fetch", tool_call_id="tc-fetch")
+    returned = ToolMessage(
+        content="Error: Jina API returned status 401: Unauthorized",
+        tool_call_id="tc-fetch",
+        name="web_fetch",
+    )
+
+    result = middleware.wrap_tool_call(req, lambda _req: returned)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.content == returned.content
+    assert result.additional_kwargs["deerflow_tool_error"] == {
+        "source": "tool_return",
+        "error_type": "auth",
+        "retryable": False,
+        "recoverable_by_model": False,
+    }
+
+
+def test_wrap_tool_call_marks_recoverable_no_results_with_structured_metadata():
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="web_search", tool_call_id="tc-search")
+    returned = ToolMessage(
+        content="Error: No results found",
+        tool_call_id="tc-search",
+        name="web_search",
+    )
+
+    result = middleware.wrap_tool_call(req, lambda _req: returned)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.additional_kwargs["deerflow_tool_error"]["error_type"] == "no_results"
+    assert result.additional_kwargs["deerflow_tool_error"]["recoverable_by_model"] is True
+
+
+def test_wrap_tool_call_normalizes_error_messages_inside_command():
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="view_image", tool_call_id="tc-image")
+    returned = Command(
+        update={
+            "viewed_images": [],
+            "messages": [
+                ToolMessage(
+                    content="Error: Permission denied: /mnt/data/private.png",
+                    tool_call_id="tc-image",
+                    name="view_image",
+                )
+            ],
+        }
+    )
+
+    result = middleware.wrap_tool_call(req, lambda _req: returned)
+
+    assert isinstance(result, Command)
+    assert result is not returned
+    assert result.update["viewed_images"] == []
+    message = result.update["messages"][0]
+    assert isinstance(message, ToolMessage)
+    assert message.status == "error"
+    assert message.additional_kwargs["deerflow_tool_error"]["error_type"] == "permission"
 
 
 def test_wrap_tool_call_uses_fallback_tool_call_id_when_missing():


### PR DESCRIPTION
## Summary
- Normalize tool-returned Error: ToolMessages in ToolErrorHandlingMiddleware instead of fixing one provider at a time.
- Mark normalized results as ToolMessage(status="error") while preserving the original content for model recovery.
- Attach additional_kwargs.deerflow_tool_error metadata with a lightweight classification (auth, transient, config, permission, no_results, not_found, internal, unknown) plus retry/recovery hints.
- Handle both direct ToolMessage results and Command updates containing ToolMessages.

Fixes #3164

Follow-up to closed #3194: this moves the fix to the shared tool error middleware so community, sandbox, and built-in tools that return Error: strings get consistent structured failure semantics.

## Validation
- uv run pytest tests/test_tool_error_handling_middleware.py
- uv run ruff check packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py tests/test_tool_error_handling_middleware.py