### PR TITLE
fix: align todo middleware state schema

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
@@ -172,6 +172,10 @@ class TodoMiddleware(TodoListMiddleware):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+        # Keep the todo channel definition identical to DeerFlow's graph state.
+        # The base LangChain middleware registers PlanningState.todos as a
+        # LastValue channel, which conflicts with ThreadState's reducer.
+        self.state_schema = ThreadState
         self._lock = threading.Lock()
         self._pending_completion_reminders: dict[tuple[str, str], list[str]] = {}
         self._completion_reminder_counts: dict[tuple[str, str], int] = {}

--- a/backend/tests/test_todo_middleware.py
+++ b/backend/tests/test_todo_middleware.py
@@ -511,6 +511,11 @@ class TestWrapModelCall:
 
 
 class TestTodoMiddlewareAgentGraphIntegration:
+    def test_uses_deerflow_thread_state_schema(self):
+        mw = TodoMiddleware()
+
+        assert mw.state_schema is ThreadState
+
     def test_reuses_thread_state_todos_schema_in_real_agent_graph(self):
         mw = TodoMiddleware()
         model = _CapturingFakeMessagesListChatModel(


### PR DESCRIPTION
## What

Fix a LangGraph state schema conflict when plan mode enables `TodoMiddleware`.

## Why

`TodoListMiddleware` registers `PlanningState.todos`, while DeerFlow also defines
`ThreadState.todos` with a reducer. These create different channel types for the
same `todos` key and cause graph creation to fail with:

`Channel 'todos' already exists with a different type`

## How

Use DeerFlow's `ThreadState` as the state schema for DeerFlow's `TodoMiddleware`,
so the `todos` channel is defined consistently.

## Testing

- `backend/.venv/bin/python -m pytest backend/tests/test_todo_middleware.py backend/tests/test_thread_state_reducers.py -q`
- `cd backend && make lint`