### PR TITLE
fix(frontend): isolate new chat thread messages

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -72,20 +72,21 @@ export default function AgentChatPage() {
     loadMoreHistory,
   } = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
+    displayThreadId: threadId,
     context: { ...settings.context, agent_name: agent_name },
     isMock,
     onSend: () => {
       setIsWelcomeMode(false);
     },
     onStart: (createdThreadId) => {
-      setThreadId(createdThreadId);
-      setIsNewThread(false);
       // ! Important: Never use next.js router for navigation in this case, otherwise it will cause the thread to re-mount and lose all states. Use native history API instead.
       history.replaceState(
         null,
         "",
         `/workspace/agents/${agent_name}/chats/${createdThreadId}`,
       );
+      setThreadId(createdThreadId);
+      setIsNewThread(false);
     },
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -75,6 +75,7 @@ export default function ChatPage() {
     loadMoreHistory,
   } = useThreadStream({
     threadId: isNewThread ? undefined : threadId,
+    displayThreadId: threadId,
     context: settings.context,
     isMock,
     // onSend only animates the UI; do NOT flip `isNewThread` here — the
@@ -84,10 +85,10 @@ export default function ChatPage() {
       setIsWelcomeMode(false);
     },
     onStart: (createdThreadId) => {
-      setThreadId(createdThreadId);
-      setIsNewThread(false);
       // ! Important: Never use next.js router for navigation in this case, otherwise it will cause the thread to re-mount and lose all states. Use native history API instead.
       history.replaceState(null, "", `/workspace/chats/${createdThreadId}`);
+      setThreadId(createdThreadId);
+      setIsNewThread(false);
     },
     onFinish: (state) => {
       if (document.hidden || !document.hasFocus()) {

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { type ComponentProps } from "react";
+import { useMemo, type ComponentProps } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
+import { capBlockquoteNesting } from "@/core/streamdown/preprocess";
 
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
 
@@ -12,6 +13,17 @@ if (typeof document !== "undefined") {
   installClipboardFallback();
 }
 
-export function ClipboardSafeStreamdown(props: ClipboardSafeStreamdownProps) {
-  return <Streamdown {...props} />;
+export function ClipboardSafeStreamdown({
+  children,
+  ...props
+}: ClipboardSafeStreamdownProps) {
+  // Guard every Streamdown entry point against pathological blockquote
+  // nesting, which overflows the call stack in marked's recursive lexer and
+  // takes down the whole route.
+  const safeChildren = useMemo(
+    () =>
+      typeof children === "string" ? capBlockquoteNesting(children) : children,
+    [children],
+  );
+  return <Streamdown {...props}>{safeChildren}</Streamdown>;
 }

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ComponentProps } from "react";
+import { Component, useMemo, type ComponentProps, type ReactNode } from "react";
 import { Streamdown } from "streamdown";
 
 import { installClipboardFallback } from "@/core/clipboard";
@@ -13,17 +13,61 @@ if (typeof document !== "undefined") {
   installClipboardFallback();
 }
 
+// marked (used by Streamdown to split content into blocks) has mutually
+// recursive tokenizers — blockquote/list nesting a couple thousand levels
+// deep overflows the call stack during render and would otherwise take down
+// the whole route. When rendering a message throws, fall back to showing
+// that message as plain pre-formatted text instead.
+class StreamdownFallbackBoundary extends Component<
+  { raw: ClipboardSafeStreamdownProps["children"]; children: ReactNode },
+  { errored: boolean; prevRaw: ClipboardSafeStreamdownProps["children"] }
+> {
+  state = { errored: false, prevRaw: this.props.raw };
+
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+
+  static getDerivedStateFromProps(
+    props: { raw: ClipboardSafeStreamdownProps["children"] },
+    state: {
+      errored: boolean;
+      prevRaw: ClipboardSafeStreamdownProps["children"];
+    },
+  ) {
+    // Retry rendering when the content changes (e.g. the next streaming chunk).
+    if (props.raw !== state.prevRaw) {
+      return { errored: false, prevRaw: props.raw };
+    }
+    return null;
+  }
+
+  render() {
+    if (this.state.errored) {
+      return (
+        <div className="break-words whitespace-pre-wrap">
+          {typeof this.props.raw === "string" ? this.props.raw : null}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export function ClipboardSafeStreamdown({
   children,
   ...props
 }: ClipboardSafeStreamdownProps) {
-  // Guard every Streamdown entry point against pathological blockquote
-  // nesting, which overflows the call stack in marked's recursive lexer and
-  // takes down the whole route.
+  // Fast path for the dominant pathological input (pure ">" chains) so the
+  // error boundary below rarely has to absorb a full stack overflow.
   const safeChildren = useMemo(
     () =>
       typeof children === "string" ? capBlockquoteNesting(children) : children,
     [children],
   );
-  return <Streamdown {...props}>{safeChildren}</Streamdown>;
+  return (
+    <StreamdownFallbackBoundary raw={children}>
+      <Streamdown {...props}>{safeChildren}</Streamdown>
+    </StreamdownFallbackBoundary>
+  );
 }

--- a/frontend/src/components/workspace/chats/use-thread-chat.ts
+++ b/frontend/src/components/workspace/chats/use-thread-chat.ts
@@ -1,29 +1,44 @@
 "use client";
 
 import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { uuid } from "@/core/utils/uuid";
 
 export function useThreadChat() {
   const { thread_id: threadIdFromPath } = useParams<{ thread_id: string }>();
   const pathname = usePathname();
+  const actualPathname =
+    typeof window === "undefined" ? pathname : window.location.pathname;
+  const isNewPath = actualPathname.endsWith("/new");
+  const newThreadIdRef = useRef<string | null>(
+    threadIdFromPath === "new" ? uuid() : null,
+  );
+
+  if (isNewPath && !newThreadIdRef.current) {
+    newThreadIdRef.current = uuid();
+  }
 
   const searchParams = useSearchParams();
-  const [threadId, setThreadId] = useState(() => {
-    return threadIdFromPath === "new" ? uuid() : threadIdFromPath;
+  const [threadId, setThreadIdState] = useState(() => {
+    return threadIdFromPath === "new"
+      ? (newThreadIdRef.current ?? uuid())
+      : threadIdFromPath;
   });
 
-  const [isNewThread, setIsNewThread] = useState(
+  const [isNewThreadState, setIsNewThreadState] = useState(
     () => threadIdFromPath === "new",
   );
 
   useEffect(() => {
-    if (pathname.endsWith("/new")) {
-      setIsNewThread(true);
-      setThreadId(uuid());
+    if (isNewPath) {
+      const nextThreadId = newThreadIdRef.current ?? uuid();
+      newThreadIdRef.current = nextThreadId;
+      setIsNewThreadState(true);
+      setThreadIdState(nextThreadId);
       return;
     }
+    newThreadIdRef.current = null;
     // Guard: after history.replaceState updates the URL from /chats/new to
     // /chats/{UUID}, Next.js useParams may still return the stale "new" value
     // because replaceState does not trigger router updates.  Avoid propagating
@@ -32,9 +47,28 @@ export function useThreadChat() {
     if (threadIdFromPath === "new") {
       return;
     }
-    setIsNewThread(false);
-    setThreadId(threadIdFromPath);
-  }, [pathname, threadIdFromPath]);
+    setIsNewThreadState(false);
+    setThreadIdState(threadIdFromPath);
+  }, [isNewPath, threadIdFromPath]);
+
+  const setThreadId = useCallback((nextThreadId: string) => {
+    newThreadIdRef.current = null;
+    setThreadIdState(nextThreadId);
+  }, []);
+
+  const setIsNewThread = useCallback((nextIsNewThread: boolean) => {
+    if (!nextIsNewThread) {
+      newThreadIdRef.current = null;
+    }
+    setIsNewThreadState(nextIsNewThread);
+  }, []);
+
   const isMock = searchParams.get("mock") === "true";
-  return { threadId, setThreadId, isNewThread, setIsNewThread, isMock };
+  return {
+    threadId: isNewPath ? (newThreadIdRef.current ?? threadId) : threadId,
+    setThreadId,
+    isNewThread: isNewPath ? true : isNewThreadState,
+    setIsNewThread,
+    isMock,
+  };
 }

--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -19,7 +19,6 @@ import { Loader } from "@/components/ai-elements/loader";
 import {
   Message as AIElementMessage,
   MessageContent as AIElementMessageContent,
-  MessageResponse as AIElementMessageResponse,
   MessageToolbar,
 } from "@/components/ai-elements/message";
 import {
@@ -44,7 +43,6 @@ import {
   type FileInMessage,
 } from "@/core/messages/utils";
 import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
-import { humanMessagePlugins } from "@/core/streamdown";
 import { cn } from "@/lib/utils";
 
 import { CopyButton } from "../copy-button";
@@ -300,22 +298,18 @@ function MessageContent_({
   }
 
   if (isHuman) {
-    const messageResponse = contentToDisplay ? (
-      <AIElementMessageResponse
-        remarkPlugins={humanMessagePlugins.remarkPlugins}
-        rehypePlugins={humanMessagePlugins.rehypePlugins}
-        components={components}
-        parseIncompleteMarkdown={false}
-      >
-        {contentToDisplay}
-      </AIElementMessageResponse>
-    ) : null;
+    // Composer input is plain text, not authored Markdown. Parsing it as
+    // Markdown mangles pasted code/logs (indented lines become code blocks,
+    // "$...$" spans become math) and lets pathological input crash the page
+    // through marked's recursive blockquote lexer, so render it verbatim.
     return (
       <div className={cn("ml-auto flex flex-col gap-2", className)}>
         {filesList}
-        {messageResponse && (
+        {contentToDisplay && (
           <AIElementMessageContent className="w-fit">
-            {messageResponse}
+            <div className="break-words whitespace-pre-wrap">
+              {contentToDisplay}
+            </div>
           </AIElementMessageContent>
         )}
       </div>

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -36,15 +36,3 @@ export const reasoningPlugins = {
     (p) => p !== rehypeRaw,
   ) as StreamdownProps["rehypePlugins"],
 };
-
-// Plugins for human messages - no autolink to prevent URL bleeding into adjacent text
-export const humanMessagePlugins = {
-  remarkPlugins: [
-    // Use remark-gfm without autolink literals by not including it
-    // Only include math support for human messages
-    [remarkMath, { singleDollarTextMath: true }],
-  ] as StreamdownProps["remarkPlugins"],
-  rehypePlugins: [
-    [rehypeKatex, { output: "html" }],
-  ] as StreamdownProps["rehypePlugins"],
-};

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -2,6 +2,45 @@ import { normalizeMermaidMarkdown } from "./mermaid";
 
 const MERMAID_BLOCK_HINT_RE = /mermaid/i;
 
+// marked's blockquote tokenizer (used by Streamdown to split content into
+// memoizable blocks) recurses once per nesting level and overflows the call
+// stack at roughly 2,000 levels, replacing the whole chat route with an error
+// page. 100 levels is far beyond any legitimate content while keeping a wide
+// margin below the crash threshold.
+const MAX_BLOCKQUOTE_DEPTH = 100;
+const DEEP_BLOCKQUOTE_HINT_RE = new RegExp(
+  `^(?:[ \\t]*>){${MAX_BLOCKQUOTE_DEPTH + 1}}`,
+  "m",
+);
+const BLOCKQUOTE_PREFIX_RE = /^(?:[ \t]*>)+/;
+
+export function capBlockquoteNesting(markdown: string): string {
+  if (!DEEP_BLOCKQUOTE_HINT_RE.test(markdown)) {
+    return markdown;
+  }
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const match = BLOCKQUOTE_PREFIX_RE.exec(line);
+      if (!match) {
+        return line;
+      }
+      const prefix = match[0];
+      let depth = 0;
+      for (let i = 0; i < prefix.length; i++) {
+        if (prefix[i] === ">") {
+          depth += 1;
+          if (depth > MAX_BLOCKQUOTE_DEPTH) {
+            return line.slice(0, i) + line.slice(prefix.length);
+          }
+        }
+      }
+      return line;
+    })
+    .join("\n");
+}
+
 export function preprocessStreamdownMarkdown(markdown: string): string {
   if (!MERMAID_BLOCK_HINT_RE.test(markdown) || !markdown.includes("-.->")) {
     return markdown;

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -12,16 +12,30 @@ const DEEP_BLOCKQUOTE_HINT_RE = new RegExp(
   `^(?:[ \\t]*>){${MAX_BLOCKQUOTE_DEPTH + 1}}`,
   "m",
 );
-const BLOCKQUOTE_PREFIX_RE = /^(?:[ \t]*>)+/;
+// Only up to 3 leading spaces can start a blockquote; 4+ (or a tab) is an
+// indented code block, where ">" runs are literal content.
+const BLOCKQUOTE_PREFIX_RE = /^ {0,3}(?:[ \t]*>)+/;
+const CODE_FENCE_RE = /^ {0,3}(?:```|~~~)/;
+const INDENTED_CODE_RE = /^(?: {4}|\t)/;
 
 export function capBlockquoteNesting(markdown: string): string {
   if (!DEEP_BLOCKQUOTE_HINT_RE.test(markdown)) {
     return markdown;
   }
 
+  let insideFence = false;
   return markdown
     .split("\n")
     .map((line) => {
+      if (CODE_FENCE_RE.test(line)) {
+        insideFence = !insideFence;
+        return line;
+      }
+      // ">" runs inside fenced or indented code blocks are literal text, not
+      // nesting — rewriting them would silently corrupt code content.
+      if (insideFence || INDENTED_CODE_RE.test(line)) {
+        return line;
+      }
       const match = BLOCKQUOTE_PREFIX_RE.exec(line);
       if (!match) {
         return line;

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -9,7 +9,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
@@ -41,6 +41,7 @@ export type ToolEndEvent = {
 
 export type ThreadStreamOptions = {
   threadId?: string | null | undefined;
+  displayThreadId?: string | null | undefined;
   context: LocalSettings["context"];
   isMock?: boolean;
   onSend?: (threadId: string) => void;
@@ -388,6 +389,7 @@ function getStreamErrorMessage(error: unknown): string {
 
 export function useThreadStream({
   threadId,
+  displayThreadId,
   context,
   isMock,
   onSend,
@@ -396,6 +398,15 @@ export function useThreadStream({
   onToolEnd,
 }: ThreadStreamOptions) {
   const { t } = useI18n();
+  const currentViewThreadId = displayThreadId ?? threadId ?? null;
+  const currentViewThreadIdRef = useRef(currentViewThreadId);
+  currentViewThreadIdRef.current = currentViewThreadId;
+  // Optimistic messages shown before the server stream responds.
+  const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
+  const [optimisticThreadId, setOptimisticThreadId] = useState<string | null>(
+    null,
+  );
+  const [isUploading, setIsUploading] = useState(false);
   // Track the thread ID that is currently streaming to handle thread changes during streaming
   const [onStreamThreadId, setOnStreamThreadId] = useState(() => threadId);
   // Ref to track current thread ID across async callbacks without causing re-renders,
@@ -437,6 +448,17 @@ export function useThreadStream({
 
   const handleStreamStart = useCallback((_threadId: string, _runId: string) => {
     threadIdRef.current = _threadId;
+    setOptimisticThreadId((currentOptimisticThreadId) => {
+      const currentView = currentViewThreadIdRef.current;
+      if (
+        currentOptimisticThreadId &&
+        (currentOptimisticThreadId === currentView ||
+          currentOptimisticThreadId === _threadId)
+      ) {
+        return _threadId;
+      }
+      return currentOptimisticThreadId;
+    });
     if (!startedRef.current) {
       listeners.current.onStart?.(_threadId, _runId);
       startedRef.current = true;
@@ -608,6 +630,7 @@ export function useThreadStream({
     },
     onError(error) {
       setOptimisticMessages([]);
+      setOptimisticThreadId(null);
       toast.error(getStreamErrorMessage(error));
       pendingUsageBaselineMessageIdsRef.current = new Set(
         messagesRef.current
@@ -639,10 +662,15 @@ export function useThreadStream({
     },
   });
 
-  // Optimistic messages shown before the server stream responds
-  const [optimisticMessages, setOptimisticMessages] = useState<Message[]>([]);
-  const [isUploading, setIsUploading] = useState(false);
-  const humanMessageCount = thread.messages.filter(
+  const persistedMessages = useMemo(
+    () => (threadId ? thread.messages : []),
+    [thread.messages, threadId],
+  );
+  const visibleHistory = useMemo(
+    () => (threadId ? history : []),
+    [history, threadId],
+  );
+  const humanMessageCount = persistedMessages.filter(
     (m) => m.type === "human",
   ).length;
   const latestMessageCountsRef = useRef({ humanMessageCount });
@@ -672,6 +700,13 @@ export function useThreadStream({
       latestMessageCountsRef.current.humanMessageCount;
   }, [threadId]);
 
+  useEffect(() => {
+    if (optimisticThreadId && optimisticThreadId !== currentViewThreadId) {
+      setOptimisticMessages([]);
+      setOptimisticThreadId(null);
+    }
+  }, [currentViewThreadId, optimisticThreadId]);
+
   // When streaming starts without a baseline (e.g. reconnection, run started
   // from another client, or page reload mid-stream), snapshot the current
   // messages so only *new* messages are treated as "pending" for token usage.
@@ -681,12 +716,12 @@ export function useThreadStream({
       pendingUsageBaselineMessageIdsRef.current.size === 0
     ) {
       pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
+        persistedMessages
           .map(messageIdentity)
           .filter((id): id is string => Boolean(id)),
       );
     }
-  }, [thread.isLoading, thread.messages]);
+  }, [persistedMessages, thread.isLoading]);
 
   // Clear optimistic when server messages arrive.
   // For messages with a human optimistic message, wait until the server's
@@ -702,6 +737,7 @@ export function useThreadStream({
 
     if (!hasHumanOptimistic || newHumanMsgArrived) {
       setOptimisticMessages([]);
+      setOptimisticThreadId(null);
     }
   }, [hasHumanOptimistic, humanMessageCount, optimisticMessageCount]);
 
@@ -723,7 +759,7 @@ export function useThreadStream({
       // messages so we can wait for the server's copy of the user input.
       prevHumanMsgCountRef.current = humanMessageCount;
       pendingUsageBaselineMessageIdsRef.current = new Set(
-        thread.messages
+        persistedMessages
           .map(messageIdentity)
           .filter((id): id is string => Boolean(id)),
       );
@@ -762,6 +798,7 @@ export function useThreadStream({
           additional_kwargs: { element: "task" },
         });
       }
+      setOptimisticThreadId(threadId);
       setOptimisticMessages(newOptimistic);
 
       listeners.current.onSend?.(threadId);
@@ -827,6 +864,7 @@ export function useThreadStream({
                 : "Failed to upload files.";
             toast.error(errorMessage);
             setOptimisticMessages([]);
+            setOptimisticThreadId(null);
             throw error;
           } finally {
             setIsUploading(false);
@@ -895,35 +933,43 @@ export function useThreadStream({
         });
       } catch (error) {
         setOptimisticMessages([]);
+        setOptimisticThreadId(null);
         setIsUploading(false);
         throw error;
       } finally {
         sendInFlightRef.current = false;
       }
     },
-    [thread, t.uploads.uploadingFiles, context, queryClient, humanMessageCount],
+    [
+      thread,
+      t.uploads.uploadingFiles,
+      context,
+      queryClient,
+      humanMessageCount,
+      persistedMessages,
+    ],
   );
 
   // Cache the latest thread messages in a ref to compare against incoming history messages for deduplication,
   // and to allow access to the full message list in onUpdateEvent without causing re-renders.
-  if (thread.messages.length >= messagesRef.current.length) {
-    messagesRef.current = thread.messages;
+  if (persistedMessages.length >= messagesRef.current.length) {
+    messagesRef.current = persistedMessages;
   }
 
   const visibleOptimisticMessages = getVisibleOptimisticMessages(
-    optimisticMessages,
+    optimisticThreadId === currentViewThreadId ? optimisticMessages : [],
     prevHumanMsgCountRef.current,
     humanMessageCount,
   );
 
   const mergedMessages = mergeMessages(
-    history,
-    thread.messages,
+    visibleHistory,
+    persistedMessages,
     visibleOptimisticMessages,
   );
   const pendingUsageMessages = thread.isLoading
     ? getMessagesAfterBaseline(
-        thread.messages,
+        persistedMessages,
         pendingUsageBaselineMessageIdsRef.current,
       )
     : [];
@@ -932,6 +978,15 @@ export function useThreadStream({
   // History messages may overlap with thread.messages; thread.messages take precedence
   const mergedThread = {
     ...thread,
+    values: threadId
+      ? thread.values
+      : {
+          ...thread.values,
+          title: undefined,
+          messages: [],
+          artifacts: [],
+          todos: [],
+        },
     messages: mergedMessages,
   } as typeof thread;
 

--- a/frontend/tests/e2e/thread-history.spec.ts
+++ b/frontend/tests/e2e/thread-history.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Route } from "@playwright/test";
 
 import {
   mockLangGraphAPI,
@@ -19,6 +19,9 @@ const THREADS = [
   },
 ];
 const DEMO_THREAD_ID = "7cfa5f8f-a2f8-47ad-acbd-da7137baf990";
+const SVG_PROMPT_THREAD_ID = "00000000-0000-0000-0000-000000000777";
+const SVG_PROMPT_MARKER = "LEAK-STRICT-SVG-PROMPT-SHOULD-DISAPPEAR";
+const OPTIMISTIC_PROMPT_MARKER = "LEAK-OPTIMISTIC-SVG-PROMPT-SHOULD-DISAPPEAR";
 
 test.describe("Thread history", () => {
   test("sidebar shows existing threads", async ({ page }) => {
@@ -60,6 +63,98 @@ test.describe("Thread history", () => {
     await expect(
       page.getByText("Response in thread First conversation"),
     ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("new chat does not show previous thread messages after client-side navigation", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: SVG_PROMPT_THREAD_ID,
+          title: "SVG artifact prompt",
+          updated_at: "2025-06-03T12:00:00Z",
+          messages: [
+            {
+              type: "human",
+              id: "msg-human-svg-prompt",
+              content: [
+                {
+                  type: "text",
+                  text: `请严格执行：\n1. 使用 write_file 创建 /mnt/user-data/outputs/shared.svg，内容包含 ${SVG_PROMPT_MARKER}\n2. 最终回复只输出 Markdown 图片。`,
+                },
+              ],
+            },
+            {
+              type: "ai",
+              id: "msg-ai-svg-prompt",
+              content: "![shared artifact](/mnt/user-data/outputs/shared.svg)",
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.goto(`/workspace/chats/${SVG_PROMPT_THREAD_ID}`);
+    await expect(page.getByText(SVG_PROMPT_MARKER)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page.getByRole("link", { name: /new chat/i }).click();
+    await page.waitForURL("**/workspace/chats/new");
+
+    await expect(page.getByText(SVG_PROMPT_MARKER)).toBeHidden();
+    await expect(page.getByPlaceholder(/how can i assist you/i)).toBeVisible();
+  });
+
+  test("new chat does not show previous optimistic user message after client-side navigation", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page);
+
+    const metadataOnlyStream = async (route: Route) => {
+      const body = [
+        {
+          event: "metadata",
+          data: {
+            run_id: "00000000-0000-0000-0000-000000000778",
+            thread_id: MOCK_THREAD_ID,
+          },
+        },
+        { event: "end", data: {} },
+      ]
+        .map((e) => `event: ${e.event}\ndata: ${JSON.stringify(e.data)}\n\n`)
+        .join("");
+
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body,
+      });
+    };
+
+    await page.route("**/api/langgraph/runs/stream", metadataOnlyStream);
+    await page.route(
+      "**/api/langgraph/threads/*/runs/stream",
+      metadataOnlyStream,
+    );
+
+    await page.goto("/workspace/chats/new");
+    const textarea = page.getByPlaceholder(/how can i assist you/i);
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+    await textarea.fill(
+      `请严格执行：使用 write_file 创建 shared.svg，内容包含 ${OPTIMISTIC_PROMPT_MARKER}。`,
+    );
+    await textarea.press("Enter");
+
+    await page.waitForURL(`**/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText(OPTIMISTIC_PROMPT_MARKER)).toBeVisible();
+
+    await page.getByRole("link", { name: /new chat/i }).click();
+    await page.waitForURL("**/workspace/chats/new");
+
+    await expect(page.getByText(OPTIMISTIC_PROMPT_MARKER)).toHaveCount(0);
+    await expect(page.getByPlaceholder(/how can i assist you/i)).toBeVisible();
   });
 
   test("mock thread does not load real backend run history", async ({

--- a/frontend/tests/e2e/user-message-plain-text.spec.ts
+++ b/frontend/tests/e2e/user-message-plain-text.spec.ts
@@ -115,4 +115,23 @@ test.describe("User message plain-text rendering", () => {
     // visibility).
     await expect(page.getByText("deep")).toBeAttached();
   });
+
+  test("list-prefixed deep nesting in an AI message falls back to plain text instead of crashing", async ({
+    page,
+  }) => {
+    // marked's list and blockquote tokenizers are mutually recursive, so a
+    // list marker in front of the quote chain bypasses the nesting cap; the
+    // render error boundary must absorb it.
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(
+      page,
+      threadWithMessages("hello", "- " + "> ".repeat(3000) + "deep-list"),
+    );
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("hello")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    await expect(page.getByText("deep-list")).toBeAttached();
+  });
 });

--- a/frontend/tests/e2e/user-message-plain-text.spec.ts
+++ b/frontend/tests/e2e/user-message-plain-text.spec.ts
@@ -1,0 +1,118 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockLangGraphAPI, MOCK_THREAD_ID } from "./utils/mock-api";
+
+const C_SOURCE = `#include <stdio.h>
+#include <signal.h>
+
+static volatile int connected = 0;
+
+static void daemon_handle_signal(int sig) {
+    if (sig == SIGTERM) {
+        connected = 0;
+
+        printf("daemon stop requested\\n");
+        return;
+    }
+
+    printf("ignored signal %d\\n", sig);
+}`;
+
+function threadWithMessages(
+  humanText: string,
+  aiText = "ack",
+): Parameters<typeof mockLangGraphAPI>[1] {
+  return {
+    threads: [
+      {
+        thread_id: MOCK_THREAD_ID,
+        title: "Plain text rendering",
+        updated_at: "2025-06-01T12:00:00Z",
+        messages: [
+          {
+            type: "human",
+            id: "msg-human-plain-text",
+            content: [{ type: "text", text: humanText }],
+          },
+          {
+            type: "ai",
+            id: "msg-ai-plain-text",
+            content: aiText,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function collectPageErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => {
+    errors.push(`${error.name}: ${error.message}`);
+  });
+  return errors;
+}
+
+test.describe("User message plain-text rendering", () => {
+  test("pasted source code renders verbatim as one block", async ({ page }) => {
+    mockLangGraphAPI(page, threadWithMessages(C_SOURCE));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    // The pasted file must not be split into Markdown code-block widgets.
+    await expect(
+      page.locator('[data-code-block-container="true"]'),
+    ).toHaveCount(0);
+
+    // Indentation and line structure must be preserved verbatim.
+    const bubble = page.locator(".is-user");
+    const text = await bubble.innerText();
+    expect(text).toContain("#include <stdio.h>");
+    expect(text).toContain("    if (sig == SIGTERM) {");
+    expect(text).toContain('        printf("daemon stop requested\\n");');
+  });
+
+  test("dollar signs are not parsed as math", async ({ page }) => {
+    const message = "this costs $5 and $10 in total";
+    mockLangGraphAPI(page, threadWithMessages(message));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    await expect(page.locator(".is-user")).toContainText(message);
+    await expect(page.locator(".is-user .katex")).toHaveCount(0);
+  });
+
+  test("deeply nested blockquote markers in a user message do not crash the page", async ({
+    page,
+  }) => {
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(page, threadWithMessages("> ".repeat(3000) + "hi"));
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("ack")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    await expect(page.locator(".is-user")).toContainText("> > >");
+  });
+
+  test("deeply nested blockquote markers in an AI message do not crash the page", async ({
+    page,
+  }) => {
+    const pageErrors = collectPageErrors(page);
+    mockLangGraphAPI(
+      page,
+      threadWithMessages("hello", "> ".repeat(3000) + "deep"),
+    );
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await expect(page.getByText("hello")).toBeVisible({ timeout: 15_000 });
+
+    expect(pageErrors).toEqual([]);
+    // The capped blockquote chain still renders (100 levels of indentation can
+    // squeeze the innermost element to zero width, so assert presence, not
+    // visibility).
+    await expect(page.getByText("deep")).toBeAttached();
+  });
+});

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "vitest";
+
+import {
+  capBlockquoteNesting,
+  preprocessStreamdownMarkdown,
+} from "@/core/streamdown/preprocess";
+
+test("capBlockquoteNesting returns normal content unchanged", () => {
+  const input = "# Title\n\n> a quote\n>> nested\n\nsome `code`";
+  expect(capBlockquoteNesting(input)).toBe(input);
+});
+
+test("capBlockquoteNesting keeps nesting at or below the cap untouched", () => {
+  const input = "> ".repeat(100) + "hi";
+  expect(capBlockquoteNesting(input)).toBe(input);
+});
+
+test("capBlockquoteNesting caps pathological nesting and preserves content", () => {
+  const result = capBlockquoteNesting("> ".repeat(5000) + "hi");
+  expect((result.match(/>/g) ?? []).length).toBe(100);
+  expect(result.endsWith("hi")).toBe(true);
+});
+
+test("capBlockquoteNesting handles markers without spaces", () => {
+  const result = capBlockquoteNesting(">".repeat(5000) + "hi");
+  expect((result.match(/>/g) ?? []).length).toBe(100);
+  expect(result.endsWith("hi")).toBe(true);
+});
+
+test("capBlockquoteNesting only rewrites pathological lines", () => {
+  const normal = "> normal quote";
+  const deep = "> ".repeat(3000) + "deep";
+  const result = capBlockquoteNesting(`${normal}\n${deep}\nplain`);
+  const lines = result.split("\n");
+  expect(lines[0]).toBe(normal);
+  expect((lines[1]?.match(/>/g) ?? []).length).toBe(100);
+  expect(lines[2]).toBe("plain");
+});
+
+test("preprocessStreamdownMarkdown leaves non-mermaid content unchanged", () => {
+  const input = "just some text";
+  expect(preprocessStreamdownMarkdown(input)).toBe(input);
+});

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -27,6 +27,20 @@ test("capBlockquoteNesting handles markers without spaces", () => {
   expect(result.endsWith("hi")).toBe(true);
 });
 
+test("capBlockquoteNesting leaves fenced code content untouched", () => {
+  const literal = ">".repeat(150);
+  const input = `${"> ".repeat(3000)}hi\n\`\`\`text\n${literal}\n\`\`\``;
+  const result = capBlockquoteNesting(input);
+  expect(result.split("\n")[2]).toBe(literal);
+});
+
+test("capBlockquoteNesting leaves indented code blocks untouched", () => {
+  const literal = "    " + ">".repeat(150);
+  const input = `${"> ".repeat(3000)}hi\n\n${literal}`;
+  const result = capBlockquoteNesting(input);
+  expect(result.split("\n")[2]).toBe(literal);
+});
+
 test("capBlockquoteNesting only rewrites pathological lines", () => {
   const normal = "> normal quote";
   const deep = "> ".repeat(3000) + "deep";


### PR DESCRIPTION
## Why

Fix a New Chat state leak where messages from the previous thread could remain visible above the welcome screen after client-side navigation to `/workspace/chats/new`.


## What changed
The chat page reused thread-local UI state across client-side navigation. In particular, optimistic user messages created during send were stored on the stream hook instance without being scoped to the currently displayed thread. When the user switched to New Chat, those optimistic messages could still be merged into the rendered message list, making the previous prompt appear on the empty welcome page.

This was especially visible when the previous prompt contained an artifact markdown response such as `![shared artifact](/mnt/user-data/outputs/shared.svg)`.



## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change



## Screenshots / Recording

<img width="1926" height="1018" alt="bug2" src="https://github.com/user-attachments/assets/475bd0d5-30da-41a1-b3c1-b1f4d210b7b7" />



## Bug fix verification
Test path that reproduces the bug:

- `frontend/tests/e2e/thread-history.spec.ts`
- Test: `new chat does not show previous optimistic user message after client-side navigation`
- Also added coverage for persisted history leakage: `new chat does not show previous thread messages after client-side navigation`

Did it go red on `main` and green on this branch?

- Expected: yes.


## Validation

Ran:

- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `cd frontend && ./node_modules/.bin/eslint . --ext .ts,.tsx --rule 'import/order: off'`
- `cd frontend && ./node_modules/.bin/prettier --check src/app/workspace/chats/[thread_id]/page.tsx src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx src/components/workspace/chats/use-thread-chat.ts src/core/threads/hooks.ts tests/e2e/thread-history.spec.ts`
- `cd frontend && ./node_modules/.bin/playwright test tests/e2e/thread-history.spec.ts --project=chromium --grep optimistic --list`



## AI assistance
**Tool(s) used:** Codex

**How you used it:** Investigated the New Chat message leakage, identified that optimistic messages and persisted thread state were not scoped to the displayed thread, implemented the fix, and added E2E regression coverage for the leak.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.