### PR TITLE
fix(dev): exclude runtime state from gateway reload

### DIFF
--- a/backend/tests/test_dev_entrypoint.py
+++ b/backend/tests/test_dev_entrypoint.py
@@ -40,6 +40,19 @@ def test_entrypoint_script_exists_and_is_posix_sh():
     assert proc.returncode == 0, proc.stderr
 
 
+def test_entrypoint_excludes_runtime_state_from_uvicorn_reload():
+    content = ENTRYPOINT.read_text(encoding="utf-8")
+
+    assert ': "${DEER_FLOW_HOME:=/app/backend/.deer-flow}"' in content
+    assert 'mkdir -p "$DEER_FLOW_HOME" /app/backend/.deer-flow' in content
+    assert "--reload-include='*.yaml .env'" not in content
+    assert "--reload-include='*.yaml'" in content
+    assert "--reload-include='.env'" in content
+    assert "--reload-exclude=/app/backend/sandbox" in content
+    assert '--reload-exclude="$DEER_FLOW_HOME"' in content
+    assert "--reload-exclude=/app/backend/.deer-flow" in content
+
+
 def test_no_uv_extras_yields_empty_flags():
     proc = _run(None)
     assert proc.returncode == 0

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -43,6 +43,19 @@ def test_service_launchers_always_use_gateway_runtime():
         assert "LANGGRAPH_REWRITE" not in content, path
 
 
+def test_local_dev_gateway_reload_excludes_runtime_state_with_absolute_dirs():
+    serve_sh = _read("scripts/serve.sh")
+
+    assert 'export DEER_FLOW_PROJECT_ROOT="$REPO_ROOT"' in serve_sh
+    assert 'BACKEND_RUNTIME_HOME="$REPO_ROOT/backend/.deer-flow"' in serve_sh
+    assert 'export DEER_FLOW_HOME="$BACKEND_RUNTIME_HOME"' in serve_sh
+    assert 'mkdir -p "$DEER_FLOW_HOME" "$BACKEND_RUNTIME_HOME"' in serve_sh
+    assert "--reload-exclude='$DEER_FLOW_HOME'" in serve_sh
+    assert "--reload-exclude='$BACKEND_RUNTIME_HOME'" in serve_sh
+    assert "--reload-exclude='sandbox/'" not in serve_sh
+    assert "--reload-exclude='.deer-flow/'" not in serve_sh
+
+
 def test_backend_container_only_exposes_gateway_port():
     dockerfile = _read("backend/Dockerfile")
 

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -64,6 +64,13 @@ if [ -n "$EXTRAS_FLAGS" ]; then
     echo "[startup] uv extras:$EXTRAS_FLAGS"
 fi
 
+# Keep runtime-owned files out of uvicorn's reload watcher. The directory must
+# exist before uvicorn starts so watchfiles treats it as an excluded directory,
+# not as a plain glob pattern.
+: "${DEER_FLOW_HOME:=/app/backend/.deer-flow}"
+export DEER_FLOW_HOME
+mkdir -p "$DEER_FLOW_HOME" /app/backend/.deer-flow
+
 # ── Sync dependencies (with self-heal) ──────────────────────────────────────
 
 cd /app/backend
@@ -82,4 +89,9 @@ fi
 
 PYTHONPATH=. exec uv run uvicorn app.gateway.app:app \
     --host 0.0.0.0 --port 8001 \
-    --reload --reload-include='*.yaml .env'
+    --reload \
+    --reload-include='*.yaml' \
+    --reload-include='.env' \
+    --reload-exclude=/app/backend/sandbox \
+    --reload-exclude="$DEER_FLOW_HOME" \
+    --reload-exclude=/app/backend/.deer-flow

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -229,9 +229,26 @@ else
     FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') pnpm run preview"
 fi
 
+# Runtime path defaults. Local `make dev` launches Gateway from `backend/`,
+# so pin DeerFlow-owned state to the expected backend runtime directory and
+# create it before uvicorn builds its reload exclude filter.
+if [ -z "$DEER_FLOW_PROJECT_ROOT" ]; then
+    export DEER_FLOW_PROJECT_ROOT="$REPO_ROOT"
+fi
+
+BACKEND_RUNTIME_HOME="$REPO_ROOT/backend/.deer-flow"
+if [ -z "$DEER_FLOW_HOME" ]; then
+    export DEER_FLOW_HOME="$BACKEND_RUNTIME_HOME"
+fi
+
+mkdir -p "$DEER_FLOW_HOME" "$BACKEND_RUNTIME_HOME"
+DEER_FLOW_HOME="$(cd "$DEER_FLOW_HOME" && pwd -P)"
+BACKEND_RUNTIME_HOME="$(cd "$BACKEND_RUNTIME_HOME" && pwd -P)"
+export DEER_FLOW_HOME
+
 # Extra flags for uvicorn
 if $DEV_MODE && ! $DAEMON_MODE; then
-    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='sandbox/' --reload-exclude='.deer-flow/'"
+    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='$REPO_ROOT/backend/sandbox' --reload-exclude='$DEER_FLOW_HOME' --reload-exclude='$BACKEND_RUNTIME_HOME'"
 else
     GATEWAY_EXTRA_FLAGS=""
 fi


### PR DESCRIPTION
Fixes #3399

## Why

`make dev` runs Gateway with `uvicorn --reload`. Runtime-owned files under `.deer-flow` are updated during long agent runs, and the existing relative reload excludes (`sandbox/`, `.deer-flow/`) do not reliably match watchfiles' absolute change paths. When generated files or runtime data change under the watched backend tree, Gateway can reload mid-run, causing temporary 503 / `Service temporarily unavailable` responses through nginx.

## What changed

- Local `make dev` now pins DeerFlow runtime state to the existing `backend/.deer-flow` location unless `DEER_FLOW_HOME` is explicitly set.
- Gateway dev reload excludes runtime-owned directories using absolute paths, so `.deer-flow` and sandbox files do not trigger backend reloads.
- Docker dev Gateway startup now applies the same runtime-state reload exclusion.
- Added regression coverage for both local and Docker dev startup scripts.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (dev reload no longer watches runtime state)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A; no frontend UI changes.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_gateway_runtime_cleanup.py::test_local_dev_gateway_reload_excludes_runtime_state_with_absolute_dirs` and `backend/tests/test_dev_entrypoint.py::test_entrypoint_excludes_runtime_state_from_uvicorn_reload`
- Did it go red on `main` and green on this branch? Yes. These assertions fail on `main` because the dev launchers use relative/no runtime reload excludes, and pass on this branch.
- Manual repro before the fix: launching Gateway with the current dev reload flags and writing `backend/.deer-flow/threads/repro/user-data/workspace/repro.py` triggers `WatchFiles detected changes ... Reloading...`.

## Validation

Ran locally:

```bash
bash -n scripts/serve.sh
sh -n docker/dev-entrypoint.sh
cd backend && ./.venv/bin/python -m pytest tests/test_gateway_runtime_cleanup.py tests/test_dev_entrypoint.py -q
cd backend && ./.venv/bin/ruff check tests/test_gateway_runtime_cleanup.py tests/test_dev_entrypoint.py
cd backend && ./.venv/bin/ruff format --check tests/test_gateway_runtime_cleanup.py tests/test_dev_entrypoint.py
```

Result: targeted tests passed (`27 passed, 1 warning`), ruff check passed, and both shell syntax checks passed.

Note: the local pre-commit hook points at a missing generated Python path and `pre-commit` is not installed on PATH in this environment, so the commit was created with `--no-verify` after running the checks above manually.
