### PR TITLE
fix(frontend): prevent user message bubble overflow with long unbreakable strings

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -302,6 +302,7 @@ function MessageContent_({
   if (isHuman) {
     const messageResponse = contentToDisplay ? (
       <AIElementMessageResponse
+        className="break-words"
         remarkPlugins={humanMessagePlugins.remarkPlugins}
         rehypePlugins={humanMessagePlugins.rehypePlugins}
         components={components}
@@ -311,10 +312,15 @@ function MessageContent_({
       </AIElementMessageResponse>
     ) : null;
     return (
-      <div className={cn("ml-auto flex flex-col gap-2", className)}>
+      <div
+        className={cn(
+          "ml-auto flex max-w-full min-w-0 flex-col gap-2",
+          className,
+        )}
+      >
         {filesList}
         {messageResponse && (
-          <AIElementMessageContent className="w-fit">
+          <AIElementMessageContent className="w-full max-w-full">
             {messageResponse}
           </AIElementMessageContent>
         )}


### PR DESCRIPTION
fix(frontend): prevent user message bubble overflow with long unbreakable strings

- Add max-w-full min-w-0 to constrain message container width
- Change bubble width from w-fit to conditional w-full max-w-full (user) / w-fit (assistant)
- Move break-words from outer wrapper to AIElementMessageResponse for precise text wrapping

Fixes #3484

## Why

用户输入包含长不可换行字符串（如 `=====================================`、长 URL、无空格连续字符）时，用户消息气泡会被内容无限撑宽，超出页面容器导致**页面出现横向滚动条**。

触发场景：用户粘贴长代码注释分隔线、长 URL、连续符号等无换行机会的字符串。

## What changed

- 用户消息气泡宽度现在与 AI 回复气泡保持一致，不再随内容无限扩展
- 长不可换行字符串现在会在气泡边界处自动换行，不再撑破容器
- 页面不再因用户消息出现横向滚动条

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under frontend/
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording
改动后的代码块或Markdown文本可以正常展示
<img width="1995" height="946" alt="QQ_1781108821784" src="https://github.com/user-attachments/assets/7d1ddf87-2cd4-445e-9687-593a63428764" />
<img width="1995" height="946" alt="QQ_1781108769790" src="https://github.com/user-attachments/assets/f6911c05-d00c-4c94-a85c-566a9f7f1418" />


## Bug fix verification

- 问题可通过在前端输入框中粘贴长不可换行字符串（如 50+ 个 `=` 号）复现
- 属于纯 CSS 样式 bug，不涉及逻辑层，不适合用单元测试覆盖
- 验证方式：Docker 开发环境中实测长字符串气泡换行正常，横向滚动条消失

## Validation

```bash
# 前端单元测试
# 结果：23/23 test files passed, 167/167 tests passed
```