### PR TITLE
chore: remove stale LangGraph server runtime remnants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ stop:
 clean: stop
 	@echo "Cleaning up..."
 	@-rm -rf backend/.deer-flow 2>/dev/null || true
-	@-rm -rf backend/.langgraph_api 2>/dev/null || true
 	@-rm -rf logs/*.log 2>/dev/null || true
 	@echo "✓ Cleanup complete"
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -64,7 +64,7 @@ FROM builder AS dev
 # Install Docker CLI (for DooD: allows starting sandbox containers via host Docker socket)
 COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
 
-EXPOSE 8001 2024
+EXPOSE 8001
 
 CMD ["sh", "-c", "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001"]
 
@@ -94,8 +94,8 @@ WORKDIR /app
 # Copy backend with pre-built virtualenv from builder
 COPY --from=builder /app/backend ./backend
 
-# Expose ports (gateway: 8001, langgraph: 2024)
-EXPOSE 8001 2024
+# Expose Gateway API port.
+EXPOSE 8001
 
 # Default command (can be overridden in docker-compose)
 CMD ["sh", "-c", "cd backend && PYTHONPATH=. uv run --no-sync uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001"]

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -46,9 +46,9 @@ def test_service_launchers_always_use_gateway_runtime():
 def test_backend_container_only_exposes_gateway_port():
     dockerfile = _read("backend/Dockerfile")
 
-    assert "EXPOSE 8001 2024" not in dockerfile
+    assert not re.search(r"^EXPOSE\s+.*\b2024\b", dockerfile, re.M)
     assert "langgraph: 2024" not in dockerfile
-    assert "EXPOSE 8001" in dockerfile
+    assert re.search(r"^EXPOSE\s+8001\b", dockerfile, re.M)
 
 
 def test_root_makefile_clean_does_not_reference_langgraph_server_cache():

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -43,6 +43,20 @@ def test_service_launchers_always_use_gateway_runtime():
         assert "LANGGRAPH_REWRITE" not in content, path
 
 
+def test_backend_container_only_exposes_gateway_port():
+    dockerfile = _read("backend/Dockerfile")
+
+    assert "EXPOSE 8001 2024" not in dockerfile
+    assert "langgraph: 2024" not in dockerfile
+    assert "EXPOSE 8001" in dockerfile
+
+
+def test_root_makefile_clean_does_not_reference_langgraph_server_cache():
+    makefile = _read("Makefile")
+
+    assert ".langgraph_api" not in makefile
+
+
 def test_nginx_routes_official_langgraph_prefix_to_gateway_api():
     for path in ("docker/nginx/nginx.local.conf", "docker/nginx/nginx.conf"):
         content = _read(path)


### PR DESCRIPTION
## Summary

Refs #3304.

This PR removes the small LangGraph Server runtime leftovers that are safe to clean up now.

## Cleanup included in this PR

### `backend/Dockerfile`

- Changed both backend image stages from `EXPOSE 8001 2024` to `EXPOSE 8001`.
- Updated the runtime-stage comment from `gateway: 8001, langgraph: 2024` to Gateway-only wording.
- This matches the actual container command, which starts only `uvicorn app.gateway.app:app` on port `8001`.

### `Makefile`

- Removed the stale `backend/.langgraph_api` deletion from `make clean`.
- The current Gateway-embedded runtime does not create this LangGraph Server / CLI cache directory.
- `make clean` still removes the active local runtime data directory and logs:
  - `backend/.deer-flow`
  - `logs/*.log`

### `backend/tests/test_gateway_runtime_cleanup.py`

- Added regression coverage that prevents the stale Docker `2024` exposure from returning.
- Added regression coverage that prevents the stale `.langgraph_api` cleanup entry from returning.

## Safety scope

- No runtime entrypoint was changed.
- No Gateway route, frontend SDK route, channel integration, or `/api/langgraph/*` compatibility behavior was changed.
- No LangGraph core package or `langgraph-sdk` dependency was changed.
- No `langgraph.json`, Studio/tooling compatibility file, or auth compatibility handler was changed in this PR.

## Tests

- `uv run pytest tests/test_gateway_runtime_cleanup.py`
  - `10 passed, 1 warning`
- `uvx ruff check tests/test_gateway_runtime_cleanup.py && uvx ruff format --check tests/test_gateway_runtime_cleanup.py`
  - passed
