### PR TITLE
fix(security): do not bind-mount host CLI auth dirs by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,3 +66,14 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # alias, or behind a different port). docker-compose already sets these.
 # DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://localhost:8001
 # DEER_FLOW_TRUSTED_ORIGINS=http://localhost:3000,http://localhost:2026
+
+# ── Claude Code / Codex CLI subscription as a model provider (optional) ───────
+# If you configure a ClaudeChatModel / Codex model provider (or an ACP agent)
+# that reuses your CLI subscription login, prefer passing a token via env over
+# bind-mounting your whole ~/.claude / ~/.codex into the container. The Gateway
+# credential loader reads these first, so no directory mount is needed.
+#   docker-compose.cli-auth.yaml is the opt-in directory-mount fallback (e.g.
+#   for ACP adapters that need the full CLI config). See SECURITY.md.
+# CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token
+# ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token
+# CODEX_AUTH_PATH=/path/to/codex/auth.json

--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,12 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # that reuses your CLI subscription login, prefer passing a token via env over
 # bind-mounting your whole ~/.claude / ~/.codex into the container. The Gateway
 # credential loader reads these first, so no directory mount is needed.
-#   docker-compose.cli-auth.yaml is the opt-in directory-mount fallback (e.g.
-#   for ACP adapters that need the full CLI config). See SECURITY.md.
+#   CLAUDE_CODE_CREDENTIALS_PATH points at a single .credentials.json (Claude)
+#   rather than the whole dir. docker-compose.cli-auth.yaml is the opt-in
+#   directory-mount fallback for adapters that need the full CLI config.
+#   ACP adapters often take their own env API key (e.g. ANTHROPIC_API_KEY) and
+#   need no mount at all — check the adapter's docs. See SECURITY.md.
 # CLAUDE_CODE_OAUTH_TOKEN=your-claude-code-oauth-token
 # ANTHROPIC_AUTH_TOKEN=your-anthropic-auth-token
+# CLAUDE_CODE_CREDENTIALS_PATH=/path/to/.claude/.credentials.json
 # CODEX_AUTH_PATH=/path/to/codex/auth.json

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,8 +32,10 @@ with the least exposure that fits your setup:
 
 The Gateway credential loader checks environment variables **before** the
 default credential files, so the env-token paths need no bind mount at all. ACP
-adapters authenticate independently of DeerFlow — their credential source is
-adapter-defined, and some require a standard API key via env rather than the CLI
-subscription login. Prefer the adapter's documented env auth, and reach for the
-`docker-compose.cli-auth.yaml` overlay only when an adapter genuinely needs the
-full CLI config directory.
+adapters authenticate independently of DeerFlow via their own documented env —
+for example the common `claude-code-acp` adapter starts as
+`ANTHROPIC_API_KEY=… claude-code-acp` and honors `CLAUDE_CONFIG_DIR` to redirect
+its config directory, so it needs no `~/.claude` mount at all. Prefer the
+adapter's documented env auth, and reach for the
+`docker-compose.cli-auth.yaml` overlay only as a fallback for an adapter that
+genuinely reads the full CLI config directory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,11 +26,14 @@ with the least exposure that fits your setup:
 
 | Need | How | Exposure |
 |------|-----|----------|
-| Claude model provider | env `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` (via `.env`) | none — token only |
+| Claude model provider | env `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` (via `.env`), or `CLAUDE_CODE_CREDENTIALS_PATH` → a single mounted `.credentials.json` | none / one file |
 | Codex model provider | env `CODEX_AUTH_PATH` pointing at a single mounted `auth.json` | one file |
-| ACP agent running the CLI in-container | opt-in `docker/docker-compose.cli-auth.yaml` overlay | full dir (read-only) |
+| ACP agent | the adapter's own auth — many ACP adapters take an env API key (e.g. `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) and need no mount; use the opt-in `docker/docker-compose.cli-auth.yaml` overlay only if your adapter reads the full CLI config dir | none / full dir |
 
 The Gateway credential loader checks environment variables **before** the
-default credential files, so the env-token paths need no bind mount at all. Use
-the `docker-compose.cli-auth.yaml` overlay only when the in-container CLI
-genuinely needs the full config directory (e.g. some ACP adapters).
+default credential files, so the env-token paths need no bind mount at all. ACP
+adapters authenticate independently of DeerFlow — their credential source is
+adapter-defined, and some require a standard API key via env rather than the CLI
+subscription login. Prefer the adapter's documented env auth, and reach for the
+`docker-compose.cli-auth.yaml` overlay only when an adapter genuinely needs the
+full CLI config directory.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,3 +10,27 @@ Currently, we have two branches to maintain:
 ## Reporting a Vulnerability
 
 Please go to https://github.com/bytedance/deer-flow/security to report the vulnerability you find.
+
+## CLI Credential Mounts (Claude Code / Codex)
+
+DeerFlow can reuse your Claude Code / Codex CLI subscription login as a model
+provider (`ClaudeChatModel`, the Codex provider) or for ACP agents that run the
+CLI in-container. The Compose stack used to bind-mount the **entire** `~/.claude`
+and `~/.codex` directories (read-only) into the gateway container in **every**
+configuration — exposing not just credentials but full conversation history,
+per-project session data, and global CLI config. A gateway compromise (prompt
+injection, tool/MCP misuse, RCE) would leak all of it.
+
+These directories are **no longer mounted by default**. Supply CLI credentials
+with the least exposure that fits your setup:
+
+| Need | How | Exposure |
+|------|-----|----------|
+| Claude model provider | env `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN` (via `.env`) | none — token only |
+| Codex model provider | env `CODEX_AUTH_PATH` pointing at a single mounted `auth.json` | one file |
+| ACP agent running the CLI in-container | opt-in `docker/docker-compose.cli-auth.yaml` overlay | full dir (read-only) |
+
+The Gateway credential loader checks environment variables **before** the
+default credential files, so the env-token paths need no bind mount at all. Use
+the `docker-compose.cli-auth.yaml` overlay only when the in-container CLI
+genuinely needs the full config directory (e.g. some ACP adapters).

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -148,19 +148,12 @@ services:
       - gateway-uv-cache:/root/.cache/uv
       # DooD: AioSandboxProvider runs inside the Gateway process.
       - /var/run/docker.sock:/var/run/docker.sock
-      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
-      - type: bind
-        source: ${HOME:?HOME must be set}/.claude
-        target: /root/.claude
-        read_only: true
-        bind:
-          create_host_path: true
-      - type: bind
-        source: ${HOME:?HOME must be set}/.codex
-        target: /root/.codex
-        read_only: true
-        bind:
-          create_host_path: true
+      # CLI auth dirs (Claude Code / Codex) are NOT mounted by default: they
+      # expose the entire ~/.claude and ~/.codex (history, projects, global
+      # config, credentials) into the container. Mount them only when you use
+      # the Claude/Codex CLI login as a model provider or ACP agent, via the
+      # opt-in docker-compose.cli-auth.yaml overlay. Prefer an env token
+      # (CLAUDE_CODE_OAUTH_TOKEN, see .env.example / SECURITY.md).
     working_dir: /app
     environment:
       - CI=true

--- a/docker/docker-compose.cli-auth.yaml
+++ b/docker/docker-compose.cli-auth.yaml
@@ -1,0 +1,36 @@
+# DeerFlow — CLI auth overlay (OPT-IN, NOT loaded by default)
+#
+# Bind-mounts the host Claude Code / Codex CLI config dirs into the gateway so:
+#   - ClaudeChatModel / Codex model providers can reuse the CLI subscription
+#     login (~/.claude/.credentials.json, ~/.codex/auth.json), and
+#   - ACP agents (acp_agents in config.yaml) that run the claude/codex CLI
+#     inside the container can read their config.
+#
+# SECURITY: these mounts expose the ENTIRE ~/.claude and ~/.codex dirs
+# (conversation history, projects, global config, long-lived credentials) into
+# the gateway container, read-only. A gateway compromise leaks all of it. That
+# is why they are NOT mounted by default.
+#
+# Prefer passing only a token via env instead (no directory exposure):
+#   CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_AUTH_TOKEN for Claude, CODEX_AUTH_PATH
+#   for a single Codex auth file — see .env.example and SECURITY.md.
+# Use this overlay only when you need the full CLI config (e.g. ACP adapters
+# that run the CLI in-container and read more than just the credential file).
+#
+# Manual use (works with both prod and dev compose):
+#   docker compose -f docker-compose.yaml -f docker-compose.cli-auth.yaml up -d
+services:
+  gateway:
+    volumes:
+      - type: bind
+        source: ${HOME:?HOME must be set}/.claude
+        target: /root/.claude
+        read_only: true
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ${HOME:?HOME must be set}/.codex
+        target: /root/.codex
+        read_only: true
+        bind:
+          create_host_path: true

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -86,19 +86,12 @@ services:
       - ${DEER_FLOW_HOME}:/app/backend/.deer-flow
       # DooD: AioSandboxProvider starts sandbox containers via host Docker daemon
       - ${DEER_FLOW_DOCKER_SOCKET}:/var/run/docker.sock
-      # CLI auth directories for auto-auth (Claude Code + Codex CLI)
-      - type: bind
-        source: ${HOME:?HOME must be set}/.claude
-        target: /root/.claude
-        read_only: true
-        bind:
-          create_host_path: true
-      - type: bind
-        source: ${HOME:?HOME must be set}/.codex
-        target: /root/.codex
-        read_only: true
-        bind:
-          create_host_path: true
+      # CLI auth dirs (Claude Code / Codex) are NOT mounted by default: they
+      # expose the entire ~/.claude and ~/.codex (history, projects, global
+      # config, credentials) into the container. Mount them only when you use
+      # the Claude/Codex CLI login as a model provider or ACP agent, via the
+      # opt-in docker-compose.cli-auth.yaml overlay. Prefer an env token
+      # (CLAUDE_CODE_OAUTH_TOKEN, see .env.example / SECURITY.md).
     working_dir: /app
     environment:
       - CI=true


### PR DESCRIPTION
## Problem

The Compose stack bind-mounts the **entire** `~/.claude` and `~/.codex`
directories (read-only) into the root `gateway` container in **every**
configuration. That exposes not just credentials but full conversation history
(`history.jsonl`), per-project session data (`projects/`), and global CLI config
(`CLAUDE.md`). The default OpenAI-compatible model providers and the local
sandbox never use these mounts — so it is an unnecessary default exposure, the
credential-mount counterpart to the Docker socket issue in #3516 / #3517.

Reported by **@greatmengqi** — the original report flagged the `$HOME/.claude` /
`$HOME/.codex` read-only mounts alongside the socket. 🙏

## Root cause

The mounts are only needed for opt-in setups: a Claude/Codex CLI login used as a
model provider (`ClaudeChatModel` / Codex provider, which read
`~/.claude/.credentials.json` / `~/.codex/auth.json`), or ACP agents that run the
CLI in-container (they inherit `HOME=/root` and read the whole dir). None of
these are on by default, yet the dirs were mounted for everyone.

## Solution

- Remove the unconditional `.claude` / `.codex` mounts from
  `docker/docker-compose.yaml` and `docker/docker-compose-dev.yaml`.
- Add an opt-in `docker/docker-compose.cli-auth.yaml` overlay (works with both
  prod and dev compose) for setups that need the full CLI config.
- `.env.example`: document `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_AUTH_TOKEN`
  and `CODEX_AUTH_PATH`. The Gateway credential loader
  (`credential_loader.py`) reads env vars **before** the default credential
  files, so model-provider setups need no bind mount at all.
- `SECURITY.md`: document the exposure and the per-mode least-exposure options.

This is explicit opt-in (not auto-detected like the socket): unlike sandbox
mode, "does this deployment need the CLI credential dir?" can't be reliably
inferred from `config.yaml`, so wiring it into the scripts would be guesswork.

## Validation (local, real Docker — Docker Desktop 28.3.3)

`docker compose config` (authoritative engine merge), exit 0:

```
prod/dev default            : gateway has ZERO .claude/.codex mounts
prod/dev + cli-auth.yaml    : mounts /root/.claude and /root/.codex (read-only)
```

Throwaway container against the **project's real** overlay:

```
Default (no overlay):   ls /root/.claude → No such file ; ls /root/.codex → No such file
With cli-auth overlay:  /root/.claude present; touch → "Read-only file system"  (read_only OK)
```

ACP note: `invoke_acp_agent_tool.py` spawns the adapter inheriting `HOME=/root`
with no `CLAUDE_CONFIG_DIR` override, so an in-container CLI *would* read
`/root/.claude` if it relied on the CLI login. In practice many ACP adapters
(e.g. claude-agent-acp) authenticate via a standard env API key
(`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) and need no mount at all — so the
overlay mounts the full dir only for adapters that genuinely read the CLI config
directory. The exact credential source is adapter-defined, not constrained by
DeerFlow.

## Breaking change + migration

Setups relying on the auto-mounted dirs for a Claude/Codex model provider must,
after upgrade, set `CLAUDE_CODE_OAUTH_TOKEN` (etc.) in `.env` (recommended) or
add `-f docker-compose.cli-auth.yaml`. Documented in `.env.example` and
`SECURITY.md`.

Closes #3520

/cc @greatmengqi — would appreciate your review; this is the credential-mount
half of your original report.
