### PR TITLE
fix(gateway): split stream_existing_run into per-method routes for unique OpenAPI operationIds

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -277,7 +277,12 @@ async def join_run(thread_id: str, run_id: str, request: Request) -> StreamingRe
     )
 
 
-@router.api_route("/{thread_id}/runs/{run_id}/stream", methods=["GET", "POST"], response_model=None)
+# Register GET and POST as separate routes so each method gets a unique OpenAPI
+# operationId. ``api_route(methods=["GET", "POST"])`` shares one route registration
+# across both methods, which makes FastAPI emit the same ``operationId`` twice and
+# warn about a duplicate operation id during OpenAPI generation.
+@router.get("/{thread_id}/runs/{run_id}/stream", response_model=None)
+@router.post("/{thread_id}/runs/{run_id}/stream", response_model=None)
 @require_permission("runs", "read", owner_check=True)
 async def stream_existing_run(
     thread_id: str,

--- a/backend/tests/test_openapi_operation_ids.py
+++ b/backend/tests/test_openapi_operation_ids.py
@@ -1,0 +1,79 @@
+"""Regression tests for the generated OpenAPI spec.
+
+The Gateway exposes its FastAPI ``app.openapi()`` schema at ``/openapi.json``
+and downstream tooling (SDK codegen, schema validators, client generators)
+relies on ``operationId`` values being globally unique. FastAPI emits a
+``UserWarning`` during spec generation when two routes share the same
+``operationId`` — concretely this happens when ``@router.api_route`` registers
+one route for multiple HTTP methods, because the auto-generated unique id is
+computed from a single method picked out of ``route.methods`` while OpenAPI
+generation iterates over every method on that route.
+
+These tests pin that invariant so the warning cannot silently come back.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def openapi_spec() -> dict:
+    """Build the OpenAPI spec for the Gateway app once per module."""
+    from app.gateway.app import app
+
+    # ``app.openapi()`` caches the result on the FastAPI instance, so reset to
+    # force a fresh generation pass that triggers any duplicate-id warnings.
+    app.openapi_schema = None
+    return app.openapi()
+
+
+def test_openapi_spec_has_no_duplicate_operation_warnings() -> None:
+    """Generating the OpenAPI schema must not emit any ``Duplicate Operation ID`` UserWarning."""
+    from app.gateway.app import app
+
+    app.openapi_schema = None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        app.openapi()
+
+    dup_messages = [str(item.message) for item in caught if "Duplicate Operation ID" in str(item.message)]
+    assert dup_messages == [], f"OpenAPI generation emitted duplicate operation id warnings: {dup_messages}"
+
+
+def test_openapi_operation_ids_are_unique(openapi_spec: dict) -> None:
+    """Every (path, method) operation in the spec must carry a unique ``operationId``."""
+    op_id_to_locations: dict[str, list[tuple[str, str]]] = {}
+
+    for path, path_item in openapi_spec.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if not isinstance(operation, dict):
+                continue
+            op_id = operation.get("operationId")
+            if op_id is None:
+                continue
+            op_id_to_locations.setdefault(op_id, []).append((path, method))
+
+    duplicates = {op_id: locations for op_id, locations in op_id_to_locations.items() if len(locations) > 1}
+    assert not duplicates, f"Duplicate operationIds in OpenAPI spec: {duplicates}"
+
+
+def test_stream_existing_run_exposes_distinct_get_and_post(openapi_spec: dict) -> None:
+    """The ``/runs/{run_id}/stream`` endpoint must expose GET and POST as distinct operations.
+
+    LangGraph SDK ``joinStream`` uses GET while ``useStream``'s stop button uses POST, so
+    both methods must remain registered with their own ``operationId``.
+    """
+    path = "/api/threads/{thread_id}/runs/{run_id}/stream"
+    path_item = openapi_spec["paths"].get(path)
+    assert path_item is not None, f"Expected {path} to be present in the OpenAPI spec"
+
+    assert "get" in path_item, f"Expected GET handler on {path}"
+    assert "post" in path_item, f"Expected POST handler on {path}"
+
+    get_op_id = path_item["get"].get("operationId")
+    post_op_id = path_item["post"].get("operationId")
+    assert get_op_id and post_op_id, "Both GET and POST must have operationIds"
+    assert get_op_id != post_op_id, f"GET and POST share operationId {get_op_id!r}, which breaks OpenAPI codegen"


### PR DESCRIPTION
### Problem

`/api/threads/{thread_id}/runs/{run_id}/stream` is registered with `@router.api_route(methods=["GET", "POST"])`. FastAPI's `generate_unique_id(route)` only uses one method from the route's `methods` set when computing the auto-generated `operationId`, while the OpenAPI generator iterates over every method on that route — so GET and POST end up sharing the same `operationId`.

Reproduced on `main` (commit f9b70713):

```python
import warnings, logging
logging.disable(logging.CRITICAL)
from app.gateway.app import app
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter("always")
    app.openapi()
    for m in w:
        if "Duplicate Operation" in str(m.message):
            print(m.message)
```

```text
UserWarning: Duplicate Operation ID
  stream_existing_run_api_threads__thread_id__runs__run_id__stream_post
  for function stream_existing_run at backend/app/gateway/authz.py
```

This is also visible at the tail of `make test` output (`tests/test_gateway_docs_toggle.py::test_docs_endpoints_available_by_default`).

Per the OpenAPI 3.x spec `operationId` must be globally unique; any downstream SDK / codegen consumer of `/openapi.json` (openapi-generator, openapi-typescript, Stainless, Speakeasy, …) will either error out or silently overwrite one method with the other.

### Fix

Replace the single `api_route(methods=["GET","POST"])` registration with two independent decorator registrations (`@router.get` + `@router.post`) stacked on the same handler. Each registration produces its own `APIRoute` with a distinct auto-generated `operationId` (`..._stream_get` and `..._stream_post`).

Behavior is otherwise unchanged: same handler body, same `@require_permission("runs", "read", owner_check=True)` decoration (`functools.wraps` preserves the wrapped callable so both registrations point at the same authenticated function), same response.

```diff
-@router.api_route("/{thread_id}/runs/{run_id}/stream", methods=["GET", "POST"], response_model=None)
+# Register GET and POST as separate routes so each method gets a unique OpenAPI
+# operationId. ``api_route(methods=["GET", "POST"])`` shares one route registration
+# across both methods, which makes FastAPI emit the same ``operationId`` twice and
+# warn about a duplicate operation id during OpenAPI generation.
+@router.get("/{thread_id}/runs/{run_id}/stream", response_model=None)
+@router.post("/{thread_id}/runs/{run_id}/stream", response_model=None)
 @require_permission("runs", "read", owner_check=True)
 async def stream_existing_run(
```

### Regression tests

Added `backend/tests/test_openapi_operation_ids.py` with three checks:

1. `test_openapi_spec_has_no_duplicate_operation_warnings` — `app.openapi()` emits no `Duplicate Operation ID` UserWarning.
2. `test_openapi_operation_ids_are_unique` — every `(path, method)` operation in the spec carries a globally unique `operationId`.
3. `test_stream_existing_run_exposes_distinct_get_and_post` — the stream path still exposes both GET (LangGraph SDK `joinStream`) and POST (`useStream` stop button), each with its own `operationId`.

To verify the tests actually guard the invariant, I stashed only the source-file change and re-ran them: all 3 tests FAILED before the fix and pass after.

### Validation

- `uvx ruff check .` → `All checks passed!`
- `uvx ruff format --check .` → `468 files already formatted`
- `make test` → **3652 passed, 19 skipped, 11 warnings** (was 3649 passed / 12 warnings before — the +3 are the new regression tests, and the dropped warning is the duplicate-op-id one).
- `make test` with `-W "error::UserWarning:fastapi.openapi.utils"` (escalating the duplicate-op-id warning to an error) → still 3652 passed.

### Notes

- Pure backend change. No new dependencies. No frontend touch points. No DB / migration / config schema change.
- The frontend uses `@langchain/langgraph-sdk` directly and does not depend on `/openapi.json` codegen, so this change is invisible to the deployed app.
- Decorator order: `@require_permission` is applied innermost; `@router.post` registers POST; `@router.get` registers GET. Both router decorators return the wrapped function unchanged, so stacking is safe.
