### PR TITLE
feat(runtime): Redis Streams stream bridge for multi-worker streaming

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -462,6 +462,23 @@ LangSmith and Langfuse are both supported. The wiring lives in two layers:
 
 Returns `{}` when Langfuse is not in the enabled providers — LangSmith-only deployments are unaffected. Set `DEER_FLOW_ENV` (or `ENVIRONMENT`) to tag traces by deployment environment. Tests live in `tests/test_tracing_factory.py`, `tests/test_tracing_metadata.py`, `tests/test_worker_langfuse_metadata.py`, and `tests/test_client_langfuse_metadata.py`.
 
+### Stream Bridge (`packages/harness/deerflow/runtime/stream_bridge/`)
+
+Decouples agent workers (producers) from SSE endpoints (consumers), aligning with LangGraph Platform's Queue + StreamManager architecture. A run's events are published by the worker and replayed/streamed to any number of SSE subscribers (with `Last-Event-ID` reconnection support).
+
+- **Abstract protocol** (`base.py`): `StreamBridge` with `publish` / `publish_end` / `subscribe` / `cleanup` / `refresh_ttl` / `has_retained_stream` / `has_events_after` / `ping`. `subscribe()` yields `StreamEvent` plus `HEARTBEAT_SENTINEL` (idle) and `END_SENTINEL` (producer done). `supports_cross_process_subscribe` tells routers whether `store_only` runs on another worker can be joined.
+- **`MemoryStreamBridge`** (`memory.py`): in-process `asyncio.Queue`, single-process only (`supports_cross_process_subscribe=False`).
+- **`RedisStreamBridge`** (`redis.py`, extra `deerflow-harness[redis]`): Redis Streams backend for multi-worker / multi-replica deployments (`supports_cross_process_subscribe=True`). Any replica can subscribe to a run regardless of which worker produced the events. Key behaviors:
+  - Data-event `publish` is **best-effort with bounded retry**: transient `redis.ConnectionError` / `redis.TimeoutError` / `OSError` are retried with short backoff (`_PUBLISH_RETRY_BACKOFFS`), then the frame is dropped + logged rather than raised, so Redis availability does not couple to run success rate. Note redis-py's `ConnectionError` / `TimeoutError` do **not** inherit from builtin `OSError`, so all three are caught explicitly (`self._retryable_errors`).
+  - **Dual connection pools**: a command pool (`redis_max_command_connections`) for publish/cleanup/refresh_ttl/boundary probes, isolated from a blocking subscribe pool (`redis_max_blocking_connections`) so SSE subscriber floods cannot starve publishes.
+  - END is written as a normal stream entry (`event=__end__`) so ordering and late-join replay are preserved; the Redis stream entry id (`<ms>-<seq>`) is used directly as the SSE `id:`.
+  - TTL: `refresh_ttl` is sampled at most once per 60s on the publish hot path; long-idle runs are kept alive by the worker TTL keeper (`worker.py`). `redis_ttl_seconds` (default 24h, min 60s) is the fallback expiry when cleanup is missed.
+  - Oversized payloads (> `redis_max_payload_bytes`) are rejected (dropped for data events) and logged.
+- **Async factory** (`async_provider.py`): `make_stream_bridge(app_config=None)` is an async context manager; reads `app_config.stream_bridge` (or the global `get_stream_bridge_config()` when called with no args), constructs the backend, and `await bridge.ping()`s redis on startup. Falls back to memory when unconfigured.
+- **Config** (`config/stream_bridge_config.py` → `config.yaml` `stream_bridge`): `type` (`memory`|`redis`), `redis_url`, `queue_maxsize`, pool sizes/timeouts, `redis_ttl_seconds`, `redis_max_payload_bytes`, `redis_key_prefix`, `redis_require_tls`. `stream_bridge` is a **startup-only** field (see reload boundary above).
+- **Terminal helpers** (`runtime/runs/terminal.py`): single source of truth for `TERMINAL_STATUSES` and `build_end_payload()`, shared by the router-level terminal short-circuit (`thread_runs.py`) and the service-layer terminal reconciliation (`services.py`) so the real / short-circuit / synthetic `end` frames never drift.
+- **Tests**: `tests/test_redis_stream_bridge.py` (fakeredis unit tests), `tests/test_terminal_reconcile.py`, `tests/test_worker_stream_ttl.py`, `tests/test_run_store_user_scope.py`.
+
 ### Config Schema
 
 **`config.yaml`** key sections:

--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -22,8 +22,8 @@ from pydantic import BaseModel, Field
 from app.gateway.authz import require_permission
 from app.gateway.deps import get_checkpointer, get_current_user, get_feedback_repo, get_run_event_store, get_run_manager, get_run_store, get_stream_bridge
 from app.gateway.pagination import trim_run_message_page
-from app.gateway.services import sse_consumer, start_run, wait_for_run_completion
-from deerflow.runtime import RunRecord, RunStatus, serialize_channel_values
+from app.gateway.services import sse_consumer, start_run, terminal_stream_response, wait_for_run_completion
+from deerflow.runtime import TERMINAL_STATUSES, RunRecord, RunStatus, serialize_channel_values
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/threads", tags=["runs"])
@@ -107,6 +107,25 @@ def _cancel_conflict_detail(run_id: str, record: RunRecord) -> str:
     if record.status in (RunStatus.pending, RunStatus.running):
         return f"Run {run_id} is not active on this worker and cannot be cancelled"
     return f"Run {run_id} is not cancellable (status: {record.status.value})"
+
+
+async def _terminal_short_circuit(bridge: Any, record: RunRecord) -> StreamingResponse | None:
+    """Short-circuit a late join on an already-terminal run (problem J/Q/T).
+
+    Returns a single terminal ``end`` response when the run is terminal *and*
+    its retained stream is gone; otherwise ``None`` so the caller falls through
+    to a normal subscribe (which replays any retained events and reads the real
+    END).  A probe failure is treated conservatively as "stream may exist".
+    """
+    if record.status not in TERMINAL_STATUSES:
+        return None
+    try:
+        retained = await bridge.has_retained_stream(record.run_id)
+    except Exception:
+        retained = True
+    if retained:
+        return None
+    return terminal_stream_response(record)
 
 
 def _record_to_response(record: RunRecord) -> RunResponse:
@@ -261,13 +280,19 @@ async def cancel_run(
 async def join_run(thread_id: str, run_id: str, request: Request) -> StreamingResponse:
     """Join an existing run's SSE stream."""
     run_mgr = get_run_manager(request)
-    record = await run_mgr.get(run_id)
+    user_id = await get_current_user(request)
+    record = await run_mgr.get(run_id, user_id=user_id)
     if record is None or record.thread_id != thread_id:
         raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-    if record.store_only:
-        raise HTTPException(status_code=409, detail=f"Run {run_id} is not active on this worker and cannot be streamed")
 
     bridge = get_stream_bridge(request)
+    if record.store_only and not bridge.supports_cross_process_subscribe:
+        raise HTTPException(status_code=409, detail=f"Run {run_id} is not active on this worker and cannot be streamed")
+
+    short_circuit = await _terminal_short_circuit(bridge, record)
+    if short_circuit is not None:
+        return short_circuit
+
     return StreamingResponse(
         sse_consumer(bridge, record, request, run_mgr),
         media_type="text/event-stream",
@@ -301,14 +326,27 @@ async def stream_existing_run(
     remaining buffered events so the client observes a clean shutdown.
     """
     run_mgr = get_run_manager(request)
-    record = await run_mgr.get(run_id)
+    user_id = await get_current_user(request)
+    record = await run_mgr.get(run_id, user_id=user_id)
     if record is None or record.thread_id != thread_id:
         raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
-    if record.store_only and action is None:
+
+    bridge = get_stream_bridge(request)
+    if record.store_only and action is None and not bridge.supports_cross_process_subscribe:
         raise HTTPException(status_code=409, detail=f"Run {run_id} is not active on this worker and cannot be streamed")
 
     # Cancel if an action was requested (stop-button / interrupt flow)
     if action is not None:
+        if record.store_only:
+            # Cross-worker cancel is not supported: the task lives on another
+            # worker and the Redis bridge does not forward control commands.
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Run is active on another worker. Cross-worker cancel is not "
+                    "supported yet; retry on the owner worker or enable sticky routing."
+                ),
+            )
         cancelled = await run_mgr.cancel(run_id, action=action)
         if not cancelled:
             raise HTTPException(status_code=409, detail=_cancel_conflict_detail(run_id, record))
@@ -319,7 +357,10 @@ async def stream_existing_run(
                 pass
             return Response(status_code=204)
 
-    bridge = get_stream_bridge(request)
+    short_circuit = await _terminal_short_circuit(bridge, record)
+    if short_circuit is not None:
+        return short_circuit
+
     return StreamingResponse(
         sse_consumer(bridge, record, request, run_mgr),
         media_type="text/event-stream",

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -11,20 +11,23 @@ import asyncio
 import json
 import logging
 import re
+import time
 from collections.abc import Mapping
 from typing import Any
 
 from fastapi import HTTPException, Request
+from fastapi.responses import StreamingResponse
 from langchain_core.messages import BaseMessage
 from langchain_core.messages.utils import convert_to_messages
 
-from app.gateway.deps import get_run_context, get_run_manager, get_stream_bridge
+from app.gateway.deps import get_current_user, get_run_context, get_run_manager, get_stream_bridge
 from app.gateway.internal_auth import INTERNAL_SYSTEM_ROLE
 from app.gateway.utils import sanitize_log_param
 from deerflow.config.app_config import get_app_config
 from deerflow.runtime import (
     END_SENTINEL,
     HEARTBEAT_SENTINEL,
+    TERMINAL_STATUSES,
     ConflictError,
     DisconnectMode,
     RunManager,
@@ -32,11 +35,17 @@ from deerflow.runtime import (
     RunStatus,
     StreamBridge,
     UnsupportedStrategyError,
+    build_end_payload,
     run_agent,
 )
 from deerflow.runtime.runs.naming import resolve_root_run_name
 
 logger = logging.getLogger(__name__)
+
+# Sustained-silence window after which an active subscription reconciles its run
+# against the RunStore (problem K/S).  Decoupled from the heartbeat period; the
+# worst-case hang for a lost ``publish_end`` is bounded by this value.
+RECONCILE_INTERVAL = 30.0
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +67,32 @@ def format_sse(event: str, data: Any, *, event_id: str | None = None) -> str:
     parts.append("")
     parts.append("")
     return "\n".join(parts)
+
+
+_SSE_HEADERS = {
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+}
+
+
+def terminal_stream_response(record: RunRecord) -> StreamingResponse:
+    """Emit a single terminal ``end`` frame for an already-finished run.
+
+    Used by the router-level terminal short-circuit (problem J/Q): when a run
+    is terminal and its retained stream is gone, a late join must not hang on
+    heartbeats.  Reuses :func:`build_end_payload` so this end frame shares the
+    same ``{status, error}`` schema as the real and synthetic end frames.
+    """
+
+    async def _gen() -> Any:
+        yield format_sse("end", build_end_payload(record))
+
+    return StreamingResponse(
+        _gen(),
+        media_type="text/event-stream",
+        headers=_SSE_HEADERS,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -394,27 +429,95 @@ async def sse_consumer(
     The ``finally`` block implements ``on_disconnect`` semantics:
     - ``cancel``: abort the background task on client disconnect.
     - ``continue``: let the task run; events are discarded.
+
+    For cross-process backends an active subscription may hang on heartbeats if
+    a best-effort ``publish_end`` was lost (problem K/U).  During sustained
+    silence the consumer reconciles against the RunStore: if the run is terminal
+    and no event exists after the current cursor, it synthesises an ``end`` frame
+    and closes.  All three end paths (real / short-circuit / synthetic) share the
+    same ``{status, error}`` payload via :func:`build_end_payload`.
     """
     last_event_id = request.headers.get("Last-Event-ID")
+    user_id = await get_current_user(request)
+    last_reconcile_at = time.monotonic()
+    last_seen_event_id = last_event_id or "0-0"
     try:
         async for entry in bridge.subscribe(record.run_id, last_event_id=last_event_id):
             if await request.is_disconnected():
                 break
 
             if entry is HEARTBEAT_SENTINEL:
+                now = time.monotonic()
+                if now - last_reconcile_at >= RECONCILE_INTERVAL:
+                    last_reconcile_at = now
+                    synthetic = await _reconcile_terminal_end(
+                        bridge, record.run_id, last_seen_event_id, run_mgr, user_id
+                    )
+                    if synthetic is not None:
+                        yield synthetic
+                        return
                 yield ": heartbeat\n\n"
                 continue
 
+            last_reconcile_at = time.monotonic()
+
             if entry is END_SENTINEL:
-                yield format_sse("end", None, event_id=entry.id or None)
+                latest = await _safe_get_run(run_mgr, record.run_id, user_id) or record
+                yield format_sse("end", build_end_payload(latest), event_id=entry.id or None)
                 return
 
+            if entry.id:
+                last_seen_event_id = entry.id
             yield format_sse(entry.event, entry.data, event_id=entry.id or None)
 
     finally:
         if record.status in (RunStatus.pending, RunStatus.running):
             if record.on_disconnect == DisconnectMode.cancel:
-                await run_mgr.cancel(record.run_id)
+                if record.store_only:
+                    # Cross-worker run: cancel is a no-op here (the owner worker
+                    # holds the task). Declare the degradation rather than
+                    # silently swallowing it (problem A).
+                    logger.info(
+                        "on_disconnect=cancel skipped for cross-worker run %s; "
+                        "owner worker retains the task",
+                        record.run_id,
+                    )
+                else:
+                    await run_mgr.cancel(record.run_id)
+
+
+async def _safe_get_run(run_mgr: RunManager, run_id: str, user_id: str | None) -> RunRecord | None:
+    """best-effort RunStore read; failures degrade to None (no synthetic end)."""
+    try:
+        return await run_mgr.get(run_id, user_id=user_id)
+    except Exception:
+        logger.warning("Reconcile RunStore lookup failed for run %s", run_id, exc_info=True)
+        return None
+
+
+async def _reconcile_terminal_end(
+    bridge: StreamBridge,
+    run_id: str,
+    last_seen_event_id: str,
+    run_mgr: RunManager,
+    user_id: str | None,
+) -> str | None:
+    """Return a synthetic terminal ``end`` frame if the run is done and drained.
+
+    Returns ``None`` (keep streaming heartbeats) unless the run is terminal in
+    the RunStore *and* no unconsumed event exists after ``last_seen_event_id``.
+    Any probe failure is conservative: return ``None``.
+    """
+    latest = await _safe_get_run(run_mgr, run_id, user_id)
+    if latest is None or latest.status not in TERMINAL_STATUSES:
+        return None
+    try:
+        if await bridge.has_events_after(run_id, last_seen_event_id):
+            return None
+    except Exception:
+        logger.warning("Reconcile has_events_after failed for run %s", run_id, exc_info=True)
+        return None
+    return format_sse("end", build_end_payload(latest))
 
 
 async def wait_for_run_completion(

--- a/backend/packages/harness/deerflow/config/stream_bridge_config.py
+++ b/backend/packages/harness/deerflow/config/stream_bridge_config.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 StreamBridgeType = Literal["memory", "redis"]
 
@@ -12,16 +12,67 @@ class StreamBridgeConfig(BaseModel):
 
     type: StreamBridgeType = Field(
         default="memory",
-        description="Stream bridge backend type. 'memory' uses in-process asyncio.Queue (single-process only). 'redis' uses Redis Streams (planned for Phase 2, not yet implemented).",
+        description="Stream bridge backend type. 'memory' uses in-process asyncio.Queue (single-process only). 'redis' uses Redis Streams for multi-worker / multi-replica deployments.",
     )
     redis_url: str | None = Field(
         default=None,
-        description="Redis URL for the redis stream bridge type. Example: 'redis://localhost:6379/0'.",
+        description="Redis URL for the redis stream bridge type. Required when type=redis. Example: 'redis://localhost:6379/0'. Environment variables use the '$REDIS_URL' form.",
     )
     queue_maxsize: int = Field(
         default=256,
-        description="Maximum number of events buffered per run in the memory bridge.",
+        gt=0,
+        description="Maximum number of events retained per run (approximate MAXLEN for redis).",
     )
+    redis_max_command_connections: int = Field(
+        default=64,
+        gt=0,
+        description="Command connection pool size, serving publish/cleanup/refresh_ttl/boundary probes. Isolated from the blocking subscribe pool so SSE subscriptions cannot starve publishes.",
+    )
+    redis_max_blocking_connections: int = Field(
+        default=1024,
+        gt=0,
+        description="Blocking subscribe connection pool size; each active SSE subscription consumes one connection. Size by single-process peak SSE concurrency.",
+    )
+    redis_pool_timeout: float = Field(
+        default=1.0,
+        gt=0,
+        description="Fail fast after waiting this many seconds for a connection from either pool.",
+    )
+    redis_socket_timeout: float = Field(
+        default=30.0,
+        gt=0,
+        description="Socket timeout for command connections. Blocking subscribe connections use heartbeat_interval + buffer instead.",
+    )
+    redis_ttl_seconds: int = Field(
+        default=86400,
+        ge=60,
+        description="Fallback key expiry when cleanup is missed. Must exceed the worker cleanup delay (60s). Default 24h so long-idle runs are not dropped.",
+    )
+    redis_max_payload_bytes: int = Field(
+        default=524288,
+        gt=0,
+        description="Maximum serialized event payload size allowed into Redis. Oversized events are rejected (dropped for data events) and logged.",
+    )
+    redis_key_prefix: str = Field(
+        default="df:sb",
+        description="Redis key prefix for stream keys.",
+    )
+    redis_require_tls: bool = Field(
+        default=False,
+        description="When true, only rediss:// URLs are accepted.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_redis(self) -> "StreamBridgeConfig":
+        if self.type != "redis":
+            return self
+        if not self.redis_url:
+            raise ValueError("redis_url is required when stream_bridge.type=redis")
+        if self.redis_ttl_seconds < 60:
+            raise ValueError("redis_ttl_seconds must be >= 60 (greater than worker cleanup delay)")
+        if self.redis_require_tls and not self.redis_url.startswith("rediss://"):
+            raise ValueError("redis_require_tls=true requires a rediss:// URL")
+        return self
 
 
 # Global configuration instance — None means no stream bridge is configured

--- a/backend/packages/harness/deerflow/persistence/run/sql.py
+++ b/backend/packages/harness/deerflow/persistence/run/sql.py
@@ -136,7 +136,10 @@ class RunRepository(RunStore):
             row = await session.get(RunRow, run_id)
             if row is None:
                 return None
-            if resolved_user_id is not None and row.user_id != resolved_user_id:
+            # legacy rows with empty user_id are not hard-filtered (problem
+            # H-compat): only reject when the row has a non-empty user_id that
+            # mismatches; owner_check + thread_id validation backstop access.
+            if resolved_user_id is not None and row.user_id and row.user_id != resolved_user_id:
                 return None
             return self._row_to_dict(row)
 

--- a/backend/packages/harness/deerflow/runtime/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/__init__.py
@@ -6,7 +6,7 @@ directly from ``deerflow.runtime``.
 """
 
 from .checkpointer import checkpointer_context, get_checkpointer, make_checkpointer, reset_checkpointer
-from .runs import ConflictError, DisconnectMode, RunContext, RunManager, RunRecord, RunStatus, UnsupportedStrategyError, run_agent
+from .runs import ConflictError, DisconnectMode, RunContext, RunManager, RunRecord, RunStatus, TERMINAL_STATUSES, UnsupportedStrategyError, build_end_payload, run_agent
 from .serialization import serialize, serialize_channel_values, serialize_lc_object, serialize_messages_tuple
 from .store import get_store, make_store, reset_store, store_context
 from .stream_bridge import END_SENTINEL, HEARTBEAT_SENTINEL, MemoryStreamBridge, StreamBridge, StreamEvent, make_stream_bridge
@@ -24,7 +24,9 @@ __all__ = [
     "RunManager",
     "RunRecord",
     "RunStatus",
+    "TERMINAL_STATUSES",
     "UnsupportedStrategyError",
+    "build_end_payload",
     "run_agent",
     # serialization
     "serialize",

--- a/backend/packages/harness/deerflow/runtime/runs/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/runs/__init__.py
@@ -2,6 +2,7 @@
 
 from .manager import ConflictError, RunManager, RunRecord, UnsupportedStrategyError
 from .schemas import DisconnectMode, RunStatus
+from .terminal import TERMINAL_STATUSES, build_end_payload
 from .worker import RunContext, run_agent
 
 __all__ = [
@@ -11,6 +12,8 @@ __all__ = [
     "RunManager",
     "RunRecord",
     "RunStatus",
+    "TERMINAL_STATUSES",
     "UnsupportedStrategyError",
+    "build_end_payload",
     "run_agent",
 ]

--- a/backend/packages/harness/deerflow/runtime/runs/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/runs/store/memory.py
@@ -50,7 +50,10 @@ class MemoryRunStore(RunStore):
         run = self._runs.get(run_id)
         if run is None:
             return None
-        if user_id is not None and run.get("user_id") != user_id:
+        # legacy rows with empty user_id are not hard-filtered (problem H-compat):
+        # only reject when the row has a non-empty user_id that mismatches.
+        row_user_id = run.get("user_id")
+        if user_id is not None and row_user_id and row_user_id != user_id:
             return None
         return run
 

--- a/backend/packages/harness/deerflow/runtime/runs/terminal.py
+++ b/backend/packages/harness/deerflow/runtime/runs/terminal.py
@@ -1,0 +1,34 @@
+"""Shared terminal-run helpers.
+
+Single source of truth for the set of terminal run statuses and the SSE
+``end`` frame payload shape.  Both the router-level terminal short-circuit
+(``thread_runs.py``) and the service-layer terminal reconciliation
+(``services.py``) import from here so the three ``end`` paths (real END,
+short-circuit end, synthetic end) never drift apart.
+
+This module lives in the harness ``runtime`` layer and must only return
+plain Python data.  It must not depend on FastAPI / Gateway / SSE
+formatting helpers — those belong to the ``app/gateway`` layer.
+"""
+
+from __future__ import annotations
+
+from .manager import RunRecord
+from .schemas import RunStatus
+
+TERMINAL_STATUSES: tuple[RunStatus, ...] = (
+    RunStatus.success,
+    RunStatus.error,
+    RunStatus.timeout,
+    RunStatus.interrupted,
+)
+
+
+def build_end_payload(record: RunRecord) -> dict:
+    """Build the canonical terminal ``end`` frame payload.
+
+    Single construction point shared by the J short-circuit and the K
+    reconciliation so all ``end`` frames carry the same ``{status, error}``
+    schema.
+    """
+    return {"status": record.status.value, "error": record.error}

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -161,6 +161,16 @@ async def run_agent(
             run_id,
         )
 
+    # Active-run TTL keeper: only meaningful for backends with a TTL (redis).
+    # Keeps a long-idle run's retained stream alive independent of event rate
+    # (problem L); cancelled in the finally block regardless of outcome.
+    ttl_keeper_task: asyncio.Task | None = None
+    keeper_ttl = getattr(bridge, "ttl_seconds", None)
+    if isinstance(keeper_ttl, int) and keeper_ttl > 0:
+        ttl_keeper_task = asyncio.create_task(
+            _run_stream_ttl_keeper(bridge, run_id, keeper_ttl)
+        )
+
     try:
         # Initialize RunJournal + write human_message event.
         # These are inside the try block so any exception (e.g. a DB
@@ -388,16 +398,24 @@ async def run_agent(
         error_msg = f"{exc}"
         logger.exception("Run %s failed: %s", run_id, error_msg)
         await run_manager.set_status(run_id, RunStatus.error, error=error_msg)
-        await bridge.publish(
-            run_id,
-            "error",
-            {
-                "message": error_msg,
-                "name": type(exc).__name__,
-            },
-        )
+        # best-effort: a failing error event must not mask the original error
+        try:
+            await bridge.publish(
+                run_id,
+                "error",
+                {
+                    "message": error_msg,
+                    "name": type(exc).__name__,
+                },
+            )
+        except Exception:
+            logger.warning("Failed to publish error event for run %s", run_id, exc_info=True)
 
     finally:
+        # Stop the active-run TTL keeper regardless of outcome.
+        if ttl_keeper_task is not None:
+            ttl_keeper_task.cancel()
+
         # Flush any buffered journal events and persist completion data
         if journal is not None:
             try:
@@ -433,13 +451,41 @@ async def run_agent(
             except Exception:
                 logger.debug("Failed to update thread_meta status for %s (non-fatal)", thread_id)
 
-        await bridge.publish_end(run_id)
-        asyncio.create_task(bridge.cleanup(run_id, delay=60))
+        # best-effort: a failing end event must not override the run status
+        try:
+            await bridge.publish_end(run_id)
+        except Exception:
+            logger.warning("Failed to publish stream end for run %s", run_id, exc_info=True)
+        asyncio.create_task(_safe_cleanup_bridge(bridge, run_id, delay=60))
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+async def _run_stream_ttl_keeper(bridge: StreamBridge, run_id: str, ttl_seconds: int) -> None:
+    """Periodically refresh a run's stream TTL while it is still executing.
+
+    Keeps long-idle runs from losing their retained stream when events are
+    sparse (problem L).  ``refresh_ttl`` is best-effort and never recreates a
+    missing key.  Cancelled by the worker once the run reaches a terminal state.
+    """
+    refresh_every = max(30, min(300, ttl_seconds // 4))
+    try:
+        while True:
+            await asyncio.sleep(refresh_every)
+            await bridge.refresh_ttl(run_id)
+    except asyncio.CancelledError:
+        raise
+
+
+async def _safe_cleanup_bridge(bridge: StreamBridge, run_id: str, *, delay: float = 0) -> None:
+    """best-effort bridge cleanup; failures are logged, never raised."""
+    try:
+        await bridge.cleanup(run_id, delay=delay)
+    except Exception:
+        logger.warning("Failed to cleanup stream bridge for run %s", run_id, exc_info=True)
 
 
 async def _call_checkpointer_method(checkpointer: Any, async_name: str, sync_name: str, *args: Any, **kwargs: Any) -> Any:

--- a/backend/packages/harness/deerflow/runtime/stream_bridge/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/stream_bridge/__init__.py
@@ -10,11 +10,13 @@ by :mod:`asyncio.Queue`.
 from .async_provider import make_stream_bridge
 from .base import END_SENTINEL, HEARTBEAT_SENTINEL, StreamBridge, StreamEvent
 from .memory import MemoryStreamBridge
+from .redis import RedisStreamBridge
 
 __all__ = [
     "END_SENTINEL",
     "HEARTBEAT_SENTINEL",
     "MemoryStreamBridge",
+    "RedisStreamBridge",
     "StreamBridge",
     "StreamEvent",
     "make_stream_bridge",

--- a/backend/packages/harness/deerflow/runtime/stream_bridge/async_provider.py
+++ b/backend/packages/harness/deerflow/runtime/stream_bridge/async_provider.py
@@ -50,6 +50,25 @@ async def make_stream_bridge(app_config: AppConfig | None = None) -> AsyncIterat
         return
 
     if config.type == "redis":
-        raise NotImplementedError("Redis stream bridge planned for Phase 2")
+        try:
+            from deerflow.runtime.stream_bridge.redis import (
+                RedisStreamBridge,
+                mask_redis_url,
+            )
+        except ImportError as exc:
+            raise ImportError(
+                "Install deerflow-harness[redis] to use stream_bridge.type=redis"
+            ) from exc
+
+        bridge = RedisStreamBridge.from_config(config)
+        await bridge.ping()
+        logger.info(
+            "Stream bridge initialised: redis (%s)", mask_redis_url(config.redis_url)
+        )
+        try:
+            yield bridge
+        finally:
+            await bridge.close()
+        return
 
     raise ValueError(f"Unknown stream bridge type: {config.type!r}")

--- a/backend/packages/harness/deerflow/runtime/stream_bridge/base.py
+++ b/backend/packages/harness/deerflow/runtime/stream_bridge/base.py
@@ -37,6 +37,17 @@ END_SENTINEL = StreamEvent(id="", event="__end__", data=None)
 class StreamBridge(abc.ABC):
     """Abstract base for stream bridges."""
 
+    @property
+    def supports_cross_process_subscribe(self) -> bool:
+        """Whether subscribers on a different worker can read this run's events.
+
+        ``False`` for in-process backends (memory).  Backends that share
+        events across processes (redis) return ``True`` so routers can allow
+        ``store_only`` runs to be joined/streamed without knowing the concrete
+        backend type.
+        """
+        return False
+
     @abc.abstractmethod
     async def publish(self, run_id: str, event: str, data: Any) -> None:
         """Enqueue a single event for *run_id* (producer side)."""
@@ -70,3 +81,31 @@ class StreamBridge(abc.ABC):
 
     async def close(self) -> None:
         """Release backend resources.  Default is a no-op."""
+
+    async def refresh_ttl(self, run_id: str) -> None:
+        """Refresh the retention TTL for a still-running stream.
+
+        Default is a no-op for backends without a TTL concept (memory).
+        """
+
+    async def has_retained_stream(self, run_id: str) -> bool:
+        """Whether the backend still retains replayable events for *run_id*.
+
+        Used by terminal short-circuit logic to avoid hanging late joins on
+        a run whose retained stream has already been cleaned up.  Default
+        returns ``True`` (conservative: assume events may exist, fall through
+        to a normal subscribe).
+        """
+        return True
+
+    async def has_events_after(self, run_id: str, last_event_id: str | None) -> bool:
+        """Whether any unconsumed event exists strictly after *last_event_id*.
+
+        Used by the service-layer terminal reconciliation to decide whether a
+        synthetic end is safe.  Default returns ``True`` (conservative).
+        """
+        return True
+
+    async def ping(self) -> None:
+        """Startup health check.  Default is a no-op."""
+

--- a/backend/packages/harness/deerflow/runtime/stream_bridge/redis.py
+++ b/backend/packages/harness/deerflow/runtime/stream_bridge/redis.py
@@ -1,0 +1,402 @@
+"""Redis Streams stream bridge.
+
+Implements :class:`StreamBridge` on top of Redis Streams so that any
+gateway worker / replica can subscribe to a run's stream regardless of
+which worker produced the events.
+
+Design notes (see docs/superpowers/specs/2026-06-10-redis-stream-bridge-design.md):
+
+- Data-event ``publish`` is **best-effort with bounded retry**: transient
+  connection/timeout errors are retried a few times with short backoff;
+  if still failing the frame is dropped (logged) rather than raised, so
+  Redis availability does not couple to run success rate.
+- Subscriptions use a **dedicated blocking connection pool**, isolated from
+  the command pool so a flood of SSE subscribers cannot starve publishes.
+- END is written as a normal stream entry (``event=__end__``) so ordering
+  and late-join replay are preserved.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+from collections import OrderedDict
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from .base import END_SENTINEL, HEARTBEAT_SENTINEL, StreamBridge, StreamEvent
+
+if TYPE_CHECKING:
+    from deerflow.config.stream_bridge_config import StreamBridgeConfig
+
+logger = logging.getLogger(__name__)
+
+END_EVENT_NAME = "__end__"
+
+# Accept either ``0`` / ``0-0`` or ``<digits>-<digits>`` Redis stream IDs.
+_STREAM_ID_RE = re.compile(r"^(?:0|\d+-\d+)$")
+# run_id must be a UUID (the only producer of run ids today).
+_RUN_ID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+# TTL refresh sampling window: only refresh at most once per this interval on
+# the publish hot path; long-idle runs are kept alive by the worker TTL keeper.
+_TTL_REFRESH_WINDOW_SECONDS = 60.0
+# Upper bound for the per-run TTL sampling state to guard against leaks when
+# cleanup is missed (process restart etc.).
+_TTL_STATE_MAXSIZE = 100_000
+
+_PUBLISH_RETRY_BACKOFFS = (0.05, 0.15, 0.3)
+_SUBSCRIBE_MAX_RETRIES = 5
+
+
+def mask_redis_url(url: str | None) -> str:
+    """Redact credentials from a redis URL for safe logging."""
+    if not url:
+        return "<none>"
+    # redis://[:password@]host:port/db -> redis://***@host:port/db
+    return re.sub(r"://[^@/]*@", "://***@", url)
+
+
+class RedisStreamBridge(StreamBridge):
+    """Redis Streams-backed :class:`StreamBridge`."""
+
+    def __init__(
+        self,
+        *,
+        redis_url: str,
+        queue_maxsize: int = 256,
+        max_command_connections: int = 64,
+        max_blocking_connections: int = 1024,
+        pool_timeout: float = 1.0,
+        socket_timeout: float = 30.0,
+        ttl_seconds: int = 86400,
+        max_payload_bytes: int = 524288,
+        key_prefix: str = "df:sb",
+        read_batch_size: int = 100,
+    ) -> None:
+        try:
+            import redis.asyncio as redis_async
+        except ImportError as exc:  # pragma: no cover - exercised via factory
+            raise ImportError(
+                "Install deerflow-harness[redis] to use stream_bridge.type=redis"
+            ) from exc
+
+        # redis-py raises its own ConnectionError / TimeoutError which do NOT
+        # inherit from the builtin OSError hierarchy, so they must be caught
+        # explicitly for the best-effort retry paths to work (problems N/D).
+        self._retryable_errors = (
+            redis_async.ConnectionError,
+            redis_async.TimeoutError,
+            OSError,
+        )
+
+        self._redis_url = redis_url
+        self._maxsize = queue_maxsize
+        self._ttl_seconds = ttl_seconds
+        self._max_payload_bytes = max_payload_bytes
+        self._key_prefix = key_prefix
+        self._read_batch_size = read_batch_size
+        self._pool_timeout = pool_timeout
+
+        # Command pool: short commands (publish / cleanup / refresh_ttl / probes).
+        self._command_pool = redis_async.BlockingConnectionPool.from_url(
+            redis_url,
+            max_connections=max_command_connections,
+            timeout=pool_timeout,
+            socket_timeout=socket_timeout,
+            decode_responses=True,
+        )
+        self._redis = redis_async.Redis(connection_pool=self._command_pool)
+
+        # Blocking subscribe pool: each active XREAD holds a connection while
+        # blocking. ``socket_timeout=None`` so long ``block`` durations do not
+        # raise spurious TimeoutError; isolated from the command pool.
+        self._blocking_pool = redis_async.BlockingConnectionPool.from_url(
+            redis_url,
+            max_connections=max_blocking_connections,
+            timeout=pool_timeout,
+            socket_timeout=None,
+            decode_responses=True,
+        )
+        self._blocking_redis = redis_async.Redis(connection_pool=self._blocking_pool)
+
+        # Per-run "last TTL refresh" timestamps (bounded LRU, see problem O).
+        self._ttl_last_refresh: OrderedDict[str, float] = OrderedDict()
+
+    # -- construction ----------------------------------------------------------
+
+    @classmethod
+    def from_config(cls, config: StreamBridgeConfig) -> RedisStreamBridge:
+        assert config.redis_url is not None  # guaranteed by config validator
+        return cls(
+            redis_url=config.redis_url,
+            queue_maxsize=config.queue_maxsize,
+            max_command_connections=config.redis_max_command_connections,
+            max_blocking_connections=config.redis_max_blocking_connections,
+            pool_timeout=config.redis_pool_timeout,
+            socket_timeout=config.redis_socket_timeout,
+            ttl_seconds=config.redis_ttl_seconds,
+            max_payload_bytes=config.redis_max_payload_bytes,
+            key_prefix=config.redis_key_prefix,
+        )
+
+    @property
+    def supports_cross_process_subscribe(self) -> bool:
+        return True
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl_seconds
+
+    # -- helpers ---------------------------------------------------------------
+
+    def _stream_key(self, run_id: str) -> str:
+        if not _RUN_ID_RE.match(run_id):
+            raise ValueError(f"Invalid run_id for redis stream key: {run_id!r}")
+        return f"{self._key_prefix}:{run_id}:stream"
+
+    def _encode_payload(self, run_id: str, event: str, data: Any) -> tuple[str | None, bool]:
+        """Serialize *data* to JSON with ``default=str`` fallback.
+
+        Returns ``(payload_json, used_fallback)``.  Returns ``(None, _)`` when
+        the payload is rejected (too large or unserializable) — the caller
+        treats that as a dropped data event.
+        """
+        used_fallback = False
+        try:
+            payload_json = json.dumps(data, ensure_ascii=False)
+        except (TypeError, ValueError):
+            try:
+                payload_json = json.dumps(data, default=str, ensure_ascii=False)
+                used_fallback = True
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Redis stream payload not serializable; dropping run=%s event=%s type=%s",
+                    run_id,
+                    event,
+                    type(data).__name__,
+                )
+                return None, used_fallback
+
+        payload_bytes = len(payload_json.encode("utf-8"))
+        if payload_bytes > self._max_payload_bytes:
+            logger.warning(
+                "Redis stream payload too large (%d > %d); dropping run=%s event=%s",
+                payload_bytes,
+                self._max_payload_bytes,
+                run_id,
+                event,
+            )
+            return None, used_fallback
+
+        return payload_json, used_fallback
+
+    def _should_refresh_ttl(self, run_id: str, now: float) -> bool:
+        last = self._ttl_last_refresh.get(run_id)
+        if last is not None and (now - last) < _TTL_REFRESH_WINDOW_SECONDS:
+            return False
+        self._ttl_last_refresh[run_id] = now
+        self._ttl_last_refresh.move_to_end(run_id)
+        while len(self._ttl_last_refresh) > _TTL_STATE_MAXSIZE:
+            self._ttl_last_refresh.popitem(last=False)
+        return True
+
+    # -- StreamBridge API ------------------------------------------------------
+
+    async def publish(self, run_id: str, event: str, data: Any) -> None:
+        key = self._stream_key(run_id)
+        payload_json, used_fallback = self._encode_payload(run_id, event, data)
+        if payload_json is None:
+            # Oversized / unserializable: best-effort drop, do not raise.
+            return
+
+        if used_fallback:
+            logger.warning(
+                "Redis stream payload used default=str fallback for run %s event %s (type=%s)",
+                run_id,
+                event,
+                type(data).__name__,
+            )
+
+        payload = {"event": event, "data": payload_json}
+        refresh = self._should_refresh_ttl(run_id, time.monotonic())
+
+        last_exc: Exception | None = None
+        for attempt in range(len(_PUBLISH_RETRY_BACKOFFS) + 1):
+            try:
+                async with self._redis.pipeline(transaction=False) as pipe:
+                    pipe.xadd(key, payload, maxlen=self._maxsize, approximate=True)
+                    if refresh:
+                        pipe.expire(key, self._ttl_seconds)
+                    await pipe.execute()
+                return
+            except self._retryable_errors as exc:
+                last_exc = exc
+                if attempt < len(_PUBLISH_RETRY_BACKOFFS):
+                    await asyncio.sleep(_PUBLISH_RETRY_BACKOFFS[attempt])
+                    continue
+
+        # Bounded retry exhausted: best-effort drop (problem N).
+        logger.warning(
+            "Redis stream publish dropped after retries for run %s event %s: %s",
+            run_id,
+            event,
+            last_exc,
+        )
+
+    async def publish_end(self, run_id: str) -> None:
+        key = self._stream_key(run_id)
+        payload = {"event": END_EVENT_NAME, "data": "null"}
+        try:
+            await self._redis.xadd(key, payload, maxlen=self._maxsize, approximate=True)
+        except Exception:
+            logger.warning("Failed to publish stream end for run %s", run_id, exc_info=True)
+
+    async def subscribe(
+        self,
+        run_id: str,
+        *,
+        last_event_id: str | None = None,
+        heartbeat_interval: float = 15.0,
+    ) -> AsyncIterator[StreamEvent]:
+        key = self._stream_key(run_id)
+        cursor = await self._resolve_cursor(key, last_event_id)
+        block_ms = max(1, int(heartbeat_interval * 1000))
+        retries = 0
+
+        while True:
+            try:
+                response = await self._blocking_redis.xread(
+                    {key: cursor},
+                    block=block_ms,
+                    count=self._read_batch_size,
+                )
+                retries = 0
+            except asyncio.CancelledError:
+                raise
+            except self._retryable_errors as exc:
+                retries += 1
+                if retries > _SUBSCRIBE_MAX_RETRIES:
+                    logger.error(
+                        "Redis stream subscribe exceeded retries for run %s cursor=%s: %s",
+                        run_id,
+                        cursor,
+                        exc,
+                    )
+                    raise
+                await asyncio.sleep(min(2.0, 0.1 * (2**retries)))
+                continue
+
+            if not response:
+                yield HEARTBEAT_SENTINEL
+                continue
+
+            _key, entries = response[0]
+            for raw_id, fields in entries:
+                cursor = raw_id
+                event_name = fields.get("event")
+                if event_name == END_EVENT_NAME:
+                    yield END_SENTINEL
+                    return
+                raw_data = fields.get("data")
+                try:
+                    parsed = json.loads(raw_data) if raw_data is not None else None
+                except (TypeError, ValueError):
+                    parsed = raw_data
+                yield StreamEvent(id=raw_id, event=event_name, data=parsed)
+
+    async def _resolve_cursor(self, key: str, last_event_id: str | None) -> str:
+        """Resolve the XREAD cursor from a client-provided Last-Event-ID."""
+        if last_event_id is None:
+            return "0-0"
+
+        if not _STREAM_ID_RE.match(last_event_id):
+            logger.warning("Invalid Last-Event-ID %r; replaying from earliest", last_event_id)
+            return "0-0"
+
+        try:
+            earliest = await self._redis.xrange(key, min="-", max="+", count=1)
+            latest = await self._redis.xrevrange(key, max="+", min="-", count=1)
+        except Exception:
+            # Boundary probe failed: fall back to the provided id (best-effort).
+            return last_event_id
+
+        if not earliest or not latest:
+            # Key missing / empty: start from beginning, block for new events.
+            return "0-0"
+
+        earliest_id = earliest[0][0]
+        latest_id = latest[0][0]
+
+        if _compare_stream_ids(last_event_id, earliest_id) < 0:
+            logger.warning(
+                "Last-Event-ID %s older than earliest retained %s; replaying from earliest",
+                last_event_id,
+                earliest_id,
+            )
+            return "0-0"
+        if _compare_stream_ids(last_event_id, latest_id) > 0:
+            logger.warning(
+                "Last-Event-ID %s ahead of latest %s; resuming from latest",
+                last_event_id,
+                latest_id,
+            )
+            return latest_id
+        return last_event_id
+
+    async def refresh_ttl(self, run_id: str) -> None:
+        key = self._stream_key(run_id)
+        try:
+            # EXPIRE on a missing key is a no-op (returns 0); never recreates it.
+            await self._redis.expire(key, self._ttl_seconds)
+        except Exception:
+            logger.warning("Failed to refresh TTL for run %s", run_id, exc_info=True)
+
+    async def has_retained_stream(self, run_id: str) -> bool:
+        key = self._stream_key(run_id)
+        return bool(await self._redis.exists(key))
+
+    async def has_events_after(self, run_id: str, last_event_id: str | None) -> bool:
+        key = self._stream_key(run_id)
+        start = f"({last_event_id}" if last_event_id else "-"
+        try:
+            entries = await self._redis.xrange(key, min=start, max="+", count=1)
+        except Exception:
+            # Probe failed: conservative — assume events may exist.
+            return True
+        return bool(entries)
+
+    async def cleanup(self, run_id: str, *, delay: float = 0) -> None:
+        if delay > 0:
+            await asyncio.sleep(delay)
+        self._ttl_last_refresh.pop(run_id, None)
+        try:
+            await self._redis.delete(self._stream_key(run_id))
+        except Exception:
+            logger.warning("Failed to cleanup Redis stream for run %s", run_id, exc_info=True)
+
+    async def ping(self) -> None:
+        await self._redis.ping()
+
+    async def close(self) -> None:
+        try:
+            await self._redis.aclose()
+        finally:
+            await self._blocking_redis.aclose()
+
+
+def _compare_stream_ids(a: str, b: str) -> int:
+    """Compare two Redis stream IDs. Returns -1 / 0 / 1."""
+    ta = _id_tuple(a)
+    tb = _id_tuple(b)
+    return (ta > tb) - (ta < tb)
+
+
+def _id_tuple(stream_id: str) -> tuple[int, int]:
+    if "-" in stream_id:
+        ms, _, seq = stream_id.partition("-")
+        return int(ms), int(seq)
+    return int(stream_id), 0

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -47,6 +47,7 @@ postgres = [
     "psycopg-pool>=3.3.0",
 ]
 pymupdf = ["pymupdf4llm>=0.0.17"]
+redis = ["redis>=5.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,11 +25,13 @@ dependencies = [
 
 [project.optional-dependencies]
 postgres = ["deerflow-harness[postgres]"]
+redis = ["deerflow-harness[redis]"]
 discord = ["discord.py>=2.7.0"]
 
 [dependency-groups]
 dev = [
     "blockbuster>=1.5.26,<1.6",
+    "fakeredis>=2.21",
     "prompt-toolkit>=3.0.0",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",

--- a/backend/tests/test_redis_stream_bridge.py
+++ b/backend/tests/test_redis_stream_bridge.py
@@ -1,0 +1,446 @@
+"""Tests for RedisStreamBridge and shared terminal helpers.
+
+Redis-backed behaviour is exercised against ``fakeredis`` (no real server).
+Pure module-level helpers and config validation run without any redis client.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+import fakeredis.aioredis as fake_aioredis  # noqa: E402
+
+from deerflow.config.stream_bridge_config import StreamBridgeConfig  # noqa: E402
+from deerflow.runtime import END_SENTINEL, HEARTBEAT_SENTINEL  # noqa: E402
+from deerflow.runtime.runs.manager import RunRecord  # noqa: E402
+from deerflow.runtime.runs.schemas import DisconnectMode, RunStatus  # noqa: E402
+from deerflow.runtime.runs.terminal import TERMINAL_STATUSES, build_end_payload  # noqa: E402
+from deerflow.runtime.stream_bridge.redis import (  # noqa: E402
+    RedisStreamBridge,
+    _compare_stream_ids,
+    _id_tuple,
+    mask_redis_url,
+)
+
+RUN_ID = "11111111-2222-3333-4444-555555555555"
+RUN_ID_2 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+
+# ---------------------------------------------------------------------------
+# Pure module-level helpers (no redis required)
+# ---------------------------------------------------------------------------
+
+
+def test_mask_redis_url_redacts_credentials():
+    assert mask_redis_url("redis://:secret@host:6379/0") == "redis://***@host:6379/0"
+    assert mask_redis_url("redis://user:secret@host:6379/0") == "redis://***@host:6379/0"
+    assert mask_redis_url("redis://host:6379/0") == "redis://host:6379/0"
+    assert mask_redis_url(None) == "<none>"
+    assert mask_redis_url("") == "<none>"
+
+
+def test_id_tuple_parses_both_forms():
+    assert _id_tuple("5-2") == (5, 2)
+    assert _id_tuple("7") == (7, 0)
+    assert _id_tuple("0-0") == (0, 0)
+
+
+def test_compare_stream_ids_orders_by_ms_then_seq():
+    assert _compare_stream_ids("1-0", "1-1") == -1
+    assert _compare_stream_ids("2-0", "1-9") == 1
+    assert _compare_stream_ids("3-4", "3-4") == 0
+    assert _compare_stream_ids("10-0", "9-0") == 1  # numeric, not lexicographic
+
+
+# ---------------------------------------------------------------------------
+# StreamBridgeConfig validation (problem E/M/P)
+# ---------------------------------------------------------------------------
+
+
+def test_config_memory_defaults_skip_redis_validation():
+    cfg = StreamBridgeConfig(type="memory")
+    assert cfg.redis_url is None
+    assert cfg.redis_ttl_seconds == 86400
+
+
+def test_config_redis_requires_url():
+    with pytest.raises(ValueError, match="redis_url is required"):
+        StreamBridgeConfig(type="redis")
+
+
+def test_config_redis_ttl_floor():
+    with pytest.raises(ValueError):
+        StreamBridgeConfig(type="redis", redis_url="redis://h:6379/0", redis_ttl_seconds=30)
+
+
+def test_config_redis_require_tls_rejects_plain_url():
+    with pytest.raises(ValueError, match="rediss://"):
+        StreamBridgeConfig(
+            type="redis",
+            redis_url="redis://h:6379/0",
+            redis_require_tls=True,
+        )
+
+
+def test_config_redis_require_tls_accepts_rediss():
+    cfg = StreamBridgeConfig(
+        type="redis",
+        redis_url="rediss://h:6379/0",
+        redis_require_tls=True,
+    )
+    assert cfg.redis_url.startswith("rediss://")
+
+
+def test_config_redis_max_payload_bytes_must_be_positive():
+    with pytest.raises(ValueError):
+        StreamBridgeConfig(
+            type="redis",
+            redis_url="redis://h:6379/0",
+            redis_max_payload_bytes=0,
+        )
+
+
+def test_config_redis_rejects_negative_connection_pools():
+    with pytest.raises(ValueError):
+        StreamBridgeConfig(
+            type="redis",
+            redis_url="redis://h:6379/0",
+            redis_max_command_connections=-1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Shared terminal helpers (problem K-schema/T)
+# ---------------------------------------------------------------------------
+
+
+def _record(status: RunStatus, error: str | None = None) -> RunRecord:
+    return RunRecord(
+        run_id=RUN_ID,
+        thread_id="t-1",
+        assistant_id=None,
+        status=status,
+        on_disconnect=DisconnectMode.continue_,
+        error=error,
+    )
+
+
+def test_terminal_statuses_include_timeout():
+    assert RunStatus.timeout in TERMINAL_STATUSES
+    assert RunStatus.success in TERMINAL_STATUSES
+    assert RunStatus.error in TERMINAL_STATUSES
+    assert RunStatus.interrupted in TERMINAL_STATUSES
+    assert RunStatus.running not in TERMINAL_STATUSES
+    assert RunStatus.pending not in TERMINAL_STATUSES
+
+
+def test_build_end_payload_shape():
+    assert build_end_payload(_record(RunStatus.success)) == {"status": "success", "error": None}
+    assert build_end_payload(_record(RunStatus.error, "boom")) == {
+        "status": "error",
+        "error": "boom",
+    }
+
+
+# ---------------------------------------------------------------------------
+# RedisStreamBridge against fakeredis
+# ---------------------------------------------------------------------------
+
+
+def _make_bridge(server: fakeredis.FakeServer, **kwargs) -> RedisStreamBridge:
+    """Build a bridge, then swap real pools for fakeredis clients on *server*."""
+    bridge = RedisStreamBridge(redis_url="redis://localhost:6379/0", **kwargs)
+    bridge._redis = fake_aioredis.FakeRedis(server=server, decode_responses=True)
+    bridge._blocking_redis = fake_aioredis.FakeRedis(server=server, decode_responses=True)
+    return bridge
+
+
+@pytest.fixture
+def server() -> fakeredis.FakeServer:
+    return fakeredis.FakeServer()
+
+
+@pytest.fixture
+async def bridge(server: fakeredis.FakeServer):
+    b = _make_bridge(server)
+    yield b
+    await b._redis.aclose()
+    await b._blocking_redis.aclose()
+
+
+async def _drain(bridge: RedisStreamBridge, run_id: str, **kwargs) -> list:
+    received = []
+    async for entry in bridge.subscribe(run_id, heartbeat_interval=0.2, **kwargs):
+        received.append(entry)
+        if entry is END_SENTINEL:
+            break
+    return received
+
+
+@pytest.mark.anyio
+async def test_supports_cross_process_subscribe(bridge: RedisStreamBridge):
+    assert bridge.supports_cross_process_subscribe is True
+
+
+@pytest.mark.anyio
+async def test_ttl_seconds_property():
+    b = _make_bridge(fakeredis.FakeServer(), ttl_seconds=120)
+    assert b.ttl_seconds == 120
+
+
+@pytest.mark.anyio
+async def test_invalid_run_id_rejected_in_stream_key(bridge: RedisStreamBridge):
+    with pytest.raises(ValueError):
+        bridge._stream_key("not-a-uuid")
+
+
+@pytest.mark.anyio
+async def test_publish_subscribe_in_order(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "metadata", {"run_id": RUN_ID})
+    await bridge.publish(RUN_ID, "values", {"messages": []})
+    await bridge.publish(RUN_ID, "updates", {"step": 1})
+    await bridge.publish_end(RUN_ID)
+
+    received = await _drain(bridge, RUN_ID)
+    assert [e.event for e in received[:-1]] == ["metadata", "values", "updates"]
+    assert received[0].data == {"run_id": RUN_ID}
+    assert received[-1] is END_SENTINEL
+
+
+@pytest.mark.anyio
+async def test_event_id_is_redis_stream_id(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "test", {"k": "v"})
+    await bridge.publish_end(RUN_ID)
+    received = await _drain(bridge, RUN_ID)
+    import re
+
+    assert re.match(r"^\d+-\d+$", received[0].id)
+
+
+@pytest.mark.anyio
+async def test_multiple_runs_isolated(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "a", {"a": 1})
+    await bridge.publish(RUN_ID_2, "b", {"b": 2})
+    await bridge.publish_end(RUN_ID)
+    await bridge.publish_end(RUN_ID_2)
+
+    ra = await _drain(bridge, RUN_ID)
+    rb = await _drain(bridge, RUN_ID_2)
+    assert ra[0].event == "a" and ra[0].data == {"a": 1}
+    assert rb[0].event == "b" and rb[0].data == {"b": 2}
+
+
+@pytest.mark.anyio
+async def test_heartbeat_when_idle(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "first", {})  # ensure key exists
+    received = []
+    async for entry in bridge.subscribe(RUN_ID, heartbeat_interval=0.1):
+        received.append(entry)
+        if entry is HEARTBEAT_SENTINEL:
+            break
+    assert received[-1] is HEARTBEAT_SENTINEL
+
+
+@pytest.mark.anyio
+async def test_serialize_fallback_uses_default_str(bridge: RedisStreamBridge):
+    """Non-JSON-serialisable payloads fall back to default=str (problem C/M)."""
+
+    class NotJson:
+        def __repr__(self) -> str:
+            return "NotJson()"
+
+    payload_json, used_fallback = bridge._encode_payload(RUN_ID, "evt", {"obj": NotJson()})
+    assert used_fallback is True
+    assert "NotJson()" in payload_json
+
+
+@pytest.mark.anyio
+async def test_oversized_payload_dropped_not_raised(server: fakeredis.FakeServer):
+    """Oversized data events are dropped, never raised, and not written (problem M/X)."""
+    b = _make_bridge(server, max_payload_bytes=32)
+    # Should not raise even though payload exceeds the limit.
+    await b.publish(RUN_ID, "big", {"blob": "x" * 1000})
+    # Nothing should have been written to the stream.
+    assert await b._redis.exists(b._stream_key(RUN_ID)) == 0
+    await b._redis.aclose()
+    await b._blocking_redis.aclose()
+
+
+@pytest.mark.anyio
+async def test_publish_drops_after_retry_exhaustion(server: fakeredis.FakeServer, monkeypatch):
+    """publish() must not raise when Redis keeps failing (problem N)."""
+    import redis.asyncio as redis_async
+
+    b = _make_bridge(server)
+
+    def boom_pipeline(*args, **kwargs):
+        raise redis_async.ConnectionError("redis down")
+
+    monkeypatch.setattr(b._redis, "pipeline", boom_pipeline)
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    # Best-effort: should swallow the error rather than propagate.
+    await b.publish(RUN_ID, "evt", {"x": 1})
+    await b._redis.aclose()
+    await b._blocking_redis.aclose()
+
+
+@pytest.mark.anyio
+async def test_publish_retries_then_succeeds(server: fakeredis.FakeServer, monkeypatch):
+    """Transient failures are retried; a later success persists the event (problem N)."""
+    import redis.asyncio as redis_async
+
+    b = _make_bridge(server)
+    real_pipeline = b._redis.pipeline
+    calls = {"n": 0}
+
+    def flaky_pipeline(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise redis_async.ConnectionError("transient")
+        return real_pipeline(*args, **kwargs)
+
+    monkeypatch.setattr(b._redis, "pipeline", flaky_pipeline)
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    await b.publish(RUN_ID, "evt", {"x": 1})
+    assert calls["n"] == 2
+    entries = await b._redis.xrange(b._stream_key(RUN_ID))
+    assert len(entries) == 1
+    await b._redis.aclose()
+    await b._blocking_redis.aclose()
+
+
+@pytest.mark.anyio
+async def test_should_refresh_ttl_sampling(bridge: RedisStreamBridge):
+    """TTL refresh is sampled at most once per window (problem O)."""
+    assert bridge._should_refresh_ttl(RUN_ID, now=1000.0) is True
+    assert bridge._should_refresh_ttl(RUN_ID, now=1000.0 + 10) is False  # within window
+    assert bridge._should_refresh_ttl(RUN_ID, now=1000.0 + 120) is True  # past window
+
+
+@pytest.mark.anyio
+async def test_ttl_state_evicted_by_lru(bridge: RedisStreamBridge):
+    """The sampling state is bounded; oldest entries are evicted (problem O)."""
+    from deerflow.runtime.stream_bridge import redis as redis_mod
+
+    original = redis_mod._TTL_STATE_MAXSIZE
+    redis_mod._TTL_STATE_MAXSIZE = 3
+    try:
+        for i in range(5):
+            bridge._should_refresh_ttl(f"run-{i}", now=float(i))
+        assert len(bridge._ttl_last_refresh) == 3
+        assert "run-0" not in bridge._ttl_last_refresh
+        assert "run-4" in bridge._ttl_last_refresh
+    finally:
+        redis_mod._TTL_STATE_MAXSIZE = original
+
+
+@pytest.mark.anyio
+async def test_cleanup_removes_stream_and_sampling_state(bridge: RedisStreamBridge):
+    """cleanup() deletes the key and pops the TTL sampling entry (problem O)."""
+    await bridge.publish(RUN_ID, "evt", {})
+    bridge._ttl_last_refresh[RUN_ID] = 1.0
+    assert await bridge._redis.exists(bridge._stream_key(RUN_ID)) == 1
+
+    await bridge.cleanup(RUN_ID)
+    assert await bridge._redis.exists(bridge._stream_key(RUN_ID)) == 0
+    assert RUN_ID not in bridge._ttl_last_refresh
+
+
+@pytest.mark.anyio
+async def test_refresh_ttl_does_not_recreate_missing_key(bridge: RedisStreamBridge):
+    """EXPIRE on a missing key is a no-op (problem L)."""
+    await bridge.refresh_ttl(RUN_ID)  # key never created
+    assert await bridge._redis.exists(bridge._stream_key(RUN_ID)) == 0
+
+
+@pytest.mark.anyio
+async def test_has_retained_stream(bridge: RedisStreamBridge):
+    assert await bridge.has_retained_stream(RUN_ID) is False
+    await bridge.publish(RUN_ID, "evt", {})
+    assert await bridge.has_retained_stream(RUN_ID) is True
+
+
+@pytest.mark.anyio
+async def test_has_events_after(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "e1", {})
+    await bridge.publish(RUN_ID, "e2", {})
+    entries = await bridge._redis.xrange(bridge._stream_key(RUN_ID))
+    first_id = entries[0][0]
+    last_id = entries[-1][0]
+
+    assert await bridge.has_events_after(RUN_ID, None) is True
+    assert await bridge.has_events_after(RUN_ID, first_id) is True
+    assert await bridge.has_events_after(RUN_ID, last_id) is False
+
+
+# -- Last-Event-ID resolution (problem) -------------------------------------
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_none_starts_from_zero(bridge: RedisStreamBridge):
+    key = bridge._stream_key(RUN_ID)
+    assert await bridge._resolve_cursor(key, None) == "0-0"
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_invalid_replays_from_earliest(bridge: RedisStreamBridge):
+    key = bridge._stream_key(RUN_ID)
+    assert await bridge._resolve_cursor(key, "not-an-id") == "0-0"
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_old_replays_from_earliest(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "e1", {})
+    await bridge.publish(RUN_ID, "e2", {})
+    key = bridge._stream_key(RUN_ID)
+    # "1-0" is older than the earliest retained id.
+    assert await bridge._resolve_cursor(key, "1-0") == "0-0"
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_future_resumes_from_latest(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "e1", {})
+    key = bridge._stream_key(RUN_ID)
+    entries = await bridge._redis.xrange(key)
+    latest_id = entries[-1][0]
+    # A far-future id should clamp to the latest retained id.
+    resolved = await bridge._resolve_cursor(key, "99999999999999-0")
+    assert resolved == latest_id
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_in_range_passthrough(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "e1", {})
+    await bridge.publish(RUN_ID, "e2", {})
+    key = bridge._stream_key(RUN_ID)
+    entries = await bridge._redis.xrange(key)
+    first_id = entries[0][0]
+    assert await bridge._resolve_cursor(key, first_id) == first_id
+
+
+@pytest.mark.anyio
+async def test_resolve_cursor_missing_key_starts_from_zero(bridge: RedisStreamBridge):
+    key = bridge._stream_key(RUN_ID)  # no events published
+    assert await bridge._resolve_cursor(key, "5-0") == "0-0"
+
+
+@pytest.mark.anyio
+async def test_subscribe_replays_after_last_event_id(bridge: RedisStreamBridge):
+    await bridge.publish(RUN_ID, "metadata", {})
+    await bridge.publish(RUN_ID, "values", {})
+    await bridge.publish(RUN_ID, "updates", {})
+    await bridge.publish_end(RUN_ID)
+
+    first = await _drain(bridge, RUN_ID)
+    resumed = await _drain(bridge, RUN_ID, last_event_id=first[0].id)
+    assert [e.event for e in resumed[:-1]] == ["values", "updates"]
+    assert resumed[-1] is END_SENTINEL
+
+
+async def _no_sleep(*_args, **_kwargs):
+    return None

--- a/backend/tests/test_run_store_user_scope.py
+++ b/backend/tests/test_run_store_user_scope.py
@@ -1,0 +1,52 @@
+"""Legacy user_id auth-compat regression tests (problem H-compat).
+
+Rows persisted before user-scoping was added have an empty ``user_id``.
+Such rows must not be hard-filtered out of ``RunStore.get`` when a caller
+supplies a ``user_id`` — only rows whose stored ``user_id`` is non-empty and
+mismatches should be rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deerflow.runtime.runs.store.memory import MemoryRunStore
+
+RUN_ID = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.mark.anyio
+async def test_legacy_empty_user_id_row_is_not_filtered():
+    store = MemoryRunStore()
+    await store.put(RUN_ID, thread_id="t-1", user_id=None)  # legacy row
+
+    # A scoped caller must still be able to read the legacy row.
+    row = await store.get(RUN_ID, user_id="alice")
+    assert row is not None
+    assert row["run_id"] == RUN_ID
+
+
+@pytest.mark.anyio
+async def test_matching_user_id_row_is_returned():
+    store = MemoryRunStore()
+    await store.put(RUN_ID, thread_id="t-1", user_id="alice")
+
+    row = await store.get(RUN_ID, user_id="alice")
+    assert row is not None
+
+
+@pytest.mark.anyio
+async def test_mismatched_nonempty_user_id_row_is_filtered():
+    store = MemoryRunStore()
+    await store.put(RUN_ID, thread_id="t-1", user_id="alice")
+
+    assert await store.get(RUN_ID, user_id="bob") is None
+
+
+@pytest.mark.anyio
+async def test_unscoped_caller_reads_any_row():
+    store = MemoryRunStore()
+    await store.put(RUN_ID, thread_id="t-1", user_id="alice")
+
+    row = await store.get(RUN_ID, user_id=None)
+    assert row is not None

--- a/backend/tests/test_terminal_reconcile.py
+++ b/backend/tests/test_terminal_reconcile.py
@@ -1,0 +1,166 @@
+"""Gateway-level terminal short-circuit and reconciliation tests.
+
+Exercises the decision logic added for problems J/Q/R/T (router short-circuit)
+and K/S/U (service-layer reconciliation) without a real Redis or FastAPI app.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+from app.gateway.routers.thread_runs import _terminal_short_circuit
+from app.gateway.services import RECONCILE_INTERVAL, _reconcile_terminal_end
+from deerflow.runtime.runs.manager import RunRecord
+from deerflow.runtime.runs.schemas import DisconnectMode, RunStatus
+
+RUN_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def _record(status: RunStatus, *, store_only: bool = False, error: str | None = None) -> RunRecord:
+    return RunRecord(
+        run_id=RUN_ID,
+        thread_id="t-1",
+        assistant_id=None,
+        status=status,
+        on_disconnect=DisconnectMode.continue_,
+        store_only=store_only,
+        error=error,
+    )
+
+
+class _FakeBridge:
+    def __init__(self, *, retained: bool = True, events_after: bool = False, raise_on=None):
+        self._retained = retained
+        self._events_after = events_after
+        self._raise_on = raise_on or set()
+
+    async def has_retained_stream(self, run_id: str) -> bool:
+        if "has_retained_stream" in self._raise_on:
+            raise RuntimeError("probe failed")
+        return self._retained
+
+    async def has_events_after(self, run_id: str, last_event_id) -> bool:
+        if "has_events_after" in self._raise_on:
+            raise RuntimeError("probe failed")
+        return self._events_after
+
+
+class _FakeRunMgr:
+    def __init__(self, record: RunRecord | None):
+        self._record = record
+
+    async def get(self, run_id: str, *, user_id=None) -> RunRecord | None:
+        return self._record
+
+
+# ---------------------------------------------------------------------------
+# Router terminal short-circuit (problem J/Q/R/T)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_short_circuit_non_terminal_returns_none():
+    bridge = _FakeBridge(retained=False)
+    assert await _terminal_short_circuit(bridge, _record(RunStatus.running)) is None
+
+
+@pytest.mark.anyio
+async def test_short_circuit_terminal_no_retained_returns_end_response():
+    bridge = _FakeBridge(retained=False)
+    resp = await _terminal_short_circuit(bridge, _record(RunStatus.success))
+    assert isinstance(resp, StreamingResponse)
+
+
+@pytest.mark.anyio
+async def test_short_circuit_terminal_with_retained_falls_through():
+    bridge = _FakeBridge(retained=True)
+    assert await _terminal_short_circuit(bridge, _record(RunStatus.success)) is None
+
+
+@pytest.mark.anyio
+async def test_short_circuit_timeout_is_terminal():
+    """RunStatus.timeout must short-circuit too (problem T)."""
+    bridge = _FakeBridge(retained=False)
+    resp = await _terminal_short_circuit(bridge, _record(RunStatus.timeout))
+    assert isinstance(resp, StreamingResponse)
+
+
+@pytest.mark.anyio
+async def test_short_circuit_works_for_store_only_run():
+    """Short-circuit is no longer bound to store_only (problem Q/R)."""
+    bridge = _FakeBridge(retained=False)
+    resp = await _terminal_short_circuit(bridge, _record(RunStatus.success, store_only=True))
+    assert isinstance(resp, StreamingResponse)
+
+
+@pytest.mark.anyio
+async def test_short_circuit_probe_failure_is_conservative():
+    """A failed retained-stream probe assumes the stream may exist."""
+    bridge = _FakeBridge(raise_on={"has_retained_stream"})
+    assert await _terminal_short_circuit(bridge, _record(RunStatus.error)) is None
+
+
+# ---------------------------------------------------------------------------
+# Service-layer reconciliation (problem K/S/U)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_reconcile_running_run_returns_none():
+    bridge = _FakeBridge(events_after=False)
+    run_mgr = _FakeRunMgr(_record(RunStatus.running))
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "0-0", run_mgr, None)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_reconcile_terminal_drained_yields_synthetic_end():
+    bridge = _FakeBridge(events_after=False)
+    run_mgr = _FakeRunMgr(_record(RunStatus.success))
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "0-0", run_mgr, None)
+    assert result is not None
+    assert "event: end" in result
+    assert '"status": "success"' in result
+
+
+@pytest.mark.anyio
+async def test_reconcile_terminal_with_pending_events_returns_none():
+    """Terminal but unconsumed events remain -> keep streaming (problem U)."""
+    bridge = _FakeBridge(events_after=True)
+    run_mgr = _FakeRunMgr(_record(RunStatus.success))
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "5-0", run_mgr, None)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_reconcile_timeout_status_yields_synthetic_end():
+    """timeout counts as terminal for reconciliation (problem T)."""
+    bridge = _FakeBridge(events_after=False)
+    run_mgr = _FakeRunMgr(_record(RunStatus.timeout, error="deadline"))
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "0-0", run_mgr, None)
+    assert result is not None
+    assert '"status": "timeout"' in result
+
+
+@pytest.mark.anyio
+async def test_reconcile_missing_record_returns_none():
+    bridge = _FakeBridge(events_after=False)
+    run_mgr = _FakeRunMgr(None)
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "0-0", run_mgr, None)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_reconcile_has_events_after_probe_failure_returns_none():
+    bridge = _FakeBridge(raise_on={"has_events_after"})
+    run_mgr = _FakeRunMgr(_record(RunStatus.success))
+    result = await _reconcile_terminal_end(bridge, RUN_ID, "0-0", run_mgr, None)
+    assert result is None
+
+
+def test_reconcile_interval_is_thirty_seconds():
+    """Reconciliation cadence is elapsed-time based, not heartbeat-count (problem S)."""
+    assert RECONCILE_INTERVAL == 30.0
+    # The window must dominate the heartbeat period so reconciliation is rare.
+    assert RECONCILE_INTERVAL > 15.0

--- a/backend/tests/test_worker_stream_ttl.py
+++ b/backend/tests/test_worker_stream_ttl.py
@@ -1,0 +1,94 @@
+"""Worker-side best-effort and TTL-keeper helper tests (problems L/N).
+
+``_run_stream_ttl_keeper`` periodically refreshes a run's stream TTL so a
+long-idle run does not lose its retained stream.  ``_safe_cleanup_bridge``
+swallows cleanup failures so the worker's finally path never raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from deerflow.runtime.runs.worker import _run_stream_ttl_keeper, _safe_cleanup_bridge
+
+RUN_ID = "11111111-2222-3333-4444-555555555555"
+
+
+class _RecordingBridge:
+    def __init__(self, *, cleanup_raises: bool = False):
+        self.refresh_calls: list[str] = []
+        self.cleanup_calls: list[tuple[str, float]] = []
+        self._cleanup_raises = cleanup_raises
+
+    async def refresh_ttl(self, run_id: str) -> None:
+        self.refresh_calls.append(run_id)
+
+    async def cleanup(self, run_id: str, *, delay: float = 0) -> None:
+        if self._cleanup_raises:
+            raise RuntimeError("cleanup failed")
+        self.cleanup_calls.append((run_id, delay))
+
+
+@pytest.mark.anyio
+async def test_ttl_keeper_refreshes_periodically(monkeypatch):
+    bridge = _RecordingBridge()
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        # Stop after a few iterations by cancelling the keeper.
+        if len(sleeps) >= 3:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        # ttl=86400 -> refresh_every clamps to 300 (max bound).
+        await _run_stream_ttl_keeper(bridge, RUN_ID, 86400)
+
+    assert sleeps == [300, 300, 300]
+    assert bridge.refresh_calls == [RUN_ID, RUN_ID]  # one per completed sleep
+
+
+@pytest.mark.anyio
+async def test_ttl_keeper_refresh_every_lower_bound(monkeypatch):
+    """A small ttl clamps the refresh interval to the 30s floor."""
+    bridge = _RecordingBridge()
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await _run_stream_ttl_keeper(bridge, RUN_ID, 60)  # 60 // 4 = 15 -> floor 30
+
+    assert sleeps == [30]
+
+
+@pytest.mark.anyio
+async def test_ttl_keeper_propagates_cancellation():
+    bridge = _RecordingBridge()
+    task = asyncio.create_task(_run_stream_ttl_keeper(bridge, RUN_ID, 86400))
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.anyio
+async def test_safe_cleanup_swallows_errors():
+    bridge = _RecordingBridge(cleanup_raises=True)
+    # Must not raise.
+    await _safe_cleanup_bridge(bridge, RUN_ID, delay=60)
+
+
+@pytest.mark.anyio
+async def test_safe_cleanup_forwards_delay():
+    bridge = _RecordingBridge()
+    await _safe_cleanup_bridge(bridge, RUN_ID, delay=60)
+    assert bridge.cleanup_calls == [(RUN_ID, 60)]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -769,10 +769,14 @@ discord = [
 postgres = [
     { name = "deerflow-harness", extra = ["postgres"] },
 ]
+redis = [
+    { name = "deerflow-harness", extra = ["redis"] },
+]
 
 [package.dev-dependencies]
 dev = [
     { name = "blockbuster" },
+    { name = "fakeredis" },
     { name = "prompt-toolkit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -784,6 +788,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "deerflow-harness", editable = "packages/harness" },
     { name = "deerflow-harness", extras = ["postgres"], marker = "extra == 'postgres'", editable = "packages/harness" },
+    { name = "deerflow-harness", extras = ["redis"], marker = "extra == 'redis'", editable = "packages/harness" },
     { name = "dingtalk-stream", specifier = ">=0.24.3" },
     { name = "discord-py", marker = "extra == 'discord'", specifier = ">=2.7.0" },
     { name = "email-validator", specifier = ">=2.0.0" },
@@ -800,11 +805,12 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
     { name = "wecom-aibot-python-sdk", specifier = ">=0.1.6" },
 ]
-provides-extras = ["postgres", "discord"]
+provides-extras = ["postgres", "redis", "discord"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "blockbuster", specifier = ">=1.5.26,<1.6" },
+    { name = "fakeredis", specifier = ">=2.21" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
@@ -863,6 +869,9 @@ postgres = [
 pymupdf = [
     { name = "pymupdf4llm" },
 ]
+redis = [
+    { name = "redis" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -901,11 +910,12 @@ requires-dist = [
     { name = "pymupdf4llm", marker = "extra == 'pymupdf'", specifier = ">=0.0.17" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "readabilipy", specifier = ">=0.3.0" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0,<3.0" },
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
-provides-extras = ["ollama", "postgres", "pymupdf"]
+provides-extras = ["ollama", "postgres", "pymupdf", "redis"]
 
 [[package]]
 name = "defusedxml"
@@ -1056,6 +1066,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/e4/11bbbc076ae420b9e00537945d48a03cb42cc6da63edc65bf50d23e4778e/exa_py-2.12.1.tar.gz", hash = "sha256:9ff1924fbfbcae822b20c0ddef0650fabc04ac75906b9153623eadc18135b7ce", size = 55792, upload-time = "2026-04-22T20:00:38.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/19/0a504b6ce7c468595cd0551f65e5c464832a1d3af8dc8acd681e21696a5f/exa_py-2.12.1-py3-none-any.whl", hash = "sha256:9e735802161482a7d5b231376257883cb4e34dbd6f75ded04ab1a5a171b69d9f", size = 74512, upload-time = "2026-04-22T20:00:34.326Z" },
+]
+
+[[package]]
+name = "fakeredis"
+version = "2.36.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/48/c08ec5c1d0d16e15247787b83d9b2a9cb1f1a27514cd85407956040cc383/fakeredis-2.36.1.tar.gz", hash = "sha256:7240567f4e1c07a2b3d30c0fd88e5e598e948c2e25850a560727de1d1d3dc946", size = 210959, upload-time = "2026-06-07T16:11:50.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/94/1f993adaa735f2922d991e1e66e64f2de1bf044bee601d03dde5b71513d4/fakeredis-2.36.1-py3-none-any.whl", hash = "sha256:220a77bebb985c59076951336478c4c983be76b5d9f44d3011dd61171d082062", size = 139357, upload-time = "2026-06-07T16:11:48.418Z" },
 ]
 
 [[package]]
@@ -3664,6 +3687,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "8.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ae/ed461cca5780b5fc8b9fe8ca0ed98d89508645fb9d880c24cc42c087678f/redis-8.0.0.tar.gz", hash = "sha256:a00c5355432051ac14e593b8b197fc76c887ee12d55a0984f69328a1115fdc49", size = 5101591, upload-time = "2026-05-28T12:45:13.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/e3/b519734372d305bd547534a9f32e4ce9f98552af753dce72cf3483a0ff0b/redis-8.0.0-py3-none-any.whl", hash = "sha256:c938c18338585009f0bc310f4c7e4e4b4d37639356c4ac072cedf3af570c8dc7", size = 499870, upload-time = "2026-05-28T12:45:11.697Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3954,6 +3986,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 11
+config_version: 12
 
 # ============================================================================
 # Logging
@@ -1130,6 +1130,38 @@ run_events:
   backend: memory
   max_trace_content: 10240
   track_token_usage: true
+
+# ============================================================================
+# Stream Bridge Configuration
+# ============================================================================
+# Transport for streaming run events from the agent worker (producer) to the
+# SSE endpoint (consumer).
+#
+# type: memory  -- In-process event log (default). Single-process only; a
+#                  subscriber on another worker/replica cannot read the stream.
+# type: redis   -- Redis Streams backend for multi-worker / multi-replica
+#                  deployments. Requires the optional dependency:
+#                  pip install "deerflow-harness[redis]"
+#
+# Notes:
+# - Environment variables are resolved only when the whole value is "$VAR"
+#   (e.g. redis_url: $REDIS_URL). "${VAR}" / inline interpolation is NOT supported.
+# - redis_ttl_seconds defaults to 86400 (24h); shortening it must still satisfy
+#   long-idle runs, late joins, and reconnection windows.
+# - Command and blocking-subscribe connection pools are sized independently so
+#   a flood of SSE subscribers cannot starve publishes.
+#
+# stream_bridge:
+#   type: redis
+#   redis_url: $REDIS_URL
+#   queue_maxsize: 256
+#   redis_max_command_connections: 64
+#   redis_max_blocking_connections: 1024
+#   redis_pool_timeout: 1.0
+#   redis_ttl_seconds: 86400
+stream_bridge:
+  type: memory
+  queue_maxsize: 256
 
 # ============================================================================
 # IM Channels Configuration


### PR DESCRIPTION
## Summary

Adds a **Redis-backed `StreamBridge`** so run events can be streamed across multiple gateway workers / replicas, not just within the single process that produced them. Today `MemoryStreamBridge` (in-process `asyncio.Queue`) is the only backend, so a run started on worker A cannot be joined/streamed from worker B — which blocks any horizontally-scaled deployment behind a load balancer.

This PR also adds the **terminal-reconciliation plumbing** required to make late joins and lost-`END` recovery correct over a shared backend, since with Redis the subscriber and producer are no longer guaranteed to share memory or lifecycle.

Default behavior is unchanged: `stream_bridge.type` defaults to `memory`. Redis is opt-in via config + the `deerflow-harness[redis]` extra.

## Usage

Enable in `config.yaml`:

```yaml
stream_bridge:
  type: redis
  redis_url: $REDIS_URL          # only the whole-value "$VAR" form is resolved
  queue_maxsize: 256             # approx MAXLEN per run
  redis_max_command_connections: 64
  redis_max_blocking_connections: 1024
  redis_pool_timeout: 1.0
  redis_ttl_seconds: 86400       # fallback expiry when cleanup is missed (>=60)
```

Install the optional dependency:

```bash
pip install "deerflow-harness[redis]"
```

`stream_bridge` is a **startup-only** field (registered in the reload boundary) — changing it requires a process restart, like `database` / `checkpointer`.

## Design

**Producer / consumer decoupling.** `StreamBridge` mirrors LangGraph Platform's Queue + StreamManager split: the worker `publish()`es events, any number of SSE endpoints `subscribe()`. The new `supports_cross_process_subscribe` property lets routers allow `store_only` runs (active on another worker) to be joined when the backend can actually see them.

**Redis Streams layout.** One stream key per run. `XADD` appends events; the Redis entry id (`<ms>-<seq>`) is used **directly** as the SSE `id:`, so `Last-Event-ID` reconnection is just an `XRANGE` from the cursor. `END` is written as a normal entry (`event=__end__`) rather than out-of-band, so ordering and late-join replay are preserved for free.

**Best-effort publish with bounded retry.** Data-event `publish` retries transient connection/timeout errors with short backoff, then drops + logs the frame rather than raising — Redis availability must not couple to run success rate. Note: redis-py's `ConnectionError`/`TimeoutError` do **not** inherit from builtin `OSError`, so all three are caught explicitly (this was a real latent bug — the original `except (ConnectionError, TimeoutError, OSError)` never matched redis-py's exceptions).

**Dual connection pools.** A command pool (publish / cleanup / refresh_ttl / boundary probes) is isolated from a blocking-subscribe pool (one connection per active SSE subscription), so a flood of subscribers cannot starve publishes.

**TTL retention + active-run keeper.** Keys carry a fallback TTL so missed cleanup cannot leak streams forever. On the publish hot path `refresh_ttl` is sampled at most once / 60s; for sparse long-idle runs the worker also runs a TTL keeper task that refreshes independently of event rate, cancelled when the run goes terminal.

**Three convergent `end` paths.** Once subscriber and producer can live on different workers, a lost best-effort `publish_end` could hang a subscription on heartbeats forever. Handled by:
1. **real END** — normal `__end__` entry replayed/streamed;
2. **terminal short-circuit** (router) — a late join on a terminal run whose retained stream is already gone returns a single `end` immediately instead of subscribing;
3. **synthetic end** (consumer) — during sustained silence the consumer reconciles against the `RunStore`; if the run is terminal *and* no event exists after the cursor, it synthesises an `end`.

All three reuse `build_end_payload()` from the new `runtime/runs/terminal.py` (also the single source of `TERMINAL_STATUSES`) so they share one `{status, error}` schema and never drift.

**Honest cross-worker degradation.** Cross-worker *cancel* is not supported (the task lives on the owner worker and the Redis bridge does not forward control commands), so it now returns `409` with an actionable message instead of silently no-op'ing; `on_disconnect=cancel` on a `store_only` run logs the skip rather than swallowing it.

**RunStore H-compat.** Legacy rows with an empty `user_id` are no longer hard-filtered out of `get()`; only a non-empty mismatching `user_id` is rejected (owner_check + thread_id validation remain the access backstop).

## Files

- `runtime/stream_bridge/redis.py` — `RedisStreamBridge` (new)
- `runtime/stream_bridge/{base,async_provider,__init__}.py` — protocol extensions + factory wiring
- `runtime/runs/terminal.py` — shared terminal helpers (new)
- `runtime/runs/worker.py` — TTL keeper + best-effort end/error/cleanup
- `app/gateway/{routers/thread_runs,services}.py` — cross-process join, short-circuit, reconciliation
- `config/stream_bridge_config.py`, `config.example.yaml` (config_version → 12), reload boundary, pyproject extras
- `runs/store/memory.py`, `persistence/run/sql.py` — H-compat user_id handling
- `backend/CLAUDE.md` — Stream Bridge architecture section

## Testing

- `tests/test_redis_stream_bridge.py` — fakeredis unit tests (publish/replay/resume/heartbeat/TTL/oversized/cleanup/config validation)
- `tests/test_terminal_reconcile.py` — short-circuit + synthetic-end reconciliation
- `tests/test_worker_stream_ttl.py` — TTL keeper + safe cleanup
- `tests/test_run_store_user_scope.py` — H-compat legacy user_id
- Verified end-to-end against a **real `redis-server`** (not fakeredis), including a cross-worker producer→consumer round trip.