### PR TITLE
fix(agents): avoid memory-only dirs shadowing shared agents

### DIFF
--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -52,9 +52,13 @@ class AgentConfig(BaseModel):
 def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     """Return the on-disk directory for an agent, preferring the per-user layout.
 
-    Resolution order:
+    Resolution order considers only directories that contain ``config.yaml``:
     1. ``{base_dir}/users/{user_id}/agents/{name}/`` (per-user, current layout).
     2. ``{base_dir}/agents/{name}/`` (legacy shared layout — read-only fallback).
+
+    A per-user directory that only contains agent memory (for example,
+    ``memory.json``) is not treated as an agent config directory and does not
+    shadow a shared legacy agent.
 
     If neither exists, the per-user path is returned so callers that intend to
     create the agent write into the new layout.
@@ -67,11 +71,11 @@ def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     paths = get_paths()
     effective_user = user_id or get_effective_user_id()
     user_path = paths.user_agent_dir(effective_user, name)
-    if user_path.exists():
+    if (user_path / "config.yaml").exists():
         return user_path
 
     legacy_path = paths.agent_dir(name)
-    if legacy_path.exists():
+    if (legacy_path / "config.yaml").exists():
         return legacy_path
 
     return user_path

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -188,6 +188,33 @@ class TestLoadAgentConfig:
 
         assert cfg.skills is None
 
+    def test_user_memory_dir_does_not_shadow_shared_agent_config(self, tmp_path):
+        _write_agent(tmp_path, "code-qa", {"name": "code-qa", "skills": ["codebase-qa"]})
+        memory_only_dir = tmp_path / "users" / "alice" / "agents" / "code-qa"
+        memory_only_dir.mkdir(parents=True)
+        (memory_only_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_config
+
+            cfg = load_agent_config("code-qa", user_id="alice")
+
+        assert cfg.name == "code-qa"
+        assert cfg.skills == ["codebase-qa"]
+
+    def test_per_user_agent_config_still_takes_precedence_over_shared_config(self, tmp_path):
+        _write_agent(tmp_path, "code-qa", {"name": "code-qa", "description": "shared"})
+        user_agent_dir = tmp_path / "users" / "alice" / "agents" / "code-qa"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "config.yaml").write_text("name: code-qa\ndescription: private\n", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_config
+
+            cfg = load_agent_config("code-qa", user_id="alice")
+
+        assert cfg.description == "private"
+
     def test_legacy_prompt_file_field_ignored(self, tmp_path):
         """Unknown fields like the old prompt_file should be silently ignored."""
         agent_dir = tmp_path / "agents" / "legacy-agent"
@@ -234,6 +261,20 @@ class TestLoadAgentSoul:
             soul = load_agent_soul(cfg.name)
 
         assert soul is None
+
+    def test_user_memory_dir_does_not_shadow_shared_agent_soul(self, tmp_path):
+        expected_soul = "Shared code QA soul."
+        _write_agent(tmp_path, "code-qa", {"name": "code-qa"}, soul=expected_soul)
+        memory_only_dir = tmp_path / "users" / "alice" / "agents" / "code-qa"
+        memory_only_dir.mkdir(parents=True)
+        (memory_only_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_soul
+
+            soul = load_agent_soul("code-qa", user_id="alice")
+
+        assert soul == expected_soul
 
     def test_empty_soul_file_returns_none(self, tmp_path):
         agent_dir = tmp_path / "agents" / "empty-soul"
@@ -318,6 +359,20 @@ class TestListCustomAgents:
 
         names = [a.name for a in agents]
         assert names == sorted(names)
+
+    def test_memory_only_user_dir_does_not_hide_shared_agent(self, tmp_path):
+        _write_agent(tmp_path, "code-qa", {"name": "code-qa", "description": "shared"})
+        memory_only_dir = tmp_path / "users" / "alice" / "agents" / "code-qa"
+        memory_only_dir.mkdir(parents=True)
+        (memory_only_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import list_custom_agents
+
+            agents = list_custom_agents(user_id="alice")
+
+        assert [agent.name for agent in agents] == ["code-qa"]
+        assert agents[0].description == "shared"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fix custom agent resolution so a per-user agent directory is only treated as an agent configuration directory when it contains `config.yaml`.

This prevents per-user memory-only directories such as `users/<user_id>/agents/<agent_name>/memory.json` from shadowing shared agents stored under `agents/<agent_name>/config.yaml`.

## Problem

Custom agents can be loaded from two locations:

1. Per-user layout: `users/<user_id>/agents/<name>/`
2. Shared legacy layout: `agents/<name>/`

The current `resolve_agent_dir()` checks only whether the per-user directory exists:

```py
if user_path.exists():
    return user_path
```

However, the memory subsystem may create a per-user agent directory only to store agent memory:

```text
users/<user_id>/agents/code-qa/memory.json
```

When that happens, the memory-only directory shadows the shared agent directory:

```text
agents/code-qa/config.yaml
agents/code-qa/SOUL.md
```

A subsequent custom-agent run then tries to load:

```text
users/<user_id>/agents/code-qa/config.yaml
```

and fails with `FileNotFoundError: Agent config not found`. The same shadowing can also make shared agents disappear from `list_custom_agents()` for that user.

## Fix

Change `resolve_agent_dir()` to consider a directory an agent config directory only if it contains `config.yaml`:

```py
if (user_path / "config.yaml").exists():
    return user_path

if (legacy_path / "config.yaml").exists():
    return legacy_path
```

This keeps the existing precedence rules intact:

- Per-user agent config still wins when `users/<user_id>/agents/<name>/config.yaml` exists.
- Shared agent config is used when the per-user directory exists only for memory.
- Missing agents still return the per-user path so create flows can write there.

## Tests

Added coverage for:

- `load_agent_config()` falls back to shared config when the per-user dir contains only `memory.json`.
- Per-user config still takes precedence over shared config.
- `load_agent_soul()` also falls back to shared SOUL in the same memory-only scenario.
- `list_custom_agents()` still lists shared agents when a per-user memory-only dir exists.

Ran:

```text
.venv/bin/python -m pytest tests/test_custom_agent.py -q
# 59 passed, 1 warning
```

Also ran pre-commit hooks on the changed files:

```text
ruff lint: passed
ruff format: passed
```

## Compatibility notes

This aligns `resolve_agent_dir()` with `list_custom_agents()` behavior, which already treats `config.yaml` as the marker for a valid agent directory.

This PR does not change create/update endpoints or migration behavior. Directory-level checks in create/update paths remain unchanged and can be handled separately if desired.
