### PR TITLE
fix(makefile): extract setup-sandbox inline bash to script for Window…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,36 +89,7 @@ install:
 
 # Pre-pull sandbox Docker image (optional but recommended)
 setup-sandbox:
-	@echo "=========================================="
-	@echo "  Pre-pulling Sandbox Container Image"
-	@echo "=========================================="
-	@echo ""
-	@IMAGE=$$(grep -A 20 "# sandbox:" config.yaml 2>/dev/null | grep "image:" | awk '{print $$2}' | head -1); \
-	if [ -z "$$IMAGE" ]; then \
-		IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest"; \
-		echo "Using default image: $$IMAGE"; \
-	else \
-		echo "Using configured image: $$IMAGE"; \
-	fi; \
-	echo ""; \
-	if command -v container >/dev/null 2>&1 && [ "$$(uname)" = "Darwin" ]; then \
-		echo "Detected Apple Container on macOS, pulling image..."; \
-		container image pull "$$IMAGE" || echo "⚠ Apple Container pull failed, will try Docker"; \
-	fi; \
-	if command -v docker >/dev/null 2>&1; then \
-		echo "Pulling image using Docker..."; \
-		if docker pull "$$IMAGE"; then \
-			echo ""; \
-			echo "✓ Sandbox image pulled successfully"; \
-		else \
-			echo ""; \
-			echo "⚠ Failed to pull sandbox image (this is OK for local sandbox mode)"; \
-		fi; \
-	else \
-		echo "✗ Neither Docker nor Apple Container is available"; \
-		echo "  Please install Docker: https://docs.docker.com/get-docker/"; \
-		exit 1; \
-	fi
+	@$(RUN_WITH_GIT_BASH) ./scripts/setup-sandbox.sh
 
 # Start all services in development mode (with hot-reloading)
 dev:

--- a/scripts/setup-sandbox.sh
+++ b/scripts/setup-sandbox.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Pre-pull sandbox container image for DeerFlow
+
+set -uo pipefail
+
+echo "=========================================="
+echo "  Pre-pulling Sandbox Container Image"
+echo "=========================================="
+echo ""
+
+# Try to extract image from config.yaml (handles both commented and uncommented sandbox sections)
+IMAGE=""
+if [ -f "config.yaml" ]; then
+    # Look for uncommented image: field under the sandbox section
+    IMAGE=$(grep -A 20 "^sandbox:" config.yaml 2>/dev/null | grep "^  image:" | awk '{print $2}' | head -1 || true)
+fi
+
+if [ -z "$IMAGE" ]; then
+    IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest"
+    echo "Using default image: $IMAGE"
+else
+    echo "Using configured image: $IMAGE"
+fi
+
+echo ""
+
+if command -v container >/dev/null 2>&1 && [ "$(uname)" = "Darwin" ]; then
+    echo "Detected Apple Container on macOS, pulling image..."
+    container image pull "$IMAGE" || echo "⚠ Apple Container pull failed, will try Docker"
+fi
+
+if command -v docker >/dev/null 2>&1; then
+    echo "Pulling image using Docker..."
+    if docker pull "$IMAGE"; then
+        echo ""
+        echo "✓ Sandbox image pulled successfully"
+    else
+        echo ""
+        echo "⚠ Failed to pull sandbox image (this is OK for local sandbox mode)"
+    fi
+else
+    echo "✗ Neither Docker nor Apple Container is available"
+    echo "  Please install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi


### PR DESCRIPTION
Fixes #3325

## Why

Because during project builds in the current Makefile, Windows is configured to use `cmd` as the shell via that command `SHELL := cmd.exe`. 

Considering that other parts of the project use `RUN_WITH_GIT_BASH` to execute the corresponding shell, this pull request also adopts that approach for the modification.


## What changed
Makefile: Replace inline bash recipe with @$(RUN_WITH_GIT_BASH) ./scripts/setup-sandbox.sh
scripts/setup-sandbox.sh: New file — contains the sandbox image pull logic with fixed config parsing
Note: current the scripts/setup-sandbox.sh greps active (uncommented) config with `^sandbox:` and `^  image:`, which correctly extracts the URL when configured.


## Bug fix verification
make setup-sandbox now correctly invokes Git Bash and pulls the Docker image