### PR TITLE
feat: implement PII and sensitive token redaction middleware

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -29,6 +29,7 @@ from deerflow.agents.memory.summarization_hook import memory_flush_hook
 from deerflow.agents.middlewares.clarification_middleware import ClarificationMiddleware
 from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
 from deerflow.agents.middlewares.memory_middleware import MemoryMiddleware
+from deerflow.agents.middlewares.redaction_middleware import RedactionMiddleware
 from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
 from deerflow.agents.middlewares.subagent_limit_middleware import SubagentLimitMiddleware
 from deerflow.agents.middlewares.summarization_middleware import BeforeSummarizationHook, DeerFlowSummarizationMiddleware
@@ -302,6 +303,9 @@ def _build_middlewares(
     todo_list_middleware = _create_todo_list_middleware(is_plan_mode)
     if todo_list_middleware is not None:
         middlewares.append(todo_list_middleware)
+
+    # Add RedactionMiddleware before Title and Memory to ensure they only see safe text
+    middlewares.append(RedactionMiddleware())
 
     # Add TokenUsageMiddleware when token_usage tracking is enabled
     if resolved_app_config.token_usage.enabled:

--- a/backend/packages/harness/deerflow/agents/middlewares/redaction_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/redaction_middleware.py
@@ -1,0 +1,98 @@
+import logging
+import re
+from collections.abc import Awaitable, Callable
+from typing import override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from deerflow.config.redaction_config import get_redaction_config
+
+logger = logging.getLogger(__name__)
+
+
+class RedactionMiddleware(AgentMiddleware[AgentState]):
+    """Middleware to redact sensitive information from messages."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.config = get_redaction_config()
+        self.compiled_patterns = [re.compile(p) for p in self.config.patterns]
+
+    def _redact_text(self, text: str) -> str:
+        """"""
+
+        if not self.config.enabled or not text:
+            return text
+
+        redacted = text
+        for pattern in self.compiled_patterns:
+            redacted = pattern.sub(self.config.redact_string, redacted)
+
+        return redacted
+
+    def _redact_message(self, message: AnyMessage) -> AnyMessage:
+
+        if not self.config.enabled:
+            return message
+
+        if isinstance(message, (AIMessage, ToolMessage)):
+            if isinstance(message.content, str):
+                message.content = self._redact_text(message.content)
+            elif isinstance(message.content, list):
+                for block in message.content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        block["text"] = self._redact_text(block.get("text", ""))
+
+        return message
+
+    @override
+    def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelCallResult:
+
+        if self.config.enabled:
+            for msg in request.messages:
+                self._redact_message(msg)
+
+        response = handler(request)
+
+        if self.config.enabled and response:
+            self._redact_message(response)
+
+        return response
+
+    @override
+    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelResponse:
+        if self.config.enabled:
+            for msg in request.messages:
+                self._redact_message(msg)
+
+        response = await handler(request)
+
+        if self.config.enabled and response:
+            self._redact_message(response)
+
+        return response
+
+    @override
+    def wrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], ToolMessage | Command]) -> ToolMessage | Command:
+        response = handler(request)
+        if self.config.enabled and isinstance(response, ToolMessage):
+            self._redact_message(response)
+
+        return response
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        response = await handler(request)
+        if self.config.enabled and isinstance(response, ToolMessage):
+            self._redact_message(response)
+
+        return response

--- a/backend/packages/harness/deerflow/agents/middlewares/redaction_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/redaction_middleware.py
@@ -1,12 +1,13 @@
 import logging
 import re
 from collections.abc import Awaitable, Callable
+from dataclasses import replace as dc_replace
 from typing import override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
-from langchain_core.messages import AIMessage, AnyMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, SystemMessage, ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
@@ -21,11 +22,17 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
     def __init__(self) -> None:
         super().__init__()
         self.config = get_redaction_config()
-        self.compiled_patterns = [re.compile(p) for p in self.config.patterns]
+        if not self.config.enabled:
+            self.compiled_patterns = []
+            return
+        try:
+            self.compiled_patterns = [re.compile(p) for p in self.config.patterns]
+        except re.error as exc:
+            logger.error("Invalid redaction regex pattern: %s", exc)
+            raise
 
     def _redact_text(self, text: str) -> str:
-        """"""
-
+        """Redacts sensitive information from a string using configured regex patterns."""
         if not self.config.enabled or not text:
             return text
 
@@ -36,11 +43,11 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
         return redacted
 
     def _redact_message(self, message: AnyMessage) -> AnyMessage:
-
+        """Helper to redact sensitive data inside a message."""
         if not self.config.enabled:
             return message
 
-        if isinstance(message, (AIMessage, ToolMessage)):
+        if isinstance(message, (AIMessage, ToolMessage, HumanMessage, SystemMessage)):
             if isinstance(message.content, str):
                 message.content = self._redact_text(message.content)
             elif isinstance(message.content, list):
@@ -49,6 +56,19 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
                         block["text"] = self._redact_text(block.get("text", ""))
 
         return message
+
+    def _redact_command(self, command: Command) -> Command:
+        """Redact messages inside a Command's update dict."""
+        update = getattr(command, "update", None)
+        if not isinstance(update, dict):
+            return command
+
+        messages = update.get("messages")
+        if not messages:
+            return command
+
+        patched = [self._redact_message(m) for m in messages]
+        return dc_replace(command, update={**update, "messages": patched})
 
     @override
     def wrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], ModelResponse]) -> ModelCallResult:
@@ -65,7 +85,7 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
         return response
 
     @override
-    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelResponse:
+    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelCallResult:
         if self.config.enabled:
             for msg in request.messages:
                 self._redact_message(msg)
@@ -79,9 +99,13 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
 
     @override
     def wrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], ToolMessage | Command]) -> ToolMessage | Command:
+
         response = handler(request)
-        if self.config.enabled and isinstance(response, ToolMessage):
-            self._redact_message(response)
+        if self.config.enabled:
+            if isinstance(response, ToolMessage):
+                self._redact_message(response)
+            elif isinstance(response, Command):
+                response = self._redact_command(response)
 
         return response
 
@@ -91,8 +115,12 @@ class RedactionMiddleware(AgentMiddleware[AgentState]):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
     ) -> ToolMessage | Command:
+
         response = await handler(request)
-        if self.config.enabled and isinstance(response, ToolMessage):
-            self._redact_message(response)
+        if self.config.enabled:
+            if isinstance(response, ToolMessage):
+                self._redact_message(response)
+            elif isinstance(response, Command):
+                response = self._redact_command(response)
 
         return response

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -18,6 +18,7 @@ from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_
 from deerflow.config.loop_detection_config import LoopDetectionConfig
 from deerflow.config.memory_config import MemoryConfig, load_memory_config_from_dict
 from deerflow.config.model_config import ModelConfig
+from deerflow.config.redaction_config import RedactionConfig, load_redaction_config_from_dict
 from deerflow.config.run_events_config import RunEventsConfig
 from deerflow.config.runtime_paths import existing_project_file
 from deerflow.config.safety_finish_reason_config import SafetyFinishReasonConfig
@@ -105,6 +106,7 @@ class AppConfig(BaseModel):
     guardrails: GuardrailsConfig = Field(default_factory=GuardrailsConfig, description="Guardrail middleware configuration")
     circuit_breaker: CircuitBreakerConfig = Field(default_factory=CircuitBreakerConfig, description="LLM circuit breaker configuration")
     loop_detection: LoopDetectionConfig = Field(default_factory=LoopDetectionConfig, description="Loop detection middleware configuration")
+    redaction: RedactionConfig = Field(default_factory=RedactionConfig, description="Redaction middleware configuration.")
     safety_finish_reason: SafetyFinishReasonConfig = Field(default_factory=SafetyFinishReasonConfig, description="Provider safety-filter finish_reason interception middleware configuration")
     model_config = ConfigDict(extra="allow")
     database: DatabaseConfig = Field(default_factory=DatabaseConfig, description="Unified database backend configuration")
@@ -202,6 +204,7 @@ class AppConfig(BaseModel):
         load_checkpointer_config_from_dict(config.checkpointer.model_dump() if config.checkpointer is not None else None)
         load_stream_bridge_config_from_dict(config.stream_bridge.model_dump() if config.stream_bridge is not None else None)
         load_acp_config_from_dict({name: agent.model_dump() for name, agent in acp_agents.items()})
+        load_redaction_config_from_dict(config.redaction.model_dump())
 
         if previous_checkpointer_config != config.checkpointer:
             # These runtime singletons derive their backend from checkpointer config.

--- a/backend/packages/harness/deerflow/config/redaction_config.py
+++ b/backend/packages/harness/deerflow/config/redaction_config.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RedactionConfig(BaseModel):
+    """Configuration for the redaction middleware."""
+
+    enabled: bool = Field(default=False, description="Enable or disable redaction middleware.")
+    redact_string: str = Field(default="[REDACTED]", description="String used to replace matched sensitive tokens.")
+    patterns: list[str] = Field(
+        default_factory=lambda: [
+            r"(?i)bearer\s+[A-Za-z0-9\-\._~\+/]+",  # Bearer tokens
+            r"(?i)api[_-]?key\s*[:=]\s*['\"]?[A-Za-z0-9\-\._]+['\"]?",  # API Keys
+            r"(?i)sk-[a-zA-Z0-9]{32,}",  # OpenAI style secret keys
+            r"gh[po]_[a-zA-Z0-9]{36}",  # GitHub tokens
+            r"(?i)password\s*[:=]\s*['\"]?[^'\"]+['\"]?",  # Passwords
+            r"eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*",  # JWT tokens
+        ],
+        description="List of regex patterns to identify and redact sensitive information.",
+    )
+
+
+_redaction_config: RedactionConfig | None = None
+
+
+def get_redaction_config() -> RedactionConfig:
+    """Get the global redaction configuration."""
+    global _redaction_config
+    if _redaction_config is None:
+        return RedactionConfig()
+    return _redaction_config
+
+
+def load_redaction_config_from_dict(config_data: dict[str, Any] | None) -> RedactionConfig:
+    """Load and set the global redaction configuration from a dictionary.
+
+    Args:
+        config_data: The dictionary containing the redaction configuration.
+
+    Returns:
+        The loaded RedactionConfig.
+    """
+    global _redaction_config
+    if config_data is None:
+        _redaction_config = RedactionConfig()
+    else:
+        _redaction_config = RedactionConfig(**config_data)
+
+    return _redaction_config

--- a/backend/tests/test_redaction_middleware.py
+++ b/backend/tests/test_redaction_middleware.py
@@ -1,0 +1,47 @@
+import pytest
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+
+from deerflow.agents.middlewares.redaction_middleware import RedactionMiddleware
+from deerflow.config.redaction_config import load_redaction_config_from_dict
+
+
+@pytest.fixture
+def middleware():
+    config_dict = {"enabled": True, "redact_string": "[REDACTED]", "patterns": [r"(?i)api_key\s*=\s*['\"][A-Za-z0-9_-]+['\"]", r"password123"]}
+    load_redaction_config_from_dict(config_dict)
+    return RedactionMiddleware()
+
+
+def test_redact_text(middleware):
+    text = "Here is my api_key='secret123' and password123"
+    redacted = middleware._redact_text(text)
+    assert "[REDACTED]" in redacted
+    assert "secret123" not in redacted
+    assert "password123" not in redacted
+
+
+def test_wrap_model_call(middleware):
+    request = ModelRequest(messages=[HumanMessage(content="Use api_key='secret'")], model=None)
+
+    def mock_handler(req: ModelRequest) -> tuple[AIMessage, bool]:
+        assert "secret123" not in req.messages[0].content
+        return AIMessage(content="i generated an api_key='secret'")
+
+    response = middleware.wrap_model_call(request, mock_handler)
+
+    assert "[REDACTED]" in response.content
+    assert "secret" not in response.content
+
+
+def test_wrap_tool_call(middleware):
+    request = ToolCallRequest(tool_call={"name": "test_tool", "id": "1", "args": {}}, tool=None, state={}, runtime=None)
+
+    def mock_handler(req: ToolCallRequest) -> ToolMessage:
+        return ToolMessage(content="Found api_key='sk_secret_123' in the file.", tool_call_id="1", name="test_tool")
+
+    response = middleware.wrap_tool_call(request, mock_handler)
+
+    assert "[REDACTED]" in response.content
+    assert "sk_secret_123" not in response.content

--- a/backend/tests/test_redaction_middleware.py
+++ b/backend/tests/test_redaction_middleware.py
@@ -11,7 +11,10 @@ from deerflow.config.redaction_config import load_redaction_config_from_dict
 def middleware():
     config_dict = {"enabled": True, "redact_string": "[REDACTED]", "patterns": [r"(?i)api_key\s*=\s*['\"][A-Za-z0-9_-]+['\"]", r"password123"]}
     load_redaction_config_from_dict(config_dict)
-    return RedactionMiddleware()
+    try:
+        yield RedactionMiddleware()
+    finally:
+        load_redaction_config_from_dict(None)
 
 
 def test_redact_text(middleware):
@@ -23,16 +26,17 @@ def test_redact_text(middleware):
 
 
 def test_wrap_model_call(middleware):
-    request = ModelRequest(messages=[HumanMessage(content="Use api_key='secret'")], model=None)
+    request = ModelRequest(messages=[HumanMessage(content="Use api_key='secret123'")], model=None)
 
     def mock_handler(req: ModelRequest) -> tuple[AIMessage, bool]:
         assert "secret123" not in req.messages[0].content
-        return AIMessage(content="i generated an api_key='secret'")
+        assert "[REDACTED]" in req.messages[0].content
+        return AIMessage(content="i generated an api_key='my_secret_key'")
 
     response = middleware.wrap_model_call(request, mock_handler)
 
     assert "[REDACTED]" in response.content
-    assert "secret" not in response.content
+    assert "secret123" not in response.content
 
 
 def test_wrap_tool_call(middleware):
@@ -45,3 +49,19 @@ def test_wrap_tool_call(middleware):
 
     assert "[REDACTED]" in response.content
     assert "sk_secret_123" not in response.content
+
+
+def test_wrap_tool_call_command(middleware):
+    """Verify that ToolMessage wrapped inside a Command are also redacted."""
+    from langgraph.types import Command
+
+    request = ToolCallRequest(tool_call={"name": "test_tool", "id": "2", "args": {}}, tool=None, state={}, runtime=None)
+
+    def mock_handler(req: ToolCallRequest):
+        return Command(update={"messages": [ToolMessage(content="Found api_key='sk_secret_123' in the file.", tool_call_id="2", name="test_tool")]})
+
+    response = middleware.wrap_tool_call(request, mock_handler)
+
+    assert isinstance(response, Command)
+    assert "sk_secret_123" not in response.update["messages"][0].content
+    assert "[REDACTED]" in response.update["messages"][0].content

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1216,3 +1216,30 @@ run_events:
 #   failure_threshold: 5
 #   # Time in seconds before attempting to recover (default: 60)
 #   recovery_timeout_sec: 60
+
+# ============================================================================
+# Redaction Middleware Configuration
+# ============================================================================
+# Used to strip sensitive information from LLM interactions to prevent data leakage.
+# By default, redaction is disabled. When enabled, any text matching the
+# defined regex patterns will be replaced with the specified string.
+#
+# This is useful for:
+# - Preventing API keys or secrets from leaking to the LLM provider
+# - Ensuring PII doesn't end up in local memory or conversation logs
+
+# redaction:
+#   # Enable or disable the redaction middleware (default: false)
+#   enabled: false
+#   
+#   # String used to replace matched sensitive tokens (default: "[REDACTED]")
+#   redact_string: "[REDACTED]"
+#
+#   # List of regex patterns to identify sensitive data
+#   patterns:
+#     - '(?i)bearer\s+[A-Za-z0-9\-\._~\+/]+'
+#     - '(?i)api[_-]?key\s*[:=]\s*[''"]?[A-Za-z0-9\-\._]+[''"]?'
+#     - '(?i)sk-[a-zA-Z0-9]{32,}'
+#     - 'gh[po]_[a-zA-Z0-9]{36}'
+#     - '(?i)password\s*[:=]\s*[''"]?[^''"]+[''"]?'
+#     - 'eyJ[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*'


### PR DESCRIPTION
## Why

Added a middleware to prevent sensitive data (like API keys or passwords) from leaking. When tools like a bash executor or file reader accidentally hit secrets (e.g., in a `.env` file), we don't want those tokens passed back to the LLM provider or saved permanently in local memory. 

## What changed

- Added `RedactionMiddleware` to intercept and sanitize inputs/outputs before they hit the LLM or get saved.
- Exposed `redaction` in `AppConfig` so users can easily define their own regex patterns.
- Hooked it into the lead agent pipeline right before `TitleMiddleware` and `MemoryMiddleware`.
- Default behavior remains completely unchanged (the middleware is toggled `off` by default).

## Validation

- Added and passed all unit tests in `tests/test_redaction_middleware.py`.
- Verified formatting and linting with `make lint` / `pre-commit`.
