### PR TITLE
fix(sandbox): evict stale container references from warm pool on acquire (#3474)

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py
@@ -459,35 +459,87 @@ class AioSandboxProvider(SandboxProvider):
         """Return deterministic IDs for thread sandboxes and random IDs otherwise."""
         return self._deterministic_sandbox_id(thread_id) if thread_id else str(uuid.uuid4())[:8]
 
+    def _probe_sandbox(self, sandbox_id: str, *, info: "SandboxInfo | None" = None) -> bool:
+        """Quick health check: is the sandbox container still alive?
+
+        Uses the backend's ``is_alive`` for a lightweight check
+        (container inspect, not HTTP health poll).  Returns False
+        when the sandbox is unknown or the backend raises.
+        """
+        if info is None:
+            info = self._sandbox_infos.get(sandbox_id)
+        if info is None:
+            return False
+        try:
+            return self._backend.is_alive(info)
+        except Exception:
+            return False
+
     def _reuse_in_process_sandbox(self, thread_id: str | None, *, post_lock: bool = False) -> str | None:
         """Reuse an active in-process sandbox for a thread if one is still tracked."""
         if thread_id is None:
             return None
 
+        # Under lock: find cached sandbox and snapshot info
         with self._lock:
             if thread_id not in self._thread_sandboxes:
                 return None
 
             existing_id = self._thread_sandboxes[thread_id]
-            if existing_id in self._sandboxes:
-                suffix = " (post-lock check)" if post_lock else ""
-                logger.info(f"Reusing in-process sandbox {existing_id} for thread {thread_id}{suffix}")
-                self._last_activity[existing_id] = time.time()
-                return existing_id
+            if existing_id not in self._sandboxes:
+                del self._thread_sandboxes[thread_id]
+                return None
+            info = self._sandbox_infos.get(existing_id)
 
-            del self._thread_sandboxes[thread_id]
+        # Outside lock: health check (Docker inspect — avoids blocking other threads)
+        if not self._probe_sandbox(existing_id, info=info):
+            logger.warning("In-process sandbox %s failed health check, evicting stale reference", existing_id)
+            with self._lock:
+                # Re-verify: idle checker or another path may have already cleaned up
+                if self._thread_sandboxes.get(thread_id) != existing_id:
+                    return None
+                del self._sandboxes[existing_id]
+                self._sandbox_infos.pop(existing_id, None)
+                self._last_activity.pop(existing_id, None)
+                del self._thread_sandboxes[thread_id]
             return None
+
+        # Under lock: update activity and return
+        with self._lock:
+            if self._thread_sandboxes.get(thread_id) != existing_id:
+                return None
+            suffix = " (post-lock check)" if post_lock else ""
+            logger.info(f"Reusing in-process sandbox {existing_id} for thread {thread_id}{suffix}")
+            self._last_activity[existing_id] = time.time()
+            return existing_id
 
     def _reclaim_warm_pool_sandbox(self, thread_id: str | None, sandbox_id: str, *, post_lock: bool = False) -> str | None:
         """Promote a warm-pool sandbox back to active tracking if available."""
         if thread_id is None:
             return None
 
+        # Under lock: pop from warm pool and snapshot info
         with self._lock:
             if sandbox_id not in self._warm_pool:
                 return None
 
             info, _ = self._warm_pool.pop(sandbox_id)
+
+        # Outside lock: health check (Docker inspect — avoids blocking other threads)
+        if not self._probe_sandbox(sandbox_id, info=info):
+            logger.warning("Warm-pool sandbox %s failed health check, evicting stale entry", sandbox_id)
+            try:
+                self._backend.destroy(info)
+            except Exception:
+                pass
+            return None
+
+        # Under lock: register as active
+        with self._lock:
+            # If another path already assigned a sandbox for this thread, put ours back
+            if thread_id in self._thread_sandboxes:
+                self._warm_pool[sandbox_id] = (info, time.time())
+                return None
             sandbox = AioSandbox(id=sandbox_id, base_url=info.sandbox_url)
             self._sandboxes[sandbox_id] = sandbox
             self._sandbox_infos[sandbox_id] = info

--- a/backend/tests/test_aio_sandbox_provider.py
+++ b/backend/tests/test_aio_sandbox_provider.py
@@ -434,3 +434,116 @@ def test_destroy_swallows_close_errors_and_still_destroys_backend(tmp_path, capl
 
     assert "Error closing sandbox sandbox-dest-err during destroy" in caplog.text
     provider._backend.destroy.assert_called_once()
+
+
+# ── Stale sandbox detection (testOnBorrow, #3474) ─────────────────────────────
+
+
+def _make_provider_for_reuse(tmp_path, sandbox_id: str):
+    """Build a provider with one in-process sandbox ready for reuse tests."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._lock = aio_mod.threading.Lock()
+    provider._warm_pool = {}
+    provider._sandbox_infos = {
+        sandbox_id: aio_mod.SandboxInfo(sandbox_id=sandbox_id, sandbox_url="http://sandbox-host"),
+    }
+    provider._thread_sandboxes = {"thread-stale": sandbox_id}
+    provider._last_activity = {sandbox_id: 0.0}
+    provider._backend = SimpleNamespace(is_alive=MagicMock(return_value=True), destroy=MagicMock())
+
+    sandbox = MagicMock()
+    sandbox.id = sandbox_id
+    provider._sandboxes = {sandbox_id: sandbox}
+    return provider, aio_mod
+
+
+def test_reuse_destroys_stale_in_process_sandbox(tmp_path, caplog):
+    """Stale in-process sandbox must be evicted when backend.is_alive returns False (#3474)."""
+    provider, _ = _make_provider_for_reuse(tmp_path, "sandbox-stale")
+    provider._backend.is_alive.return_value = False
+
+    with caplog.at_level("WARNING"):
+        result = provider._reuse_in_process_sandbox("thread-stale")
+
+    assert result is None
+    assert "stale" in caplog.text.lower()
+    # Tracking must be fully cleaned up
+    assert "sandbox-stale" not in provider._sandboxes
+    assert "sandbox-stale" not in provider._sandbox_infos
+    assert "sandbox-stale" not in provider._last_activity
+    assert "thread-stale" not in provider._thread_sandboxes
+
+
+def test_reuse_keeps_healthy_in_process_sandbox(tmp_path):
+    """Healthy sandbox should be returned normally when is_alive returns True."""
+    provider, _ = _make_provider_for_reuse(tmp_path, "sandbox-healthy")
+
+    result = provider._reuse_in_process_sandbox("thread-stale")
+
+    assert result == "sandbox-healthy"
+    assert provider._backend.is_alive.call_count == 1
+
+
+def test_reclaim_destroys_stale_warm_pool_sandbox(tmp_path, caplog):
+    """Stale warm-pool sandbox must be evicted when backend.is_alive returns False (#3474)."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._lock = aio_mod.threading.Lock()
+    provider._sandbox_infos = {}
+    info = aio_mod.SandboxInfo(sandbox_id="sandbox-warm-stale", sandbox_url="http://sandbox-host")
+    provider._warm_pool = {"sandbox-warm-stale": (info, 0.0)}
+    provider._thread_sandboxes = {}
+    provider._last_activity = {}
+    provider._sandboxes = {}
+    provider._backend = SimpleNamespace(is_alive=MagicMock(return_value=False), destroy=MagicMock())
+
+    with caplog.at_level("WARNING"):
+        result = provider._reclaim_warm_pool_sandbox("thread-warm", "sandbox-warm-stale")
+
+    assert result is None
+    assert "stale" in caplog.text.lower()
+    # Warm pool entry must be removed
+    assert "sandbox-warm-stale" not in provider._warm_pool
+    # Backend destroy should be called to clean up the dead container
+    provider._backend.destroy.assert_called_once_with(info)
+
+
+def test_reclaim_keeps_healthy_warm_pool_sandbox(tmp_path):
+    """Healthy warm-pool sandbox should be reclaimed normally when is_alive returns True."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._lock = aio_mod.threading.Lock()
+    provider._sandbox_infos = {}
+    info = aio_mod.SandboxInfo(sandbox_id="sandbox-warm-ok", sandbox_url="http://sandbox-host")
+    provider._warm_pool = {"sandbox-warm-ok": (info, 0.0)}
+    provider._thread_sandboxes = {}
+    provider._last_activity = {}
+    provider._sandboxes = {}
+    provider._backend = SimpleNamespace(is_alive=MagicMock(return_value=True), destroy=MagicMock())
+
+    result = provider._reclaim_warm_pool_sandbox("thread-warm", "sandbox-warm-ok")
+
+    assert result == "sandbox-warm-ok"
+    assert "sandbox-warm-ok" not in provider._warm_pool
+    assert "thread-warm" in provider._thread_sandboxes
+
+
+def test_probe_sandbox_returns_false_on_exception(tmp_path):
+    """_probe_sandbox must return False when backend.is_alive raises."""
+    aio_mod = importlib.import_module("deerflow.community.aio_sandbox.aio_sandbox_provider")
+    provider = _make_provider(tmp_path)
+    provider._sandbox_infos = {
+        "sandbox-err": aio_mod.SandboxInfo(sandbox_id="sandbox-err", sandbox_url="http://sandbox-host"),
+    }
+    provider._backend = SimpleNamespace(is_alive=MagicMock(side_effect=RuntimeError("inspect failed")))
+
+    assert provider._probe_sandbox("sandbox-err") is False
+
+
+def test_probe_sandbox_returns_false_for_unknown_id(tmp_path):
+    """_probe_sandbox must return False when sandbox_id has no SandboxInfo."""
+    provider = _make_provider(tmp_path)
+    provider._sandbox_infos = {}
+
+    assert provider._probe_sandbox("nonexistent") is False


### PR DESCRIPTION
Fixes #3474

## Why

When a sandbox container dies unexpectedly (OOM, manual docker rm -f, host reboot), the AioSandboxProvider warm pool and in-process cache hold stale references. Every subsequent tool call returns Connection refused indefinitely until gateway restart.

## What changed

Added a testOnBorrow pattern: before reusing a sandbox from the in-process cache or warm pool, probe its health via backend.is_alive() (lightweight container inspect, no HTTP health poll). If the container is dead, evict the stale entry and return None so the caller proceeds to create a fresh sandbox.

Key design decisions:
- Probe runs outside the provider lock to avoid blocking other threads during Docker inspect, consistent with how _create_sandbox avoids I/O under lock
- Re-verification under lock after probe to handle concurrent eviction by the idle checker
- Both reuse paths covered: _reuse_in_process_sandbox and _reclaim_warm_pool_sandbox

## Surface area

- [ ] Backend API
- [ ] Agents / LangGraph
- [ ] Frontend UI
- [x] Sandbox
- [ ] Skills
- [ ] Dependencies
- [ ] Default behavior change
- [x] Docs / tests / CI only

## Bug fix verification

- Test path: backend/tests/test_aio_sandbox_provider.py::test_reuse_destroys_stale_in_process_sandbox (and 5 related tests)
- Did it go red on main and green on this branch? yes (stale sandbox evicted → returns None → new sandbox created)

## Validation

```bash
cd backend && PYTHONPATH=packages/harness python -m pytest tests/test_aio_sandbox_provider.py -k "stale or healthy or probe" -v
# Result: 6 passed, 24 deselected

ruff check backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py backend/tests/test_aio_sandbox_provider.py
# Result: All checks passed

ruff format --check backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox_provider.py backend/tests/test_aio_sandbox_provider.py
# Result: 2 files already formatted
```

## AI assistance

Tool(s) used: Claude Code