### PR TITLE
feat(models): detect OpenAI-compatible provider models

### DIFF
--- a/backend/app/gateway/authz.py
+++ b/backend/app/gateway/authz.py
@@ -58,6 +58,9 @@ class Permissions:
     RUNS_READ = "runs:read"
     RUNS_CANCEL = "runs:cancel"
 
+    # Models
+    MODELS_WRITE = "models:write"
+
 
 class AuthContext:
     """Authentication context for the current request.
@@ -116,6 +119,7 @@ _ALL_PERMISSIONS: list[str] = [
     Permissions.RUNS_CREATE,
     Permissions.RUNS_READ,
     Permissions.RUNS_CANCEL,
+    Permissions.MODELS_WRITE,
 ]
 
 

--- a/backend/app/gateway/routers/models.py
+++ b/backend/app/gateway/routers/models.py
@@ -1,10 +1,31 @@
-from fastapi import APIRouter, Depends, HTTPException
+import asyncio
+import ipaddress
+import logging
+import re
+import socket
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from app.gateway.authz import require_permission
 from app.gateway.deps import get_config
 from deerflow.config.app_config import AppConfig
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api", tags=["models"])
+CAPABILITY_CONTEXT_KEYS = (
+    "context_length",
+    "context_window",
+    "max_context_length",
+    "max_context_tokens",
+    "max_input_tokens",
+    "input_token_limit",
+    "n_ctx",
+)
 
 
 class ModelResponse(BaseModel):
@@ -29,6 +50,146 @@ class ModelsListResponse(BaseModel):
 
     models: list[ModelResponse]
     token_usage: TokenUsageResponse
+
+
+class DetectedModelResponse(BaseModel):
+    """Model discovered from an OpenAI-compatible /models endpoint."""
+
+    id: str
+    name: str
+    display_name: str
+    context_length: int | None = None
+    modalities: list[str] = Field(default_factory=list)
+    supports_thinking: bool = False
+    supports_reasoning_effort: bool = False
+    supports_vision: bool = False
+
+
+class DetectModelsRequest(BaseModel):
+    """Request for probing an OpenAI-compatible provider."""
+
+    base_url: str = Field(..., description="OpenAI-compatible base URL")
+    api_key: str | None = Field(default=None, description="API key used only for the detection request")
+
+
+class DetectModelsResponse(BaseModel):
+    """Response for OpenAI-compatible model detection."""
+
+    models: list[DetectedModelResponse]
+    endpoint: str
+
+
+def _slugify_model_name(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-").lower()
+    return slug or "model"
+
+
+def _first_int(payload: dict[str, Any]) -> int | None:
+    for key in CAPABILITY_CONTEXT_KEYS:
+        value = payload.get(key)
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.isdigit():
+            return int(value)
+    for nested_key in ("info", "metadata", "details", "capabilities"):
+        nested = payload.get(nested_key)
+        if isinstance(nested, dict):
+            value = _first_int(nested)
+            if value is not None:
+                return value
+    return None
+
+
+def _extract_modalities(payload: dict[str, Any], model_id: str) -> list[str]:
+    raw_values: list[Any] = []
+    for key in ("modalities", "input_modalities", "output_modalities"):
+        value = payload.get(key)
+        if isinstance(value, list):
+            raw_values.extend(value)
+    capabilities = payload.get("capabilities")
+    if isinstance(capabilities, dict):
+        for key, enabled in capabilities.items():
+            if enabled is True:
+                raw_values.append(key)
+    modalities = {str(value).lower() for value in raw_values if isinstance(value, str)}
+    if not modalities:
+        modalities.add("text")
+    if "vision" in model_id.lower() or "image" in model_id.lower():
+        modalities.add("vision")
+    return sorted(modalities)
+
+
+def _detect_reasoning_effort(model_id: str) -> bool:
+    lowered = model_id.lower()
+    return lowered.startswith(("o1", "o3", "o4")) or lowered.startswith("gpt-5")
+
+
+def _detect_thinking(model_id: str) -> bool:
+    lowered = model_id.lower()
+    return _detect_reasoning_effort(model_id) or any(marker in lowered for marker in ("reason", "thinking", "deepseek-r1", "qwen3"))
+
+
+def _model_payload_to_detected(payload: dict[str, Any]) -> DetectedModelResponse | None:
+    raw_id = payload.get("id") or payload.get("name")
+    if not isinstance(raw_id, str) or not raw_id.strip():
+        return None
+    model_id = raw_id.strip()
+    display_name = payload.get("display_name") or payload.get("name") or model_id
+    modalities = _extract_modalities(payload, model_id)
+    return DetectedModelResponse(
+        id=model_id,
+        name=_slugify_model_name(model_id),
+        display_name=str(display_name),
+        context_length=_first_int(payload),
+        modalities=modalities,
+        supports_thinking=_detect_thinking(model_id),
+        supports_reasoning_effort=_detect_reasoning_effort(model_id),
+        supports_vision=bool({"vision", "image"} & set(modalities)),
+    )
+
+
+async def _validate_detection_base_url(base_url: str) -> None:
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise HTTPException(status_code=422, detail="base_url must be an http(s) URL")
+    if parsed.username or parsed.password:
+        raise HTTPException(status_code=422, detail="base_url must not include credentials")
+
+    host = parsed.hostname
+    try:
+        addresses = await asyncio.get_running_loop().getaddrinfo(host, None)
+    except socket.gaierror as exc:
+        raise HTTPException(status_code=422, detail=f"Unable to resolve base_url host: {host}") from exc
+
+    for *_, sockaddr in addresses:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_unspecified:
+            raise HTTPException(status_code=422, detail="base_url host must resolve to a public address")
+
+
+async def _fetch_models(base_url: str, api_key: str | None) -> tuple[str, dict[str, Any]]:
+    await _validate_detection_base_url(base_url)
+    normalized_base = base_url.rstrip("/")
+    candidates = [f"{normalized_base}/models"]
+    if not normalized_base.endswith("/v1"):
+        candidates.append(f"{normalized_base}/v1/models")
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    last_error: Exception | None = None
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0)) as client:
+        for endpoint in candidates:
+            try:
+                response = await client.get(endpoint, headers=headers)
+                response.raise_for_status()
+                data = response.json()
+                if not isinstance(data, dict):
+                    raise ValueError("Provider returned a non-object response")
+                return endpoint, data
+            except Exception as exc:
+                last_error = exc
+                logger.debug("Model detection failed for %s: %s", endpoint, exc)
+    exc_info = (type(last_error), last_error, last_error.__traceback__) if last_error else None
+    logger.warning("Model detection failed for all candidate endpoints under %s", normalized_base, exc_info=exc_info)
+    raise HTTPException(status_code=502, detail="Failed to detect models from provider")
 
 
 @router.get(
@@ -88,6 +249,22 @@ async def list_models(config: AppConfig = Depends(get_config)) -> ModelsListResp
         models=models,
         token_usage=TokenUsageResponse(enabled=config.token_usage.enabled),
     )
+
+
+@router.post(
+    "/models/detect",
+    response_model=DetectModelsResponse,
+    summary="Detect OpenAI-Compatible Models",
+    description="Probe an OpenAI-compatible provider /models endpoint and return discovered model metadata.",
+)
+@require_permission("models", "write")
+async def detect_models(body: DetectModelsRequest, request: Request) -> DetectModelsResponse:
+    endpoint, data = await _fetch_models(str(body.base_url), body.api_key)
+    raw_models = data.get("data", data.get("models", []))
+    if not isinstance(raw_models, list):
+        raise HTTPException(status_code=502, detail="Provider response did not include a model list")
+    models = [model for item in raw_models if isinstance(item, dict) and (model := _model_payload_to_detected(item))]
+    return DetectModelsResponse(models=models, endpoint=endpoint)
 
 
 @router.get(

--- a/backend/tests/test_models_detection_router.py
+++ b/backend/tests/test_models_detection_router.py
@@ -1,0 +1,108 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.gateway import authz
+from app.gateway.routers import models as models_router
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(models_router.router)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _authenticated_models_writer(monkeypatch):
+    async def fake_authenticate(request):  # noqa: ARG001
+        return authz.AuthContext(
+            user=SimpleNamespace(id="test-user"),
+            permissions=[*authz._ALL_PERMISSIONS, "models:write"],
+        )
+
+    monkeypatch.setattr(authz, "_authenticate", fake_authenticate)
+
+
+def test_detect_models_reads_openai_compatible_payload(monkeypatch):
+    async def fake_validate(base_url):  # noqa: ARG001
+        return None
+
+    monkeypatch.setattr(models_router, "_validate_detection_base_url", fake_validate)
+
+    async def fake_get(self, url, headers=None):  # noqa: ARG001
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "gpt-4o",
+                        "context_length": 128000,
+                        "modalities": ["text", "vision"],
+                    }
+                ]
+            },
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    with _client() as client:
+        response = client.post(
+            "/api/models/detect",
+            json={"base_url": "https://api.example.com/v1", "api_key": "key"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["endpoint"] == "https://api.example.com/v1/models"
+    assert body["models"][0]["id"] == "gpt-4o"
+    assert body["models"][0]["context_length"] == 128000
+    assert body["models"][0]["supports_vision"] is True
+
+
+def test_detect_models_returns_safe_error_detail(monkeypatch):
+    async def fake_validate(base_url):  # noqa: ARG001
+        return None
+
+    async def fake_get(self, url, headers=None):  # noqa: ARG001
+        raise httpx.ConnectError("internal dial failure with token=secret", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(models_router, "_validate_detection_base_url", fake_validate)
+    monkeypatch.setattr(httpx.AsyncClient, "get", fake_get)
+
+    with _client() as client:
+        response = client.post(
+            "/api/models/detect",
+            json={"base_url": "https://api.example.com/v1", "api_key": "key"},
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Failed to detect models from provider"
+    assert "secret" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_validate_detection_base_url_uses_async_dns(monkeypatch):
+    loop = asyncio.get_running_loop()
+    getaddrinfo = AsyncMock(return_value=[(None, None, None, None, ("93.184.216.34", 0))])
+    monkeypatch.setattr(loop, "getaddrinfo", getaddrinfo)
+
+    await models_router._validate_detection_base_url("https://api.example.com/v1")
+
+    getaddrinfo.assert_awaited_once_with("api.example.com", None)
+
+
+def test_detect_models_rejects_localhost_url():
+    with _client() as client:
+        response = client.post(
+            "/api/models/detect",
+            json={"base_url": "http://127.0.0.1:11434/v1", "api_key": "key"},
+        )
+
+    assert response.status_code == 422
+    assert "public address" in response.json()["detail"]


### PR DESCRIPTION
## 问题原因

模型管理 UI 需要从 OpenAI-compatible provider 读取 `/models` 结果，但外部 URL 探测必须独立收紧安全边界，避免把 provider detection 和配置写入混在同一个大 PR 中 review。

## 修改内容

- 新增 `POST /api/models/detect`，用于探测 OpenAI-compatible provider 的模型列表。
- 支持 `/models` 和 `/v1/models` 两种候选路径。
- 解析 provider 返回的模型 ID、display name、context length、modalities、thinking/reasoning/vision 能力。
- 对 detection `base_url` 做 http(s)、凭据、异步 DNS 和公网地址校验，拒绝 localhost/private/link-local 等地址。
- 对外返回安全的错误信息，不把 provider 连接异常或密钥信息暴露给客户端。

## 关联 issue

拆自 #2413
Closes #2401 的 provider detection 部分
---

## Problem Cause

The model management UI needs to read `/models` from OpenAI-compatible providers, but external URL probing needs a separate security review boundary instead of being bundled with config writes in one large PR.

## Changes

- Add `POST /api/models/detect` for probing OpenAI-compatible provider model lists.
- Try both `/models` and `/v1/models` candidate paths.
- Parse model ID, display name, context length, modalities, and thinking/reasoning/vision capability hints.
- Validate detection `base_url` for http(s), credentials, async DNS, and public-address resolution; reject localhost/private/link-local targets.
- Return safe client-facing errors without exposing provider connection details or secrets.

## Related Issue

Split from #2413
Covers the provider detection part of #2401