### PR TITLE
fix(frontend): show new thread in sidebar immediately on creation

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -1,7 +1,12 @@
 import type { AIMessage, Message, Run } from "@langchain/langgraph-sdk";
 import type { ThreadsClient } from "@langchain/langgraph-sdk/client";
 import { useStream } from "@langchain/langgraph-sdk/react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -149,6 +154,48 @@ export function getVisibleOptimisticMessages(
   return optimisticMessages;
 }
 
+export function upsertThreadInSearchCache(
+  queryClient: QueryClient,
+  thread: AgentThread,
+) {
+  queryClient.setQueriesData(
+    {
+      queryKey: ["threads", "search"],
+      exact: false,
+    },
+    (oldData: Array<AgentThread> | undefined) => {
+      if (!oldData) {
+        return [thread];
+      }
+
+      const existingIndex = oldData.findIndex(
+        (t) => t.thread_id === thread.thread_id,
+      );
+      if (existingIndex === -1) {
+        return [thread, ...oldData];
+      }
+
+      return oldData.map((t, index) => {
+        if (index !== existingIndex) {
+          return t;
+        }
+        return {
+          ...thread,
+          ...t,
+          metadata: {
+            ...(thread.metadata ?? {}),
+            ...(t.metadata ?? {}),
+          },
+          values: {
+            ...thread.values,
+            ...t.values,
+          },
+        };
+      });
+    },
+  );
+}
+
 function getStreamErrorMessage(error: unknown): string {
   if (typeof error === "string" && error.trim()) {
     return error;
@@ -241,6 +288,20 @@ export function useThreadStream({
     fetchStateHistory: { limit: 1 },
     onCreated(meta) {
       handleStreamStart(meta.thread_id, meta.run_id);
+      const now = new Date().toISOString();
+      upsertThreadInSearchCache(queryClient, {
+        thread_id: meta.thread_id,
+        created_at: now,
+        updated_at: now,
+        metadata: context.agent_name ? { agent_name: context.agent_name } : {},
+        status: "busy",
+        values: {
+          title: t.pages.newChat,
+          messages: [],
+          artifacts: [],
+        },
+        interrupts: {},
+      });
       if (context.agent_name && !isMock) {
         void getAPIClient()
           .threads.update(meta.thread_id, {


### PR DESCRIPTION
Fixes #3276

## Why

When a user starts a new conversation the sidebar thread list stays empty until the AI finishes streaming and the backend generates a title. During that window (which can last seconds to minutes) the user cannot switch back to the in-progress conversation — a painful UX gap when working with multiple threads concurrently.

## What changed

- Added `upsertThreadInSearchCache()` utility that inserts or merges a thread entry into the `["threads", "search"]` TanStack Query cache.
- In the `onCreated` callback (fires the moment the backend acknowledges thread creation), optimistically insert a placeholder thread with title "New chat" and status `busy`.
- The existing `onUpdateEvent` title handler updates the sidebar entry in-place once the AI-generated title arrives via stream event.
- The existing `onFinish` query invalidation replaces the optimistic entry with authoritative backend data when streaming completes.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`

## Screenshots / Recording
<img width="2928" height="712" alt="image" src="https://github.com/user-attachments/assets/8564ca5b-2ffa-4005-921c-b55e285ff0cb" />

<!-- User will attach verification screenshots -->

## Bug fix verification

- Reproduced locally: new conversation does not appear in sidebar until stream completes
- After fix: sidebar shows "New chat" entry immediately on first message send, title updates in-place once generated

## Validation

```
cd frontend && pnpm typecheck  # pass
cd frontend && pnpm lint       # pass
```

Manual verification: started multiple concurrent conversations, confirmed sidebar entries appear immediately and switching between them works throughout streaming.