### PR TITLE
fix(artifacts): show selected preview filename

### DIFF
--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -110,6 +110,13 @@ export function ArtifactFileDetail({
     isSupportPreview,
     toolResult,
   });
+  const selectableArtifacts = useMemo(() => {
+    const artifactPaths = artifacts ?? [];
+    if (isWriteFile || artifactPaths.includes(filepath)) {
+      return artifactPaths;
+    }
+    return [filepath, ...artifactPaths];
+  }, [artifacts, filepath, isWriteFile]);
   const { content, url } = useArtifactContent({
     threadId,
     filepath: filepathFromProps,
@@ -167,7 +174,7 @@ export function ArtifactFileDetail({
                 </SelectTrigger>
                 <SelectContent className="select-none">
                   <SelectGroup>
-                    {(artifacts ?? []).map((filepath) => (
+                    {selectableArtifacts.map((filepath) => (
                       <SelectItem key={filepath} value={filepath}>
                         {getFileName(filepath)}
                       </SelectItem>

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -9,6 +9,7 @@ const IN_PROGRESS_THREAD_ID = "00000000-0000-0000-0000-000000003119";
 const COMPLETE_THREAD_ID = "00000000-0000-0000-0000-000000003120";
 const MARKDOWN_THREAD_ID = "00000000-0000-0000-0000-000000003121";
 const JSON_THREAD_ID = "00000000-0000-0000-0000-000000003122";
+const PRESENT_FILES_THREAD_ID = "00000000-0000-0000-0000-000000003192";
 
 function writeFileMessages({
   path = ARTIFACT_PATH,
@@ -54,6 +55,30 @@ function writeFileMessages({
   }
 
   return messages;
+}
+
+function presentFileMessages(path = "/mnt/user-data/outputs/report.html") {
+  return [
+    {
+      type: "human",
+      id: "msg-human-present-file",
+      content: [{ type: "text", text: "Create a report artifact" }],
+    },
+    {
+      type: "ai",
+      id: "msg-ai-present-file",
+      content: "I created the report.",
+      tool_calls: [
+        {
+          id: "present-file-artifact",
+          name: "present_files",
+          args: {
+            filepaths: [path],
+          },
+        },
+      ],
+    },
+  ];
 }
 
 test.describe("Artifact preview stability", () => {
@@ -169,6 +194,43 @@ test.describe("Artifact preview stability", () => {
     await expect(artifactsPanel.getByText('"status": "draft"')).toBeVisible();
     await expect(
       artifactsPanel.getByText('"中文字段": "测试内容"'),
+    ).toBeVisible();
+  });
+
+  test("shows the selected filename for presented files outside the thread artifact list", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: PRESENT_FILES_THREAD_ID,
+          title: "Presented artifact without thread list entry",
+          messages: presentFileMessages(),
+          artifacts: [],
+        },
+      ],
+    });
+    await page.route(
+      `**/api/threads/${PRESENT_FILES_THREAD_ID}/artifacts/mnt/user-data/outputs/report.html`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/html",
+          body: "<!doctype html><html><body><h1>Presented report</h1></body></html>",
+        }),
+    );
+
+    await page.goto(`/workspace/chats/${PRESENT_FILES_THREAD_ID}`);
+
+    await expect(page.getByText("report.html")).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByText("report.html").click();
+
+    const artifactsPanel = page.locator("#artifacts");
+    await expect(artifactsPanel.getByText("report.html")).toBeVisible();
+    await expect(
+      artifactsPanel.locator('iframe[title="Artifact preview"]'),
     ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Keep the currently selected artifact path available in the preview title dropdown even when it is not present in `thread.values.artifacts`.
- This preserves the filename when opening artifacts from `present_files` / historical message content, matching the write-file preview behavior.
- Add an artifact-preview E2E regression for a presented file outside the thread artifact list.

Fixes #3192

## Validation
- `./node_modules/.bin/eslint.cmd src/components/workspace/artifacts/artifact-file-detail.tsx tests/e2e/artifact-preview.spec.ts` (passed)
- `./node_modules/.bin/prettier.cmd --check src/components/workspace/artifacts/artifact-file-detail.tsx tests/e2e/artifact-preview.spec.ts` (passed)
- `corepack pnpm build` (passed; existing Turbopack NFT-list warning from mock artifact route)
- `./node_modules/.bin/playwright.cmd test tests/e2e/artifact-preview.spec.ts --config .codex-playwright.config.ts` (5 passed using system Chrome; default Playwright Chromium download failed in this environment with ECONNRESET)