### PR TITLE
fix(frontend): render user messages as plain text and cap blockquote nesting

### DIFF
--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { type ComponentProps } from "react";
+import { useMemo, type ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
+import { capBlockquoteNesting } from "@/core/streamdown/preprocess";
 
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
@@ -12,6 +13,17 @@ if (typeof document !== "undefined") {
   installClipboardFallback();
 }
 
-export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
-  return <Streamdown {...props} />;
+export function ClipboardSafeStreamdown({
+  children,
+  ...props
+}: ClipboardSafeStreamdownProps) {
+  // Guard every Streamdown entry point against pathological blockquote
+  // nesting, which overflows the call stack in marked's recursive lexer and
+  // takes down the whole route.
+  const safeChildren = useMemo(
+    () =>
+      typeof children === "string" ? capBlockquoteNesting(children) : children,
+    [children],
+  );
+  return <Streamdown {...props}>{safeChildren}</Streamdown>;
 }

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ComponentProps } from "react";
+import { Component, useMemo, type ComponentProps, type ReactNode } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
@@ -13,17 +13,61 @@ if (typeof document !== "undefined") {
   installClipboardFallback();
 }
 
+// marked (used by Streamdown to split content into blocks) has mutually
+// recursive tokenizers — blockquote/list nesting a couple thousand levels
+// deep overflows the call stack during render and would otherwise take down
+// the whole route. When rendering a message throws, fall back to showing
+// that message as plain pre-formatted text instead.
+class StreamdownFallbackBoundary extends Component<
+  { raw: ClipboardSafeStreamdownProps["children"]; children: ReactNode },
+  { errored: boolean; prevRaw: ClipboardSafeStreamdownProps["children"] }
+> {
+  state = { errored: false, prevRaw: this.props.raw };
+
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: { raw: ClipboardSafeStreamdownProps["children"] },
+    state: {
+      errored: boolean;
+      prevRaw: ClipboardSafeStreamdownProps["children"];
+    },
+  ) {
+    // Retry rendering when the content changes (e.g. the next streaming chunk).
+    if (props.raw !== state.prevRaw) {
+      return { errored: false, prevRaw: props.raw };
+    }
+    return null;
+  }
+
+  render() {
+    if (this.state.errored) {
+      return (
+        <div className="break-words whitespace-pre-wrap">
+          {typeof this.props.raw === "string" ? this.props.raw : null}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export function ClipboardSafeStreamdown({
   children,
   ...props
 }: ClipboardSafeStreamdownProps) {
-  // Guard every Streamdown entry point against pathological blockquote
-  // nesting, which overflows the call stack in marked's recursive lexer and
-  // takes down the whole route.
+  // Fast path for the dominant pathological input (pure ">" chains) so the
+  // error boundary below rarely has to absorb a full stack overflow.
   const safeChildren = useMemo(
     () =>
       typeof children === "string" ? capBlockquoteNesting(children) : children,
     [children],
   );
-  return <Streamdown {...props}>{safeChildren}</Streamdown>;
+  return (
+    <StreamdownFallbackBoundary raw={children}>
+      <Streamdown {...props}>{safeChildren}</Streamdown>
+    </StreamdownFallbackBoundary>
+  );
 }

--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -19,7 +19,6 @@ import { Loader } from "@/components/ai-elements/loader";
 import {
   Message as AIElementMessage,
   MessageContent as AIElementMessageContent,
-  MessageResponse as AIElementMessageResponse,
   MessageToolbar,
 } from "@/components/ai-elements/message";
 import {
@@ -44,7 +43,6 @@ import {
   type FileInMessage,
 } from "@/core/messages/utils";
 import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
-import { humanMessagePlugins } from "@/core/streamdown";
 import { cn } from "@/lib/utils";
 
 import { CopyButton } from "../copy-button";
@@ -300,17 +298,10 @@ function MessageContent_({
   }
 
   if (isHuman) {
-    const messageResponse = contentToDisplay ? (
-      <AIElementMessageResponse
-        className="break-words"
-        remarkPlugins={humanMessagePlugins.remarkPlugins}
-        rehypePlugins={humanMessagePlugins.rehypePlugins}
-        components={components}
-        parseIncompleteMarkdown={false}
-      >
-        {contentToDisplay}
-      </AIElementMessageResponse>
-    ) : null;
+    // Composer input is plain text, not authored Markdown. Parsing it as
+    // Markdown mangles pasted code/logs (indented lines become code blocks,
+    // "$...$" spans become math) and lets pathological input crash the page
+    // through marked's recursive blockquote lexer, so render it verbatim.
     return (
       <div
         className={cn(
@@ -319,9 +310,11 @@ function MessageContent_({
         )}
       >
         {filesList}
-        {messageResponse && (
+        {contentToDisplay && (
           <AIElementMessageContent className="w-full max-w-full">
-            {messageResponse}
+            <div className="break-words whitespace-pre-wrap">
+              {contentToDisplay}
+            </div>
           </AIElementMessageContent>
         )}
       </div>

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -36,15 +36,3 @@ export const reasoningPlugins = {
     (p) => p !== rehypeRaw,
   ) as StreamdownProps["rehypePlugins"],
 };
-
-// Plugins for human messages - no autolink to prevent URL bleeding into adjacent text
-export const humanMessagePlugins = {
-  remarkPlugins: [
-    // Use remark-gfm without autolink literals by not including it
-    // Only include math support for human messages
-    [remarkMath, { singleDollarTextMath: true }],
-  ] as StreamdownProps["remarkPlugins"],
-  rehypePlugins: [
-    [rehypeKatex, { output: "html" }],
-  ] as StreamdownProps["rehypePlugins"],
-};

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -2,6 +2,45 @@ import { normalizeMermaidMarkdown } from "./mermaid";
 
 const MERMAID_BLOCK_HINT_RE = /mermaid/i;
 
+// marked's blockquote tokenizer (used by Streamdown to split content into
+// memoizable blocks) recurses once per nesting level and overflows the call
+// stack at roughly 2,000 levels, replacing the whole chat route with an error
+// page. 100 levels is far beyond any legitimate content while keeping a wide
+// margin below the crash threshold.
+const MAX_BLOCKQUOTE_DEPTH = 100;
+const DEEP_BLOCKQUOTE_HINT_RE = new RegExp(
+  `^(?:[ \\t]*>){${MAX_BLOCKQUOTE_DEPTH + 1}}`,
+  "m",
+);
+const BLOCKQUOTE_PREFIX_RE = /^(?:[ \t]*>)+/;
+
+export function capBlockquoteNesting(markdown: string): string {
+  if (!DEEP_BLOCKQUOTE_HINT_RE.test(markdown)) {
+    return markdown;
+  }
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const match = BLOCKQUOTE_PREFIX_RE.exec(line);
+      if (!match) {
+        return line;
+      }
+      const prefix = match[0];
+      let depth = 0;
+      for (let i = 0; i < prefix.length; i++) {
+        if (prefix[i] === ">") {
+          depth += 1;
+          if (depth > MAX_BLOCKQUOTE_DEPTH) {
+            return line.slice(0, i) + line.slice(prefix.length);
+          }
+        }
+      }
+      return line;
+    })
+    .join("\n");
+}
+
 export function preprocessStreamdownMarkdown(markdown: string): string {
   if (!MERMAID_BLOCK_HINT_RE.test(markdown) || !markdown.includes("-.->")) {
     return markdown;

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -12,16 +12,30 @@ const DEEP_BLOCKQUOTE_HINT_RE = new RegExp(
   `^(?:[ \\t]*>){${MAX_BLOCKQUOTE_DEPTH + 1}}`,
   "m",
 );
-const BLOCKQUOTE_PREFIX_RE = /^(?:[ \t]*>)+/;
+// Only up to 3 leading spaces can start a blockquote; 4+ (or a tab) is an
+// indented code block, where ">" runs are literal content.
+const BLOCKQUOTE_PREFIX_RE = /^ {0,3}(?:[ \t]*>)+/;
+const CODE_FENCE_RE = /^ {0,3}(?:```|~~~)/;
+const INDENTED_CODE_RE = /^(?: {4}|\t)/;
 
 export function capBlockquoteNesting(markdown: string): string {
   if (!DEEP_BLOCKQUOTE_HINT_RE.test(markdown)) {
     return markdown;
   }
 
+  let insideFence = false;
   return markdown
     .split("\n")
     .map((line) => {
+      if (CODE_FENCE_RE.test(line)) {
+        insideFence = !insideFence;
+        return line;
+      }
+      // ">" runs inside fenced or indented code blocks are literal text, not
+      // nesting — rewriting them would silently corrupt code content.
+      if (insideFence || INDENTED_CODE_RE.test(line)) {
+        return line;
+      }
       const match = BLOCKQUOTE_PREFIX_RE.exec(line);
       if (!match) {
         return line;

--- a/frontend/tests/e2e/user-message-plain-text.spec.ts
+++ b/frontend/tests/e2e/user-message-plain-text.spec.ts
@@ -115,4 +115,23 @@ test.describe("User message plain-text rendering", () => {
     // visibility).
     await expect(page.getByText("deep")).toBeAttached();
   });
+
+  test("list-prefixed deep nesting in an AI message falls back to plain text instead of crashing", async ({
+    page,
+  }) => {
+    // marked's list and blockquote tokenizers are mutually recursive, so a
+    // list marker in front of the quote chain bypasses the nesting cap; the
+    // render error boundary must absorb it.
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(
+      page,
+      threadWithMessages("hello", "- " + "> ".repeat(3000) + "deep-list"),
+    );
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("hello")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    await expect(page.getByText("deep-list")).toBeAttached();
+  });
 });

--- a/frontend/tests/e2e/user-message-plain-text.spec.ts
+++ b/frontend/tests/e2e/user-message-plain-text.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockLangGraphAPI, MOCK_THREAD_ID } from "./utils/mock-api";
+
+const C_SOURCE = `#include <stdio.h>
+#include <signal.h>
+
+static volatile int connected = 0;
+
+static void daemon_handle_signal(int sig) {
+    if (sig == SIGTERM) {
+        connected = 0;
+
+        printf("daemon stop requested\\n");
+        return;
+    }
+
+    printf("ignored signal %d\\n", sig);
+}`;
+
+function threadWithMessages(
+  humanText: string,
+  aiText = "ack",
+): Parameters<typeof mockLangGraphAPI>[1] {
+  return {
+    threads: [
+      {
+        thread_id: MOCK_THREAD_ID,
+        title: "Plain text rendering",
+        updated_at: "2025-06-01T12:00:00Z",
+        messages: [
+          {
+            type: "human",
+            id: "msg-human-plain-text",
+            content: [{ type: "text", text: humanText }],
+          },
+          {
+            type: "ai",
+            id: "msg-ai-plain-text",
+            content: aiText,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => {
+    errors.push(`${error.name}: ${error.message}`);
+  });
+  return errors;
+}
+
+test.describe("User message plain-text rendering", () => {
+  test("pasted source code renders verbatim as one block", async ({ page }) => {
+    mockLangGraphAPI(page, threadWithMessages(C_SOURCE));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    // The pasted file must not be split into Markdown code-block widgets.
+    await expect(
+      page.locator('[data-code-block-container="true"]'),
+    ).toHaveCount(0);
+
+    // Indentation and line structure must be preserved verbatim.
+    const bubble = page.locator(".is-user");
+    const text = await bubble.innerText();
+    expect(text).toContain("#include <stdio.h>");
+    expect(text).toContain("    if (sig == SIGTERM) {");
+    expect(text).toContain('        printf("daemon stop requested\\n");');
+  });
+
+  test("dollar signs are not parsed as math", async ({ page }) => {
+    const message = "this costs $5 and $10 in total";
+    mockLangGraphAPI(page, threadWithMessages(message));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    await expect(page.locator(".is-user")).toContainText(message);
+    await expect(page.locator(".is-user .katex")).toHaveCount(0);
+  });
+
+  test("deeply nested blockquote markers in a user message do not crash the page", async ({
+    page,
+  }) => {
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(page, threadWithMessages("> ".repeat(3000) + "hi"));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    await expect(page.locator(".is-user")).toContainText("> > >");
+  });
+
+  test("deeply nested blockquote markers in an AI message do not crash the page", async ({
+    page,
+  }) => {
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(
+      page,
+      threadWithMessages("hello", "> ".repeat(3000) + "deep"),
+    );
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("hello")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    // The capped blockquote chain still renders (100 levels of indentation can
+    // squeeze the innermost element to zero width, so assert presence, not
+    // visibility).
+    await expect(page.getByText("deep")).toBeAttached();
+  });
+});

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+
+import {
+  capBlockquoteNesting,
+  preprocessStreamdownMarkdown,
+} from "@/core/streamdown/preprocess";
+
+test("capBlockquoteNesting returns normal content unchanged", () => {
+  const input = "# Title\n\n> a quote\n>> nested\n\nsome `code`";
+  expect(capBlockquoteNesting(input)).toBe(input);
+});
+
+test("capBlockquoteNesting keeps nesting at or below the cap untouched", () => {
+  const input = "> ".repeat(100) + "hi";
+  expect(capBlockquoteNesting(input)).toBe(input);
+});
+
+test("capBlockquoteNesting caps pathological nesting and preserves content", () => {
+  const result = capBlockquoteNesting("> ".repeat(5000) + "hi");
+  expect((result.match(/>/g) ?? []).length).toBe(100);
+  expect(result.endsWith("hi")).toBe(true);
+});
+
+test("capBlockquoteNesting handles markers without spaces", () => {
+  const result = capBlockquoteNesting(">".repeat(5000) + "hi");
+  expect((result.match(/>/g) ?? []).length).toBe(100);
+  expect(result.endsWith("hi")).toBe(true);
+});
+
+test("capBlockquoteNesting only rewrites pathological lines", () => {
+  const normal = "> normal quote";
+  const deep = "> ".repeat(3000) + "deep";
+  const result = capBlockquoteNesting(`${normal}\n${deep}\nplain`);
+  const lines = result.split("\n");
+  expect(lines[0]).toBe(normal);
+  expect((lines[1]?.match(/>/g) ?? []).length).toBe(100);
+  expect(lines[2]).toBe("plain");
+});
+
+test("preprocessStreamdownMarkdown leaves non-mermaid content unchanged", () => {
+  const input = "just some text";
+  expect(preprocessStreamdownMarkdown(input)).toBe(input);
+});

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -27,6 +27,20 @@ test("capBlockquoteNesting handles markers without spaces", () => {
   expect(result.endsWith("hi")).toBe(true);
 });
 
+test("capBlockquoteNesting leaves fenced code content untouched", () => {
+  const literal = ">".repeat(150);
+  const input = `${"> ".repeat(3000)}hi\n\`\`\`text\n${literal}\n\`\`\``;
+  const result = capBlockquoteNesting(input);
+  expect(result.split("\n")[2]).toBe(literal);
+});
+
+test("capBlockquoteNesting leaves indented code blocks untouched", () => {
+  const literal = "    " + ">".repeat(150);
+  const input = `${"> ".repeat(3000)}hi\n\n${literal}`;
+  const result = capBlockquoteNesting(input);
+  expect(result.split("\n")[2]).toBe(literal);
+});
+
 test("capBlockquoteNesting only rewrites pathological lines", () => {
   const normal = "> normal quote";
   const deep = "> ".repeat(3000) + "deep";


### PR DESCRIPTION
Closes #3500

## Why

Pasting a raw source file (or any plain text) into the chat input produces a mangled user bubble: indented chunks become standalone Markdown code-block widgets, the remaining lines collapse into paragraphs with their indentation stripped, and any message containing two `$` characters gets KaTeX-ified into garbled math (`export PATH=$HOME/bin … echo $PATH` renders as `PATH=HOME/binandthenechoPATH`).

Worse, the follow-up repro in the issue (a message of a few thousand nested `>` markers) throws `RangeError: Maximum call stack size exceeded` inside Streamdown's block splitter (marked's blockquote tokenizer is mutually recursive with `blockTokens`) and replaces the whole chat route with an error page. Since the message is persisted, the thread crashes again on every load — one message permanently bricks a conversation, and AI messages flow through the same path, so model output can trigger it too. Full root-cause analysis: https://github.com/bytedance/deer-flow/issues/3500#issuecomment-4678832212

The root cause shared by all symptoms: composer input is plain text, not authored Markdown, but it was rendered through the full Markdown pipeline. This is the same root cause 738b71be already patched once (GFM autolinks swallowing adjacent CJK text).

## What changed

- **User message bubbles now show the text verbatim** (`whitespace-pre-wrap`), exactly as typed/pasted — indentation, line breaks, `$`, `>` and `#` included. Markdown syntax in user messages is no longer interpreted (AI messages are unchanged). This matches what ChatGPT, Claude, claude-code, codex, opencode, and deepagents all do: plain text for user input, Markdown for assistant output.
- **A render fallback boundary wraps every Streamdown render** (`ClipboardSafeStreamdown`): if rendering a message throws — marked's list and blockquote tokenizers are *mutually* recursive, so e.g. `- > > > …` chains can overflow the stack through paths a prefix regex can't anticipate — that one message falls back to plain pre-wrap text and retries on the next content change, instead of taking down the whole route.
- **Blockquote nesting is additionally capped at 100 levels** at the same chokepoint as a fast path for the dominant pure-`>` case (so the boundary rarely has to absorb a full stack overflow during streaming). The cap is fence-aware: literal `>` runs inside fenced/indented code blocks are never rewritten. 100 is far beyond legitimate content and far below the ~2,000-level crash threshold.
- `humanMessagePlugins` is removed as dead code (its autolink concern from 738b71be is trivially satisfied by not parsing at all).

Trade-off made explicit: users who intentionally typed `**bold**`, fenced code, or `$math$` in their own messages lose the pretty rendering in their bubble (rendering only — the raw text still reaches the model, the thread state, and the copy button). The reporter's alternative ("detect code-looking messages") was considered and rejected: heuristics misclassify mixed prose+code messages in both directions, and the crash input isn't "code-like" at all, so detection would not have covered it.

Note: this touches the same human-bubble block as PR 3488 (overflow fix); the plain-text `div` here carries `break-words`, so long unbreakable strings wrap within the bubble.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — user messages no longer render Markdown; they display verbatim
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before — pasted C file fragmented (reporter's screenshot in #3500), and the nested-`>` crash taking down the route:

![before: RangeError overlay pointing at ClipboardSafeStreamdown](https://github.com/fancyboi999/deer-flow/releases/download/_gh-attach-assets/repro-3500-crash.png)

After — the same C file renders as one verbatim block with indentation preserved:

![after: pasted code rendered verbatim](https://github.com/fancyboi999/deer-flow/releases/download/_gh-attach-assets/after-pasted-code.png)

After — the same nested-`>` message is a harmless plain-text bubble; the page stays alive:

![after: nested quotes rendered as plain text](https://github.com/fancyboi999/deer-flow/releases/download/_gh-attach-assets/after-nested-quotes.png)

## Bug fix verification

- Test path: `frontend/tests/e2e/user-message-plain-text.spec.ts` (5 tests: verbatim pasted code, `$` not parsed as math, nested-`>` user message no crash, nested-`>` AI message no crash, list-prefixed `- > > > …` AI message falls back to plain text) and `frontend/tests/unit/core/streamdown/preprocess.test.ts` (8 tests for `capBlockquoteNesting`, incl. fenced/indented code immunity).
- Red on `main`, green on this branch? **Yes** — all e2e tests fail on `main` (the crash tests die with `RangeError: Maximum call stack size exceeded`); the list-prefixed case was additionally verified red against the cap-only first commit before the boundary was added.

## Validation

```
cd frontend
pnpm format                                  # pass
pnpm check (eslint + tsc --noEmit)           # pass
pnpm test                                    # 253 passed (25 files), incl. 8 new unit tests
BETTER_AUTH_SECRET=local-dev-secret pnpm build  # pass
pnpm exec playwright test                    # full e2e suite: 35 passed, incl. 5 new
```

Not covered: Firefox/Safari (e2e project is Chromium-only); the stack-overflow threshold differs per engine but the capped depth (100) is two orders of magnitude below all of them.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Used it for the root-cause investigation (SSR-level repro of the streamdown/marked recursion, e2e crash repro) and the first draft of the fix and tests; I reviewed, adjusted scope (chokepoint guard instead of per-call-site preprocessing), and verified every gate locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

