### PR TITLE
fix(agent): fix custom agent config resolution

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from deerflow.config.agents_api_config import get_agents_api_config
-from deerflow.config.agents_config import AgentConfig, list_custom_agents, load_agent_config, load_agent_soul
+from deerflow.config.agents_config import AgentConfig, agent_config_exists, list_custom_agents, load_agent_config, load_agent_soul
 from deerflow.config.paths import get_paths
 from deerflow.runtime.user_context import get_effective_user_id
 
@@ -151,7 +151,7 @@ async def check_agent_name(name: str) -> dict:
     # Treat the name as taken if either the per-user path or the legacy shared
     # path holds an agent — picking a name that collides with an unmigrated
     # legacy agent would shadow the legacy entry once migration runs.
-    available = not paths.user_agent_dir(user_id, normalized).exists() and not paths.agent_dir(normalized).exists()
+    available = not agent_config_exists(paths.user_agent_dir(user_id, normalized)) and not agent_config_exists(paths.agent_dir(normalized))
     return {"available": available, "name": normalized}
 
 
@@ -215,8 +215,11 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
 
     agent_dir = paths.user_agent_dir(user_id, normalized_name)
     legacy_dir = paths.agent_dir(normalized_name)
+    config_file = agent_dir / "config.yaml"
+    soul_file = agent_dir / "SOUL.md"
+    agent_dir_preexisted = agent_dir.exists()
 
-    if agent_dir.exists() or legacy_dir.exists():
+    if agent_config_exists(agent_dir) or agent_config_exists(legacy_dir):
         raise HTTPException(status_code=409, detail=f"Agent '{normalized_name}' already exists")
 
     try:
@@ -233,12 +236,10 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
         if request.skills is not None:
             config_data["skills"] = request.skills
 
-        config_file = agent_dir / "config.yaml"
         with open(config_file, "w", encoding="utf-8") as f:
             yaml.dump(config_data, f, default_flow_style=False, allow_unicode=True)
 
         # Write SOUL.md
-        soul_file = agent_dir / "SOUL.md"
         soul_file.write_text(request.soul, encoding="utf-8")
 
         logger.info(f"Created agent '{normalized_name}' at {agent_dir}")
@@ -250,7 +251,10 @@ async def create_agent_endpoint(request: AgentCreateRequest) -> AgentResponse:
         raise
     except Exception as e:
         # Clean up on failure
-        if agent_dir.exists():
+        if agent_dir_preexisted:
+            config_file.unlink(missing_ok=True)
+            soul_file.unlink(missing_ok=True)
+        elif agent_dir.exists():
             shutil.rmtree(agent_dir)
         logger.error(f"Failed to create agent '{request.name}': {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to create agent: {str(e)}")
@@ -287,7 +291,7 @@ async def update_agent(name: str, request: AgentUpdateRequest) -> AgentResponse:
 
     paths = get_paths()
     agent_dir = paths.user_agent_dir(user_id, name)
-    if not agent_dir.exists() and paths.agent_dir(name).exists():
+    if not agent_config_exists(agent_dir) and agent_config_exists(paths.agent_dir(name)):
         raise HTTPException(
             status_code=409,
             detail=(f"Agent '{name}' only exists in the legacy shared layout and is not scoped to a user. Run scripts/migrate_user_isolation.py to move legacy agents into the per-user layout before updating."),
@@ -430,8 +434,8 @@ async def delete_agent(name: str) -> None:
     paths = get_paths()
     agent_dir = paths.user_agent_dir(user_id, name)
 
-    if not agent_dir.exists():
-        if paths.agent_dir(name).exists():
+    if not agent_config_exists(agent_dir):
+        if agent_config_exists(paths.agent_dir(name)):
             raise HTTPException(
                 status_code=409,
                 detail=(f"Agent '{name}' only exists in the legacy shared layout and is not scoped to a user. Run scripts/migrate_user_isolation.py to move legacy agents into the per-user layout before deleting."),

--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -20,6 +20,7 @@ from deerflow.runtime.user_context import get_effective_user_id
 
 logger = logging.getLogger(__name__)
 
+AGENT_CONFIG_FILENAME = "config.yaml"
 SOUL_FILENAME = "SOUL.md"
 AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
 
@@ -49,6 +50,11 @@ class AgentConfig(BaseModel):
     skills: list[str] | None = None
 
 
+def agent_config_exists(agent_dir: Path) -> bool:
+    """Return true when a directory contains an agent config file."""
+    return (agent_dir / AGENT_CONFIG_FILENAME).is_file()
+
+
 def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     """Return the on-disk directory for an agent, preferring the per-user layout.
 
@@ -56,8 +62,8 @@ def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     1. ``{base_dir}/users/{user_id}/agents/{name}/`` (per-user, current layout).
     2. ``{base_dir}/agents/{name}/`` (legacy shared layout — read-only fallback).
 
-    If neither exists, the per-user path is returned so callers that intend to
-    create the agent write into the new layout.
+    If neither config exists, the per-user path is returned so callers that
+    intend to create the agent write into the new layout.
 
     Args:
         name: Validated agent name.
@@ -67,11 +73,11 @@ def resolve_agent_dir(name: str, *, user_id: str | None = None) -> Path:
     paths = get_paths()
     effective_user = user_id or get_effective_user_id()
     user_path = paths.user_agent_dir(effective_user, name)
-    if user_path.exists():
+    if agent_config_exists(user_path):
         return user_path
 
     legacy_path = paths.agent_dir(name)
-    if legacy_path.exists():
+    if agent_config_exists(legacy_path):
         return legacy_path
 
     return user_path
@@ -92,7 +98,7 @@ def load_agent_config(name: str | None, *, user_id: str | None = None) -> AgentC
         AgentConfig instance, or ``None`` if ``name`` is ``None``.
 
     Raises:
-        FileNotFoundError: If the agent directory or config.yaml does not exist.
+        FileNotFoundError: If config.yaml does not exist.
         ValueError: If config.yaml cannot be parsed.
     """
 
@@ -101,12 +107,9 @@ def load_agent_config(name: str | None, *, user_id: str | None = None) -> AgentC
 
     name = validate_agent_name(name)
     agent_dir = resolve_agent_dir(name, user_id=user_id)
-    config_file = agent_dir / "config.yaml"
+    config_file = agent_dir / AGENT_CONFIG_FILENAME
 
-    if not agent_dir.exists():
-        raise FileNotFoundError(f"Agent directory not found: {agent_dir}")
-
-    if not config_file.exists():
+    if not config_file.is_file():
         raise FileNotFoundError(f"Agent config not found: {config_file}")
 
     try:
@@ -142,6 +145,8 @@ def load_agent_soul(agent_name: str | None, *, user_id: str | None = None) -> st
     """
     if agent_name:
         agent_dir = resolve_agent_dir(agent_name, user_id=user_id)
+        if not agent_config_exists(agent_dir):
+            return None
     else:
         agent_dir = get_paths().base_dir
     soul_path = agent_dir / SOUL_FILENAME
@@ -175,15 +180,12 @@ def list_custom_agents(*, user_id: str | None = None) -> list[AgentConfig]:
     legacy_root = paths.agents_dir
 
     for root in (user_root, legacy_root):
-        if not root.exists():
+        if not root.is_dir():
             continue
         for entry in sorted(root.iterdir()):
-            if not entry.is_dir():
-                continue
             if entry.name in seen:
                 continue
-            config_file = entry / "config.yaml"
-            if not config_file.exists():
+            if not agent_config_exists(entry):
                 logger.debug(f"Skipping {entry.name}: no config.yaml")
                 continue
 

--- a/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
@@ -25,7 +25,7 @@ from langchain_core.tools import tool
 from langgraph.types import Command
 from pydantic import BeforeValidator
 
-from deerflow.config.agents_config import load_agent_config, validate_agent_name
+from deerflow.config.agents_config import agent_config_exists, load_agent_config, validate_agent_name
 from deerflow.config.app_config import get_app_config
 from deerflow.config.paths import get_paths
 from deerflow.runtime.user_context import resolve_runtime_user_id
@@ -151,7 +151,7 @@ def update_agent(
 
     paths = get_paths()
     agent_dir = paths.user_agent_dir(user_id, agent_name)
-    if not agent_dir.exists() and paths.agent_dir(agent_name).exists():
+    if not agent_config_exists(agent_dir) and agent_config_exists(paths.agent_dir(agent_name)):
         return _err(f"Agent '{agent_name}' only exists in the legacy shared layout and is not scoped to a user. Run scripts/migrate_user_isolation.py to move legacy agents into the per-user layout before updating.")
 
     try:

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -202,6 +202,22 @@ class TestLoadAgentConfig:
 
         assert cfg.name == "legacy-agent"
 
+    def test_memory_only_user_agent_dir_does_not_shadow_legacy_config(self, tmp_path):
+        _write_agent(tmp_path, "legacy-agent", {"name": "legacy-agent", "description": "legacy"}, soul="legacy soul")
+        user_agent_dir = tmp_path / "users" / "alice" / "agents" / "legacy-agent"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_config, load_agent_soul
+
+            cfg = load_agent_config("legacy-agent", user_id="alice")
+            soul = load_agent_soul("legacy-agent", user_id="alice")
+
+        assert cfg.name == "legacy-agent"
+        assert cfg.description == "legacy"
+        assert soul == "legacy soul"
+
 
 # ===========================================================================
 # 4. load_agent_soul
@@ -246,6 +262,18 @@ class TestLoadAgentSoul:
 
             cfg = AgentConfig(name="empty-soul")
             soul = load_agent_soul(cfg.name)
+
+        assert soul is None
+
+    def test_soul_without_config_is_not_loaded_as_agent(self, tmp_path):
+        agent_dir = tmp_path / "agents" / "soul-only"
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "SOUL.md").write_text("orphan soul")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import load_agent_soul
+
+            soul = load_agent_soul("soul-only")
 
         assert soul is None
 
@@ -318,6 +346,19 @@ class TestListCustomAgents:
 
         names = [a.name for a in agents]
         assert names == sorted(names)
+
+    def test_memory_only_user_agent_dir_does_not_hide_legacy_agent(self, tmp_path):
+        _write_agent(tmp_path, "legacy-agent", {"name": "legacy-agent", "description": "legacy"})
+        user_agent_dir = tmp_path / "users" / "alice" / "agents" / "legacy-agent"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        with patch("deerflow.config.agents_config.get_paths", return_value=_make_paths(tmp_path)):
+            from deerflow.config.agents_config import list_custom_agents
+
+            agents = list_custom_agents(user_id="alice")
+
+        assert [agent.name for agent in agents] == ["legacy-agent"]
 
 
 # ===========================================================================
@@ -502,6 +543,22 @@ class TestAgentsAPI:
         assert response.status_code == 200
         assert response.json()["description"] == "new desc"
 
+    def test_update_memory_only_user_dir_with_legacy_agent_returns_409(self, agent_client, tmp_path):
+        legacy_dir = tmp_path / "agents" / "legacy-agent"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "config.yaml").write_text("name: legacy-agent\ndescription: legacy\n", encoding="utf-8")
+        (legacy_dir / "SOUL.md").write_text("legacy soul", encoding="utf-8")
+
+        user_agent_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "legacy-agent"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        response = agent_client.put("/api/agents/legacy-agent", json={"soul": "should not write"})
+
+        assert response.status_code == 409
+        assert not (user_agent_dir / "config.yaml").exists()
+        assert not (user_agent_dir / "SOUL.md").exists()
+
     def test_update_missing_agent_404(self, agent_client):
         response = agent_client.put("/api/agents/ghost-agent", json={"soul": "new"})
         assert response.status_code == 404
@@ -564,6 +621,20 @@ class TestAgentsAPI:
 
         response = agent_client.post("/api/agents", json={"name": "legacy-agent", "soul": "x"})
         assert response.status_code == 409
+
+    def test_memory_only_user_agent_dir_does_not_make_name_unavailable(self, agent_client, tmp_path):
+        user_agent_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "memory-only"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        check = agent_client.get("/api/agents/check", params={"name": "memory-only"})
+        assert check.status_code == 200
+        assert check.json()["available"] is True
+
+        response = agent_client.post("/api/agents", json={"name": "memory-only", "soul": "new soul"})
+        assert response.status_code == 201
+        assert (user_agent_dir / "config.yaml").exists()
+        assert (user_agent_dir / "SOUL.md").read_text(encoding="utf-8") == "new soul"
 
 
 # ===========================================================================

--- a/backend/tests/test_update_agent_tool.py
+++ b/backend/tests/test_update_agent_tool.py
@@ -155,6 +155,25 @@ def test_update_agent_accepts_known_model(tmp_path, patched_paths, stub_app_conf
     assert "model" in result.update["messages"][0].content
 
 
+def test_update_agent_rejects_legacy_agent_even_with_memory_only_user_dir(tmp_path, patched_paths):
+    legacy_dir = tmp_path / "agents" / "legacy-agent"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "config.yaml").write_text(yaml.safe_dump({"name": "legacy-agent", "description": "legacy"}), encoding="utf-8")
+    (legacy_dir / "SOUL.md").write_text("legacy soul", encoding="utf-8")
+
+    user_agent_dir = _user_agent_dir(tmp_path, "legacy-agent")
+    user_agent_dir.mkdir(parents=True)
+    (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+    result = update_agent.func(runtime=_runtime(agent_name="legacy-agent"), soul="should not write")
+
+    msg = result.update["messages"][0]
+    assert "only exists in the legacy shared layout" in msg.content
+    assert msg.status == "error"
+    assert not (user_agent_dir / "config.yaml").exists()
+    assert not (user_agent_dir / "SOUL.md").exists()
+
+
 def test_update_agent_treats_nullish_optional_text_as_omitted(tmp_path, patched_paths):
     """Models sometimes pass literal "null" strings while trying to omit fields.
 


### PR DESCRIPTION
## Summary

- Treat `config.yaml` as the canonical signal that a custom agent exists.
- Keep legacy shared agents readable when per-user memory creates a user agent directory containing only `memory.json`.
- Align gateway agent CRUD and `update_agent` guards with the same config-based existence check.

## Root Cause

When memory is enabled for a legacy shared custom agent, memory writes to:

```text
.deer-flow/users/<user-id>/agents/<agent-name>/memory.json
```

That creates a per-user agent directory without `config.yaml`. The old resolution logic treated the directory itself as a valid per-user agent and stopped falling back to:

```text
.deer-flow/agents/<agent-name>/config.yaml
```

This caused the second conversation turn to fail with `Agent config not found`.

## Validation

```bash
PYTHONPATH=. uv run pytest tests/test_custom_agent.py tests/test_update_agent_tool.py tests/test_memory_storage_user_isolation.py
```

Result: 88 passed.

Fixes #3390
