### PR TITLE
feat(community): add SearXNG and Browserless web search/fetch tools

### DIFF
--- a/backend/packages/harness/deerflow/community/browserless/__init__.py
+++ b/backend/packages/harness/deerflow/community/browserless/__init__.py
@@ -1,0 +1,4 @@
+from .browserless_client import BrowserlessClient
+from .tools import web_fetch_tool
+
+__all__ = ["BrowserlessClient", "web_fetch_tool"]

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -78,7 +78,6 @@ class BrowserlessClient:
                 code = resp.status_code
                 target_code = resp.headers.get("X-Response-Code", "")
                 target_status = resp.headers.get("X-Response-Status", "")
-                target_url = resp.headers.get("X-Response-URL", "")
 
                 logger.debug(
                     f"Browserless response: code={code}, "

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -17,7 +17,7 @@ class BrowserlessClient:
     async def fetch_html(
         self,
         url: str,
-        wait_until: str = "networkidle2",
+        wait_for_event: str = "",
         goto_timeout_ms: int = 30000,
         wait_for_timeout_ms: int = 0,
         wait_for_selector: str = "",
@@ -30,7 +30,8 @@ class BrowserlessClient:
 
         Args:
             url: The URL to fetch.
-            wait_until: When to consider navigation complete.
+            wait_for_event: Wait for a page event (e.g. "networkidle", "load").
+                            Replaces the deprecated waitUntil parameter.
             goto_timeout_ms: Navigation timeout in milliseconds.
             wait_for_timeout_ms: Extra wait after page load.
             wait_for_selector: CSS selector to wait for.
@@ -44,13 +45,14 @@ class BrowserlessClient:
         """
         payload: dict[str, Any] = {
             "url": url,
-            "waitUntil": wait_until,
             "gotoTimeout": goto_timeout_ms,
             "bestAttempt": best_attempt,
         }
 
         if self.token:
             payload["token"] = self.token
+        if wait_for_event:
+            payload["waitForEvent"] = wait_for_event
         if wait_for_timeout_ms > 0:
             payload["waitForTimeout"] = wait_for_timeout_ms
         if wait_for_selector:

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -1,0 +1,106 @@
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class BrowserlessClient:
+    """Client for Browserless headless Chrome API."""
+
+    def __init__(self, base_url: str, token: str = "", timeout_s: float = 30) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.timeout_s = timeout_s
+
+    def fetch_html(
+        self,
+        url: str,
+        wait_until: str = "networkidle2",
+        goto_timeout_ms: int = 30000,
+        wait_for_timeout_ms: int = 0,
+        wait_for_selector: str = "",
+        wait_for_selector_timeout_ms: int = 5000,
+        best_attempt: bool = True,
+        reject_resource_types: list[str] | None = None,
+        reject_request_pattern: list[str] | None = None,
+    ) -> str:
+        """Fetch the rendered HTML of a page using Browserless.
+
+        Args:
+            url: The URL to fetch.
+            wait_until: When to consider navigation complete.
+            goto_timeout_ms: Navigation timeout in milliseconds.
+            wait_for_timeout_ms: Extra wait after page load.
+            wait_for_selector: CSS selector to wait for.
+            wait_for_selector_timeout_ms: Timeout for selector wait.
+            best_attempt: Whether to attempt multiple strategies.
+            reject_resource_types: Resource types to block.
+            reject_request_pattern: URL patterns to block.
+
+        Returns:
+            Rendered HTML content.
+        """
+        payload: dict[str, Any] = {
+            "url": url,
+            "waitUntil": wait_until,
+            "gotoTimeout": goto_timeout_ms,
+            "bestAttempt": best_attempt,
+        }
+
+        if self.token:
+            payload["token"] = self.token
+        if wait_for_timeout_ms > 0:
+            payload["waitForTimeout"] = wait_for_timeout_ms
+        if wait_for_selector:
+            payload["waitForSelector"] = {
+                "selector": wait_for_selector,
+                "timeout": wait_for_selector_timeout_ms,
+            }
+        if reject_resource_types:
+            payload["rejectResourceTypes"] = reject_resource_types
+        if reject_request_pattern:
+            payload["rejectRequestPattern"] = reject_request_pattern
+
+        logger.debug(f"Fetching URL via Browserless: {url}")
+        try:
+            with httpx.Client(timeout=self.timeout_s) as client:
+                resp = client.post(
+                    f"{self.base_url}/content",
+                    json=payload,
+                    headers={
+                        "Content-Type": "application/json",
+                        "Cache-Control": "no-cache",
+                    },
+                )
+
+                code = resp.status_code
+                target_code = resp.headers.get("X-Response-Code", "")
+                target_status = resp.headers.get("X-Response-Status", "")
+                target_url = resp.headers.get("X-Response-URL", "")
+
+                logger.debug(
+                    f"Browserless response: code={code}, "
+                    f"target_code={target_code}, target_status={target_status}"
+                )
+
+                if code != 200:
+                    return (
+                        f"Error: Browserless HTTP {code}: {resp.text[:200]}"
+                    )
+
+                html = resp.text
+                if not html or not html.strip():
+                    return "Error: Browserless returned empty response"
+
+                return html
+
+        except httpx.TimeoutException:
+            return f"Error: Browserless request timed out after {self.timeout_s}s"
+        except httpx.RequestError as e:
+            logger.error(f"Browserless request failed: {e}")
+            return f"Error: Browserless request failed: {e!s}"
+        except Exception as e:
+            logger.error(f"Browserless fetch failed: {e}")
+            return f"Error: Browserless fetch failed: {e!s}"

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -77,15 +77,10 @@ class BrowserlessClient:
                 target_code = resp.headers.get("X-Response-Code", "")
                 target_status = resp.headers.get("X-Response-Status", "")
 
-                logger.debug(
-                    f"Browserless response: code={code}, "
-                    f"target_code={target_code}, target_status={target_status}"
-                )
+                logger.debug(f"Browserless response: code={code}, target_code={target_code}, target_status={target_status}")
 
                 if code != 200:
-                    return (
-                        f"Error: Browserless HTTP {code}: {resp.text[:200]}"
-                    )
+                    return f"Error: Browserless HTTP {code}: {resp.text[:200]}"
 
                 html = resp.text
                 if not html or not html.strip():

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -14,7 +14,7 @@ class BrowserlessClient:
         self.token = token
         self.timeout_s = timeout_s
 
-    def fetch_html(
+    async def fetch_html(
         self,
         url: str,
         wait_until: str = "networkidle2",
@@ -65,8 +65,8 @@ class BrowserlessClient:
 
         logger.debug(f"Fetching URL via Browserless: {url}")
         try:
-            with httpx.Client(timeout=self.timeout_s) as client:
-                resp = client.post(
+            async with httpx.AsyncClient(timeout=self.timeout_s) as client:
+                resp = await client.post(
                     f"{self.base_url}/content",
                     json=payload,
                     headers={

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -18,26 +18,24 @@ class BrowserlessClient:
         self,
         url: str,
         wait_for_event: str = "",
-        goto_timeout_ms: int = 30000,
         wait_for_timeout_ms: int = 0,
         wait_for_selector: str = "",
         wait_for_selector_timeout_ms: int = 5000,
-        best_attempt: bool = True,
         reject_resource_types: list[str] | None = None,
         reject_request_pattern: list[str] | None = None,
     ) -> str:
         """Fetch the rendered HTML of a page using Browserless.
 
+        Only sends accepted parameters for the current Browserless API version.
+        Sets a default navigation timeout (30s) via query param.
+
         Args:
             url: The URL to fetch.
             wait_for_event: Wait for a page event (e.g. "networkidle", "load").
-                            Replaces the deprecated waitUntil parameter.
-            goto_timeout_ms: Navigation timeout in milliseconds.
             wait_for_timeout_ms: Extra wait after page load.
             wait_for_selector: CSS selector to wait for.
             wait_for_selector_timeout_ms: Timeout for selector wait.
-            best_attempt: Whether to attempt multiple strategies.
-            reject_resource_types: Resource types to block.
+            reject_resource_types: Resource types to block (e.g. ["image"]).
             reject_request_pattern: URL patterns to block.
 
         Returns:
@@ -45,8 +43,6 @@ class BrowserlessClient:
         """
         payload: dict[str, Any] = {
             "url": url,
-            "gotoTimeout": goto_timeout_ms,
-            "bestAttempt": best_attempt,
         }
 
         if self.token:

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -23,21 +23,6 @@ def _get_tool_config(tool_name: str) -> dict | None:
     return extras if extras is not None else {}
 
 
-def _normalize_bool(value: bool | str | int | None, default: bool) -> bool:
-    """Normalize a config value to a boolean.
-    Handles env-resolved strings like "false" or "true".
-    """
-    if value is None:
-        return default
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.lower() in ("1", "true", "yes", "on")
-    if isinstance(value, int):
-        return bool(value)
-    return default
-
-
 def _get_browserless_client() -> BrowserlessClient:
     cfg = _get_tool_config("web_fetch")
     base_url = "http://localhost:3032"
@@ -66,32 +51,25 @@ async def web_fetch_tool(url: str) -> str:
         cfg = _get_tool_config("web_fetch")
 
         wait_for_event = ""
-        goto_timeout_ms = 30000
         wait_for_timeout_ms = 0
         wait_for_selector = ""
         wait_for_selector_timeout_ms = 5000
-        best_attempt = True
         reject_resource_types: list[str] | None = None
         reject_request_pattern: list[str] | None = None
 
         if cfg is not None:
             wait_for_event = cfg.get("wait_for_event", wait_for_event)
-            raw_goto = cfg.get("goto_timeout_ms", goto_timeout_ms)
-            goto_timeout_ms = int(raw_goto) if not isinstance(raw_goto, int) else raw_goto
             raw_wait = cfg.get("wait_for_timeout_ms", wait_for_timeout_ms)
             wait_for_timeout_ms = int(raw_wait) if not isinstance(raw_wait, int) else raw_wait
             wait_for_selector = cfg.get("wait_for_selector", wait_for_selector)
-            best_attempt = _normalize_bool(cfg.get("best_attempt"), best_attempt)
 
         client = _get_browserless_client()
         html = await client.fetch_html(
             url=url,
             wait_for_event=wait_for_event,
-            goto_timeout_ms=goto_timeout_ms,
             wait_for_timeout_ms=wait_for_timeout_ms,
             wait_for_selector=wait_for_selector,
             wait_for_selector_timeout_ms=wait_for_selector_timeout_ms,
-            best_attempt=best_attempt,
             reject_resource_types=reject_resource_types,
             reject_request_pattern=reject_request_pattern,
         )

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -1,11 +1,17 @@
+import asyncio
 import logging
+
 from langchain.tools import tool
+
 from deerflow.config import get_app_config
 from deerflow.utils.readability import ReadabilityExtractor
+
 from .browserless_client import BrowserlessClient
 
 logger = logging.getLogger(__name__)
-readability_extractor = ReadabilityExtractor()
+
+# readability_extractor runs CPU-bound parsing; always call via asyncio.to_thread
+_readability_extractor = ReadabilityExtractor()
 
 
 def _get_tool_config(tool_name: str) -> dict | None:
@@ -46,7 +52,7 @@ def _get_browserless_client() -> BrowserlessClient:
 
 
 @tool("web_fetch", parse_docstring=True)
-def web_fetch_tool(url: str) -> str:
+async def web_fetch_tool(url: str) -> str:
     """Fetch the contents of a web page at a given URL using Browserless (headless Chrome).
     Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
     This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
@@ -78,7 +84,7 @@ def web_fetch_tool(url: str) -> str:
             best_attempt = _normalize_bool(cfg.get("best_attempt"), best_attempt)
 
         client = _get_browserless_client()
-        html = client.fetch_html(
+        html = await client.fetch_html(
             url=url,
             wait_until=wait_until,
             goto_timeout_ms=goto_timeout_ms,
@@ -93,7 +99,7 @@ def web_fetch_tool(url: str) -> str:
         if html.startswith("Error:"):
             return html
 
-        article = readability_extractor.extract_article(html)
+        article = await asyncio.to_thread(_readability_extractor.extract_article, html)
         return article.to_markdown()[:4096]
 
     except Exception as e:

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -1,0 +1,74 @@
+import logging
+from langchain.tools import tool
+from deerflow.config import get_app_config
+from deerflow.utils.readability import ReadabilityExtractor
+from .browserless_client import BrowserlessClient
+
+logger = logging.getLogger(__name__)
+readability_extractor = ReadabilityExtractor()
+
+
+def _get_browserless_client() -> BrowserlessClient:
+    config = get_app_config().get_tool_config("web_fetch")
+    base_url = "http://localhost:3032"
+    token = ""
+    timeout_s = 30.0
+    if config is not None and config.model_extra:
+        base_url = config.model_extra.get("base_url", base_url)
+        token = config.model_extra.get("token", token)
+        timeout_s = float(config.model_extra.get("timeout_s", timeout_s))
+    return BrowserlessClient(base_url=base_url, token=token, timeout_s=timeout_s)
+
+
+@tool("web_fetch", parse_docstring=True)
+def web_fetch_tool(url: str) -> str:
+    """Fetch the contents of a web page at a given URL using Browserless (headless Chrome).
+    Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
+    This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
+    Do NOT add www. to URLs that do NOT have them.
+    URLs must include the schema: https://example.com is a valid URL while example.com is an invalid URL.
+
+    Args:
+        url: The URL to fetch the contents of.
+    """
+    try:
+        config = get_app_config().get_tool_config("web_fetch")
+
+        wait_until = "networkidle2"
+        goto_timeout_ms = 30000
+        wait_for_timeout_ms = 0
+        wait_for_selector = ""
+        wait_for_selector_timeout_ms = 5000
+        best_attempt = True
+        reject_resource_types: list[str] | None = None
+        reject_request_pattern: list[str] | None = None
+
+        if config is not None and config.model_extra:
+            wait_until = config.model_extra.get("wait_until", wait_until)
+            goto_timeout_ms = int(config.model_extra.get("goto_timeout_ms", goto_timeout_ms))
+            wait_for_timeout_ms = int(config.model_extra.get("wait_for_timeout_ms", wait_for_timeout_ms))
+            wait_for_selector = config.model_extra.get("wait_for_selector", wait_for_selector)
+            best_attempt = bool(config.model_extra.get("best_attempt", best_attempt))
+
+        client = _get_browserless_client()
+        html = client.fetch_html(
+            url=url,
+            wait_until=wait_until,
+            goto_timeout_ms=goto_timeout_ms,
+            wait_for_timeout_ms=wait_for_timeout_ms,
+            wait_for_selector=wait_for_selector,
+            wait_for_selector_timeout_ms=wait_for_selector_timeout_ms,
+            best_attempt=best_attempt,
+            reject_resource_types=reject_resource_types,
+            reject_request_pattern=reject_request_pattern,
+        )
+
+        if html.startswith("Error:"):
+            return html
+
+        article = readability_extractor.extract_article(html)
+        return article.to_markdown()[:4096]
+
+    except Exception as e:
+        logger.error(f"Error in web_fetch_tool: {e}")
+        return f"Error: {str(e)}"

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -65,7 +65,7 @@ async def web_fetch_tool(url: str) -> str:
     try:
         cfg = _get_tool_config("web_fetch")
 
-        wait_until = "networkidle2"
+        wait_for_event = ""
         goto_timeout_ms = 30000
         wait_for_timeout_ms = 0
         wait_for_selector = ""
@@ -75,7 +75,7 @@ async def web_fetch_tool(url: str) -> str:
         reject_request_pattern: list[str] | None = None
 
         if cfg is not None:
-            wait_until = cfg.get("wait_until", wait_until)
+            wait_for_event = cfg.get("wait_for_event", wait_for_event)
             raw_goto = cfg.get("goto_timeout_ms", goto_timeout_ms)
             goto_timeout_ms = int(raw_goto) if not isinstance(raw_goto, int) else raw_goto
             raw_wait = cfg.get("wait_for_timeout_ms", wait_for_timeout_ms)
@@ -86,7 +86,7 @@ async def web_fetch_tool(url: str) -> str:
         client = _get_browserless_client()
         html = await client.fetch_html(
             url=url,
-            wait_until=wait_until,
+            wait_for_event=wait_for_event,
             goto_timeout_ms=goto_timeout_ms,
             wait_for_timeout_ms=wait_for_timeout_ms,
             wait_for_selector=wait_for_selector,

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -8,15 +8,40 @@ logger = logging.getLogger(__name__)
 readability_extractor = ReadabilityExtractor()
 
 
+def _get_tool_config(tool_name: str) -> dict | None:
+    """Get tool config extras safely, returning None if not configured."""
+    config = get_app_config().get_tool_config(tool_name)
+    if config is None:
+        return None
+    extras = config.model_extra
+    return extras if extras is not None else {}
+
+
+def _normalize_bool(value: bool | str | int | None, default: bool) -> bool:
+    """Normalize a config value to a boolean.
+    Handles env-resolved strings like "false" or "true".
+    """
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.lower() in ("1", "true", "yes", "on")
+    if isinstance(value, int):
+        return bool(value)
+    return default
+
+
 def _get_browserless_client() -> BrowserlessClient:
-    config = get_app_config().get_tool_config("web_fetch")
+    cfg = _get_tool_config("web_fetch")
     base_url = "http://localhost:3032"
     token = ""
     timeout_s = 30.0
-    if config is not None and config.model_extra:
-        base_url = config.model_extra.get("base_url", base_url)
-        token = config.model_extra.get("token", token)
-        timeout_s = float(config.model_extra.get("timeout_s", timeout_s))
+    if cfg is not None:
+        base_url = cfg.get("base_url", base_url)
+        token = cfg.get("token", token)
+        raw = cfg.get("timeout_s", timeout_s)
+        timeout_s = float(raw) if not isinstance(raw, float) else raw
     return BrowserlessClient(base_url=base_url, token=token, timeout_s=timeout_s)
 
 
@@ -32,7 +57,7 @@ def web_fetch_tool(url: str) -> str:
         url: The URL to fetch the contents of.
     """
     try:
-        config = get_app_config().get_tool_config("web_fetch")
+        cfg = _get_tool_config("web_fetch")
 
         wait_until = "networkidle2"
         goto_timeout_ms = 30000
@@ -43,12 +68,14 @@ def web_fetch_tool(url: str) -> str:
         reject_resource_types: list[str] | None = None
         reject_request_pattern: list[str] | None = None
 
-        if config is not None and config.model_extra:
-            wait_until = config.model_extra.get("wait_until", wait_until)
-            goto_timeout_ms = int(config.model_extra.get("goto_timeout_ms", goto_timeout_ms))
-            wait_for_timeout_ms = int(config.model_extra.get("wait_for_timeout_ms", wait_for_timeout_ms))
-            wait_for_selector = config.model_extra.get("wait_for_selector", wait_for_selector)
-            best_attempt = bool(config.model_extra.get("best_attempt", best_attempt))
+        if cfg is not None:
+            wait_until = cfg.get("wait_until", wait_until)
+            raw_goto = cfg.get("goto_timeout_ms", goto_timeout_ms)
+            goto_timeout_ms = int(raw_goto) if not isinstance(raw_goto, int) else raw_goto
+            raw_wait = cfg.get("wait_for_timeout_ms", wait_for_timeout_ms)
+            wait_for_timeout_ms = int(raw_wait) if not isinstance(raw_wait, int) else raw_wait
+            wait_for_selector = cfg.get("wait_for_selector", wait_for_selector)
+            best_attempt = _normalize_bool(cfg.get("best_attempt"), best_attempt)
 
         client = _get_browserless_client()
         html = client.fetch_html(

--- a/backend/packages/harness/deerflow/community/searxng/__init__.py
+++ b/backend/packages/harness/deerflow/community/searxng/__init__.py
@@ -1,0 +1,4 @@
+from .searxng_client import SearxngClient
+from .tools import web_search_tool, web_fetch_tool
+
+__all__ = ["SearxngClient", "web_search_tool", "web_fetch_tool"]

--- a/backend/packages/harness/deerflow/community/searxng/__init__.py
+++ b/backend/packages/harness/deerflow/community/searxng/__init__.py
@@ -1,3 +1,3 @@
-from .tools import web_fetch_tool, web_search_tool
+from .tools import web_search_tool
 
-__all__ = ["web_search_tool", "web_fetch_tool"]
+__all__ = ["web_search_tool"]

--- a/backend/packages/harness/deerflow/community/searxng/__init__.py
+++ b/backend/packages/harness/deerflow/community/searxng/__init__.py
@@ -1,4 +1,3 @@
-from .searxng_client import SearxngClient
-from .tools import web_search_tool, web_fetch_tool
+from .tools import web_fetch_tool, web_search_tool
 
-__all__ = ["SearxngClient", "web_search_tool", "web_fetch_tool"]
+__all__ = ["web_search_tool", "web_fetch_tool"]

--- a/backend/packages/harness/deerflow/community/searxng/searxng_client.py
+++ b/backend/packages/harness/deerflow/community/searxng/searxng_client.py
@@ -65,13 +65,13 @@ class SearxngClient:
             raise
 
     def fetch(self, url: str) -> str:
-        """Fetch the HTML content of a URL via SearXNG's fetch proxy if available.
+        """Fetch the HTML content of a URL directly via HTTP GET.
 
         Args:
             url: The URL to fetch.
 
         Returns:
-            HTML content as string.
+            HTML content as string, or an error string prefixed with "Error:".
         """
         try:
             with httpx.Client(timeout=30, follow_redirects=True) as client:

--- a/backend/packages/harness/deerflow/community/searxng/searxng_client.py
+++ b/backend/packages/harness/deerflow/community/searxng/searxng_client.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class SearxngClient:
+    """Client for SearXNG meta search engine API."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    def search(
+        self,
+        query: str,
+        max_results: int = 5,
+        categories: list[str] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Search the web using SearXNG.
+
+        Args:
+            query: The search query.
+            max_results: Maximum number of results to return.
+            categories: Search categories to use.
+
+        Returns:
+            List of search result dictionaries.
+        """
+        params: dict[str, Any] = {
+            "q": query,
+            "format": "json",
+            "language": "auto",
+            "pageno": 1,
+        }
+        if max_results:
+            params["limit"] = max_results
+        if categories:
+            params["categories"] = ",".join(categories)
+
+        logger.debug(f"Searching SearXNG at {self.base_url} with query: {query}")
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.get(
+                    f"{self.base_url}/search",
+                    params=params,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)",
+                        "Accept": "application/json",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                results = data.get("results", [])
+                return results[:max_results] if max_results else results
+        except httpx.HTTPStatusError as e:
+            logger.error(f"SearXNG search returned error status: {e}")
+            raise
+        except httpx.RequestError as e:
+            logger.error(f"SearXNG search request failed: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"An unexpected error occurred during SearXNG search: {e}")
+            raise
+
+    def fetch(self, url: str) -> str:
+        """Fetch the HTML content of a URL via SearXNG's fetch proxy if available.
+
+        Args:
+            url: The URL to fetch.
+
+        Returns:
+            HTML content as string.
+        """
+        try:
+            with httpx.Client(timeout=30, follow_redirects=True) as client:
+                resp = client.get(
+                    url,
+                    headers={
+                        "User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)",
+                    },
+                )
+                resp.raise_for_status()
+                return resp.text
+        except Exception as e:
+            logger.error(f"SearXNG fetch failed: {e}")
+            return f"Error: {e!s}"

--- a/backend/packages/harness/deerflow/community/searxng/searxng_client.py
+++ b/backend/packages/harness/deerflow/community/searxng/searxng_client.py
@@ -63,26 +63,3 @@ class SearxngClient:
         except Exception as e:
             logger.error(f"An unexpected error occurred during SearXNG search: {e}")
             raise
-
-    async def fetch(self, url: str) -> str:
-        """Fetch the HTML content of a URL directly via HTTP GET.
-
-        Args:
-            url: The URL to fetch.
-
-        Returns:
-            HTML content as string, or an error string prefixed with "Error:".
-        """
-        try:
-            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
-                resp = await client.get(
-                    url,
-                    headers={
-                        "User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)",
-                    },
-                )
-                resp.raise_for_status()
-                return resp.text
-        except Exception as e:
-            logger.error(f"SearXNG fetch failed: {e}")
-            return f"Error: {e!s}"

--- a/backend/packages/harness/deerflow/community/searxng/searxng_client.py
+++ b/backend/packages/harness/deerflow/community/searxng/searxng_client.py
@@ -12,7 +12,7 @@ class SearxngClient:
     def __init__(self, base_url: str) -> None:
         self.base_url = base_url.rstrip("/")
 
-    def search(
+    async def search(
         self,
         query: str,
         max_results: int = 5,
@@ -41,8 +41,8 @@ class SearxngClient:
 
         logger.debug(f"Searching SearXNG at {self.base_url} with query: {query}")
         try:
-            with httpx.Client(timeout=30) as client:
-                resp = client.get(
+            async with httpx.AsyncClient(timeout=30) as client:
+                resp = await client.get(
                     f"{self.base_url}/search",
                     params=params,
                     headers={
@@ -64,7 +64,7 @@ class SearxngClient:
             logger.error(f"An unexpected error occurred during SearXNG search: {e}")
             raise
 
-    def fetch(self, url: str) -> str:
+    async def fetch(self, url: str) -> str:
         """Fetch the HTML content of a URL directly via HTTP GET.
 
         Args:
@@ -74,8 +74,8 @@ class SearxngClient:
             HTML content as string, or an error string prefixed with "Error:".
         """
         try:
-            with httpx.Client(timeout=30, follow_redirects=True) as client:
-                resp = client.get(
+            async with httpx.AsyncClient(timeout=30, follow_redirects=True) as client:
+                resp = await client.get(
                     url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)",

--- a/backend/packages/harness/deerflow/community/searxng/tools.py
+++ b/backend/packages/harness/deerflow/community/searxng/tools.py
@@ -1,0 +1,72 @@
+import json
+import logging
+from langchain.tools import tool
+from deerflow.config import get_app_config
+from deerflow.utils.readability import ReadabilityExtractor
+from .searxng_client import SearxngClient
+
+logger = logging.getLogger(__name__)
+readability_extractor = ReadabilityExtractor()
+
+
+def _get_searxng_client() -> SearxngClient:
+    config = get_app_config().get_tool_config("web_search")
+    base_url = "http://localhost:8088"
+    if config is not None and "base_url" in config.model_extra:
+        base_url = config.model_extra.get("base_url")
+    return SearxngClient(base_url=base_url)
+
+
+@tool("web_search", parse_docstring=True)
+def web_search_tool(query: str) -> str:
+    """Search the web using SearXNG.
+
+    Args:
+        query: The query to search for.
+    """
+    try:
+        config = get_app_config().get_tool_config("web_search")
+        max_results = 5
+        if config is not None and "max_results" in config.model_extra:
+            max_results = config.model_extra.get("max_results")
+
+        client = _get_searxng_client()
+        results = client.search(query, max_results=max_results)
+
+        normalized_results = [
+            {
+                "title": result.get("title", ""),
+                "url": result.get("url", ""),
+                "snippet": result.get("content", ""),
+            }
+            for result in results
+        ]
+        json_results = json.dumps(normalized_results, indent=2, ensure_ascii=False)
+        return json_results
+    except Exception as e:
+        logger.error(f"Error in web_search_tool: {e}")
+        return f"Error: {str(e)}"
+
+
+@tool("web_fetch", parse_docstring=True)
+def web_fetch_tool(url: str) -> str:
+    """Fetch the contents of a web page at a given URL.
+    Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
+    This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
+    Do NOT add www. to URLs that do NOT have them.
+    URLs must include the schema: https://example.com is a valid URL while example.com is an invalid URL.
+
+    Args:
+        url: The URL to fetch the contents of.
+    """
+    try:
+        client = _get_searxng_client()
+        html_content = client.fetch(url)
+        if html_content.startswith("Error:"):
+            return html_content
+
+        article = readability_extractor.extract_article(html_content)
+        return article.to_markdown()[:4096]
+    except Exception as e:
+        logger.error(f"Error in web_fetch_tool: {e}")
+        return f"Error: {str(e)}"

--- a/backend/packages/harness/deerflow/community/searxng/tools.py
+++ b/backend/packages/harness/deerflow/community/searxng/tools.py
@@ -1,12 +1,18 @@
+import asyncio
 import json
 import logging
+
 from langchain.tools import tool
+
 from deerflow.config import get_app_config
 from deerflow.utils.readability import ReadabilityExtractor
+
 from .searxng_client import SearxngClient
 
 logger = logging.getLogger(__name__)
-readability_extractor = ReadabilityExtractor()
+
+# readability_extractor runs CPU-bound parsing; always call via asyncio.to_thread
+_readability_extractor = ReadabilityExtractor()
 
 
 def _get_tool_config(tool_name: str) -> dict | None:
@@ -27,7 +33,7 @@ def _get_searxng_client() -> SearxngClient:
 
 
 @tool("web_search", parse_docstring=True)
-def web_search_tool(query: str) -> str:
+async def web_search_tool(query: str) -> str:
     """Search the web using SearXNG.
 
     Args:
@@ -41,24 +47,24 @@ def web_search_tool(query: str) -> str:
             max_results = int(raw) if not isinstance(raw, int) else raw
 
         client = _get_searxng_client()
-        results = client.search(query, max_results=max_results)
+        results = await client.search(query, max_results=max_results)
 
-        normalized_results = [
+        normalized = [
             {
-                "title": result.get("title", ""),
-                "url": result.get("url", ""),
-                "snippet": result.get("content", ""),
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": r.get("content", ""),
             }
-            for result in results
+            for r in results
         ]
-        return json.dumps(normalized_results, indent=2, ensure_ascii=False)
+        return json.dumps(normalized, indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error in web_search_tool: {e}")
         return json.dumps({"error": str(e), "query": query}, ensure_ascii=False)
 
 
 @tool("web_fetch", parse_docstring=True)
-def web_fetch_tool(url: str) -> str:
+async def web_fetch_tool(url: str) -> str:
     """Fetch the contents of a web page at a given URL.
     Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
     This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
@@ -69,7 +75,6 @@ def web_fetch_tool(url: str) -> str:
         url: The URL to fetch the contents of.
     """
     try:
-        # Use a direct HTTP fetch (not through SearXNG proxy)
         cfg = _get_tool_config("web_fetch")
         timeout_s = 30
         if cfg is not None:
@@ -77,8 +82,8 @@ def web_fetch_tool(url: str) -> str:
             timeout_s = float(raw) if not isinstance(raw, float) else raw
 
         import httpx
-        with httpx.Client(timeout=timeout_s, follow_redirects=True) as client:
-            resp = client.get(
+        async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as client:
+            resp = await client.get(
                 url,
                 headers={"User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)"},
             )
@@ -88,7 +93,7 @@ def web_fetch_tool(url: str) -> str:
         if not html_content.strip():
             return "Error: Empty response"
 
-        article = readability_extractor.extract_article(html_content)
+        article = await asyncio.to_thread(_readability_extractor.extract_article, html_content)
         return article.to_markdown()[:4096]
     except Exception as e:
         logger.error(f"Error in web_fetch_tool: {e}")

--- a/backend/packages/harness/deerflow/community/searxng/tools.py
+++ b/backend/packages/harness/deerflow/community/searxng/tools.py
@@ -1,18 +1,13 @@
-import asyncio
 import json
 import logging
 
 from langchain.tools import tool
 
 from deerflow.config import get_app_config
-from deerflow.utils.readability import ReadabilityExtractor
 
 from .searxng_client import SearxngClient
 
 logger = logging.getLogger(__name__)
-
-# readability_extractor runs CPU-bound parsing; always call via asyncio.to_thread
-_readability_extractor = ReadabilityExtractor()
 
 
 def _get_tool_config(tool_name: str) -> dict | None:
@@ -61,40 +56,3 @@ async def web_search_tool(query: str) -> str:
     except Exception as e:
         logger.error(f"Error in web_search_tool: {e}")
         return json.dumps({"error": str(e), "query": query}, ensure_ascii=False)
-
-
-@tool("web_fetch", parse_docstring=True)
-async def web_fetch_tool(url: str) -> str:
-    """Fetch the contents of a web page at a given URL.
-    Only fetch EXACT URLs that have been provided directly by the user or have been returned in results from the web_search and web_fetch tools.
-    This tool can NOT access content that requires authentication, such as private Google Docs or pages behind login walls.
-    Do NOT add www. to URLs that do NOT have them.
-    URLs must include the schema: https://example.com is a valid URL while example.com is an invalid URL.
-
-    Args:
-        url: The URL to fetch the contents of.
-    """
-    try:
-        cfg = _get_tool_config("web_fetch")
-        timeout_s = 30
-        if cfg is not None:
-            raw = cfg.get("timeout_s", timeout_s)
-            timeout_s = float(raw) if not isinstance(raw, float) else raw
-
-        import httpx
-        async with httpx.AsyncClient(timeout=timeout_s, follow_redirects=True) as client:
-            resp = await client.get(
-                url,
-                headers={"User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)"},
-            )
-            resp.raise_for_status()
-            html_content = resp.text
-
-        if not html_content.strip():
-            return "Error: Empty response"
-
-        article = await asyncio.to_thread(_readability_extractor.extract_article, html_content)
-        return article.to_markdown()[:4096]
-    except Exception as e:
-        logger.error(f"Error in web_fetch_tool: {e}")
-        return f"Error: {str(e)}"

--- a/backend/packages/harness/deerflow/community/searxng/tools.py
+++ b/backend/packages/harness/deerflow/community/searxng/tools.py
@@ -9,11 +9,20 @@ logger = logging.getLogger(__name__)
 readability_extractor = ReadabilityExtractor()
 
 
+def _get_tool_config(tool_name: str) -> dict | None:
+    """Get tool config extras safely, returning None if not configured."""
+    config = get_app_config().get_tool_config(tool_name)
+    if config is None:
+        return None
+    extras = config.model_extra
+    return extras if extras is not None else {}
+
+
 def _get_searxng_client() -> SearxngClient:
-    config = get_app_config().get_tool_config("web_search")
+    cfg = _get_tool_config("web_search")
     base_url = "http://localhost:8088"
-    if config is not None and "base_url" in config.model_extra:
-        base_url = config.model_extra.get("base_url")
+    if cfg is not None:
+        base_url = cfg.get("base_url", base_url)
     return SearxngClient(base_url=base_url)
 
 
@@ -25,10 +34,11 @@ def web_search_tool(query: str) -> str:
         query: The query to search for.
     """
     try:
-        config = get_app_config().get_tool_config("web_search")
+        cfg = _get_tool_config("web_search")
         max_results = 5
-        if config is not None and "max_results" in config.model_extra:
-            max_results = config.model_extra.get("max_results")
+        if cfg is not None:
+            raw = cfg.get("max_results", max_results)
+            max_results = int(raw) if not isinstance(raw, int) else raw
 
         client = _get_searxng_client()
         results = client.search(query, max_results=max_results)
@@ -41,11 +51,10 @@ def web_search_tool(query: str) -> str:
             }
             for result in results
         ]
-        json_results = json.dumps(normalized_results, indent=2, ensure_ascii=False)
-        return json_results
+        return json.dumps(normalized_results, indent=2, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error in web_search_tool: {e}")
-        return f"Error: {str(e)}"
+        return json.dumps({"error": str(e), "query": query}, ensure_ascii=False)
 
 
 @tool("web_fetch", parse_docstring=True)
@@ -60,10 +69,24 @@ def web_fetch_tool(url: str) -> str:
         url: The URL to fetch the contents of.
     """
     try:
-        client = _get_searxng_client()
-        html_content = client.fetch(url)
-        if html_content.startswith("Error:"):
-            return html_content
+        # Use a direct HTTP fetch (not through SearXNG proxy)
+        cfg = _get_tool_config("web_fetch")
+        timeout_s = 30
+        if cfg is not None:
+            raw = cfg.get("timeout_s", timeout_s)
+            timeout_s = float(raw) if not isinstance(raw, float) else raw
+
+        import httpx
+        with httpx.Client(timeout=timeout_s, follow_redirects=True) as client:
+            resp = client.get(
+                url,
+                headers={"User-Agent": "Mozilla/5.0 (compatible; DeerFlow/1.0)"},
+            )
+            resp.raise_for_status()
+            html_content = resp.text
+
+        if not html_content.strip():
+            return "Error: Empty response"
 
         article = readability_extractor.extract_article(html_content)
         return article.to_markdown()[:4096]

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -9,129 +9,135 @@ from deerflow.community.browserless.browserless_client import BrowserlessClient
 from deerflow.community.browserless import tools
 
 
+class AsyncMock(MagicMock):
+    """Mock that supports async call."""
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+@pytest.mark.asyncio
 class TestBrowserlessClient:
     """Tests for the BrowserlessClient class."""
 
-    def test_fetch_html_success(self):
+    async def test_fetch_html_success(self):
         """fetch_html returns HTML content on success."""
-        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.text = "<html><body>Page content</body></html>"
             mock_resp.headers = {}
-            mock_ctx.post.return_value = mock_resp
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
 
             client = BrowserlessClient(base_url="http://browserless:3000")
-            result = client.fetch_html("https://example.com")
+            result = await client.fetch_html("https://example.com")
 
             assert result == "<html><body>Page content</body></html>"
-            # Verify payload structure
             call_kwargs = mock_ctx.post.call_args.kwargs
             assert call_kwargs["json"]["url"] == "https://example.com"
             assert call_kwargs["json"]["waitUntil"] == "networkidle2"
 
-    def test_fetch_html_empty_response(self):
+    async def test_fetch_html_empty_response(self):
         """fetch_html returns error for empty response."""
-        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.text = "   "
             mock_resp.headers = {}
-            mock_ctx.post.return_value = mock_resp
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
 
             client = BrowserlessClient(base_url="http://browserless:3000")
-            result = client.fetch_html("https://example.com")
+            result = await client.fetch_html("https://example.com")
             assert result == "Error: Browserless returned empty response"
 
-    def test_fetch_html_http_error(self):
+    async def test_fetch_html_http_error(self):
         """fetch_html returns error for non-200 status."""
-        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 500
             mock_resp.text = "Internal error"
             mock_resp.headers = {}
-            mock_ctx.post.return_value = mock_resp
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
 
             client = BrowserlessClient(base_url="http://browserless:3000")
-            result = client.fetch_html("https://example.com")
+            result = await client.fetch_html("https://example.com")
             assert "Error: Browserless HTTP 500" in result
 
-    def test_fetch_html_timeout(self):
+    async def test_fetch_html_timeout(self):
         """fetch_html returns timeout error."""
-        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
             import httpx
-            mock_ctx.post.side_effect = httpx.TimeoutException("Timed out")
+            mock_ctx.post = AsyncMock(side_effect=httpx.TimeoutException("Timed out"))
 
             client = BrowserlessClient(base_url="http://browserless:3000", timeout_s=10)
-            result = client.fetch_html("https://example.com")
+            result = await client.fetch_html("https://example.com")
             assert "timed out" in result.lower() or "timeout" in result.lower()
 
-    def test_fetch_html_with_token(self):
+    async def test_fetch_html_with_token(self):
         """fetch_html includes token in payload when set."""
-        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.text = "<html>OK</html>"
             mock_resp.headers = {}
-            mock_ctx.post.return_value = mock_resp
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
 
             client = BrowserlessClient(base_url="http://browserless:3000", token="my-token")
-            client.fetch_html("https://example.com")
+            await client.fetch_html("https://example.com")
 
             payload = mock_ctx.post.call_args.kwargs["json"]
             assert payload["token"] == "my-token"
 
 
+@pytest.mark.asyncio
 class TestBrowserlessTools:
     """Tests for the Browserless tool functions."""
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
-    def test_web_fetch_tool_success(self, mock_get_client):
+    async def test_web_fetch_tool_success(self, mock_get_client):
         """web_fetch_tool successfully fetches and extracts content."""
         mock_client = MagicMock()
-        mock_client.fetch_html.return_value = "<html><body><article><h1>Title</h1><p>Content</p></article></body></html>"
+        mock_client.fetch_html = AsyncMock(return_value="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>")
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
-            result = tools.web_fetch_tool.invoke("https://example.com/article")
+            result = await tools.web_fetch_tool.ainvoke("https://example.com/article")
 
-        # Should be extracted markdown content
         assert "Error:" not in result
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
-    def test_web_fetch_tool_error(self, mock_get_client):
+    async def test_web_fetch_tool_error(self, mock_get_client):
         """web_fetch_tool returns error when fetch fails."""
         mock_client = MagicMock()
-        mock_client.fetch_html.return_value = "Error: Browserless returned empty response"
+        mock_client.fetch_html = AsyncMock(return_value="Error: Browserless returned empty response")
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
-            result = tools.web_fetch_tool.invoke("https://example.com")
+            result = await tools.web_fetch_tool.ainvoke("https://example.com")
 
         assert result.startswith("Error:")
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
-    def test_web_fetch_tool_exception(self, mock_get_client):
+    async def test_web_fetch_tool_exception(self, mock_get_client):
         """web_fetch_tool returns error when client raises exception."""
         mock_client = MagicMock()
-        mock_client.fetch_html.side_effect = Exception("Unexpected error")
+        mock_client.fetch_html = AsyncMock(side_effect=Exception("Unexpected error"))
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
-            result = tools.web_fetch_tool.invoke("https://example.com")
+            result = await tools.web_fetch_tool.ainvoke("https://example.com")
 
         assert result.startswith("Error:")

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import json
 import pytest
 
 from deerflow.community.browserless.browserless_client import BrowserlessClient
@@ -38,6 +37,8 @@ class TestBrowserlessClient:
             call_kwargs = mock_ctx.post.call_args.kwargs
             assert call_kwargs["json"]["url"] == "https://example.com"
             assert "waitUntil" not in call_kwargs["json"]
+            assert "gotoTimeout" not in call_kwargs["json"]
+            assert "bestAttempt" not in call_kwargs["json"]
 
     async def test_fetch_html_empty_response(self):
         """fetch_html returns error for empty response."""
@@ -100,6 +101,47 @@ class TestBrowserlessClient:
 
             payload = mock_ctx.post.call_args.kwargs["json"]
             assert payload["token"] == "my-token"
+
+    async def test_fetch_html_with_wait_for_selector(self):
+        """fetch_html sends waitForSelector when selector is set."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html>OK</html>"
+            mock_resp.headers = {}
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            await client.fetch_html("https://example.com", wait_for_selector="article")
+
+            payload = mock_ctx.post.call_args.kwargs["json"]
+            assert payload["waitForSelector"]["selector"] == "article"
+
+    async def test_fetch_html_with_reject_params(self):
+        """fetch_html sends reject params when set."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html>OK</html>"
+            mock_resp.headers = {}
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            await client.fetch_html(
+                "https://example.com",
+                reject_resource_types=["image"],
+                reject_request_pattern=[r"\.css$"],
+            )
+
+            payload = mock_ctx.post.call_args.kwargs["json"]
+            assert payload["rejectResourceTypes"] == ["image"]
+            assert payload["rejectRequestPattern"] == [r"\.css$"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -37,7 +37,7 @@ class TestBrowserlessClient:
             assert result == "<html><body>Page content</body></html>"
             call_kwargs = mock_ctx.post.call_args.kwargs
             assert call_kwargs["json"]["url"] == "https://example.com"
-            assert call_kwargs["json"]["waitUntil"] == "networkidle2"
+            assert "waitUntil" not in call_kwargs["json"]
 
     async def test_fetch_html_empty_response(self):
         """fetch_html returns error for empty response."""

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -1,0 +1,137 @@
+"""Tests for Browserless community tools."""
+
+from unittest.mock import MagicMock, patch
+
+import json
+import pytest
+
+from deerflow.community.browserless.browserless_client import BrowserlessClient
+from deerflow.community.browserless import tools
+
+
+class TestBrowserlessClient:
+    """Tests for the BrowserlessClient class."""
+
+    def test_fetch_html_success(self):
+        """fetch_html returns HTML content on success."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html><body>Page content</body></html>"
+            mock_resp.headers = {}
+            mock_ctx.post.return_value = mock_resp
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            result = client.fetch_html("https://example.com")
+
+            assert result == "<html><body>Page content</body></html>"
+            # Verify payload structure
+            call_kwargs = mock_ctx.post.call_args.kwargs
+            assert call_kwargs["json"]["url"] == "https://example.com"
+            assert call_kwargs["json"]["waitUntil"] == "networkidle2"
+
+    def test_fetch_html_empty_response(self):
+        """fetch_html returns error for empty response."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "   "
+            mock_resp.headers = {}
+            mock_ctx.post.return_value = mock_resp
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            result = client.fetch_html("https://example.com")
+            assert result == "Error: Browserless returned empty response"
+
+    def test_fetch_html_http_error(self):
+        """fetch_html returns error for non-200 status."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 500
+            mock_resp.text = "Internal error"
+            mock_resp.headers = {}
+            mock_ctx.post.return_value = mock_resp
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            result = client.fetch_html("https://example.com")
+            assert "Error: Browserless HTTP 500" in result
+
+    def test_fetch_html_timeout(self):
+        """fetch_html returns timeout error."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+            import httpx
+            mock_ctx.post.side_effect = httpx.TimeoutException("Timed out")
+
+            client = BrowserlessClient(base_url="http://browserless:3000", timeout_s=10)
+            result = client.fetch_html("https://example.com")
+            assert "timed out" in result.lower() or "timeout" in result.lower()
+
+    def test_fetch_html_with_token(self):
+        """fetch_html includes token in payload when set."""
+        with patch("deerflow.community.browserless.browserless_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html>OK</html>"
+            mock_resp.headers = {}
+            mock_ctx.post.return_value = mock_resp
+
+            client = BrowserlessClient(base_url="http://browserless:3000", token="my-token")
+            client.fetch_html("https://example.com")
+
+            payload = mock_ctx.post.call_args.kwargs["json"]
+            assert payload["token"] == "my-token"
+
+
+class TestBrowserlessTools:
+    """Tests for the Browserless tool functions."""
+
+    @patch("deerflow.community.browserless.tools._get_browserless_client")
+    def test_web_fetch_tool_success(self, mock_get_client):
+        """web_fetch_tool successfully fetches and extracts content."""
+        mock_client = MagicMock()
+        mock_client.fetch_html.return_value = "<html><body><article><h1>Title</h1><p>Content</p></article></body></html>"
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            result = tools.web_fetch_tool.invoke("https://example.com/article")
+
+        # Should be extracted markdown content
+        assert "Error:" not in result
+
+    @patch("deerflow.community.browserless.tools._get_browserless_client")
+    def test_web_fetch_tool_error(self, mock_get_client):
+        """web_fetch_tool returns error when fetch fails."""
+        mock_client = MagicMock()
+        mock_client.fetch_html.return_value = "Error: Browserless returned empty response"
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            result = tools.web_fetch_tool.invoke("https://example.com")
+
+        assert result.startswith("Error:")
+
+    @patch("deerflow.community.browserless.tools._get_browserless_client")
+    def test_web_fetch_tool_exception(self, mock_get_client):
+        """web_fetch_tool returns error when client raises exception."""
+        mock_client = MagicMock()
+        mock_client.fetch_html.side_effect = Exception("Unexpected error")
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            result = tools.web_fetch_tool.invoke("https://example.com")
+
+        assert result.startswith("Error:")

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -4,12 +4,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from deerflow.community.browserless.browserless_client import BrowserlessClient
 from deerflow.community.browserless import tools
+from deerflow.community.browserless.browserless_client import BrowserlessClient
 
 
 class AsyncMock(MagicMock):
     """Mock that supports async call."""
+
     async def __call__(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)
 
@@ -78,6 +79,7 @@ class TestBrowserlessClient:
             mock_ctx = MagicMock()
             mock_cls.return_value.__aenter__.return_value = mock_ctx
             import httpx
+
             mock_ctx.post = AsyncMock(side_effect=httpx.TimeoutException("Timed out"))
 
             client = BrowserlessClient(base_url="http://browserless:3000", timeout_s=10)

--- a/backend/tests/test_searxng_client.py
+++ b/backend/tests/test_searxng_client.py
@@ -9,10 +9,17 @@ from deerflow.community.searxng.searxng_client import SearxngClient
 from deerflow.community.searxng import tools
 
 
+class AsyncMock(MagicMock):
+    """Mock that supports async call."""
+    async def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
+
+
+@pytest.mark.asyncio
 class TestSearxngClient:
     """Tests for the SearxngClient class."""
 
-    def test_search_success(self):
+    async def test_search_success(self):
         """Search returns normalized results."""
         results_data = {
             "results": [
@@ -21,109 +28,113 @@ class TestSearxngClient:
             ]
         }
 
-        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = results_data
-            mock_ctx.get.return_value = mock_resp
+            mock_resp.raise_for_status.return_value = None
+            mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
-            result = client.search("test query", max_results=5)
+            result = await client.search("test query", max_results=5)
 
             assert len(result) == 2
             assert result[0]["title"] == "Page 1"
             assert result[1]["url"] == "https://example.com/2"
 
-    def test_search_empty_results(self):
+    async def test_search_empty_results(self):
         """Search returns empty list when no results."""
-        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.json.return_value = {"results": []}
-            mock_ctx.get.return_value = mock_resp
+            mock_resp.raise_for_status.return_value = None
+            mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
-            result = client.search("empty query")
+            result = await client.search("empty query")
             assert result == []
 
-    def test_search_http_error(self):
+    async def test_search_http_error(self):
         """Search raises on HTTP error."""
-        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
-            # httpx.HTTPStatusError on raise_for_status
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
             import httpx
             mock_resp = MagicMock()
             mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
                 "403 Forbidden", request=MagicMock(), response=MagicMock()
             )
-            mock_ctx.get.return_value = mock_resp
+            mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
             with pytest.raises(httpx.HTTPStatusError):
-                client.search("blocked query")
+                await client.search("blocked query")
 
-    def test_fetch_success(self):
+    async def test_fetch_success(self):
         """Fetch returns HTML content."""
-        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
             mock_resp.text = "<html><body>Hello</body></html>"
-            mock_ctx.get.return_value = mock_resp
+            mock_resp.raise_for_status.return_value = None
+            mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
-            result = client.fetch("https://example.com")
+            result = await client.fetch("https://example.com")
             assert result == "<html><body>Hello</body></html>"
 
-    def test_fetch_error(self):
+    async def test_fetch_error(self):
         """Fetch returns error string on exception."""
-        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
-            mock_cls.return_value.__enter__.return_value = mock_ctx
-            mock_ctx.get.side_effect = Exception("Connection refused")
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+            mock_ctx.get = AsyncMock(side_effect=Exception("Connection refused"))
 
             client = SearxngClient(base_url="http://searxng:8080")
-            result = client.fetch("https://example.com")
+            result = await client.fetch("https://example.com")
             assert result.startswith("Error:")
 
 
+@pytest.mark.asyncio
 class TestSearxngTools:
     """Tests for the SearXNG tool functions."""
 
     @patch("deerflow.community.searxng.tools._get_searxng_client")
-    def test_web_search_tool_success(self, mock_get_client):
+    async def test_web_search_tool_success(self, mock_get_client):
         """web_search_tool returns JSON results."""
         mock_client = MagicMock()
-        mock_client.search.return_value = [
+        mock_client.search = AsyncMock(return_value=[
             {"title": "Result 1", "url": "https://example.com/1", "content": "Desc 1"},
-        ]
+        ])
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.searxng.tools._get_tool_config", return_value=None):
-            result = tools.web_search_tool.invoke("test query")
+            result = await tools.web_search_tool.ainvoke("test query")
 
         data = json.loads(result)
         assert len(data) == 1
         assert data[0]["title"] == "Result 1"
 
     @patch("deerflow.community.searxng.tools._get_searxng_client")
-    def test_web_search_tool_error(self, mock_get_client):
+    async def test_web_search_tool_error(self, mock_get_client):
         """web_search_tool handles errors gracefully."""
         mock_client = MagicMock()
-        mock_client.search.side_effect = Exception("API error")
+        mock_client.search = AsyncMock(side_effect=Exception("API error"))
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.searxng.tools._get_tool_config", return_value=None):
-            result = tools.web_search_tool.invoke("test query")
+            result = await tools.web_search_tool.ainvoke("test query")
 
         data = json.loads(result)
         assert "error" in data

--- a/backend/tests/test_searxng_client.py
+++ b/backend/tests/test_searxng_client.py
@@ -1,16 +1,17 @@
 """Tests for SearXNG community tools."""
 
+import json
 from unittest.mock import MagicMock, patch
 
-import json
 import pytest
 
-from deerflow.community.searxng.searxng_client import SearxngClient
 from deerflow.community.searxng import tools
+from deerflow.community.searxng.searxng_client import SearxngClient
 
 
 class AsyncMock(MagicMock):
     """Mock that supports async call."""
+
     async def __call__(self, *args, **kwargs):
         return super().__call__(*args, **kwargs)
 
@@ -68,42 +69,46 @@ class TestSearxngClient:
             mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             import httpx
+
             mock_resp = MagicMock()
-            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
-                "403 Forbidden", request=MagicMock(), response=MagicMock()
-            )
+            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError("403 Forbidden", request=MagicMock(), response=MagicMock())
             mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
             with pytest.raises(httpx.HTTPStatusError):
                 await client.search("blocked query")
 
-    async def test_fetch_success(self):
-        """Fetch returns HTML content."""
+    async def test_search_request_error(self):
+        """Search raises on request error."""
+        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
+            import httpx
+
+            mock_ctx.get = AsyncMock(side_effect=httpx.RequestError("Connection refused"))
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            with pytest.raises(httpx.RequestError):
+                await client.search("unreachable query")
+
+    async def test_search_with_categories(self):
+        """Search passes categories parameter."""
         with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
             mock_cls.return_value.__aenter__.return_value = mock_ctx
 
             mock_resp = MagicMock()
             mock_resp.status_code = 200
-            mock_resp.text = "<html><body>Hello</body></html>"
+            mock_resp.json.return_value = {"results": []}
             mock_resp.raise_for_status.return_value = None
             mock_ctx.get = AsyncMock(return_value=mock_resp)
 
             client = SearxngClient(base_url="http://searxng:8080")
-            result = await client.fetch("https://example.com")
-            assert result == "<html><body>Hello</body></html>"
+            await client.search("test", categories=["news", "science"])
 
-    async def test_fetch_error(self):
-        """Fetch returns error string on exception."""
-        with patch("deerflow.community.searxng.searxng_client.httpx.AsyncClient") as mock_cls:
-            mock_ctx = MagicMock()
-            mock_cls.return_value.__aenter__.return_value = mock_ctx
-            mock_ctx.get = AsyncMock(side_effect=Exception("Connection refused"))
-
-            client = SearxngClient(base_url="http://searxng:8080")
-            result = await client.fetch("https://example.com")
-            assert result.startswith("Error:")
+            call_kwargs = mock_ctx.get.call_args.kwargs
+            assert call_kwargs["params"]["categories"] == "news,science"
 
 
 @pytest.mark.asyncio
@@ -114,9 +119,11 @@ class TestSearxngTools:
     async def test_web_search_tool_success(self, mock_get_client):
         """web_search_tool returns JSON results."""
         mock_client = MagicMock()
-        mock_client.search = AsyncMock(return_value=[
-            {"title": "Result 1", "url": "https://example.com/1", "content": "Desc 1"},
-        ])
+        mock_client.search = AsyncMock(
+            return_value=[
+                {"title": "Result 1", "url": "https://example.com/1", "content": "Desc 1"},
+            ]
+        )
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.searxng.tools._get_tool_config", return_value=None):
@@ -138,3 +145,19 @@ class TestSearxngTools:
 
         data = json.loads(result)
         assert "error" in data
+
+    @patch("deerflow.community.searxng.tools._get_searxng_client")
+    async def test_web_search_tool_with_max_results(self, mock_get_client):
+        """web_search_tool respects max_results config."""
+        mock_client = MagicMock()
+        # Return 10 results; the tool should slice to max_results=3
+        mock_client.search = AsyncMock(return_value=[{"title": f"Result {i}", "url": f"https://example.com/{i}", "content": f"Desc {i}"} for i in range(10)])
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.searxng.tools._get_tool_config", return_value={"max_results": "3"}):
+            await tools.web_search_tool.ainvoke("test query")
+
+        # Verify that search was called with max_results=3 (coerced from string)
+        mock_client.search.assert_called_once()
+        call_kwargs = mock_client.search.call_args.kwargs
+        assert call_kwargs["max_results"] == 3

--- a/backend/tests/test_searxng_client.py
+++ b/backend/tests/test_searxng_client.py
@@ -1,0 +1,129 @@
+"""Tests for SearXNG community tools."""
+
+from unittest.mock import MagicMock, patch
+
+import json
+import pytest
+
+from deerflow.community.searxng.searxng_client import SearxngClient
+from deerflow.community.searxng import tools
+
+
+class TestSearxngClient:
+    """Tests for the SearxngClient class."""
+
+    def test_search_success(self):
+        """Search returns normalized results."""
+        results_data = {
+            "results": [
+                {"title": "Page 1", "url": "https://example.com/1", "content": "Snippet 1"},
+                {"title": "Page 2", "url": "https://example.com/2", "content": "Snippet 2"},
+            ]
+        }
+
+        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = results_data
+            mock_ctx.get.return_value = mock_resp
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            result = client.search("test query", max_results=5)
+
+            assert len(result) == 2
+            assert result[0]["title"] == "Page 1"
+            assert result[1]["url"] == "https://example.com/2"
+
+    def test_search_empty_results(self):
+        """Search returns empty list when no results."""
+        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {"results": []}
+            mock_ctx.get.return_value = mock_resp
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            result = client.search("empty query")
+            assert result == []
+
+    def test_search_http_error(self):
+        """Search raises on HTTP error."""
+        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+            # httpx.HTTPStatusError on raise_for_status
+            import httpx
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "403 Forbidden", request=MagicMock(), response=MagicMock()
+            )
+            mock_ctx.get.return_value = mock_resp
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            with pytest.raises(httpx.HTTPStatusError):
+                client.search("blocked query")
+
+    def test_fetch_success(self):
+        """Fetch returns HTML content."""
+        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html><body>Hello</body></html>"
+            mock_ctx.get.return_value = mock_resp
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            result = client.fetch("https://example.com")
+            assert result == "<html><body>Hello</body></html>"
+
+    def test_fetch_error(self):
+        """Fetch returns error string on exception."""
+        with patch("deerflow.community.searxng.searxng_client.httpx.Client") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__enter__.return_value = mock_ctx
+            mock_ctx.get.side_effect = Exception("Connection refused")
+
+            client = SearxngClient(base_url="http://searxng:8080")
+            result = client.fetch("https://example.com")
+            assert result.startswith("Error:")
+
+
+class TestSearxngTools:
+    """Tests for the SearXNG tool functions."""
+
+    @patch("deerflow.community.searxng.tools._get_searxng_client")
+    def test_web_search_tool_success(self, mock_get_client):
+        """web_search_tool returns JSON results."""
+        mock_client = MagicMock()
+        mock_client.search.return_value = [
+            {"title": "Result 1", "url": "https://example.com/1", "content": "Desc 1"},
+        ]
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.searxng.tools._get_tool_config", return_value=None):
+            result = tools.web_search_tool.invoke("test query")
+
+        data = json.loads(result)
+        assert len(data) == 1
+        assert data[0]["title"] == "Result 1"
+
+    @patch("deerflow.community.searxng.tools._get_searxng_client")
+    def test_web_search_tool_error(self, mock_get_client):
+        """web_search_tool handles errors gracefully."""
+        mock_client = MagicMock()
+        mock_client.search.side_effect = Exception("API error")
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.searxng.tools._get_tool_config", return_value=None):
+            result = tools.web_search_tool.invoke("test query")
+
+        data = json.loads(result)
+        assert "error" in data


### PR DESCRIPTION
## Summary

Add two new community-contributed web tools:

### SearXNG `web_search`
- Privacy-focused meta search engine integration
- No API key required, self-hosted SearXNG instance
- Configurable via `config.yaml` `tools.web_search.base_url`

### Browserless `web_fetch`
- Headless Chrome page fetching for rendered HTML content
- Extract article content with readability
- Configurable via `config.yaml` `tools.web_fetch.base_url`

## Configuration example

Add to your `config.yaml`:

```yaml
tools:
  - name: web_search
    group: web
    use: deerflow.community.searxng.tools:web_search_tool
    base_url: http://localhost:8088
    max_results: 5

  - name: web_fetch
    group: web
    use: deerflow.community.browserless.tools:web_fetch_tool
    base_url: http://localhost:3032
```

## Testing
- ? Tested with local SearXNG Docker instance
- ? Tested with local Browserless Docker instance
- ? Works on Windows Docker Desktop