### PR TITLE
feat(frontend): add public share UI

### DIFF
--- a/frontend/src/app/share/[share_id]/page.tsx
+++ b/frontend/src/app/share/[share_id]/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import type { BaseStream } from "@langchain/langgraph-sdk/react";
+import { useParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { ArtifactsProvider } from "@/components/workspace/artifacts";
+import { MessageList } from "@/components/workspace/messages";
+import { getBackendBaseURL } from "@/core/config";
+import { SubtasksProvider } from "@/core/tasks/context";
+import type { AgentThreadState, ThreadShareResponse } from "@/core/threads";
+import { readErrorDetail } from "@/core/threads/api";
+
+async function readShareLoadError(response: Response) {
+  const message = await readErrorDetail(
+    response,
+    response.status === 404 ? "Share not found" : "Failed to load share",
+  );
+  return message.includes(`(${response.status})`)
+    ? message
+    : `${message} (${response.status})`;
+}
+
+export default function SharePage() {
+  const { share_id: shareId } = useParams<{ share_id: string }>();
+  const [share, setShare] = useState<ThreadShareResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadShare() {
+      try {
+        const response = await fetch(
+          `${getBackendBaseURL()}/api/shares/${encodeURIComponent(shareId)}`,
+        );
+        if (!response.ok) {
+          throw new Error(await readShareLoadError(response));
+        }
+        const data = (await response.json()) as ThreadShareResponse;
+        if (!cancelled) {
+          setShare(data);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to load share");
+        }
+      }
+    }
+
+    void loadShare();
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId]);
+
+  const thread = useMemo(
+    () =>
+      ({
+        messages: share?.messages ?? [],
+        values: {
+          title: share?.title ?? "",
+          messages: share?.messages ?? [],
+          artifacts: [],
+        },
+        isLoading: false,
+        isThreadLoading: share === null && error === null,
+        getMessagesMetadata: () => [],
+      }) as unknown as BaseStream<AgentThreadState>,
+    [error, share],
+  );
+
+  return (
+    <SubtasksProvider>
+      <SidebarProvider defaultOpen={false}>
+        <ArtifactsProvider>
+          <main className="bg-background flex min-h-screen flex-col">
+            <header className="bg-background/80 sticky top-0 z-20 border-b px-4 py-3 backdrop-blur">
+              <div className="mx-auto flex w-full max-w-(--container-width-md) items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-primary font-serif text-lg">
+                    DeerFlow
+                  </div>
+                  {share?.title && (
+                    <h1 className="truncate text-sm font-medium">
+                      {share.title}
+                    </h1>
+                  )}
+                </div>
+              </div>
+            </header>
+            {error ? (
+              <div className="text-muted-foreground flex flex-1 items-center justify-center px-4 text-sm">
+                {error}
+              </div>
+            ) : (
+              <div className="min-h-0 flex-1">
+                <MessageList
+                  className="min-h-screen"
+                  threadId={shareId}
+                  thread={thread}
+                  hasMoreHistory={false}
+                  enableSharing={false}
+                />
+              </div>
+            )}
+          </main>
+        </ArtifactsProvider>
+      </SidebarProvider>
+    </SubtasksProvider>
+  );
+}

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -1,7 +1,8 @@
 import type { Message } from "@langchain/langgraph-sdk";
 import type { BaseStream } from "@langchain/langgraph-sdk/react";
-import { ChevronUpIcon, Loader2Icon } from "lucide-react";
+import { ChevronUpIcon, Loader2Icon, Share2Icon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
+import { toast } from "sonner";
 
 import {
   Conversation,
@@ -31,11 +32,13 @@ import type { Subtask } from "@/core/tasks";
 import { useUpdateSubtask } from "@/core/tasks/context";
 import { parseSubtaskResult } from "@/core/tasks/subtask-result";
 import type { AgentThreadState } from "@/core/threads";
+import { createThreadShare } from "@/core/threads/api";
 import { cn } from "@/lib/utils";
 
 import { ArtifactFileList } from "../artifacts/artifact-file-list";
 import { CopyButton } from "../copy-button";
 import { StreamingIndicator } from "../streaming-indicator";
+import { Tooltip } from "../tooltip";
 
 import { MarkdownContent } from "./markdown-content";
 import { MessageGroup } from "./message-group";
@@ -165,6 +168,7 @@ export function MessageList({
   hasMoreHistory,
   loadMoreHistory,
   isHistoryLoading,
+  enableSharing = true,
 }: {
   className?: string;
   threadId: string;
@@ -174,14 +178,30 @@ export function MessageList({
   hasMoreHistory?: boolean;
   loadMoreHistory?: () => void;
   isHistoryLoading?: boolean;
+  enableSharing?: boolean;
 }) {
   const { t } = useI18n();
   const rehypePlugins = useRehypeSplitWordsIntoSpans(thread.isLoading);
   const updateSubtask = useUpdateSubtask();
   const messages = thread.messages;
-  const groupedMessages = getMessageGroups(messages);
+  const groupedMessages = useMemo(() => getMessageGroups(messages), [messages]);
   const turnUsageMessagesByGroupIndex =
     getAssistantTurnUsageMessages(groupedMessages);
+  const previousHumanMessagesByGroupIndex = useMemo(() => {
+    const previousByIndex: Message[][] = [];
+    let previousHumanMessages: Message[] | null = null;
+
+    groupedMessages.forEach((group, index) => {
+      previousByIndex[index] = previousHumanMessages ?? [];
+      if (group.type === "human") {
+        previousHumanMessages = group.messages;
+      } else if (group.type === "assistant") {
+        previousHumanMessages = null;
+      }
+    });
+
+    return previousByIndex;
+  }, [groupedMessages]);
   const tokenDebugSteps = useMemo(
     () => buildTokenDebugSteps(messages, t),
     [messages, t],
@@ -196,21 +216,84 @@ export function MessageList({
     [messages, thread.getMessagesMetadata, thread.isLoading],
   );
 
-  const renderAssistantCopyButton = useCallback(
-    (messages: Message[], isStreaming: boolean) => {
+  const renderAssistantActions = useCallback(
+    (
+      messages: Message[],
+      isStreaming: boolean,
+      previousMessages: Message[],
+    ) => {
       const clipboardData = getAssistantTurnCopyData(messages, { isStreaming });
 
       if (!clipboardData) {
         return null;
       }
 
+      const shareMessageIds = [...previousMessages, ...messages]
+        .map((message) => message.id)
+        .filter((id): id is string => typeof id === "string" && id.length > 0);
+
       return (
-        <div className="mt-2 flex justify-start opacity-0 transition-opacity delay-200 duration-300 group-hover/assistant-turn:opacity-100">
+        <div
+          className={cn(
+            "mt-2 flex justify-start gap-1 opacity-0 transition-opacity",
+            "delay-200 duration-300 group-hover/assistant-turn:opacity-100",
+          )}
+        >
           <CopyButton clipboardData={clipboardData} />
+          {enableSharing && (
+            <Tooltip content={t.common.share}>
+              <Button
+                aria-label={t.common.share}
+                size="icon-sm"
+                type="button"
+                variant="ghost"
+                onClick={async () => {
+                  if (shareMessageIds.length === 0) {
+                    toast.error(t.conversation.noMessages);
+                    return;
+                  }
+                  try {
+                    const share = await createThreadShare({
+                      threadId,
+                      messageIds: shareMessageIds,
+                      title: thread.values.title,
+                    });
+                    const shareUrl = new URL(
+                      `/share/${share.share_id}`,
+                      window.location.origin,
+                    ).toString();
+                    try {
+                      await navigator.clipboard.writeText(shareUrl);
+                    } catch {
+                      toast.error(t.clipboard.failedToCopyToClipboard);
+                      return;
+                    }
+                    toast.success(t.clipboard.linkCopied);
+                  } catch (err) {
+                    toast.error(
+                      err instanceof Error
+                        ? err.message
+                        : "Failed to create share.",
+                    );
+                  }
+                }}
+              >
+                <Share2Icon size={12} />
+              </Button>
+            </Tooltip>
+          )}
         </div>
       );
     },
-    [],
+    [
+      t.clipboard.failedToCopyToClipboard,
+      t.clipboard.linkCopied,
+      t.common.share,
+      t.conversation.noMessages,
+      enableSharing,
+      thread.values.title,
+      threadId,
+    ],
   );
 
   const renderTokenUsage = useCallback(
@@ -275,6 +358,8 @@ export function MessageList({
         />
         {groupedMessages.map((group, groupIndex) => {
           const turnUsageMessages = turnUsageMessagesByGroupIndex[groupIndex];
+          const previousMessages =
+            previousHumanMessagesByGroupIndex[groupIndex] ?? [];
 
           if (group.type === "human" || group.type === "assistant") {
             return (
@@ -301,12 +386,13 @@ export function MessageList({
                   turnUsageMessages,
                 })}
                 {group.type === "assistant" &&
-                  renderAssistantCopyButton(
+                  renderAssistantActions(
                     group.messages,
                     isAssistantMessageGroupStreaming(
                       group.messages,
                       streamingMessages,
                     ),
+                    previousMessages,
                   )}
               </div>
             );
@@ -375,7 +461,6 @@ export function MessageList({
                 if (taskId) {
                   const parsed = parseSubtaskResult(
                     extractTextFromMessage(message),
-                    message.additional_kwargs,
                   );
                   updateSubtask({ id: taskId, ...parsed });
                 }

--- a/frontend/src/core/threads/api.ts
+++ b/frontend/src/core/threads/api.ts
@@ -1,7 +1,54 @@
 import { fetch as fetchWithAuth } from "@/core/api/fetcher";
 import { getBackendBaseURL } from "@/core/config";
 
-import type { ThreadTokenUsageResponse } from "./types";
+import type {
+  ThreadShareCreateResponse,
+  ThreadTokenUsageResponse,
+} from "./types";
+
+function formatErrorDetail(detail: unknown): string | null {
+  if (typeof detail === "string" && detail) {
+    return detail;
+  }
+  if (Array.isArray(detail)) {
+    const messages = detail
+      .map((item) => {
+        if (typeof item === "string") {
+          return item;
+        }
+        if (item && typeof item === "object" && "msg" in item) {
+          const message = (item as { msg?: unknown }).msg;
+          return typeof message === "string" && message ? message : null;
+        }
+        return null;
+      })
+      .filter((message): message is string => Boolean(message));
+    if (messages.length > 0) {
+      return messages.join("; ");
+    }
+  }
+  if (detail && typeof detail === "object") {
+    try {
+      return JSON.stringify(detail);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export async function readErrorDetail(response: Response, fallback: string) {
+  try {
+    const body = (await response.json()) as { detail?: unknown };
+    const detail = formatErrorDetail(body.detail);
+    if (detail) {
+      return detail;
+    }
+  } catch {
+    // Ignore malformed error bodies and keep the stable fallback message.
+  }
+  return `${fallback} (${response.status})`;
+}
 
 export async function fetchThreadTokenUsage(
   threadId: string,
@@ -21,4 +68,32 @@ export async function fetchThreadTokenUsage(
   }
 
   return (await response.json()) as ThreadTokenUsageResponse;
+}
+
+export async function createThreadShare({
+  threadId,
+  messageIds,
+  title,
+}: {
+  threadId: string;
+  messageIds: string[];
+  title?: string;
+}): Promise<ThreadShareCreateResponse> {
+  const response = await fetchWithAuth(
+    `${getBackendBaseURL()}/api/shares/threads/${encodeURIComponent(threadId)}`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message_ids: messageIds,
+        title,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error(await readErrorDetail(response, "Failed to create share."));
+  }
+
+  return (await response.json()) as ThreadShareCreateResponse;
 }

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -46,3 +46,13 @@ export interface ThreadTokenUsageResponse {
     middleware: number;
   };
 }
+
+export interface ThreadShareCreateResponse {
+  share_id: string;
+  title?: string | null;
+  created_at: string;
+}
+
+export interface ThreadShareResponse extends ThreadShareCreateResponse {
+  messages: Message[];
+}

--- a/frontend/tests/e2e/share.spec.ts
+++ b/frontend/tests/e2e/share.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const SHARE_ID = "share-public-1";
+
+test.describe("Public share page", () => {
+  test("renders a shared answer snapshot without workspace APIs", async ({
+    page,
+  }) => {
+    await page.route(`**/api/shares/${SHARE_ID}`, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          share_id: SHARE_ID,
+          title: "Research summary",
+          created_at: "2026-01-01T00:00:00Z",
+          messages: [
+            {
+              type: "human",
+              id: "human-1",
+              content: [{ type: "text", text: "Summarize the report" }],
+            },
+            {
+              type: "ai",
+              id: "ai-1",
+              content: "The report highlights revenue growth.",
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto(`/share/${SHARE_ID}`);
+
+    await expect(
+      page.getByRole("heading", { name: "Research summary" }),
+    ).toBeVisible();
+    await expect(page.getByText("Summarize the report")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText("The report highlights revenue growth."),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /share/i })).toHaveCount(0);
+  });
+
+  test("shows the public share load error", async ({ page }) => {
+    await page.route("**/api/shares/missing-share", (route) =>
+      route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Share not found" }),
+      }),
+    );
+
+    await page.goto("/share/missing-share");
+
+    await expect(page.getByText("Share not found (404)")).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/frontend/tests/unit/core/threads/api.test.ts
+++ b/frontend/tests/unit/core/threads/api.test.ts
@@ -53,3 +53,91 @@ test("fetchThreadTokenUsage returns null for unavailable token usage", async () 
 
   await expect(fetchThreadTokenUsage("thread-1")).resolves.toBeNull();
 });
+
+test("createThreadShare posts selected message ids", async () => {
+  fetchWithAuth.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      share_id: "share-1",
+      title: "Shared answer",
+      created_at: "2026-05-28T00:00:00+00:00",
+    }),
+  });
+
+  const { createThreadShare } = await import("@/core/threads/api");
+
+  await expect(
+    createThreadShare({
+      threadId: "thread-1",
+      messageIds: ["human-1", "ai-1"],
+      title: "Shared answer",
+    }),
+  ).resolves.toMatchObject({ share_id: "share-1" });
+
+  expect(fetchWithAuth).toHaveBeenCalledWith(
+    expect.stringContaining("/api/shares/threads/thread-1"),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message_ids: ["human-1", "ai-1"],
+        title: "Shared answer",
+      }),
+    },
+  );
+});
+
+test("createThreadShare rejects with backend error detail", async () => {
+  fetchWithAuth.mockResolvedValue({
+    ok: false,
+    status: 400,
+    json: async () => ({ detail: "Message IDs not found: missing-message" }),
+  });
+
+  const { createThreadShare } = await import("@/core/threads/api");
+
+  await expect(
+    createThreadShare({
+      threadId: "thread-1",
+      messageIds: ["missing-message"],
+    }),
+  ).rejects.toThrow("Message IDs not found: missing-message");
+});
+
+test("createThreadShare rejects with validation array details", async () => {
+  fetchWithAuth.mockResolvedValue({
+    ok: false,
+    status: 422,
+    json: async () => ({
+      detail: [
+        { msg: "Field required", loc: ["body", "message_ids"] },
+        { msg: "String should have at most 256 characters" },
+      ],
+    }),
+  });
+
+  const { createThreadShare } = await import("@/core/threads/api");
+
+  await expect(
+    createThreadShare({
+      threadId: "thread-1",
+      messageIds: [],
+    }),
+  ).rejects.toThrow(
+    "Field required; String should have at most 256 characters",
+  );
+});
+
+test("readErrorDetail formats object details", async () => {
+  const { readErrorDetail } = await import("@/core/threads/api");
+
+  await expect(
+    readErrorDetail(
+      {
+        status: 503,
+        json: async () => ({ detail: { error: "Store not available" } }),
+      } as Response,
+      "Failed to load share",
+    ),
+  ).resolves.toBe('{"error":"Store not available"}');
+});


### PR DESCRIPTION
## 问题原因

后端分享 API 合并后，前端需要在助手回答上提供分享入口，并提供免登录的只读公开分享页。这个 PR 从 #3306 中拆出前端交互，避免和后端权限/存储逻辑一起 review。

## 修改内容

- 在助手回答操作区增加分享按钮，创建分享后复制 `/share/{share_id}` 链接。
- 新增 `/share/[share_id]` 公开只读页面，展示分享快照中的问答内容。
- 新增前端 share API/types，封装 create/read/revoke 相关调用。
- 增加单测覆盖 create share payload，增加 e2e 覆盖公开分享页读取流程。

## 关联 issue

Draft：依赖后端分享 API PR 合并后再转 ready。
拆自 #3306
Closes #3288 的前端分享 UI 部分
---

## Problem Cause

After the backend share API lands, the frontend needs a share action on assistant answers and a public read-only share page. This PR splits the frontend workflow out of #3306 so it can be reviewed separately from backend permission and storage logic.

## Changes

- Add a share button to assistant answer actions and copy `/share/{share_id}` after share creation.
- Add a public read-only `/share/[share_id]` page for rendering shared Q&A snapshots.
- Add frontend share API/types for create/read/revoke calls.
- Add unit coverage for create share payload and e2e coverage for the public share page read flow.

## Related Issue

Draft: should be marked ready after the backend share API PR merges.
Split from #3306
Covers the frontend share UI part of #3288