### PR TITLE
fix(dev): fix runtime reload exclusions

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -2,7 +2,10 @@ install:
 	uv sync
 
 dev:
-	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload
+	@runtime_home="$${DEER_FLOW_HOME:-.deer-flow}"; \
+	mkdir -p "$$runtime_home"; \
+	runtime_home="$$(cd "$$runtime_home" && pwd -P)"; \
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --reload --reload-exclude "$$runtime_home"
 
 gateway:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001

--- a/docker/dev-entrypoint.sh
+++ b/docker/dev-entrypoint.sh
@@ -68,6 +68,11 @@ fi
 
 cd /app/backend
 
+RUNTIME_HOME="${DEER_FLOW_HOME:-/app/backend/.deer-flow}"
+# Uvicorn only treats reload exclusions as directories if they exist at startup.
+mkdir -p "$RUNTIME_HOME"
+RUNTIME_HOME="$(cd "$RUNTIME_HOME" && pwd -P)"
+
 # `--all-packages` propagates extras into workspace members (PR #2584).
 # `$EXTRAS_FLAGS` intentionally unquoted so each `--extra X` becomes its own arg.
 # shellcheck disable=SC2086 # word-splitting is intentional here
@@ -82,4 +87,5 @@ fi
 
 PYTHONPATH=. exec uv run uvicorn app.gateway.app:app \
     --host 0.0.0.0 --port 8001 \
-    --reload --reload-include='*.yaml .env'
+    --reload --reload-include='*.yaml .env' \
+    --reload-exclude="$RUNTIME_HOME"

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -287,7 +287,28 @@ fi
 
 # Extra flags for uvicorn
 if $DEV_MODE && ! $DAEMON_MODE; then
-    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='sandbox/' --reload-exclude='.deer-flow/'"
+    if [ -n "${DEER_FLOW_HOME:-}" ]; then
+        case "$DEER_FLOW_HOME" in
+            /*) GATEWAY_RUNTIME_HOME="$DEER_FLOW_HOME" ;;
+            *)  GATEWAY_RUNTIME_HOME="$REPO_ROOT/backend/$DEER_FLOW_HOME" ;;
+        esac
+    elif [ -n "${DEER_FLOW_PROJECT_ROOT:-}" ]; then
+        case "$DEER_FLOW_PROJECT_ROOT" in
+            /*) GATEWAY_PROJECT_ROOT="$DEER_FLOW_PROJECT_ROOT" ;;
+            *)  GATEWAY_PROJECT_ROOT="$REPO_ROOT/backend/$DEER_FLOW_PROJECT_ROOT" ;;
+        esac
+        if [ -d "$GATEWAY_PROJECT_ROOT" ]; then
+            GATEWAY_RUNTIME_HOME="$GATEWAY_PROJECT_ROOT/.deer-flow"
+        else
+            GATEWAY_RUNTIME_HOME="$REPO_ROOT/backend/.deer-flow"
+        fi
+    else
+        GATEWAY_RUNTIME_HOME="$REPO_ROOT/backend/.deer-flow"
+    fi
+    # Uvicorn only treats reload exclusions as directories if they exist at startup.
+    mkdir -p "$GATEWAY_RUNTIME_HOME"
+    GATEWAY_RUNTIME_HOME="$(builtin cd "$GATEWAY_RUNTIME_HOME" >/dev/null 2>&1 && pwd -P)"
+    GATEWAY_EXTRA_FLAGS="--reload --reload-include='*.yaml' --reload-include='.env' --reload-exclude='*.pyc' --reload-exclude='__pycache__' --reload-exclude='sandbox/' --reload-exclude='$GATEWAY_RUNTIME_HOME'"
 else
     GATEWAY_EXTRA_FLAGS=""
 fi


### PR DESCRIPTION
## Summary

- resolve the effective DeerFlow runtime home before starting Gateway hot reload
- create and canonicalize that runtime directory before passing it to `uvicorn --reload-exclude`
- apply the same exclusion behavior to local `make dev`, backend-only `make dev`, and Docker dev startup

## Root Cause

The previous dev reload exclusion used a relative `.deer-flow/` path. With uvicorn/watchfiles, directory exclusions are only reliable when the directory exists at startup and the excluded path shape matches the paths emitted by WatchFiles. Runtime custom agent writes under `.deer-flow/users/.../agents/.../config.yaml` could therefore be treated as reloadable changes.

## Impact

Runtime-owned custom agent config writes no longer restart the Gateway app during local development. Source files, project `config.yaml`, and `.env` still remain reloadable.

Fixes #3449.

## Scope

This is a dev tooling / DevOps-adjacent change. It only changes how local and Docker development entrypoints configure Gateway hot reload; it does not change production Gateway behavior or custom agent runtime logic.

## Validation

- `bash -n scripts/serve.sh`
- `sh -n docker/dev-entrypoint.sh`
- `make -n -C backend dev`
- `uv run pytest tests/test_dev_entrypoint.py -q`
- verified `uvicorn.supervisors.watchfilesreload.FileFilter` returns `False` for `.deer-flow/users/.../agents/.../config.yaml` and `True` for a normal `config.yaml`
- manually tested custom agent config writes under `.deer-flow/users/.../agents/.../config.yaml` and confirmed they no longer trigger Gateway reload
