### PR TITLE
fix(agent): truncate oversized tool outputs

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -77,9 +77,11 @@ def _build_runtime_middlewares(
     """Build shared base middlewares for agent execution."""
     from deerflow.agents.middlewares.llm_error_handling_middleware import LLMErrorHandlingMiddleware
     from deerflow.agents.middlewares.thread_data_middleware import ThreadDataMiddleware
+    from deerflow.agents.middlewares.tool_output_truncation_middleware import ToolOutputTruncationMiddleware
     from deerflow.sandbox.middleware import SandboxMiddleware
 
     middlewares: list[AgentMiddleware] = [
+        ToolOutputTruncationMiddleware.from_config(app_config),
         ThreadDataMiddleware(lazy_init=lazy_init),
         SandboxMiddleware(lazy_init=lazy_init),
     ]
@@ -87,7 +89,7 @@ def _build_runtime_middlewares(
     if include_uploads:
         from deerflow.agents.middlewares.uploads_middleware import UploadsMiddleware
 
-        middlewares.insert(1, UploadsMiddleware())
+        middlewares.insert(2, UploadsMiddleware())
 
     if include_dangling_tool_call_patch:
         from deerflow.agents.middlewares.dangling_tool_call_middleware import DanglingToolCallMiddleware

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_output_truncation_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_output_truncation_middleware.py
@@ -1,0 +1,180 @@
+"""Truncate oversized tool results before they reach the next model call."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from typing import Any, override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from deerflow.config.app_config import AppConfig
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOOL_OUTPUT_MAX_BYTES = 50_000
+_TRUNCATED_PREFIX = "[输出已截断，共{total_bytes}字节] 请使用过滤条件缩小查询范围"
+
+
+def _message_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        if all(isinstance(part, str) for part in content):
+            return "".join(content)
+        pieces: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                pieces.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if isinstance(text, str):
+                    pieces.append(text)
+        return "\n".join(pieces)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _truncate_text(text: str, max_bytes: int) -> tuple[str, bool, int]:
+    if max_bytes <= 0:
+        return text, False, len(text.encode("utf-8"))
+
+    encoded = text.encode("utf-8")
+    total_bytes = len(encoded)
+    if total_bytes <= max_bytes:
+        return text, False, total_bytes
+
+    kept = encoded[:max_bytes]
+    while kept:
+        try:
+            truncated_text = kept.decode("utf-8")
+            break
+        except UnicodeDecodeError:
+            kept = kept[:-1]
+    else:
+        truncated_text = ""
+
+    return truncated_text, True, total_bytes
+
+
+def _truncate_tool_message(message: ToolMessage, max_bytes: int) -> ToolMessage:
+    text = _message_text(message.content)
+    truncated_text, truncated, total_bytes = _truncate_text(text, max_bytes)
+    if not truncated:
+        return message
+
+    prefix = _TRUNCATED_PREFIX.format(total_bytes=total_bytes)
+    if truncated_text:
+        content = f"{prefix}\n{truncated_text}"
+    else:
+        content = prefix
+
+    logger.warning(
+        "Truncated tool result before model call: name=%s id=%s size=%d bytes limit=%d",
+        message.name,
+        message.tool_call_id,
+        total_bytes,
+        max_bytes,
+    )
+
+    update: dict[str, Any] = {"content": content}
+    if getattr(message, "response_metadata", None):
+        update["response_metadata"] = dict(message.response_metadata)
+    if getattr(message, "additional_kwargs", None):
+        update["additional_kwargs"] = dict(message.additional_kwargs)
+    return message.model_copy(update=update)
+
+
+def _truncate_messages(messages: list[Any], max_bytes: int) -> list[Any]:
+    updated: list[Any] = []
+    changed = False
+    for msg in messages:
+        if isinstance(msg, ToolMessage):
+            new_msg = _truncate_tool_message(msg, max_bytes)
+            if new_msg is not msg:
+                changed = True
+            updated.append(new_msg)
+        else:
+            updated.append(msg)
+    return updated if changed else messages
+
+
+def _truncate_result(result: ToolMessage | Command, max_bytes: int) -> ToolMessage | Command:
+    if isinstance(result, ToolMessage):
+        return _truncate_tool_message(result, max_bytes)
+
+    update = getattr(result, "update", None)
+    if not isinstance(update, dict):
+        return result
+
+    messages = update.get("messages")
+    if not isinstance(messages, list):
+        return result
+
+    new_messages = _truncate_messages(messages, max_bytes)
+    if new_messages is messages:
+        return result
+
+    return replace(result, update={**update, "messages": new_messages})
+
+
+class ToolOutputTruncationMiddleware(AgentMiddleware[AgentState]):
+    """Clamp tool results so oversized outputs cannot blow the model context."""
+
+    def __init__(self, *, max_bytes: int = _DEFAULT_TOOL_OUTPUT_MAX_BYTES) -> None:
+        super().__init__()
+        self.max_bytes = max(0, max_bytes)
+
+    @classmethod
+    def from_config(cls, config: AppConfig) -> ToolOutputTruncationMiddleware:
+        return cls(max_bytes=getattr(config.tool_output, "max_bytes", _DEFAULT_TOOL_OUTPUT_MAX_BYTES))
+
+    def _truncate_model_request(self, request: ModelRequest) -> ModelRequest:
+        messages = getattr(request, "messages", [])
+        if not isinstance(messages, list):
+            return request
+
+        new_messages = _truncate_messages(messages, self.max_bytes)
+        if new_messages is messages:
+            return request
+
+        return request.override(messages=new_messages)
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        return handler(self._truncate_model_request(request))
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        return await handler(self._truncate_model_request(request))
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        return _truncate_result(handler(request), self.max_bytes)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        return _truncate_result(await handler(request), self.max_bytes)

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -30,6 +30,7 @@ from deerflow.config.summarization_config import SummarizationConfig, load_summa
 from deerflow.config.title_config import TitleConfig, load_title_config_from_dict
 from deerflow.config.token_usage_config import TokenUsageConfig
 from deerflow.config.tool_config import ToolConfig, ToolGroupConfig
+from deerflow.config.tool_output_config import ToolOutputConfig
 from deerflow.config.tool_search_config import ToolSearchConfig, load_tool_search_config_from_dict
 
 load_dotenv()
@@ -94,6 +95,7 @@ class AppConfig(BaseModel):
     skill_evolution: SkillEvolutionConfig = Field(default_factory=SkillEvolutionConfig, description="Agent-managed skill evolution configuration")
     extensions: ExtensionsConfig = Field(default_factory=ExtensionsConfig, description="Extensions configuration (MCP servers and skills state)")
     tool_search: ToolSearchConfig = Field(default_factory=ToolSearchConfig, description="Tool search / deferred loading configuration")
+    tool_output: ToolOutputConfig = Field(default_factory=ToolOutputConfig, description="Generic tool output truncation configuration")
     title: TitleConfig = Field(default_factory=TitleConfig, description="Automatic title generation configuration")
     summarization: SummarizationConfig = Field(default_factory=SummarizationConfig, description="Conversation summarization configuration")
     memory: MemoryConfig = Field(default_factory=MemoryConfig, description="Memory subsystem configuration")
@@ -196,6 +198,7 @@ class AppConfig(BaseModel):
         load_agents_api_config_from_dict(config.agents_api.model_dump())
         load_subagents_config_from_dict(config.subagents.model_dump())
         load_tool_search_config_from_dict(config.tool_search.model_dump())
+        # tool_output is currently a plain config object only; no singleton state.
         load_guardrails_config_from_dict(config.guardrails.model_dump())
         load_checkpointer_config_from_dict(config.checkpointer.model_dump() if config.checkpointer is not None else None)
         load_stream_bridge_config_from_dict(config.stream_bridge.model_dump() if config.stream_bridge is not None else None)

--- a/backend/packages/harness/deerflow/config/tool_output_config.py
+++ b/backend/packages/harness/deerflow/config/tool_output_config.py
@@ -1,0 +1,13 @@
+"""Configuration for generic tool output protection."""
+
+from pydantic import BaseModel, Field
+
+
+class ToolOutputConfig(BaseModel):
+    """Config section for tool-result output limits."""
+
+    max_bytes: int = Field(
+        default=50_000,
+        ge=0,
+        description="Maximum UTF-8 bytes to keep from any tool result before it is sent back to the model. Set to 0 to disable truncation.",
+    )

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -9,6 +9,7 @@ from deerflow.agents.middlewares.tool_error_handling_middleware import (
     ToolErrorHandlingMiddleware,
     build_subagent_runtime_middlewares,
 )
+from deerflow.agents.middlewares.tool_output_truncation_middleware import ToolOutputTruncationMiddleware
 from deerflow.agents.middlewares.view_image_middleware import ViewImageMiddleware
 from deerflow.config.app_config import AppConfig, CircuitBreakerConfig
 from deerflow.config.guardrails_config import GuardrailsConfig
@@ -134,12 +135,13 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
     middlewares = build_subagent_runtime_middlewares(app_config=app_config, lazy_init=False)
 
     assert captured["app_config"] is app_config
-    # 6 baseline (ThreadData, Sandbox, DanglingToolCall, LLMErrorHandling,
-    # SandboxAudit, ToolErrorHandling) + 1 SafetyFinishReasonMiddleware
+    # 7 baseline (ToolOutputTruncation, ThreadData, Sandbox, DanglingToolCall,
+    # LLMErrorHandling, SandboxAudit, ToolErrorHandling) + 1 SafetyFinishReasonMiddleware
     # (enabled by default — see SafetyFinishReasonConfig).
     from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
 
-    assert len(middlewares) == 7
+    assert len(middlewares) == 8
+    assert isinstance(middlewares[0], ToolOutputTruncationMiddleware)
     assert any(isinstance(m, ToolErrorHandlingMiddleware) for m in middlewares)
     assert isinstance(middlewares[-1], SafetyFinishReasonMiddleware)
 

--- a/backend/tests/test_tool_output_truncation_middleware.py
+++ b/backend/tests/test_tool_output_truncation_middleware.py
@@ -1,0 +1,140 @@
+from types import SimpleNamespace
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from deerflow.agents.middlewares.tool_output_truncation_middleware import ToolOutputTruncationMiddleware
+from deerflow.config.app_config import AppConfig
+from deerflow.config.sandbox_config import SandboxConfig
+
+
+def _request(name: str = "remote_executor", tool_call_id: str = "tc-1"):
+    return SimpleNamespace(tool_call={"name": name, "id": tool_call_id})
+
+
+def test_tool_message_over_limit_is_truncated_with_standard_hint():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=10)
+    message = ToolMessage(content="a" * 200, tool_call_id="tc-1", name="remote_executor")
+
+    result = middleware.wrap_tool_call(_request(), lambda _req: message)
+
+    assert isinstance(result, ToolMessage)
+    assert result.tool_call_id == "tc-1"
+    assert result.name == "remote_executor"
+    assert result.status == "success"
+    assert result.text.startswith("[输出已截断，共200字节] 请使用过滤条件缩小查询范围\n")
+    assert result.text.endswith("a" * 10)
+    assert len(result.text.encode("utf-8")) < len(message.text.encode("utf-8"))
+
+
+def test_tool_message_under_limit_is_preserved():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=50)
+    message = ToolMessage(content="small output", tool_call_id="tc-1", name="remote_executor")
+
+    result = middleware.wrap_tool_call(_request(), lambda _req: message)
+
+    assert result is message
+
+
+def test_zero_limit_disables_truncation():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=0)
+    message = ToolMessage(content="a" * 100, tool_call_id="tc-1", name="remote_executor")
+
+    result = middleware.wrap_tool_call(_request(), lambda _req: message)
+
+    assert result is message
+
+
+def test_truncation_respects_utf8_boundaries():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=5)
+    message = ToolMessage(content="你好世界", tool_call_id="tc-1", name="remote_executor")
+
+    result = middleware.wrap_tool_call(_request(), lambda _req: message)
+
+    assert isinstance(result, ToolMessage)
+    assert result.text.startswith("[输出已截断，共12字节] 请使用过滤条件缩小查询范围\n")
+    assert result.text.endswith("你")
+
+
+def test_command_update_messages_are_truncated():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=12)
+    tool_message = ToolMessage(content="x" * 40, tool_call_id="tc-1", name="present_files")
+    command = Command(update={"messages": [tool_message], "artifacts": ["/mnt/user-data/outputs/report.md"]})
+
+    result = middleware.wrap_tool_call(_request(name="present_files"), lambda _req: command)
+
+    assert isinstance(result, Command)
+    assert result is not command
+    assert result.update["artifacts"] == ["/mnt/user-data/outputs/report.md"]
+    new_message = result.update["messages"][0]
+    assert isinstance(new_message, ToolMessage)
+    assert new_message.text.startswith("[输出已截断，共40字节] 请使用过滤条件缩小查询范围\n")
+    assert new_message.text.endswith("x" * 12)
+
+
+def test_model_request_history_tool_messages_are_truncated():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=15)
+    oversized = ToolMessage(content="h" * 60, tool_call_id="tc-history", name="remote_executor")
+    request = ModelRequest(model=None, messages=[oversized], tools=[], state={})
+    captured: dict[str, ModelRequest] = {}
+
+    def handler(req):
+        captured["request"] = req
+        return []
+
+    middleware.wrap_model_call(request, handler)
+
+    forwarded = captured["request"]
+    assert forwarded is not request
+    new_message = forwarded.messages[0]
+    assert isinstance(new_message, ToolMessage)
+    assert new_message.text.startswith("[输出已截断，共60字节] 请使用过滤条件缩小查询范围\n")
+    assert new_message.text.endswith("h" * 15)
+
+
+def test_from_config_uses_tool_output_limit():
+    config = AppConfig(
+        sandbox=SandboxConfig(use="test"),
+        tool_output={"max_bytes": 123},
+    )
+
+    middleware = ToolOutputTruncationMiddleware.from_config(config)
+
+    assert middleware.max_bytes == 123
+
+
+@pytest.mark.anyio
+async def test_async_tool_message_over_limit_is_truncated():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=8)
+    message = ToolMessage(content="z" * 20, tool_call_id="tc-async", name="remote_executor")
+
+    async def handler(_request):
+        return message
+
+    result = await middleware.awrap_tool_call(_request(tool_call_id="tc-async"), handler)
+
+    assert isinstance(result, ToolMessage)
+    assert result.tool_call_id == "tc-async"
+    assert result.text.startswith("[输出已截断，共20字节] 请使用过滤条件缩小查询范围\n")
+    assert result.text.endswith("z" * 8)
+
+
+@pytest.mark.anyio
+async def test_async_model_request_history_tool_messages_are_truncated():
+    middleware = ToolOutputTruncationMiddleware(max_bytes=6)
+    oversized = ToolMessage(content="q" * 30, tool_call_id="tc-history", name="remote_executor")
+    request = ModelRequest(model=None, messages=[oversized], tools=[], state={})
+    captured: dict[str, ModelRequest] = {}
+
+    async def handler(req):
+        captured["request"] = req
+        return []
+
+    await middleware.awrap_model_call(request, handler)
+
+    new_message = captured["request"].messages[0]
+    assert isinstance(new_message, ToolMessage)
+    assert new_message.text.startswith("[输出已截断，共30字节] 请使用过滤条件缩小查询范围\n")
+    assert new_message.text.endswith("q" * 6)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 10
+config_version: 11
 
 # ============================================================================
 # Logging
@@ -511,6 +511,16 @@ tools:
 
 tool_search:
   enabled: false
+
+# ============================================================================
+# Tool Output Protection
+# ============================================================================
+# Maximum UTF-8 bytes to keep from any tool result before it is sent back to the
+# model. This protects the next model call from oversized external tool output.
+# Set to 0 to disable.
+
+tool_output:
+  max_bytes: 50000
 
 # ============================================================================
 # Loop Detection Configuration


### PR DESCRIPTION
## 概要

修复 #3289。

新增通用工具输出保护层，避免外部工具返回超大结果后被原样传入下一轮 LLM 上下文，导致上下文溢出。

- 新增 `ToolOutputTruncationMiddleware`，默认限制为 50KB UTF-8 字节。
- 覆盖普通 `ToolMessage` 和 `Command(update={"messages": [...]})` 形式的工具返回。
- 在模型调用前也会截断历史 `ToolMessage`，因此从 checkpoint 恢复时，如果历史里已有超大工具输出，也能继续执行。
- 新增 `tool_output.max_bytes` 配置项，并更新 `config.example.yaml`。

## 测试

- `python -m pytest tests/test_tool_output_truncation_middleware.py tests/test_tool_error_handling_middleware.py tests/test_app_config_reload.py tests/test_config_version.py tests/test_lead_agent_model_resolution.py -q`
- `python -m ruff check packages/harness/deerflow/agents/middlewares/tool_output_truncation_middleware.py packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py packages/harness/deerflow/config/app_config.py packages/harness/deerflow/config/tool_output_config.py tests/test_tool_output_truncation_middleware.py tests/test_tool_error_handling_middleware.py`
