### PR TITLE
fix(frontend): fallback Streamdown clipboard copy

### DIFF
--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -18,7 +18,8 @@ import {
 } from "lucide-react";
 import type { ComponentProps, HTMLAttributes, ReactElement } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
-import { Streamdown } from "streamdown";
+
+import { ClipboardSafeStreamdown } from "./streamdown";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -302,11 +303,13 @@ export const MessageBranchPage = ({
   );
 };
 
-export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+export type MessageResponseProps = ComponentProps<
+  typeof ClipboardSafeStreamdown
+>;
 
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
-    <Streamdown
+    <ClipboardSafeStreamdown
       className={cn(
         "size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
         className,

--- a/frontend/src/components/ai-elements/reasoning.tsx
+++ b/frontend/src/components/ai-elements/reasoning.tsx
@@ -10,9 +10,9 @@ import { cn } from "@/lib/utils";
 import { BrainIcon, ChevronDownIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";
 import { createContext, memo, useContext, useEffect, useState } from "react";
-import { Streamdown } from "streamdown";
 import { reasoningPlugins } from "@/core/streamdown/plugins";
 import { Shimmer } from "./shimmer";
+import { ClipboardSafeStreamdown } from "./streamdown";
 
 type ReasoningContextValue = {
   isStreaming: boolean;
@@ -178,7 +178,9 @@ export const ReasoningContent = memo(
       )}
       {...props}
     >
-      <Streamdown {...reasoningPlugins}>{children}</Streamdown>
+      <ClipboardSafeStreamdown {...reasoningPlugins}>
+        {children}
+      </ClipboardSafeStreamdown>
     </CollapsibleContent>
   ),
 );

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,16 +1,14 @@
 "use client";
 
-import { useEffect, type ComponentProps } from "react";
+import { type ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
 
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
-export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
-  useEffect(() => {
-    installClipboardFallback();
-  }, []);
+installClipboardFallback();
 
+export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
   return <Streamdown {...props} />;
 }

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, type ComponentProps } from "react";
+import { useLayoutEffect, type ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
@@ -8,7 +8,7 @@ import { installClipboardFallback } from "@/core/clipboard";
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
 export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
-  useEffect(() => {
+  useLayoutEffect(() => {
     installClipboardFallback();
   }, []);
 

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -7,7 +7,10 @@ import { installClipboardFallback } from "@/core/clipboard";
 
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
-installClipboardFallback();
+// Only patch browser globals in client context; skip during SSR
+if (typeof document !== "undefined") {
+  installClipboardFallback();
+}
 
 export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
   return <Streamdown {...props} />;

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useLayoutEffect, type ComponentProps } from "react";
+import { useEffect, type ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
@@ -8,7 +8,7 @@ import { installClipboardFallback } from "@/core/clipboard";
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
 export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
-  useLayoutEffect(() => {
+  useEffect(() => {
     installClipboardFallback();
   }, []);
 

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect, type ComponentProps } from "react";
+import { Streamdown } from "streamdown";
+
+import { installClipboardFallback } from "@/core/clipboard";
+
+export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
+
+export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
+  useEffect(() => {
+    installClipboardFallback();
+  }, []);
+
+  return <Streamdown {...props} />;
+}

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Streamdown } from "streamdown";
 
 import {
   Artifact,
@@ -20,6 +19,7 @@ import {
   ArtifactHeader,
   ArtifactTitle,
 } from "@/components/ai-elements/artifact";
+import { ClipboardSafeStreamdown } from "@/components/ai-elements/streamdown";
 import { Select, SelectItem } from "@/components/ui/select";
 import {
   SelectContent,
@@ -400,13 +400,13 @@ export function ArtifactFilePreview({
   if (language === "markdown") {
     return (
       <div className="size-full px-4">
-        <Streamdown
+        <ClipboardSafeStreamdown
           className="size-full"
           {...streamdownPlugins}
           components={{ a: ArtifactLink }}
         >
           {content ?? ""}
-        </Streamdown>
+        </ClipboardSafeStreamdown>
       </div>
     );
   }

--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -6,7 +6,6 @@ import {
   XCircleIcon,
 } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Streamdown } from "streamdown";
 
 import {
   ChainOfThought,
@@ -14,6 +13,7 @@ import {
   ChainOfThoughtStep,
 } from "@/components/ai-elements/chain-of-thought";
 import { Shimmer } from "@/components/ai-elements/shimmer";
+import { ClipboardSafeStreamdown } from "@/components/ai-elements/streamdown";
 import { Button } from "@/components/ui/button";
 import { ShineBorder } from "@/components/ui/shine-border";
 import { useI18n } from "@/core/i18n/hooks";
@@ -126,12 +126,12 @@ export function SubtaskCard({
           {task.prompt && (
             <ChainOfThoughtStep
               label={
-                <Streamdown
+                <ClipboardSafeStreamdown
                   {...streamdownPluginsWithWordAnimation}
                   components={{ a: CitationLink }}
                 >
                   {task.prompt}
-                </Streamdown>
+                </ClipboardSafeStreamdown>
               }
             ></ChainOfThoughtStep>
           )}

--- a/frontend/src/components/workspace/settings/about-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/about-settings-page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Streamdown } from "streamdown";
+import { ClipboardSafeStreamdown } from "@/components/ai-elements/streamdown";
 
 import { aboutMarkdown } from "./about-content";
 
 export function AboutSettingsPage() {
-  return <Streamdown>{aboutMarkdown}</Streamdown>;
+  return <ClipboardSafeStreamdown>{aboutMarkdown}</ClipboardSafeStreamdown>;
 }

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -10,8 +10,8 @@ import {
 import Link from "next/link";
 import { useDeferredValue, useId, useRef, useState } from "react";
 import { toast } from "sonner";
-import { Streamdown } from "streamdown";
 
+import { ClipboardSafeStreamdown } from "@/components/ai-elements/streamdown";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -628,12 +628,12 @@ export function MemorySettingsPage() {
                 <div className="text-muted-foreground mb-4 text-sm">
                   {summaryReadOnly}
                 </div>
-                <Streamdown
+                <ClipboardSafeStreamdown
                   className="size-full min-w-0 [overflow-wrap:anywhere] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
                   {...streamdownPlugins}
                 >
                   {summariesToMarkdown(memory, filteredSectionGroups, t)}
-                </Streamdown>
+                </ClipboardSafeStreamdown>
               </div>
             ) : null}
 

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -216,9 +216,13 @@ export function installClipboardFallback(): void {
       }
     }
 
-    Object.defineProperty(globalThis, "ClipboardItem", {
-      configurable: true,
-      value: ClipboardItemFallback,
-    });
+    try {
+      Object.defineProperty(globalThis, "ClipboardItem", {
+        configurable: true,
+        value: ClipboardItemFallback,
+      });
+    } catch {
+      return;
+    }
   }
 }

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -23,15 +23,26 @@ function copyTextWithExecCommand(text: string): boolean {
   document.body.appendChild(textarea);
   textarea.select();
 
+  let copied = false;
   try {
-    return document.execCommand("copy");
+    copied = document.execCommand("copy");
   } finally {
     if (typeof textarea.remove === "function") {
       textarea.remove();
-    } else if (typeof textarea.parentNode?.removeChild === "function") {
-      textarea.parentNode?.removeChild(textarea);
+    } else {
+      const parentNode = textarea.parentNode;
+      if (typeof parentNode?.removeChild === "function") {
+        parentNode.removeChild(textarea);
+      } else if (
+        parentNode === document.body &&
+        typeof document.body.removeChild === "function"
+      ) {
+        document.body.removeChild(textarea);
+      }
     }
   }
+
+  return copied;
 }
 
 export async function writeTextToClipboard(text: string): Promise<boolean> {
@@ -74,6 +85,10 @@ async function readPlainTextFromClipboardItem(
   }
   if (plainText instanceof Blob) {
     return await plainText.text();
+  }
+
+  if (item.types && !item.types.includes("text/plain")) {
+    throw new Error("Clipboard item type not available");
   }
 
   const blob = await item.getType?.("text/plain");
@@ -125,12 +140,14 @@ export function installClipboardFallback(): void {
       missingMethods.write = {
         configurable: true,
         value: write,
+        writable: true,
       };
     }
     if (!hasWriteText) {
       missingMethods.writeText = {
         configurable: true,
         value: writeText,
+        writable: true,
       };
     }
 
@@ -156,6 +173,7 @@ export function installClipboardFallback(): void {
         Object.defineProperty(replacement, methodName, {
           configurable: true,
           value: method.bind(clipboard),
+          writable: true,
         });
       }
     }
@@ -163,10 +181,12 @@ export function installClipboardFallback(): void {
       write: {
         configurable: true,
         value: write,
+        writable: true,
       },
       writeText: {
         configurable: true,
         value: writeText,
+        writable: true,
       },
     });
     try {

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -1,3 +1,31 @@
+type ClipboardItemLike = {
+  types?: readonly string[];
+  getType?: (type: string) => Promise<Blob>;
+  items?: Record<string, Blob | string>;
+};
+
+function copyTextWithExecCommand(text: string): boolean {
+  const document = globalThis.document;
+  if (!document?.body?.appendChild || !document.execCommand) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    textarea.remove();
+  }
+}
+
 export async function writeTextToClipboard(text: string): Promise<boolean> {
   try {
     const clipboard = globalThis.navigator?.clipboard;
@@ -6,26 +34,105 @@ export async function writeTextToClipboard(text: string): Promise<boolean> {
       return true;
     }
 
-    const document = globalThis.document;
-    if (!document?.body?.appendChild || !document.execCommand) {
-      return false;
-    }
-
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.top = "-9999px";
-    textarea.style.left = "-9999px";
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    try {
-      return document.execCommand("copy");
-    } finally {
-      textarea.remove();
-    }
+    return copyTextWithExecCommand(text);
   } catch {
     return false;
+  }
+}
+
+function fallbackWriteText(text: string): Promise<void> {
+  if (!copyTextWithExecCommand(text)) {
+    throw new Error("Clipboard API not available");
+  }
+  return Promise.resolve();
+}
+
+async function readPlainTextFromClipboardItem(
+  item: ClipboardItemLike,
+): Promise<string> {
+  const plainText = item.items?.["text/plain"];
+  if (typeof plainText === "string") {
+    return plainText;
+  }
+  if (plainText instanceof Blob) {
+    return await plainText.text();
+  }
+
+  const blob = await item.getType?.("text/plain");
+  return (await blob?.text()) ?? "";
+}
+
+export function installClipboardFallback(): void {
+  const navigator = globalThis.navigator;
+  if (!navigator) {
+    return;
+  }
+
+  const clipboard = navigator.clipboard as Partial<Clipboard> | undefined;
+  const hasWriteText = typeof clipboard?.writeText === "function";
+  const hasWrite = typeof clipboard?.write === "function";
+
+  if (hasWriteText && hasWrite && "ClipboardItem" in globalThis) {
+    return;
+  }
+
+  const writeText = hasWriteText
+    ? clipboard.writeText!.bind(clipboard)
+    : fallbackWriteText;
+  const write = hasWrite
+    ? clipboard.write!.bind(clipboard)
+    : (items: ClipboardItemLike[]) => {
+        const firstItem = items[0];
+        if (!firstItem) {
+          return Promise.reject(new Error("Clipboard item not available"));
+        }
+
+        const plainText = firstItem.items?.["text/plain"];
+        if (typeof plainText === "string") {
+          return writeText(plainText);
+        }
+
+        return readPlainTextFromClipboardItem(firstItem).then(writeText);
+      };
+
+  try {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        ...clipboard,
+        write,
+        writeText,
+      },
+    });
+  } catch {
+    return;
+  }
+
+  if (!globalThis.ClipboardItem) {
+    class ClipboardItemFallback {
+      items: Record<string, Blob | string>;
+      types: string[];
+
+      constructor(items: Record<string, Blob | string>) {
+        this.items = items;
+        this.types = Object.keys(items);
+      }
+
+      getType(type: string): Promise<Blob> {
+        const value = this.items[type];
+        if (value instanceof Blob) {
+          return Promise.resolve(value);
+        }
+        if (typeof value === "string") {
+          return Promise.resolve(new Blob([value], { type }));
+        }
+        return Promise.reject(new Error("Clipboard item type not available"));
+      }
+    }
+
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: ClipboardItemFallback,
+    });
   }
 }

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -73,7 +73,11 @@ async function readPlainTextFromClipboardItem(
   }
 
   const blob = await item.getType?.("text/plain");
-  return (await blob?.text()) ?? "";
+  if (blob instanceof Blob) {
+    return await blob.text();
+  }
+
+  throw new Error("Clipboard item type not available");
 }
 
 export function installClipboardFallback(): void {
@@ -102,25 +106,63 @@ export function installClipboardFallback(): void {
           return Promise.reject(new Error("Clipboard item not available"));
         }
 
-        const plainText = firstItem.items?.["text/plain"];
-        if (typeof plainText === "string") {
-          return writeText(plainText);
-        }
-
         return readPlainTextFromClipboardItem(firstItem).then(writeText);
       };
 
+  const fallbackClipboard = clipboard ?? {};
+
   try {
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: {
-        ...clipboard,
-        write,
-        writeText,
+    const missingMethods: PropertyDescriptorMap = {};
+    if (!hasWrite) {
+      missingMethods.write = {
+        configurable: true,
+        value: write,
+      };
+    }
+    if (!hasWriteText) {
+      missingMethods.writeText = {
+        configurable: true,
+        value: writeText,
+      };
+    }
+
+    Object.defineProperties(fallbackClipboard, missingMethods);
+
+    if (!clipboard) {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: fallbackClipboard,
+      });
+    }
+  } catch {
+    const replacement = Object.create(clipboard ?? null);
+    for (const methodName of ["read", "readText"] as const) {
+      const method = clipboard?.[methodName];
+      if (typeof method === "function") {
+        Object.defineProperty(replacement, methodName, {
+          configurable: true,
+          value: method.bind(clipboard),
+        });
+      }
+    }
+    Object.defineProperties(replacement, {
+      write: {
+        configurable: true,
+        value: write,
+      },
+      writeText: {
+        configurable: true,
+        value: writeText,
       },
     });
-  } catch {
-    return;
+    try {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: replacement,
+      });
+    } catch {
+      return;
+    }
   }
 
   if (!hasClipboardItem) {

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -6,7 +6,11 @@ type ClipboardItemLike = {
 
 function copyTextWithExecCommand(text: string): boolean {
   const document = globalThis.document;
-  if (!document?.body?.appendChild || !document.execCommand) {
+  if (
+    typeof document?.createElement !== "function" ||
+    typeof document.body?.appendChild !== "function" ||
+    typeof document.execCommand !== "function"
+  ) {
     return false;
   }
 
@@ -41,10 +45,18 @@ export async function writeTextToClipboard(text: string): Promise<boolean> {
 }
 
 function fallbackWriteText(text: string): Promise<void> {
-  if (!copyTextWithExecCommand(text)) {
-    throw new Error("Clipboard API not available");
+  try {
+    if (!copyTextWithExecCommand(text)) {
+      return Promise.reject(new Error("Clipboard API not available"));
+    }
+  } catch (error) {
+    return Promise.reject(error);
   }
   return Promise.resolve();
+}
+
+function hasUsableClipboardItem(): boolean {
+  return typeof globalThis.ClipboardItem === "function";
 }
 
 async function readPlainTextFromClipboardItem(
@@ -71,8 +83,9 @@ export function installClipboardFallback(): void {
   const clipboard = navigator.clipboard as Partial<Clipboard> | undefined;
   const hasWriteText = typeof clipboard?.writeText === "function";
   const hasWrite = typeof clipboard?.write === "function";
+  const hasClipboardItem = hasUsableClipboardItem();
 
-  if (hasWriteText && hasWrite && "ClipboardItem" in globalThis) {
+  if (hasWriteText && hasWrite && hasClipboardItem) {
     return;
   }
 
@@ -108,7 +121,7 @@ export function installClipboardFallback(): void {
     return;
   }
 
-  if (!globalThis.ClipboardItem) {
+  if (!hasClipboardItem) {
     class ClipboardItemFallback {
       items: Record<string, Blob | string>;
       types: string[];

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -50,7 +50,9 @@ function fallbackWriteText(text: string): Promise<void> {
       return Promise.reject(new Error("Clipboard API not available"));
     }
   } catch (error) {
-    return Promise.reject(error);
+    return Promise.reject(
+      error instanceof Error ? error : new Error(String(error)),
+    );
   }
   return Promise.resolve();
 }

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -33,11 +33,6 @@ function copyTextWithExecCommand(text: string): boolean {
       const parentNode = textarea.parentNode;
       if (typeof parentNode?.removeChild === "function") {
         parentNode.removeChild(textarea);
-      } else if (
-        parentNode === document.body &&
-        typeof document.body.removeChild === "function"
-      ) {
-        document.body.removeChild(textarea);
       }
     }
   }

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -26,7 +26,11 @@ function copyTextWithExecCommand(text: string): boolean {
   try {
     return document.execCommand("copy");
   } finally {
-    textarea.remove();
+    if (typeof textarea.remove === "function") {
+      textarea.remove();
+    } else if (typeof textarea.parentNode?.removeChild === "function") {
+      textarea.parentNode?.removeChild(textarea);
+    }
   }
 }
 
@@ -87,6 +91,10 @@ export function installClipboardFallback(): void {
   }
 
   const clipboard = navigator.clipboard as Partial<Clipboard> | undefined;
+  const clipboardDescriptor = Object.getOwnPropertyDescriptor(
+    navigator,
+    "clipboard",
+  );
   const hasWriteText = typeof clipboard?.writeText === "function";
   const hasWrite = typeof clipboard?.write === "function";
   const hasClipboardItem = hasUsableClipboardItem();
@@ -129,10 +137,16 @@ export function installClipboardFallback(): void {
     Object.defineProperties(fallbackClipboard, missingMethods);
 
     if (!clipboard) {
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: fallbackClipboard,
-      });
+      const cannotDefineClipboard =
+        Object.isExtensible(navigator) === false &&
+        clipboardDescriptor?.configurable !== true;
+
+      if (!cannotDefineClipboard) {
+        Object.defineProperty(navigator, "clipboard", {
+          configurable: true,
+          value: fallbackClipboard,
+        });
+      }
     }
   } catch {
     const replacement = Object.create(clipboard ?? null);
@@ -161,7 +175,7 @@ export function installClipboardFallback(): void {
         value: replacement,
       });
     } catch {
-      return;
+      // The ClipboardItem fallback below is independent from navigator.clipboard.
     }
   }
 

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -11,7 +11,7 @@ function copyTextWithExecCommand(text: string): boolean {
     typeof document.body?.appendChild !== "function" ||
     typeof document.execCommand !== "function"
   ) {
-    return false;
+    throw new Error("Clipboard DOM fallback not available");
   }
 
   const textarea = document.createElement("textarea");
@@ -47,7 +47,7 @@ export async function writeTextToClipboard(text: string): Promise<boolean> {
 function fallbackWriteText(text: string): Promise<void> {
   try {
     if (!copyTextWithExecCommand(text)) {
-      return Promise.reject(new Error("Clipboard API not available"));
+      return Promise.reject(new Error("Clipboard copy command failed"));
     }
   } catch (error) {
     return Promise.reject(

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -85,15 +85,29 @@ async function readPlainTextFromClipboardItem(
   }
 
   if (item.types && !item.types.includes("text/plain")) {
-    throw new Error("Clipboard item type not available");
+    throw new Error("Clipboard item is missing text/plain data");
   }
 
-  const blob = await item.getType?.("text/plain");
+  if (typeof item.getType !== "function") {
+    throw new Error("Clipboard item cannot read text/plain data");
+  }
+
+  const blob = await item.getType("text/plain");
   if (blob instanceof Blob) {
     return await blob.text();
   }
 
-  throw new Error("Clipboard item type not available");
+  throw new Error("Clipboard item text/plain data is not a Blob");
+}
+
+function canDefineNavigatorClipboard(
+  navigator: Navigator,
+  descriptor: PropertyDescriptor | undefined,
+): boolean {
+  if (descriptor) {
+    return descriptor.configurable === true;
+  }
+  return Object.isExtensible(navigator);
 }
 
 /**
@@ -106,7 +120,11 @@ export function installClipboardFallback(): void {
     return;
   }
 
-  const clipboard = navigator.clipboard as Partial<Clipboard> | undefined;
+  const rawClipboard = navigator.clipboard;
+  const clipboard =
+    typeof rawClipboard === "object" && rawClipboard !== null
+      ? (rawClipboard as Partial<Clipboard>)
+      : undefined;
   const clipboardDescriptor = Object.getOwnPropertyDescriptor(
     navigator,
     "clipboard",
@@ -154,49 +172,53 @@ export function installClipboardFallback(): void {
 
     Object.defineProperties(fallbackClipboard, missingMethods);
 
-    if (!clipboard) {
-      const cannotDefineClipboard =
-        Object.isExtensible(navigator) === false &&
-        clipboardDescriptor?.configurable !== true;
-
-      if (!cannotDefineClipboard) {
-        Object.defineProperty(navigator, "clipboard", {
-          configurable: true,
-          value: fallbackClipboard,
-        });
-      }
-    }
-  } catch {
-    const replacement = Object.create(clipboard ?? null);
-    for (const methodName of ["read", "readText"] as const) {
-      const method = clipboard?.[methodName];
-      if (typeof method === "function") {
-        Object.defineProperty(replacement, methodName, {
-          configurable: true,
-          value: method.bind(clipboard),
-          writable: true,
-        });
-      }
-    }
-    Object.defineProperties(replacement, {
-      write: {
-        configurable: true,
-        value: write,
-        writable: true,
-      },
-      writeText: {
-        configurable: true,
-        value: writeText,
-        writable: true,
-      },
-    });
-    try {
+    if (
+      !clipboard &&
+      canDefineNavigatorClipboard(navigator, clipboardDescriptor)
+    ) {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
-        value: replacement,
+        value: fallbackClipboard,
       });
-    } catch {
+    }
+  } catch {
+    if (!canDefineNavigatorClipboard(navigator, clipboardDescriptor)) {
       // The ClipboardItem fallback below is independent from navigator.clipboard.
+      if (hasClipboardItem) {
+        return;
+      }
+    } else {
+      const replacement = Object.create(clipboard ?? null);
+      for (const methodName of ["read", "readText"] as const) {
+        const method = clipboard?.[methodName];
+        if (typeof method === "function") {
+          Object.defineProperty(replacement, methodName, {
+            configurable: true,
+            value: method.bind(clipboard),
+            writable: true,
+          });
+        }
+      }
+      Object.defineProperties(replacement, {
+        write: {
+          configurable: true,
+          value: write,
+          writable: true,
+        },
+        writeText: {
+          configurable: true,
+          value: writeText,
+          writable: true,
+        },
+      });
+      try {
+        Object.defineProperty(navigator, "clipboard", {
+          configurable: true,
+          value: replacement,
+        });
+      } catch {
+        // The ClipboardItem fallback below is independent from navigator.clipboard.
+      }
     }
   }
 
@@ -218,7 +240,9 @@ export function installClipboardFallback(): void {
         if (typeof value === "string") {
           return Promise.resolve(new Blob([value], { type }));
         }
-        return Promise.reject(new Error("Clipboard item type not available"));
+        return Promise.reject(
+          new Error(`Clipboard item is missing ${type} data`),
+        );
       }
     }
 

--- a/frontend/src/core/clipboard.ts
+++ b/frontend/src/core/clipboard.ts
@@ -20,18 +20,20 @@ function copyTextWithExecCommand(text: string): boolean {
   textarea.style.position = "fixed";
   textarea.style.top = "-9999px";
   textarea.style.left = "-9999px";
-  document.body.appendChild(textarea);
-  textarea.select();
 
   let copied = false;
+  let appended = false;
   try {
+    document.body.appendChild(textarea);
+    appended = true;
+    textarea.select();
     copied = document.execCommand("copy");
   } finally {
-    if (typeof textarea.remove === "function") {
-      textarea.remove();
-    } else {
+    if (appended) {
       const parentNode = textarea.parentNode;
-      if (typeof parentNode?.removeChild === "function") {
+      if (typeof textarea.remove === "function") {
+        textarea.remove();
+      } else if (typeof parentNode?.removeChild === "function") {
         parentNode.removeChild(textarea);
       }
     }
@@ -94,6 +96,10 @@ async function readPlainTextFromClipboardItem(
   throw new Error("Clipboard item type not available");
 }
 
+/**
+ * Installs browser clipboard fallbacks for Streamdown copy controls by patching
+ * missing navigator.clipboard methods and ClipboardItem when the host permits it.
+ */
 export function installClipboardFallback(): void {
   const navigator = globalThis.navigator;
   if (!navigator) {

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, expect, test, vi } from "vitest";
 
-import { writeTextToClipboard } from "@/core/clipboard";
+import {
+  installClipboardFallback,
+  writeTextToClipboard,
+} from "@/core/clipboard";
 
 const originalNavigator = globalThis.navigator;
 const hadOriginalNavigator = "navigator" in globalThis;
 const originalDocument = globalThis.document;
 const hadOriginalDocument = "document" in globalThis;
+const originalClipboardItem = globalThis.ClipboardItem;
+const hadOriginalClipboardItem = "ClipboardItem" in globalThis;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -24,6 +29,15 @@ afterEach(() => {
     Object.defineProperty(globalThis, "document", {
       configurable: true,
       value: originalDocument,
+    });
+  }
+
+  if (!hadOriginalClipboardItem) {
+    Reflect.deleteProperty(globalThis, "ClipboardItem");
+  } else {
+    Object.defineProperty(globalThis, "ClipboardItem", {
+      configurable: true,
+      value: originalClipboardItem,
     });
   }
 });
@@ -143,4 +157,81 @@ test("returns false when Clipboard API rejects", async () => {
   });
 
   await expect(writeTextToClipboard("hello")).resolves.toBe(false);
+});
+
+test("installs a writeText fallback when Clipboard API is unavailable", async () => {
+  const textarea = {
+    remove: vi.fn(),
+    select: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+  const appendChild = vi.fn();
+  const execCommand = vi.fn().mockReturnValue(true);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild,
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand,
+    },
+  });
+
+  installClipboardFallback();
+
+  await expect(globalThis.navigator.clipboard.writeText("hello")).resolves.toBe(
+    undefined,
+  );
+  expect(textarea.value).toBe("hello");
+  expect(appendChild).toHaveBeenCalledWith(textarea);
+  expect(textarea.select).toHaveBeenCalled();
+  expect(execCommand).toHaveBeenCalledWith("copy");
+  expect(textarea.remove).toHaveBeenCalled();
+});
+
+test("installs a write fallback for ClipboardItem text/plain payloads", async () => {
+  const textarea = {
+    remove: vi.fn(),
+    select: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+  const execCommand = vi.fn().mockReturnValue(true);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand,
+    },
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+
+  const item = new globalThis.ClipboardItem({
+    "text/html": new Blob(["<table></table>"], { type: "text/html" }),
+    "text/plain": "| A |\n| B |",
+  });
+  await expect(globalThis.navigator.clipboard.write([item])).resolves.toBe(
+    undefined,
+  );
+  expect(textarea.value).toBe("| A |\n| B |");
+  expect(execCommand).toHaveBeenCalledWith("copy");
 });

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -296,6 +296,178 @@ test("installs a write fallback for ClipboardItem text/plain payloads", async ()
   expect(execCommand).toHaveBeenCalledWith("copy");
 });
 
+test("installed write fallback rejects when ClipboardItem lacks text/plain", async () => {
+  const execCommand = vi.fn().mockReturnValue(true);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue({
+        remove: vi.fn(),
+        select: vi.fn(),
+        setAttribute: vi.fn(),
+        style: {},
+        value: "",
+      }),
+      execCommand,
+    },
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+
+  const item = new globalThis.ClipboardItem({
+    "text/html": new Blob(["<table></table>"], { type: "text/html" }),
+  });
+  await expect(globalThis.navigator.clipboard.write([item])).rejects.toThrow(
+    "Clipboard item type not available",
+  );
+  expect(execCommand).not.toHaveBeenCalled();
+});
+
+test("installed write fallback rejects when getType cannot provide text/plain", async () => {
+  const execCommand = vi.fn().mockReturnValue(true);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue({
+        remove: vi.fn(),
+        select: vi.fn(),
+        setAttribute: vi.fn(),
+        style: {},
+        value: "",
+      }),
+      execCommand,
+    },
+  });
+
+  installClipboardFallback();
+
+  await expect(
+    globalThis.navigator.clipboard.write([
+      {
+        getType: vi.fn().mockRejectedValue(new Error("missing")),
+        types: ["text/html"],
+      } as unknown as ClipboardItem,
+    ]),
+  ).rejects.toThrow("missing");
+  expect(execCommand).not.toHaveBeenCalled();
+});
+
+test("installed write fallback preserves existing clipboard prototype methods", async () => {
+  const readText = vi.fn().mockResolvedValue("existing");
+  const clipboard = Object.create({
+    readText,
+  });
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      clipboard,
+    },
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+
+  expect(globalThis.navigator.clipboard).toBe(clipboard);
+  await expect(globalThis.navigator.clipboard.readText()).resolves.toBe(
+    "existing",
+  );
+  expect(readText).toHaveBeenCalled();
+  await expect(
+    globalThis.navigator.clipboard.writeText("hello"),
+  ).rejects.toThrow("Clipboard API not available");
+});
+
+test("installClipboardFallback does not replace existing clipboard methods when only ClipboardItem is missing", async () => {
+  const write = vi.fn().mockResolvedValue(undefined);
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  const clipboard = {
+    write,
+    writeText,
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      clipboard,
+    },
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+
+  expect(globalThis.navigator.clipboard).toBe(clipboard);
+  expect(Reflect.get(globalThis.navigator.clipboard, "write")).toBe(write);
+  expect(Reflect.get(globalThis.navigator.clipboard, "writeText")).toBe(
+    writeText,
+  );
+  expect(typeof globalThis.ClipboardItem).toBe("function");
+});
+
+test("installClipboardFallback is idempotent for the same navigator", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+  const clipboard = globalThis.navigator.clipboard;
+  const ClipboardItemFallback = globalThis.ClipboardItem;
+
+  installClipboardFallback();
+
+  expect(globalThis.navigator.clipboard).toBe(clipboard);
+  expect(globalThis.ClipboardItem).toBe(ClipboardItemFallback);
+});
+
+test("installClipboardFallback can recover when the same navigator loses fallback globals", async () => {
+  const navigator = {};
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: navigator,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+  Reflect.deleteProperty(navigator, "clipboard");
+
+  installClipboardFallback();
+
+  expect(typeof globalThis.navigator.clipboard.writeText).toBe("function");
+  expect(typeof globalThis.ClipboardItem).toBe("function");
+});
+
 test("installs ClipboardItem fallback when the global property exists but is unusable", async () => {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -620,6 +620,31 @@ test("installClipboardFallback skips missing clipboard on non-extensible navigat
   expect(typeof globalThis.ClipboardItem).toBe("function");
 });
 
+test("installClipboardFallback does not throw when ClipboardItem cannot be defined", async () => {
+  const originalDefineProperty = Object.defineProperty;
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+  vi.spyOn(Object, "defineProperty").mockImplementation(
+    (target, property, descriptor) => {
+      if (target === globalThis && property === "ClipboardItem") {
+        throw new Error("locked global");
+      }
+      return originalDefineProperty(target, property, descriptor);
+    },
+  );
+
+  expect(() => installClipboardFallback()).not.toThrow();
+  expect(typeof globalThis.navigator.clipboard.writeText).toBe("function");
+  expect("ClipboardItem" in globalThis).toBe(false);
+});
+
 test("installs ClipboardItem fallback when the global property exists but is unusable", async () => {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -166,6 +166,36 @@ test("does not fail cleanup when textarea removal APIs are unavailable", async (
   await expect(writeTextToClipboard("hello")).resolves.toBe(true);
 });
 
+test("falls back to document body removal when parent removal is unavailable", async () => {
+  const body = {
+    appendChild: vi.fn(),
+    removeChild: vi.fn(),
+  };
+  const textarea = {
+    parentNode: body,
+    select: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body,
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand: vi.fn().mockReturnValue(true),
+    },
+  });
+
+  await expect(writeTextToClipboard("hello")).resolves.toBe(true);
+  expect(body.removeChild).toHaveBeenCalledWith(textarea);
+});
+
 test("returns false when execCommand fallback fails", async () => {
   const textarea = {
     remove: vi.fn(),
@@ -453,11 +483,35 @@ test("installed write fallback rejects when getType cannot provide text/plain", 
     globalThis.navigator.clipboard.write([
       {
         getType: vi.fn().mockRejectedValue(new Error("missing")),
-        types: ["text/html"],
+        types: ["text/plain"],
       } as unknown as ClipboardItem,
     ]),
   ).rejects.toThrow("missing");
   expect(execCommand).not.toHaveBeenCalled();
+});
+
+test("installed write fallback rejects before getType when item types exclude text/plain", async () => {
+  const getType = vi.fn().mockResolvedValue(new Blob(["ignored"]));
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  await expect(
+    globalThis.navigator.clipboard.write([
+      {
+        getType,
+        types: ["text/html"],
+      } as unknown as ClipboardItem,
+    ]),
+  ).rejects.toThrow("Clipboard item type not available");
+  expect(getType).not.toHaveBeenCalled();
 });
 
 test("installed write fallback preserves existing clipboard prototype methods", async () => {
@@ -557,6 +611,28 @@ test("installClipboardFallback can recover when the same navigator loses fallbac
 
   expect(typeof globalThis.navigator.clipboard.writeText).toBe("function");
   expect(typeof globalThis.ClipboardItem).toBe("function");
+});
+
+test("installClipboardFallback defines writable fallback methods", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  expect(
+    Object.getOwnPropertyDescriptor(globalThis.navigator.clipboard, "write")
+      ?.writable,
+  ).toBe(true);
+  expect(
+    Object.getOwnPropertyDescriptor(globalThis.navigator.clipboard, "writeText")
+      ?.writable,
+  ).toBe(true);
 });
 
 test("installClipboardFallback skips missing clipboard on non-extensible navigator while installing ClipboardItem", async () => {

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -9,8 +9,10 @@ const originalNavigator = globalThis.navigator;
 const hadOriginalNavigator = "navigator" in globalThis;
 const originalDocument = globalThis.document;
 const hadOriginalDocument = "document" in globalThis;
-const originalClipboardItem = globalThis.ClipboardItem;
-const hadOriginalClipboardItem = "ClipboardItem" in globalThis;
+const originalClipboardItemDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  "ClipboardItem",
+);
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -32,13 +34,14 @@ afterEach(() => {
     });
   }
 
-  if (!hadOriginalClipboardItem) {
+  if (!originalClipboardItemDescriptor) {
     Reflect.deleteProperty(globalThis, "ClipboardItem");
   } else {
-    Object.defineProperty(globalThis, "ClipboardItem", {
-      configurable: true,
-      value: originalClipboardItem,
-    });
+    Object.defineProperty(
+      globalThis,
+      "ClipboardItem",
+      originalClipboardItemDescriptor,
+    );
   }
 });
 
@@ -102,6 +105,65 @@ test("falls back to execCommand when Clipboard API is unavailable", async () => 
   expect(textarea.select).toHaveBeenCalled();
   expect(execCommand).toHaveBeenCalledWith("copy");
   expect(textarea.remove).toHaveBeenCalled();
+});
+
+test("falls back to parent removal when textarea.remove is unavailable", async () => {
+  const parentNode = {
+    removeChild: vi.fn(),
+  };
+  const textarea = {
+    parentNode,
+    select: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+  const execCommand = vi.fn().mockReturnValue(true);
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand,
+    },
+  });
+
+  await expect(writeTextToClipboard("hello")).resolves.toBe(true);
+  expect(parentNode.removeChild).toHaveBeenCalledWith(textarea);
+});
+
+test("does not fail cleanup when textarea removal APIs are unavailable", async () => {
+  const textarea = {
+    parentNode: {},
+    select: vi.fn(),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand: vi.fn().mockReturnValue(true),
+    },
+  });
+
+  await expect(writeTextToClipboard("hello")).resolves.toBe(true);
 });
 
 test("returns false when execCommand fallback fails", async () => {
@@ -494,6 +556,21 @@ test("installClipboardFallback can recover when the same navigator loses fallbac
   installClipboardFallback();
 
   expect(typeof globalThis.navigator.clipboard.writeText).toBe("function");
+  expect(typeof globalThis.ClipboardItem).toBe("function");
+});
+
+test("installClipboardFallback skips missing clipboard on non-extensible navigator while installing ClipboardItem", async () => {
+  const navigator = {};
+  Object.preventExtensions(navigator);
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: navigator,
+  });
+  Reflect.deleteProperty(globalThis, "ClipboardItem");
+
+  installClipboardFallback();
+
+  expect("clipboard" in globalThis.navigator).toBe(false);
   expect(typeof globalThis.ClipboardItem).toBe("function");
 });
 

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -166,36 +166,6 @@ test("does not fail cleanup when textarea removal APIs are unavailable", async (
   await expect(writeTextToClipboard("hello")).resolves.toBe(true);
 });
 
-test("falls back to document body removal when parent removal is unavailable", async () => {
-  const body = {
-    appendChild: vi.fn(),
-    removeChild: vi.fn(),
-  };
-  const textarea = {
-    parentNode: body,
-    select: vi.fn(),
-    setAttribute: vi.fn(),
-    style: {},
-    value: "",
-  };
-
-  Object.defineProperty(globalThis, "navigator", {
-    configurable: true,
-    value: {},
-  });
-  Object.defineProperty(globalThis, "document", {
-    configurable: true,
-    value: {
-      body,
-      createElement: vi.fn().mockReturnValue(textarea),
-      execCommand: vi.fn().mockReturnValue(true),
-    },
-  });
-
-  await expect(writeTextToClipboard("hello")).resolves.toBe(true);
-  expect(body.removeChild).toHaveBeenCalledWith(textarea);
-});
-
 test("returns false when execCommand fallback fails", async () => {
   const textarea = {
     remove: vi.fn(),

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -229,7 +229,7 @@ test("installed writeText fallback rejects instead of throwing synchronously", a
 
   const result = globalThis.navigator.clipboard.writeText("hello");
   expect(result).toBeInstanceOf(Promise);
-  await expect(result).rejects.toThrow("Clipboard API not available");
+  await expect(result).rejects.toThrow("Clipboard DOM fallback not available");
 });
 
 test("installed writeText fallback converts thrown DOM failures to rejections", async () => {
@@ -255,6 +255,35 @@ test("installed writeText fallback converts thrown DOM failures to rejections", 
   const result = globalThis.navigator.clipboard.writeText("hello");
   expect(result).toBeInstanceOf(Promise);
   await expect(result).rejects.toThrow("dom unavailable");
+});
+
+test("installed writeText fallback distinguishes copy command failure", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue({
+        remove: vi.fn(),
+        select: vi.fn(),
+        setAttribute: vi.fn(),
+        style: {},
+        value: "",
+      }),
+      execCommand: vi.fn().mockReturnValue(false),
+    },
+  });
+
+  installClipboardFallback();
+
+  await expect(
+    globalThis.navigator.clipboard.writeText("hello"),
+  ).rejects.toThrow("Clipboard copy command failed");
 });
 
 test("installs a write fallback for ClipboardItem text/plain payloads", async () => {
@@ -396,7 +425,7 @@ test("installed write fallback preserves existing clipboard prototype methods", 
   expect(readText).toHaveBeenCalled();
   await expect(
     globalThis.navigator.clipboard.writeText("hello"),
-  ).rejects.toThrow("Clipboard API not available");
+  ).rejects.toThrow("Clipboard DOM fallback not available");
 });
 
 test("installClipboardFallback does not replace existing clipboard methods when only ClipboardItem is missing", async () => {

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -448,7 +448,7 @@ test("installed write fallback rejects when ClipboardItem lacks text/plain", asy
     "text/html": new Blob(["<table></table>"], { type: "text/html" }),
   });
   await expect(globalThis.navigator.clipboard.write([item])).rejects.toThrow(
-    "Clipboard item type not available",
+    "Clipboard item is missing text/plain data",
   );
   expect(execCommand).not.toHaveBeenCalled();
 });
@@ -510,8 +510,51 @@ test("installed write fallback rejects before getType when item types exclude te
         types: ["text/html"],
       } as unknown as ClipboardItem,
     ]),
-  ).rejects.toThrow("Clipboard item type not available");
+  ).rejects.toThrow("Clipboard item is missing text/plain data");
   expect(getType).not.toHaveBeenCalled();
+});
+
+test("installed write fallback rejects when getType is missing", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  await expect(
+    globalThis.navigator.clipboard.write([
+      {
+        types: ["text/plain"],
+      } as unknown as ClipboardItem,
+    ]),
+  ).rejects.toThrow("Clipboard item cannot read text/plain data");
+});
+
+test("installed write fallback rejects when getType returns a non-Blob", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  await expect(
+    globalThis.navigator.clipboard.write([
+      {
+        getType: vi.fn().mockResolvedValue("plain text"),
+        types: ["text/plain"],
+      } as unknown as ClipboardItem,
+    ]),
+  ).rejects.toThrow("Clipboard item text/plain data is not a Blob");
 });
 
 test("installed write fallback preserves existing clipboard prototype methods", async () => {
@@ -648,6 +691,29 @@ test("installClipboardFallback skips missing clipboard on non-extensible navigat
 
   expect("clipboard" in globalThis.navigator).toBe(false);
   expect(typeof globalThis.ClipboardItem).toBe("function");
+});
+
+test("installClipboardFallback handles non-object navigator.clipboard values", async () => {
+  const navigator = {};
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: "locked",
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: navigator,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  expect(typeof globalThis.navigator.clipboard.writeText).toBe("function");
+  await expect(
+    globalThis.navigator.clipboard.writeText("hello"),
+  ).rejects.toThrow("Clipboard DOM fallback not available");
 });
 
 test("installClipboardFallback does not throw when ClipboardItem cannot be defined", async () => {

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -166,6 +166,36 @@ test("does not fail cleanup when textarea removal APIs are unavailable", async (
   await expect(writeTextToClipboard("hello")).resolves.toBe(true);
 });
 
+test("cleans up the textarea when selecting text fails", async () => {
+  const textarea = {
+    remove: vi.fn(),
+    select: vi.fn(() => {
+      throw new Error("selection failed");
+    }),
+    setAttribute: vi.fn(),
+    style: {},
+    value: "",
+  };
+
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn().mockReturnValue(textarea),
+      execCommand: vi.fn(),
+    },
+  });
+
+  await expect(writeTextToClipboard("hello")).resolves.toBe(false);
+  expect(textarea.remove).toHaveBeenCalled();
+});
+
 test("returns false when execCommand fallback fails", async () => {
   const textarea = {
     remove: vi.fn(),

--- a/frontend/tests/unit/core/clipboard.test.ts
+++ b/frontend/tests/unit/core/clipboard.test.ts
@@ -132,6 +132,24 @@ test("returns false when execCommand fallback fails", async () => {
   expect(textarea.remove).toHaveBeenCalled();
 });
 
+test("returns false when execCommand fallback cannot create an element", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      execCommand: vi.fn(),
+    },
+  });
+
+  await expect(writeTextToClipboard("hello")).resolves.toBe(false);
+});
+
 test("returns false when navigator is unavailable", async () => {
   Object.defineProperty(globalThis, "navigator", {
     configurable: true,
@@ -197,6 +215,48 @@ test("installs a writeText fallback when Clipboard API is unavailable", async ()
   expect(textarea.remove).toHaveBeenCalled();
 });
 
+test("installed writeText fallback rejects instead of throwing synchronously", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  const result = globalThis.navigator.clipboard.writeText("hello");
+  expect(result).toBeInstanceOf(Promise);
+  await expect(result).rejects.toThrow("Clipboard API not available");
+});
+
+test("installed writeText fallback converts thrown DOM failures to rejections", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {},
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      body: {
+        appendChild: vi.fn(),
+      },
+      createElement: vi.fn(() => {
+        throw new Error("dom unavailable");
+      }),
+      execCommand: vi.fn(),
+    },
+  });
+
+  installClipboardFallback();
+
+  const result = globalThis.navigator.clipboard.writeText("hello");
+  expect(result).toBeInstanceOf(Promise);
+  await expect(result).rejects.toThrow("dom unavailable");
+});
+
 test("installs a write fallback for ClipboardItem text/plain payloads", async () => {
   const textarea = {
     remove: vi.fn(),
@@ -234,4 +294,24 @@ test("installs a write fallback for ClipboardItem text/plain payloads", async ()
   );
   expect(textarea.value).toBe("| A |\n| B |");
   expect(execCommand).toHaveBeenCalledWith("copy");
+});
+
+test("installs ClipboardItem fallback when the global property exists but is unusable", async () => {
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: {
+      clipboard: {
+        write: vi.fn().mockResolvedValue(undefined),
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+  });
+  Object.defineProperty(globalThis, "ClipboardItem", {
+    configurable: true,
+    value: undefined,
+  });
+
+  installClipboardFallback();
+
+  expect(typeof globalThis.ClipboardItem).toBe("function");
 });


### PR DESCRIPTION
## 问题原因

`streamdown` 内置的代码块和表格复制按钮仍直接依赖 Clipboard API。在通过 HTTP/IP 访问的非安全上下文中，浏览器不会提供 `navigator.clipboard` 或 `ClipboardItem`，导致消息区域和 Markdown 产物预览中的代码块、表格复制无效。

## 修改内容

新增安全的 Streamdown 包装组件，在渲染 Streamdown 前安装剪贴板兼容层；当原生 Clipboard API 缺失时，代码块复制和表格纯文本复制会降级到 `document.execCommand(copy)`。同时覆盖所有直接使用 Streamdown 的前端入口，并补充 clipboard fallback 单测。

## 关联 issue

Fixes #3387
---

## Problem Cause

Streamdown's built-in code block and table copy controls still depend directly on the Clipboard API. In insecure contexts such as HTTP/IP access, browsers do not expose `navigator.clipboard` or `ClipboardItem`, so copying code blocks and tables in messages and Markdown artifact previews does not work.

## Changes

Added a clipboard-safe Streamdown wrapper that installs a compatibility layer before rendering Streamdown. When the native Clipboard API is missing, code block copy and table plain-text copy fall back to `document.execCommand(copy)`. This covers all direct Streamdown frontend entry points and adds clipboard fallback unit tests.

## Related Issue

Fixes #3387