### PR TITLE
fix(chat): preserve messages after summarization

### DIFF
--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -476,6 +476,33 @@ def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch
     fake_model.with_config.assert_called_once_with(tags=["middleware:summarize"])
 
 
+def test_create_summarization_middleware_preserves_frontend_update_key_contract(monkeypatch):
+    """LangGraph update keys use the middleware class name plus hook name.
+
+    The frontend treats any ``*.SummarizationMiddleware.before_model`` update as
+    the summarization state reset signal, so the lead agent's runtime middleware
+    must keep that suffix stable even when using a DeerFlow-specific subclass.
+
+    Temporary regression guard for issue#2965. Remove this test once the
+    frontend and backend have a stronger explicit contract than matching 
+    middleware-generated update keys.
+    """
+
+    app_config = _make_app_config([_make_model("safe-model", supports_thinking=False)])
+    app_config.summarization = SummarizationConfig(enabled=True)
+    app_config.memory = MemoryConfig(enabled=False)
+
+    fake_model = MagicMock()
+    fake_model.with_config.return_value = fake_model
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: fake_model)
+
+    middleware = lead_agent_module._create_summarization_middleware(app_config=app_config)
+
+    assert middleware is not None
+    update_key = f"{type(middleware).__name__}.before_model"
+    assert update_key.endswith("SummarizationMiddleware.before_model")
+
+
 def test_create_summarization_middleware_threads_resolved_app_config_to_model(monkeypatch):
     fallback_app_config = _make_app_config([_make_model("fallback-model", supports_thinking=False)])
     fallback_app_config.summarization = SummarizationConfig(enabled=True, model_name="fallback-model")

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -476,17 +476,8 @@ def test_create_summarization_middleware_uses_configured_model_alias(monkeypatch
     fake_model.with_config.assert_called_once_with(tags=["middleware:summarize"])
 
 
-def test_create_summarization_middleware_preserves_frontend_update_key_contract(monkeypatch):
-    """LangGraph update keys use the middleware class name plus hook name.
-
-    The frontend treats any ``*.SummarizationMiddleware.before_model`` update as
-    the summarization state reset signal, so the lead agent's runtime middleware
-    must keep that suffix stable even when using a DeerFlow-specific subclass.
-
-    Temporary regression guard for issue#2965. Remove this test once the
-    frontend and backend have a stronger explicit contract than matching
-    middleware-generated update keys.
-    """
+def test_create_summarization_middleware_uses_frontend_supported_update_key(monkeypatch):
+    """LangGraph update keys use the middleware class name plus hook name."""
 
     app_config = _make_app_config([_make_model("safe-model", supports_thinking=False)])
     app_config.summarization = SummarizationConfig(enabled=True)
@@ -500,7 +491,7 @@ def test_create_summarization_middleware_preserves_frontend_update_key_contract(
 
     assert middleware is not None
     update_key = f"{type(middleware).__name__}.before_model"
-    assert update_key.endswith("SummarizationMiddleware.before_model")
+    assert update_key == "DeerFlowSummarizationMiddleware.before_model"
 
 
 def test_create_summarization_middleware_threads_resolved_app_config_to_model(monkeypatch):

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -484,7 +484,7 @@ def test_create_summarization_middleware_preserves_frontend_update_key_contract(
     must keep that suffix stable even when using a DeerFlow-specific subclass.
 
     Temporary regression guard for issue#2965. Remove this test once the
-    frontend and backend have a stronger explicit contract than matching 
+    frontend and backend have a stronger explicit contract than matching
     middleware-generated update keys.
     """
 

--- a/backend/tests/test_summarization_middleware.py
+++ b/backend/tests/test_summarization_middleware.py
@@ -5,7 +5,10 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from langchain.agents import create_agent
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 
 from deerflow.agents.memory.summarization_hook import memory_flush_hook
 from deerflow.agents.middlewares.dynamic_context_middleware import _DYNAMIC_CONTEXT_REMINDER_KEY, DynamicContextMiddleware
@@ -20,6 +23,23 @@ def _messages() -> list:
         HumanMessage(content="user-2"),
         AIMessage(content="assistant-2"),
     ]
+
+
+class _StaticChatModel(BaseChatModel):
+    text: str = "ok"
+
+    @property
+    def _llm_type(self) -> str:
+        return "static-test-chat-model"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content=self.text))])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+        return self._generate(messages, stop=stop, run_manager=run_manager, **kwargs)
 
 
 def _dynamic_context_reminder(msg_id: str = "reminder-1") -> HumanMessage:
@@ -112,6 +132,32 @@ def test_before_summarization_hook_receives_messages_before_compression() -> Non
     assert captured[0].agent_name is None
     assert isinstance(result["messages"][0], RemoveMessage)
     assert result["messages"][1].content.startswith("Here is a summary")
+
+
+def test_summarization_middleware_emits_frontend_update_key_in_agent_stream() -> None:
+    middleware = DeerFlowSummarizationMiddleware(
+        model=_StaticChatModel(text="compressed summary"),
+        trigger=("messages", 4),
+        keep=("messages", 2),
+        token_counter=len,
+    )
+    agent = create_agent(
+        model=_StaticChatModel(text="done"),
+        tools=[],
+        middleware=[middleware],
+    )
+
+    chunks = list(agent.stream({"messages": _messages()}, stream_mode="updates"))
+    update = next(
+        (chunk["DeerFlowSummarizationMiddleware.before_model"] for chunk in chunks if "DeerFlowSummarizationMiddleware.before_model" in chunk),
+        None,
+    )
+
+    assert update is not None
+    emitted = update["messages"]
+    assert isinstance(emitted[0], RemoveMessage)
+    assert emitted[1].name == "summary"
+    assert emitted[1].content == ("Here is a summary of the conversation to date:\n\ncompressed summary")
 
 
 def test_dynamic_context_reminder_is_preserved_across_summarization() -> None:

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -50,6 +50,11 @@ function isNonEmptyString(value: string | undefined): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
+const SUMMARIZATION_MIDDLEWARE_UPDATE_KEYS = new Set([
+  "SummarizationMiddleware.before_model",
+  "DeerFlowSummarizationMiddleware.before_model",
+]);
+
 function messageIdentity(message: Message): string | undefined {
   if (
     "tool_call_id" in message &&
@@ -68,6 +73,11 @@ function dedupeMessagesByIdentity(messages: Message[]): Message[] {
   const lastIndexByIdentity = new Map<string, number>();
   const lastVisibleIndexByIdentity = new Map<string, number>();
 
+  // This is a UI-display dedupe rule, not a general LangChain message-stream
+  // contract. Hidden messages that share an identity with a visible message are
+  // treated as control messages for this merged view; hidden messages carrying
+  // independent tracing/task semantics should use a distinct id or a custom
+  // stream/state channel instead of relying on message dedupe preservation.
   messages.forEach((message, index) => {
     const identity = messageIdentity(message);
     if (identity) {
@@ -109,6 +119,10 @@ export function mergeMessages(
   threadMessages: Message[],
   optimisticMessages: Message[],
 ): Message[] {
+  // Only visible live messages should trim overlapping history. Hidden messages
+  // are UI control messages in this path, not observability records; any hidden
+  // message that must survive as task/tracing data should use custom events or a
+  // separate state channel instead of participating in this overlap heuristic.
   const threadMessageIds = new Set(
     threadMessages
       .filter((message) => !isHiddenFromUIMessage(message))
@@ -172,7 +186,7 @@ export function getSummarizationMiddlewareMessages(
   }
 
   for (const [key, update] of Object.entries(data)) {
-    if (!key.endsWith("SummarizationMiddleware.before_model")) {
+    if (!SUMMARIZATION_MIDDLEWARE_UPDATE_KEYS.has(key)) {
       continue;
     }
     if (typeof update !== "object" || update === null) {

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -11,6 +11,7 @@ import { getAPIClient } from "../api";
 import { fetch } from "../api/fetcher";
 import { getBackendBaseURL } from "../config";
 import { useI18n } from "../i18n/hooks";
+import { isHiddenFromUIMessage } from "../messages/utils";
 import type { FileInMessage } from "../messages/utils";
 import type { LocalSettings } from "../settings";
 import { useUpdateSubtask } from "../tasks/context";
@@ -65,17 +66,28 @@ function messageIdentity(message: Message): string | undefined {
 
 function dedupeMessagesByIdentity(messages: Message[]): Message[] {
   const lastIndexByIdentity = new Map<string, number>();
+  const lastVisibleIndexByIdentity = new Map<string, number>();
 
   messages.forEach((message, index) => {
     const identity = messageIdentity(message);
     if (identity) {
       lastIndexByIdentity.set(identity, index);
+      if (!isHiddenFromUIMessage(message)) {
+        lastVisibleIndexByIdentity.set(identity, index);
+      }
     }
   });
 
   return messages.filter((message, index) => {
     const identity = messageIdentity(message);
-    return !identity || lastIndexByIdentity.get(identity) === index;
+    if (!identity) {
+      return true;
+    }
+    const visibleIndex = lastVisibleIndexByIdentity.get(identity);
+    if (visibleIndex !== undefined) {
+      return visibleIndex === index;
+    }
+    return lastIndexByIdentity.get(identity) === index;
   });
 }
 
@@ -98,7 +110,10 @@ export function mergeMessages(
   optimisticMessages: Message[],
 ): Message[] {
   const threadMessageIds = new Set(
-    threadMessages.map(messageIdentity).filter(isNonEmptyString),
+    threadMessages
+      .filter((message) => !isHiddenFromUIMessage(message))
+      .map(messageIdentity)
+      .filter(isNonEmptyString),
   );
 
   // The overlap is a contiguous suffix of historyMessages (newest history == oldest thread).
@@ -147,6 +162,30 @@ export function getVisibleOptimisticMessages(
     return [];
   }
   return optimisticMessages;
+}
+
+export function getSummarizationMiddlewareMessages(
+  data: unknown,
+): Message[] | undefined {
+  if (typeof data !== "object" || data === null) {
+    return undefined;
+  }
+
+  for (const [key, update] of Object.entries(data)) {
+    if (!key.endsWith("SummarizationMiddleware.before_model")) {
+      continue;
+    }
+    if (typeof update !== "object" || update === null) {
+      continue;
+    }
+
+    const messages = Reflect.get(update, "messages");
+    if (Array.isArray(messages)) {
+      return [...messages] as Message[];
+    }
+  }
+
+  return undefined;
 }
 
 function getStreamErrorMessage(error: unknown): string {
@@ -258,24 +297,25 @@ export function useThreadStream({
       }
     },
     onUpdateEvent(data) {
-      if (data["SummarizationMiddleware.before_model"]) {
-        const _messages = [
-          ...(data["SummarizationMiddleware.before_model"].messages ?? []),
-        ];
-
-        if (_messages.length < 2) {
-          return;
-        }
+      const _messages = getSummarizationMiddlewareMessages(data);
+      if (_messages && _messages.length >= 2) {
         for (const m of _messages) {
           if (m.name === "summary" && m.type === "human") {
             summarizedRef.current?.add(m.id ?? "");
           }
         }
-        const _lastKeepMessage = _messages[2];
+        const firstRetainedVisibleIdentity = _messages
+          .filter((message) => message.type !== "remove")
+          .filter((message) => !isHiddenFromUIMessage(message))
+          .map(messageIdentity)
+          .find(isNonEmptyString);
         const _currentMessages = [...messagesRef.current];
         const _movedMessages: Message[] = [];
         for (const m of _currentMessages) {
-          if (m.id !== undefined && m.id === _lastKeepMessage?.id) {
+          if (
+            firstRetainedVisibleIdentity &&
+            messageIdentity(m) === firstRetainedVisibleIdentity
+          ) {
             break;
           }
           if (!summarizedRef.current?.has(m.id ?? "")) {

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -91,6 +91,24 @@ test("mergeMessages keeps a visible history message when a hidden live message r
   ]);
 });
 
+test("mergeMessages lets a visible live message replace overlapping hidden history", () => {
+  const hiddenHistoryHuman = {
+    id: "human-1",
+    type: "human",
+    content: "<system-reminder>hidden</system-reminder>",
+    additional_kwargs: { hide_from_ui: true },
+  } as Message;
+  const liveHuman = {
+    id: "human-1",
+    type: "human",
+    content: "visible user prompt",
+  } as Message;
+
+  expect(mergeMessages([hiddenHistoryHuman], [liveHuman], [])).toEqual([
+    liveHuman,
+  ]);
+});
+
 test("getSummarizationMiddlewareMessages matches DeerFlow summarization update keys", () => {
   const removeAll = {
     id: "__remove_all__",
@@ -111,6 +129,40 @@ test("getSummarizationMiddlewareMessages matches DeerFlow summarization update k
       },
     }),
   ).toEqual([removeAll, summary]);
+});
+
+test("getSummarizationMiddlewareMessages matches base LangChain summarization update keys", () => {
+  const summary = {
+    id: "summary-1",
+    type: "human",
+    name: "summary",
+    content: "summary",
+  } as Message;
+
+  expect(
+    getSummarizationMiddlewareMessages({
+      "SummarizationMiddleware.before_model": {
+        messages: [summary],
+      },
+    }),
+  ).toEqual([summary]);
+});
+
+test("getSummarizationMiddlewareMessages ignores unrelated suffix-sharing update keys", () => {
+  const summary = {
+    id: "summary-1",
+    type: "human",
+    name: "summary",
+    content: "summary",
+  } as Message;
+
+  expect(
+    getSummarizationMiddlewareMessages({
+      "OtherSummarizationMiddleware.before_model": {
+        messages: [summary],
+      },
+    }),
+  ).toBeUndefined();
 });
 
 test("getVisibleOptimisticMessages hides optimistic user input after server human arrives", () => {

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -2,6 +2,7 @@ import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
 import {
+  getSummarizationMiddlewareMessages,
   getVisibleOptimisticMessages,
   mergeMessages,
 } from "@/core/threads/hooks";
@@ -64,6 +65,52 @@ test("mergeMessages deduplicates tool messages by tool_call_id", () => {
   } as Message;
 
   expect(mergeMessages([oldTool], [liveTool], [])).toEqual([liveTool]);
+});
+
+test("mergeMessages keeps a visible history message when a hidden live message reuses its id", () => {
+  const historyHuman = {
+    id: "human-1",
+    type: "human",
+    content: "visible user prompt",
+  } as Message;
+  const hiddenReminder = {
+    id: "human-1",
+    type: "human",
+    content: "<system-reminder>hidden</system-reminder>",
+    additional_kwargs: { hide_from_ui: true },
+  } as Message;
+  const liveAi = {
+    id: "ai-1",
+    type: "ai",
+    content: "live answer",
+  } as Message;
+
+  expect(mergeMessages([historyHuman], [hiddenReminder, liveAi], [])).toEqual([
+    historyHuman,
+    liveAi,
+  ]);
+});
+
+test("getSummarizationMiddlewareMessages matches DeerFlow summarization update keys", () => {
+  const removeAll = {
+    id: "__remove_all__",
+    type: "remove",
+    content: "",
+  } as Message;
+  const summary = {
+    id: "summary-1",
+    type: "human",
+    name: "summary",
+    content: "summary",
+  } as Message;
+
+  expect(
+    getSummarizationMiddlewareMessages({
+      "DeerFlowSummarizationMiddleware.before_model": {
+        messages: [removeAll, summary],
+      },
+    }),
+  ).toEqual([removeAll, summary]);
 });
 
 test("getVisibleOptimisticMessages hides optimistic user input after server human arrives", () => {


### PR DESCRIPTION

## Summary

Fixed #2965 

- Preserve visible chat history when summarization resets the live message stream.
- Match DeerFlow summarization update keys by the stable SummarizationMiddleware.before_model suffix instead of one exact class name.
- Add frontend coverage for hidden control-message dedupe and DeerFlow summarization update keys.
- Add a backend regression guard for the frontend/backend summarization update-key contract.

## Root Cause

The backend emits summarization updates under DeerFlowSummarizationMiddleware.before_model, while the frontend only listened for SummarizationMiddleware.before_model. As a result, the frontend missed the summarization reset update and did not move visible messages into local history before RemoveMessage(__remove_all__) cleared the live stream.

## Validation
```
pnpm test tests/unit/core/threads/message-merge.test.ts
pnpm lint
uv run pytest tests/test_lead_agent_model_resolution.py -k summarization_middleware_preserves_frontend_update_key_contract
uv run pytest tests/test_lead_agent_model_resolution.py -k "create_summarization_middleware"
commit hook: frontend check and backend lint passed
```

Note: pnpm typecheck was previously blocked by stale Next generated route types under .next/types versus .next/dev/types, unrelated to this change.