### PR TITLE
fix(memory): stop deleted agents from being resurrected by late memory writes (#3364)

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -439,6 +439,17 @@ async def delete_agent(name: str) -> None:
         raise HTTPException(status_code=404, detail=f"Agent '{name}' not found")
 
     try:
+        # Cancel any pending debounced memory writes for this agent before
+        # removing the directory. Otherwise a lagging write can recreate the
+        # agent dir (with a stray memory.json) and block recreating a
+        # same-named agent (issue #3364).
+        try:
+            from deerflow.agents.memory.queue import get_memory_queue
+
+            get_memory_queue().discard(user_id=user_id, agent_name=name)
+        except Exception as e:
+            logger.warning(f"Failed to discard pending memory updates for agent '{name}': {e}")
+
         shutil.rmtree(agent_dir)
         logger.info(f"Deleted agent '{name}' from {agent_dir}")
     except Exception as e:

--- a/backend/packages/harness/deerflow/agents/memory/queue.py
+++ b/backend/packages/harness/deerflow/agents/memory/queue.py
@@ -39,6 +39,13 @@ class MemoryUpdateQueue:
         self._lock = threading.Lock()
         self._timer: threading.Timer | None = None
         self._processing = False
+        # (user_id, agent_name) tombstones for agents deleted while a
+        # _process_queue run already holds an in-flight snapshot of the queue.
+        # Without this an update copied out before discard() ran would still
+        # call save() and recreate the deleted agent's directory (issue #3364).
+        # Checked per-context in _process_queue and cleared when that run ends,
+        # so the set never grows unbounded.
+        self._deleted_agents: set[tuple[str | None, str | None]] = set()
 
     @staticmethod
     def _queue_key(
@@ -189,6 +196,15 @@ class MemoryUpdateQueue:
 
             for context in contexts_to_process:
                 try:
+                    with self._lock:
+                        deleted = (context.user_id, context.agent_name) in self._deleted_agents
+                    if deleted:
+                        logger.info(
+                            "Skipping memory update for deleted agent %s (thread %s)",
+                            context.agent_name,
+                            context.thread_id,
+                        )
+                        continue
                     logger.info("Updating memory for thread %s", context.thread_id)
                     success = updater.update_memory(
                         messages=context.messages,
@@ -212,6 +228,9 @@ class MemoryUpdateQueue:
         finally:
             with self._lock:
                 self._processing = False
+                # This in-flight snapshot is fully processed; tombstones have
+                # served their purpose and must not leak into future runs.
+                self._deleted_agents.clear()
 
     def flush(self) -> None:
         """Force immediate processing of the queue.
@@ -232,6 +251,32 @@ class MemoryUpdateQueue:
             # before _process_queue completes. Acceptable for best-effort memory updates.
             self._schedule_timer(0)
 
+    def discard(self, *, user_id: str | None = None, agent_name: str | None = None) -> int:
+        """Drop pending updates targeting a specific agent (any thread).
+
+        Called when an agent is deleted so a debounced memory write cannot fire
+        after deletion and recreate the agent's directory (issue #3364). If a
+        _process_queue run is already in flight (it copied the queue out before
+        this call), an agent-level tombstone is recorded so the in-flight write
+        is skipped before it reaches save().
+
+        Returns the number of pending contexts removed from the queue.
+        """
+        with self._lock:
+            matching = [context for context in self._queue if context.user_id == user_id and context.agent_name == agent_name]
+            self._queue = [context for context in self._queue if not (context.user_id == user_id and context.agent_name == agent_name)]
+            removed = len(matching)
+            # Only needed when a worker already holds a snapshot; the tombstone
+            # is consumed and cleared at the end of that run.
+            if self._processing:
+                self._deleted_agents.add((user_id, agent_name))
+            if not self._queue and self._timer is not None:
+                self._timer.cancel()
+                self._timer = None
+        if removed:
+            logger.info("Discarded %d pending memory update(s) for agent %s (user %s)", removed, agent_name, user_id)
+        return removed
+
     def clear(self) -> None:
         """Clear the queue without processing.
 
@@ -242,6 +287,7 @@ class MemoryUpdateQueue:
                 self._timer.cancel()
                 self._timer = None
             self._queue.clear()
+            self._deleted_agents.clear()
             self._processing = False
 
     @property

--- a/backend/packages/harness/deerflow/agents/memory/storage.py
+++ b/backend/packages/harness/deerflow/agents/memory/storage.py
@@ -163,7 +163,21 @@ class FileMemoryStorage(MemoryStorage):
         cache_key = self._cache_key(agent_name, user_id=user_id)
 
         try:
-            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if agent_name is not None:
+                # A per-agent memory directory is created when the agent is
+                # created and removed (rmtree) when it is deleted. Never
+                # recreate it here: a debounced / in-flight memory write that
+                # lands after the agent was deleted must not resurrect the
+                # directory, otherwise a same-named agent can no longer be
+                # created (issue #3364). If the directory is already gone, give
+                # up the write. Even if it is removed between this check and the
+                # open() below, open() fails cleanly with OSError (handled
+                # below) and never recreates the directory.
+                if not file_path.parent.exists():
+                    logger.info("Skipping memory save for missing agent directory %s", file_path.parent)
+                    return False
+            else:
+                file_path.parent.mkdir(parents=True, exist_ok=True)
             # Shallow-copy before adding lastUpdated so the caller's dict is not
             # mutated as a side-effect, and the cache reference is not silently
             # updated before the file write succeeds.

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -554,6 +554,20 @@ class TestAgentsAPI:
         agent_client.delete("/api/agents/remove-me")
         assert not agent_dir.exists()
 
+    def test_delete_discards_pending_memory_updates(self, agent_client):
+        """Deleting an agent must cancel its pending memory writes so a lagging
+        debounced write cannot recreate the directory (issue #3364)."""
+        agent_client.post("/api/agents", json={"name": "race-agent", "soul": "hi"})
+
+        with patch("deerflow.agents.memory.queue.get_memory_queue") as get_queue:
+            queue = get_queue.return_value
+            response = agent_client.delete("/api/agents/race-agent")
+
+        assert response.status_code == 204
+        queue.discard.assert_called_once()
+        _, kwargs = queue.discard.call_args
+        assert kwargs["agent_name"] == "race-agent"
+
     def test_create_rejects_legacy_name_collision(self, agent_client, tmp_path):
         """An unmigrated legacy agent must still block name collision so that
         running the migration script later won't shadow the legacy entry."""

--- a/backend/tests/test_memory_queue.py
+++ b/backend/tests/test_memory_queue.py
@@ -246,3 +246,118 @@ def test_process_queue_updates_different_agents_in_same_thread_separately() -> N
             ),
         ]
     )
+
+
+def test_discard_removes_pending_updates_for_agent() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="t1", messages=["agent-a"], agent_name="agent-a", user_id="alice")
+        queue.add(thread_id="t2", messages=["agent-a-2"], agent_name="agent-a", user_id="alice")
+        queue.add(thread_id="t3", messages=["agent-b"], agent_name="agent-b", user_id="alice")
+
+    removed = queue.discard(user_id="alice", agent_name="agent-a")
+
+    assert removed == 2
+    assert [context.agent_name for context in queue._queue] == ["agent-b"]
+
+
+def test_discard_is_scoped_by_user_id() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="t1", messages=["alice"], agent_name="shared", user_id="alice")
+        queue.add(thread_id="t1", messages=["bob"], agent_name="shared", user_id="bob")
+
+    removed = queue.discard(user_id="alice", agent_name="shared")
+
+    assert removed == 1
+    assert [(context.user_id, context.agent_name) for context in queue._queue] == [("bob", "shared")]
+
+
+def test_discard_skips_inflight_update_already_dequeued() -> None:
+    """The core issue #3364 race: a worker copies the queue out, then the agent
+    is deleted (discard) before update_memory runs. _process_queue must skip the
+    write so it cannot recreate the deleted agent's directory.
+    """
+    queue = MemoryUpdateQueue()
+    queue._queue = [
+        ConversationContext(
+            thread_id="t1",
+            messages=["conversation"],
+            agent_name="agent-a",
+            user_id="alice",
+        )
+    ]
+
+    mock_updater = MagicMock()
+    mock_updater.update_memory.return_value = True
+
+    # By the time _process_queue builds the updater it has already
+    # snapshotted+cleared the queue and set _processing=True. Deleting the
+    # agent here mirrors discard() racing with that in-flight run.
+    def delete_agent_mid_flight(*args, **kwargs):
+        queue.discard(user_id="alice", agent_name="agent-a")
+        return mock_updater
+
+    with (
+        patch("deerflow.agents.memory.updater.MemoryUpdater", side_effect=delete_agent_mid_flight),
+        patch("deerflow.agents.memory.queue.time.sleep"),
+    ):
+        queue._process_queue()
+
+    mock_updater.update_memory.assert_not_called()
+    # Tombstones are cleared once the run finishes, so the set never leaks.
+    assert queue._deleted_agents == set()
+
+
+def test_discard_without_inflight_run_records_no_tombstone() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="t1", messages=["first"], agent_name="agent-a", user_id="alice")
+
+    removed = queue.discard(user_id="alice", agent_name="agent-a")
+
+    assert removed == 1
+    assert queue._deleted_agents == set()
+
+
+def test_recreated_agent_after_discard_writes_memory() -> None:
+    queue = MemoryUpdateQueue()
+
+    with (
+        patch("deerflow.agents.memory.queue.get_memory_config", return_value=_memory_config(enabled=True)),
+        patch.object(queue, "_reset_timer"),
+    ):
+        queue.add(thread_id="t1", messages=["first"], agent_name="agent-a", user_id="alice")
+        queue.discard(user_id="alice", agent_name="agent-a")
+        # A same-named agent recreated and used again must not be suppressed.
+        queue.add(thread_id="t1", messages=["second"], agent_name="agent-a", user_id="alice")
+
+    mock_updater = MagicMock()
+    mock_updater.update_memory.return_value = True
+
+    with (
+        patch("deerflow.agents.memory.updater.MemoryUpdater", return_value=mock_updater),
+        patch("deerflow.agents.memory.queue.time.sleep"),
+    ):
+        queue.flush()
+
+    mock_updater.update_memory.assert_called_once_with(
+        messages=["second"],
+        thread_id="t1",
+        agent_name="agent-a",
+        correction_detected=False,
+        reinforcement_detected=False,
+        user_id="alice",
+    )

--- a/backend/tests/test_memory_storage.py
+++ b/backend/tests/test_memory_storage.py
@@ -110,6 +110,56 @@ class TestFileMemoryStorage:
                 assert result is True
                 assert memory_file.exists()
 
+    def test_save_skips_when_agent_dir_missing(self, tmp_path):
+        """Per-agent save must not recreate a deleted agent's directory (#3364).
+
+        A debounced / in-flight memory write that lands after the agent was
+        deleted must give up rather than mkdir the directory back into
+        existence, which would block recreating a same-named agent.
+        """
+        agent_dir = tmp_path / "agents" / "ghost-agent"
+        memory_file = agent_dir / "memory.json"
+        # Agent directory intentionally does NOT exist (agent was deleted).
+
+        def mock_get_paths():
+            mock_paths = MagicMock()
+            mock_paths.user_agent_memory_file.return_value = memory_file
+            return mock_paths
+
+        with patch("deerflow.agents.memory.storage.get_paths", side_effect=mock_get_paths):
+            storage = FileMemoryStorage()
+            result = storage.save(
+                {"version": "1.0", "facts": [{"content": "late write"}]},
+                "ghost-agent",
+                user_id="alice",
+            )
+
+        assert result is False
+        assert not memory_file.exists()
+        assert not agent_dir.exists(), "save() must not recreate the deleted agent directory"
+
+    def test_save_writes_when_agent_dir_exists(self, tmp_path):
+        """Per-agent save still works normally when the directory exists."""
+        agent_dir = tmp_path / "agents" / "live-agent"
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        memory_file = agent_dir / "memory.json"
+
+        def mock_get_paths():
+            mock_paths = MagicMock()
+            mock_paths.user_agent_memory_file.return_value = memory_file
+            return mock_paths
+
+        with patch("deerflow.agents.memory.storage.get_paths", side_effect=mock_get_paths):
+            storage = FileMemoryStorage()
+            result = storage.save(
+                {"version": "1.0", "facts": [{"content": "ok"}]},
+                "live-agent",
+                user_id="alice",
+            )
+
+        assert result is True
+        assert memory_file.exists()
+
     def test_save_does_not_mutate_caller_dict(self, tmp_path):
         """save() must not mutate the caller's dict (lastUpdated side-effect)."""
         memory_file = tmp_path / "memory.json"

--- a/backend/tests/test_memory_storage_user_isolation.py
+++ b/backend/tests/test_memory_storage_user_isolation.py
@@ -109,8 +109,11 @@ class TestUserIsolatedStorage:
             s = FileMemoryStorage()
             memory = create_empty_memory()
             memory["user"]["workContext"]["summary"] = "agent scoped"
-            s.save(memory, "test-agent", user_id="alice")
             expected_path = base_dir / "users" / "alice" / "agents" / "test-agent" / "memory.json"
+            # The agent directory exists in real flow (created at agent creation);
+            # per-agent save() no longer recreates it (issue #3364).
+            expected_path.parent.mkdir(parents=True, exist_ok=True)
+            s.save(memory, "test-agent", user_id="alice")
             assert expected_path.exists()
 
     def test_cache_key_is_user_agent_tuple(self, base_dir: Path):


### PR DESCRIPTION
## Summary

Fixes #3364. Deleting a custom agent could leave behind a stray directory containing a `memory.json`, after which recreating a same-named agent failed with `409 already exists`.

### Root cause

Memory updates run on a debounced background queue, decoupled from agent deletion. When an agent was deleted, a still-pending (or in-flight) memory write would later call `FileMemoryStorage.save()`, whose `mkdir(parents=True, exist_ok=True)` **recreated the just-deleted agent directory** along with a `memory.json`. The recreated directory then tripped the `exists()` check in `create_agent`, blocking recreation of a same-named agent.

### Fix

- **Root cause — `FileMemoryStorage.save()`**: per-agent writes (`agent_name` set) no longer recreate the agent directory. If the directory is gone (agent deleted), the write is skipped and returns `False` instead of resurrecting it. This closes the race regardless of *when* the deletion lands relative to the write — even a TOCTOU delete between the `exists()` check and `open()` just fails cleanly via the existing `OSError` path. Global/per-user memory keeps creating its parent directory as before.
- **Best-effort queue guard**: `delete_agent()` now calls `MemoryUpdateQueue.discard()` before `rmtree()` to drop pending updates. If a processing run already holds an in-flight snapshot, an agent-level tombstone is recorded so an already-dequeued context is skipped before reaching `save()`. Tombstones are cleared when the run ends, so the set never grows unbounded.

### Tests

- `test_save_skips_when_agent_dir_missing` / `test_save_writes_when_agent_dir_exists` — per-agent save respects directory existence.
- New queue tests for `discard()`, the in-flight race, and recreation after discard.
- Adjusted `test_user_agent_memory_file_location` to reflect that the agent directory is created by the agent-creation flow.

All 158 related tests pass; `ruff check` is clean.