### PR TITLE
fix(docker): auto-create .env files from examples on start

### DIFF
--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -41,6 +41,24 @@ load_proxy_env_from_dotenv() {
     done
 }
 
+ensure_env_file() {
+    local example_file="$1"
+    local env_file="$2"
+    local label="$3"
+
+    if [ -f "$env_file" ]; then
+        return
+    fi
+
+    if [ ! -f "$example_file" ]; then
+        echo -e "${YELLOW}✗ $label not found and no example file to copy from: $example_file${NC}"
+        exit 1
+    fi
+
+    cp "$example_file" "$env_file"
+    echo -e "${BLUE}Created $label from example${NC}"
+}
+
 detect_sandbox_mode() {
     local config_file="$PROJECT_ROOT/config.yaml"
     local sandbox_use=""
@@ -245,6 +263,9 @@ start() {
             echo -e "${BLUE}Created empty extensions_config.json${NC}"
         fi
     fi
+
+    ensure_env_file "$PROJECT_ROOT/.env.example" "$PROJECT_ROOT/.env" ".env"
+    ensure_env_file "$PROJECT_ROOT/frontend/.env.example" "$PROJECT_ROOT/frontend/.env" "frontend/.env"
 
     load_proxy_env_from_dotenv
 


### PR DESCRIPTION
---
  # Fixes 

  ## Why

  First-time users who clone the repo and jump straight to `./scripts/docker.sh start`
  (or follow the Docker quick-start path) hit an immediate startup failure if they
  haven't manually copied `.env.example → .env` and `frontend/.env.example → frontend/.env`.
  This is a common friction point that produces a confusing error with no clear remediation
  hint — especially for users who are not yet familiar with the project layout.

  ## What changed

  `scripts/docker.sh` now auto-provisions missing env files before starting the stack:

  - A reusable `ensure_env_file <example> <target> <label>` helper was added.
    It is a no-op when the target already exists, copies from the example when it doesn't,
    and exits with a clear message if the example itself is also absent.
  - `start()` calls the helper twice — once for the root `.env` and once for `frontend/.env` —
    so both locations are covered in a single startup pass.

  Existing users with `.env` files already in place are unaffected.

  ## Surface area

  - [x] **Sandbox** — change is inside `docker/` / `scripts/docker.sh`

  ## Validation

  Simulate a clean-clone state

  mv .env .env.bak && mv frontend/.env frontend/.env.bak

  ./scripts/docker.sh start
  Expected: two "Created … from example" lines, then normal container bring-up

  Verify idempotence — no duplicate copies on second run

  ./scripts/docker.sh start
  Expected: no "Created" lines, normal startup

  Restore

  mv .env.bak .env && mv frontend/.env.bak frontend/.env

  ## AI assistance

  **Tool(s) used:** Claude Code
  **How you used it:** Generated the PR description from the commit diff and existing code context.

  - [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.