### PR TITLE
fix(sandbox): persist lazily-acquired sandbox state via Command

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -1,10 +1,14 @@
 import asyncio
 import logging
+from collections.abc import Awaitable, Callable
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
+from langgraph.types import Command
 
 from deerflow.agents.thread_state import SandboxState, ThreadDataState
 from deerflow.sandbox import get_sandbox_provider
@@ -126,3 +130,92 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
 
         # No sandbox to release
         return await super().aafter_agent(state, runtime)
+
+    # ------------------------------------------------------------------
+    # Tool-call wrappers: persist lazily-acquired sandbox state into the
+    # graph state via Command(update=...).
+    #
+    # Background:
+    #   ``ensure_sandbox_initialized*`` in ``deerflow.sandbox.tools`` mutates
+    #   ``runtime.state["sandbox"]`` directly. That mutation is local to the
+    #   current tool invocation and is NOT picked up by LangGraph's channel
+    #   reducer, so subsequent graph steps (and downstream consumers such as
+    #   ``ToolOutputBudgetMiddleware`` and the sub-agent ``task_tool``)
+    #   cannot observe the sandbox id. Wrapping the tool call lets us detect
+    #   a fresh lazy init by diffing the state snapshot before/after the
+    #   handler and emit a proper state update via ``Command``.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_sandbox_id_from_state(state: object) -> str | None:
+        if not isinstance(state, dict):
+            return None
+        sandbox_state = state.get("sandbox")
+        if not isinstance(sandbox_state, dict):
+            return None
+        sandbox_id = sandbox_state.get("sandbox_id")
+        return sandbox_id if isinstance(sandbox_id, str) else None
+
+    @staticmethod
+    def _attach_sandbox_update(result: ToolMessage | Command, sandbox_id: str) -> ToolMessage | Command:
+        """Wrap or merge ``result`` so that ``sandbox.sandbox_id`` is persisted.
+
+        - ``ToolMessage`` -> ``Command(update={"sandbox": ..., "messages": [msg]})``
+        - ``Command`` with dict update -> merge ``sandbox`` key, preserve all
+          existing fields (``messages``, ``goto``, ``graph``, ``resume``, ...).
+        - ``Command`` with non-dict / None update -> leave it untouched to
+          avoid silent data loss on unknown update shapes.
+        """
+        sandbox_update = {"sandbox": {"sandbox_id": sandbox_id}}
+
+        if isinstance(result, ToolMessage):
+            return Command(update={**sandbox_update, "messages": [result]})
+
+        existing_update = result.update
+        if isinstance(existing_update, dict):
+            merged_update = {**existing_update, **sandbox_update}
+            return Command(
+                update=merged_update,
+                graph=result.graph,
+                resume=result.resume,
+                goto=result.goto,
+            )
+        return result
+
+    @staticmethod
+    def _read_sandbox_id_from_request(request: ToolCallRequest) -> str | None:
+        """Read sandbox_id from runtime.state (where ensure_sandbox_initialized writes)."""
+        runtime = request.runtime
+        if runtime is None or runtime.state is None:
+            return None
+        return SandboxMiddleware._read_sandbox_id_from_state(runtime.state)
+
+    @override
+    def wrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    ) -> ToolMessage | Command:
+        prev_sandbox_id = self._read_sandbox_id_from_request(request)
+        result = handler(request)
+        if prev_sandbox_id is not None:
+            return result
+        curr_sandbox_id = self._read_sandbox_id_from_request(request)
+        if curr_sandbox_id is None:
+            return result
+        return self._attach_sandbox_update(result, curr_sandbox_id)
+
+    @override
+    async def awrap_tool_call(
+        self,
+        request: ToolCallRequest,
+        handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
+    ) -> ToolMessage | Command:
+        prev_sandbox_id = self._read_sandbox_id_from_request(request)
+        result = await handler(request)
+        if prev_sandbox_id is not None:
+            return result
+        curr_sandbox_id = self._read_sandbox_id_from_request(request)
+        if curr_sandbox_id is None:
+            return result
+        return self._attach_sandbox_update(result, curr_sandbox_id)

--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import replace as dc_replace
 from typing import NotRequired, override
 
 from langchain.agents import AgentState
@@ -174,12 +175,7 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
         existing_update = result.update
         if isinstance(existing_update, dict):
             merged_update = {**existing_update, **sandbox_update}
-            return Command(
-                update=merged_update,
-                graph=result.graph,
-                resume=result.resume,
-                goto=result.goto,
-            )
+            return dc_replace(result, update=merged_update)
         return result
 
     @staticmethod

--- a/backend/tests/fixtures/replay/write_read_file.ultra.events.json
+++ b/backend/tests/fixtures/replay/write_read_file.ultra.events.json
@@ -69,6 +69,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"
@@ -79,6 +80,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"
@@ -89,6 +91,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"
@@ -99,6 +102,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"
@@ -109,6 +113,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"
@@ -119,6 +124,7 @@
       "keys": [
         "artifacts",
         "messages",
+        "sandbox",
         "thread_data",
         "title",
         "viewed_images"

--- a/backend/tests/test_sandbox_middleware.py
+++ b/backend/tests/test_sandbox_middleware.py
@@ -5,7 +5,10 @@ import asyncio
 import pytest
 from langchain.agents.middleware import AgentMiddleware
 from langchain.tools import ToolRuntime
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
+from langgraph.types import Command
 
 from deerflow.sandbox.middleware import SandboxMiddleware
 from deerflow.sandbox.sandbox import Sandbox
@@ -223,3 +226,153 @@ async def test_aafter_agent_delegates_to_super_when_no_sandbox(monkeypatch: pyte
 
     assert result == {"delegated": True}
     assert calls == [(state, runtime)]
+
+
+# ---------------------------------------------------------------------------
+# wrap_tool_call / awrap_tool_call: persistent sandbox state via Command
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_call_request(state: dict) -> ToolCallRequest:
+    """Build a minimal ToolCallRequest backed by a real ToolRuntime."""
+    runtime = ToolRuntime(
+        state=state,
+        context={},
+        config={"configurable": {}},
+        stream_writer=lambda _: None,
+        tools=[],
+        tool_call_id="call-1",
+        store=None,
+    )
+    return ToolCallRequest(
+        tool_call={"id": "call-1", "name": "bash", "args": {}},
+        tool=None,
+        state=state,
+        runtime=runtime,
+    )
+
+
+def test_wrap_tool_call_emits_command_when_lazy_init_happens() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+
+    def handler(req: ToolCallRequest) -> ToolMessage:
+        # Simulate ensure_sandbox_initialized() mutating runtime.state in-place.
+        req.runtime.state["sandbox"] = {"sandbox_id": "new-sandbox"}
+        return ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert isinstance(result.update, dict)
+    assert result.update["sandbox"] == {"sandbox_id": "new-sandbox"}
+    messages = result.update["messages"]
+    assert len(messages) == 1
+    assert messages[0].content == "ok"
+    assert messages[0].tool_call_id == "call-1"
+
+
+def test_wrap_tool_call_passthrough_when_sandbox_already_in_state() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {"sandbox": {"sandbox_id": "existing"}}
+    request = _make_tool_call_request(state)
+    original = ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    def handler(req: ToolCallRequest) -> ToolMessage:
+        return original
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert result is original
+
+
+def test_wrap_tool_call_passthrough_when_handler_did_not_initialize_sandbox() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+    original = ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    def handler(req: ToolCallRequest) -> ToolMessage:
+        return original
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert result is original
+
+
+def test_wrap_tool_call_merges_with_existing_command_update() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+    tool_msg = ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    def handler(req: ToolCallRequest) -> Command:
+        req.runtime.state["sandbox"] = {"sandbox_id": "new-sandbox"}
+        return Command(
+            update={
+                "messages": [tool_msg],
+                "viewed_images": {"a.png": {"base64": "x", "mime_type": "image/png"}},
+            },
+            goto="next-node",
+        )
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert result.goto == "next-node"
+    assert isinstance(result.update, dict)
+    assert result.update["messages"] == [tool_msg]
+    assert result.update["viewed_images"] == {"a.png": {"base64": "x", "mime_type": "image/png"}}
+    assert result.update["sandbox"] == {"sandbox_id": "new-sandbox"}
+
+
+def test_wrap_tool_call_does_not_override_non_dict_update() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+    cmd = Command(update=[("messages", [ToolMessage(content="x", tool_call_id="c", name="bash")])])
+
+    def handler(req: ToolCallRequest) -> Command:
+        req.runtime.state["sandbox"] = {"sandbox_id": "new-sandbox"}
+        return cmd
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    # Non-dict update is left untouched to avoid silent data loss.
+    assert result is cmd
+
+
+@pytest.mark.anyio
+async def test_awrap_tool_call_emits_command_when_lazy_init_happens() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        req.runtime.state["sandbox"] = {"sandbox_id": "async-new"}
+        return ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert isinstance(result.update, dict)
+    assert result.update["sandbox"] == {"sandbox_id": "async-new"}
+    messages = result.update["messages"]
+    assert len(messages) == 1
+    assert messages[0].content == "ok"
+
+
+@pytest.mark.anyio
+async def test_awrap_tool_call_passthrough_when_sandbox_already_in_state() -> None:
+    middleware = SandboxMiddleware()
+    state: dict = {"sandbox": {"sandbox_id": "existing"}}
+    request = _make_tool_call_request(state)
+    original = ToolMessage(content="ok", tool_call_id="call-1", name="bash")
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        return original
+
+    result = await middleware.awrap_tool_call(request, handler)
+
+    assert result is original

--- a/backend/tests/test_sandbox_middleware.py
+++ b/backend/tests/test_sandbox_middleware.py
@@ -376,3 +376,33 @@ async def test_awrap_tool_call_passthrough_when_sandbox_already_in_state() -> No
     result = await middleware.awrap_tool_call(request, handler)
 
     assert result is original
+
+
+def test_wrap_tool_call_preserves_existing_command_fields_when_merging() -> None:
+    """Regression: when merging sandbox_update into an existing Command,
+    all other Command fields (e.g. graph, goto, resume) must be preserved.
+    """
+    middleware = SandboxMiddleware()
+    state: dict = {}
+    request = _make_tool_call_request(state)
+
+    def handler(req: ToolCallRequest) -> Command:
+        req.runtime.state["sandbox"] = {"sandbox_id": "sbx-merge"}
+        return Command(
+            update={"existing_key": "existing_value"},
+            graph="parent",
+            goto="next_node",
+            resume="resume-token",
+        )
+
+    result = middleware.wrap_tool_call(request, handler)
+
+    assert isinstance(result, Command)
+    assert result.update == {
+        "existing_key": "existing_value",
+        "sandbox": {"sandbox_id": "sbx-merge"},
+    }
+    # Critical: other Command fields must NOT be dropped by the merge.
+    assert result.graph == "parent"
+    assert result.goto == "next_node"
+    assert result.resume == "resume-token"


### PR DESCRIPTION
Fixes #3463

## Why

While using the sandbox, `ensure_sandbox_initialized` is invoked and
acquires a sandbox successfully, but the freshly-acquired `sandbox_id`
cannot be observed from `state["sandbox"]` in any subsequent graph step.

Root cause: `ensure_sandbox_initialized` /
`ensure_sandbox_initialized_async` in `deerflow/sandbox/tools.py`
persist the sandbox id by **mutating `runtime.state["sandbox"]` in
place**. LangGraph's state is an immutable snapshot that can only be
updated by returning a `dict` or `Command(update=...)` so the channel
reducer can merge it. In-place mutation is local to the current tool
invocation and is silently dropped — so:

- subsequent graph steps don't see the sandbox id
- downstream consumers (`ToolOutputBudgetMiddleware`, sub-agent
  `task_tool`, checkpoint/resume) cannot read the sandbox from state
- the sandbox may be unnecessarily re-acquired

The reporter asked for a fix that goes through "a proper middleware /
update path", which matches the approach taken here.

## What changed

- `SandboxMiddleware` now overrides the official `wrap_tool_call` /
  `awrap_tool_call` hooks. It snapshots `runtime.state["sandbox"]
  ["sandbox_id"]` before the handler runs; if it transitions from
  `None` to a value, the handler triggered a lazy init and the wrapper
  emits a proper `Command(update={"sandbox": {"sandbox_id": <id>}})` so
  the channel reducer persists it.
- Three handler return shapes are handled explicitly:
  - `ToolMessage` → wrapped into
    `Command(update={"sandbox": ..., "messages": [msg]})`
  - `Command` with a dict `update` → merge the `sandbox` key while
    preserving `messages` / `goto` / `graph` / `resume`
  - `Command` with a non-dict `update` (e.g. list of tuples) →
    passthrough unchanged, to avoid silent data loss on unknown shapes
- If sandbox id was already in state (`prev is not None`), the wrapper
  short-circuits — no duplicate emits.
- The production `ensure_sandbox_initialized` body is intentionally
  not touched. The fix is confined to the middleware, keeping the
  change surface minimal and avoiding ripple effects across the ~8
  tool call-sites that depend on it.

From a caller's perspective: after this PR, any tool that triggers
lazy sandbox initialization will correctly propagate the
`sandbox.sandbox_id` to graph state, and all downstream middleware /
sub-agents / SSE consumers will see it.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [x] **Agents / LangGraph** — `SandboxMiddleware` gains
      `wrap_tool_call` / `awrap_tool_call` hooks that emit `Command`
      state updates
- [x] **Sandbox** — fix targets sandbox lazy-init state persistence
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change** — state now correctly contains
      `sandbox.sandbox_id` after lazy init; this is the intended /
      documented behavior, just previously broken
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

N/A — backend-only change.

## Bug fix verification

- The bug shows up as a missing `"sandbox"` key in the streamed SSE
  `values` events for any scenario that triggers lazy sandbox init.
  This is captured by the existing replay golden test
  `tests/test_replay_golden.py::test_replay_write_read_file_ultra_matches_golden`.
- On `main`, the golden expects no `"sandbox"` key in the `values`
  events; with this fix the test goes red because the streamed events
  now correctly carry `"sandbox"`. The golden was regenerated with
  `DEERFLOW_WRITE_GOLDEN=1` per the in-file instructions, and the diff
  is exactly six insertions of `"sandbox"` in alphabetical position —
  no other changes. This is the direct evidence that the fix is
  effective.
- 7 new unit tests in `tests/test_sandbox_middleware.py` cover:
  - sync / async lazy-init → emits `Command` with merged
    `sandbox` + `messages`
  - passthrough when sandbox already in state (sync + async)
  - passthrough when handler did not initialize sandbox
  - merge with existing `Command` dict update preserves `goto` and
    other fields
  - non-dict `Command` update is left untouched

## Validation

Backend:

```bash
cd backend && make format
# All checks passed!
# 515 files left unchanged
```

In the Docker dev container (per CONTRIBUTING.md):

```bash
# Focused: middleware test file
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
  tests/test_sandbox_middleware.py -v
# 16 passed (9 existing + 7 new, no regression)

# Sandbox-related suites
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
  tests/test_sandbox_middleware.py \
  tests/test_sandbox_tools_security.py \
  tests/test_sandbox_search_tools.py \
  tests/test_write_file_tool_size_guard.py -v
# 148 passed

# Replay golden (regenerate then verify)
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 DEERFLOW_WRITE_GOLDEN=1 \
  uv run pytest tests/test_replay_golden.py -v
# 1 passed
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
  uv run pytest tests/test_replay_golden.py -v
# 1 passed
```