### PR TITLE
fix: render assistant text bubble for messages with tool calls

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -90,19 +90,30 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
     }
 
     if (message.type === "ai") {
+      const messageHasContent = hasContent(message);
+      const messageHasToolCalls = hasToolCalls(message);
+      const messageHasReasoning = hasReasoning(message);
+      const needsProcessing = messageHasReasoning || messageHasToolCalls;
+
       if (hasPresentFiles(message)) {
         groups.push({
           id: message.id,
           type: "assistant:present-files",
           messages: [message],
         });
-      } else if (hasSubagent(message)) {
+        continue;
+      }
+
+      if (hasSubagent(message)) {
         groups.push({
           id: message.id,
           type: "assistant:subagent",
           messages: [message],
         });
-      } else if (hasReasoning(message) || hasToolCalls(message)) {
+        continue;
+      }
+
+      if (needsProcessing) {
         const lastGroup = groups[groups.length - 1];
         // Accumulate consecutive intermediate AI messages into one processing group.
         if (lastGroup?.type !== "assistant:processing") {
@@ -116,10 +127,29 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
         }
       }
 
-      // Not an else-if: a message with reasoning + content (but no tool calls) goes
-      // into the processing group above AND gets its own assistant bubble here.
-      if (hasContent(message) && !hasToolCalls(message)) {
-        groups.push({ id: message.id, type: "assistant", messages: [message] });
+      // Not an else-if: a message with reasoning + content goes into the
+      // processing group above AND gets its own assistant bubble. This
+      // includes messages with tool calls — their text content was previously
+      // hidden behind the Chain of Thought panel.
+      //
+      // When *this message* triggered a processing group, insert the
+      // assistant bubble BEFORE it so lastOpenGroup() still finds the
+      // processing group for subsequent tool messages. Otherwise push
+      // normally at the end (plain final answer).
+      if (messageHasContent) {
+        const authorGroup = {
+          id: message.id,
+          type: "assistant" as const,
+          messages: [message],
+        };
+        if (
+          messageHasToolCalls &&
+          groups[groups.length - 1]?.type === "assistant:processing"
+        ) {
+          groups.splice(groups.length - 1, 0, authorGroup);
+        } else {
+          groups.push(authorGroup);
+        }
       }
     }
   }

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -95,23 +95,14 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
       const messageHasReasoning = hasReasoning(message);
       const needsProcessing = messageHasReasoning || messageHasToolCalls;
 
+      // The present-files renderer shows visible text and the file-list panel
+      // from this single group, so do not also create an assistant bubble.
       if (hasPresentFiles(message)) {
-        // Show visible text in a regular assistant bubble so "Here are
-        // the files…" renders before the file-list panel.
-        if (messageHasContent) {
-          groups.push({
-            id: message.id,
-            type: "assistant",
-            messages: [message],
-          });
-        }
-
         groups.push({
           id: message.id,
           type: "assistant:present-files",
           messages: [message],
         });
-
         continue;
       }
 

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -96,20 +96,42 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
       const needsProcessing = messageHasReasoning || messageHasToolCalls;
 
       if (hasPresentFiles(message)) {
+        // Show visible text in a regular assistant bubble so "Here are
+        // the files…" renders before the file-list panel.
+        if (messageHasContent) {
+          groups.push({
+            id: message.id,
+            type: "assistant",
+            messages: [message],
+          });
+        }
+
         groups.push({
           id: message.id,
           type: "assistant:present-files",
           messages: [message],
         });
+
         continue;
       }
 
       if (hasSubagent(message)) {
+        // Render visible text in a regular assistant bubble so the user
+        // sees "Launching a subagent…" before the subagent panel unfolds.
+        if (messageHasContent) {
+          groups.push({
+            id: message.id,
+            type: "assistant",
+            messages: [message],
+          });
+        }
+
         groups.push({
           id: message.id,
           type: "assistant:subagent",
           messages: [message],
         });
+
         continue;
       }
 

--- a/frontend/tests/unit/core/messages/utils-regression.test.ts
+++ b/frontend/tests/unit/core/messages/utils-regression.test.ts
@@ -123,7 +123,13 @@ describe("regression: tool-call messages must not swallow text/reasoning content
           id: "ai-1",
           type: "ai",
           content: "Launching a subagent to help",
-          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+          tool_calls: [
+            {
+              id: "tc-1",
+              name: "task",
+              args: { subagent_type: "general-purpose" },
+            },
+          ],
         },
       ] as Message[];
 
@@ -154,7 +160,13 @@ describe("regression: tool-call messages must not swallow text/reasoning content
           id: "ai-1",
           type: "ai",
           content: "Launching a subagent to help",
-          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+          tool_calls: [
+            {
+              id: "tc-1",
+              name: "task",
+              args: { subagent_type: "general-purpose" },
+            },
+          ],
         },
         {
           id: "tool-1",
@@ -192,16 +204,36 @@ describe("regression: tool-call messages must not swallow text/reasoning content
           id: "ai-2",
           type: "ai",
           content: "Launching subagent",
-          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+          tool_calls: [
+            {
+              id: "tc-1",
+              name: "task",
+              args: { subagent_type: "general-purpose" },
+            },
+          ],
         },
-        { id: "tool-1", type: "tool", name: "task", tool_call_id: "tc-1", content: "Subagent done" },
+        {
+          id: "tool-1",
+          type: "tool",
+          name: "task",
+          tool_call_id: "tc-1",
+          content: "Subagent done",
+        },
         {
           id: "ai-3",
           type: "ai",
           content: "Now let me search the web",
-          tool_calls: [{ id: "tc-2", name: "web_search", args: { query: "test" } }],
+          tool_calls: [
+            { id: "tc-2", name: "web_search", args: { query: "test" } },
+          ],
         },
-        { id: "tool-2", type: "tool", name: "web_search", tool_call_id: "tc-2", content: "Results found" },
+        {
+          id: "tool-2",
+          type: "tool",
+          name: "web_search",
+          tool_call_id: "tc-2",
+          content: "Results found",
+        },
         { id: "ai-4", type: "ai", content: "Here is the combined result" },
       ] as Message[];
 
@@ -225,13 +257,18 @@ describe("regression: tool-call messages must not swallow text/reasoning content
       expect(groups.find((g) => g.id === "ai-1")!.messages[0]!.id).toBe("ai-1");
 
       // Subagent assistant bubble: ai-2's visible content is shown.
-      const subagentBubble = groups.find((g) => g.id === "ai-2" && g.type === "assistant");
+      const subagentBubble = groups.find(
+        (g) => g.id === "ai-2" && g.type === "assistant",
+      );
       expect(subagentBubble).toBeDefined();
       expect(subagentBubble!.messages[0]!.content).toBe("Launching subagent");
 
       // Subagent group: ai-2 + tool-1 (tool result goes to subagent via lastOpenGroup)
       const subagentGroup = groups.find((g) => g.type === "assistant:subagent");
-      expect(subagentGroup!.messages.map((m) => m.id)).toEqual(["ai-2", "tool-1"]);
+      expect(subagentGroup!.messages.map((m) => m.id)).toEqual([
+        "ai-2",
+        "tool-1",
+      ]);
 
       // The only processing group is for the web_search turn (ai-3 + tool-2).
       // Subagent messages skip the generic needsProcessing path entirely.

--- a/frontend/tests/unit/core/messages/utils-regression.test.ts
+++ b/frontend/tests/unit/core/messages/utils-regression.test.ts
@@ -1,0 +1,117 @@
+import type { AIMessage, Message } from "@langchain/langgraph-sdk";
+import { describe, expect, test } from "vitest";
+
+import { getMessageGroups } from "@/core/messages/utils";
+
+describe("regression: tool-call messages must not swallow text/reasoning content", () => {
+  test("AI message with tool_calls + text content generates both processing and assistant bubble", () => {
+    const messages = [
+      {
+        id: "human-1",
+        type: "human",
+        content: "Search for deer",
+      },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "Let me search that for you",
+        tool_calls: [
+          { id: "tc-1", name: "web_search", args: { query: "deer" } },
+        ],
+      },
+      {
+        id: "tool-1",
+        type: "tool",
+        name: "web_search",
+        tool_call_id: "tc-1",
+        content: "Results about deer",
+      },
+      {
+        id: "ai-2",
+        type: "ai",
+        content: "Here is what I found",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant",
+      "assistant:processing",
+      "assistant",
+    ]);
+
+    // The assistant bubble with the tool-call message text must exist
+    // and contain the visible content.
+    const assistantGroups = groups.filter((g) => g.type === "assistant");
+    expect(assistantGroups).toHaveLength(2);
+    expect(assistantGroups[0]!.messages).toHaveLength(1);
+    expect(assistantGroups[0]!.messages[0]!.content).toBe(
+      "Let me search that for you",
+    );
+
+    // The processing group must contain the tool-call AI + tool result.
+    const processingGroup = groups.find(
+      (g) => g.type === "assistant:processing",
+    );
+    expect(processingGroup).toBeDefined();
+    expect(processingGroup!.messages.map((m) => m.id)).toEqual([
+      "ai-1",
+      "tool-1",
+    ]);
+  });
+
+  test("AI message with reasoning + tool_calls + text content produces all three", () => {
+    const messages = [
+      {
+        id: "human-1",
+        type: "human",
+        content: "Hello",
+      },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "<think>need to search</think>Let me check",
+        tool_calls: [{ id: "tc-1", name: "web_search", args: {} }],
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    // Order: human, assistant bubble (before processing), processing
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant",
+      "assistant:processing",
+    ]);
+
+    const assistantGroup = groups.find((g) => g.type === "assistant");
+    expect(assistantGroup).toBeDefined();
+    // The visible content after stripping <think> should be "Let me check"
+    expect(assistantGroup!.messages[0]!.content).toContain("Let me check");
+
+    // The processing group must be the last group (after the assistant bubble)
+    // and contain both reasoning and tool_calls.
+    const processingGroup = groups.at(-1);
+    expect(processingGroup?.type).toBe("assistant:processing");
+    expect(processingGroup!.messages).toHaveLength(1);
+
+    const processingMessage = processingGroup!.messages[0]! as AIMessage;
+    expect(processingMessage.id).toBe("ai-1");
+    // Both reasoning (<think>) and tool_calls must be present
+    expect(processingMessage.content).toContain("<think>");
+    expect(processingMessage.tool_calls).toBeDefined();
+    expect(processingMessage.tool_calls).toHaveLength(1);
+  });
+
+  test("plain AI answer without tool_calls produces only an assistant bubble", () => {
+    const messages = [
+      { id: "human-1", type: "human", content: "Hi" },
+      { id: "ai-1", type: "ai", content: "Hello there" },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+    expect(groups.map((g) => g.type)).toEqual(["human", "assistant"]);
+  });
+});

--- a/frontend/tests/unit/core/messages/utils-regression.test.ts
+++ b/frontend/tests/unit/core/messages/utils-regression.test.ts
@@ -114,4 +114,232 @@ describe("regression: tool-call messages must not swallow text/reasoning content
     const groups = getMessageGroups(messages);
     expect(groups.map((g) => g.type)).toEqual(["human", "assistant"]);
   });
+
+  describe("subagent ordering", () => {
+    test("subagent message shows visible content in assistant bubble, then subagent group", () => {
+      const messages = [
+        { id: "human-1", type: "human", content: "Run a subagent" },
+        {
+          id: "ai-1",
+          type: "ai",
+          content: "Launching a subagent to help",
+          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+        },
+      ] as Message[];
+
+      const groups = getMessageGroups(messages);
+
+      // hasSubagent is checked before needsProcessing. The user-visible text
+      // goes into a regular assistant bubble, then the subagent group is
+      // created to collect follow-up tool results. No processing group is
+      // needed — the subagent group itself acts as the processing container.
+      expect(groups.map((g) => g.type)).toEqual([
+        "human",
+        "assistant",
+        "assistant:subagent",
+      ]);
+
+      // The assistant bubble contains the visible text.
+      const assistantGroup = groups.find((g) => g.type === "assistant");
+      expect(assistantGroup).toBeDefined();
+      expect(assistantGroup!.messages[0]!.content).toBe(
+        "Launching a subagent to help",
+      );
+    });
+
+    test("subagent tool result lands in the subagent group", () => {
+      const messages = [
+        { id: "human-1", type: "human", content: "Run a subagent" },
+        {
+          id: "ai-1",
+          type: "ai",
+          content: "Launching a subagent to help",
+          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+        },
+        {
+          id: "tool-1",
+          type: "tool",
+          name: "task",
+          tool_call_id: "tc-1",
+          content: "Subagent completed",
+        },
+      ] as Message[];
+
+      const groups = getMessageGroups(messages);
+
+      // tool-1 is absorbed by the subagent group (the last open group),
+      // not by the processing group.
+      const subagentGroup = groups.find((g) => g.type === "assistant:subagent");
+      expect(subagentGroup!.messages.map((m) => m.id)).toEqual([
+        "ai-1",
+        "tool-1",
+      ]);
+
+      // Subagent messages skip the generic needsProcessing path, so there
+      // is no assistant:processing group — the subagent group itself acts
+      // as the tool-result container.
+      const processingGroup = groups.find(
+        (g) => g.type === "assistant:processing",
+      );
+      expect(processingGroup).toBeUndefined();
+    });
+
+    test("human, plain ai, subagent ai, tool, web_search ai, tool, final ai — mixed turn", () => {
+      const messages = [
+        { id: "human-1", type: "human", content: "Run a subagent then search" },
+        { id: "ai-1", type: "ai", content: "Let me delegate and search" },
+        {
+          id: "ai-2",
+          type: "ai",
+          content: "Launching subagent",
+          tool_calls: [{ id: "tc-1", name: "task", args: { subagent_type: "general-purpose" } }],
+        },
+        { id: "tool-1", type: "tool", name: "task", tool_call_id: "tc-1", content: "Subagent done" },
+        {
+          id: "ai-3",
+          type: "ai",
+          content: "Now let me search the web",
+          tool_calls: [{ id: "tc-2", name: "web_search", args: { query: "test" } }],
+        },
+        { id: "tool-2", type: "tool", name: "web_search", tool_call_id: "tc-2", content: "Results found" },
+        { id: "ai-4", type: "ai", content: "Here is the combined result" },
+      ] as Message[];
+
+      const groups = getMessageGroups(messages);
+
+      // Subagent messages (hasSubagent) are checked before needsProcessing.
+      // They get a regular assistant bubble for visible text + a subagent
+      // group for tool results — no processing group. Regular tool calls
+      // (like web_search) still get assistant + processing.
+      expect(groups.map((g) => g.type)).toEqual([
+        "human",
+        "assistant",
+        "assistant",
+        "assistant:subagent",
+        "assistant",
+        "assistant:processing",
+        "assistant",
+      ]);
+
+      // ai-1: plain → own bubble
+      expect(groups.find((g) => g.id === "ai-1")!.messages[0]!.id).toBe("ai-1");
+
+      // Subagent assistant bubble: ai-2's visible content is shown.
+      const subagentBubble = groups.find((g) => g.id === "ai-2" && g.type === "assistant");
+      expect(subagentBubble).toBeDefined();
+      expect(subagentBubble!.messages[0]!.content).toBe("Launching subagent");
+
+      // Subagent group: ai-2 + tool-1 (tool result goes to subagent via lastOpenGroup)
+      const subagentGroup = groups.find((g) => g.type === "assistant:subagent");
+      expect(subagentGroup!.messages.map((m) => m.id)).toEqual(["ai-2", "tool-1"]);
+
+      // The only processing group is for the web_search turn (ai-3 + tool-2).
+      // Subagent messages skip the generic needsProcessing path entirely.
+      const processingGroups = groups.filter(
+        (g) => g.type === "assistant:processing",
+      );
+      expect(processingGroups).toHaveLength(1);
+      expect(processingGroups[0]!.messages.map((m) => m.id)).toEqual([
+        "ai-3",
+        "tool-2",
+      ]);
+
+      // web_search bubble: ai-3 splice'd before its processing group
+      const searchBubble = groups.find((g) => g.id === "ai-3");
+      expect(searchBubble!.type).toBe("assistant");
+
+      // ai-4: final plain → own bubble
+      expect(groups.find((g) => g.id === "ai-4")!.messages[0]!.id).toBe("ai-4");
+    });
+
+    test("keeps visible content and attaches tool result for subagent task calls", () => {
+      const messages = [
+        {
+          id: "human-1",
+          type: "human",
+          content: "Run a subagent",
+        },
+        {
+          id: "ai-1",
+          type: "ai",
+          content: "Launching a subagent to help",
+          tool_calls: [
+            {
+              id: "tc-1",
+              name: "task",
+              args: { subagent_type: "general-purpose" },
+            },
+          ],
+        },
+        {
+          id: "tool-1",
+          type: "tool",
+          name: "task",
+          tool_call_id: "tc-1",
+          content: "Subagent completed: found 3 results",
+        },
+      ] as Message[];
+
+      const groups = getMessageGroups(messages);
+
+      expect(groups.map((group) => group.type)).toEqual([
+        "human",
+        "assistant",
+        "assistant:subagent",
+      ]);
+
+      expect(groups[1]!.messages.map((message) => message.id)).toEqual([
+        "ai-1",
+      ]);
+
+      expect(groups[2]!.messages.map((message) => message.id)).toEqual([
+        "ai-1",
+        "tool-1",
+      ]);
+    });
+  });
+
+  describe("present-files ordering", () => {
+    test("present_files message with visible content shows assistant bubble then file panel", () => {
+      const messages = [
+        { id: "human-1", type: "human", content: "Show me the files" },
+        {
+          id: "ai-1",
+          type: "ai",
+          content: "Here are the files you requested",
+          tool_calls: [
+            {
+              id: "tc-1",
+              name: "present_files",
+              args: { filepaths: ["/tmp/result.txt"] },
+            },
+          ],
+        },
+      ] as Message[];
+
+      const groups = getMessageGroups(messages);
+
+      // Visible text goes into a regular assistant bubble. The present-files
+      // group renders the file-list panel below it.
+      expect(groups.map((g) => g.type)).toEqual([
+        "human",
+        "assistant",
+        "assistant:present-files",
+      ]);
+
+      // Assistant bubble shows the visible text.
+      const assistantGroup = groups.find((g) => g.type === "assistant");
+      expect(assistantGroup).toBeDefined();
+      expect(assistantGroup!.messages[0]!.content).toBe(
+        "Here are the files you requested",
+      );
+
+      // Present-files group carries the tool-call data for the file panel.
+      const presentGroup = groups.find(
+        (g) => g.type === "assistant:present-files",
+      );
+      expect(presentGroup).toBeDefined();
+      expect(presentGroup!.messages[0]!.id).toBe("ai-1");
+    });
+  });
 });

--- a/frontend/tests/unit/core/messages/utils-regression.test.ts
+++ b/frontend/tests/unit/core/messages/utils-regression.test.ts
@@ -1,7 +1,10 @@
 import type { AIMessage, Message } from "@langchain/langgraph-sdk";
 import { describe, expect, test } from "vitest";
 
-import { getMessageGroups } from "@/core/messages/utils";
+import {
+  extractPresentFilesFromMessage,
+  getMessageGroups,
+} from "@/core/messages/utils";
 
 describe("regression: tool-call messages must not swallow text/reasoning content", () => {
   test("AI message with tool_calls + text content generates both processing and assistant bubble", () => {
@@ -115,268 +118,148 @@ describe("regression: tool-call messages must not swallow text/reasoning content
     expect(groups.map((g) => g.type)).toEqual(["human", "assistant"]);
   });
 
-  describe("subagent ordering", () => {
-    test("subagent message shows visible content in assistant bubble, then subagent group", () => {
-      const messages = [
-        { id: "human-1", type: "human", content: "Run a subagent" },
-        {
-          id: "ai-1",
-          type: "ai",
-          content: "Launching a subagent to help",
-          tool_calls: [
-            {
-              id: "tc-1",
-              name: "task",
-              args: { subagent_type: "general-purpose" },
+  test("AI message with files presented will not be displayed twice in processing and assistant bubble", () => {
+    const messages = [
+      { id: "human-1", type: "human", content: "Hi" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "Here are the files you requested",
+        tool_calls: [
+          {
+            id: "tc-1",
+            name: "present_files",
+            args: {
+              filepaths: ["/path/to/file1.txt", "test.txt"],
             },
-          ],
-        },
-      ] as Message[];
+          },
+        ],
+      },
+    ] as Message[];
 
-      const groups = getMessageGroups(messages);
-
-      // hasSubagent is checked before needsProcessing. The user-visible text
-      // goes into a regular assistant bubble, then the subagent group is
-      // created to collect follow-up tool results. No processing group is
-      // needed — the subagent group itself acts as the processing container.
-      expect(groups.map((g) => g.type)).toEqual([
-        "human",
-        "assistant",
-        "assistant:subagent",
-      ]);
-
-      // The assistant bubble contains the visible text.
-      const assistantGroup = groups.find((g) => g.type === "assistant");
-      expect(assistantGroup).toBeDefined();
-      expect(assistantGroup!.messages[0]!.content).toBe(
-        "Launching a subagent to help",
-      );
-    });
-
-    test("subagent tool result lands in the subagent group", () => {
-      const messages = [
-        { id: "human-1", type: "human", content: "Run a subagent" },
-        {
-          id: "ai-1",
-          type: "ai",
-          content: "Launching a subagent to help",
-          tool_calls: [
-            {
-              id: "tc-1",
-              name: "task",
-              args: { subagent_type: "general-purpose" },
-            },
-          ],
-        },
-        {
-          id: "tool-1",
-          type: "tool",
-          name: "task",
-          tool_call_id: "tc-1",
-          content: "Subagent completed",
-        },
-      ] as Message[];
-
-      const groups = getMessageGroups(messages);
-
-      // tool-1 is absorbed by the subagent group (the last open group),
-      // not by the processing group.
-      const subagentGroup = groups.find((g) => g.type === "assistant:subagent");
-      expect(subagentGroup!.messages.map((m) => m.id)).toEqual([
-        "ai-1",
-        "tool-1",
-      ]);
-
-      // Subagent messages skip the generic needsProcessing path, so there
-      // is no assistant:processing group — the subagent group itself acts
-      // as the tool-result container.
-      const processingGroup = groups.find(
-        (g) => g.type === "assistant:processing",
-      );
-      expect(processingGroup).toBeUndefined();
-    });
-
-    test("human, plain ai, subagent ai, tool, web_search ai, tool, final ai — mixed turn", () => {
-      const messages = [
-        { id: "human-1", type: "human", content: "Run a subagent then search" },
-        { id: "ai-1", type: "ai", content: "Let me delegate and search" },
-        {
-          id: "ai-2",
-          type: "ai",
-          content: "Launching subagent",
-          tool_calls: [
-            {
-              id: "tc-1",
-              name: "task",
-              args: { subagent_type: "general-purpose" },
-            },
-          ],
-        },
-        {
-          id: "tool-1",
-          type: "tool",
-          name: "task",
-          tool_call_id: "tc-1",
-          content: "Subagent done",
-        },
-        {
-          id: "ai-3",
-          type: "ai",
-          content: "Now let me search the web",
-          tool_calls: [
-            { id: "tc-2", name: "web_search", args: { query: "test" } },
-          ],
-        },
-        {
-          id: "tool-2",
-          type: "tool",
-          name: "web_search",
-          tool_call_id: "tc-2",
-          content: "Results found",
-        },
-        { id: "ai-4", type: "ai", content: "Here is the combined result" },
-      ] as Message[];
-
-      const groups = getMessageGroups(messages);
-
-      // Subagent messages (hasSubagent) are checked before needsProcessing.
-      // They get a regular assistant bubble for visible text + a subagent
-      // group for tool results — no processing group. Regular tool calls
-      // (like web_search) still get assistant + processing.
-      expect(groups.map((g) => g.type)).toEqual([
-        "human",
-        "assistant",
-        "assistant",
-        "assistant:subagent",
-        "assistant",
-        "assistant:processing",
-        "assistant",
-      ]);
-
-      // ai-1: plain → own bubble
-      expect(groups.find((g) => g.id === "ai-1")!.messages[0]!.id).toBe("ai-1");
-
-      // Subagent assistant bubble: ai-2's visible content is shown.
-      const subagentBubble = groups.find(
-        (g) => g.id === "ai-2" && g.type === "assistant",
-      );
-      expect(subagentBubble).toBeDefined();
-      expect(subagentBubble!.messages[0]!.content).toBe("Launching subagent");
-
-      // Subagent group: ai-2 + tool-1 (tool result goes to subagent via lastOpenGroup)
-      const subagentGroup = groups.find((g) => g.type === "assistant:subagent");
-      expect(subagentGroup!.messages.map((m) => m.id)).toEqual([
-        "ai-2",
-        "tool-1",
-      ]);
-
-      // The only processing group is for the web_search turn (ai-3 + tool-2).
-      // Subagent messages skip the generic needsProcessing path entirely.
-      const processingGroups = groups.filter(
-        (g) => g.type === "assistant:processing",
-      );
-      expect(processingGroups).toHaveLength(1);
-      expect(processingGroups[0]!.messages.map((m) => m.id)).toEqual([
-        "ai-3",
-        "tool-2",
-      ]);
-
-      // web_search bubble: ai-3 splice'd before its processing group
-      const searchBubble = groups.find((g) => g.id === "ai-3");
-      expect(searchBubble!.type).toBe("assistant");
-
-      // ai-4: final plain → own bubble
-      expect(groups.find((g) => g.id === "ai-4")!.messages[0]!.id).toBe("ai-4");
-    });
-
-    test("keeps visible content and attaches tool result for subagent task calls", () => {
-      const messages = [
-        {
-          id: "human-1",
-          type: "human",
-          content: "Run a subagent",
-        },
-        {
-          id: "ai-1",
-          type: "ai",
-          content: "Launching a subagent to help",
-          tool_calls: [
-            {
-              id: "tc-1",
-              name: "task",
-              args: { subagent_type: "general-purpose" },
-            },
-          ],
-        },
-        {
-          id: "tool-1",
-          type: "tool",
-          name: "task",
-          tool_call_id: "tc-1",
-          content: "Subagent completed: found 3 results",
-        },
-      ] as Message[];
-
-      const groups = getMessageGroups(messages);
-
-      expect(groups.map((group) => group.type)).toEqual([
-        "human",
-        "assistant",
-        "assistant:subagent",
-      ]);
-
-      expect(groups[1]!.messages.map((message) => message.id)).toEqual([
-        "ai-1",
-      ]);
-
-      expect(groups[2]!.messages.map((message) => message.id)).toEqual([
-        "ai-1",
-        "tool-1",
-      ]);
-    });
+    const groups = getMessageGroups(messages);
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant:present-files",
+    ]);
+    expect(groups[1]!.messages).toHaveLength(1);
+    expect(groups[1]!.messages[0]!.content).toBe(
+      "Here are the files you requested",
+    );
+    expect(extractPresentFilesFromMessage(groups[1]!.messages[0]!)).toEqual([
+      "/path/to/file1.txt",
+      "test.txt",
+    ]);
   });
 
-  describe("present-files ordering", () => {
-    test("present_files message with visible content shows assistant bubble then file panel", () => {
-      const messages = [
-        { id: "human-1", type: "human", content: "Show me the files" },
-        {
-          id: "ai-1",
-          type: "ai",
-          content: "Here are the files you requested",
-          tool_calls: [
-            {
-              id: "tc-1",
-              name: "present_files",
-              args: { filepaths: ["/tmp/result.txt"] },
+  test("present_files tool result attaches to the present-files group", () => {
+    const messages = [
+      { id: "human-1", type: "human", content: "Show me the report" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "Here is the report.",
+        tool_calls: [
+          {
+            id: "tc-1",
+            name: "present_files",
+            args: {
+              filepaths: ["/mnt/user-data/outputs/report.md"],
             },
-          ],
-        },
-      ] as Message[];
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        type: "tool",
+        name: "present_files",
+        tool_call_id: "tc-1",
+        content: "Successfully presented files",
+      },
+    ] as Message[];
 
-      const groups = getMessageGroups(messages);
+    const groups = getMessageGroups(messages);
 
-      // Visible text goes into a regular assistant bubble. The present-files
-      // group renders the file-list panel below it.
-      expect(groups.map((g) => g.type)).toEqual([
-        "human",
-        "assistant",
-        "assistant:present-files",
-      ]);
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant:present-files",
+    ]);
+    expect(groups[1]!.messages.map((message) => message.id)).toEqual([
+      "ai-1",
+      "tool-1",
+    ]);
+  });
 
-      // Assistant bubble shows the visible text.
-      const assistantGroup = groups.find((g) => g.type === "assistant");
-      expect(assistantGroup).toBeDefined();
-      expect(assistantGroup!.messages[0]!.content).toBe(
-        "Here are the files you requested",
-      );
+  test("subagent AI message with content creates assistant bubble and subagent group", () => {
+    const messages = [
+      { id: "human-1", type: "human", content: "Delegate this" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "Launching a subagent to help.",
+        tool_calls: [
+          {
+            id: "tc-1",
+            name: "task",
+            args: {
+              subagent_type: "general-purpose",
+              description: "Inspect the issue",
+              prompt: "Inspect the issue",
+            },
+          },
+        ],
+      },
+    ] as Message[];
 
-      // Present-files group carries the tool-call data for the file panel.
-      const presentGroup = groups.find(
-        (g) => g.type === "assistant:present-files",
-      );
-      expect(presentGroup).toBeDefined();
-      expect(presentGroup!.messages[0]!.id).toBe("ai-1");
-    });
+    const groups = getMessageGroups(messages);
+
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant",
+      "assistant:subagent",
+    ]);
+    expect(groups[1]!.messages.map((message) => message.id)).toEqual(["ai-1"]);
+    expect(groups[2]!.messages.map((message) => message.id)).toEqual(["ai-1"]);
+  });
+
+  test("subagent tool result attaches to the subagent group", () => {
+    const messages = [
+      { id: "human-1", type: "human", content: "Delegate this" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "Launching a subagent to help.",
+        tool_calls: [
+          {
+            id: "tc-1",
+            name: "task",
+            args: {
+              subagent_type: "general-purpose",
+              description: "Inspect the issue",
+              prompt: "Inspect the issue",
+            },
+          },
+        ],
+      },
+      {
+        id: "tool-1",
+        type: "tool",
+        name: "task",
+        tool_call_id: "tc-1",
+        content: "Done",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    expect(groups.map((g) => g.type)).toEqual([
+      "human",
+      "assistant",
+      "assistant:subagent",
+    ]);
+    expect(groups[2]!.messages.map((message) => message.id)).toEqual([
+      "ai-1",
+      "tool-1",
+    ]);
   });
 });

--- a/frontend/tests/unit/core/messages/utils-regression.test.ts
+++ b/frontend/tests/unit/core/messages/utils-regression.test.ts
@@ -219,7 +219,22 @@ describe("regression: tool-call messages must not swallow text/reasoning content
       "assistant:subagent",
     ]);
     expect(groups[1]!.messages.map((message) => message.id)).toEqual(["ai-1"]);
+    expect(groups[1]!.messages[0]!.content).toBe(
+      "Launching a subagent to help.",
+    );
     expect(groups[2]!.messages.map((message) => message.id)).toEqual(["ai-1"]);
+    expect(groups[2]!.messages[0]!.type).toBe("ai");
+    expect(groups[2]!.messages[0]!.tool_calls).toEqual([
+      {
+        id: "tc-1",
+        name: "task",
+        args: {
+          subagent_type: "general-purpose",
+          description: "Inspect the issue",
+          prompt: "Inspect the issue",
+        },
+      },
+    ]);
   });
 
   test("subagent tool result attaches to the subagent group", () => {


### PR DESCRIPTION
Fixes #3251

## Why
In the previous version, an AI message containing both text content and tool calls would be hidden from the normal assistant message stream. It would not be rendered directly to the user as a regular text bubble, and would instead only appear in the TOOL-CALLS panel or the Chain of Thought section.
This behavior does not match our expected UI behavior.
This PR ensures that assistant messages with text content are shown in the normal message stream, while Chain of Thought and tool calls continue to be displayed only in their respective panels.

## What changed
Messages with both tool_calls and text content now produce two groups: an assistant bubble (renders the reply text) and an assistant:processing group (handles the tool call chain). Previously only the processing group was created, leaving the text trapped inside the Chain of Thought panel.
The bubble is spliced before the processing group rather than pushed to the end. This keeps lastOpenGroup() working correctly — subsequent tool results still land in the processing group.
Also added a regression test covering: tool calls + text, reasoning + tool calls + text, and plain text (no tool calls).



## Surface area


- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording
<img width="2772" height="1522" alt="image" src="https://github.com/user-attachments/assets/a3e16bb7-77b9-4155-b112-5411dee20e38" />
previous version can't display some normal assisant 
<img width="2772" height="1522" alt="image" src="https://github.com/user-attachments/assets/b16441ad-9af9-47fe-852d-8b51387ac778" />
These output texts appear after it fixed



## Bug fix verification
<img width="1424" height="168" alt="image" src="https://github.com/user-attachments/assets/c7a5002a-a825-47ec-8ed4-3ce764299f84" />
Previous version failed in the regression test above
<img width="1438" height="300" alt="image" src="https://github.com/user-attachments/assets/fdc0e3ac-6c5c-47d6-92fe-fb439ec37b59" />
while the fixed one passes in all three regression test.



## Validation
Test Files  24 passed (24)
      Tests  163 passed (163)
   Start at  15:35:28
   Duration  592ms (transform 764ms, setup 0ms, import 1.60s, tests 298ms, environment 1ms)

I recloned the repository from my fork that I used to submit this PR, then ran cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test. All checks passed.