### PR TITLE
fix(frontend): resolve build permission issues introduced by node:22-alpine Alpine 3.24 upgrade

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG PNPM_STORE_PATH=/root/.local/share/pnpm/store
 ARG NPM_REGISTRY
 
 # ── Base: shared setup ────────────────────────────────────────────────────────
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
 ARG PNPM_STORE_PATH
 ARG NPM_REGISTRY
 # Configure corepack registry before installing pnpm so the download itself
@@ -35,7 +35,7 @@ RUN cd /app/frontend && pnpm install --frozen-lockfile
 RUN cd /app/frontend && SKIP_ENV_VALIDATION=1 pnpm build
 
 # ── Prod: minimal runtime with pre-built output ───────────────────────────────
-FROM node:22-alpine AS prod
+FROM node:22-alpine3.22 AS prod
 ARG PNPM_STORE_PATH
 ARG NPM_REGISTRY
 RUN if [ -n "${NPM_REGISTRY}" ]; then \


### PR DESCRIPTION
## Summary

Pin the frontend base image from `node:22-alpine` to `node:22-alpine3.22` to avoid build failures introduced by the upstream Alpine 3.24 upgrade.

## Background

The `node:22-alpine` image now tracks Alpine 3.24:

[https://github.com/nodejs/docker-node/blob/c94b4249a1a1bfb2ebb05fac9012cd34fecc2db7/22/alpine3.24/Dockerfile](https://github.com/nodejs/docker-node/blob/c94b4249a1a1bfb2ebb05fac9012cd34fecc2db7/22/alpine3.24/Dockerfile)

After the underlying Alpine version changed from 3.22 to 3.24, the frontend image build started failing with permission-related errors during the pnpm setup stage:

```text
EPERM: operation not permitted, write
```

This issue is caused by changes in the base image behavior rather than any DeerFlow application code changes.

## Changes

```diff
-FROM node:22-alpine AS base
+FROM node:22-alpine3.22 AS base
```

## Impact

* Keeps the Alpine runtime version consistent with the previously working environment.
* Avoids permission-related build failures introduced by Alpine 3.24.
* No application code or runtime behavior changes.
* Reduces the risk of unexpected regressions caused by upstream base image updates.

## Validation

* Verified that the frontend image builds successfully after pinning the base image to `node:22-alpine3.22`.
* Confirmed no functional changes to the application runtime.

## PR Title

`fix(frontend): pin node:22-alpine to Alpine 3.22 to prevent build permission issues`
