### PR TITLE
fix(channels): surface WeCom WebSocket connection failures (#2000)

### DIFF
--- a/backend/app/channels/wecom.py
+++ b/backend/app/channels/wecom.py
@@ -79,11 +79,33 @@ class WeComChannel(Channel):
             self._ws_client.on("message.mixed", self._on_ws_mixed)
             self._ws_client.on("message.image", self._on_ws_image)
             self._ws_client.on("message.file", self._on_ws_file)
+            self._ws_client.on("error", self._on_ws_error)
+            self._ws_client.on("disconnected", self._on_ws_disconnected)
             self._ws_task = asyncio.create_task(self._ws_client.connect())
+            self._ws_task.add_done_callback(self._on_ws_task_done)
 
             self._running = True
             self.bus.subscribe_outbound(self._on_outbound)
         logger.info("WeCom channel started")
+
+    def _on_ws_task_done(self, task: asyncio.Task) -> None:
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is None:
+            return
+        logger.error(
+            "WeCom WebSocket connection task failed: %s. "
+            "Check that the network/proxy allows wss://openws.work.weixin.qq.com "
+            "and that bot_id/bot_secret are valid.",
+            exc,
+        )
+
+    def _on_ws_error(self, error: Any) -> None:
+        logger.error("WeCom WebSocket error: %s", error)
+
+    def _on_ws_disconnected(self, *_args: Any) -> None:
+        logger.warning("WeCom WebSocket disconnected; SDK will attempt to reconnect")
 
     async def stop(self) -> None:
         self._running = False

--- a/backend/app/channels/wecom.py
+++ b/backend/app/channels/wecom.py
@@ -102,8 +102,9 @@ class WeComChannel(Channel):
     def _on_ws_error(self, error: Any) -> None:
         logger.error("WeCom WebSocket error: %s", error)
 
-    def _on_ws_disconnected(self, *_args: Any) -> None:
-        logger.warning("WeCom WebSocket disconnected; SDK will attempt to reconnect")
+    def _on_ws_disconnected(self, *args: Any) -> None:
+        detail = f" ({args[0]})" if args else ""
+        logger.warning("WeCom WebSocket disconnected%s; SDK will attempt to reconnect", detail)
 
     async def stop(self) -> None:
         self._running = False

--- a/backend/app/channels/wecom.py
+++ b/backend/app/channels/wecom.py
@@ -95,9 +95,7 @@ class WeComChannel(Channel):
         if exc is None:
             return
         logger.error(
-            "WeCom WebSocket connection task failed: %s. "
-            "Check that the network/proxy allows wss://openws.work.weixin.qq.com "
-            "and that bot_id/bot_secret are valid.",
+            "WeCom WebSocket connection task failed: %s. Check that the network/proxy allows wss://openws.work.weixin.qq.com and that bot_id/bot_secret are valid.",
             exc,
         )
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -3143,6 +3143,18 @@ class TestWeComChannel:
 
         assert any("WeCom WebSocket disconnected" in r.message and r.levelno == logging.WARNING for r in caplog.records)
 
+    def test_on_ws_disconnected_logs_reason_when_present(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+
+        with caplog.at_level(logging.WARNING):
+            channel._on_ws_disconnected("connection reset")
+
+        assert any("connection reset" in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
     def test_start_subscribes_connection_lifecycle_events(self, monkeypatch):
         from app.channels.wecom import WeComChannel
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -3074,6 +3074,109 @@ class TestWeComChannel:
 
         _run(go())
 
+    def test_on_ws_task_done_logs_error_on_exception(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+        task = MagicMock()
+        task.cancelled.return_value = False
+        task.exception.return_value = RuntimeError("boom")
+
+        with caplog.at_level(logging.ERROR):
+            channel._on_ws_task_done(task)
+
+        assert any("WeCom WebSocket connection task failed" in r.message and r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_on_ws_task_done_silent_when_cancelled(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+        task = MagicMock()
+        task.cancelled.return_value = True
+
+        with caplog.at_level(logging.ERROR):
+            channel._on_ws_task_done(task)
+
+        task.exception.assert_not_called()
+        assert caplog.records == []
+
+    def test_on_ws_task_done_silent_when_no_exception(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+        task = MagicMock()
+        task.cancelled.return_value = False
+        task.exception.return_value = None
+
+        with caplog.at_level(logging.ERROR):
+            channel._on_ws_task_done(task)
+
+        assert caplog.records == []
+
+    def test_on_ws_error_logs_error(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+
+        with caplog.at_level(logging.ERROR):
+            channel._on_ws_error(RuntimeError("handshake failed"))
+
+        assert any("WeCom WebSocket error" in r.message and r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_on_ws_disconnected_logs_warning(self, caplog):
+        import logging
+
+        from app.channels.wecom import WeComChannel
+
+        channel = WeComChannel(MessageBus(), config={})
+
+        with caplog.at_level(logging.WARNING):
+            channel._on_ws_disconnected()
+
+        assert any("WeCom WebSocket disconnected" in r.message and r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_start_subscribes_connection_lifecycle_events(self, monkeypatch):
+        from app.channels.wecom import WeComChannel
+
+        async def go():
+            bus = MessageBus()
+            channel = WeComChannel(bus, config={"bot_id": "corp123", "bot_secret": "secret"})
+
+            ws_client = MagicMock()
+
+            async def fake_connect():
+                return None
+
+            ws_client.connect = fake_connect
+
+            monkeypatch.setitem(
+                __import__("sys").modules,
+                "aibot",
+                SimpleNamespace(
+                    WSClient=lambda options: ws_client,
+                    WSClientOptions=lambda **kwargs: SimpleNamespace(**kwargs),
+                ),
+            )
+
+            await channel.start()
+
+            subscribed_events = {call.args[0] for call in ws_client.on.call_args_list}
+            assert "error" in subscribed_events
+            assert "disconnected" in subscribed_events
+            assert channel._ws_task is not None
+
+            await channel.stop()
+
+        _run(go())
+
 
 class TestChannelService:
     def test_get_status_no_channels(self):


### PR DESCRIPTION
## What

Fixes #2000.

The WeCom channel started the SDK connection with a fire-and-forget `asyncio.create_task(self._ws_client.connect())` and never inspected the task result. As a result, connection failures (e.g. the gateway WebSocket handshake to `wss://openws.work.weixin.qq.com` failing) were silently swallowed:

- the channel still logged `WeCom channel started`, falsely reporting success;
- SDK `error` / `disconnected` events went unobserved, so the real cause never reached the logs;
- the unawaited connect task produced `Task exception was never retrieved` noise.

## How

- Add a done-callback on `_ws_task` that logs a clear, actionable error when the connect task fails (pointing users to check that the network/proxy allows `wss://openws.work.weixin.qq.com` and that `bot_id`/`bot_secret` are valid), and stays silent on cancellation (`stop()`) and on clean exit — eliminating the "Task exception was never retrieved" noise.
- Subscribe to the SDK's `error` / `disconnected` events in `start()` and translate them into DeerFlow's own readable logs.

This does not change the async/background-reconnect model; it only makes failures visible instead of silent.

> Note: the underlying `websockets` `AttributeError` (when `connection_lost` runs before `connection_made`) is a third-party library issue and is intentionally not touched here, but such exceptions are now captured by the task done-callback and surfaced as readable logs.

## Test

- `uv run ruff check` passes.
- Added 6 unit tests in `backend/tests/test_channels.py` covering: connect-task exception → error log, cancellation → silent, clean exit → silent, `error` event → error log, `disconnected` event → warning, and `start()` subscribing to the lifecycle events. Full `TestWeComChannel` suite (11 tests) passes.