### PR TITLE
docs(config): add SearXNG and Browserless configuration examples

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -517,7 +517,7 @@ tools:
   # - name: web_search
   #   group: web
   #   use: deerflow.community.searxng.tools:web_search_tool
-  #   base_url: http://localhost:8080   # SearXNG instance URL (Docker: http://searxng:8080)
+  #   base_url: http://localhost:8088   # SearXNG instance URL (default: :8088; Docker: http://searxng:8080)
   #   max_results: 5                     # Maximum number of search results
 
   # Web search tool (uses Serper - Google Search API, requires SERPER_API_KEY)
@@ -569,15 +569,12 @@ tools:
   # - name: web_fetch
   #   group: web
   #   use: deerflow.community.browserless.tools:web_fetch_tool
-  #   base_url: http://localhost:3000    # Browserless instance URL (Docker: http://browserless:3000)
+  #   base_url: http://localhost:3032    # Browserless instance URL (default: :3032; Docker: http://browserless:3000)
   #   # token: $BROWSERLESS_TOKEN        # API token (required for Browserless Cloud; optional for self-hosted)
   #   timeout_s: 30                       # Request timeout in seconds
   #   # wait_for_event: "networkidle"    # Wait for a page event before returning (e.g. "load", "networkidle")
   #   # wait_for_timeout_ms: 2000        # Extra wait after page load in milliseconds
   #   # wait_for_selector: "article"     # CSS selector to wait for before returning
-  #   # wait_for_selector_timeout_ms: 5000  # Timeout for selector wait in milliseconds
-  #   # reject_resource_types: ["image"]    # Resource types to block for faster loads (e.g. ["image", "stylesheet"])
-  #   # reject_request_pattern: ["/\\.css$/"]  # URL patterns to block (regex strings)
 
   # Web fetch tool (uses Exa)
   # NOTE: Only one web_fetch provider can be active at a time.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -510,6 +510,16 @@ tools:
     # region: wt-wt          # wt-wt is normalized for Wikipedia when backend includes auto/all/wikipedia.
     # safesearch: moderate   # on, moderate, off
 
+  # Web search tool (uses SearXNG, self-hosted, no API key required)
+  # SearXNG is a free internet metasearch engine which aggregates results from
+  # various search services. Deploy your own instance: https://github.com/searxng/searxng
+  # For Docker deployments, use the Docker service name instead of localhost.
+  # - name: web_search
+  #   group: web
+  #   use: deerflow.community.searxng.tools:web_search_tool
+  #   base_url: http://localhost:8080   # SearXNG instance URL (Docker: http://searxng:8080)
+  #   max_results: 5                     # Maximum number of search results
+
   # Web search tool (uses Serper - Google Search API, requires SERPER_API_KEY)
   # Serper provides real-time Google Search results. Sign up at https://serper.dev
   # Note: set SERPER_API_KEY in your environment before starting the app, or
@@ -549,6 +559,25 @@ tools:
   #   use: deerflow.community.firecrawl.tools:web_search_tool
   #   max_results: 5
   #   # api_key: $FIRECRAWL_API_KEY
+
+  # Web fetch tool (uses Browserless - headless Chrome, self-hosted or cloud)
+  # Browserless renders pages with a real headless Chrome, ideal for JavaScript-heavy
+  # sites and SPAs. Deploy your own: https://github.com/browserless/browserless
+  # For Docker deployments, use the Docker service name instead of localhost.
+  # NOTE: Only one web_fetch provider can be active at a time.
+  # Comment out the Jina AI web_fetch entry below before enabling this one.
+  # - name: web_fetch
+  #   group: web
+  #   use: deerflow.community.browserless.tools:web_fetch_tool
+  #   base_url: http://localhost:3000    # Browserless instance URL (Docker: http://browserless:3000)
+  #   # token: $BROWSERLESS_TOKEN        # API token (required for Browserless Cloud; optional for self-hosted)
+  #   timeout_s: 30                       # Request timeout in seconds
+  #   # wait_for_event: "networkidle"    # Wait for a page event before returning (e.g. "load", "networkidle")
+  #   # wait_for_timeout_ms: 2000        # Extra wait after page load in milliseconds
+  #   # wait_for_selector: "article"     # CSS selector to wait for before returning
+  #   # wait_for_selector_timeout_ms: 5000  # Timeout for selector wait in milliseconds
+  #   # reject_resource_types: ["image"]    # Resource types to block for faster loads (e.g. ["image", "stylesheet"])
+  #   # reject_request_pattern: ["/\\.css$/"]  # URL patterns to block (regex strings)
 
   # Web fetch tool (uses Exa)
   # NOTE: Only one web_fetch provider can be active at a time.


### PR DESCRIPTION
## Summary

Follow-up to #3451 - adds configuration examples for the SearXNG and Browserless tools that were merged but lack config.example.yaml documentation.

### Changes

- **SearXNG** (web_search): Self-hosted metasearch engine config example
  - base_url - SearXNG instance URL (defaults to http://localhost:8080; use Docker service name in containers)
  - max_results - Maximum search results

- **Browserless** (web_fetch): Headless Chrome renderer config example
  - base_url - Browserless instance URL (defaults to http://localhost:3000; use Docker service name in containers)
  - token - API token (required for Browserless Cloud, optional for self-hosted)
  - timeout_s - Request timeout in seconds
  - wait_for_event - Page event to wait for (e.g. networkidle, load)
  - wait_for_timeout_ms - Extra wait after page load
  - wait_for_selector - CSS selector to wait for
  - wait_for_selector_timeout_ms - Selector wait timeout
  - reject_resource_types - Resource types to block (e.g. [image])
  - reject_request_pattern - URL patterns to block (regex strings)

### Notes

- Both entries are commented out (consistent with other tool examples in the file)
- Docker deployment guidance included (use service names instead of localhost)