### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -95,20 +95,30 @@ models:
         thinking:
           type: enabled
 
-  - name: minimax-m2.5
-    display_name: MiniMax M2.5
+  - name: minimax-m3
+    display_name: MiniMax M3
     use: langchain_openai:ChatOpenAI
-    model: MiniMax-M2.5
+    model: MiniMax-M3
     api_key: $MINIMAX_API_KEY
     base_url: https://api.minimax.io/v1
     max_tokens: 4096
     temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
     supports_vision: true
 
-  - name: minimax-m2.5-highspeed
-    display_name: MiniMax M2.5 Highspeed
+  - name: minimax-m2.7
+    display_name: MiniMax M2.7
     use: langchain_openai:ChatOpenAI
-    model: MiniMax-M2.5-highspeed
+    model: MiniMax-M2.7
+    api_key: $MINIMAX_API_KEY
+    base_url: https://api.minimax.io/v1
+    max_tokens: 4096
+    temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+    supports_vision: true
+
+  - name: minimax-m2.7-highspeed
+    display_name: MiniMax M2.7 Highspeed
+    use: langchain_openai:ChatOpenAI
+    model: MiniMax-M2.7-highspeed
     api_key: $MINIMAX_API_KEY
     base_url: https://api.minimax.io/v1
     max_tokens: 4096

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -566,11 +566,11 @@ def test_thinking_shortcut_not_leaked_into_model_when_disabled(monkeypatch):
 def test_openai_compatible_provider_passes_base_url(monkeypatch):
     """OpenAI-compatible providers like MiniMax should pass base_url through to the model."""
     model = ModelConfig(
-        name="minimax-m2.5",
-        display_name="MiniMax M2.5",
+        name="minimax-m3",
+        display_name="MiniMax M3",
         description=None,
         use="langchain_openai:ChatOpenAI",
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         base_url="https://api.minimax.io/v1",
         api_key="test-key",
         max_tokens=4096,
@@ -590,9 +590,9 @@ def test_openai_compatible_provider_passes_base_url(monkeypatch):
 
     monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
 
-    factory_module.create_chat_model(name="minimax-m2.5")
+    factory_module.create_chat_model(name="minimax-m3")
 
-    assert captured.get("model") == "MiniMax-M2.5"
+    assert captured.get("model") == "MiniMax-M3"
     assert captured.get("base_url") == "https://api.minimax.io/v1"
     assert captured.get("api_key") == "test-key"
     assert captured.get("temperature") == 1.0
@@ -603,11 +603,11 @@ def test_openai_compatible_provider_passes_base_url(monkeypatch):
 def test_openai_compatible_provider_respects_explicit_stream_usage(monkeypatch):
     """Explicit stream_usage should not be overwritten by the factory default."""
     model = ModelConfig(
-        name="minimax-m2.5",
-        display_name="MiniMax M2.5",
+        name="minimax-m3",
+        display_name="MiniMax M3",
         description=None,
         use="langchain_openai:ChatOpenAI",
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         base_url="https://api.minimax.io/v1",
         api_key="test-key",
         stream_usage=False,
@@ -626,7 +626,7 @@ def test_openai_compatible_provider_respects_explicit_stream_usage(monkeypatch):
 
     monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
 
-    factory_module.create_chat_model(name="minimax-m2.5")
+    factory_module.create_chat_model(name="minimax-m3")
 
     assert captured.get("stream_usage") is False
 
@@ -695,11 +695,11 @@ def test_non_openai_provider_does_not_receive_stream_usage_default(monkeypatch):
 def test_openai_compatible_provider_multiple_models(monkeypatch):
     """Multiple models from the same OpenAI-compatible provider should coexist."""
     m1 = ModelConfig(
-        name="minimax-m2.5",
-        display_name="MiniMax M2.5",
+        name="minimax-m3",
+        display_name="MiniMax M3",
         description=None,
         use="langchain_openai:ChatOpenAI",
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         base_url="https://api.minimax.io/v1",
         api_key="test-key",
         temperature=1.0,
@@ -707,11 +707,11 @@ def test_openai_compatible_provider_multiple_models(monkeypatch):
         supports_thinking=False,
     )
     m2 = ModelConfig(
-        name="minimax-m2.5-highspeed",
-        display_name="MiniMax M2.5 Highspeed",
+        name="minimax-m2.7-highspeed",
+        display_name="MiniMax M2.7 Highspeed",
         description=None,
         use="langchain_openai:ChatOpenAI",
-        model="MiniMax-M2.5-highspeed",
+        model="MiniMax-M2.7-highspeed",
         base_url="https://api.minimax.io/v1",
         api_key="test-key",
         temperature=1.0,
@@ -731,12 +731,12 @@ def test_openai_compatible_provider_multiple_models(monkeypatch):
     monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
 
     # Create first model
-    factory_module.create_chat_model(name="minimax-m2.5")
-    assert captured.get("model") == "MiniMax-M2.5"
+    factory_module.create_chat_model(name="minimax-m3")
+    assert captured.get("model") == "MiniMax-M3"
 
     # Create second model
-    factory_module.create_chat_model(name="minimax-m2.5-highspeed")
-    assert captured.get("model") == "MiniMax-M2.5-highspeed"
+    factory_module.create_chat_model(name="minimax-m2.7-highspeed")
+    assert captured.get("model") == "MiniMax-M2.7-highspeed"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_patched_minimax.py
+++ b/backend/tests/test_patched_minimax.py
@@ -5,7 +5,7 @@ from deerflow.models.patched_minimax import PatchedChatMiniMax
 
 def _make_model(**kwargs) -> PatchedChatMiniMax:
     return PatchedChatMiniMax(
-        model="MiniMax-M2.5",
+        model="MiniMax-M3",
         api_key="test-key",
         base_url="https://example.com/v1",
         **kwargs,
@@ -42,7 +42,7 @@ def test_create_chat_result_maps_reasoning_details_to_reasoning_content():
                 "finish_reason": "stop",
             }
         ],
-        "model": "MiniMax-M2.5",
+        "model": "MiniMax-M3",
     }
 
     result = model._create_chat_result(response)
@@ -65,7 +65,7 @@ def test_create_chat_result_strips_inline_think_tags():
                 "finish_reason": "stop",
             }
         ],
-        "model": "MiniMax-M2.5",
+        "model": "MiniMax-M3",
     }
 
     result = model._create_chat_result(response)
@@ -133,7 +133,7 @@ def test_convert_chunk_to_generation_chunk_preserves_reasoning_deltas():
                     "finish_reason": "stop",
                 }
             ],
-            "model": "MiniMax-M2.5",
+            "model": "MiniMax-M3",
         },
         AIMessageChunk,
         {},

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -275,12 +275,12 @@ models:
   #         type: disabled
 
   # Example: MiniMax (OpenAI-compatible) - International Edition
-  # MiniMax provides high-performance models with 204K context window
+  # MiniMax provides high-performance models with 512K context window and 128K max output
   # Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
-  # - name: minimax-m2.5
-  #   display_name: MiniMax M2.5
+  # - name: minimax-m3
+  #   display_name: MiniMax M3
   #   use: langchain_openai:ChatOpenAI
-  #   model: MiniMax-M2.5
+  #   model: MiniMax-M3
   #   api_key: $MINIMAX_API_KEY
   #   base_url: https://api.minimax.io/v1
   #   request_timeout: 600.0
@@ -290,10 +290,23 @@ models:
   #   supports_vision: true
   #   supports_thinking: true
 
-  # - name: minimax-m2.5-highspeed
-  #   display_name: MiniMax M2.5 Highspeed
+  # - name: minimax-m2.7
+  #   display_name: MiniMax M2.7
   #   use: langchain_openai:ChatOpenAI
-  #   model: MiniMax-M2.5-highspeed
+  #   model: MiniMax-M2.7
+  #   api_key: $MINIMAX_API_KEY
+  #   base_url: https://api.minimax.io/v1
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 4096
+  #   temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+  #   supports_vision: true
+  #   supports_thinking: true
+
+  # - name: minimax-m2.7-highspeed
+  #   display_name: MiniMax M2.7 Highspeed
+  #   use: langchain_openai:ChatOpenAI
+  #   model: MiniMax-M2.7-highspeed
   #   api_key: $MINIMAX_API_KEY
   #   base_url: https://api.minimax.io/v1
   #   request_timeout: 600.0
@@ -304,8 +317,21 @@ models:
   #   supports_thinking: true
 
   # Example: MiniMax (OpenAI-compatible) - CN 中国区用户
-  # MiniMax provides high-performance models with 204K context window
+  # MiniMax provides high-performance models with 512K context window and 128K max output
   # Docs: https://platform.minimaxi.com/docs/api-reference/text-openai-api
+  # - name: minimax-m3
+  #   display_name: MiniMax M3
+  #   use: langchain_openai:ChatOpenAI
+  #   model: MiniMax-M3
+  #   api_key: $MINIMAX_API_KEY
+  #   base_url: https://api.minimaxi.com/v1
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 4096
+  #   temperature: 1.0  # MiniMax requires temperature in (0.0, 1.0]
+  #   supports_vision: true
+  #   supports_thinking: true
+
   # - name: minimax-m2.7
   #   display_name: MiniMax M2.7
   #   use: langchain_openai:ChatOpenAI


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration to use M3 as the default model.

## Changes
- Add `MiniMax-M3` to the model selection list and set as default
- Keep `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as alternatives
- Remove older model (`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`)
- Update related unit tests in `backend/tests/test_model_factory.py` and `backend/tests/test_patched_minimax.py`
- Update documentation (`backend/docs/CONFIGURATION.md`) and the example config (`config.example.yaml`)

## Why
`MiniMax-M3` is the latest model from MiniMax, with a 512K context window, up to 128K max output, and image input support on the OpenAI-compatible endpoint.

## Testing
- `backend/tests/test_patched_minimax.py`: 4 passed
- `backend/tests/test_model_factory.py`: 38 passed