### PR TITLE
feat(cli): add production CLI with session management and chat streaming

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -1,0 +1,165 @@
+"""
+DeerFlow Production Engine CLI
+
+Command-line interface for the DeerFlow Production Engine.
+Provides interactive chat and session management.
+
+Author: heart-scalpel
+License: MIT
+"""
+
+import sys
+from engine import DeerFlowProductionEngine
+
+
+def safe_input(prompt):
+    """
+    Safely read input with UTF-8 encoding.
+
+    Args:
+        prompt: The input prompt to display.
+
+    Returns:
+        str: The input line, stripped of trailing newline.
+    """
+    try:
+        sys.stdin.reconfigure(encoding='utf-8')
+        sys.stdout.reconfigure(encoding='utf-8')
+    except AttributeError:
+        pass
+    while True:
+        try:
+            return input(prompt).rstrip('\n')
+        except UnicodeDecodeError:
+            print("\n[Error] Input encoding error. Please use UTF-8. | 输入编码错误，请使用UTF-8\n")
+        except EOFError:
+            return ""
+
+
+def multi_line_input(prompt):
+    """
+    Read multi-line input from the user.
+
+    Args:
+        prompt: The prompt to display before entering multi-line mode.
+
+    Returns:
+        str: The combined multi-line input.
+    """
+    print(prompt)
+    print("Enter !end to finish multi-line input | 输入 !end 结束多行输入\n")
+    lines = []
+    while True:
+        try:
+            line = input()
+            if line.strip().lower() == '!end':
+                break
+            lines.append(line)
+        except UnicodeDecodeError:
+            print("\n[Error] Input encoding error. Please use UTF-8. | 输入编码错误，请使用UTF-8\n")
+        except EOFError:
+            break
+    return '\n'.join(lines)
+
+
+def main():
+    """Main entry point for the DeerFlow Production Engine CLI."""
+    engine = DeerFlowProductionEngine()
+
+    print("=" * 70)
+    print("DeerFlow Production Engine - Local Test Mode")
+    print("DeerFlow 生产引擎 - 本地测试模式")
+    print("=" * 70)
+    print("Type !help to see all available commands | 输入 !help 查看所有可用命令")
+    print("Type !multi to enter multi-line input mode | 输入 !multi 进入多行输入模式")
+    print("=" * 70)
+    print()
+
+    while True:
+        try:
+            if engine.current_session_id is None:
+                engine.create_session()
+
+            prompt = f"[{engine.current_session_id[:8]}] You: "
+            user_input = safe_input(prompt).strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == '!multi':
+                user_input = multi_line_input(f"\n[{engine.current_session_id[:8]}] Multi-line Input Mode | 多行输入模式")
+                if not user_input.strip():
+                    print("\n[Info] Empty input ignored | 空输入已忽略\n")
+                    continue
+                print()
+
+            if user_input.lower() == "!exit":
+                break
+
+            if user_input.lower() == "!help":
+                print("\n[Available Commands | 可用命令]")
+                print("  Session Management | 会话管理:")
+                print("    !new [id] [title]  Create new session | 创建新会话")
+                print("    !switch <id>       Switch to session | 切换会话")
+                print("    !delete session <id> Delete session | 删除会话")
+                print("    !rename <title>    Rename current session | 重命名当前会话")
+                print("    !sessions          List all sessions | 列出所有会话")
+                print("  Input | 输入:")
+                print("    !multi             Enter multi-line input mode | 进入多行输入模式")
+                print("  System | 系统:")
+                print("    !help              Show this help message | 显示帮助信息")
+                print("    !exit              Exit the system | 退出系统")
+                print()
+                continue
+
+            if user_input.lower().startswith("!new"):
+                parts = user_input.split(maxsplit=2)
+                sid = parts[1] if len(parts) > 1 else None
+                title = parts[2] if len(parts) > 2 else None
+                engine.create_session(sid, title)
+                continue
+
+            if user_input.lower().startswith("!switch"):
+                parts = user_input.split()
+                if len(parts) < 2:
+                    print("[Error] Usage: !switch <session_id> | 用法: !switch <会话ID>")
+                    continue
+                engine.switch_session(parts[1])
+                continue
+
+            if user_input.lower().startswith("!delete session"):
+                parts = user_input.split()
+                if len(parts) < 3:
+                    print("[Error] Usage: !delete session <session_id> | 用法: !delete session <会话ID>")
+                    continue
+                engine.delete_session(parts[2])
+                continue
+
+            if user_input.lower().startswith("!rename"):
+                parts = user_input.split(maxsplit=1)
+                if len(parts) < 2:
+                    print("[Error] Usage: !rename <new_title> | 用法: !rename <新标题>")
+                    continue
+                engine.rename_session(engine.current_session_id, parts[1])
+                continue
+
+            if user_input.lower() == "!sessions":
+                engine.list_sessions()
+                continue
+
+            # Normal chat interaction
+            print("AI: ", end="", flush=True)
+            for chunk in engine.chat(user_input):
+                print(chunk, end="", flush=True)
+            print("\n")
+
+        except KeyboardInterrupt:
+            engine.shutdown()
+            break
+        except Exception as e:
+            print(f"\n\n[Error | 错误] {str(e)}")
+            print()
+
+
+if __name__ == "__main__":
+    main()

--- a/cli/deerflow_cli/cli.py
+++ b/cli/deerflow_cli/cli.py
@@ -34,7 +34,7 @@ def safe_input(prompt):
         except UnicodeDecodeError:
             print("\n[Error] Input encoding error. Please use UTF-8. | 输入编码错误，请使用UTF-8\n")
         except EOFError:
-            return ""
+            return None
 
 
 def multi_line_input(prompt):
@@ -59,7 +59,7 @@ def multi_line_input(prompt):
         except UnicodeDecodeError:
             print("\n[Error] Input encoding error. Please use UTF-8. | 输入编码错误，请使用UTF-8\n")
         except EOFError:
-            break
+            return None
     return '\n'.join(lines)
 
 
@@ -82,19 +82,25 @@ def main():
                 engine.create_session()
 
             prompt = f"[{engine.current_session_id[:8]}] You: "
-            user_input = safe_input(prompt).strip()
+            user_input = safe_input(prompt)
+            if user_input is None:
+                break
+            user_input = user_input.strip()
 
             if not user_input:
                 continue
 
             if user_input.lower() == '!multi':
                 user_input = multi_line_input(f"\n[{engine.current_session_id[:8]}] Multi-line Input Mode | 多行输入模式")
+                if user_input is None:
+                    break
                 if not user_input.strip():
                     print("\n[Info] Empty input ignored | 空输入已忽略\n")
                     continue
                 print()
 
             if user_input.lower() == "!exit":
+                engine.shutdown()
                 break
 
             if user_input.lower() == "!help":

--- a/cli/deerflow_cli/cli.py
+++ b/cli/deerflow_cli/cli.py
@@ -9,7 +9,8 @@ License: MIT
 """
 
 import sys
-from engine import DeerFlowProductionEngine
+
+from .engine import DeerFlowProductionEngine
 
 
 def safe_input(prompt):

--- a/cli/deerflow_cli/engine.py
+++ b/cli/deerflow_cli/engine.py
@@ -31,7 +31,6 @@ Author: heart-scalpel
 License: MIT
 """
 
-import os
 import time
 import re
 import uuid
@@ -39,7 +38,7 @@ from pathlib import Path
 
 from langgraph.checkpoint.sqlite import SqliteSaver
 from deerflow.client import DeerFlowClient
-from session_store import SessionStore
+from .session_store import SessionStore
 
 # Configuration constants
 WORK_DIR = Path("./.deer-flow")

--- a/cli/deerflow_cli/engine.py
+++ b/cli/deerflow_cli/engine.py
@@ -423,6 +423,8 @@ class DeerFlowProductionEngine:
         session_id = session_id or self.current_session_id
         if not session_id or session_id not in self.store.sessions:
             session_id = self.create_session()
+        elif session_id != self.current_session_id:
+            self._activate_session(session_id)
 
         self.store.sessions[session_id]["last_active"] = time.time()
         stream_kwargs = {"thread_id": session_id, **kwargs}

--- a/cli/deerflow_cli/session_store.py
+++ b/cli/deerflow_cli/session_store.py
@@ -48,6 +48,7 @@ class SessionStore:
         self._write_queue = queue.Queue()
         self._pending_writes = {}
         self._lock = threading.Lock()
+        self._shutdown = False
         self._write_thread = threading.Thread(target=self._write_worker, daemon=True)
         self._write_thread.start()
 
@@ -102,17 +103,19 @@ class SessionStore:
         Args:
             session_id: ID of the session to save
         """
-        if session_id not in self.sessions:
+        if self._shutdown:
             return
 
-        data = {
-            "session_id": session_id,
-            "info": self.sessions[session_id],
-            "metrics": self.session_metrics[session_id],
-        }
-
         with self._lock:
+            if session_id not in self.sessions:
+                return
+            data = {
+                "session_id": session_id,
+                "info": self.sessions[session_id].copy(),
+                "metrics": self.session_metrics[session_id].copy(),
+            }
             self._pending_writes[session_id] = data
+
         self._write_queue.put(session_id)
 
     def delete_session_files(self, session_id: str):
@@ -167,9 +170,10 @@ class SessionStore:
 
     def shutdown(self):
         """Gracefully shut down the session store, flushing all pending writes."""
-        # Wait for all pending writes to complete
-        self._write_queue.join()
-        # Send shutdown signal to worker thread
+        if self._shutdown:
+            return
+        self._shutdown = True
+        # Send shutdown signal — worker will drain remaining items first.
         self._write_queue.put(None)
-        # Wait for worker thread to exit
+        # Wait for worker thread to exit (it calls task_done for every item).
         self._write_thread.join(timeout=5)

--- a/cli/deerflow_cli/session_store.py
+++ b/cli/deerflow_cli/session_store.py
@@ -95,10 +95,10 @@ class SessionStore:
     def save_async(self, session_id: str):
         """
         Queue a session for asynchronous saving to disk.
-        
+
         Multiple rapid calls to save_async for the same session will be
         coalesced into a single write operation.
-        
+
         Args:
             session_id: ID of the session to save
         """

--- a/cli/engine.py
+++ b/cli/engine.py
@@ -1,0 +1,468 @@
+"""
+DeerFlow Production Engine
+
+A production-grade, session-aware runtime engine for DeerFlow AI agents.
+Features complete session management, persistence, streaming, and tool integration.
+
+Isolation design
+================
+Session-level isolation is enforced through two complementary mechanisms:
+
+1. **Per-session DeerFlowClient instances.**  Each session owns an independent
+   DeerFlowClient and SQLite checkpointer.  Agent state, runtime settings, and
+   conversation history never leak across sessions.
+
+2. **Global shared-resource reset on session switch.**  The deerflow backend
+   package holds module-level singletons (MCP session pool, MCP tool cache,
+   subagent background tasks, memory queue, etc.) that outlive any single
+   client instance.  ``_reset_shared_resources()`` clears every known global
+   on each user-initiated session switch.
+
+   This is a *best-effort* reset — it depends on the backend exposing public
+   reset functions for every piece of mutable global state.  If a future
+   backend version adds new global state without a corresponding reset API,
+   it will not be caught here.  For single-user CLI use this trade-off is
+   acceptable; a multi-tenant server should spawn a subprocess per session
+   for guaranteed isolation (see issue #3292).
+
+All checkpoints are preserved for full model behavior auditing.
+
+Author: heart-scalpel
+License: MIT
+"""
+
+import os
+import time
+import re
+import uuid
+from pathlib import Path
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+from deerflow.client import DeerFlowClient
+from session_store import SessionStore
+
+# Configuration constants
+WORK_DIR = Path("./.deer-flow")
+SESSIONS_DIR = WORK_DIR / "deerflow_sessions"
+ARCHIVE_DIR = SESSIONS_DIR / "archive"
+
+
+class DeerFlowProductionEngine:
+    """
+    Production-grade singleton engine for DeerFlow agent execution.
+
+    Manages session lifecycle, persistence, streaming responses, and agent
+    configuration.  Each session owns an independent DeerFlowClient and
+    SQLite checkpointer so that agent state, runtime settings, and
+    conversation history are fully isolated.
+
+    On every user-initiated session switch, ``_reset_shared_resources()``
+    clears all known module-level globals in the deerflow backend:
+    MCP session pool + tool cache, subagent background tasks + usage cache,
+    memory storage cache + update queue.  See that method's docstring for
+    the full inventory and the residual risks of this best-effort approach.
+    """
+
+    _instance = None
+    _initialized = False
+
+    def __new__(cls):
+        """Create or return the singleton instance."""
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        """Initialize the engine if not already initialized."""
+        if self._initialized:
+            return
+        self._initialized = True
+
+        # ------------------------------------------------------------------
+        # Session persistence
+        # ------------------------------------------------------------------
+        self.store = SessionStore(SESSIONS_DIR, ARCHIVE_DIR)
+
+        # ------------------------------------------------------------------
+        # Per-session client instances (complete agent state isolation)
+        # ------------------------------------------------------------------
+        self._clients: dict[str, DeerFlowClient] = {}
+        self._checkpointer_cms: dict[str, object] = {}
+        self._checkpointers: dict[str, object] = {}
+
+        self.current_session_id = None
+
+        # Runtime settings template — applied to every new client so that
+        # user preferences (model, plan mode, subagent, thinking) survive
+        # across session switches.
+        self._runtime_settings = {
+            "model_name": None,
+            "plan_mode": False,
+            "subagent_enabled": False,
+            "thinking_enabled": True,
+        }
+
+        # ------------------------------------------------------------------
+        # Bootstrap: load existing sessions or create a default
+        # ------------------------------------------------------------------
+        if not self.store.sessions:
+            self._create_default_session()
+        else:
+            first_session_id = next(iter(self.store.sessions.keys()))
+            self._activate_session(first_session_id)
+
+    # ------------------------------------------------------------------
+    # Checkpointer paths
+    # ------------------------------------------------------------------
+
+    def _get_checkpoint_path(self, session_id: str) -> Path:
+        """Get the database path for a specific session."""
+        return SESSIONS_DIR / f"{session_id}_checkpoints.db"
+
+    # ------------------------------------------------------------------
+    # Client property
+    # ------------------------------------------------------------------
+
+    @property
+    def client(self) -> DeerFlowClient | None:
+        """Return the DeerFlowClient for the current session."""
+        if self.current_session_id is None:
+            return None
+        return self._clients.get(self.current_session_id)
+
+    # ------------------------------------------------------------------
+    # Per-session client and checkpointer management
+    # ------------------------------------------------------------------
+
+    def _get_or_create_client(self, session_id: str) -> DeerFlowClient:
+        """Return (or create) the DeerFlowClient for *session_id*.
+
+        Ensures the session's SQLite checkpointer is open.  Does **not**
+        reset shared global resources — use ``_activate_session`` for
+        user-initiated switches that require a full reset.
+        """
+        # Ensure a live checkpointer for this session.
+        if session_id not in self._checkpointer_cms:
+            db_path = self._get_checkpoint_path(session_id)
+            cm = SqliteSaver.from_conn_string(str(db_path))
+            self._checkpointer_cms[session_id] = cm
+            self._checkpointers[session_id] = cm.__enter__()
+
+        checkpointer = self._checkpointers[session_id]
+
+        # Return existing client after refreshing its checkpointer ref
+        # (the old SqliteSaver may have been closed across a switch).
+        if session_id in self._clients:
+            client = self._clients[session_id]
+            client._checkpointer = checkpointer
+            return client
+
+        # First time this session is used — create a fresh client.
+        client = DeerFlowClient(checkpointer=checkpointer)
+        settings = self._runtime_settings
+        if settings["model_name"]:
+            client._model_name = settings["model_name"]
+        client._plan_mode = settings["plan_mode"]
+        client._subagent_enabled = settings["subagent_enabled"]
+        client._thinking_enabled = settings["thinking_enabled"]
+
+        self._clients[session_id] = client
+        return client
+
+    def _activate_session(self, session_id: str):
+        """Activate *session_id* for user interaction.
+
+        Closes the previous session's checkpointer (keeping its client
+        alive for later reuse), ensures the target session has a live
+        client and checkpointer, then resets shared global resources.
+        """
+        # Close the *previous* session's checkpointer to release the
+        # SQLite connection, but leave its client in the dict so runtime
+        # settings are preserved.
+        if self.current_session_id and self.current_session_id != session_id:
+            self._close_checkpointer(self.current_session_id)
+
+        # Ensure target session is ready.
+        self._get_or_create_client(session_id)
+
+        # Prevent cross-session contamination from module-level globals.
+        self._reset_shared_resources()
+
+        self.current_session_id = session_id
+
+    def _close_checkpointer(self, session_id: str):
+        """Close the SQLite checkpointer for *session_id*."""
+        cm = self._checkpointer_cms.pop(session_id, None)
+        if cm is not None:
+            cm.__exit__(None, None, None)
+        self._checkpointers.pop(session_id, None)
+
+    def _destroy_client(self, session_id: str):
+        """Fully tear down a session's client and checkpointer."""
+        self._clients.pop(session_id, None)
+        self._close_checkpointer(session_id)
+
+    def _reset_shared_resources(self):
+        """Reset all known module-level globals in the deerflow backend.
+
+        This method is the single point of accountability for cross-session
+        cleanup.  Every piece of mutable global state discovered in the
+        backend audit that has a public reset API is cleared here.
+
+        Resources intentionally NOT reset:
+        - ``_isolated_subagent_loop`` — persistent event loop, expensive to
+          recreate, carries no session-specific state, atexit-managed.
+        - ``_scheduler_pool`` — ThreadPoolExecutor, expensive, stateless.
+        - ``_SYNC_TOOL_EXECUTOR``, ``_SYNC_MEMORY_UPDATER_EXECUTOR`` —
+          stateless thread pools, atexit-managed.
+        - Middleware dicts (todo, loop_detection) — keyed by
+          ``(thread_id, run_id)``, naturally scoped; no public reset API.
+
+        Fragility note: if a future backend version adds new global state
+        without a corresponding reset function, it will NOT be caught here.
+        This is the fundamental limitation of option 2 vs subprocess
+        isolation.  For single-user CLI use this trade-off is acceptable.
+        """
+        # ── MCP layer ───────────────────────────────────────────────
+        try:
+            from deerflow.mcp.cache import reset_mcp_tools_cache
+            reset_mcp_tools_cache()
+        except Exception:
+            pass
+
+        # ── Subagent layer ──────────────────────────────────────────
+        try:
+            from deerflow.subagents.executor import (
+                _background_tasks,
+                _background_tasks_lock,
+            )
+            with _background_tasks_lock:
+                _background_tasks.clear()
+        except Exception:
+            pass
+
+        try:
+            from deerflow.tools.builtins.task_tool import _subagent_usage_cache
+            _subagent_usage_cache.clear()
+        except Exception:
+            pass
+
+        # ── Memory layer ────────────────────────────────────────────
+        try:
+            from deerflow.agents.memory.storage import get_memory_storage
+            storage = get_memory_storage()
+            if hasattr(storage, "reload"):
+                storage.reload()
+        except Exception:
+            pass
+
+        try:
+            from deerflow.agents.memory.queue import reset_memory_queue
+            reset_memory_queue()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Session lifecycle
+    # ------------------------------------------------------------------
+
+    def _create_default_session(self):
+        """Create a default session when no sessions exist."""
+        return self.create_session(title="New Session")
+
+    def _ensure_current_session(self):
+        """Ensure a valid current session exists."""
+        if self.current_session_id is None or self.current_session_id not in self.store.sessions:
+            if self.store.sessions:
+                first_session_id = next(iter(self.store.sessions.keys()))
+                self._activate_session(first_session_id)
+            else:
+                self._create_default_session()
+
+    def shutdown(self):
+        """Gracefully shut down the engine and release all resources."""
+        print("\n[Engine] Shutting down gracefully...")
+        self.store.shutdown()
+        for sid in list(self._clients.keys()):
+            self._destroy_client(sid)
+        for sid in list(self._checkpointer_cms.keys()):
+            self._close_checkpointer(sid)
+        print("[Engine] Shutdown complete")
+
+    def create_session(self, session_id=None, title=None):
+        """
+        Create a new conversation session with its own isolated database
+        and DeerFlowClient instance.
+
+        Args:
+            session_id: Optional custom session ID. Auto-generated if None.
+            title: Optional session title. Defaults to "New Session".
+
+        Returns:
+            str: The created session ID.
+        """
+        if session_id is None or not re.fullmatch(r'[\w-]+', session_id):
+            session_id = uuid.uuid4().hex
+        if session_id in self.store.sessions:
+            print(f"[Session] ID already exists: {session_id}")
+            return session_id
+        self.store.sessions[session_id] = {
+            "created_at": time.time(),
+            "last_active": time.time(),
+            "title": title or "New Session",
+            "last_checkpoint_id": None,
+        }
+        self.store.session_metrics[session_id] = {
+            "total_tokens": 0,
+            "tool_calls": 0,
+            "turns": 0,
+        }
+        self.store.save_async(session_id)
+
+        self._activate_session(session_id)
+
+        print(f"[Session] Created: {session_id}")
+        return session_id
+
+    def switch_session(self, session_id):
+        """
+        Switch to an existing session with complete state isolation.
+
+        Args:
+            session_id: ID of the session to switch to.
+
+        Returns:
+            bool: True if switch was successful, False otherwise.
+        """
+        if session_id not in self.store.sessions:
+            print(f"[Error] Session {session_id} not found")
+            return False
+
+        self._activate_session(session_id)
+        self.store.sessions[session_id]["last_active"] = time.time()
+        self.store.save_async(session_id)
+
+        print(f"[Session] Switched to: {session_id}")
+        return True
+
+    def delete_session(self, session_id):
+        """
+        Delete a session and all associated files including its database.
+
+        Args:
+            session_id: ID of the session to delete.
+
+        Returns:
+            bool: True if deletion was successful, False otherwise.
+        """
+        if session_id not in self.store.sessions:
+            print(f"[Error] Session {session_id} not found")
+            return False
+
+        self._destroy_client(session_id)
+
+        self.store.delete_session_files(session_id)
+        db_path = self._get_checkpoint_path(session_id)
+        if db_path.exists():
+            db_path.unlink()
+
+        if self.current_session_id == session_id:
+            self.current_session_id = None
+            self._ensure_current_session()
+
+        print(f"[Session] Deleted: {session_id}")
+        return True
+
+    def rename_session(self, session_id, new_title):
+        """
+        Rename an existing session.
+
+        Args:
+            session_id: ID of the session to rename.
+            new_title: New title for the session.
+
+        Returns:
+            bool: True if rename was successful, False otherwise.
+        """
+        if session_id not in self.store.sessions:
+            print(f"[Error] Session {session_id} not found")
+            return False
+        self.store.sessions[session_id]["title"] = new_title
+        self.store.save_async(session_id)
+        print(f"[Session] Renamed to: {new_title}")
+        return True
+
+    def list_sessions(self):
+        """Print a list of all active sessions with their metrics."""
+        print("\n[Session List]")
+        for sid, info in self.store.sessions.items():
+            metrics = self.store.session_metrics[sid]
+            current = "← Current" if sid == self.current_session_id else ""
+            title = info.get("title", "New Session")
+            print(
+                f"  {sid} | {title} | Turns: {metrics['turns']} | "
+                f"Tokens: {metrics['total_tokens']} {current}"
+            )
+        print()
+
+    # ------------------------------------------------------------------
+    # Chat
+    # ------------------------------------------------------------------
+
+    def chat(self, message, session_id=None, **kwargs):
+        """
+        Send a message to the agent and stream the response.
+
+        Args:
+            message: The user's input message.
+            session_id: ID of the session. Uses current session if None.
+            **kwargs: Additional keyword arguments passed to client.stream().
+
+        Yields:
+            str: Chunks of the AI response, followed by metrics.
+        """
+        session_id = session_id or self.current_session_id
+        if not session_id or session_id not in self.store.sessions:
+            session_id = self.create_session()
+
+        self.store.sessions[session_id]["last_active"] = time.time()
+        stream_kwargs = {"thread_id": session_id, **kwargs}
+
+        full_response = ""
+        tool_calls = 0
+        total_tokens = 0
+
+        client = self._get_or_create_client(session_id)
+        for event in client.stream(message, **stream_kwargs):
+            if event.type == "messages-tuple":
+                d = event.data
+                if d.get("type") == "ai" and d.get("content"):
+                    content = d["content"]
+                    full_response += content
+                    yield content
+                if d.get("tool_calls"):
+                    tool_calls += len(d["tool_calls"])
+            elif event.type == "end":
+                usage = event.data.get("usage", {})
+                total_tokens = usage.get("total_tokens", 0)
+
+        self.store.session_metrics[session_id]["turns"] += 1
+        self.store.session_metrics[session_id]["tool_calls"] += tool_calls
+        self.store.session_metrics[session_id]["total_tokens"] += total_tokens
+
+        thread_data = client.get_thread(session_id)
+        if thread_data["checkpoints"]:
+            last_checkpoint_id = thread_data["checkpoints"][-1]["checkpoint_id"]
+            self.store.sessions[session_id]["last_checkpoint_id"] = last_checkpoint_id
+
+        if (
+            self.store.sessions[session_id].get("title") in (None, "New Session")
+            and full_response
+        ):
+            self.store.sessions[session_id]["title"] = (
+                message[:30] + ("..." if len(message) > 30 else "")
+            )
+
+        self.store.save_async(session_id)
+
+        yield f"\n\n[Metrics] Tokens: {total_tokens} | Tool Calls: {tool_calls}"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "deerflow-cli"
+version = "0.1.0"
+description = "DeerFlow AI agent platform CLI"
+requires-python = ">=3.12"
+dependencies = [
+    "deerflow-harness",
+]
+
+[project.scripts]
+deerflow = "deerflow_cli.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["deerflow_cli"]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/cli/session_store.py
+++ b/cli/session_store.py
@@ -1,0 +1,175 @@
+"""
+Session Store for DeerFlow Production Engine
+
+Thread-safe asynchronous session persistence layer.
+Handles loading, saving, archiving, and deletion of session metadata.
+Uses a background worker thread to avoid blocking the main event loop.
+
+Author: heart-scalpel
+License: MIT
+"""
+
+import json
+import queue
+import threading
+from collections import defaultdict
+from pathlib import Path
+
+
+class SessionStore:
+    """
+    Thread-safe asynchronous session storage manager.
+    
+    Provides non-blocking save operations via a background worker thread.
+    Maintains in-memory cache of session metadata and metrics for fast access.
+    Supports session archiving and graceful shutdown.
+    """
+
+    def __init__(self, sessions_dir: Path, archive_dir: Path):
+        """
+        Initialize the session store.
+        
+        Args:
+            sessions_dir: Directory to store active session files
+            archive_dir: Directory to store archived session files
+        """
+        self.sessions_dir = sessions_dir
+        self.archive_dir = archive_dir
+        
+        # Create directories if they don't exist
+        self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self.archive_dir.mkdir(parents=True, exist_ok=True)
+
+        # In-memory session cache
+        self.sessions = {}
+        self.session_metrics = defaultdict(lambda: {"total_tokens": 0, "tool_calls": 0, "turns": 0})
+
+        # Async write infrastructure
+        self._write_queue = queue.Queue()
+        self._pending_writes = {}
+        self._lock = threading.Lock()
+        self._write_thread = threading.Thread(target=self._write_worker, daemon=True)
+        self._write_thread.start()
+
+        # Load existing sessions from disk
+        self._load_sessions_from_disk()
+
+    def _load_sessions_from_disk(self):
+        """Load all active sessions from disk into memory on startup."""
+        for session_file in self.sessions_dir.glob("*.json"):
+            try:
+                with open(session_file, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                session_id = data["session_id"]
+                self.sessions[session_id] = data["info"]
+                self.session_metrics[session_id] = data["metrics"]
+            except Exception:
+                # Skip corrupted files silently
+                continue
+
+    def _write_worker(self):
+        """Background worker thread that handles asynchronous file writes."""
+        while True:
+            try:
+                session_id = self._write_queue.get(timeout=1)
+            except queue.Empty:
+                continue
+
+            if session_id is None:
+                self._write_queue.task_done()
+                break
+
+            try:
+                with self._lock:
+                    data = self._pending_writes.pop(session_id, None)
+
+                if data is not None:
+                    session_file = self.sessions_dir / f"{session_id}.json"
+                    with open(session_file, "w", encoding="utf-8") as f:
+                        json.dump(data, f, indent=2)
+            except Exception:
+                pass
+            finally:
+                self._write_queue.task_done()
+
+    def save_async(self, session_id: str):
+        """
+        Queue a session for asynchronous saving to disk.
+        
+        Multiple rapid calls to save_async for the same session will be
+        coalesced into a single write operation.
+        
+        Args:
+            session_id: ID of the session to save
+        """
+        if session_id not in self.sessions:
+            return
+
+        data = {
+            "session_id": session_id,
+            "info": self.sessions[session_id],
+            "metrics": self.session_metrics[session_id],
+        }
+
+        with self._lock:
+            self._pending_writes[session_id] = data
+        self._write_queue.put(session_id)
+
+    def delete_session_files(self, session_id: str):
+        """
+        Delete a session and all associated files.
+        
+        Args:
+            session_id: ID of the session to delete
+        """
+        with self._lock:
+            self._pending_writes.pop(session_id, None)
+
+        session_file = self.sessions_dir / f"{session_id}.json"
+        if session_file.exists():
+            session_file.unlink()
+
+        # Remove from in-memory cache
+        if session_id in self.sessions:
+            del self.sessions[session_id]
+        if session_id in self.session_metrics:
+            del self.session_metrics[session_id]
+
+    def archive_session_files(self, session_id: str):
+        """
+        Move a session from active to archived status.
+
+        Flushes any pending async write before archiving so the archive
+        file is always created, even if the worker hasn't written the
+        active file to disk yet.
+
+        Args:
+            session_id: ID of the session to archive
+        """
+        with self._lock:
+            pending_data = self._pending_writes.pop(session_id, None)
+
+        session_file = self.sessions_dir / f"{session_id}.json"
+        archive_file = self.archive_dir / f"{session_id}.json"
+
+        if session_file.exists():
+            session_file.rename(archive_file)
+        elif pending_data is not None:
+            # Pending write never flushed — write directly to archive.
+            with open(archive_file, "w", encoding="utf-8") as f:
+                json.dump(pending_data, f, indent=2)
+
+        # Remove from in-memory cache
+        if session_id in self.sessions:
+            del self.sessions[session_id]
+        if session_id in self.session_metrics:
+            del self.session_metrics[session_id]
+
+    def shutdown(self):
+        """Gracefully shut down the session store, flushing all pending writes."""
+        # Wait for all pending writes to complete
+        self._write_queue.join()
+        # Send shutdown signal to worker thread
+        self._write_queue.put(None)
+        # Wait for worker thread to exit
+        self._write_thread.join(timeout=5)

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Test configuration for the CLI test suite.
+
+Pre-mocks external dependencies (DeerFlowClient, SqliteSaver) so that
+engine.py can be imported without pulling in the full LangGraph runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Make 'cli' package importable from any working directory
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# ---------------------------------------------------------------------------
+# Pre-mock DeerFlowClient — each constructor call returns a fresh mock so
+# per-session client identity checks work correctly.
+# ---------------------------------------------------------------------------
+
+
+def _make_deerflow_client(*args, **kwargs):
+    client = MagicMock()
+    client.stream.return_value = iter([])
+    client.get_thread.return_value = {"checkpoints": []}
+    client.list_models.return_value = {"models": []}
+    client.list_skills.return_value = {"skills": []}
+    client.upload_files.return_value = {"message": "ok"}
+    client.list_uploads.return_value = {"count": 0, "files": []}
+    client.delete_upload.return_value = {"message": "deleted"}
+    client.get_memory.return_value = {"facts": []}
+    client.clear_memory.return_value = None
+    client.update_skill.return_value = None
+    return client
+
+
+_mock_client = MagicMock()
+_mock_client.side_effect = _make_deerflow_client
+
+sys.modules["deerflow.client"] = MagicMock(DeerFlowClient=_mock_client)
+
+# ---------------------------------------------------------------------------
+# Pre-mock SqliteSaver — each from_conn_string call returns a fresh context
+# manager so per-session checkpointer identity works correctly.
+# ---------------------------------------------------------------------------
+
+
+def _make_sqlite_cm(conn_string=None):
+    cm = MagicMock()
+    cm.__enter__.return_value = MagicMock()
+    return cm
+
+
+_mock_sqlite_saver = MagicMock()
+_mock_sqlite_saver.from_conn_string.side_effect = _make_sqlite_cm
+
+sys.modules["langgraph.checkpoint.sqlite"] = MagicMock(SqliteSaver=_mock_sqlite_saver)
+sys.modules["langgraph.checkpoint"] = MagicMock()
+sys.modules["langgraph"] = MagicMock()

--- a/cli/tests/conftest.py
+++ b/cli/tests/conftest.py
@@ -10,8 +10,11 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-# Make 'cli' package importable from any working directory
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Make the project directory importable so `from deerflow_cli.engine import ...`
+# resolves to cli/deerflow_cli/engine.py regardless of where pytest is launched from.
+_project_dir = str(Path(__file__).resolve().parent.parent)
+if _project_dir not in sys.path:
+    sys.path.insert(0, _project_dir)
 
 # ---------------------------------------------------------------------------
 # Pre-mock DeerFlowClient — each constructor call returns a fresh mock so

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,0 +1,291 @@
+"""Integration tests for cli.py — command parsing and user interaction."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# safe_input
+# ---------------------------------------------------------------------------
+
+class TestSafeInput:
+    """Input handling with UTF-8 encoding recovery."""
+
+    def test_returns_stripped_input(self):
+        from cli.cli import safe_input
+
+        with patch("cli.cli.input", return_value="  hello  \n"):
+            result = safe_input("> ")
+        assert result == "  hello  "
+
+    def test_handles_unicode_decode_error(self):
+        from cli.cli import safe_input
+
+        call_count = [0]
+
+        def broken_input(prompt):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "mock error")
+            return "recovered"
+
+        with patch("cli.cli.input", side_effect=broken_input):
+            result = safe_input("> ")
+        assert result == "recovered"
+
+    def test_handles_eof(self):
+        from cli.cli import safe_input
+
+        with patch("cli.cli.input", side_effect=EOFError()):
+            result = safe_input("> ")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# multi_line_input
+# ---------------------------------------------------------------------------
+
+class TestMultiLineInput:
+    """Multi-line input mode with !end sentinel."""
+
+    def test_reads_until_end_sentinel(self):
+        from cli.cli import multi_line_input
+
+        lines = iter(["line1", "line2", "!end"])
+
+        with patch("cli.cli.input", side_effect=lambda: next(lines)):
+            result = multi_line_input("Enter:")
+
+        assert result == "line1\nline2"
+
+    def test_handles_eof(self):
+        from cli.cli import multi_line_input
+
+        with patch("cli.cli.input", side_effect=EOFError()):
+            result = multi_line_input("Enter:")
+
+        assert result == ""
+
+    def test_handles_unicode_decode_error(self):
+        from cli.cli import multi_line_input
+
+        call_count = [0]
+
+        def broken_input():
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise UnicodeDecodeError("utf-8", b"", 0, 1, "mock error")
+            return "!end"
+
+        with patch("cli.cli.input", side_effect=broken_input):
+            result = multi_line_input("Enter:")
+
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# main — command dispatch
+# ---------------------------------------------------------------------------
+
+class TestMainCommandDispatch:
+    """Verify that !commands correctly delegate to engine methods."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        """Reset the engine singleton before each test."""
+        from engine import DeerFlowProductionEngine
+        DeerFlowProductionEngine._instance = None
+        DeerFlowProductionEngine._initialized = False
+        yield
+        DeerFlowProductionEngine._instance = None
+        DeerFlowProductionEngine._initialized = False
+
+    def _run_main(self, inputs: list[str], mock_engine: MagicMock, monkeypatch) -> None:
+        """Run main() with a fixed list of inputs, then raise KeyboardInterrupt to exit."""
+        mock_engine.current_session_id = "test1234"
+        mock_engine.client = MagicMock()
+
+        input_iter = iter(inputs)
+
+        def mock_input(prompt=""):
+            try:
+                return next(input_iter)
+            except StopIteration:
+                raise KeyboardInterrupt
+
+        with patch("cli.cli.DeerFlowProductionEngine", return_value=mock_engine), \
+             patch("cli.cli.safe_input", side_effect=mock_input), \
+             patch("cli.cli.multi_line_input", return_value="multi line content"):
+            try:
+                from cli.cli import main
+                main()
+            except (KeyboardInterrupt, SystemExit):
+                pass
+
+    # --- Session management ---
+
+    def test_new_creates_session(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!new custom-id My Title", "!exit"], engine, monkeypatch)
+        engine.create_session.assert_called_with("custom-id", "My Title")
+
+    def test_new_without_args(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!new", "!exit"], engine, monkeypatch)
+        engine.create_session.assert_called_with(None, None)
+
+    def test_switch_session(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!switch other-session", "!exit"], engine, monkeypatch)
+        engine.switch_session.assert_called_with("other-session")
+
+    def test_switch_missing_arg_shows_error(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!switch", "!exit"], engine, monkeypatch)
+        engine.switch_session.assert_not_called()
+
+    def test_delete_session(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!delete session sid123", "!exit"], engine, monkeypatch)
+        engine.delete_session.assert_called_with("sid123")
+
+    def test_rename_session(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!rename New Title", "!exit"], engine, monkeypatch)
+        engine.rename_session.assert_called_with("test1234", "New Title")
+
+    def test_rename_missing_title(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!rename", "!exit"], engine, monkeypatch)
+        engine.rename_session.assert_not_called()
+
+    def test_list_sessions(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!sessions", "!exit"], engine, monkeypatch)
+        engine.list_sessions.assert_called_once()
+
+    # --- Help / Exit ---
+
+    def test_help(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!help", "!exit"], engine, monkeypatch)
+
+    def test_exit_breaks_loop(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        self._run_main(["!exit"], engine, monkeypatch)
+
+    # --- Multi-line ---
+
+    def test_multi_line_mode(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        engine.chat.return_value = iter(["response"])
+
+        self._run_main(["!multi", "!exit"], engine, monkeypatch)
+        engine.chat.assert_called_with("multi line content")
+
+    def test_multi_line_empty_ignored(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+
+        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("cli.cli.safe_input", side_effect=["!multi", KeyboardInterrupt]), \
+             patch("cli.cli.multi_line_input", return_value=""):
+            try:
+                from cli.cli import main
+                main()
+            except (KeyboardInterrupt, SystemExit):
+                pass
+        engine.chat.assert_not_called()
+
+    # --- Normal chat ---
+
+    def test_default_chat_path(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        engine.chat.return_value = iter(["Hello!"])
+
+        self._run_main(["What is AI?", "!exit"], engine, monkeypatch)
+        engine.chat.assert_called_with("What is AI?")
+
+    def test_creates_session_when_none_active(self, monkeypatch):
+        engine = MagicMock()
+        engine.current_session_id = None
+        engine.client = MagicMock()
+        engine.chat.return_value = iter(["response"])
+
+        def _create(*args, **kwargs):
+            engine.current_session_id = "new12345"
+            return "new12345"
+        engine.create_session.side_effect = _create
+
+        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("cli.cli.safe_input", side_effect=["Hello", "!exit"]):
+            try:
+                from cli.cli import main
+                main()
+            except (KeyboardInterrupt, SystemExit):
+                pass
+
+        engine.create_session.assert_called_once()
+
+    # --- Error handling ---
+
+    def test_generic_exception_handling(self, monkeypatch):
+        """Exceptions in command handling are caught and printed, not propagated."""
+        engine = MagicMock()
+        engine.current_session_id = "test1234"
+        engine.chat.side_effect = RuntimeError("Something went wrong")
+
+        self._run_main(["broken", "!exit"], engine, monkeypatch)
+
+
+# ---------------------------------------------------------------------------
+# main — null session handling
+# ---------------------------------------------------------------------------
+
+class TestMainNullSession:
+    """main() creates a session when current_session_id is None."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_singleton(self):
+        from engine import DeerFlowProductionEngine
+        DeerFlowProductionEngine._instance = None
+        DeerFlowProductionEngine._initialized = False
+        yield
+        DeerFlowProductionEngine._instance = None
+        DeerFlowProductionEngine._initialized = False
+
+    def test_null_session_triggers_create(self, monkeypatch):
+        """When current_session_id is None, main() calls create_session()."""
+        engine = MagicMock()
+        engine.current_session_id = None
+
+        def _create(*args, **kwargs):
+            engine.current_session_id = "new12345"
+            return "new12345"
+        engine.create_session.side_effect = _create
+
+        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("cli.cli.safe_input", side_effect=["!sessions", KeyboardInterrupt]):
+            try:
+                from cli.cli import main
+                main()
+            except (KeyboardInterrupt, SystemExit):
+                pass
+
+        engine.create_session.assert_called()

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -42,7 +42,7 @@ class TestSafeInput:
 
         with patch("deerflow_cli.cli.input", side_effect=EOFError()):
             result = safe_input("> ")
-        assert result == ""
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -68,7 +68,7 @@ class TestMultiLineInput:
         with patch("deerflow_cli.cli.input", side_effect=EOFError()):
             result = multi_line_input("Enter:")
 
-        assert result == ""
+        assert result is None
 
     def test_handles_unicode_decode_error(self):
         from deerflow_cli.cli import multi_line_input

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Integration tests for cli.py — command parsing and user interaction."""
+"""Integration tests for deerflow_cli.py — command parsing and user interaction."""
 
 from __future__ import annotations
 
@@ -16,14 +16,14 @@ class TestSafeInput:
     """Input handling with UTF-8 encoding recovery."""
 
     def test_returns_stripped_input(self):
-        from cli.cli import safe_input
+        from deerflow_cli.cli import safe_input
 
-        with patch("cli.cli.input", return_value="  hello  \n"):
+        with patch("deerflow_cli.cli.input", return_value="  hello  \n"):
             result = safe_input("> ")
         assert result == "  hello  "
 
     def test_handles_unicode_decode_error(self):
-        from cli.cli import safe_input
+        from deerflow_cli.cli import safe_input
 
         call_count = [0]
 
@@ -33,14 +33,14 @@ class TestSafeInput:
                 raise UnicodeDecodeError("utf-8", b"", 0, 1, "mock error")
             return "recovered"
 
-        with patch("cli.cli.input", side_effect=broken_input):
+        with patch("deerflow_cli.cli.input", side_effect=broken_input):
             result = safe_input("> ")
         assert result == "recovered"
 
     def test_handles_eof(self):
-        from cli.cli import safe_input
+        from deerflow_cli.cli import safe_input
 
-        with patch("cli.cli.input", side_effect=EOFError()):
+        with patch("deerflow_cli.cli.input", side_effect=EOFError()):
             result = safe_input("> ")
         assert result == ""
 
@@ -53,25 +53,25 @@ class TestMultiLineInput:
     """Multi-line input mode with !end sentinel."""
 
     def test_reads_until_end_sentinel(self):
-        from cli.cli import multi_line_input
+        from deerflow_cli.cli import multi_line_input
 
         lines = iter(["line1", "line2", "!end"])
 
-        with patch("cli.cli.input", side_effect=lambda: next(lines)):
+        with patch("deerflow_cli.cli.input", side_effect=lambda: next(lines)):
             result = multi_line_input("Enter:")
 
         assert result == "line1\nline2"
 
     def test_handles_eof(self):
-        from cli.cli import multi_line_input
+        from deerflow_cli.cli import multi_line_input
 
-        with patch("cli.cli.input", side_effect=EOFError()):
+        with patch("deerflow_cli.cli.input", side_effect=EOFError()):
             result = multi_line_input("Enter:")
 
         assert result == ""
 
     def test_handles_unicode_decode_error(self):
-        from cli.cli import multi_line_input
+        from deerflow_cli.cli import multi_line_input
 
         call_count = [0]
 
@@ -81,7 +81,7 @@ class TestMultiLineInput:
                 raise UnicodeDecodeError("utf-8", b"", 0, 1, "mock error")
             return "!end"
 
-        with patch("cli.cli.input", side_effect=broken_input):
+        with patch("deerflow_cli.cli.input", side_effect=broken_input):
             result = multi_line_input("Enter:")
 
         assert result == ""
@@ -97,7 +97,7 @@ class TestMainCommandDispatch:
     @pytest.fixture(autouse=True)
     def _reset_singleton(self):
         """Reset the engine singleton before each test."""
-        from engine import DeerFlowProductionEngine
+        from deerflow_cli.engine import DeerFlowProductionEngine
         DeerFlowProductionEngine._instance = None
         DeerFlowProductionEngine._initialized = False
         yield
@@ -117,11 +117,11 @@ class TestMainCommandDispatch:
             except StopIteration:
                 raise KeyboardInterrupt
 
-        with patch("cli.cli.DeerFlowProductionEngine", return_value=mock_engine), \
-             patch("cli.cli.safe_input", side_effect=mock_input), \
-             patch("cli.cli.multi_line_input", return_value="multi line content"):
+        with patch("deerflow_cli.cli.DeerFlowProductionEngine", return_value=mock_engine), \
+             patch("deerflow_cli.cli.safe_input", side_effect=mock_input), \
+             patch("deerflow_cli.cli.multi_line_input", return_value="multi line content"):
             try:
-                from cli.cli import main
+                from deerflow_cli.cli import main
                 main()
             except (KeyboardInterrupt, SystemExit):
                 pass
@@ -202,11 +202,11 @@ class TestMainCommandDispatch:
         engine = MagicMock()
         engine.current_session_id = "test1234"
 
-        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
-             patch("cli.cli.safe_input", side_effect=["!multi", KeyboardInterrupt]), \
-             patch("cli.cli.multi_line_input", return_value=""):
+        with patch("deerflow_cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("deerflow_cli.cli.safe_input", side_effect=["!multi", KeyboardInterrupt]), \
+             patch("deerflow_cli.cli.multi_line_input", return_value=""):
             try:
-                from cli.cli import main
+                from deerflow_cli.cli import main
                 main()
             except (KeyboardInterrupt, SystemExit):
                 pass
@@ -233,10 +233,10 @@ class TestMainCommandDispatch:
             return "new12345"
         engine.create_session.side_effect = _create
 
-        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
-             patch("cli.cli.safe_input", side_effect=["Hello", "!exit"]):
+        with patch("deerflow_cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("deerflow_cli.cli.safe_input", side_effect=["Hello", "!exit"]):
             try:
-                from cli.cli import main
+                from deerflow_cli.cli import main
                 main()
             except (KeyboardInterrupt, SystemExit):
                 pass
@@ -263,7 +263,7 @@ class TestMainNullSession:
 
     @pytest.fixture(autouse=True)
     def _reset_singleton(self):
-        from engine import DeerFlowProductionEngine
+        from deerflow_cli.engine import DeerFlowProductionEngine
         DeerFlowProductionEngine._instance = None
         DeerFlowProductionEngine._initialized = False
         yield
@@ -280,10 +280,10 @@ class TestMainNullSession:
             return "new12345"
         engine.create_session.side_effect = _create
 
-        with patch("cli.cli.DeerFlowProductionEngine", return_value=engine), \
-             patch("cli.cli.safe_input", side_effect=["!sessions", KeyboardInterrupt]):
+        with patch("deerflow_cli.cli.DeerFlowProductionEngine", return_value=engine), \
+             patch("deerflow_cli.cli.safe_input", side_effect=["!sessions", KeyboardInterrupt]):
             try:
-                from cli.cli import main
+                from deerflow_cli.cli import main
                 main()
             except (KeyboardInterrupt, SystemExit):
                 pass

--- a/cli/tests/test_engine.py
+++ b/cli/tests/test_engine.py
@@ -1,0 +1,533 @@
+"""Unit tests for engine.py — session lifecycle, client management, and chat."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from engine import (
+    SESSIONS_DIR,
+    ARCHIVE_DIR,
+    DeerFlowProductionEngine,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_engine_singleton():
+    """Destroy the singleton state and stop any active patches between tests."""
+    yield
+    instance = DeerFlowProductionEngine._instance
+    if instance is not None and hasattr(instance, "_patchers"):
+        for p in reversed(instance._patchers):
+            p.stop()
+    DeerFlowProductionEngine._instance = None
+    DeerFlowProductionEngine._initialized = False
+
+
+def _make_engine(mock_store, tmp_path: Path) -> DeerFlowProductionEngine:
+    """Construct an engine with SessionStore patched and dirs redirected."""
+    mock_store.sessions = {}
+    mock_store.session_metrics = {}
+    mock_store.save_async = MagicMock()
+    mock_store.delete_session_files = MagicMock()
+    mock_store.archive_session_files = MagicMock()
+    mock_store.shutdown = MagicMock()
+    DeerFlowProductionEngine._instance = None
+    DeerFlowProductionEngine._initialized = False
+
+    p_store = patch("engine.SessionStore", return_value=mock_store)
+    p_sessions = patch("engine.SESSIONS_DIR", tmp_path / "sessions")
+    p_archive = patch("engine.ARCHIVE_DIR", tmp_path / "archive")
+
+    p_store.start()
+    p_sessions.start()
+    p_archive.start()
+
+    engine = DeerFlowProductionEngine()
+    engine._patchers = [p_store, p_sessions, p_archive]
+    return engine
+
+
+def _clear_all_sessions(engine: DeerFlowProductionEngine):
+    """Remove the default session auto-created by __init__."""
+    engine.current_session_id = None
+    engine.store.sessions.clear()
+    engine.store.session_metrics.clear()
+    engine._clients.clear()
+    engine._checkpointer_cms.clear()
+    engine._checkpointers.clear()
+
+
+def _prime_session(engine: DeerFlowProductionEngine, sid="s1", title="Test"):
+    """Register a session in the store and activate it."""
+    engine.store.sessions[sid] = {
+        "created_at": time.time(),
+        "last_active": time.time(),
+        "title": title,
+        "last_checkpoint_id": None,
+    }
+    engine.store.session_metrics[sid] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+    engine.current_session_id = sid
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+class TestSingleton:
+    """DeerFlowProductionEngine must behave as a singleton."""
+
+    def test_same_instance_returned(self):
+        a = DeerFlowProductionEngine()
+        b = DeerFlowProductionEngine()
+        assert a is b
+
+    def test_init_guards_against_reinit(self):
+        engine = DeerFlowProductionEngine()
+        original_store = engine.store
+        engine.__init__()
+        assert engine.store is original_store
+
+
+# ---------------------------------------------------------------------------
+# _get_or_create_client — per-session client setup
+# ---------------------------------------------------------------------------
+
+class TestGetOrCreateClient:
+    """Client creation and reuse for session isolation."""
+
+    def test_creates_new_client_for_unknown_session(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        client = engine._get_or_create_client("s1")
+
+        assert "s1" in engine._clients
+        assert engine._clients["s1"] is client
+
+    def test_reuses_existing_client(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        c1 = engine._get_or_create_client("s1")
+        c2 = engine._get_or_create_client("s1")
+
+        assert c1 is c2
+
+    def test_each_session_gets_own_client(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        _prime_session(engine, "s2")
+
+        c1 = engine._get_or_create_client("s1")
+        c2 = engine._get_or_create_client("s2")
+
+        assert c1 is not c2
+        assert "s1" in engine._clients
+        assert "s2" in engine._clients
+
+    def test_applies_runtime_settings_to_new_client(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        engine._runtime_settings["model_name"] = "opus"
+        engine._runtime_settings["plan_mode"] = True
+        engine._runtime_settings["thinking_enabled"] = False
+
+        client = engine._get_or_create_client("s1")
+
+        assert client._model_name == "opus"
+        assert client._plan_mode is True
+        assert client._thinking_enabled is False
+
+    def test_does_not_reapply_settings_to_existing_client(self, tmp_path: Path):
+        """Settings are only applied on first creation, not on reuse."""
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        engine._runtime_settings["model_name"] = "opus"
+        c1 = engine._get_or_create_client("s1")
+
+        engine._runtime_settings["model_name"] = "sonnet"
+        c2 = engine._get_or_create_client("s1")
+
+        assert c1 is c2
+        assert c1._model_name == "opus"
+
+
+# ---------------------------------------------------------------------------
+# client property
+# ---------------------------------------------------------------------------
+
+class TestClientProperty:
+    """The client property returns the current session's client."""
+
+    def test_returns_none_when_no_current_session(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _clear_all_sessions(engine)
+        assert engine.client is None
+
+    def test_returns_client_for_current_session(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        engine._get_or_create_client("s1")
+        assert engine.client is engine._clients["s1"]
+
+    def test_returns_none_when_session_has_no_client(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        engine.current_session_id = "orphan"
+        assert engine.client is None
+
+
+# ---------------------------------------------------------------------------
+# Session lifecycle
+# ---------------------------------------------------------------------------
+
+class TestSessionLifecycle:
+    """CRUD operations on sessions."""
+
+    def test_create_session_assigns_uuid(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        sid = engine.create_session()
+        assert len(sid) == 32
+        assert sid in engine.store.sessions
+
+    def test_create_session_with_custom_id(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        sid = engine.create_session(session_id="my-session-42", title="Custom")
+        assert sid == "my-session-42"
+        assert engine.store.sessions["my-session-42"]["title"] == "Custom"
+
+    def test_create_session_rejects_invalid_id(self, tmp_path: Path):
+        """Non-alphanumeric-underscore-dash IDs are replaced with uuid."""
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        sid = engine.create_session(session_id="bad id!")
+        assert sid != "bad id!"
+        assert len(sid) == 32
+
+    def test_create_session_duplicate_id_returns_same(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        sid = engine.create_session(session_id="dup", title="First")
+        sid2 = engine.create_session(session_id="dup", title="Second")
+        assert sid == sid2
+        assert engine.store.sessions["dup"]["title"] == "First"
+
+    def test_switch_session_success(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        _prime_session(engine, "s2")
+
+        result = engine.switch_session("s2")
+
+        assert result is True
+        assert engine.current_session_id == "s2"
+
+    def test_switch_session_not_found(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        result = engine.switch_session("nonexistent")
+
+        assert result is False
+        assert engine.current_session_id == "s1"
+
+    def test_switch_session_updates_last_active(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        _prime_session(engine, "s2")
+        old_active = engine.store.sessions["s2"]["last_active"]
+
+        engine.switch_session("s2")
+
+        assert engine.store.sessions["s2"]["last_active"] > old_active
+
+    def test_delete_session_removes_everything(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _clear_all_sessions(engine)
+        _prime_session(engine, "s1")
+
+        engine._get_or_create_client("s1")
+
+        def _delete(sid):
+            engine.store.sessions.pop(sid, None)
+        store.delete_session_files.side_effect = _delete
+
+        engine.delete_session("s1")
+
+        assert "s1" not in engine.store.sessions
+        assert engine.current_session_id is not None
+        assert engine.current_session_id != "s1"
+        store.delete_session_files.assert_called_once_with("s1")
+
+    def test_delete_session_not_found(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        result = engine.delete_session("nonexistent")
+
+        assert result is False
+        assert "s1" in engine.store.sessions
+
+    def test_rename_session_success(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1", "Old")
+
+        result = engine.rename_session("s1", "New Title")
+
+        assert result is True
+        assert engine.store.sessions["s1"]["title"] == "New Title"
+        store.save_async.assert_called_with("s1")
+
+    def test_rename_session_not_found(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        result = engine.rename_session("ghost", "Nope")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _ensure_current_session
+# ---------------------------------------------------------------------------
+
+class TestEnsureCurrentSession:
+    """Automatic recovery when current_session_id becomes invalid."""
+
+    def test_falls_back_to_first_session(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _clear_all_sessions(engine)
+        _prime_session(engine, "s1")
+        _prime_session(engine, "s2")
+        engine.current_session_id = "orphan"
+
+        engine._ensure_current_session()
+
+        assert engine.current_session_id == "s1"
+
+    def test_creates_default_when_store_empty(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _clear_all_sessions(engine)
+        engine.current_session_id = None
+
+        engine._ensure_current_session()
+
+        assert engine.current_session_id is not None
+        assert engine.current_session_id in engine.store.sessions
+
+
+# ---------------------------------------------------------------------------
+# Chat
+# ---------------------------------------------------------------------------
+
+class TestChat:
+    """Streaming chat and metrics tracking."""
+
+    def test_chat_creates_session_when_none_active(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _clear_all_sessions(engine)
+        with patch.object(engine, "create_session", wraps=engine.create_session) as spy:
+            list(engine.chat("hello"))
+            spy.assert_called_once()
+
+    def test_chat_streams_response_chunks(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+
+        from types import SimpleNamespace
+
+        client = engine._get_or_create_client("s1")
+        Event = SimpleNamespace
+        client.stream.return_value = iter([
+            Event(type="messages-tuple", data={"type": "ai", "content": "Hello"}),
+            Event(type="messages-tuple", data={"type": "ai", "content": " world"}),
+            Event(type="end", data={"usage": {"total_tokens": 50}}),
+        ])
+        client.get_thread.return_value = {"checkpoints": [{"checkpoint_id": "cp1"}]}
+
+        chunks = list(engine.chat("Hi"))
+
+        assert "Hello" in chunks
+        assert " world" in chunks
+        assert any("50" in c for c in chunks if isinstance(c, str))
+
+    def test_chat_increments_metrics(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        engine.store.session_metrics["s1"]["turns"] = 0
+        engine.store.session_metrics["s1"]["total_tokens"] = 0
+
+        from types import SimpleNamespace
+
+        client = engine._get_or_create_client("s1")
+        Event = SimpleNamespace
+        client.stream.return_value = iter([
+            Event(type="messages-tuple", data={"type": "ai", "content": "A"}),
+            Event(type="messages-tuple", data={"type": "ai", "content": "B", "tool_calls": [{"id": "t1"}]}),
+            Event(type="end", data={"usage": {"total_tokens": 30}}),
+        ])
+        client.get_thread.return_value = {"checkpoints": [{"checkpoint_id": "cp1"}]}
+
+        list(engine.chat("Q"))
+
+        assert engine.store.session_metrics["s1"]["turns"] == 1
+        assert engine.store.session_metrics["s1"]["total_tokens"] == 30
+        assert engine.store.session_metrics["s1"]["tool_calls"] == 1
+
+    def test_chat_updates_title_on_first_turn(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1", "New Session")
+
+        from types import SimpleNamespace
+
+        client = engine._get_or_create_client("s1")
+        Event = SimpleNamespace
+        client.stream.return_value = iter([
+            Event(type="messages-tuple", data={"type": "ai", "content": "A long response about weather"}),
+            Event(type="end", data={"usage": {"total_tokens": 10}}),
+        ])
+        client.get_thread.return_value = {"checkpoints": [{"checkpoint_id": "cp1"}]}
+
+        list(engine.chat("What is the weather today?"))
+
+        assert engine.store.sessions["s1"]["title"] == "What is the weather today?"
+
+    def test_chat_does_not_overwrite_custom_title(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1", "My Custom Title")
+
+        from types import SimpleNamespace
+
+        client = engine._get_or_create_client("s1")
+        Event = SimpleNamespace
+        client.stream.return_value = iter([
+            Event(type="messages-tuple", data={"type": "ai", "content": "OK"}),
+            Event(type="end", data={"usage": {"total_tokens": 5}}),
+        ])
+        client.get_thread.return_value = {"checkpoints": [{"checkpoint_id": "cp1"}]}
+
+        list(engine.chat("Another message"))
+
+        assert engine.store.sessions["s1"]["title"] == "My Custom Title"
+
+    def test_runtime_settings_persisted_across_sessions(self, tmp_path: Path):
+        """Settings survive across session switches because _runtime_settings
+        is applied to each new client."""
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        engine._get_or_create_client("s1")
+
+        engine._runtime_settings["model_name"] = "haiku"
+        engine._runtime_settings["plan_mode"] = True
+
+        _prime_session(engine, "s2")
+        client2 = engine._get_or_create_client("s2")
+
+        assert client2._model_name == "haiku"
+        assert client2._plan_mode is True
+
+
+# ---------------------------------------------------------------------------
+# Shutdown
+# ---------------------------------------------------------------------------
+
+class TestShutdown:
+    """Graceful shutdown releases all resources."""
+
+    def test_shutdown_calls_store_shutdown(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        engine.shutdown()
+        store.shutdown.assert_called_once()
+
+    def test_shutdown_destroys_all_clients(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1")
+        _prime_session(engine, "s2")
+        engine._get_or_create_client("s1")
+        engine._get_or_create_client("s2")
+
+        engine.shutdown()
+
+        assert "s1" not in engine._clients
+        assert "s2" not in engine._clients
+        assert "s1" not in engine._checkpointer_cms
+        assert "s2" not in engine._checkpointer_cms
+
+
+# ---------------------------------------------------------------------------
+# list_sessions
+# ---------------------------------------------------------------------------
+
+class TestListing:
+    """List sessions (output-only, no return value)."""
+
+    def test_list_sessions(self, tmp_path: Path):
+        store = MagicMock()
+        store.sessions = {}
+        engine = _make_engine(store, tmp_path)
+        _prime_session(engine, "s1", "First")
+        _prime_session(engine, "s2", "Second")
+        engine.list_sessions()

--- a/cli/tests/test_engine.py
+++ b/cli/tests/test_engine.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from engine import (
+from deerflow_cli.engine import (
     SESSIONS_DIR,
     ARCHIVE_DIR,
     DeerFlowProductionEngine,
@@ -44,9 +44,9 @@ def _make_engine(mock_store, tmp_path: Path) -> DeerFlowProductionEngine:
     DeerFlowProductionEngine._instance = None
     DeerFlowProductionEngine._initialized = False
 
-    p_store = patch("engine.SessionStore", return_value=mock_store)
-    p_sessions = patch("engine.SESSIONS_DIR", tmp_path / "sessions")
-    p_archive = patch("engine.ARCHIVE_DIR", tmp_path / "archive")
+    p_store = patch("deerflow_cli.engine.SessionStore", return_value=mock_store)
+    p_sessions = patch("deerflow_cli.engine.SESSIONS_DIR", tmp_path / "sessions")
+    p_archive = patch("deerflow_cli.engine.ARCHIVE_DIR", tmp_path / "archive")
 
     p_store.start()
     p_sessions.start()

--- a/cli/tests/test_session_store.py
+++ b/cli/tests/test_session_store.py
@@ -1,0 +1,372 @@
+"""Unit tests for session_store.py — async persistence and file operations."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from session_store import SessionStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_session_json(sessions_dir: Path, session_id: str, title="Test Session"):
+    """Write a well-formed session JSON to disk for load-on-startup tests."""
+    data = {
+        "session_id": session_id,
+        "info": {
+            "created_at": 1000000.0,
+            "last_active": 1000001.0,
+            "title": title,
+            "last_checkpoint_id": None,
+        },
+        "metrics": {"total_tokens": 42, "tool_calls": 3, "turns": 1},
+    }
+    path = sessions_dir / f"{session_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _join_worker(store: SessionStore, timeout=2.0):
+    """Signal the worker thread to stop and join it."""
+    store.shutdown()
+    store._write_thread.join(timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# __init__ and disk loading
+# ---------------------------------------------------------------------------
+
+class TestInitAndDiskLoading:
+    """Startup behavior: directory creation, session loading from disk."""
+
+    def test_creates_directories(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            assert sessions_dir.exists()
+            assert archive_dir.exists()
+        finally:
+            _join_worker(store)
+
+    def test_loads_valid_sessions_from_disk(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        _write_session_json(sessions_dir, "abc123", "Hello")
+
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            assert "abc123" in store.sessions
+            assert store.sessions["abc123"]["title"] == "Hello"
+            assert store.session_metrics["abc123"]["total_tokens"] == 42
+        finally:
+            _join_worker(store)
+
+    def test_skips_corrupted_json_files(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        bad_file = sessions_dir / "bad.json"
+        bad_file.parent.mkdir(parents=True, exist_ok=True)
+        bad_file.write_text("not json at all {{{")
+
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            assert "bad" not in store.sessions
+        finally:
+            _join_worker(store)
+
+    def test_empty_sessions_dir_starts_clean(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            assert store.sessions == {}
+        finally:
+            _join_worker(store)
+
+
+# ---------------------------------------------------------------------------
+# save_async — enqueue writes
+# ---------------------------------------------------------------------------
+
+class TestSaveAsync:
+    """Asynchronous save behaviour."""
+
+    def test_queues_write_for_known_session(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.sessions["s1"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "T",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["s1"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+
+            store.save_async("s1")
+
+            # The pending-writes dict holds the coalesced data
+            with store._lock:
+                assert "s1" in store._pending_writes
+
+            # Let the worker flush
+            _join_worker(store)
+            assert (sessions_dir / "s1.json").exists()
+        finally:
+            _join_worker(store)
+
+    def test_noop_for_unknown_session(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.save_async("nonexistent")
+            with store._lock:
+                assert "nonexistent" not in store._pending_writes
+        finally:
+            _join_worker(store)
+
+    def test_coalesces_multiple_rapid_calls(self, tmp_path: Path):
+        """Multiple save_async calls for the same session produce one write."""
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.sessions["s2"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "Before",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["s2"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+
+            store.save_async("s2")
+            # Mutate after first enqueue — the pending write snapshot is stale
+            store.sessions["s2"]["title"] = "After"
+            store.save_async("s2")
+
+            _join_worker(store)
+
+            # The second call overwrote the pending write, so disk gets "After"
+            data = json.loads((sessions_dir / "s2.json").read_text())
+            assert data["info"]["title"] == "After"
+        finally:
+            _join_worker(store)
+
+
+# ---------------------------------------------------------------------------
+# _write_worker — background thread behavior
+# ---------------------------------------------------------------------------
+
+class TestWriteWorker:
+    """Background thread lifecycle and error handling."""
+
+    def test_exits_on_none_sentinel(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        store.shutdown()
+        store._write_thread.join(timeout=3)
+        assert not store._write_thread.is_alive()
+
+    def test_drains_queue_on_shutdown(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        store.sessions["s3"] = {
+            "created_at": 1.0,
+            "last_active": 2.0,
+            "title": "Q",
+            "last_checkpoint_id": None,
+        }
+        store.session_metrics["s3"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+
+        for _ in range(5):
+            store.save_async("s3")
+
+        _join_worker(store)
+
+        # All queued items were consumed (queue is empty) and file was written
+        assert (sessions_dir / "s3.json").exists()
+        # Queue should be empty after successful shutdown
+        assert store._write_queue.empty()
+
+
+# ---------------------------------------------------------------------------
+# delete_session_files
+# ---------------------------------------------------------------------------
+
+class TestDeleteSessionFiles:
+    """Session file deletion and in-memory cleanup."""
+
+    def test_removes_file_and_memory_state(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            # Prime session in memory and on disk
+            store.sessions["d1"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "D",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["d1"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+            store.save_async("s1")  # Just to exercise queue
+            (sessions_dir / "d1.json").write_text("{}")
+
+            store.delete_session_files("d1")
+
+            assert "d1" not in store.sessions
+            assert "d1" not in store.session_metrics
+            assert not (sessions_dir / "d1.json").exists()
+        finally:
+            _join_worker(store)
+
+    def test_clears_pending_write(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.sessions["d2"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "D2",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["d2"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+            store.save_async("d2")
+
+            store.delete_session_files("d2")
+
+            with store._lock:
+                assert "d2" not in store._pending_writes
+        finally:
+            _join_worker(store)
+
+
+# ---------------------------------------------------------------------------
+# archive_session_files
+# ---------------------------------------------------------------------------
+
+class TestArchiveSessionFiles:
+    """Moving sessions to the archive directory."""
+
+    def test_moves_existing_file_to_archive(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.sessions["a1"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "A",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["a1"] = {"total_tokens": 1, "tool_calls": 0, "turns": 1}
+            # Write to disk first so the file exists
+            store.save_async("a1")
+            # Drain so it's on disk
+            _join_worker(store)
+            # Recreate store with a fresh worker (the old one is now dead)
+            store = SessionStore(sessions_dir, archive_dir)
+            store.sessions["a1"] = {
+                "created_at": 1.0,
+                "last_active": 2.0,
+                "title": "A",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["a1"] = {"total_tokens": 1, "tool_calls": 0, "turns": 1}
+
+            assert (sessions_dir / "a1.json").exists()
+
+            store.archive_session_files("a1")
+
+            assert "a1" not in store.sessions
+            assert "a1" not in store.session_metrics
+            assert not (sessions_dir / "a1.json").exists()
+            assert (archive_dir / "a1.json").exists()
+        finally:
+            _join_worker(store)
+
+    def test_handles_unflushed_pending_write(self, tmp_path: Path):
+        """When archiving a session that was saved but not yet flushed to disk."""
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        try:
+            store.sessions["a2"] = {
+                "created_at": 1.0,
+                "last_active": 3.0,
+                "title": "Unflushed",
+                "last_checkpoint_id": None,
+            }
+            store.session_metrics["a2"] = {"total_tokens": 5, "tool_calls": 1, "turns": 1}
+            store.save_async("a2")
+            # Do NOT drain — the file isn't on disk yet
+
+            store.archive_session_files("a2")
+
+            assert "a2" not in store.sessions
+            assert not (sessions_dir / "a2.json").exists()
+            # Archive file was written directly from pending data
+            assert (archive_dir / "a2.json").exists()
+
+            data = json.loads((archive_dir / "a2.json").read_text())
+            assert data["info"]["title"] == "Unflushed"
+        finally:
+            _join_worker(store)
+
+
+# ---------------------------------------------------------------------------
+# Thread safety
+# ---------------------------------------------------------------------------
+
+class TestThreadSafety:
+    """Concurrent access to SessionStore from multiple threads."""
+
+    def test_concurrent_saves_from_multiple_threads(self, tmp_path: Path):
+        sessions_dir = tmp_path / "sessions"
+        archive_dir = tmp_path / "archive"
+        store = SessionStore(sessions_dir, archive_dir)
+        errors: list[Exception] = []
+
+        def writer(sid: str):
+            try:
+                store.sessions[sid] = {
+                    "created_at": time.time(),
+                    "last_active": time.time(),
+                    "title": f"Thread-{sid}",
+                    "last_checkpoint_id": None,
+                }
+                store.session_metrics[sid] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
+                for _ in range(10):
+                    store.save_async(sid)
+            except Exception as e:
+                errors.append(e)
+
+        threads = []
+        for i in range(5):
+            t = threading.Thread(target=writer, args=(f"t{i}",))
+            threads.append(t)
+            t.start()
+
+        for t in threads:
+            t.join()
+
+        _join_worker(store)
+
+        assert len(errors) == 0
+        for i in range(5):
+            assert (sessions_dir / f"t{i}.json").exists()

--- a/cli/tests/test_session_store.py
+++ b/cli/tests/test_session_store.py
@@ -223,7 +223,7 @@ class TestDeleteSessionFiles:
                 "last_checkpoint_id": None,
             }
             store.session_metrics["d1"] = {"total_tokens": 0, "tool_calls": 0, "turns": 0}
-            store.save_async("s1")  # Just to exercise queue
+            store.save_async("d1")  # Exercise queue with pending write for d1
             (sessions_dir / "d1.json").write_text("{}")
 
             store.delete_session_files("d1")

--- a/cli/tests/test_session_store.py
+++ b/cli/tests/test_session_store.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
-from session_store import SessionStore
+from deerflow_cli.session_store import SessionStore
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Introduce a minimal production-grade CLI for DeerFlow with:
- Thread-safe async session persistence (SessionStore)
- Singleton engine with per-session DeerFlowClient isolation
- Session lifecycle: create, switch, delete, rename, list
- Streaming chat with metrics tracking
- Automatic title generation from first message
- Shared resource reset on session switch (MCP, subagent, memory)
- Interactive REPL with UTF-8 encoding support

Fixes #3292 

## Why

Interacting with DeerFlow currently requires the full web frontend, which makes quick testing and architecture evaluation cumbersome. This is especially painful in air-gapped / private-network environments where standing up the complete stack (DeerFlow + Langfuse + dependencies) is heavyweight and time-consuming.

A lightweight CLI solves three real use cases:

- **Fast evaluation in restricted environments.** Deploy and test DeerFlow in private networks without the frontend overhead — spin up a session, chat with an agent, and iterate in seconds.
- **Architecture exploration.** As a developer evaluating DeerFlow as a framework, the CLI provides a direct path to exercise core primitives — skill loading, MCP tool integration, agent graph wiring — without UI friction.
- **Rapid prototyping and migration.** Validate internal agent logic by porting it into DeerFlow sessions, compare behavior side-by-side, and iterate without touching the web stack.

This is the first of three stacked PRs:
1. **Session core + chat** (this PR)
2. Archive, export, search, and introspection
3. Runtime controls, file operations, Docker, and docs

## What changed

- New `cli/` package — a standalone CLI tool, no changes to existing frontend, backend API, or agent code.
- `SessionStore` provides thread-safe async persistence via a background write worker with write coalescing — rapid saves for the same session collapse into one disk write.
- `DeerFlowProductionEngine` is a singleton that manages per-session `DeerFlowClient` + `SqliteSaver` instances. On every session switch it closes the previous checkpointer, opens the target session's, and resets all known module-level globals (MCP pool/cache, subagent background tasks, memory storage/queue) to prevent cross-session state leakage.
- The CLI REPL supports `!new`, `!switch`, `!delete session`, `!rename`, `!sessions`, `!multi` (multi-line input), `!help`, `!exit`, and plain-text chat with streaming output and per-turn metrics.
- All checkpoints are preserved for full auditing; no data is discarded.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

> **Note:** This PR adds a new standalone `cli/` directory. It does not touch any existing surface area — no frontend, backend API, agent graph, sandbox, or skills code is modified.

## Validation

- Unit tests for `SessionStore` (8 tests): init/disk-loading, async save + coalescing, write worker lifecycle, delete, archive, thread safety with concurrent writers.
- Unit tests for `Engine` (25 tests): singleton, per-session client isolation, runtime settings propagation, full session CRUD, chat streaming + metrics, title auto-generation, graceful shutdown.
- Integration tests for `CLI` (17 tests): UTF-8 input handling, multi-line mode, all session command dispatch, chat path, null-session recovery, error handling.
- All tests mock external dependencies (`DeerFlowClient`, `SqliteSaver`) so no backend runtime is required.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Generated the initial module structure, test scaffolding, and commit messages from a spec discussion. Human reviewed and refined every file.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.