### PR TITLE
chore: add AI assistance disclosure to PR template and CONTRIBUTING

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -59,3 +59,17 @@ Fixes #
        Frontend:  cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test
        Frontend E2E (if you touched frontend/): cd frontend && make test-e2e -->
 
+
+## AI assistance
+
+<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
+     welcome. Disclosing it just helps reviewers calibrate how closely to read the
+     diff. Please fill all three; don't delete the section. -->
+
+**Tool(s) used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, or "none" -->
+
+**How you used it:** <!-- e.g. "generated the module from a spec", "autocomplete only",
+     "AI wrote tests, I wrote the impl". A prompt or conversation link is great too. -->
+
+- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,21 @@ Nginx (port 2026) ← Unified entry point
    git push origin feature/your-feature-name
    ```
 
+## AI assistance disclosure
+
+DeerFlow is an AI project and we welcome AI-assisted contributions. To help
+reviewers calibrate how closely to read a change, **every pull request must
+complete the "AI assistance" section of the
+[PR template](.github/pull_request_template.md)**:
+
+- which tool(s) you used (or `none`),
+- how you used them, and
+- a confirmation that a human has read, understands, and takes responsibility
+  for the change.
+
+Please don't delete the section. PRs that ignore it may be asked to fill it in
+before review.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Why

DeerFlow is an AI project, and in practice almost every contribution here is
written with AI coding tools. Today there's nowhere for a contributor to say
*whether* and *how* they used AI, so reviewers can't calibrate how closely to
read a diff — a 500-line AI-generated change and a hand-written 5-line fix get
the same default scrutiny.

Disclosing AI usage is now common practice in well-known projects:

- **Ghostty** — [`AI_POLICY.md`](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md):
  *"All AI usage in any form must be disclosed. You must state the tool you used
  ... along with the extent that the work was AI-assisted."*
- **MicroPython** — its [PR template](https://github.com/micropython/micropython/blob/master/.github/pull_request_template.md)
  asks every PR to answer a generative-AI question (didn't use / used but a human
  has checked the code).
- A growing number of other projects (e.g. **VisiData**, **Drupal**) have added
  similar disclosure prompts to their contribution flow.

The goal isn't to police AI — DeerFlow welcomes it — it's transparency so
reviewers know what they're looking at, mirroring Ghostty's stance that "it's
the people, not the tools."

## What changed

- `.github/pull_request_template.md`: a new **AI assistance** section — tool(s)
  used, how they were used, and a checkbox confirming a human has reviewed and
  takes responsibility for the change.
- `CONTRIBUTING.md`: a short **AI assistance disclosure** subsection that points
  to the template section and asks contributors to complete it.

Docs-only; no runtime behavior change.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

Markdown-only change. Reviewed the rendered PR template and CONTRIBUTING section
locally. No code paths touched, so no tests apply.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Researched how other projects (Ghostty, MicroPython,
VisiData, Drupal) word their AI-disclosure sections, then drafted the template
and CONTRIBUTING wording. I reviewed and finalized the copy myself.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
