### PR TITLE
fix(backend): align todo middleware state schema

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
@@ -25,6 +25,8 @@ from langchain.agents.middleware.types import ModelCallResult, ModelRequest, Mod
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.runtime import Runtime
 
+from deerflow.agents.thread_state import ThreadState
+
 
 def _todos_in_messages(messages: list[Any]) -> bool:
     """Return True if any AIMessage in *messages* contains a write_todos tool call."""
@@ -112,6 +114,10 @@ class TodoMiddleware(TodoListMiddleware):
     todo list. This middleware detects that gap in `before_model` / `abefore_model`
     and injects a reminder message so the model can continue tracking progress.
     """
+
+    # Align the middleware state schema with DeerFlow's shared thread state so
+    # `todos` is declared exactly once with the reducer needed by #3123.
+    state_schema = ThreadState
 
     @override
     def before_model(

--- a/backend/tests/test_todo_middleware.py
+++ b/backend/tests/test_todo_middleware.py
@@ -17,6 +17,7 @@ from deerflow.agents.middlewares.todo_middleware import (
     _reminder_in_messages,
     _todos_in_messages,
 )
+from deerflow.agents.thread_state import ThreadState
 
 
 def _ai_with_write_todos():
@@ -510,6 +511,33 @@ class TestWrapModelCall:
 
 
 class TestTodoMiddlewareAgentGraphIntegration:
+    def test_thread_state_schema_builds_and_runs_with_todo_middleware(self):
+        mw = TodoMiddleware()
+        model = _CapturingFakeMessagesListChatModel(
+            responses=[
+                AIMessage(
+                    content="",
+                    tool_calls=[
+                        {
+                            "name": "write_todos",
+                            "id": "todos-thread-state",
+                            "args": {"todos": [{"content": "Step 1", "status": "completed"}]},
+                        }
+                    ],
+                ),
+                AIMessage(content="done"),
+            ],
+        )
+        graph = create_agent(model=model, tools=[], middleware=[mw], state_schema=ThreadState)
+
+        result = graph.invoke(
+            {"messages": [("user", "track this work")]},
+            context={"thread_id": "thread-state-thread", "run_id": "thread-state-run"},
+        )
+
+        assert result["todos"] == [{"content": "Step 1", "status": "completed"}]
+        assert result["messages"][-1].content == "done"
+
     def test_completion_reminder_is_transient_in_real_agent_graph(self):
         mw = TodoMiddleware()
         model = _CapturingFakeMessagesListChatModel(


### PR DESCRIPTION
## Problem
When plan mode is enabled, lead-agent graph construction can fail before execution starts with:

```text
ValueError: Channel `todos` already exists with a different type
```

The failure happens during LangGraph state schema resolution, so the frontend only sees the downstream stream/runtime error.

## Root Cause
- DeerFlow's shared `ThreadState` already defines `todos` with the custom `merge_todos` reducer.
- `TodoMiddleware` inherits LangChain's `TodoListMiddleware`, whose default `state_schema` also declares `todos`, but with a different channel type.
- In plan mode both schemas are merged by `create_agent()`, which makes LangGraph reject the duplicate `todos` channel.

## Fix
- Align `TodoMiddleware` to use DeerFlow's `ThreadState` as its `state_schema`.
- Keep the existing `merge_todos` reducer semantics from `ThreadState`, so this fix does not regress the earlier todos-retention behavior.
- Add a regression test that builds a real agent graph with `TodoMiddleware` + `ThreadState` and verifies the graph runs successfully.

## Validation
- `backend/.venv/bin/pytest backend/tests/test_todo_middleware.py backend/tests/test_thread_state_reducers.py -q`
- `backend/.venv/bin/pytest backend/tests/test_create_deerflow_agent.py -q -k plan_mode`
- minimal repro: `create_agent(..., middleware=[TodoMiddleware()], state_schema=ThreadState)` builds successfully
- lead-agent repro path: `make_lead_agent(config={"configurable": {"is_plan_mode": True, ...}})` builds successfully

## Scope
Only these Python files are changed:
- `backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py`
- `backend/tests/test_todo_middleware.py`

Closes #3256