### PR TITLE
fix(provisioner): keep K8s API TLS verification with server override

### DIFF
--- a/backend/tests/test_provisioner_kubeconfig.py
+++ b/backend/tests/test_provisioner_kubeconfig.py
@@ -71,6 +71,76 @@ def test_init_k8s_client_uses_file_kubeconfig(tmp_path, monkeypatch, provisioner
     assert result == "core-v1"
 
 
+def test_init_k8s_client_api_server_override_keeps_tls_verification_by_default(tmp_path, monkeypatch, provisioner_module):
+    """K8S_API_SERVER should not implicitly disable Kubernetes API TLS checks."""
+    kubeconfig_file = tmp_path / "config"
+    kubeconfig_file.write_text("apiVersion: v1\n")
+
+    class FakeConfiguration:
+        def __init__(self):
+            self.host = "https://from-kubeconfig.example"
+            self.verify_ssl = True
+
+        @staticmethod
+        def get_default_copy():
+            config = FakeConfiguration()
+            captured["config"] = config
+            return config
+
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("K8S_API_SERVER", "https://host.docker.internal:26443")
+    monkeypatch.delenv("K8S_INSECURE_SKIP_TLS_VERIFY", raising=False)
+    monkeypatch.setattr(provisioner_module.k8s_config, "load_kube_config", lambda config_file: None)
+    monkeypatch.setattr(provisioner_module.k8s_client, "Configuration", FakeConfiguration)
+    monkeypatch.setattr(provisioner_module.k8s_client, "ApiClient", lambda configuration: captured.setdefault("api_client_config", configuration))
+    monkeypatch.setattr(provisioner_module.k8s_client, "CoreV1Api", lambda api_client: captured.setdefault("api_client", api_client))
+
+    provisioner_module.KUBECONFIG_PATH = str(kubeconfig_file)
+
+    result = provisioner_module._init_k8s_client()
+
+    config = captured["config"]
+    assert config.host == "https://host.docker.internal:26443"
+    assert config.verify_ssl is True
+    assert captured["api_client_config"] is config
+    assert result is config
+
+
+def test_init_k8s_client_api_server_override_can_explicitly_skip_tls_verification(tmp_path, monkeypatch, provisioner_module):
+    """Local development can still opt into insecure API server TLS behavior."""
+    kubeconfig_file = tmp_path / "config"
+    kubeconfig_file.write_text("apiVersion: v1\n")
+
+    class FakeConfiguration:
+        def __init__(self):
+            self.host = "https://from-kubeconfig.example"
+            self.verify_ssl = True
+
+        @staticmethod
+        def get_default_copy():
+            config = FakeConfiguration()
+            captured["config"] = config
+            return config
+
+    captured: dict[str, object] = {}
+    monkeypatch.setenv("K8S_API_SERVER", "https://host.docker.internal:26443")
+    monkeypatch.setenv("K8S_INSECURE_SKIP_TLS_VERIFY", "true")
+    monkeypatch.setattr(provisioner_module.k8s_config, "load_kube_config", lambda config_file: None)
+    monkeypatch.setattr(provisioner_module.k8s_client, "Configuration", FakeConfiguration)
+    monkeypatch.setattr(provisioner_module.k8s_client, "ApiClient", lambda configuration: captured.setdefault("api_client_config", configuration))
+    monkeypatch.setattr(provisioner_module.k8s_client, "CoreV1Api", lambda api_client: captured.setdefault("api_client", api_client))
+
+    provisioner_module.KUBECONFIG_PATH = str(kubeconfig_file)
+
+    result = provisioner_module._init_k8s_client()
+
+    config = captured["config"]
+    assert config.host == "https://host.docker.internal:26443"
+    assert config.verify_ssl is False
+    assert captured["api_client_config"] is config
+    assert result is config
+
+
 def test_init_k8s_client_falls_back_to_incluster_when_missing(tmp_path, monkeypatch, provisioner_module):
     """When kubeconfig file is missing, in-cluster config should be attempted."""
     missing_path = tmp_path / "missing-config"

--- a/docker/provisioner/README.md
+++ b/docker/provisioner/README.md
@@ -145,6 +145,7 @@ The provisioner is configured via environment variables (set in [docker-compose-
 | `KUBECONFIG_PATH` | `/root/.kube/config` | Path to kubeconfig **inside** the provisioner container |
 | `NODE_HOST` | `host.docker.internal` | Hostname that backend containers use to reach host NodePorts |
 | `K8S_API_SERVER` | (from kubeconfig) | Override K8s API server URL (e.g., `https://host.docker.internal:26443`) |
+| `K8S_INSECURE_SKIP_TLS_VERIFY` | `false` | Set to `true` only for local development clusters when the API server certificate cannot be verified |
 
 ### PVC User-Data Upgrade Note
 
@@ -172,6 +173,8 @@ provisioner:
   environment:
     - K8S_API_SERVER=https://host.docker.internal:26443  # Replace 26443 with your API port
 ```
+
+TLS server certificate verification remains enabled when `K8S_API_SERVER` is set. If a local development cluster uses a self-signed certificate that is not valid for `host.docker.internal`, explicitly set `K8S_INSECURE_SKIP_TLS_VERIFY=true`. Do not use this insecure option for production clusters.
 
 Check your kubeconfig API server:
 ```bash
@@ -293,6 +296,8 @@ docker exec deer-flow-gateway curl -s $SANDBOX_URL/v1/sandbox
    ```yaml
    environment:
      - K8S_API_SERVER=https://host.docker.internal:PORT
+     # Local development only, when the API server certificate cannot be verified:
+     # - K8S_INSECURE_SKIP_TLS_VERIFY=true
    ```
 
 ### Issue: "Unprocessable Entity" when creating Pod

--- a/docker/provisioner/app.py
+++ b/docker/provisioner/app.py
@@ -65,6 +65,7 @@ USERDATA_PVC_NAME = os.environ.get("USERDATA_PVC_NAME", "")
 SAFE_THREAD_ID_PATTERN = r"^[A-Za-z0-9_\-]+$"
 SAFE_USER_ID_PATTERN = r"^[A-Za-z0-9_\-]+$"
 DEFAULT_USER_ID = "default"
+TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 # Path to the kubeconfig *inside* the provisioner container.
 # Typically the host's ~/.kube/config is mounted here.
@@ -100,6 +101,11 @@ def join_host_path(base: str, *parts: str) -> str:
 # ── K8s client setup ────────────────────────────────────────────────────
 
 core_v1: k8s_client.CoreV1Api | None = None
+
+
+def _env_flag(name: str) -> bool:
+    """Return True when an environment variable is explicitly truthy."""
+    return os.environ.get(name, "").strip().lower() in TRUE_ENV_VALUES
 
 
 def _init_k8s_client() -> k8s_client.CoreV1Api:
@@ -139,8 +145,12 @@ def _init_k8s_client() -> k8s_client.CoreV1Api:
     if k8s_api_server:
         configuration = k8s_client.Configuration.get_default_copy()
         configuration.host = k8s_api_server
-        # Self-signed certs are common for local clusters
-        configuration.verify_ssl = False
+        if _env_flag("K8S_INSECURE_SKIP_TLS_VERIFY"):
+            logger.warning(
+                "K8S_INSECURE_SKIP_TLS_VERIFY is enabled; Kubernetes API server "
+                "certificate verification is disabled."
+            )
+            configuration.verify_ssl = False
         api_client = k8s_client.ApiClient(configuration)
         return k8s_client.CoreV1Api(api_client)
 


### PR DESCRIPTION
## What

This keeps Kubernetes API server TLS verification enabled when `K8S_API_SERVER` is used to override the kubeconfig server URL.

It also adds an explicit `K8S_INSECURE_SKIP_TLS_VERIFY=true` opt-in for local development clusters where the API server certificate cannot be verified, and documents that this should not be used for production clusters.

## Why

`K8S_API_SERVER` currently changes two behaviors at once: it overrides the API server URL and also disables TLS certificate verification.

That makes the override broader than expected. A user may only intend to point the provisioner at a reachable API endpoint, but the provisioner silently switches to insecure TLS behavior on that path.

## How

- Keep `configuration.verify_ssl` unchanged by default when `K8S_API_SERVER` is set.
- Only set `configuration.verify_ssl = False` when `K8S_INSECURE_SKIP_TLS_VERIFY` is explicitly truthy.
- Add regression tests for both the secure default and the explicit insecure opt-in.
- Update the provisioner README with the new environment variable.

## Testing

- `cd backend && uv run pytest -q tests/test_provisioner_kubeconfig.py`
  - `7 passed, 1 warning`
- `cd backend && uv run ruff check ../docker/provisioner/app.py tests/test_provisioner_kubeconfig.py`
- `cd backend && uv run ruff format --check tests/test_provisioner_kubeconfig.py`
- `git diff --check`
- Manual k3d smoke test with a temporary local cluster:
  - default kubeconfig kept `verify_ssl=True` and listed namespaces successfully
  - `K8S_API_SERVER=https://127.0.0.1:6550` kept `verify_ssl=True` and listed namespaces successfully
  - `K8S_INSECURE_SKIP_TLS_VERIFY=true` set `verify_ssl=False` explicitly and listed namespaces successfully