### PR TITLE
build(docker): exclude local runtime state from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -45,6 +45,20 @@ npm-debug.log
 Thumbs.db
 
 # Project specific
+config.yaml
+config.yml
+configure.yml
+mcp_config.json
+extensions_config.json
+config.yaml.bak
+backend/config.yaml
+backend/config.yml
+backend/configure.yml
+backend/mcp_config.json
+backend/extensions_config.json
+backend/config.yaml.bak
+.deer-flow/
+backend/.deer-flow/
 conf.yaml
 web/
 docs/


### PR DESCRIPTION
## Summary

- Exclude local DeerFlow configuration files from Docker build contexts, including root-level and legacy `backend/` config paths.
- Exclude local runtime state directories (`.deer-flow/` and `backend/.deer-flow/`).
- Keep Docker build inputs aligned with files that are already treated as local-only by `.gitignore`.

The documented Docker setup has contributors create `config.yaml` before Docker image builds. Without matching `.dockerignore` entries, these local config/runtime files can still be sent in the Docker build context. In particular, `backend/.deer-flow/` can be copied into backend image layers by `COPY backend ./backend`.

This is a build hygiene hardening change, not a security vulnerability report.

## Test plan

- [x] `git diff --check -- .dockerignore`
- [x] Built a temporary Docker sentinel context with local config/runtime files and verified they are excluded while normal backend files remain included