### PR TITLE
refactor(todo): remove unused completion reminder counter

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/todo_middleware.py
@@ -46,11 +46,6 @@ def _reminder_in_messages(messages: list[Any]) -> bool:
     return False
 
 
-def _completion_reminder_count(messages: list[Any]) -> int:
-    """Return the number of todo_completion_reminder HumanMessages in *messages*."""
-    return sum(1 for msg in messages if isinstance(msg, HumanMessage) and getattr(msg, "name", None) == "todo_completion_reminder")
-
-
 def _format_todos(todos: list[Todo]) -> str:
     """Format a list of Todo items into a human-readable string."""
     lines: list[str] = []

--- a/backend/tests/test_todo_middleware.py
+++ b/backend/tests/test_todo_middleware.py
@@ -11,7 +11,6 @@ from pydantic import PrivateAttr
 
 from deerflow.agents.middlewares.todo_middleware import (
     TodoMiddleware,
-    _completion_reminder_count,
     _format_todos,
     _has_tool_call_intent_or_error,
     _reminder_in_messages,
@@ -189,10 +188,6 @@ class TestAbeforeModel:
         assert result["messages"][0].name == "todo_reminder"
 
 
-def _completion_reminder_msg():
-    return HumanMessage(name="todo_completion_reminder", content="finish your todos")
-
-
 def _todo_completion_reminders(messages):
     reminders = []
     for message in messages:
@@ -262,20 +257,6 @@ def _all_completed_todos():
         {"status": "completed", "content": "Step 1"},
         {"status": "completed", "content": "Step 2"},
     ]
-
-
-class TestCompletionReminderCount:
-    def test_zero_when_no_reminders(self):
-        msgs = [HumanMessage(content="hi"), _ai_no_tool_calls()]
-        assert _completion_reminder_count(msgs) == 0
-
-    def test_counts_completion_reminders(self):
-        msgs = [_completion_reminder_msg(), _completion_reminder_msg()]
-        assert _completion_reminder_count(msgs) == 2
-
-    def test_does_not_count_todo_reminders(self):
-        msgs = [_reminder_msg(), _completion_reminder_msg()]
-        assert _completion_reminder_count(msgs) == 1
 
 
 class TestToolCallIntentOrError:


### PR DESCRIPTION
## Summary

Remove the unused `_completion_reminder_count` helper from `TodoMiddleware` and delete the tests that only covered that dead helper.

## Why

Todo completion reminder limiting now uses the middleware's per thread/run `_completion_reminder_counts` bookkeeping via `_completion_reminder_count_for_runtime()`. The old helper counted persisted `todo_completion_reminder` messages, but completion reminders are now injected transiently into model requests instead of being persisted as graph state.

## Validation

- `uv run pytest tests/test_todo_middleware.py`