### PR TITLE
fix(frontend): truncate overflowing text in agent cards

### DIFF
--- a/frontend/src/components/workspace/agents/agent-card.tsx
+++ b/frontend/src/components/workspace/agents/agent-card.tsx
@@ -66,7 +66,9 @@ function TruncatedTooltip({
         {children}
       </TooltipTrigger>
       {truncated && (
-        <TooltipContent className="max-w-xs text-wrap">{text}</TooltipContent>
+        <TooltipContent className="max-w-xs text-wrap break-words">
+          {text}
+        </TooltipContent>
       )}
     </Tooltip>
   );

--- a/frontend/src/components/workspace/agents/agent-card.tsx
+++ b/frontend/src/components/workspace/agents/agent-card.tsx
@@ -52,7 +52,7 @@ function TruncatedTooltip({
 }) {
   const [truncated, setTruncated] = useState(false);
   return (
-    <Tooltip delayDuration={500}>
+    <Tooltip>
       <TooltipTrigger
         asChild
         onPointerEnter={(e) => {

--- a/frontend/src/components/workspace/agents/agent-card.tsx
+++ b/frontend/src/components/workspace/agents/agent-card.tsx
@@ -2,7 +2,7 @@
 
 import { BotIcon, MessageSquareIcon, Trash2Icon } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { type ComponentProps, type ReactElement, useState } from "react";
 import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
@@ -23,12 +23,79 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useDeleteAgent } from "@/core/agents";
 import type { Agent } from "@/core/agents";
 import { useI18n } from "@/core/i18n/hooks";
+import { cn } from "@/lib/utils";
 
 interface AgentCardProps {
   agent: Agent;
+}
+
+/**
+ * Reveals the full text in a tooltip ONLY when its trigger is actually clipped.
+ * Clipping is measured on pointer enter against the trigger's own box, covering
+ * both single-line `truncate` (width) and multi-line `line-clamp` (height), so
+ * untruncated content never pops a redundant tooltip.
+ */
+function TruncatedTooltip({
+  text,
+  children,
+}: {
+  text: string;
+  children: ReactElement;
+}) {
+  const [truncated, setTruncated] = useState(false);
+  return (
+    <Tooltip delayDuration={500}>
+      <TooltipTrigger
+        asChild
+        onPointerEnter={(e) => {
+          const el = e.currentTarget;
+          setTruncated(
+            el.scrollWidth > el.clientWidth ||
+              el.scrollHeight > el.clientHeight,
+          );
+        }}
+      >
+        {children}
+      </TooltipTrigger>
+      {truncated && (
+        <TooltipContent className="max-w-xs text-wrap">{text}</TooltipContent>
+      )}
+    </Tooltip>
+  );
+}
+
+/**
+ * Long, user-controlled labels (agent model, skills, tool groups) that must
+ * never break the card layout: width is capped to the parent and the text is
+ * truncated with an ellipsis, with the full value revealed on hover.
+ */
+function TruncatedBadge({
+  label,
+  variant,
+  className,
+}: {
+  label: string;
+  variant: ComponentProps<typeof Badge>["variant"];
+  className?: string;
+}) {
+  return (
+    <TruncatedTooltip text={label}>
+      <Badge
+        variant={variant}
+        className={cn("block max-w-full truncate", className)}
+      >
+        {label}
+      </Badge>
+    </TruncatedTooltip>
+  );
 }
 
 export function AgentCard({ agent }: AgentCardProps) {
@@ -55,27 +122,33 @@ export function AgentCard({ agent }: AgentCardProps) {
     <>
       <Card className="group flex flex-col transition-shadow hover:shadow-md">
         <CardHeader className="pb-3">
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
               <div className="bg-primary/10 text-primary flex h-9 w-9 shrink-0 items-center justify-center rounded-lg">
                 <BotIcon className="h-5 w-5" />
               </div>
               <div className="min-w-0">
-                <CardTitle className="truncate text-base">
-                  {agent.name}
-                </CardTitle>
+                <TruncatedTooltip text={agent.name}>
+                  <CardTitle className="truncate text-base">
+                    {agent.name}
+                  </CardTitle>
+                </TruncatedTooltip>
                 {agent.model && (
-                  <Badge variant="secondary" className="mt-0.5 text-xs">
-                    {agent.model}
-                  </Badge>
+                  <TruncatedBadge
+                    label={agent.model}
+                    variant="secondary"
+                    className="mt-0.5 text-xs"
+                  />
                 )}
               </div>
             </div>
           </div>
           {agent.description && (
-            <CardDescription className="mt-2 line-clamp-2 text-sm">
-              {agent.description}
-            </CardDescription>
+            <TruncatedTooltip text={agent.description}>
+              <CardDescription className="mt-2 line-clamp-2 text-sm">
+                {agent.description}
+              </CardDescription>
+            </TruncatedTooltip>
           )}
         </CardHeader>
 
@@ -83,22 +156,20 @@ export function AgentCard({ agent }: AgentCardProps) {
           <CardContent className="pt-0 pb-3">
             <div className="flex flex-wrap gap-1">
               {agent.tool_groups?.map((group) => (
-                <Badge
+                <TruncatedBadge
                   key={`tg:${group}`}
+                  label={group}
                   variant="outline"
                   className="text-xs"
-                >
-                  {group}
-                </Badge>
+                />
               ))}
               {agent.skills?.map((skill) => (
-                <Badge
+                <TruncatedBadge
                   key={`sk:${skill}`}
+                  label={skill}
                   variant="secondary"
                   className="text-xs"
-                >
-                  {skill}
-                </Badge>
+                />
               ))}
             </div>
           </CardContent>


### PR DESCRIPTION
Fixes #3389

## Why

A custom agent whose name is long enough overflows the agent card and breaks its
layout: the name runs past the card's right edge instead of being truncated or
wrapped, as reported in the issue. The same overflow hits long descriptions,
skills and tool-group labels, so an agent with descriptive names leaves a
visibly broken card.

## What changed

From a user's perspective, on `/workspace/agents`:

- Long agent names, descriptions, skills and tool-group labels no longer break
  the card. They truncate with an ellipsis and stay within the card bounds.
- Hovering a name / description / label that is actually clipped reveals the full
  text in a tooltip. Short, non-clipped labels stay quiet (no tooltip).

## Surface area

- [x] **Frontend UI** — `frontend/src/components/workspace/agents/agent-card.tsx`
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Bug fix verification

This is a pure CSS/layout bug (overflow clipping inside a flex container). jsdom
does not lay out or render CSS, so a Vitest unit test cannot meaningfully go
red/green on it, and the repo has no component-level render test for the agent
card. It was instead verified in a real browser via `make dev` on
`/workspace/agents`:

- **Before:** a long name overflows the card's right edge (the reported
  behavior).
- **After:** the name truncates with an ellipsis and the card layout is intact.
- Injected an over-long skill label (front-end DOM only, no backend write) and
  confirmed the badge truncates within the card instead of overflowing.
- Confirmed the hover tooltip appears only when the text is actually clipped, and
  that its text fills the width with no blank gap (computed `text-wrap: wrap`).

Root cause: `CardTitle` already had `truncate`, but a wrapping flex ancestor was
missing `min-w-0`, so with the default `min-width: auto` the flex item refused to
shrink below its content and pushed past the card. Badges additionally ship
`whitespace-nowrap shrink-0 w-fit`, so a single long label never shrinks. The fix
restores the truncation chain (`min-w-0`), caps + ellipsizes the badges, and adds
a clip-aware tooltip, all in the agent card without touching the shared `ui/`
primitives.

## Validation

Run from `frontend/`:

- `pnpm lint` (eslint) — pass
- `pnpm typecheck` — pass
- `pnpm format` (prettier --check) — pass
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — pass
- `pnpm exec vitest run` — 179 passed (23 files)

The agents E2E (`agent-chat.spec.ts`) only asserts the visible agent-name text,
which `truncate` keeps intact in the DOM, so it is unaffected.
