### PR TITLE
docs: clean gateway runtime transition remnants

### DIFF
--- a/backend/docs/AUTH_TEST_DOCKER_GAP.md
+++ b/backend/docs/AUTH_TEST_DOCKER_GAP.md
@@ -29,7 +29,7 @@ All other test plan sections were executed against either:
 | TC-DOCKER-03 | Per-worker rate limiter divergence | Confirms in-process `_login_attempts` dict doesn't share state across `gunicorn` workers (4 by default in the compose file); known limitation, documented | needs multi-worker container |
 | TC-DOCKER-04 | IM channels use internal Gateway auth | Verify Feishu/Slack/Telegram dispatchers attach the process-local internal auth header plus CSRF cookie/header when calling Gateway-compatible LangGraph APIs | needs `docker logs` |
 | TC-DOCKER-05 | Reset credentials surfacing | `reset_admin` writes a 0600 credential file in `DEER_FLOW_HOME` instead of logging plaintext. The file-based behavior is validated by non-Docker reset tests, so the only Docker-specific gap is verifying the volume mount carries the file out to the host | needs container + host volume |
-| TC-DOCKER-06 | Gateway-mode Docker deploy | `./scripts/deploy.sh --gateway` produces a 3-container topology (no `langgraph` container); same auth flow as standard mode | needs `docker compose --profile gateway` |
+| TC-DOCKER-06 | Docker deploy uses Gateway embedded runtime | `./scripts/deploy.sh` produces a Gateway + frontend + nginx topology (no `langgraph` container); same auth flow as local `make dev` | needs `docker compose up` |
 
 ## Coverage already provided by non-Docker tests
 
@@ -43,7 +43,7 @@ the test cases that ran on sg_dev or local:
 | TC-DOCKER-03 (per-worker rate limit) | TC-GW-04 + TC-REENT-09 (single-worker rate limit + 5min expiry). The cross-worker divergence is an architectural property of the in-memory dict; no auth code path differs |
 | TC-DOCKER-04 (IM channels use internal auth) | Code-level: `app/channels/manager.py` creates the `langgraph_sdk` client with `create_internal_auth_headers()` plus CSRF cookie/header, so channel workers do not rely on browser cookies |
 | TC-DOCKER-05 (credential surfacing) | `reset_admin` writes `.deer-flow/admin_initial_credentials.txt` with mode 0600 and logs only the path — the only Docker-unique step is whether the bind mount projects this path onto the host, which is a `docker compose` config check, not a runtime behavior change |
-| TC-DOCKER-06 (gateway-mode container) | Section 七 7.2 covered by TC-GW-01..05 + Section 二 (gateway-mode auth flow on sg_dev) — same Gateway code, container is just a packaging change |
+| TC-DOCKER-06 (Gateway embedded runtime container) | Section 七 7.2 covered by TC-GW-01..05 + Section 二 (Gateway auth flow on sg_dev) — same Gateway code, container is just a packaging change |
 
 ## Reproduction steps when Docker becomes available
 

--- a/backend/docs/AUTH_UPGRADE.md
+++ b/backend/docs/AUTH_UPGRADE.md
@@ -124,8 +124,8 @@ python -c "import secrets; print(secrets.token_urlsafe(32))"
 
 ## 兼容性
 
-- **标准模式**（`make dev`）：完全兼容；无 admin 时访问 `/setup` 初始化
-- **Gateway 模式**（`make dev-pro`）：完全兼容
+- **本地开发**（`make dev`）：Gateway embedded runtime 完全兼容；无 admin 时访问 `/setup` 初始化
+- **Gateway embedded runtime**：标准脚本、Docker dev 和生产部署均通过 Gateway 提供认证与 LangGraph-compatible API
 - **Docker 部署**：完全兼容，`.deer-flow/data/deerflow.db` 需持久化卷挂载
 - **IM 渠道**（Feishu/Slack/Telegram）：通过 Gateway 内部认证通信，使用 `default` 用户桶
 - **DeerFlowClient**（嵌入式）：不经过 HTTP，不受认证影响

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -104,3 +104,17 @@ def test_smoke_test_docs_do_not_expect_standalone_langgraph_server():
         assert "langgraph.log" not in content, path
         assert "LangGraph service" not in content, path
         assert "langgraph dev" not in content, path
+
+
+def test_gateway_runtime_docs_do_not_reference_transition_modes():
+    docs = {
+        "backend/docs/AUTH_UPGRADE.md": _read("backend/docs/AUTH_UPGRADE.md"),
+        "backend/docs/AUTH_TEST_DOCKER_GAP.md": _read("backend/docs/AUTH_TEST_DOCKER_GAP.md"),
+        "docs/CODE_CHANGE_SUMMARY_BY_FILE.md": _read("docs/CODE_CHANGE_SUMMARY_BY_FILE.md"),
+    }
+
+    for path, content in docs.items():
+        assert "make dev-pro" not in content, path
+        assert "./scripts/deploy.sh --gateway" not in content, path
+        assert "docker compose --profile gateway" not in content, path
+        assert "`/api/langgraph/*` → LangGraph" not in content, path

--- a/docs/CODE_CHANGE_SUMMARY_BY_FILE.md
+++ b/docs/CODE_CHANGE_SUMMARY_BY_FILE.md
@@ -16,7 +16,7 @@
 -| **Artifacts** (`/api/threads/{id}/artifacts`) | `GET /{path}` - serve artifacts; `?download=true` for download with citation removal |
 +| **Artifacts** (`/api/threads/{id}/artifacts`) | `GET /{path}` - serve artifacts; `?download=true` for file download |
 
- Proxied through nginx: `/api/langgraph/*` → LangGraph, all other `/api/*` → Gateway.
+ Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runtime, all other `/api/*` → Gateway REST APIs.
 ```
 
 - **第 159 行**：表格中 Artifacts 描述由「download with citation removal」改为「file download」。


### PR DESCRIPTION
## Summary

Refs #3304.

This is a second low-risk cleanup pass for the Gateway-embedded runtime docs. It removes remaining transition-era wording that could still point maintainers toward the old standalone/Gateway-mode split.

## Changes

- Update `backend/docs/AUTH_UPGRADE.md` to describe `make dev` and the standard Gateway embedded runtime instead of a removed `make dev-pro` mode.
- Update `backend/docs/AUTH_TEST_DOCKER_GAP.md` to describe Docker deploys as Gateway embedded runtime deployments and remove references to `deploy.sh --gateway` / `docker compose --profile gateway`.
- Fix `docs/CODE_CHANGE_SUMMARY_BY_FILE.md` so `/api/langgraph/*` is documented as routing to the Gateway LangGraph-compatible runtime, not a standalone LangGraph upstream.
- Extend `test_gateway_runtime_cleanup.py` so these transition-mode strings do not reappear in the cleaned docs.

## Scope

This PR intentionally does not remove `langgraph.json`, `langgraph_auth.py`, Studio/tooling compatibility docs, demo replay metadata, or historical superpowers plan/spec records. Those are deeper compatibility decisions tracked separately by #3304.

## Tests

- `uv run pytest tests/test_gateway_runtime_cleanup.py`
  - `8 passed, 1 warning`
- `uvx ruff check tests/test_gateway_runtime_cleanup.py && uvx ruff format --check tests/test_gateway_runtime_cleanup.py`
  - passed
