### PR TITLE
fix(subagents): make ultra mode limits configurable

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -338,7 +338,7 @@ def _build_middlewares(
     # Add SubagentLimitMiddleware to truncate excess parallel task calls
     subagent_enabled = cfg.get("subagent_enabled", False)
     if subagent_enabled:
-        max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
+        max_concurrent_subagents = cfg.get("max_concurrent_subagents", resolved_app_config.subagents.max_concurrent)
         middlewares.append(SubagentLimitMiddleware(max_concurrent=max_concurrent_subagents))
 
     # LoopDetectionMiddleware — detect and break repetitive tool call loops
@@ -426,7 +426,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     requested_model_name: str | None = cfg.get("model_name") or cfg.get("model")
     is_plan_mode = cfg.get("is_plan_mode", False)
     subagent_enabled = cfg.get("subagent_enabled", False)
-    max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
+    max_concurrent_subagents = cfg.get("max_concurrent_subagents", resolved_app_config.subagents.max_concurrent)
     is_bootstrap = cfg.get("is_bootstrap", False)
     agent_name = validate_agent_name(cfg.get("agent_name"))
 

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -225,6 +225,7 @@ class DeerFlowClient:
             cfg.get("thinking_enabled"),
             cfg.get("is_plan_mode"),
             cfg.get("subagent_enabled"),
+            cfg.get("max_concurrent_subagents", self._app_config.subagents.max_concurrent),
             self._agent_name,
             frozenset(self._available_skills) if self._available_skills is not None else None,
         )
@@ -235,7 +236,7 @@ class DeerFlowClient:
         thinking_enabled = cfg.get("thinking_enabled", True)
         model_name = cfg.get("model_name")
         subagent_enabled = cfg.get("subagent_enabled", False)
-        max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
+        max_concurrent_subagents = cfg.get("max_concurrent_subagents", self._app_config.subagents.max_concurrent)
 
         tools = self._get_tools(model_name=model_name, subagent_enabled=subagent_enabled)
         final_tools, deferred_setup = _assemble_deferred(tools, enabled=self._app_config.tool_search.enabled)

--- a/backend/packages/harness/deerflow/config/subagents_config.py
+++ b/backend/packages/harness/deerflow/config/subagents_config.py
@@ -81,6 +81,12 @@ class SubagentsAppConfig(BaseModel):
         ge=1,
         description="Optional default max-turn override for all subagents (None = keep builtin defaults)",
     )
+    max_concurrent: int = Field(
+        default=3,
+        ge=2,
+        le=4,
+        description="Maximum number of subagents that can run concurrently",
+    )
     agents: dict[str, SubagentOverrideConfig] = Field(
         default_factory=dict,
         description="Per-agent configuration overrides keyed by agent name",
@@ -173,9 +179,10 @@ def load_subagents_config_from_dict(config_dict: dict) -> None:
 
     if overrides_summary or custom_agents_names:
         logger.info(
-            "Subagents config loaded: default timeout=%ss, default max_turns=%s, per-agent overrides=%s, custom_agents=%s",
+            "Subagents config loaded: default timeout=%ss, default max_turns=%s, max_concurrent=%s, per-agent overrides=%s, custom_agents=%s",
             _subagents_config.timeout_seconds,
             _subagents_config.max_turns,
+            _subagents_config.max_concurrent,
             overrides_summary or "none",
             custom_agents_names or "none",
         )

--- a/backend/packages/harness/deerflow/subagents/builtins/general_purpose.py
+++ b/backend/packages/harness/deerflow/subagents/builtins/general_purpose.py
@@ -46,5 +46,5 @@ You have access to the same sandbox environment as the parent agent:
     tools=None,  # Inherit all tools from parent
     disallowed_tools=["task", "ask_clarification", "present_files"],  # Prevent nesting and clarification
     model="inherit",
-    max_turns=100,
+    max_turns=50,
 )

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -133,8 +133,8 @@ _background_tasks_lock = threading.Lock()
 MAX_CONCURRENT_SUBAGENTS = 3
 
 # Thread pool for background task scheduling and orchestration
-_scheduler_pool: ThreadPoolExecutor | None = None
-_scheduler_pool_max_workers: int | None = None
+_scheduler_pool: ThreadPoolExecutor | None = ThreadPoolExecutor(max_workers=MAX_CONCURRENT_SUBAGENTS, thread_name_prefix="subagent-scheduler-")
+_scheduler_pool_max_workers: int | None = MAX_CONCURRENT_SUBAGENTS
 _scheduler_pool_lock = threading.Lock()
 
 # Persistent event loop for isolated subagent executions triggered from an

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -130,8 +130,12 @@ class SubagentResult:
 _background_tasks: dict[str, SubagentResult] = {}
 _background_tasks_lock = threading.Lock()
 
+MAX_CONCURRENT_SUBAGENTS = 3
+
 # Thread pool for background task scheduling and orchestration
-_scheduler_pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix="subagent-scheduler-")
+_scheduler_pool: ThreadPoolExecutor | None = None
+_scheduler_pool_max_workers: int | None = None
+_scheduler_pool_lock = threading.Lock()
 
 # Persistent event loop for isolated subagent executions triggered from an
 # already-running parent loop. Reusing one long-lived loop avoids creating a
@@ -140,6 +144,18 @@ _isolated_subagent_loop: asyncio.AbstractEventLoop | None = None
 _isolated_subagent_loop_thread: threading.Thread | None = None
 _isolated_subagent_loop_started: threading.Event | None = None
 _isolated_subagent_loop_lock = threading.Lock()
+
+
+def _get_scheduler_pool(max_workers: int = MAX_CONCURRENT_SUBAGENTS) -> ThreadPoolExecutor:
+    global _scheduler_pool, _scheduler_pool_max_workers
+
+    with _scheduler_pool_lock:
+        if _scheduler_pool is None or _scheduler_pool_max_workers != max_workers:
+            if _scheduler_pool is not None:
+                _scheduler_pool.shutdown(wait=False, cancel_futures=False)
+            _scheduler_pool = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="subagent-scheduler-")
+            _scheduler_pool_max_workers = max_workers
+        return _scheduler_pool
 
 
 def _run_isolated_subagent_loop(
@@ -157,7 +173,7 @@ def _run_isolated_subagent_loop(
 
 def _shutdown_isolated_subagent_loop() -> None:
     """Stop and close the persistent isolated subagent loop."""
-    global _isolated_subagent_loop, _isolated_subagent_loop_thread, _isolated_subagent_loop_started
+    global _isolated_subagent_loop, _isolated_subagent_loop_thread, _isolated_subagent_loop_started, _scheduler_pool, _scheduler_pool_max_workers
 
     with _isolated_subagent_loop_lock:
         loop = _isolated_subagent_loop
@@ -165,6 +181,12 @@ def _shutdown_isolated_subagent_loop() -> None:
         _isolated_subagent_loop = None
         _isolated_subagent_loop_thread = None
         _isolated_subagent_loop_started = None
+
+    with _scheduler_pool_lock:
+        if _scheduler_pool is not None:
+            _scheduler_pool.shutdown(wait=False, cancel_futures=False)
+            _scheduler_pool = None
+            _scheduler_pool_max_workers = None
 
     if loop is None:
         return
@@ -742,12 +764,15 @@ class SubagentExecutor:
             status=SubagentStatus.PENDING,
         )
 
-        logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} starting async execution, task_id={task_id}, timeout={self.config.timeout_seconds}s")
+        max_concurrent = self.app_config.subagents.max_concurrent if self.app_config is not None else MAX_CONCURRENT_SUBAGENTS
+        logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} starting async execution, task_id={task_id}, timeout={self.config.timeout_seconds}s, max_concurrent={max_concurrent}")
 
         with _background_tasks_lock:
             _background_tasks[task_id] = result
 
         parent_context = copy_context()
+
+        scheduler_pool = _get_scheduler_pool(max_concurrent)
 
         # Submit to scheduler pool
         def run_task():
@@ -781,11 +806,8 @@ class SubagentExecutor:
                     task_result = _background_tasks[task_id]
                 task_result.try_set_terminal(SubagentStatus.FAILED, error=str(e))
 
-        _scheduler_pool.submit(run_task)
+        scheduler_pool.submit(run_task)
         return task_id
-
-
-MAX_CONCURRENT_SUBAGENTS = 3
 
 
 def request_cancel_background_task(task_id: str) -> None:

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import uuid
 from dataclasses import replace
+from datetime import datetime
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from langchain.tools import InjectedToolCallId, tool
@@ -282,9 +283,7 @@ async def task_tool(
 
     # Inherit parent agent's tool_groups so subagents respect the same restrictions
     parent_tool_groups = metadata.get("tool_groups")
-    resolved_app_config = runtime_app_config
-    if config.model == "inherit" and parent_model is None and resolved_app_config is None:
-        resolved_app_config = get_app_config()
+    resolved_app_config = runtime_app_config or get_app_config()
     effective_model = resolve_subagent_model_name(config, parent_model, app_config=resolved_app_config)
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)
@@ -314,6 +313,7 @@ async def task_tool(
     # Start background execution (always async to prevent blocking)
     # Use tool_call_id as task_id for better traceability
     task_id = executor.execute_async(prompt, task_id=tool_call_id)
+    task_started_at = datetime.now()
 
     # Poll for task completion in backend (removes need for LLM to poll)
     poll_count = 0
@@ -364,32 +364,35 @@ async def task_tool(
 
             # Check if task completed, failed, or timed out
             usage = _summarize_usage(getattr(result, "token_usage_records", None))
+            completed_at = getattr(result, "completed_at", None) or datetime.now()
+            started_at = getattr(result, "started_at", None) or task_started_at
+            duration_seconds = round((completed_at - started_at).total_seconds(), 2)
             if result.status == SubagentStatus.COMPLETED:
                 _cache_subagent_usage(tool_call_id, usage, enabled=cache_token_usage)
                 _report_subagent_usage(runtime, result)
                 writer({"type": "task_completed", "task_id": task_id, "result": result.result, "usage": usage})
-                logger.info(f"[trace={trace_id}] Task {task_id} completed after {poll_count} polls")
+                logger.info(f"[trace={trace_id}] Task {task_id} completed after {poll_count} polls in {duration_seconds}s")
                 cleanup_background_task(task_id)
                 return f"Task Succeeded. Result: {result.result}"
             elif result.status == SubagentStatus.FAILED:
                 _cache_subagent_usage(tool_call_id, usage, enabled=cache_token_usage)
                 _report_subagent_usage(runtime, result)
                 writer({"type": "task_failed", "task_id": task_id, "error": result.error, "usage": usage})
-                logger.error(f"[trace={trace_id}] Task {task_id} failed: {result.error}")
+                logger.error(f"[trace={trace_id}] Task {task_id} failed after {duration_seconds}s: {result.error}")
                 cleanup_background_task(task_id)
                 return f"Task failed. Error: {result.error}"
             elif result.status == SubagentStatus.CANCELLED:
                 _cache_subagent_usage(tool_call_id, usage, enabled=cache_token_usage)
                 _report_subagent_usage(runtime, result)
                 writer({"type": "task_cancelled", "task_id": task_id, "error": result.error, "usage": usage})
-                logger.info(f"[trace={trace_id}] Task {task_id} cancelled: {result.error}")
+                logger.info(f"[trace={trace_id}] Task {task_id} cancelled after {duration_seconds}s: {result.error}")
                 cleanup_background_task(task_id)
                 return "Task cancelled by user."
             elif result.status == SubagentStatus.TIMED_OUT:
                 _cache_subagent_usage(tool_call_id, usage, enabled=cache_token_usage)
                 _report_subagent_usage(runtime, result)
                 writer({"type": "task_timed_out", "task_id": task_id, "error": result.error, "usage": usage})
-                logger.warning(f"[trace={trace_id}] Task {task_id} timed out: {result.error}")
+                logger.warning(f"[trace={trace_id}] Task {task_id} timed out after {duration_seconds}s: {result.error}")
                 cleanup_background_task(task_id)
                 return f"Task timed out. Error: {result.error}"
 

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -283,7 +283,9 @@ async def task_tool(
 
     # Inherit parent agent's tool_groups so subagents respect the same restrictions
     parent_tool_groups = metadata.get("tool_groups")
-    resolved_app_config = runtime_app_config or get_app_config()
+    resolved_app_config = runtime_app_config
+    if config.model == "inherit" and parent_model is None and resolved_app_config is None:
+        resolved_app_config = get_app_config()
     effective_model = resolve_subagent_model_name(config, parent_model, app_config=resolved_app_config)
 
     # Subagents should not have subagent tools enabled (prevent recursive nesting)

--- a/backend/tests/test_subagent_timeout_config.py
+++ b/backend/tests/test_subagent_timeout_config.py
@@ -103,26 +103,39 @@ class TestSubagentsAppConfigDefaults:
         config = SubagentsAppConfig()
         assert config.max_turns is None
 
+    def test_default_max_concurrent(self):
+        config = SubagentsAppConfig()
+        assert config.max_concurrent == 3
+
     def test_default_agents_empty(self):
         config = SubagentsAppConfig()
         assert config.agents == {}
 
     def test_custom_global_runtime_overrides(self):
-        config = SubagentsAppConfig(timeout_seconds=1800, max_turns=120)
+        config = SubagentsAppConfig(timeout_seconds=1800, max_turns=120, max_concurrent=2)
         assert config.timeout_seconds == 1800
         assert config.max_turns == 120
+        assert config.max_concurrent == 2
 
     def test_rejects_zero_timeout(self):
         with pytest.raises(ValueError):
             SubagentsAppConfig(timeout_seconds=0)
         with pytest.raises(ValueError):
             SubagentsAppConfig(max_turns=0)
+        with pytest.raises(ValueError):
+            SubagentsAppConfig(max_concurrent=1)
 
     def test_rejects_negative_timeout(self):
         with pytest.raises(ValueError):
             SubagentsAppConfig(timeout_seconds=-60)
         with pytest.raises(ValueError):
             SubagentsAppConfig(max_turns=-60)
+        with pytest.raises(ValueError):
+            SubagentsAppConfig(max_concurrent=-3)
+
+    def test_rejects_too_large_max_concurrent(self):
+        with pytest.raises(ValueError):
+            SubagentsAppConfig(max_concurrent=5)
 
 
 # ---------------------------------------------------------------------------
@@ -325,7 +338,7 @@ class TestRegistryGetSubagentConfig:
         _reset_subagents_config(timeout_seconds=900)
         config = get_subagent_config("general-purpose")
         assert config.timeout_seconds == 900
-        assert config.max_turns == 100
+        assert config.max_turns == 50
 
     def test_global_timeout_override_applied(self):
         from deerflow.subagents.registry import get_subagent_config

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -763,14 +763,16 @@ sandbox:
 # subagents:
 #   # Default timeout in seconds for all subagents (default: 900 = 15 minutes)
 #   timeout_seconds: 900
+#   # Maximum number of subagents that can run concurrently
+#   max_concurrent: 3
 #   # Optional global max-turn override for all subagents
-#   # max_turns: 120
+#   # max_turns: 50
 #
 #   # Optional per-agent overrides (applies to both built-in and custom agents)
 #   agents:
 #     general-purpose:
 #       timeout_seconds: 1800  # 30 minutes for complex multi-step tasks
-#       max_turns: 160
+#       max_turns: 80
 #       # model: qwen3:32b     # Use a specific model (default: inherit from lead agent)
 #       # skills:               # Skill whitelist (default: inherit all enabled skills)
 #       #   - web-search


### PR DESCRIPTION
## Summary

- Add configurable `subagents.max_concurrent` and wire it into Ultra mode prompt limits, middleware enforcement, and subagent scheduling.
- Reduce the default `general-purpose` subagent max turns from 100 to 50 to avoid long runaway executions.
- Add duration logging for subagent task completion, failure, cancellation, and timeout.

## Test plan

- `UV_CACHE_DIR="$TMPDIR/uv-cache" uv run pytest tests/test_subagent_timeout_config.py tests/test_subagent_limit_middleware.py tests/test_lead_agent_model_resolution.py -q`