### PR TITLE
fix(agents): require config.yaml before treating per-user agent dir as resolved

### DIFF
--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -53,7 +53,10 @@ def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     """Return the on-disk directory for an agent, preferring the per-user layout.
 
     Resolution order:
-    1. ``{base_dir}/users/{user_id}/agents/{name}/`` (per-user, current layout).
+    1. ``{base_dir}/users/{user_id}/agents/{name}/`` (per-user, current layout),
+       only when it contains a ``config.yaml`` — the memory writer creates this
+       directory with just ``memory.json`` after the first chat, so directory
+       existence alone is not a reliable signal that the user owns the agent.
     2. ``{base_dir}/agents/{name}/`` (legacy shared layout — read-only fallback).
 
     If neither exists, the per-user path is returned so callers that intend to
@@ -67,7 +70,7 @@ def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     paths = get_paths()
     effective_user = user_id or get_effective_user_id()
     user_path = paths.user_agent_dir(effective_user, name)
-    if user_path.exists():
+    if user_path.exists() and (user_path / "config.yaml").exists():
         return user_path
 
     legacy_path = paths.agent_dir(name)

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -106,6 +106,84 @@ class TestAgentConfig:
 
 
 # ===========================================================================
+# 2a. resolve_agent_dir
+# ===========================================================================
+
+
+class TestResolveAgentDir:
+    """``resolve_agent_dir`` must not treat a memory-only per-user directory as
+    a valid agent dir. The memory writer creates ``users/{uid}/agents/{name}/``
+    with just ``memory.json`` after the first chat; without a ``config.yaml``
+    guard, the next request resolves to that directory and the subsequent
+    ``load_agent_config`` call raises ``FileNotFoundError``, which surfaces as
+    the agent disappearing from the assistant menu.
+    """
+
+    def test_skips_user_dir_with_memory_only(self, tmp_path):
+        """Per-user dir without config.yaml must fall through to legacy path."""
+        # Per-user dir from memory writer: only memory.json present.
+        user_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "my-agent"
+        user_dir.mkdir(parents=True)
+        (user_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        # Legacy shared template that should win.
+        _write_agent(tmp_path, "my-agent", {"name": "my-agent"})
+        legacy_dir = tmp_path / "agents" / "my-agent"
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import resolve_agent_dir
+
+            resolved = resolve_agent_dir("my-agent")
+
+        assert resolved == legacy_dir
+
+    def test_prefers_user_dir_when_config_yaml_exists(self, tmp_path):
+        """Per-user dir with a valid config.yaml must win over legacy."""
+        user_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "my-agent"
+        user_dir.mkdir(parents=True)
+        (user_dir / "config.yaml").write_text("name: my-agent\n", encoding="utf-8")
+        (user_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        _write_agent(tmp_path, "my-agent", {"name": "my-agent"})
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import resolve_agent_dir
+
+            resolved = resolve_agent_dir("my-agent")
+
+        assert resolved == user_dir
+
+    def test_returns_user_path_when_neither_exists(self, tmp_path):
+        """If nothing exists, return the per-user write target."""
+        expected = tmp_path / "users" / "test-user-autouse" / "agents" / "fresh-agent"
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import resolve_agent_dir
+
+            resolved = resolve_agent_dir("fresh-agent")
+
+        assert resolved == expected
+
+    def test_load_agent_config_falls_back_when_user_has_memory_only(self, tmp_path):
+        """End-to-end: load_agent_config succeeds via legacy fallback when the
+        per-user dir is memory-only.
+        """
+        user_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "shared-agent"
+        user_dir.mkdir(parents=True)
+        (user_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        _write_agent(tmp_path, "shared-agent", {"name": "shared-agent", "description": "Legacy"})
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_config
+
+            cfg = load_agent_config("shared-agent")
+
+        assert cfg.name == "shared-agent"
+        assert cfg.description == "Legacy"
+
+
+# ===========================================================================
 # 3. load_agent_config
 # ===========================================================================
 


### PR DESCRIPTION
## Background

When a user starts their first chat with a custom agent, the memory writer creates
`{base_dir}/users/{uid}/agents/{name}/memory.json` to persist agent memory.
At that point the per-user directory exists, but **only `memory.json` is in it** —
no `config.yaml` is written there because the agent itself still lives under
the legacy shared location `{base_dir}/agents/{name}/`.

`resolve_agent_dir` currently treats the existence of `users/{uid}/agents/{name}/`
as sufficient evidence that the user owns the agent:

```python
user_path = paths.user_agent_dir(effective_user, name)
if user_path.exists():
    return user_path
```

So on the **next** request from the same user, `resolve_agent_dir` returns the
memory-only path. The downstream `load_agent_config` cannot find `config.yaml`
there and raises:

```
FileNotFoundError: Agent config not found: .../users/{uid}/agents/{name}/config.yaml
```

User-visible symptom: the custom agent disappears from the assistant menu after
the user's first successful chat with it. The agent only reappears after manual
intervention (deleting `memory.json`, restarting, or seeding `config.yaml`).

This was reproduced on a downstream deployment that uses a custom auth
middleware mapping external users to DeerFlow user IDs, but the failure is
intrinsic to upstream `resolve_agent_dir` and reproducible on plain `bytedance/deer-flow`
with any custom agent (including those created via the agents API).

## Goal

`resolve_agent_dir` should resolve to the per-user directory **only when that
directory actually contains a config.yaml**, otherwise it should fall through
to the legacy shared layout (or to the empty per-user write target if neither
exists).

This keeps the existing semantics for:
- properly-installed per-user agents (per-user dir wins)
- legacy/pre-migration installs (legacy fallback)
- brand-new agents (returns per-user write target)

…while fixing the case where the memory subsystem has lazily created a per-user
agent dir but no agent config lives there yet.

## Solution

Add an explicit `config.yaml` existence check to the per-user fast path:

```python
user_path = paths.user_agent_dir(effective_user, name)
if user_path.exists() and (user_path / "config.yaml").exists():
    return user_path
```

This mirrors the gate that `list_custom_agents` already applies when scanning
directories (it skips entries without `config.yaml`). Now `resolve_agent_dir` is
consistent with that contract.

The docstring is updated to spell out *why* directory existence alone is not
enough, so the next person who reads the code understands the memory-writer
interaction.

## Tests

Added a new `TestResolveAgentDir` class in `backend/tests/test_custom_agent.py`
covering:

| Test | Behaviour |
|------|-----------|
| `test_skips_user_dir_with_memory_only` | per-user dir with only `memory.json` falls through to legacy |
| `test_prefers_user_dir_when_config_yaml_exists` | per-user dir with valid `config.yaml` still wins |
| `test_returns_user_path_when_neither_exists` | empty FS returns per-user write target (unchanged) |
| `test_load_agent_config_falls_back_when_user_has_memory_only` | end-to-end: `load_agent_config` succeeds via legacy fallback |

### Test results

Run on `python 3.12.13`, `pytest 9.0.3`, `uv` managed environment.

**With this patch:**

```
tests/test_custom_agent.py::TestResolveAgentDir::test_skips_user_dir_with_memory_only PASSED
tests/test_custom_agent.py::TestResolveAgentDir::test_prefers_user_dir_when_config_yaml_exists PASSED
tests/test_custom_agent.py::TestResolveAgentDir::test_returns_user_path_when_neither_exists PASSED
tests/test_custom_agent.py::TestResolveAgentDir::test_load_agent_config_falls_back_when_user_has_memory_only PASSED
======================== 4 passed in 0.91s ========================
```

**Without this patch (reverting just the 1-line change, tests kept):**

```
FAILED tests/test_custom_agent.py::TestResolveAgentDir::test_skips_user_dir_with_memory_only
FAILED tests/test_custom_agent.py::TestResolveAgentDir::test_load_agent_config_falls_back_when_user_has_memory_only
============================================
E   FileNotFoundError: Agent config not found:
    .../users/test-user-autouse/agents/shared-agent/config.yaml
```

i.e. the two new tests that target the bug reliably reproduce the original
production symptom, and pass once the guard is added.

**No regression in nearby modules:**

```
tests/test_custom_agent.py ........................................... 59 passed
tests/test_paths_user_isolation.py ......................................... 34 passed
tests/test_update_agent_e2e_user_isolation.py ........................... 3 passed
tests/test_update_agent_tool.py .......................................... 16 passed
tests/test_lead_agent_skills.py .......................................... 13 passed
```

Total: **125 passed** across `test_custom_agent.py` and the four most directly
related test modules.

### Lint / format

```
$ uv run ruff check packages/harness/deerflow/config/agents_config.py tests/test_custom_agent.py
All checks passed!

$ uv run ruff format --check packages/harness/deerflow/config/agents_config.py tests/test_custom_agent.py
2 files already formatted
```

## Compatibility

- No public API change.
- No config / docs / migration change required.
- Behaviour for fully-installed per-user agents and for legacy-only installs is unchanged.
- The only behavioural change is for the previously-broken case (memory-only user dir),
  which is silently steered back onto the legacy fallback.


Made with [Cursor](https://cursor.com)