### PR TITLE
fix(frontend): route AuthProvider auth requests through shared fetcher (#3264)

### DIFF
--- a/frontend/src/core/api/fetcher.ts
+++ b/frontend/src/core/api/fetcher.ts
@@ -36,6 +36,19 @@ export function readCsrfCookie(): string | null {
   return null;
 }
 
+/** Extra options accepted by :func:`fetch` on top of the standard ``RequestInit``. */
+export interface AuthFetchInit extends RequestInit {
+  /**
+   * Whether a 401 response should auto-redirect to ``/login`` and throw.
+   *
+   * Defaults to ``true``. Set to ``false`` for the rare call site that needs
+   * to handle session expiry itself (e.g. ``AuthProvider.refreshUser``, which
+   * clears local state and only redirects on protected routes). The request
+   * still goes through this wrapper so ``credentials`` and CSRF stay centralized.
+   */
+  redirectOnUnauthorized?: boolean;
+}
+
 /**
  * Fetch with credentials and automatic CSRF protection.
  *
@@ -49,20 +62,21 @@ export function readCsrfCookie(): string | null {
  *    403 if the header is missing — silently breaking every call site
  *    that uses raw ``fetch()`` instead of this wrapper.
  *
- * Auto-redirects to ``/login`` on 401. Caller-supplied headers are
- * preserved; the helper only ADDS the CSRF header when it isn't already
- * present, so explicit overrides win.
+ * Auto-redirects to ``/login`` on 401 unless ``redirectOnUnauthorized`` is
+ * ``false``. Caller-supplied headers are preserved; the helper only ADDS the
+ * CSRF header when it isn't already present, so explicit overrides win.
  */
 export async function fetch(
   input: RequestInfo | string,
-  init?: RequestInit,
+  init?: AuthFetchInit,
 ): Promise<Response> {
+  const { redirectOnUnauthorized = true, ...requestInit } = init ?? {};
   const url = typeof input === "string" ? input : input.url;
 
   // Inject CSRF for state-changing methods. GET/HEAD/OPTIONS/TRACE skip
   // it to mirror the gateway's ``should_check_csrf`` logic exactly.
-  let headers = init?.headers;
-  if (isStateChangingMethod(init?.method ?? "GET")) {
+  let headers = requestInit.headers;
+  if (isStateChangingMethod(requestInit.method ?? "GET")) {
     const token = readCsrfCookie();
     if (token) {
       // Fresh Headers instance so we don't mutate caller-supplied objects.
@@ -75,12 +89,12 @@ export async function fetch(
   }
 
   const res = await globalThis.fetch(url, {
-    ...init,
+    ...requestInit,
     headers,
     credentials: "include",
   });
 
-  if (res.status === 401) {
+  if (res.status === 401 && redirectOnUnauthorized) {
     window.location.href = buildLoginUrl(window.location.pathname);
     throw new Error("Unauthorized");
   }

--- a/frontend/src/core/auth/AuthProvider.tsx
+++ b/frontend/src/core/auth/AuthProvider.tsx
@@ -10,6 +10,8 @@ import React, {
   type ReactNode,
 } from "react";
 
+import { fetch as fetchWithAuth } from "@/core/api/fetcher";
+
 import { isStaticWebsiteOnly } from "../static-mode";
 
 import { type User, buildLoginUrl } from "./types";
@@ -61,8 +63,10 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
 
     try {
       setIsLoading(true);
-      const res = await fetch("/api/v1/auth/me", {
-        credentials: "include",
+      // refreshUser handles 401 itself (clear local state, redirect only on
+      // protected routes), so opt out of the wrapper's auto-redirect.
+      const res = await fetchWithAuth("/api/v1/auth/me", {
+        redirectOnUnauthorized: false,
       });
 
       if (res.ok) {
@@ -98,9 +102,13 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
     }
 
     try {
-      await fetch("/api/v1/auth/logout", {
+      // POST is a state-changing method, so it must carry the X-CSRF-Token
+      // header injected by the shared fetcher; a raw fetch would be rejected
+      // by the gateway's CSRFMiddleware with 403. The session is already
+      // expiring here, so don't auto-redirect on a 401 from logout itself.
+      await fetchWithAuth("/api/v1/auth/logout", {
         method: "POST",
-        credentials: "include",
+        redirectOnUnauthorized: false,
       });
     } catch (err) {
       console.error("Logout request failed:", err);

--- a/frontend/tests/unit/core/api/fetcher.test.ts
+++ b/frontend/tests/unit/core/api/fetcher.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression tests for the shared auth fetcher (`@/core/api/fetcher`).
+ *
+ * Issue #3264: auth requests in `AuthProvider` used raw `fetch`, bypassing the
+ * centralized credentials / CSRF / 401 handling. These tests pin the contracts
+ * every auth call site relies on:
+ *
+ * 1. `credentials: "include"` is always sent.
+ * 2. State-changing methods (POST/PUT/DELETE/PATCH) carry `X-CSRF-Token`
+ *    echoed from the `csrf_token` cookie, so the gateway's CSRFMiddleware
+ *    does not reject them with 403.
+ * 3. GET/HEAD skip the CSRF header (mirrors the gateway's `should_check_csrf`).
+ * 4. A 401 auto-redirects to `/login` and throws, unless the caller opts out
+ *    via `redirectOnUnauthorized: false` (the documented exception used by
+ *    `AuthProvider.refreshUser` / `logout`).
+ */
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { fetch as fetchWithAuth } from "@/core/api/fetcher";
+
+let globalFetch: ReturnType<typeof vi.fn>;
+let assignedHref: string[];
+
+function stubCookie(token: string | null): void {
+  vi.stubGlobal("document", {
+    cookie: token === null ? "" : `csrf_token=${token}; other=1`,
+  });
+}
+
+function stubWindow(pathname: string): void {
+  assignedHref = [];
+  vi.stubGlobal("window", {
+    location: {
+      pathname,
+      set href(value: string) {
+        assignedHref.push(value);
+      },
+    },
+  });
+}
+
+beforeEach(() => {
+  globalFetch = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+  vi.stubGlobal("fetch", globalFetch);
+  stubCookie("csrf-abc");
+  stubWindow("/workspace/chats");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("always sends credentials: include", async () => {
+  await fetchWithAuth("/api/v1/auth/me");
+
+  expect(globalFetch).toHaveBeenCalledTimes(1);
+  const init = globalFetch.mock.calls[0]![1] as RequestInit;
+  expect(init.credentials).toBe("include");
+});
+
+test("injects X-CSRF-Token on state-changing methods from the cookie", async () => {
+  await fetchWithAuth("/api/v1/auth/logout", { method: "POST" });
+
+  const init = globalFetch.mock.calls[0]![1] as RequestInit;
+  const headers = new Headers(init.headers);
+  expect(headers.get("X-CSRF-Token")).toBe("csrf-abc");
+});
+
+test("does not add X-CSRF-Token on GET requests", async () => {
+  await fetchWithAuth("/api/v1/auth/me", { method: "GET" });
+
+  const init = globalFetch.mock.calls[0]![1] as RequestInit;
+  const headers = new Headers(init.headers);
+  expect(headers.has("X-CSRF-Token")).toBe(false);
+});
+
+test("does not overwrite a caller-supplied X-CSRF-Token", async () => {
+  await fetchWithAuth("/api/v1/auth/logout", {
+    method: "POST",
+    headers: { "X-CSRF-Token": "explicit" },
+  });
+
+  const init = globalFetch.mock.calls[0]![1] as RequestInit;
+  const headers = new Headers(init.headers);
+  expect(headers.get("X-CSRF-Token")).toBe("explicit");
+});
+
+test("redirects to /login and throws on 401 by default", async () => {
+  globalFetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+  await expect(fetchWithAuth("/api/v1/auth/me")).rejects.toThrow(
+    "Unauthorized",
+  );
+  expect(assignedHref).toHaveLength(1);
+  expect(assignedHref[0]).toContain("/login");
+});
+
+test("does not redirect on 401 when redirectOnUnauthorized is false", async () => {
+  globalFetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+
+  const res = await fetchWithAuth("/api/v1/auth/me", {
+    redirectOnUnauthorized: false,
+  });
+
+  expect(res.status).toBe(401);
+  expect(assignedHref).toHaveLength(0);
+});
+
+test("does not forward redirectOnUnauthorized to the underlying fetch init", async () => {
+  await fetchWithAuth("/api/v1/auth/me", { redirectOnUnauthorized: false });
+
+  const init = globalFetch.mock.calls[0]![1] as Record<string, unknown>;
+  expect("redirectOnUnauthorized" in init).toBe(false);
+});


### PR DESCRIPTION
## Problem

Closes #3264.

`AuthProvider` issued its auth requests with the native `fetch` instead of the shared wrapper in `@/core/api/fetcher`:

- `refreshUser()` → `GET /api/v1/auth/me`
- `logout()` → `POST /api/v1/auth/logout`

The shared fetcher centralizes three contracts every auth call depends on:

1. `credentials: "include"` so the HttpOnly `access_token` cookie rides along with SSR-routed requests.
2. `X-CSRF-Token` injection on state-changing methods (POST/PUT/DELETE/PATCH), echoed from the `csrf_token` cookie for the gateway's Double-Submit-Cookie check.
3. Consistent 401 handling.

Because `logout()` used raw `fetch` for a **POST**, it never carried `X-CSRF-Token`. The gateway's `CSRFMiddleware` rejects such requests with **403**, so server-side sign-out was silently broken — the logout call failed even though the UI optimistically cleared local state. This is exactly the "raw fetch bypasses the wrapper" class of bug the wrapper was built to prevent, and it left auth requests without a single, enforced convention.

## Solution

**1. `fetcher.ts` — opt-out for 401 auto-redirect**

The wrapper auto-redirects to `/login` and throws on 401. That default is wrong for `AuthProvider`, which must own its 401 handling (it clears local user state and only redirects on protected routes). Rather than push these call sites back to raw `fetch` (losing credentials + CSRF), I added an explicit opt-out:

- New `AuthFetchInit extends RequestInit` with `redirectOnUnauthorized?: boolean` (default `true`).
- The flag is destructured out and **never forwarded** to the underlying native `fetch` init, so it can't leak into the real request.
- All other behavior (credentials, CSRF injection, caller-header precedence) is unchanged.

**2. `AuthProvider.tsx` — route both calls through the shared fetcher**

- `refreshUser()` and `logout()` now call `fetchWithAuth(..., { redirectOnUnauthorized: false })`.
- `refreshUser()` keeps its existing 401 semantics (clear local user; redirect only when on a `/workspace` route).
- `logout()` now automatically carries `X-CSRF-Token`, **fixing the latent 403**. Since the session is already expiring at logout, it opts out of the wrapper's auto-redirect.

**3. Tests — pin the fetcher contract**

Added `frontend/tests/unit/core/api/fetcher.test.ts` (7 cases):

- `credentials: "include"` is always sent.
- `X-CSRF-Token` is injected on state-changing methods from the cookie.
- GET requests skip CSRF (mirrors the gateway's `should_check_csrf`).
- A caller-supplied `X-CSRF-Token` is not overwritten.
- 401 redirects to `/login` and throws by default.
- `redirectOnUnauthorized: false` suppresses the redirect and returns the 401 response.
- The custom flag is not forwarded to the native `fetch` init.

## Verification

- `vitest run tests/unit/core/api/fetcher.test.ts` → 7/7 pass.
- `eslint` clean on all three files.
- No new type/linter diagnostics.

## Notes / scope

This PR fixes the highest-impact path (`AuthProvider`). Enforcing "all auth requests must go through the shared fetcher" as a lint rule across the codebase is a reasonable follow-up but is intentionally out of scope here to keep the change focused.