### PR TITLE
fix(frontend): set allowedDevOrigins so make dev loads from non-localhost hosts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ JINA_API_KEY=your-jina-api-key
 INFOQUEST_API_KEY=your-infoquest-api-key
 # Browser CORS allowlist for split-origin or port-forwarded deployments (comma-separated exact origins).
 # Leave unset when using the unified nginx endpoint, e.g. http://localhost:2026.
+# In `make dev`, the hostnames here are also passed to Next.js allowedDevOrigins so
+# the dev UI loads from non-local hosts (LAN IP / remote / SSH tunnel); otherwise
+# next dev blocks its HMR WebSocket, the client runtime never hydrates, and the page
+# hangs on a "Loading…" screen. 127.0.0.1 works without this; for other hosts (e.g.
+# a LAN serverhost) add their origin here. See issues #3385 / #2983.
 # GATEWAY_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # Optional:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -20,3 +20,15 @@
 # Defaults to localhost — only override for non-local deployments.
 # DEER_FLOW_INTERNAL_GATEWAY_BASE_URL="http://localhost:8001"
 # DEER_FLOW_TRUSTED_ORIGINS="http://localhost:3000,http://localhost:2026"
+
+# Browser CORS allowlist for split-origin / port-forwarded deployments
+# (comma-separated origins). Primarily read by the Gateway; with `make dev` it
+# is set in the repo-root .env. In development the hostnames are also fed to
+# Next.js `allowedDevOrigins`, so the dev UI opened from a non-local host (a LAN
+# IP, a remote box, an SSH tunnel) keeps its HMR socket instead of having it
+# blocked, failing to hydrate, and hanging on a blank "Loading…" screen (issues
+# #3385, #2983). `127.0.0.1` is
+# allowed without configuration and `localhost` is always allowed by Next.js;
+# add any other host you browse from here. Matched by hostname only (port and
+# scheme are ignored); bracket IPv6 literals; `*` is ignored.
+# GATEWAY_CORS_ORIGINS="http://localhost:2026,http://127.0.0.1:2026"

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -10,7 +10,9 @@ function getInternalServiceURL(envKey, fallbackURL) {
     ? configured.replace(/\/+$/, "")
     : fallbackURL;
 }
+
 import nextra from "nextra";
+import { getAllowedDevOrigins } from "./src/lib/dev-origins.mjs";
 
 const withNextra = nextra({});
 
@@ -25,6 +27,7 @@ const config = {
     defaultLocale: "en",
   },
   devIndicators: false,
+  allowedDevOrigins: getAllowedDevOrigins(),
   async rewrites() {
     const rewrites = [];
     const gatewayURL = getInternalServiceURL(

--- a/frontend/src/lib/dev-origins.mjs
+++ b/frontend/src/lib/dev-origins.mjs
@@ -1,0 +1,79 @@
+/**
+ * Helpers for Next.js `allowedDevOrigins` (dev-only cross-origin allow-list).
+ *
+ * `next dev` blocks cross-origin requests to /_next/* dev endpoints for any
+ * request whose `Origin` hostname is not allow-listed. The request that
+ * actually breaks the page is the Turbopack HMR WebSocket
+ * (ws://<host>/_next/webpack-hmr): plain <script> chunks still load (a `<script>`
+ * tag sends no Origin header, so it is not blocked), but once the HMR socket is
+ * refused the dev client runtime never initializes, React never hydrates, and
+ * every client page is frozen on its server-rendered initial markup. For /setup
+ * that markup is the literal "Loading…", so it hangs there forever (verified in
+ * a real browser: hostname not allow-listed -> 0 React fibers, stuck on
+ * "Loading…"; allow-listed -> hydrates and proceeds). Issues #3385, #2983.
+ *
+ * DeerFlow's dev server sits behind the nginx proxy on port 2026 and is reached
+ * through whatever host the browser uses — `localhost`, `127.0.0.1`, a LAN IP,
+ * or an SSH-tunnelled host. Next.js only allows `localhost` / `*.localhost` out
+ * of the box, so opening `make dev` via anything else (e.g. `127.0.0.1:2026` on
+ * an autodl tunnel, or `<host>:2026` on a LAN) blocks the HMR socket and hangs
+ * the UI. Docker (`make up`) runs a production build, which has no dev
+ * cross-origin protection (and no HMR), so it is unaffected.
+ *
+ * `allowedDevOrigins` is dev-only — production builds ignore it.
+ *
+ * This module is `.mjs` (not `.ts`) because `next.config.js` is loaded by
+ * Node's native ESM loader, which cannot import TypeScript. It is still unit
+ * tested via Vitest (see tests/unit/lib/dev-origins.test.ts).
+ */
+
+/**
+ * Resolve the hostname from an origin string. Accepts full origins
+ * (`http://host:port`) and bare `host[:port]` values; returns null for blank or
+ * unparseable input. Next.js matches on hostname only (port/scheme are
+ * ignored), so we normalize down to the hostname here. IPv6 literals keep their
+ * brackets (e.g. `http://[::1]:2026` -> `[::1]`), matching how Next.js parses
+ * the incoming Origin header.
+ *
+ * @param {string | null | undefined} origin
+ * @returns {string | null}
+ */
+export function hostnameOf(origin) {
+  if (!origin) return null;
+  try {
+    return new URL(origin.includes("://") ? origin : `http://${origin}`)
+      .hostname;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build the `allowedDevOrigins` list for `next dev`.
+ *
+ * Always allows the loopback IP `127.0.0.1` (the most common remote-access
+ * shape — an SSH tunnel to `127.0.0.1:2026`). Additional hosts are derived from
+ * the existing `GATEWAY_CORS_ORIGINS` browser allow-list (already required for
+ * split-origin / port-forwarded deployments per `.env.example`) so LAN/remote
+ * hosts only need to be configured in one place. `localhost` / `*.localhost`
+ * are allowed by Next.js itself and need not be listed here.
+ *
+ * `*` is intentionally skipped to stay aligned with the backend CORS parser
+ * (`app/gateway/csrf_middleware.py`), which treats `*` as "not an explicit
+ * origin". Next.js would not honour a bare `*` as a wildcard anyway.
+ *
+ * @param {string | undefined} [corsOrigins] defaults to GATEWAY_CORS_ORIGINS
+ * @returns {string[]}
+ */
+export function getAllowedDevOrigins(
+  corsOrigins = process.env.GATEWAY_CORS_ORIGINS,
+) {
+  const hosts = new Set(["127.0.0.1"]);
+  for (const raw of (corsOrigins ?? "").split(",")) {
+    const value = raw.trim();
+    if (!value || value === "*") continue;
+    const host = hostnameOf(value);
+    if (host && host !== "*") hosts.add(host);
+  }
+  return [...hosts];
+}

--- a/frontend/tests/unit/lib/dev-origins.test.ts
+++ b/frontend/tests/unit/lib/dev-origins.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { getAllowedDevOrigins, hostnameOf } from "@/lib/dev-origins.mjs";
+
+describe("hostnameOf", () => {
+  test.each([
+    ["http://127.0.0.1:2026", "127.0.0.1"],
+    ["http://serverhost.example:2026", "serverhost.example"],
+    ["192.168.1.5:2026", "192.168.1.5"], // bare host:port (no scheme)
+    ["localhost", "localhost"],
+    ["http://[::1]:2026", "[::1]"], // IPv6 keeps its brackets
+    ["HTTP://Example.COM", "example.com"], // URL lowercases the host
+  ])("parses %s -> %s", (input, expected) => {
+    expect(hostnameOf(input)).toBe(expected);
+  });
+
+  test("returns null for blank or unparseable input", () => {
+    expect(hostnameOf(undefined)).toBeNull();
+    expect(hostnameOf(null)).toBeNull();
+    expect(hostnameOf("")).toBeNull();
+    expect(hostnameOf("http://")).toBeNull();
+  });
+});
+
+describe("getAllowedDevOrigins", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("always allows 127.0.0.1 when no origins are configured", () => {
+    expect(getAllowedDevOrigins(undefined)).toEqual(["127.0.0.1"]);
+    expect(getAllowedDevOrigins("")).toEqual(["127.0.0.1"]);
+  });
+
+  test("derives hostnames from GATEWAY_CORS_ORIGINS and dedupes", () => {
+    expect(
+      getAllowedDevOrigins(
+        "http://serverhost.example:2026,http://192.168.1.5:2026,http://serverhost.example:2026",
+      ),
+    ).toEqual(["127.0.0.1", "serverhost.example", "192.168.1.5"]);
+  });
+
+  test("skips '*' (aligns with backend CORS parser) and blank entries", () => {
+    expect(getAllowedDevOrigins("*, ,http://serverhost.example:2026")).toEqual([
+      "127.0.0.1",
+      "serverhost.example",
+    ]);
+  });
+
+  test("drops a scheme-qualified '*' (http://*) instead of adding '*'", () => {
+    // hostnameOf("http://*") resolves to "*", which Next.js would not honour
+    // as a wildcard; keep it out of the list so it never leaks in.
+    expect(
+      getAllowedDevOrigins("http://*,http://serverhost.example:2026"),
+    ).toEqual(["127.0.0.1", "serverhost.example"]);
+  });
+
+  test("does not duplicate 127.0.0.1 when it is also configured", () => {
+    expect(getAllowedDevOrigins("http://127.0.0.1:2026")).toEqual([
+      "127.0.0.1",
+    ]);
+  });
+
+  test("reads GATEWAY_CORS_ORIGINS from the environment by default", () => {
+    vi.stubEnv("GATEWAY_CORS_ORIGINS", "http://env-host.example:2026");
+    expect(getAllowedDevOrigins()).toEqual(["127.0.0.1", "env-host.example"]);
+  });
+});


### PR DESCRIPTION
## 问题

`make dev` 起的服务，从非 localhost 的 host 打开会一直卡在 "Loading…"。常见两种：autodl 上走 SSH 隧道访问 `127.0.0.1:2026`，或者局域网里访问 `serverhost:2026`。Docker（`make up`）没这问题。对应 #3385、#2983。

## 原因

`next dev` 有个跨域保护，会拦掉 `Origin` host 不在白名单里的 `/_next/*` 请求，默认白名单只有 `localhost` / `*.localhost`。`127.0.0.1` 和局域网 IP 都不在里面。

我一开始以为是 JS chunk 被 403 导致水合失败。用浏览器实测后发现不是：chunk 其实都是 200，普通 `<script>` 标签不带 Origin 头，不会被拦。真正被拦的是 HMR WebSocket（`/_next/webpack-hmr`，它带 Origin）。Turbopack 的 dev runtime 依赖这个 ws，它一被拒，客户端 runtime 起不来，React 不水合，页面就冻在服务端渲染的初始状态。`/setup` 的初始状态正好是 "Loading…"，于是永远卡在那。

浏览器实测（Next 16.2.6，chrome-devtools）：

- 未放行的 host 打开 `/setup`：内容是 "Loading…"，整页 0 个 React fiber，等多久都不动。
- 放行的 host 打开：正常水合，流程继续往下走。

Docker 跑的是生产构建，没有这个 dev 保护也没有 HMR，所以不受影响。

## 改动

`next.config.js` 里配 `allowedDevOrigins`：默认放行 `127.0.0.1`，额外 host 从项目已有的 `GATEWAY_CORS_ORIGINS` 取 hostname（这个变量 `.env.example` 里本来就是给端口转发 / split-origin 部署用的浏览器白名单）。autodl 那种 `127.0.0.1` 隧道开箱即修；局域网域名只要加进本来就要配的 `GATEWAY_CORS_ORIGINS`，不用改源码。

解析逻辑单独放在 `src/lib/dev-origins.mjs`，因为 `next.config.js` 走 Node ESM、没法 import `.ts`。`*` 会跳过，跟后端 CORS 解析（`app/gateway/csrf_middleware.py`）保持一致。`allowedDevOrigins` 只在 dev 生效，生产构建忽略它。

## 验证

- 浏览器（Next 16.2.6）：未放行 host → `/setup` 卡 "Loading…"、fiber=0；放行 host → 水合、脱离 loading。
- curl：未放行 host 的 HMR ws 和带 Origin 的资源返回 403，放行后 200；未配置的 host 和 `*` 仍被拦。
- `pnpm test`（含新增 12 个单测）、`pnpm typecheck`、`prettier --check` 全过。

Closes #3385
Related: #2983
