### PR TITLE
fix(persistence): fix runtime journal run lifecycle events

### DIFF
--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -164,7 +164,18 @@ class RunJournal(BaseCallbackHandler):
                 metadata={"caller": caller, **(metadata or {})},
             )
 
-    def on_chain_end(self, outputs: Any, *, run_id: UUID, **kwargs: Any) -> None:
+    def on_chain_end(
+        self,
+        outputs: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Nested chain ends fire for internal graph nodes; only the root chain
+        # represents the user-visible run lifecycle.
+        if parent_run_id is not None:
+            return
         self._put(event_type="run.end", category="outputs", content=outputs, metadata={"status": "success"})
         self._flush_sync()
 

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -179,15 +179,16 @@ class TestLifecycleCallbacks:
         assert "run.end" in types
 
     @pytest.mark.anyio
-    async def test_nested_chain_no_run_start(self, journal_setup):
-        """Nested chains (parent_run_id set) should NOT produce run.start."""
+    async def test_nested_chain_no_run_lifecycle_events(self, journal_setup):
+        """Nested chains (parent_run_id set) should NOT produce root run lifecycle events."""
         j, store = journal_setup
         parent_id = uuid4()
         j.on_chain_start({}, {}, run_id=uuid4(), parent_run_id=parent_id)
-        j.on_chain_end({}, run_id=uuid4())
+        j.on_chain_end({}, run_id=uuid4(), parent_run_id=parent_id)
         await j.flush()
         events = await store.list_events("t1", "r1")
         assert not any(e["event_type"] == "run.start" for e in events)
+        assert not any(e["event_type"] == "run.end" for e in events)
 
 
 class TestToolCallbacks:


### PR DESCRIPTION
## Summary

- prevent nested LangChain chain completions from being persisted as root `run.end` events
- keep `run.end` reserved for the root agent invocation lifecycle
- add regression coverage for nested chain lifecycle callbacks

## Root Cause

`RunJournal.on_chain_start()` already treats only `parent_run_id is None` as the root run start, but `on_chain_end()` wrote `run.end` for every chain completion. In LangGraph agent runs, nested graph nodes also emit `on_chain_end`, so a single run could produce many misleading `run.end` records.

## Impact

This keeps run lifecycle observability accurate. Nested/internal graph node outputs no longer pollute `run_events` as user-visible run completions.

Fixes #3469.

## Validation

```bash
uv run pytest tests/test_run_journal.py
```
