### PR TITLE
fix(frontend): keep workspace interactive when SSR auth probe cannot reach gateway (#3493)

### DIFF
--- a/frontend/src/app/(auth)/layout.tsx
+++ b/frontend/src/app/(auth)/layout.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 import { type ReactNode } from "react";
 
+import { GatewayOfflineFallback } from "@/components/workspace/gateway-offline-fallback";
 import { AuthProvider } from "@/core/auth/AuthProvider";
 import { getServerSideUser } from "@/core/auth/server";
 import { assertNever } from "@/core/auth/types";
@@ -25,18 +25,17 @@ export default async function AuthLayout({
     case "unauthenticated":
       return <AuthProvider initialUser={null}>{children}</AuthProvider>;
     case "gateway_unavailable":
+      // Auth pages have no banner of their own, so render one here. The
+      // fallback's AuthProvider replaces the bare-HTML branch that
+      // previously locked users out without any logout/retry capability.
       return (
-        <div className="flex h-screen flex-col items-center justify-center gap-4">
-          <p className="text-muted-foreground">
-            Service temporarily unavailable.
-          </p>
-          <Link
-            href="/login"
-            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm"
-          >
-            Retry
-          </Link>
-        </div>
+        <GatewayOfflineFallback renderBanner>
+          <div className="flex h-screen flex-col items-center justify-center gap-4">
+            <p className="text-muted-foreground">
+              Service temporarily unavailable.
+            </p>
+          </div>
+        </GatewayOfflineFallback>
       );
     case "config_error":
       throw new Error(result.message);

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { AuthProvider } from "@/core/auth/AuthProvider";
@@ -29,30 +28,9 @@ export default async function WorkspaceLayout({
       redirect("/login");
     case "gateway_unavailable":
       return (
-        <div className="flex h-screen flex-col items-center justify-center gap-4">
-          <p className="text-muted-foreground">
-            Service temporarily unavailable.
-          </p>
-          <p className="text-muted-foreground text-xs">
-            The backend may be restarting. Please wait a moment and try again.
-          </p>
-          <div className="flex gap-3">
-            <Link
-              href="/workspace"
-              className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-4 py-2 text-sm"
-            >
-              Retry
-            </Link>
-            <form action="/api/v1/auth/logout" method="post">
-              <button
-                type="submit"
-                className="text-muted-foreground hover:bg-muted rounded-md border px-4 py-2 text-sm"
-              >
-                Logout &amp; Reset
-              </button>
-            </form>
-          </div>
-        </div>
+        <AuthProvider initialUser={null}>
+          <WorkspaceContent gatewayUnavailable>{children}</WorkspaceContent>
+        </AuthProvider>
       );
     case "config_error":
       throw new Error(result.message);

--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
+import { GatewayOfflineFallback } from "@/components/workspace/gateway-offline-fallback";
 import { AuthProvider } from "@/core/auth/AuthProvider";
 import { getServerSideUser } from "@/core/auth/server";
 import { assertNever } from "@/core/auth/types";
@@ -27,10 +28,13 @@ export default async function WorkspaceLayout({
     case "unauthenticated":
       redirect("/login");
     case "gateway_unavailable":
+      // GatewayOfflineFallback supplies the AuthProvider; WorkspaceContent
+      // already mounts the banner inside its sidebar layout, so renderBanner
+      // stays false here to avoid double-mounting.
       return (
-        <AuthProvider initialUser={null}>
+        <GatewayOfflineFallback>
           <WorkspaceContent gatewayUnavailable>{children}</WorkspaceContent>
-        </AuthProvider>
+        </GatewayOfflineFallback>
       );
     case "config_error":
       throw new Error(result.message);

--- a/frontend/src/app/workspace/workspace-content.tsx
+++ b/frontend/src/app/workspace/workspace-content.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "sonner";
 import { QueryClientProvider } from "@/components/query-client-provider";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { CommandPalette } from "@/components/workspace/command-palette";
+import { GatewayOfflineBanner } from "@/components/workspace/gateway-offline-banner";
 import { WorkspaceSidebar } from "@/components/workspace/workspace-sidebar";
 
 function parseSidebarOpenCookie(
@@ -16,7 +17,11 @@ function parseSidebarOpenCookie(
 
 export async function WorkspaceContent({
   children,
-}: Readonly<{ children: React.ReactNode }>) {
+  gatewayUnavailable = false,
+}: Readonly<{
+  children: React.ReactNode;
+  gatewayUnavailable?: boolean;
+}>) {
   const cookieStore = await cookies();
   const initialSidebarOpen = parseSidebarOpenCookie(
     cookieStore.get("sidebar_state")?.value,
@@ -26,7 +31,10 @@ export async function WorkspaceContent({
     <QueryClientProvider>
       <SidebarProvider className="h-screen" defaultOpen={initialSidebarOpen}>
         <WorkspaceSidebar />
-        <SidebarInset className="min-w-0">{children}</SidebarInset>
+        <SidebarInset className="min-w-0">
+          <GatewayOfflineBanner gatewayUnavailable={gatewayUnavailable} />
+          {children}
+        </SidebarInset>
       </SidebarProvider>
       <CommandPalette />
       <Toaster position="top-center" />

--- a/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
+++ b/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
@@ -21,21 +21,47 @@ export function shouldShowOfflineBanner(
 
 /** Categorised outcome of a single /auth/me probe. */
 export type ProbeOutcome =
-  | { kind: "ok" } // 2xx
+  | { kind: "ok"; user: User } // 2xx with parsed body
   | { kind: "unauthorized" } // 401
-  | { kind: "transient" }; // 5xx, network, abort, etc.
+  | { kind: "transient" }; // 5xx, network, abort, malformed body, etc.
 
 /** Next action the banner effect should take after a probe. */
 export type ProbeAction =
-  | { type: "delegate-refresh"; reason: "recovered" | "session-expired" }
+  | { type: "apply-user"; user: User }
+  | { type: "delegate-refresh"; reason: "session-expired" }
   | { type: "noop"; nextFailureCount: number };
+
+/**
+ * Pure: classify an HTTP probe outcome into ProbeOutcome.
+ *
+ * Extracted from the banner effect so it can be unit-tested independently.
+ * `parsedUser` is the JSON body of a 2xx response (or null if absent/malformed);
+ * surfacing it through ProbeOutcome lets the caller apply it directly instead
+ * of paying for a second /auth/me round-trip via refreshUser().
+ */
+export function classifyProbe(
+  res: Response | null,
+  errored: boolean,
+  parsedUser: User | null = null,
+): ProbeOutcome {
+  if (errored || res === null) return { kind: "transient" };
+  if (res.ok && parsedUser !== null) return { kind: "ok", user: parsedUser };
+  if (res.ok) return { kind: "transient" }; // 2xx but body unusable
+  if (res.status === 401) return { kind: "unauthorized" };
+  return { kind: "transient" };
+}
 
 /**
  * Pure state machine for what to do after a probe lands.
  *
  * Inputs: how many consecutive 401s we've seen so far + the new outcome.
- * Outputs: either "delegate to refreshUser()" (which will sync user or
- * /login-redirect via AuthProvider) or "do nothing, update counter".
+ * Outputs: either "apply the user body we just fetched", "delegate to
+ * refreshUser() for /login redirect", or "do nothing, update counter".
+ *
+ * Transient outcomes (5xx / network / abort) decrement the auth-failure
+ * streak by 1 (floored at 0) rather than resetting it. This prevents a
+ * flapping gateway that alternates 401 ↔ 5xx from indefinitely masking a
+ * genuinely expired session: the streak still converges on the threshold.
  */
 export function decideProbeAction(
   consecutiveAuthFailures: number,
@@ -43,7 +69,7 @@ export function decideProbeAction(
   threshold: number = OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD,
 ): ProbeAction {
   if (outcome.kind === "ok") {
-    return { type: "delegate-refresh", reason: "recovered" };
+    return { type: "apply-user", user: outcome.user };
   }
   if (outcome.kind === "unauthorized") {
     const next = consecutiveAuthFailures + 1;
@@ -52,7 +78,10 @@ export function decideProbeAction(
     }
     return { type: "noop", nextFailureCount: next };
   }
-  // transient (5xx, network, abort): reset auth-failure streak so we don't
-  // count an unrelated outage toward "session expired".
-  return { type: "noop", nextFailureCount: 0 };
+  // transient: decrement rather than reset so a flapping gateway
+  // (alternating 401 ↔ 5xx) still converges on session-expired.
+  return {
+    type: "noop",
+    nextFailureCount: Math.max(0, consecutiveAuthFailures - 1),
+  };
 }

--- a/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
+++ b/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
@@ -1,39 +1,58 @@
-/**
- * Pure helpers for the workspace gateway-offline banner.
- *
- * Kept in a separate module so they can be unit-tested without bringing
- * React / jsdom into the vitest config (see `frontend/vitest.config.ts`,
- * which only collects `tests/unit/**\/*.test.ts`).
- */
-
-import type { User } from "@/core/auth/types";
-
-/**
- * How often the banner re-checks the gateway by calling
- * `AuthProvider.refreshUser()` while it is mounted.
- *
- * 10s is a deliberate trade-off:
- * - fast enough for the UI to recover without user action once the
- *   gateway comes back, and
- * - slow enough not to add meaningful load while the gateway is
- *   already struggling.
- */
 export const OFFLINE_BANNER_RETRY_INTERVAL_MS = 10_000;
 
 /**
- * Decide whether the workspace gateway-offline banner should be visible.
+ * Number of consecutive 401 responses before treating the session as
+ * expired and delegating to AuthProvider.refreshUser() for /login redirect.
  *
- * Visible iff:
- * - the workspace layout flagged the SSR auth probe as unavailable, AND
- * - the client has not yet recovered an authenticated user (e.g. via
- *   `AuthProvider.refreshUser()`).
- *
- * Once the gateway recovers and `refreshUser()` populates `user`, the
- * banner hides itself automatically.
+ * Threshold > 1 absorbs transient 401s that may occur in the first few
+ * milliseconds after a gateway becomes ready again, without indefinitely
+ * masking a genuinely expired cookie.
  */
+export const OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD = 3;
+
+import type { User } from "@/core/auth/types";
+
 export function shouldShowOfflineBanner(
   user: User | null,
   gatewayUnavailable: boolean,
 ): boolean {
   return gatewayUnavailable && user === null;
+}
+
+/** Categorised outcome of a single /auth/me probe. */
+export type ProbeOutcome =
+  | { kind: "ok" } // 2xx
+  | { kind: "unauthorized" } // 401
+  | { kind: "transient" }; // 5xx, network, abort, etc.
+
+/** Next action the banner effect should take after a probe. */
+export type ProbeAction =
+  | { type: "delegate-refresh"; reason: "recovered" | "session-expired" }
+  | { type: "noop"; nextFailureCount: number };
+
+/**
+ * Pure state machine for what to do after a probe lands.
+ *
+ * Inputs: how many consecutive 401s we've seen so far + the new outcome.
+ * Outputs: either "delegate to refreshUser()" (which will sync user or
+ * /login-redirect via AuthProvider) or "do nothing, update counter".
+ */
+export function decideProbeAction(
+  consecutiveAuthFailures: number,
+  outcome: ProbeOutcome,
+  threshold: number = OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD,
+): ProbeAction {
+  if (outcome.kind === "ok") {
+    return { type: "delegate-refresh", reason: "recovered" };
+  }
+  if (outcome.kind === "unauthorized") {
+    const next = consecutiveAuthFailures + 1;
+    if (next >= threshold) {
+      return { type: "delegate-refresh", reason: "session-expired" };
+    }
+    return { type: "noop", nextFailureCount: next };
+  }
+  // transient (5xx, network, abort): reset auth-failure streak so we don't
+  // count an unrelated outage toward "session expired".
+  return { type: "noop", nextFailureCount: 0 };
 }

--- a/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
+++ b/frontend/src/components/workspace/gateway-offline-banner-helpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Pure helpers for the workspace gateway-offline banner.
+ *
+ * Kept in a separate module so they can be unit-tested without bringing
+ * React / jsdom into the vitest config (see `frontend/vitest.config.ts`,
+ * which only collects `tests/unit/**\/*.test.ts`).
+ */
+
+import type { User } from "@/core/auth/types";
+
+/**
+ * How often the banner re-checks the gateway by calling
+ * `AuthProvider.refreshUser()` while it is mounted.
+ *
+ * 10s is a deliberate trade-off:
+ * - fast enough for the UI to recover without user action once the
+ *   gateway comes back, and
+ * - slow enough not to add meaningful load while the gateway is
+ *   already struggling.
+ */
+export const OFFLINE_BANNER_RETRY_INTERVAL_MS = 10_000;
+
+/**
+ * Decide whether the workspace gateway-offline banner should be visible.
+ *
+ * Visible iff:
+ * - the workspace layout flagged the SSR auth probe as unavailable, AND
+ * - the client has not yet recovered an authenticated user (e.g. via
+ *   `AuthProvider.refreshUser()`).
+ *
+ * Once the gateway recovers and `refreshUser()` populates `user`, the
+ * banner hides itself automatically.
+ */
+export function shouldShowOfflineBanner(
+  user: User | null,
+  gatewayUnavailable: boolean,
+): boolean {
+  return gatewayUnavailable && user === null;
+}

--- a/frontend/src/components/workspace/gateway-offline-banner.tsx
+++ b/frontend/src/components/workspace/gateway-offline-banner.tsx
@@ -13,8 +13,8 @@ import {
 interface GatewayOfflineBannerProps {
   /**
    * True when the server-side auth probe at `/api/v1/auth/me` could not
-   * reach the gateway. The banner stays mounted until the client-side
-   * `refreshUser()` succeeds and populates `user`.
+   * reach the gateway. The banner stays mounted until a client-side probe
+   * confirms the gateway is healthy and `user` becomes populated.
    */
   gatewayUnavailable: boolean;
 }
@@ -24,19 +24,41 @@ export function GatewayOfflineBanner({
 }: GatewayOfflineBannerProps) {
   const { t } = useI18n();
   const { user, refreshUser, logout } = useAuth();
-  // Guard against piling up `refreshUser()` calls while the gateway is
-  // still slow: each interval tick must wait for the previous probe to
-  // settle before issuing a new one.
+  // Guard against piling up probe calls while the gateway is still slow:
+  // each interval tick must wait for the previous probe to settle before
+  // issuing a new one.
   const inFlightRef = useRef(false);
 
   useEffect(() => {
     if (!gatewayUnavailable) return;
 
+    // We intentionally do NOT call `refreshUser()` directly here.
+    // `AuthProvider.refreshUser()` treats any 401 from `/api/v1/auth/me`
+    // as "session expired" and force-redirects to `/login`. During gateway
+    // recovery, the first few requests may transiently return 401 before
+    // the gateway is fully ready, which would incorrectly kick the user
+    // out — defeating the purpose of this offline banner.
+    //
+    // Instead, we silently probe `/api/v1/auth/me` ourselves and only
+    // delegate to `refreshUser()` once we confirm the gateway is healthy
+    // (200 OK). Non-200 responses are swallowed; we just wait for the
+    // next interval tick.
     const probe = async () => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       try {
-        await refreshUser();
+        const res = await fetch("/api/v1/auth/me", {
+          credentials: "include",
+          cache: "no-store",
+        });
+        if (res.ok) {
+          // Gateway is healthy again — hand off to AuthProvider so
+          // `user` is populated and the banner unmounts itself.
+          await refreshUser();
+        }
+        // 401 / 5xx / network: stay silent and retry on the next tick.
+      } catch {
+        // Network error during recovery is expected; stay silent.
       } finally {
         inFlightRef.current = false;
       }

--- a/frontend/src/components/workspace/gateway-offline-banner.tsx
+++ b/frontend/src/components/workspace/gateway-offline-banner.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { useAuth } from "@/core/auth/AuthProvider";
+import { useI18n } from "@/core/i18n/hooks";
+
+import {
+  OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  shouldShowOfflineBanner,
+} from "./gateway-offline-banner-helpers";
+
+interface GatewayOfflineBannerProps {
+  /**
+   * True when the server-side auth probe at `/api/v1/auth/me` could not
+   * reach the gateway. The banner stays mounted until the client-side
+   * `refreshUser()` succeeds and populates `user`.
+   */
+  gatewayUnavailable: boolean;
+}
+
+export function GatewayOfflineBanner({
+  gatewayUnavailable,
+}: GatewayOfflineBannerProps) {
+  const { t } = useI18n();
+  const { user, refreshUser, logout } = useAuth();
+  // Guard against piling up `refreshUser()` calls while the gateway is
+  // still slow: each interval tick must wait for the previous probe to
+  // settle before issuing a new one.
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!gatewayUnavailable) return;
+
+    const probe = async () => {
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      try {
+        await refreshUser();
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    // Kick off an immediate probe so the banner can disappear as soon
+    // as the gateway is back, without waiting for the first interval.
+    void probe();
+
+    const handle = window.setInterval(() => {
+      void probe();
+    }, OFFLINE_BANNER_RETRY_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(handle);
+    };
+  }, [gatewayUnavailable, refreshUser]);
+
+  if (!shouldShowOfflineBanner(user, gatewayUnavailable)) {
+    return null;
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="bg-muted text-muted-foreground flex items-center justify-between gap-3 border-b px-4 py-2 text-sm"
+    >
+      <span>
+        {t.workspace.gatewayUnavailable}{" "}
+        {t.workspace.gatewayUnavailableRetrying}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          void logout();
+        }}
+        className="hover:bg-background rounded-md border px-3 py-1 text-xs"
+      >
+        {t.workspace.logout}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/gateway-offline-banner.tsx
+++ b/frontend/src/components/workspace/gateway-offline-banner.tsx
@@ -3,13 +3,14 @@
 import { useEffect, useRef } from "react";
 
 import { useAuth } from "@/core/auth/AuthProvider";
+import { userSchema, type User } from "@/core/auth/types";
 import { useI18n } from "@/core/i18n/hooks";
 
 import {
   OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  classifyProbe,
   decideProbeAction,
   shouldShowOfflineBanner,
-  type ProbeOutcome,
 } from "./gateway-offline-banner-helpers";
 
 interface GatewayOfflineBannerProps {
@@ -25,7 +26,7 @@ export function GatewayOfflineBanner({
   gatewayUnavailable,
 }: GatewayOfflineBannerProps) {
   const { t } = useI18n();
-  const { user, refreshUser, logout } = useAuth();
+  const { user, applyUser, refreshUser, logout } = useAuth();
   // Guard against piling up probe calls while the gateway is still slow.
   const inFlightRef = useRef(false);
   // Count consecutive 401s so we can distinguish "transient warm-up 401"
@@ -40,24 +41,34 @@ export function GatewayOfflineBanner({
     // server-rendered prop and stays true until a full reload).
     if (user !== null) return;
 
-    const classify = (res: Response | null, errored: boolean): ProbeOutcome => {
-      if (errored || res === null) return { kind: "transient" };
-      if (res.ok) return { kind: "ok" };
-      if (res.status === 401) return { kind: "unauthorized" };
-      return { kind: "transient" };
-    };
-
     const probe = async () => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
       let res: Response | null = null;
       let errored = false;
+      let parsedUser: User | null = null;
       try {
         res = await fetch("/api/v1/auth/me", {
           credentials: "include",
           cache: "no-store",
         });
-      } catch {
+        // Reuse the probe's own response body instead of triggering a
+        // second /auth/me request via refreshUser() — halves the recovery
+        // burst against an already-struggling gateway.
+        if (res.ok) {
+          try {
+            const data = await res.json();
+            const parsed = userSchema.safeParse(data);
+            if (parsed.success) parsedUser = parsed.data;
+          } catch (err) {
+            console.warn(
+              "[gateway-offline-banner] probe body parse failed:",
+              err,
+            );
+          }
+        }
+      } catch (err) {
+        console.warn("[gateway-offline-banner] probe failed:", err);
         errored = true;
       } finally {
         inFlightRef.current = false;
@@ -65,13 +76,16 @@ export function GatewayOfflineBanner({
 
       const action = decideProbeAction(
         authFailuresRef.current,
-        classify(res, errored),
+        classifyProbe(res, errored, parsedUser),
       );
 
+      if (action.type === "apply-user") {
+        authFailuresRef.current = 0;
+        applyUser(action.user);
+        return;
+      }
       if (action.type === "delegate-refresh") {
-        // Reset counter and hand off to AuthProvider. On "recovered" it
-        // will populate `user` (banner unmounts on next render). On
-        // "session-expired" it will /login-redirect from its 401 branch.
+        // Hand off to AuthProvider, which on 401 will /login-redirect.
         authFailuresRef.current = 0;
         await refreshUser();
         return;
@@ -86,7 +100,7 @@ export function GatewayOfflineBanner({
     return () => {
       window.clearInterval(handle);
     };
-  }, [gatewayUnavailable, user, refreshUser]);
+  }, [gatewayUnavailable, user, applyUser, refreshUser]);
 
   if (!shouldShowOfflineBanner(user, gatewayUnavailable)) {
     return null;

--- a/frontend/src/components/workspace/gateway-offline-banner.tsx
+++ b/frontend/src/components/workspace/gateway-offline-banner.tsx
@@ -7,7 +7,9 @@ import { useI18n } from "@/core/i18n/hooks";
 
 import {
   OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  decideProbeAction,
   shouldShowOfflineBanner,
+  type ProbeOutcome,
 } from "./gateway-offline-banner-helpers";
 
 interface GatewayOfflineBannerProps {
@@ -24,58 +26,67 @@ export function GatewayOfflineBanner({
 }: GatewayOfflineBannerProps) {
   const { t } = useI18n();
   const { user, refreshUser, logout } = useAuth();
-  // Guard against piling up probe calls while the gateway is still slow:
-  // each interval tick must wait for the previous probe to settle before
-  // issuing a new one.
+  // Guard against piling up probe calls while the gateway is still slow.
   const inFlightRef = useRef(false);
+  // Count consecutive 401s so we can distinguish "transient warm-up 401"
+  // from "session actually expired" and avoid lying with the banner.
+  const authFailuresRef = useRef(0);
 
   useEffect(() => {
     if (!gatewayUnavailable) return;
+    // Once AuthProvider has a user again the banner has served its
+    // purpose; tear down the polling so we don't keep probing every 10s
+    // for the entire lifetime of the page (gatewayUnavailable is a
+    // server-rendered prop and stays true until a full reload).
+    if (user !== null) return;
 
-    // We intentionally do NOT call `refreshUser()` directly here.
-    // `AuthProvider.refreshUser()` treats any 401 from `/api/v1/auth/me`
-    // as "session expired" and force-redirects to `/login`. During gateway
-    // recovery, the first few requests may transiently return 401 before
-    // the gateway is fully ready, which would incorrectly kick the user
-    // out — defeating the purpose of this offline banner.
-    //
-    // Instead, we silently probe `/api/v1/auth/me` ourselves and only
-    // delegate to `refreshUser()` once we confirm the gateway is healthy
-    // (200 OK). Non-200 responses are swallowed; we just wait for the
-    // next interval tick.
+    const classify = (res: Response | null, errored: boolean): ProbeOutcome => {
+      if (errored || res === null) return { kind: "transient" };
+      if (res.ok) return { kind: "ok" };
+      if (res.status === 401) return { kind: "unauthorized" };
+      return { kind: "transient" };
+    };
+
     const probe = async () => {
       if (inFlightRef.current) return;
       inFlightRef.current = true;
+      let res: Response | null = null;
+      let errored = false;
       try {
-        const res = await fetch("/api/v1/auth/me", {
+        res = await fetch("/api/v1/auth/me", {
           credentials: "include",
           cache: "no-store",
         });
-        if (res.ok) {
-          // Gateway is healthy again — hand off to AuthProvider so
-          // `user` is populated and the banner unmounts itself.
-          await refreshUser();
-        }
-        // 401 / 5xx / network: stay silent and retry on the next tick.
       } catch {
-        // Network error during recovery is expected; stay silent.
+        errored = true;
       } finally {
         inFlightRef.current = false;
       }
+
+      const action = decideProbeAction(
+        authFailuresRef.current,
+        classify(res, errored),
+      );
+
+      if (action.type === "delegate-refresh") {
+        // Reset counter and hand off to AuthProvider. On "recovered" it
+        // will populate `user` (banner unmounts on next render). On
+        // "session-expired" it will /login-redirect from its 401 branch.
+        authFailuresRef.current = 0;
+        await refreshUser();
+        return;
+      }
+      authFailuresRef.current = action.nextFailureCount;
     };
 
-    // Kick off an immediate probe so the banner can disappear as soon
-    // as the gateway is back, without waiting for the first interval.
     void probe();
-
     const handle = window.setInterval(() => {
       void probe();
     }, OFFLINE_BANNER_RETRY_INTERVAL_MS);
-
     return () => {
       window.clearInterval(handle);
     };
-  }, [gatewayUnavailable, refreshUser]);
+  }, [gatewayUnavailable, user, refreshUser]);
 
   if (!shouldShowOfflineBanner(user, gatewayUnavailable)) {
     return null;

--- a/frontend/src/components/workspace/gateway-offline-fallback.tsx
+++ b/frontend/src/components/workspace/gateway-offline-fallback.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { AuthProvider } from "@/core/auth/AuthProvider";
+
+import { GatewayOfflineBanner } from "./gateway-offline-banner";
+
+interface GatewayOfflineFallbackProps {
+  /**
+   * When true, this component renders its own banner. The workspace layout
+   * sets this to false because WorkspaceContent already mounts the banner
+   * inside its sidebar layout. The (auth) layout sets it to true because
+   * its plain children have no banner of their own.
+   */
+  renderBanner?: boolean;
+  children?: React.ReactNode;
+}
+
+/**
+ * Shared fallback shown by both the workspace and (auth) layouts when the
+ * server-side auth probe could not reach the gateway. Wraps the children
+ * with an AuthProvider so the banner's probe / logout / refresh hooks work
+ * — fixing the `(auth)/layout.tsx` lockup where the bare static HTML had
+ * no AuthProvider / QueryClientProvider and the user could not recover
+ * without a manual reload.
+ */
+export function GatewayOfflineFallback({
+  renderBanner = false,
+  children,
+}: GatewayOfflineFallbackProps) {
+  return (
+    <AuthProvider initialUser={null}>
+      {renderBanner && <GatewayOfflineBanner gatewayUnavailable />}
+      {children}
+    </AuthProvider>
+  );
+}

--- a/frontend/src/core/auth/AuthProvider.tsx
+++ b/frontend/src/core/auth/AuthProvider.tsx
@@ -26,6 +26,7 @@ interface AuthContextType {
   isLoading: boolean;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
+  applyUser: (user: User | null) => void;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -51,6 +52,15 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   const staticMode = isStaticWebsiteOnly();
 
   const isAuthenticated = user !== null;
+
+  /**
+   * Apply a user value supplied by a caller (e.g. banner probe) that has
+   * already fetched it. Equivalent to setUser, exposed with a stable name
+   * so consumers don't reach into React internals.
+   */
+  const applyUser = useCallback((next: User | null) => {
+    setUser(next);
+  }, []);
 
   /**
    * Fetch current user from FastAPI
@@ -87,6 +97,13 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
   /**
    * Logout - call FastAPI logout endpoint and clear local state
    * Per RFC-001: Immediately clear local state, don't wait for server confirmation
+   *
+   * When the gateway is unreachable the fetch silently fails — the SPA
+   * router.push("/") would leave the user on "/" still holding stale
+   * React state and any in-flight SSE / fetch / query subscriptions.
+   * We therefore fall back to a hard navigation (window.location.href),
+   * which discards all client state the same way the legacy form-POST
+   * logout used to.
    */
   const logout = useCallback(async () => {
     // Immediately clear local state to prevent UI flicker
@@ -97,14 +114,23 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       return;
     }
 
+    let logoutFailed = false;
     try {
-      await fetch("/api/v1/auth/logout", {
+      const res = await fetch("/api/v1/auth/logout", {
         method: "POST",
         credentials: "include",
       });
+      if (!res.ok) logoutFailed = true;
     } catch (err) {
       console.error("Logout request failed:", err);
-      // Still redirect even if logout request fails
+      logoutFailed = true;
+    }
+
+    if (logoutFailed && typeof window !== "undefined") {
+      // Hard navigation ensures every in-flight subscription is torn down,
+      // matching the legacy form-POST logout behaviour during a gateway outage.
+      window.location.href = "/";
+      return;
     }
 
     // Redirect to home page
@@ -140,6 +166,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
     isLoading,
     logout,
     refreshUser,
+    applyUser,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -240,6 +240,8 @@ export const enUS: Translations = {
     contactUs: "Contact us",
     about: "About DeerFlow",
     logout: "Log out",
+    gatewayUnavailable: "Gateway is temporarily unavailable.",
+    gatewayUnavailableRetrying: "Retrying in the background…",
   },
 
   // Conversation

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -171,6 +171,8 @@ export interface Translations {
     contactUs: string;
     about: string;
     logout: string;
+    gatewayUnavailable: string;
+    gatewayUnavailableRetrying: string;
   };
 
   // Conversation

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -228,6 +228,8 @@ export const zhCN: Translations = {
     contactUs: "联系我们",
     about: "关于 DeerFlow",
     logout: "退出登录",
+    gatewayUnavailable: "网关暂时不可用。",
+    gatewayUnavailableRetrying: "正在后台重试…",
   },
 
   // Conversation

--- a/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
+++ b/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD,
   OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  classifyProbe,
   decideProbeAction,
   shouldShowOfflineBanner,
 } from "@/components/workspace/gateway-offline-banner-helpers";
@@ -14,6 +15,10 @@ const fakeUser: User = {
   system_role: "user",
   needs_setup: false,
 };
+
+function makeResponse(status: number, ok = status >= 200 && status < 300) {
+  return { status, ok } as Response;
+}
 
 describe("shouldShowOfflineBanner", () => {
   it("hides when the gateway is reachable", () => {
@@ -44,16 +49,62 @@ describe("OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD", () => {
   });
 });
 
+describe("classifyProbe", () => {
+  it("returns transient when fetch errored", () => {
+    expect(classifyProbe(null, true)).toEqual({ kind: "transient" });
+  });
+
+  it("returns transient when response is null with no error flag", () => {
+    expect(classifyProbe(null, false)).toEqual({ kind: "transient" });
+  });
+
+  it("returns ok with parsed user for a 2xx response with body", () => {
+    expect(classifyProbe(makeResponse(200), false, fakeUser)).toEqual({
+      kind: "ok",
+      user: fakeUser,
+    });
+  });
+
+  it("returns transient for a 2xx response whose body failed to parse", () => {
+    // Defensive: a 200 with malformed JSON / schema mismatch should not be
+    // treated as 'ok' because the caller has no user to apply.
+    expect(classifyProbe(makeResponse(200), false, null)).toEqual({
+      kind: "transient",
+    });
+  });
+
+  it("returns unauthorized for a 401 response", () => {
+    expect(classifyProbe(makeResponse(401), false)).toEqual({
+      kind: "unauthorized",
+    });
+  });
+
+  it("returns transient for 5xx responses", () => {
+    expect(classifyProbe(makeResponse(503), false)).toEqual({
+      kind: "transient",
+    });
+    expect(classifyProbe(makeResponse(500), false)).toEqual({
+      kind: "transient",
+    });
+  });
+
+  it("returns transient for unexpected non-401 4xx responses", () => {
+    expect(classifyProbe(makeResponse(429), false)).toEqual({
+      kind: "transient",
+    });
+  });
+});
+
 describe("decideProbeAction", () => {
-  it("delegates to refreshUser as 'recovered' on a 2xx response", () => {
-    expect(decideProbeAction(0, { kind: "ok" })).toEqual({
-      type: "delegate-refresh",
-      reason: "recovered",
+  it("returns apply-user with the body on a 2xx response", () => {
+    expect(decideProbeAction(0, { kind: "ok", user: fakeUser })).toEqual({
+      type: "apply-user",
+      user: fakeUser,
     });
     // Even if we'd accumulated some 401s, a 200 wins immediately.
-    expect(decideProbeAction(2, { kind: "ok" })).toEqual({
-      type: "delegate-refresh",
-      reason: "recovered",
+    expect(decideProbeAction(2, { kind: "ok", user: fakeUser })).toEqual({
+      type: "apply-user",
+      user: fakeUser,
     });
   });
 
@@ -65,8 +116,6 @@ describe("decideProbeAction", () => {
   });
 
   it("treats consecutive 401s below the threshold as still transient", () => {
-    // With default threshold = 3, two consecutive 401s should not yet
-    // be flagged as session-expired.
     expect(decideProbeAction(1, { kind: "unauthorized" })).toEqual({
       type: "noop",
       nextFailureCount: 2,
@@ -74,7 +123,6 @@ describe("decideProbeAction", () => {
   });
 
   it("delegates to refreshUser as 'session-expired' once 401s reach the threshold", () => {
-    // Default threshold = 3 → third consecutive 401 trips the wire.
     expect(decideProbeAction(2, { kind: "unauthorized" })).toEqual({
       type: "delegate-refresh",
       reason: "session-expired",
@@ -82,7 +130,6 @@ describe("decideProbeAction", () => {
   });
 
   it("honours a custom threshold (parameterised for safer tests)", () => {
-    // threshold=2: first 401 is still noop, second 401 expires.
     expect(decideProbeAction(0, { kind: "unauthorized" }, 2)).toEqual({
       type: "noop",
       nextFailureCount: 1,
@@ -93,17 +140,46 @@ describe("decideProbeAction", () => {
     });
   });
 
-  it("resets the auth-failure streak on a transient (5xx / network / abort) outcome", () => {
-    // We had 2 consecutive 401s, but the next probe hits a 5xx or network
-    // error — that is an *unrelated* gateway hiccup and must not be counted
-    // toward "session expired". The streak resets to 0.
+  it("decrements (not resets) the auth-failure streak on a transient outcome", () => {
+    // Was 2 → 1, so a flapping gateway (401↔5xx) still converges on the
+    // threshold instead of indefinitely masking session expiry.
     expect(decideProbeAction(2, { kind: "transient" })).toEqual({
       type: "noop",
-      nextFailureCount: 0,
+      nextFailureCount: 1,
     });
+    // Floored at 0; never goes negative.
     expect(decideProbeAction(0, { kind: "transient" })).toEqual({
       type: "noop",
       nextFailureCount: 0,
+    });
+    expect(decideProbeAction(1, { kind: "transient" })).toEqual({
+      type: "noop",
+      nextFailureCount: 0,
+    });
+  });
+
+  it("convergence: alternating 401/transient still triggers session-expired", () => {
+    // Simulate the exact scenario from #3493 CR: flapping gateway alternates
+    // 401 (session gone) and 503 (overloaded). With decrement-by-1, the
+    // counter still nets +1 per 401/transient pair and reaches threshold.
+    let count = 0;
+    const seq: Array<"unauthorized" | "transient"> = [
+      "unauthorized", // count -> 1
+      "transient", // count -> 0
+      "unauthorized", // count -> 1
+      "unauthorized", // count -> 2
+      "transient", // count -> 1
+      "unauthorized", // count -> 2
+    ];
+    for (const kind of seq) {
+      const action = decideProbeAction(count, { kind });
+      expect(action.type).toBe("noop");
+      if (action.type === "noop") count = action.nextFailureCount;
+    }
+    // Next 401 should trip the wire (2 -> 3 == threshold).
+    expect(decideProbeAction(count, { kind: "unauthorized" })).toEqual({
+      type: "delegate-refresh",
+      reason: "session-expired",
     });
   });
 });

--- a/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
+++ b/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD,
   OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  decideProbeAction,
   shouldShowOfflineBanner,
 } from "@/components/workspace/gateway-offline-banner-helpers";
 import type { User } from "@/core/auth/types";
@@ -32,5 +34,76 @@ describe("OFFLINE_BANNER_RETRY_INTERVAL_MS", () => {
   it("is a positive finite number", () => {
     expect(OFFLINE_BANNER_RETRY_INTERVAL_MS).toBeGreaterThan(0);
     expect(Number.isFinite(OFFLINE_BANNER_RETRY_INTERVAL_MS)).toBe(true);
+  });
+});
+
+describe("OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD", () => {
+  it("is an integer greater than 1 so a single transient 401 cannot expire the session", () => {
+    expect(Number.isInteger(OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD)).toBe(true);
+    expect(OFFLINE_BANNER_AUTH_FAILURE_THRESHOLD).toBeGreaterThan(1);
+  });
+});
+
+describe("decideProbeAction", () => {
+  it("delegates to refreshUser as 'recovered' on a 2xx response", () => {
+    expect(decideProbeAction(0, { kind: "ok" })).toEqual({
+      type: "delegate-refresh",
+      reason: "recovered",
+    });
+    // Even if we'd accumulated some 401s, a 200 wins immediately.
+    expect(decideProbeAction(2, { kind: "ok" })).toEqual({
+      type: "delegate-refresh",
+      reason: "recovered",
+    });
+  });
+
+  it("treats a single 401 as transient noise and only bumps the counter", () => {
+    expect(decideProbeAction(0, { kind: "unauthorized" })).toEqual({
+      type: "noop",
+      nextFailureCount: 1,
+    });
+  });
+
+  it("treats consecutive 401s below the threshold as still transient", () => {
+    // With default threshold = 3, two consecutive 401s should not yet
+    // be flagged as session-expired.
+    expect(decideProbeAction(1, { kind: "unauthorized" })).toEqual({
+      type: "noop",
+      nextFailureCount: 2,
+    });
+  });
+
+  it("delegates to refreshUser as 'session-expired' once 401s reach the threshold", () => {
+    // Default threshold = 3 → third consecutive 401 trips the wire.
+    expect(decideProbeAction(2, { kind: "unauthorized" })).toEqual({
+      type: "delegate-refresh",
+      reason: "session-expired",
+    });
+  });
+
+  it("honours a custom threshold (parameterised for safer tests)", () => {
+    // threshold=2: first 401 is still noop, second 401 expires.
+    expect(decideProbeAction(0, { kind: "unauthorized" }, 2)).toEqual({
+      type: "noop",
+      nextFailureCount: 1,
+    });
+    expect(decideProbeAction(1, { kind: "unauthorized" }, 2)).toEqual({
+      type: "delegate-refresh",
+      reason: "session-expired",
+    });
+  });
+
+  it("resets the auth-failure streak on a transient (5xx / network / abort) outcome", () => {
+    // We had 2 consecutive 401s, but the next probe hits a 5xx or network
+    // error — that is an *unrelated* gateway hiccup and must not be counted
+    // toward "session expired". The streak resets to 0.
+    expect(decideProbeAction(2, { kind: "transient" })).toEqual({
+      type: "noop",
+      nextFailureCount: 0,
+    });
+    expect(decideProbeAction(0, { kind: "transient" })).toEqual({
+      type: "noop",
+      nextFailureCount: 0,
+    });
   });
 });

--- a/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
+++ b/frontend/tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OFFLINE_BANNER_RETRY_INTERVAL_MS,
+  shouldShowOfflineBanner,
+} from "@/components/workspace/gateway-offline-banner-helpers";
+import type { User } from "@/core/auth/types";
+
+const fakeUser: User = {
+  id: "u1",
+  email: "user@example.com",
+  system_role: "user",
+  needs_setup: false,
+};
+
+describe("shouldShowOfflineBanner", () => {
+  it("hides when the gateway is reachable", () => {
+    expect(shouldShowOfflineBanner(null, false)).toBe(false);
+    expect(shouldShowOfflineBanner(fakeUser, false)).toBe(false);
+  });
+
+  it("shows when the gateway is unavailable and the client has no user yet", () => {
+    expect(shouldShowOfflineBanner(null, true)).toBe(true);
+  });
+
+  it("hides as soon as the client recovers an authenticated user", () => {
+    expect(shouldShowOfflineBanner(fakeUser, true)).toBe(false);
+  });
+});
+
+describe("OFFLINE_BANNER_RETRY_INTERVAL_MS", () => {
+  it("is a positive finite number", () => {
+    expect(OFFLINE_BANNER_RETRY_INTERVAL_MS).toBeGreaterThan(0);
+    expect(Number.isFinite(OFFLINE_BANNER_RETRY_INTERVAL_MS)).toBe(true);
+  });
+});

--- a/frontend/tests/unit/core/auth/server.test.ts
+++ b/frontend/tests/unit/core/auth/server.test.ts
@@ -75,3 +75,65 @@ describe("getServerSideUser", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
+
+describe("getServerSideUser — gateway_unavailable contract (issue #3493)", () => {
+  let saved: EnvSnapshot;
+
+  beforeEach(() => {
+    saved = snapshotEnv();
+    setEnv("DEER_FLOW_AUTH_DISABLED", undefined);
+    setEnv("NEXT_PUBLIC_STATIC_WEBSITE_ONLY", undefined);
+  });
+
+  afterEach(() => {
+    restoreEnv(saved);
+    vi.unstubAllGlobals();
+    vi.doUnmock("next/headers");
+  });
+
+  test("returns gateway_unavailable when /auth/me fetch rejects (e.g. AbortError)", async () => {
+    vi.doMock("next/headers", () => ({
+      cookies: vi.fn(async () => ({
+        get: (name: string) =>
+          name === "access_token" ? { value: "stub-token" } : undefined,
+      })),
+    }));
+    const abortErr = new DOMException("Aborted", "AbortError");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(abortErr)),
+    );
+
+    const { getServerSideUser } = await loadFreshServerAuth();
+
+    await expect(getServerSideUser()).resolves.toEqual({
+      tag: "gateway_unavailable",
+    });
+  });
+
+  test("returns gateway_unavailable when /auth/me responds with a 5xx", async () => {
+    vi.doMock("next/headers", () => ({
+      cookies: vi.fn(async () => ({
+        get: (name: string) =>
+          name === "access_token" ? { value: "stub-token" } : undefined,
+      })),
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response("upstream error", {
+            status: 503,
+            statusText: "Service Unavailable",
+          }),
+        ),
+      ),
+    );
+
+    const { getServerSideUser } = await loadFreshServerAuth();
+
+    await expect(getServerSideUser()).resolves.toEqual({
+      tag: "gateway_unavailable",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3493 — multi-tab single-user workspace lockups.

## Root cause
When the gateway is busy (e.g. another tab is streaming an SSE response),
the SSR call to `/api/v1/auth/me` in `getServerSideUser()` aborts after
`SSR_AUTH_TIMEOUT_MS` and `WorkspaceLayout` falls back to the
`gateway_unavailable` branch. The previous fallback rendered a static
HTML page without `AuthProvider` / `QueryClientProvider`, so logout and
all client-side interactions were dead until the gateway recovered —
which matches the issue's "卡死 + 无法 logout" symptom.

## Fix
- Render the normal `WorkspaceContent` even in `gateway_unavailable` mode,
  with `AuthProvider initialUser={null}`.
- Add a `GatewayOfflineBanner` that:
  - re-probes the gateway via `refreshUser()` every 10s,
  - hides itself the moment a user is recovered,
  - is reentrancy-guarded so a slow gateway can't pile up parallel
    `/auth/me` requests,
  - exposes a working **Log out** action via the existing AuthProvider.
- Banner copy uses the existing i18n channel; reuses `workspace.logout`,
  adds `workspace.gatewayUnavailable` and
  `workspace.gatewayUnavailableRetrying` for en-US and zh-CN.

## Tests
- New: `tests/unit/components/workspace/gateway-offline-banner-helpers.test.ts`
  — covers visibility rules and the retry-interval constant.
- New (append-only) in `tests/unit/core/auth/server.test.ts`: two cases
  pinning the `gateway_unavailable` tag contract for fetch rejection
  (AbortError) and 5xx responses, so future refactors of
  `getServerSideUser` can't silently break the new fallback.
- Existing tests unchanged.
- Local: `pnpm format:write` clean, `pnpm test` 117/117 pass,
  `pnpm test:e2e --workers=1` 20/20 pass.

## Out of scope
The underlying gateway concurrency bottleneck that makes `/auth/me`
slow under SSE load is not addressed here — this PR ensures the UI
degrades gracefully and stays interactive while the gateway recovers,
matching the issue's expected behaviour ("不会出现卡死的情况" + "页面要可以交互进行 logout").