### PR TITLE
fix(channels): ignore hidden control messages when extracting replies (#3219)

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -173,6 +173,8 @@ def _extract_response_text(result: dict | list) -> str:
 
         # Stop at the last human message — anything before it is a previous turn
         if msg_type == "human":
+            if _is_hidden_human_control_message(msg):
+                continue
             break
 
         # Check for tool messages from ask_clarification (interrupt case)
@@ -313,6 +315,8 @@ def _extract_artifacts(result: dict | list) -> list[str]:
             continue
         # Stop at the last human message — anything before it is a previous turn
         if msg.get("type") == "human":
+            if _is_hidden_human_control_message(msg):
+                continue
             break
         # Look for AI messages with present_files tool calls
         if msg.get("type") == "ai":
@@ -323,6 +327,18 @@ def _extract_artifacts(result: dict | list) -> list[str]:
                     if isinstance(paths, list):
                         artifacts.extend(p for p in paths if isinstance(p, str))
     return artifacts
+
+
+def _is_hidden_human_control_message(msg: Mapping[str, Any]) -> bool:
+    """Return whether a human message is an internal control message hidden from UI."""
+    if msg.get("type") != "human":
+        return False
+
+    additional_kwargs = msg.get("additional_kwargs")
+    if not isinstance(additional_kwargs, Mapping):
+        return False
+
+    return additional_kwargs.get("hide_from_ui") is True
 
 
 def _format_artifact_text(artifacts: list[str]) -> str:

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -372,6 +372,25 @@ class TestExtractResponseText:
         # Should return "" (no text in current turn), NOT "Hi there!" from previous turn
         assert _extract_response_text(result) == ""
 
+    def test_ignores_hidden_human_control_messages(self):
+        """Hidden control messages should not terminate current-turn response extraction."""
+        from app.channels.manager import _extract_response_text
+
+        result = {
+            "messages": [
+                {"type": "human", "content": "plan this"},
+                {"type": "ai", "content": "Here is the plan."},
+                {
+                    "type": "human",
+                    "name": "todo_reminder",
+                    "content": "keep todos updated",
+                    "additional_kwargs": {"hide_from_ui": True},
+                },
+            ]
+        }
+
+        assert _extract_response_text(result) == "Here is the plan."
+
 
 # ---------------------------------------------------------------------------
 # ChannelManager tests
@@ -1678,6 +1697,31 @@ class TestExtractArtifacts:
         }
         assert _extract_artifacts(result) == ["/mnt/user-data/outputs/a.txt", "/mnt/user-data/outputs/b.csv"]
 
+    def test_ignores_hidden_human_control_messages(self):
+        """Hidden control messages should not hide current-turn present_files artifacts."""
+        from app.channels.manager import _extract_artifacts
+
+        result = {
+            "messages": [
+                {"type": "human", "content": "export"},
+                {
+                    "type": "ai",
+                    "content": "Done.",
+                    "tool_calls": [
+                        {"name": "present_files", "args": {"filepaths": ["/mnt/user-data/outputs/plan.md"]}},
+                    ],
+                },
+                {
+                    "type": "human",
+                    "name": "todo_completion_reminder",
+                    "content": "mark tasks complete",
+                    "additional_kwargs": {"hide_from_ui": True},
+                },
+            ]
+        }
+
+        assert _extract_artifacts(result) == ["/mnt/user-data/outputs/plan.md"]
+
 
 class TestFormatArtifactText:
     def test_single_artifact(self):
@@ -1787,6 +1831,50 @@ class TestHandleChatWithArtifacts:
             assert outbound_received[0].text != "(No response from agent)"
             assert "output.csv" in outbound_received[0].text
             assert outbound_received[0].artifacts == ["/mnt/user-data/outputs/output.csv"]
+
+        _run(go())
+
+    def test_hidden_human_control_message_does_not_trigger_no_response_fallback(self):
+        """Plan-mode hidden control messages should not mask the final AI response."""
+        from app.channels.manager import ChannelManager
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+
+            run_result = {
+                "messages": [
+                    {"type": "human", "content": "make a plan"},
+                    {"type": "ai", "content": "Here is a concrete plan."},
+                    {
+                        "type": "human",
+                        "name": "todo_reminder",
+                        "content": "sync todos",
+                        "additional_kwargs": {"hide_from_ui": True},
+                    },
+                ]
+            }
+            mock_client = _make_mock_langgraph_client(run_result=run_result)
+            manager._client = mock_client
+
+            outbound_received = []
+            bus.subscribe_outbound(lambda msg: outbound_received.append(msg))
+            await manager.start()
+
+            await bus.publish_inbound(
+                InboundMessage(
+                    channel_name="test",
+                    chat_id="c1",
+                    user_id="u1",
+                    text="make a plan",
+                )
+            )
+            await _wait_for(lambda: len(outbound_received) >= 1)
+            await manager.stop()
+
+            assert len(outbound_received) == 1
+            assert outbound_received[0].text == "Here is a concrete plan."
 
         _run(go())
 


### PR DESCRIPTION
## Summary

Closes #3219.

When plan mode is enabled, DeerFlow may append internal hidden `human` control messages such as `todo_reminder` / `todo_completion_reminder` with `additional_kwargs.hide_from_ui = true`. `ChannelManager` currently treats any trailing `human` message as the current-turn boundary, so these hidden control messages can make `_extract_response_text()` and `_extract_artifacts()` stop too early. In IM channels this falls through to the `"(No response from agent)"` fallback even though the run actually produced a valid AI reply or artifacts.

## Changes

- add `_is_hidden_human_control_message()` in `backend/app/channels/manager.py`
- make `_extract_response_text()` skip hidden `human` control messages instead of treating them as a turn boundary
- make `_extract_artifacts()` do the same so `present_files` output from the current turn is still surfaced
- add regression tests in `backend/tests/test_channels.py` for:
  - response extraction with trailing hidden control messages
  - artifact extraction with trailing hidden control messages
  - end-to-end ChannelManager fallback avoidance

## Validation

```bash
cd backend
.venv/bin/python -m pytest tests/test_channels.py -q
.venv/bin/python -m pytest tests/test_todo_middleware.py -q
.venv/bin/python -m pytest tests/test_dynamic_context_middleware.py -q
```

Results:
- `tests/test_channels.py`: 104 passed
- `tests/test_todo_middleware.py`: 49 passed
- `tests/test_dynamic_context_middleware.py`: 14 passed
