### PR TITLE
fix(ux): remove Backspace shortcut for deleting prompt attachments

### DIFF
--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -912,18 +912,6 @@ export const PromptInputTextarea = ({
       form?.requestSubmit();
     }
 
-    // Remove last attachment when Backspace is pressed and textarea is empty
-    if (
-      e.key === "Backspace" &&
-      e.currentTarget.value === "" &&
-      attachments.files.length > 0
-    ) {
-      e.preventDefault();
-      const lastAttachment = attachments.files.at(-1);
-      if (lastAttachment) {
-        attachments.remove(lastAttachment.id);
-      }
-    }
   };
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -911,7 +911,6 @@ export const PromptInputTextarea = ({
 
       form?.requestSubmit();
     }
-
   };
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {


### PR DESCRIPTION
## Summary
- remove the textarea Backspace shortcut that deleted the last prompt attachment when the input was empty
- keep attachment removal limited to the visible remove control on each attachment card

## Context
Closes #3409.

This is a small UX preference change. I found the current behavior a little easy to trigger accidentally: after attaching a file, if the prompt is focused and empty, pressing Backspace removes the attachment immediately, so the file has to be selected again.

That said, this is subjective. The current behavior can also be interpreted as an intentional chip/tag-style deletion shortcut. If maintainers prefer keeping that keyboard interaction, closing this PR is completely fine.

## Validation
- cd frontend && pnpm check
  - eslint and tsc completed successfully
- pre-commit hook reran cd frontend && pnpm check during commit and passed