### PR TITLE
fix(skills): offload blocking filesystem IO in async skill installation

### DIFF
--- a/backend/packages/harness/deerflow/skills/storage/local_skill_storage.py
+++ b/backend/packages/harness/deerflow/skills/storage/local_skill_storage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import errno
 import json
 import logging
@@ -107,49 +108,67 @@ class LocalSkillStorage(SkillStorage):
 
         logger.info("Installing skill from %s", archive_path)
         path = Path(archive_path)
-        if not path.is_file():
-            if not path.exists():
-                raise FileNotFoundError(f"Skill file not found: {archive_path}")
-            raise ValueError(f"Path is not a file: {archive_path}")
-        if path.suffix != ".skill":
-            raise ValueError("File must have .skill extension")
-
         custom_dir = self._host_root / "custom"
-        custom_dir.mkdir(parents=True, exist_ok=True)
 
-        with tempfile.TemporaryDirectory() as tmp:
-            tmp_path = Path(tmp)
+        def _extract_and_validate() -> tuple[str, Path, str]:
+            # Worker thread: path probing, mkdir, tempdir creation, zip
+            # extraction, and frontmatter reads are all blocking filesystem IO
+            # that must stay off the event loop. The extraction tempdir is
+            # returned (not auto-cleaned) so it survives the ``await`` below; the
+            # caller's ``finally`` removes it.
+            if not path.is_file():
+                if not path.exists():
+                    raise FileNotFoundError(f"Skill file not found: {archive_path}")
+                raise ValueError(f"Path is not a file: {archive_path}")
+            if path.suffix != ".skill":
+                raise ValueError("File must have .skill extension")
 
+            custom_dir.mkdir(parents=True, exist_ok=True)
+            tmp = tempfile.mkdtemp()
             try:
-                zf = zipfile.ZipFile(path, "r")
-            except FileNotFoundError:
-                raise FileNotFoundError(f"Skill file not found: {archive_path}") from None
-            except (zipfile.BadZipFile, IsADirectoryError):
-                raise ValueError("File is not a valid ZIP archive") from None
+                tmp_path = Path(tmp)
+                try:
+                    zf = zipfile.ZipFile(path, "r")
+                except FileNotFoundError:
+                    raise FileNotFoundError(f"Skill file not found: {archive_path}") from None
+                except (zipfile.BadZipFile, IsADirectoryError):
+                    raise ValueError("File is not a valid ZIP archive") from None
+                with zf:
+                    safe_extract_skill_archive(zf, tmp_path)
 
-            with zf:
-                safe_extract_skill_archive(zf, tmp_path)
+                skill_dir = resolve_skill_dir_from_archive(tmp_path)
 
-            skill_dir = resolve_skill_dir_from_archive(tmp_path)
+                is_valid, message, skill_name = _validate_skill_frontmatter(skill_dir)
+                if not is_valid:
+                    raise ValueError(f"Invalid skill: {message}")
+                if not skill_name or "/" in skill_name or "\\" in skill_name or ".." in skill_name:
+                    raise ValueError(f"Invalid skill name: {skill_name}")
 
-            is_valid, message, skill_name = _validate_skill_frontmatter(skill_dir)
-            if not is_valid:
-                raise ValueError(f"Invalid skill: {message}")
-            if not skill_name or "/" in skill_name or "\\" in skill_name or ".." in skill_name:
-                raise ValueError(f"Invalid skill name: {skill_name}")
+                if (custom_dir / skill_name).exists():
+                    raise SkillAlreadyExistsError(f"Skill '{skill_name}' already exists")
 
+                return tmp, skill_dir, skill_name
+            except BaseException:
+                shutil.rmtree(tmp, ignore_errors=True)
+                raise
+
+        def _stage_and_commit(skill_dir: Path, skill_name: str) -> Path:
+            # Worker thread: copytree + atomic move are blocking filesystem IO.
             target = custom_dir / skill_name
-            if target.exists():
-                raise SkillAlreadyExistsError(f"Skill '{skill_name}' already exists")
-
-            await _scan_skill_archive_contents_or_raise(skill_dir, skill_name)
-
             with tempfile.TemporaryDirectory(prefix=f".installing-{skill_name}-", dir=custom_dir) as staging_root:
                 staging_target = Path(staging_root) / skill_name
                 shutil.copytree(skill_dir, staging_target)
                 _move_staged_skill_into_reserved_target(staging_target, target)
-            logger.info("Skill %r installed to %s", skill_name, target)
+            return target
 
+        tmp, skill_dir, skill_name = await asyncio.to_thread(_extract_and_validate)
+        try:
+            await _scan_skill_archive_contents_or_raise(skill_dir, skill_name)
+            target = await asyncio.to_thread(_stage_and_commit, skill_dir, skill_name)
+        finally:
+            await asyncio.to_thread(shutil.rmtree, tmp, ignore_errors=True)
+
+        logger.info("Skill %r installed to %s", skill_name, target)
         return {
             "success": True,
             "skill_name": skill_name,

--- a/backend/tests/blocking_io/test_skill_install.py
+++ b/backend/tests/blocking_io/test_skill_install.py
@@ -1,0 +1,86 @@
+"""Regression anchor: installing a skill must not block the event loop.
+
+``LocalSkillStorage.ainstall_skill_from_archive`` probes the archive, creates a
+tempdir, extracts the zip, and ``shutil.copytree``s the staged skill into place —
+all blocking filesystem IO. The async method offloads each phase via
+``asyncio.to_thread``; if any regresses back onto the event loop, the strict
+Blockbuster gate raises ``BlockingError`` and this test fails.
+
+The security scanner (``_scan_skill_archive_contents_or_raise``) is patched to a
+no-op here: it has its own, separate ``rglob`` enumeration on the event loop
+(out of scope for this anchor), which locks the extract/copytree offload
+specifically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from deerflow.skills.storage.local_skill_storage import LocalSkillStorage
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_install_skill_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    # Test-side seeding (test-module stack → not gated): a minimal .skill zip.
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    archive = tmp_path / "demo.skill"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("demo/SKILL.md", "---\nname: demo\ndescription: regression anchor\n---\n# demo\n")
+
+    # Isolate the extract/copytree offload under test: the security scanner has a
+    # separate (unaddressed) blocking rglob that is out of scope for this anchor.
+    async def _noop_scan(skill_dir: Path, skill_name: str) -> None:
+        return None
+
+    monkeypatch.setattr("deerflow.skills.installer._scan_skill_archive_contents_or_raise", _noop_scan)
+
+    # LocalSkillStorage.__init__ resolves paths synchronously, so build it off-loop.
+    storage = await asyncio.to_thread(LocalSkillStorage, host_path=str(skills_root))
+
+    result = await storage.ainstall_skill_from_archive(str(archive))
+
+    assert result["success"] is True
+    assert result["skill_name"] == "demo"
+    assert (skills_root / "custom" / "demo" / "SKILL.md").exists()
+
+
+async def test_install_cleans_up_extraction_tempdir_on_failure(tmp_path: Path, monkeypatch) -> None:
+    """A failure after extraction must still remove the extraction tempdir.
+
+    The refactor manages the extraction dir manually (``mkdtemp`` + a ``finally``
+    ``rmtree``) so it survives the ``await`` scan; this locks that it does not
+    leak a temp directory when a later step raises.
+    """
+    skills_root = tmp_path / "skills"
+    skills_root.mkdir()
+    archive = tmp_path / "demo.skill"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("demo/SKILL.md", "---\nname: demo\ndescription: regression anchor\n---\n# demo\n")
+
+    created: list[str] = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _tracking_mkdtemp(*args, **kwargs):
+        path = real_mkdtemp(*args, **kwargs)
+        created.append(path)
+        return path
+
+    async def _failing_scan(skill_dir: Path, skill_name: str) -> None:
+        raise RuntimeError("scan boom")
+
+    monkeypatch.setattr("tempfile.mkdtemp", _tracking_mkdtemp)
+    monkeypatch.setattr("deerflow.skills.installer._scan_skill_archive_contents_or_raise", _failing_scan)
+
+    storage = await asyncio.to_thread(LocalSkillStorage, host_path=str(skills_root))
+    with pytest.raises(RuntimeError, match="scan boom"):
+        await storage.ainstall_skill_from_archive(str(archive))
+
+    assert created, "install should have created an extraction tempdir"
+    assert not any(Path(d).exists() for d in created), "extraction tempdir leaked after failure"


### PR DESCRIPTION
## Why

`LocalSkillStorage.ainstall_skill_from_archive` is an async method (the `POST /api/skills/install` path), but it ran its entire filesystem workload directly on the event loop:

- archive probing (`is_file` / `exists`), `mkdir`, `tempfile.TemporaryDirectory`
- zip open + `safe_extract_skill_archive` (extract every member)
- `shutil.copytree` of the staged skill into `custom/`

So a skill install blocks the event loop for its full duration — flagged by `make detect-blocking-io`. Same class of issue DeerFlow already guards against in `tests/blocking_io/` (e.g. #1917, the skill *load* path).

## What changed

Split the blocking work into two sync helpers dispatched via `asyncio.to_thread`:

- `_extract_and_validate` — probe / mkdir / extract / frontmatter-validate. Returns the extraction tempdir (created with `mkdtemp`, not auto-cleaned) so it survives the **awaited** security scan that runs between the two phases.
- `_stage_and_commit` — `copytree` + atomic move.

The extraction tempdir is removed in a `finally` (also offloaded). Externally observable behavior is unchanged: same `FileNotFoundError` / `ValueError` / `SkillAlreadyExistsError` paths, same cleanup-on-failure, same result dict.

> Note: the security scanner `_scan_skill_archive_contents_or_raise` has its own `rglob` enumeration on the event loop — a separate, smaller blocking spot left for a focused follow-up (it's security-sensitive and best changed on its own).

## Surface area

- [x] **Backend** — `packages/harness/deerflow/skills/storage/local_skill_storage.py` + tests. No API / schema change.

## Validation

- New `tests/blocking_io/test_skill_install.py` anchor under the strict Blockbuster gate (verified **red→green**: fails without the offload), plus a tempdir-cleanup-on-failure regression test → **2 passed**
- Full `tests/blocking_io` suite → **8 passed**
- Skill install/storage regression (`test_skills_installer`, `test_local_skill_storage_write`, `test_skills_custom_router`, `test_skill_manage_tool`) → **65 passed**
- `ruff check` + `ruff format` → clean

## AI assistance

**Tool(s) used:** Claude Code (Claude Opus 4.8)

**How you used it:** AI located the finding via `make detect-blocking-io`, implemented the two-phase `asyncio.to_thread` offload (handling the tempdir lifetime across the awaited scan), and wrote the gate anchor + cleanup regression test. I reviewed the change.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
