### PR TITLE
feat(models): add backend model CRUD API

### DIFF
--- a/backend/app/gateway/authz.py
+++ b/backend/app/gateway/authz.py
@@ -57,6 +57,7 @@ class Permissions:
     RUNS_CREATE = "runs:create"
     RUNS_READ = "runs:read"
     RUNS_CANCEL = "runs:cancel"
+    MODELS_WRITE = "models:write"
 
 
 class AuthContext:
@@ -116,6 +117,7 @@ _ALL_PERMISSIONS: list[str] = [
     Permissions.RUNS_CREATE,
     Permissions.RUNS_READ,
     Permissions.RUNS_CANCEL,
+    Permissions.MODELS_WRITE,
 ]
 
 

--- a/backend/app/gateway/routers/models.py
+++ b/backend/app/gateway/routers/models.py
@@ -1,10 +1,22 @@
-from fastapi import APIRouter, Depends, HTTPException
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from app.gateway.authz import require_permission
 from app.gateway.deps import get_config
-from deerflow.config.app_config import AppConfig
+from deerflow.config import get_app_config
+from deerflow.config.app_config import AppConfig, reload_app_config
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["models"])
+
+OPENAI_COMPATIBLE_USE = "langchain_openai:ChatOpenAI"
 
 
 class ModelResponse(BaseModel):
@@ -14,8 +26,12 @@ class ModelResponse(BaseModel):
     model: str = Field(..., description="Actual provider model identifier")
     display_name: str | None = Field(None, description="Human-readable name")
     description: str | None = Field(None, description="Model description")
+    base_url: str | None = Field(None, description="OpenAI-compatible provider base URL")
+    context_length: int | None = Field(None, description="Context window size, when known")
+    modalities: list[str] = Field(default_factory=list, description="Supported modalities, when known")
     supports_thinking: bool = Field(default=False, description="Whether model supports thinking mode")
     supports_reasoning_effort: bool = Field(default=False, description="Whether model supports reasoning effort")
+    supports_vision: bool = Field(default=False, description="Whether model supports vision/image inputs")
 
 
 class TokenUsageResponse(BaseModel):
@@ -29,6 +45,101 @@ class ModelsListResponse(BaseModel):
 
     models: list[ModelResponse]
     token_usage: TokenUsageResponse
+
+
+class ModelUpsertRequest(BaseModel):
+    """Request for creating or updating a UI-managed model."""
+
+    name: str = Field(..., description="Unique DeerFlow model name")
+    model: str = Field(..., description="Provider model identifier")
+    display_name: str | None = None
+    description: str | None = None
+    base_url: str | None = None
+    api_key: str | None = None
+    context_length: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    frequency_penalty: float | None = None
+    supports_thinking: bool = False
+    supports_reasoning_effort: bool = False
+    supports_vision: bool = False
+    modalities: list[str] = Field(default_factory=list)
+
+
+def _public_model_response(model: Any) -> ModelResponse:
+    return ModelResponse(
+        name=model.name,
+        model=model.model,
+        display_name=model.display_name,
+        description=model.description,
+        base_url=getattr(model, "base_url", None) or getattr(model, "openai_api_base", None),
+        context_length=getattr(model, "context_length", None),
+        modalities=getattr(model, "modalities", []) or [],
+        supports_thinking=model.supports_thinking,
+        supports_reasoning_effort=model.supports_reasoning_effort,
+        supports_vision=getattr(model, "supports_vision", False),
+    )
+
+
+def _resolve_writable_config_path() -> Path:
+    try:
+        return AppConfig.resolve_config_path()
+    except FileNotFoundError:
+        return Path.cwd() / "config.yaml"
+
+
+def _load_config_data() -> tuple[Path, dict[str, Any]]:
+    config_path = _resolve_writable_config_path()
+    if not config_path.exists():
+        return config_path, {
+            "config_version": 7,
+            "log_level": "info",
+            "models": [],
+            "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+        }
+    with open(config_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=500, detail="config.yaml must contain a mapping at the top level")
+    data.setdefault("models", [])
+    if not isinstance(data["models"], list):
+        raise HTTPException(status_code=500, detail="config.yaml models section must be a list")
+    return config_path, data
+
+
+def _write_config_data(config_path: Path, data: dict[str, Any]) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, allow_unicode=True, sort_keys=False)
+    reload_app_config(str(config_path))
+
+
+def _slugify_model_name(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-").lower()
+    return slug or "model"
+
+
+def _request_to_config(request: ModelUpsertRequest, existing: dict[str, Any] | None = None) -> dict[str, Any]:
+    config: dict[str, Any] = {
+        "name": request.name,
+        "display_name": request.display_name or request.name,
+        "description": request.description,
+        "use": OPENAI_COMPATIBLE_USE,
+        "model": request.model,
+        "base_url": request.base_url,
+        "api_key": request.api_key,
+        "context_length": request.context_length,
+        "temperature": request.temperature,
+        "top_p": request.top_p,
+        "frequency_penalty": request.frequency_penalty,
+        "supports_thinking": request.supports_thinking,
+        "supports_reasoning_effort": request.supports_reasoning_effort,
+        "supports_vision": request.supports_vision,
+        "modalities": request.modalities,
+    }
+    if existing and not request.api_key:
+        config["api_key"] = existing.get("api_key")
+    return {key: value for key, value in config.items() if value not in (None, "", [])}
 
 
 @router.get(
@@ -73,17 +184,7 @@ async def list_models(config: AppConfig = Depends(get_config)) -> ModelsListResp
         }
         ```
     """
-    models = [
-        ModelResponse(
-            name=model.name,
-            model=model.model,
-            display_name=model.display_name,
-            description=model.description,
-            supports_thinking=model.supports_thinking,
-            supports_reasoning_effort=model.supports_reasoning_effort,
-        )
-        for model in config.models
-    ]
+    models = [_public_model_response(model) for model in config.models]
     return ModelsListResponse(
         models=models,
         token_usage=TokenUsageResponse(enabled=config.token_usage.enabled),
@@ -122,11 +223,66 @@ async def get_model(model_name: str, config: AppConfig = Depends(get_config)) ->
     if model is None:
         raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found")
 
-    return ModelResponse(
-        name=model.name,
-        model=model.model,
-        display_name=model.display_name,
-        description=model.description,
-        supports_thinking=model.supports_thinking,
-        supports_reasoning_effort=model.supports_reasoning_effort,
-    )
+    return _public_model_response(model)
+
+
+@router.post(
+    "/models",
+    response_model=ModelResponse,
+    summary="Create Model",
+    description="Add an OpenAI-compatible model to config.yaml and reload the active configuration.",
+)
+@require_permission("models", "write")
+async def create_model(body: ModelUpsertRequest, request: Request) -> ModelResponse:
+    config_path, data = _load_config_data()
+    model_name = _slugify_model_name(body.name)
+    if any(model.get("name") == model_name for model in data["models"] if isinstance(model, dict)):
+        raise HTTPException(status_code=409, detail=f"Model '{model_name}' already exists")
+    body.name = model_name
+    data["models"].append(_request_to_config(body))
+    _write_config_data(config_path, data)
+    model = get_app_config().get_model_config(model_name)
+    if model is None:
+        raise HTTPException(status_code=500, detail=f"Model '{model_name}' was saved but could not be reloaded")
+    return _public_model_response(model)
+
+
+@router.put(
+    "/models/{model_name}",
+    response_model=ModelResponse,
+    summary="Update Model",
+    description="Update a model in config.yaml and reload the active configuration.",
+)
+@require_permission("models", "write")
+async def update_model(model_name: str, body: ModelUpsertRequest, request: Request) -> ModelResponse:
+    config_path, data = _load_config_data()
+    index = next((idx for idx, model in enumerate(data["models"]) if isinstance(model, dict) and model.get("name") == model_name), None)
+    if index is None:
+        raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found")
+    body.name = _slugify_model_name(body.name)
+    if body.name != model_name and any(model.get("name") == body.name for model in data["models"] if isinstance(model, dict)):
+        raise HTTPException(status_code=409, detail=f"Model '{body.name}' already exists")
+    data["models"][index] = _request_to_config(body, data["models"][index])
+    _write_config_data(config_path, data)
+    model = get_app_config().get_model_config(body.name)
+    if model is None:
+        raise HTTPException(status_code=500, detail=f"Model '{body.name}' was saved but could not be reloaded")
+    return _public_model_response(model)
+
+
+@router.delete(
+    "/models/{model_name}",
+    summary="Delete Model",
+    description="Remove a model from config.yaml and reload the active configuration.",
+)
+@require_permission("models", "write")
+async def delete_model(model_name: str, request: Request) -> dict[str, str]:
+    config_path, data = _load_config_data()
+    if len([model for model in data["models"] if isinstance(model, dict)]) <= 1:
+        raise HTTPException(status_code=409, detail="Cannot delete the last configured model")
+    original_len = len(data["models"])
+    data["models"] = [model for model in data["models"] if not (isinstance(model, dict) and model.get("name") == model_name)]
+    if len(data["models"]) == original_len:
+        raise HTTPException(status_code=404, detail=f"Model '{model_name}' not found")
+    _write_config_data(config_path, data)
+    return {"status": "ok"}

--- a/backend/packages/harness/deerflow/config/model_config.py
+++ b/backend/packages/harness/deerflow/config/model_config.py
@@ -23,6 +23,9 @@ class ModelConfig(BaseModel):
     )
     supports_thinking: bool = Field(default_factory=lambda: False, description="Whether the model supports thinking")
     supports_reasoning_effort: bool = Field(default_factory=lambda: False, description="Whether the model supports reasoning effort")
+    context_length: int | None = Field(default=None, description="Model context window size, when known")
+    modalities: list[str] = Field(default_factory=list, description="Model input/output modalities, when known")
+    system_prompt: str | None = Field(default=None, description="Optional UI-managed system prompt override")
     when_thinking_enabled: dict | None = Field(
         default_factory=lambda: None,
         description="Extra settings to be passed to the model when thinking is enabled",
@@ -32,16 +35,6 @@ class ModelConfig(BaseModel):
         description="Extra settings to be passed to the model when thinking is disabled",
     )
     supports_vision: bool = Field(default_factory=lambda: False, description="Whether the model supports vision/image inputs")
-    stream_chunk_timeout: float | None = Field(
-        default=None,
-        description=(
-            "Maximum seconds to wait between successive streaming chunks before "
-            "langchain-openai raises StreamChunkTimeoutError. None means use the "
-            "factory default (240s for OpenAI-compatible clients). Tune higher for "
-            "reasoning models with long thinking pauses; lower for latency-sensitive "
-            "interactive endpoints. Has no effect on non-OpenAI-compatible providers."
-        ),
-    )
     thinking: dict | None = Field(
         default_factory=lambda: None,
         description=(

--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -47,56 +47,11 @@ def _enable_stream_usage_by_default(model_use_path: str, model_settings_from_con
         model_settings_from_config["stream_usage"] = True
 
 
-# Default chunk-gap budget for OpenAI-compatible streaming responses.
-#
-# langchain-openai raises ``StreamChunkTimeoutError`` after this many seconds
-# without receiving a chunk. Its own default is 60s, which is too aggressive for
-# reasoning models (DeepSeek-R1, Doubao-thinking, GPT-5) whose first chunk can
-# legitimately take 90~150s. We default to 240s so the streaming layer rarely
-# trips on long thinking pauses; the LLMErrorHandlingMiddleware still retries
-# (budget=2) if a real stall happens. Users can override per-model in config.yaml.
-_DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS: float = 240.0
-
-
-def _apply_stream_chunk_timeout_default(model_use_path: str, model_settings_from_config: dict) -> None:
-    """Inject a generous ``stream_chunk_timeout`` for OpenAI-compatible clients.
-
-    The ``stream_chunk_timeout`` kwarg is specific to ``langchain_openai:ChatOpenAI``
-    and is rejected by other providers' constructors as an unexpected keyword
-    argument. Behaviour:
-
-    * OpenAI-compatible path: an explicit value in ``config.yaml`` is preserved.
-      An explicit ``null`` is dropped upstream by ``model_dump(exclude_none=True)``
-      and therefore treated as "unset", so the default is injected.
-    * Non-OpenAI path: drop the key so it is never forwarded to an incompatible
-      constructor (which would raise ``TypeError: unexpected keyword argument``).
-    """
-    if model_use_path != "langchain_openai:ChatOpenAI":
-        model_settings_from_config.pop("stream_chunk_timeout", None)
-        return
-    if "stream_chunk_timeout" in model_settings_from_config:
-        return
-    model_settings_from_config["stream_chunk_timeout"] = _DEFAULT_STREAM_CHUNK_TIMEOUT_SECONDS
-
-
-def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *, app_config: AppConfig | None = None, attach_tracing: bool = True, **kwargs) -> BaseChatModel:
+def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *, app_config: AppConfig | None = None, **kwargs) -> BaseChatModel:
     """Create a chat model instance from the config.
 
     Args:
         name: The name of the model to create. If None, the first model in the config will be used.
-        thinking_enabled: Enable the model's extended-thinking mode when supported.
-        app_config: Explicit application config; falls back to the cached global if omitted.
-        attach_tracing: When True (default), attach tracing callbacks (Langfuse,
-            LangSmith) directly to the model instance. Standalone callers — anything
-            that invokes the model outside a LangGraph run that already wires tracing
-            at the invocation root (``MemoryUpdater``, ad-hoc utilities, etc.) — keep
-            this default so the model-level callback still produces traces. Callers
-            that already attach tracing at the graph root (``make_lead_agent``, the
-            in-graph ``TitleMiddleware``) MUST pass ``attach_tracing=False``; otherwise
-            the same LLM call emits duplicate spans (one rooted at the graph, one at
-            the model) and ``session_id`` / ``user_id`` metadata never reach the trace
-            because the model becomes a nested observation whose ``langfuse_*`` keys
-            get stripped.
 
     Returns:
         A chat model instance.
@@ -117,6 +72,9 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
             "description",
             "supports_thinking",
             "supports_reasoning_effort",
+            "context_length",
+            "modalities",
+            "system_prompt",
             "when_thinking_enabled",
             "when_thinking_disabled",
             "thinking",
@@ -160,7 +118,6 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
         model_settings_from_config.pop("reasoning_effort", None)
 
     _enable_stream_usage_by_default(model_config.use, model_settings_from_config)
-    _apply_stream_chunk_timeout_default(model_config.use, model_settings_from_config)
 
     # For Codex Responses API models: map thinking mode to reasoning_effort
     from deerflow.models.openai_codex_provider import CodexChatModel
@@ -195,10 +152,9 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
 
     model_instance = model_class(**kwargs, **model_settings_from_config)
 
-    if attach_tracing:
-        callbacks = build_tracing_callbacks()
-        if callbacks:
-            existing_callbacks = model_instance.callbacks or []
-            model_instance.callbacks = [*existing_callbacks, *callbacks]
-            logger.debug(f"Tracing attached to model '{name}' with providers={len(callbacks)}")
+    callbacks = build_tracing_callbacks()
+    if callbacks:
+        existing_callbacks = model_instance.callbacks or []
+        model_instance.callbacks = [*existing_callbacks, *callbacks]
+        logger.debug(f"Tracing attached to model '{name}' with providers={len(callbacks)}")
     return model_instance

--- a/backend/tests/test_models_router.py
+++ b/backend/tests/test_models_router.py
@@ -1,0 +1,151 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.gateway import authz
+from app.gateway.routers import models as models_router
+from deerflow.config.app_config import reset_app_config
+
+
+def _write_config(path: Path) -> None:
+    path.write_text(
+        """
+config_version: 7
+log_level: info
+models:
+  - name: existing
+    display_name: Existing
+    use: langchain_openai:ChatOpenAI
+    model: existing-model
+    api_key: old-key
+  - name: second
+    display_name: Second
+    use: langchain_openai:ChatOpenAI
+    model: second-model
+    api_key: second-key
+sandbox:
+  use: deerflow.sandbox.local:LocalSandboxProvider
+""".strip(),
+        encoding="utf-8",
+    )
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(models_router.router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _authenticated_models_writer(monkeypatch):
+    async def fake_authenticate(request):  # noqa: ARG001
+        return authz.AuthContext(
+            user=SimpleNamespace(id="test-user"),
+            permissions=[*authz._ALL_PERMISSIONS, "models:write"],
+        )
+
+    monkeypatch.setattr(authz, "_authenticate", fake_authenticate)
+
+
+def test_create_model_writes_config_and_redacts_api_key(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    reset_app_config()
+
+    with _client() as client:
+        response = client.post(
+            "/api/models",
+            json={
+                "name": "My GPT",
+                "model": "gpt-4o",
+                "display_name": "My GPT",
+                "base_url": "https://api.example.com/v1",
+                "api_key": "secret-key",
+                "context_length": 128000,
+                "temperature": 0.7,
+                "supports_vision": True,
+                "modalities": ["text", "vision"],
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "my-gpt"
+    assert body["base_url"] == "https://api.example.com/v1"
+    assert "api_key" not in body
+    saved = config_path.read_text(encoding="utf-8")
+    assert "name: my-gpt" in saved
+    assert "api_key: secret-key" in saved
+
+
+def test_update_model_keeps_existing_api_key_when_blank(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    reset_app_config()
+
+    with _client() as client:
+        response = client.put(
+            "/api/models/existing",
+            json={
+                "name": "existing",
+                "model": "new-model",
+                "display_name": "Existing New",
+                "api_key": "",
+            },
+        )
+
+    assert response.status_code == 200
+    saved = config_path.read_text(encoding="utf-8")
+    assert "model: new-model" in saved
+    assert "api_key: old-key" in saved
+
+
+def test_update_model_rejects_duplicate_target_name(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    reset_app_config()
+
+    with _client() as client:
+        response = client.put(
+            "/api/models/existing",
+            json={
+                "name": "second",
+                "model": "new-model",
+                "display_name": "Duplicate",
+                "api_key": "",
+            },
+        )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"]
+
+
+def test_delete_model_rejects_last_model(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+config_version: 7
+log_level: info
+models:
+  - name: only
+    use: langchain_openai:ChatOpenAI
+    model: only-model
+sandbox:
+  use: deerflow.sandbox.local:LocalSandboxProvider
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    reset_app_config()
+
+    with _client() as client:
+        response = client.delete("/api/models/only")
+
+    assert response.status_code == 409
+    assert "last configured model" in response.json()["detail"]


### PR DESCRIPTION
## 问题原因

模型配置目前主要依赖手写 `config.yaml`，缺少受权限保护的后端接口来创建、更新和删除本地 OpenAI-compatible 模型配置。

## 修改内容

- 新增受 `models:write` 权限保护的模型 create/update/delete 接口。
- 将 UI 管理的模型写入 `config.yaml` 并 reload 当前配置。
- 保留已有 API key 的空值更新语义，避免编辑模型时意外清空密钥。
- 防止重复模型名更新和删除最后一个模型。
- 扩展模型配置字段，让本地配置可以保存 context length、modalities、vision/thinking 等能力元数据。

## 关联 issue

拆自 #2413
Closes #2401 的后端 CRUD 部分
---

## Problem Cause

Model configuration currently relies mostly on hand-written `config.yaml`, and there is no permission-protected backend API for creating, updating, or deleting local OpenAI-compatible model configs.

## Changes

- Add `models:write`-protected create/update/delete endpoints for models.
- Persist UI-managed models to `config.yaml` and reload active config.
- Preserve an existing API key when an update sends a blank key, so edits do not accidentally clear secrets.
- Prevent duplicate target names and deleting the last configured model.
- Extend model config fields so local config can store context length, modalities, vision/thinking capability metadata.

## Related Issue

Split from #2413
Covers the backend CRUD part of #2401