### PR TITLE
fix(docker): default Gateway to a single worker to prevent multi-worker breakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ Access: http://localhost:2026
 
 The unified nginx endpoint is same-origin by default and does not emit browser CORS headers. If you run a split-origin or port-forwarded browser client, set `GATEWAY_CORS_ORIGINS` to comma-separated exact origins such as `http://localhost:3000`; the Gateway then applies the CORS allowlist and matching CSRF origin checks.
 
+> [!IMPORTANT]
+> The Gateway holds run state (RunManager and the stream bridge) in process, so production defaults to a single Gateway worker (`GATEWAY_WORKERS=1`). Raising the worker count without a shared cross-worker stream bridge — which is not yet available — breaks run cancellation, SSE reconnects, request de-duplication, and IM channels, because nginx uses no sticky sessions and each worker keeps its own run state. Scale a single worker up with more CPU/RAM (or move the database and sandbox onto dedicated tiers) instead of raising `GATEWAY_WORKERS`.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed Docker development guide.
 
 #### Option 2: Local Development

--- a/backend/tests/test_compose_default_workers.py
+++ b/backend/tests/test_compose_default_workers.py
@@ -1,0 +1,45 @@
+"""Regression test for the Docker Compose default Gateway worker count.
+
+The Gateway holds run state (RunManager and the stream bridge) in process, so
+the default deployment must run a single Uvicorn worker. Running more than one
+worker without a shared cross-worker stream bridge breaks run cancellation, SSE
+reconnects, request de-duplication, and IM channels (nginx has no sticky
+sessions, so requests scatter across workers that each keep their own run
+state). This test pins the safe default so it cannot silently regress to a
+multi-worker default, while still allowing operators to override it once a
+shared stream bridge exists.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPOSE_PATH = REPO_ROOT / "docker" / "docker-compose.yaml"
+
+
+def _gateway_command() -> str:
+    """Return the gateway service command as a single string."""
+    compose = yaml.safe_load(COMPOSE_PATH.read_text(encoding="utf-8"))
+    command = compose["services"]["gateway"]["command"]
+    # ``command`` may load as a scalar string or a list depending on YAML style.
+    if isinstance(command, list):
+        command = " ".join(str(part) for part in command)
+    return command
+
+
+def test_gateway_defaults_to_single_worker():
+    """With GATEWAY_WORKERS unset, the worker count must default to 1."""
+    command = _gateway_command()
+    match = re.search(r"GATEWAY_WORKERS:-(\d+)", command)
+    assert match is not None, f"gateway command must set a GATEWAY_WORKERS default; got: {command}"
+    assert match.group(1) == "1", f"default Gateway worker count must be 1, got {match.group(1)}"
+
+
+def test_gateway_worker_count_remains_overridable():
+    """The worker count must stay configurable, not hard-coded to 1."""
+    command = _gateway_command()
+    assert "${GATEWAY_WORKERS:-1}" in command, f"worker count must use ${{GATEWAY_WORKERS:-1}} so operators can override it; got: {command}"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -72,7 +72,13 @@ services:
         UV_INDEX_URL: ${UV_INDEX_URL:-https://pypi.org/simple}
         UV_EXTRAS: ${UV_EXTRAS:-}
     container_name: deer-flow-gateway
-    command: sh -c "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers ${GATEWAY_WORKERS:-4}"
+    # Gateway hosts the agent runtime with in-process RunManager + StreamBridge
+    # singletons -- run state lives in this worker's memory. Default to a single
+    # worker: with >1 worker and no nginx sticky sessions, run cancel, SSE
+    # reconnect, request dedup, and per-worker IM channel services all break
+    # across workers until a shared (e.g. redis) stream bridge lands, which is
+    # not yet implemented. Override GATEWAY_WORKERS only once that is in place.
+    command: sh -c "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers ${GATEWAY_WORKERS:-1}"
     volumes:
       - ${DEER_FLOW_CONFIG_PATH}:/app/backend/config.yaml:ro
       - ${DEER_FLOW_EXTENSIONS_CONFIG_PATH}:/app/backend/extensions_config.json:ro


### PR DESCRIPTION
## Problem

The default production deployment (`make up`) starts the Gateway with `--workers 4`. But the Gateway holds run state — `RunManager._runs` and the stream bridge — as **in-process singletons**, and nginx in front of it uses **no sticky sessions**. So with the default config, requests for the same run scatter across workers that each keep their own copy of run state. The result, out of the box:

- **Run cancellation** returns 409 when the cancel request lands on a worker that does not own the run.
- **SSE reconnect** (`join`/stream) rebuilds an empty stream on a worker that never ran the request, so clients hang on heartbeats instead of receiving a terminal event.
- **`multitask=reject` de-duplication** only checks the local process, so the same thread can run concurrently on two workers and write the same checkpoint.
- **IM channels** start one channel service per worker, causing duplicate consumption / duplicate replies (and Telegram `getUpdates` 409s).

This is the default `docker compose` configuration, so a fresh `make up` is broken for anything beyond a single in-flight conversation. Reported in #3239 and #3260.

## Root cause

`docker/docker-compose.yaml` defaulted `GATEWAY_WORKERS` to `4`, while the runtime keeps all run state in process and the shared cross-worker stream bridge (e.g. the Redis bridge proposed in #3191) is not yet implemented — the redis path currently raises `NotImplementedError`. Multi-worker safety therefore does not exist yet; the default just silently enabled an unsafe topology.

## Solution (m1 stop-gap)

Make the **default** deployment correct by running a single Gateway worker:

- `docker-compose.yaml`: default `GATEWAY_WORKERS` to `1` (was `4`), with a comment explaining why.
- `README.md`: document the single-worker boundary in the production deployment section so operators understand why and what raising the count breaks.
- Regression test pinning the default to `1` while asserting it stays overridable via `GATEWAY_WORKERS`.

**Scope / trade-offs.** This is a stop-gap, not a multi-worker implementation. It does **not** make the Gateway multi-worker safe — it only stops the default config from shipping a broken topology. The worker count remains operator-overridable via `GATEWAY_WORKERS` for when a shared stream bridge exists. The full fix (shared run state + stream bridge + distributed cancel) is tracked separately in #3191. The Gateway is async I/O–bound, so a single Uvicorn worker comfortably handles concurrent SSE streams; scale a single worker up with more CPU/RAM (or move the database and sandbox onto dedicated tiers) instead of raising the worker count.

Hence `Refs` rather than `Closes`: #3239 / #3260 are only fully resolved once cross-worker run state lands.

## Validation

`docker compose config` renders the effective command (no build / up needed):

```
# default (GATEWAY_WORKERS unset)
... uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 --workers 1

# override still works
GATEWAY_WORKERS=4 ... --workers 4
```

Regression test (`backend/tests/test_compose_default_workers.py`, no Docker dependency — pure YAML parse, runs in CI):

- `test_gateway_defaults_to_single_worker` — default worker count is `1`.
- `test_gateway_worker_count_remains_overridable` — command uses `${GATEWAY_WORKERS:-1}`, so operators can still override it.

Both pass; `make lint` clean.

Refs #3239, #3260
