### PR TITLE
fix(channels): share internal auth token across workers

### DIFF
--- a/backend/app/gateway/internal_auth.py
+++ b/backend/app/gateway/internal_auth.py
@@ -1,23 +1,25 @@
-"""Process-local authentication for Gateway internal callers."""
+"""Shared-token authentication for Gateway internal callers."""
 
 from __future__ import annotations
 
+import os
 import secrets
 from types import SimpleNamespace
 
 from deerflow.runtime.user_context import DEFAULT_USER_ID
 
 INTERNAL_AUTH_HEADER_NAME = "X-DeerFlow-Internal-Token"
-_INTERNAL_AUTH_TOKEN = secrets.token_urlsafe(32)
+INTERNAL_AUTH_TOKEN_ENV = "DEER_FLOW_INTERNAL_AUTH_TOKEN"
+_INTERNAL_AUTH_TOKEN = os.getenv(INTERNAL_AUTH_TOKEN_ENV) or secrets.token_urlsafe(32)
 
 
 def create_internal_auth_headers() -> dict[str, str]:
-    """Return headers that authenticate same-process Gateway internal calls."""
+    """Return headers that authenticate trusted Gateway internal calls."""
     return {INTERNAL_AUTH_HEADER_NAME: _INTERNAL_AUTH_TOKEN}
 
 
 def is_valid_internal_auth_token(token: str | None) -> bool:
-    """Return True when *token* matches the process-local internal token."""
+    """Return True when *token* matches the configured internal token."""
     return bool(token) and secrets.compare_digest(token, _INTERNAL_AUTH_TOKEN)
 
 

--- a/backend/tests/test_internal_auth.py
+++ b/backend/tests/test_internal_auth.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+import sys
+
+
+def _run_internal_auth_snippet(code: str, *, token: str | None = None) -> str:
+    env = os.environ.copy()
+    if token is None:
+        env.pop("DEER_FLOW_INTERNAL_AUTH_TOKEN", None)
+    else:
+        env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = token
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def test_internal_auth_token_env_is_stable_across_processes():
+    token = "shared-internal-auth-token"
+
+    emitted = _run_internal_auth_snippet(
+        "from app.gateway.internal_auth import create_internal_auth_headers; print(create_internal_auth_headers()['X-DeerFlow-Internal-Token'])",
+        token=token,
+    )
+    validated = _run_internal_auth_snippet(
+        f"from app.gateway.internal_auth import is_valid_internal_auth_token; print(is_valid_internal_auth_token({emitted!r}))",
+        token=token,
+    )
+
+    assert emitted == token
+    assert validated == "True"
+
+
+def test_internal_auth_rejects_different_configured_token():
+    emitted = _run_internal_auth_snippet(
+        "from app.gateway.internal_auth import create_internal_auth_headers; print(create_internal_auth_headers()['X-DeerFlow-Internal-Token'])",
+        token="worker-a-token",
+    )
+    validated = _run_internal_auth_snippet(
+        f"from app.gateway.internal_auth import is_valid_internal_auth_token; print(is_valid_internal_auth_token({emitted!r}))",
+        token="worker-b-token",
+    )
+
+    assert validated == "False"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -71,7 +71,7 @@ services:
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
         UV_EXTRAS: ${UV_EXTRAS:-}
     container_name: deer-flow-gateway
-    command: sh -c "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers ${GATEWAY_WORKERS:-4}"
+    command: sh -c "cd backend && export DEER_FLOW_INTERNAL_AUTH_TOKEN=$${DEER_FLOW_INTERNAL_AUTH_TOKEN:-$$(python -c 'import secrets; print(secrets.token_urlsafe(32))')} && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers ${GATEWAY_WORKERS:-4}"
     volumes:
       - ${DEER_FLOW_CONFIG_PATH}:/app/backend/config.yaml:ro
       - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/backend/extensions_config.json:ro


### PR DESCRIPTION
## 问题原因

Docker 生产模式下 Gateway 默认使用多个 uvicorn worker。内部认证 token 原先在每个 Python 进程中随机生成，飞书 channel 在某个 worker 中发起的内部请求如果被另一个 worker 处理，就会因为 token 不一致返回 401。

## 修改内容

- 支持通过 `DEER_FLOW_INTERNAL_AUTH_TOKEN` 提供跨 worker 共享的内部认证 token。
- Docker 生产启动 Gateway 时，如果未显式配置该环境变量，则在启动 uvicorn 前生成一次共享 token，并让所有 worker 继承。
- 新增内部认证回归测试，覆盖跨进程共享 token 可通过校验，以及不同 token 会被拒绝。

## 关联 issue

Fixes #3215