### PR TITLE
fix: ignore stale run reconnect conflicts

### DIFF
--- a/frontend/src/core/api/api-client.ts
+++ b/frontend/src/core/api/api-client.ts
@@ -52,6 +52,9 @@ export function isInactiveRunStreamError(error: unknown): boolean {
           ? String(Reflect.get(error, "message") ?? "")
           : "";
 
+  // Match the gateway's store-only run response in
+  // backend/app/gateway/routers/thread_runs.py until the API exposes a
+  // structured error code for inactive run streams.
   return (
     (status === 409 || message.includes("HTTP 409")) &&
     message.includes("not active on this worker") &&

--- a/frontend/src/core/api/api-client.ts
+++ b/frontend/src/core/api/api-client.ts
@@ -66,8 +66,13 @@ export function clearReconnectRun(
   if (typeof window === "undefined" || !threadId) return;
 
   const key = `lg:stream:${threadId}`;
-  if (window.sessionStorage.getItem(key) === runId) {
-    window.sessionStorage.removeItem(key);
+  try {
+    const storage = window.sessionStorage;
+    if (storage.getItem(key) === runId) {
+      storage.removeItem(key);
+    }
+  } catch {
+    // Ignore storage access failures so reconnect cleanup never throws.
   }
 }
 

--- a/frontend/src/core/api/api-client.ts
+++ b/frontend/src/core/api/api-client.ts
@@ -38,6 +38,39 @@ function injectCsrfHeader(_url: URL, init: RequestInit): RequestInit {
   return { ...init, headers };
 }
 
+export function isInactiveRunStreamError(error: unknown): boolean {
+  const status =
+    typeof error === "object" && error !== null
+      ? Reflect.get(error, "status")
+      : undefined;
+  const message =
+    typeof error === "string"
+      ? error
+      : error instanceof Error
+        ? error.message
+        : typeof error === "object" && error !== null
+          ? String(Reflect.get(error, "message") ?? "")
+          : "";
+
+  return (
+    (status === 409 || message.includes("HTTP 409")) &&
+    message.includes("not active on this worker") &&
+    message.includes("cannot be streamed")
+  );
+}
+
+export function clearReconnectRun(
+  threadId: string | null | undefined,
+  runId: string,
+): void {
+  if (typeof window === "undefined" || !threadId) return;
+
+  const key = `lg:stream:${threadId}`;
+  if (window.sessionStorage.getItem(key) === runId) {
+    window.sessionStorage.removeItem(key);
+  }
+}
+
 function createCompatibleClient(isMock?: boolean): LangGraphClient {
   if (isStaticWebsiteOnly() && !isMock) {
     return createStaticClient();
@@ -59,12 +92,21 @@ function createCompatibleClient(isMock?: boolean): LangGraphClient {
     )) as typeof client.runs.stream;
 
   const originalJoinStream = client.runs.joinStream.bind(client.runs);
-  client.runs.joinStream = ((threadId, runId, options) =>
-    originalJoinStream(
-      threadId,
-      runId,
-      sanitizeRunStreamOptions(options),
-    )) as typeof client.runs.joinStream;
+  client.runs.joinStream = async function* (threadId, runId, options) {
+    try {
+      yield* originalJoinStream(
+        threadId,
+        runId,
+        sanitizeRunStreamOptions(options),
+      );
+    } catch (error) {
+      if (isInactiveRunStreamError(error)) {
+        clearReconnectRun(threadId, runId);
+        return;
+      }
+      throw error;
+    }
+  } as typeof client.runs.joinStream;
 
   return client;
 }

--- a/frontend/tests/unit/core/api/api-client.test.ts
+++ b/frontend/tests/unit/core/api/api-client.test.ts
@@ -62,6 +62,16 @@ test("keeps newer reconnect metadata", () => {
   expect(sessionStorage.removeItem).not.toHaveBeenCalled();
 });
 
+test("ignores reconnect metadata storage access failures", () => {
+  vi.stubGlobal("window", {
+    get sessionStorage() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+  });
+
+  expect(() => clearReconnectRun("thread-1", "run-1")).not.toThrow();
+});
+
 test("clears stale reconnect metadata when join stream cannot be resumed", async () => {
   const sessionStorage = makeSessionStorage();
   sessionStorage.setItem("lg:stream:thread-1", "run-1");
@@ -87,4 +97,27 @@ test("clears stale reconnect metadata when join stream cannot be resumed", async
   ).resolves.toMatchObject({ done: true });
 
   expect(sessionStorage.removeItem).toHaveBeenCalledWith("lg:stream:thread-1");
+});
+
+test("rethrows unrelated streaming errors", async () => {
+  const sessionStorage = makeSessionStorage();
+  sessionStorage.setItem("lg:stream:thread-1", "run-1");
+  vi.stubGlobal("window", {
+    location: { origin: "http://localhost:2026" },
+    sessionStorage,
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      return new Response(JSON.stringify({ detail: "run is still active" }), {
+        status: 409,
+      });
+    }),
+  );
+
+  await expect(
+    getAPIClient(true).runs.joinStream("thread-1", "run-1").next(),
+  ).rejects.toThrow("HTTP 409");
+
+  expect(sessionStorage.removeItem).not.toHaveBeenCalled();
 });

--- a/frontend/tests/unit/core/api/api-client.test.ts
+++ b/frontend/tests/unit/core/api/api-client.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import {
+  clearReconnectRun,
+  getAPIClient,
+  isInactiveRunStreamError,
+} from "@/core/api/api-client";
+
+function makeSessionStorage() {
+  const values = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    removeItem: vi.fn((key: string) => {
+      values.delete(key);
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      values.set(key, value);
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("identifies inactive run stream errors", () => {
+  const error = Object.assign(
+    new Error(
+      'HTTP 409: {"detail":"Run run-1 is not active on this worker and cannot be streamed"}',
+    ),
+    { status: 409 },
+  );
+
+  expect(isInactiveRunStreamError(error)).toBe(true);
+});
+
+test("does not classify unrelated conflict errors as inactive streams", () => {
+  const error = Object.assign(new Error("HTTP 409: run is still active"), {
+    status: 409,
+  });
+
+  expect(isInactiveRunStreamError(error)).toBe(false);
+});
+
+test("clears matching reconnect metadata", () => {
+  const sessionStorage = makeSessionStorage();
+  sessionStorage.setItem("lg:stream:thread-1", "run-1");
+  vi.stubGlobal("window", { sessionStorage });
+
+  clearReconnectRun("thread-1", "run-1");
+
+  expect(sessionStorage.removeItem).toHaveBeenCalledWith("lg:stream:thread-1");
+});
+
+test("keeps newer reconnect metadata", () => {
+  const sessionStorage = makeSessionStorage();
+  sessionStorage.setItem("lg:stream:thread-1", "newer-run");
+  vi.stubGlobal("window", { sessionStorage });
+
+  clearReconnectRun("thread-1", "stale-run");
+
+  expect(sessionStorage.removeItem).not.toHaveBeenCalled();
+});
+
+test("clears stale reconnect metadata when join stream cannot be resumed", async () => {
+  const sessionStorage = makeSessionStorage();
+  sessionStorage.setItem("lg:stream:thread-1", "run-1");
+  vi.stubGlobal("window", {
+    location: { origin: "http://localhost:2026" },
+    sessionStorage,
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          detail:
+            "Run run-1 is not active on this worker and cannot be streamed",
+        }),
+        { status: 409 },
+      );
+    }),
+  );
+
+  await expect(
+    getAPIClient(true).runs.joinStream("thread-1", "run-1").next(),
+  ).resolves.toMatchObject({ done: true });
+
+  expect(sessionStorage.removeItem).toHaveBeenCalledWith("lg:stream:thread-1");
+});


### PR DESCRIPTION
## Why

A stale LangGraph reconnect run id can remain in `sessionStorage` after a dev server restart or when the active run is no longer available on the current worker.

When `useStream({ reconnectOnMount: true })` mounts again, the frontend tries to `joinStream` that old run id. The gateway correctly returns:

`HTTP 409: Run ... is not active on this worker and cannot be streamed`

However, the frontend currently surfaces this as a user-visible error and keeps the stale reconnect metadata, so refreshing the page can keep hitting the same failure.

## What changed

- Detect the specific inactive-run streaming 409 returned by the gateway.
- Clear the matching `lg:stream:<threadId>` reconnect entry from `sessionStorage`.
- Let that stale reconnect attempt finish quietly.
- Keep unrelated 409 errors untouched and rethrow them normally.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — stale reconnect 409s are now treated as expired reconnect state instead of surfaced as errors
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

No screenshot. This is a frontend stream reconnect error-handling fix with no visible UI change.

## Bug fix verification

Test path that reproduces the bug:

`frontend/tests/unit/core/api/api-client.test.ts`

The regression test simulates `joinStream` receiving the inactive-run 409 and verifies that the stale reconnect metadata is cleared without surfacing an error.

Did it go red on `main` and green on this branch?

Not explicitly run on `main`. The new test covers behavior that was missing on `main`, where inactive-run 409s were not handled by the frontend client wrapper.

## Validation

```bash
cd frontend
pnpm vitest run tests/unit/core/api/api-client.test.ts
pnpm check
pnpm prettier --check src/core/api/api-client.ts tests/unit/core/api/api-client.test.ts