### PR TITLE
fix(frontend): hide stale follow-up chips while a turn is streaming (#3395)

### DIFF
--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -1923,6 +1923,10 @@ export function InputBox({
     !showSkillSuggestions &&
     !selectedSlashSkill &&
     !followupsHidden &&
+    // Never show stale follow-up chips while a turn is streaming: a message
+    // sent before the previous response finished would otherwise leave the
+    // old chips (and the lone close button) overlapping the input box.
+    status !== "streaming" &&
     (followupsLoading || followups.length > 0);
 
   useEffect(() => {

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -417,6 +417,9 @@ export function InputBox({
     useState<string | null>(null);
   const lastGeneratedForAiIdRef = useRef<string | null>(null);
   const wasStreamingRef = useRef(false);
+  // Set when the user stops a streaming turn. Such a turn ends on a
+  // half-finished response, so we must NOT generate follow-up suggestions for it.
+  const stoppedByUserRef = useRef(false);
   const messagesRef = useRef(thread.messages);
 
   const clearVoiceRestartTimer = useCallback(() => {
@@ -1148,6 +1151,16 @@ export function InputBox({
     ],
   );
 
+  const handleStopStreaming = useCallback(() => {
+    // Mark the in-progress turn as user-interrupted so the next
+    // streaming->ready transition does not suggest follow-ups for it.
+    stoppedByUserRef.current = true;
+    setFollowups([]);
+    setFollowupsHidden(true);
+    setFollowupsLoading(false);
+    onStop?.();
+  }, [onStop]);
+
   const handleSubmit = useCallback(
     async (message: PromptInputMessage) => {
       if (status === "streaming") {
@@ -1200,7 +1213,7 @@ export function InputBox({
         return handleCompactCommand();
       }
       if (submitAction.kind === "stop") {
-        onStop?.();
+        handleStopStreaming();
         return;
       }
       if (submitAction.kind === "empty") {
@@ -1215,7 +1228,7 @@ export function InputBox({
       abortVoiceInput,
       handleCompactCommand,
       handleGoalCommand,
-      onStop,
+      handleStopStreaming,
       selectedSlashSkill,
       status,
       submitThreadMessage,
@@ -1949,6 +1962,13 @@ export function InputBox({
       return;
     }
 
+    // The turn was interrupted by the user, so skip generating follow-ups for
+    // this half-finished response.
+    if (stoppedByUserRef.current) {
+      stoppedByUserRef.current = false;
+      return;
+    }
+
     if (disabled || isMock) {
       return;
     }
@@ -2670,7 +2690,7 @@ export function InputBox({
               onClick={(e) => {
                 if (status === "streaming") {
                   e.preventDefault();
-                  onStop?.();
+                  handleStopStreaming();
                 }
               }}
             />


### PR DESCRIPTION
## Summary

Fixes #3395.

When a message is sent **before the previous response finishes streaming**, the follow-up suggestion chips (the row of suggested questions above the input box) can be left in a broken, overlapping layout. Stale chips plus a lone `X` close button may overlap the To-dos panel and the input box.

## Root cause

Follow-up chips are generated when a turn transitions from streaming to ready, and their visibility is controlled by `showFollowups` in `frontend/src/components/workspace/input-box.tsx`:

```tsx
const showFollowups =
  !disabled &&
  !isWelcomeMode &&
  !followupsHidden &&
  (followupsLoading || followups.length > 0);
```

This condition did not account for the in-progress/streaming state. When the user interrupts an in-progress response by sending a new message or stopping the current turn, the previous turn can still be treated like a normally completed turn for follow-up generation. That allows stale suggestions from a half-finished response to remain visible or be regenerated during the interrupted transition.

## Fix

This PR now handles the interrupted-turn lifecycle explicitly:

- Gate `showFollowups` on `status !== "streaming"`, so stale chips are never displayed while a response is in progress.
- When the user interrupts streaming from submit/stop, immediately clear follow-up state and hide the suggestion area.
- Track the user-interrupted turn with `stoppedByUserRef`, so the streaming→ready effect skips follow-up generation for the half-finished response.

```tsx
const showFollowups =
  !disabled &&
  !isWelcomeMode &&
  !followupsHidden &&
  status !== "streaming" &&
  (followupsLoading || followups.length > 0);
```

## Why this approach

- Follow-up chips are only meaningful after a turn completes normally, so suppressing them during streaming matches their intended lifecycle.
- Clearing stale follow-up state at the interrupt point prevents the orphaned chips/close-button layout from persisting during the next turn.
- Skipping follow-up generation for interrupted turns avoids suggesting questions for a truncated response.

## Alternatives considered

- Only hiding chips during streaming — this prevents the visual overlap but still leaves stale state and can regenerate suggestions for a half-finished response.
- Clearing `followups`/`followupsHidden` in every code path that can start a new turn — more invasive and easy to miss a path; the interrupt marker keeps the behavior scoped to user-interrupted streaming turns.
- Unmounting the chips container via CSS only — would still keep stale state around and risks flicker.

## Testing

- `eslint src/components/workspace/input-box.tsx` — clean.
- `tsc --noEmit` — clean.
- Verified the visibility logic: chips are hidden while `status === "streaming"`, stale chips are cleared on user interrupt, and follow-up generation is skipped for interrupted turns.
