### PR TITLE
fix(mcp): surface admin-required state on settings tools page (#3527)

### DIFF
--- a/frontend/src/components/workspace/settings/tool-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/tool-settings-page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/item";
 import { Switch } from "@/components/ui/switch";
 import { useI18n } from "@/core/i18n/hooks";
+import { MCPConfigRequestError } from "@/core/mcp/api";
 import { useMCPConfig, useEnableMCPServer } from "@/core/mcp/hooks";
 import type { MCPServerConfig } from "@/core/mcp/types";
 import { env } from "@/env";
@@ -18,6 +19,8 @@ import { SettingsSection } from "./settings-section";
 export function ToolSettingsPage() {
   const { t } = useI18n();
   const { config, isLoading, error } = useMCPConfig();
+  const adminRequired =
+    error instanceof MCPConfigRequestError && error.isAdminRequired;
   return (
     <SettingsSection
       title={t.settings.tools.title}
@@ -25,6 +28,10 @@ export function ToolSettingsPage() {
     >
       {isLoading ? (
         <div className="text-muted-foreground text-sm">{t.common.loading}</div>
+      ) : adminRequired ? (
+        <div className="text-muted-foreground text-sm">
+          {t.settings.tools.adminRequired}
+        </div>
       ) : error ? (
         <div>Error: {error.message}</div>
       ) : (
@@ -37,12 +44,21 @@ export function ToolSettingsPage() {
 function MCPServerList({
   servers,
 }: {
-  servers: Record<string, MCPServerConfig>;
+  servers?: Record<string, MCPServerConfig>;
 }) {
+  const { t } = useI18n();
   const { mutate: enableMCPServer } = useEnableMCPServer();
+  const entries = Object.entries(servers ?? {});
+  if (entries.length === 0) {
+    return (
+      <div className="text-muted-foreground text-sm">
+        {t.settings.tools.empty}
+      </div>
+    );
+  }
   return (
     <div className="flex w-full flex-col gap-4">
-      {Object.entries(servers).map(([name, config]) => (
+      {entries.map(([name, config]) => (
         <Item className="w-full" variant="outline" key={name}>
           <ItemContent>
             <ItemTitle>

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -495,6 +495,8 @@ export const enUS: Translations = {
     tools: {
       title: "Tools",
       description: "Manage the configuration and enabled status of MCP tools.",
+      adminRequired: "Admin privileges are required to manage MCP tools.",
+      empty: "No MCP tools configured.",
     },
     channels: {
       title: "Channels",

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -406,6 +406,8 @@ export interface Translations {
     tools: {
       title: string;
       description: string;
+      adminRequired: string;
+      empty: string;
     };
     channels: {
       title: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -476,6 +476,8 @@ export const zhCN: Translations = {
     tools: {
       title: "工具",
       description: "管理 MCP 工具的配置和启用状态。",
+      adminRequired: "需要管理员权限才能管理 MCP 工具。",
+      empty: "暂无 MCP 工具。",
     },
     channels: {
       title: "渠道",

--- a/frontend/src/core/mcp/api.ts
+++ b/frontend/src/core/mcp/api.ts
@@ -3,8 +3,36 @@ import { getBackendBaseURL } from "@/core/config";
 
 import type { MCPConfig } from "./types";
 
+export class MCPConfigRequestError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "MCPConfigRequestError";
+    this.status = status;
+  }
+  get isAdminRequired(): boolean {
+    return this.status === 403;
+  }
+}
+
+async function readErrorDetail(
+  response: Response,
+  fallback: string,
+): Promise<string> {
+  const error = (await response.json().catch(() => ({}))) as {
+    detail?: unknown;
+  };
+  return typeof error.detail === "string" ? error.detail : fallback;
+}
+
 export async function loadMCPConfig() {
   const response = await fetch(`${getBackendBaseURL()}/api/mcp/config`);
+  if (!response.ok) {
+    throw new MCPConfigRequestError(
+      response.status,
+      await readErrorDetail(response, "Failed to load MCP configuration"),
+    );
+  }
   return response.json() as Promise<MCPConfig>;
 }
 
@@ -16,5 +44,11 @@ export async function updateMCPConfig(config: MCPConfig) {
     },
     body: JSON.stringify(config),
   });
+  if (!response.ok) {
+    throw new MCPConfigRequestError(
+      response.status,
+      await readErrorDetail(response, "Failed to update MCP configuration"),
+    );
+  }
   return response.json();
 }

--- a/frontend/src/core/mcp/hooks.ts
+++ b/frontend/src/core/mcp/hooks.ts
@@ -1,11 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { loadMCPConfig, updateMCPConfig } from "./api";
+import { loadMCPConfig, MCPConfigRequestError, updateMCPConfig } from "./api";
 
 export function useMCPConfig() {
   const { data, isLoading, error } = useQuery({
     queryKey: ["mcpConfig"],
     queryFn: () => loadMCPConfig(),
+    retry: (count, error) =>
+      !(error instanceof MCPConfigRequestError) && count < 3,
   });
   return { config: data, isLoading, error };
 }

--- a/frontend/tests/unit/core/mcp/api.test.ts
+++ b/frontend/tests/unit/core/mcp/api.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for the error-handling behaviour of the MCP config API client.
+ *
+ * Issue #3527: when a non-admin user opens Settings → Tools, the gateway
+ * returns 403 `{detail: "Admin privileges required to manage MCP
+ * configuration."}` for `GET /api/mcp/config`. The previous client
+ * silently treated the 403 body as a valid `MCPConfig`, so the UI then
+ * crashed with `Cannot convert undefined or null to object` when it tried
+ * `Object.entries(config.mcp_servers)`.
+ *
+ * These tests pin the contract that non-2xx responses are surfaced as
+ * `MCPConfigRequestError` carrying the HTTP status and backend `detail`,
+ * so the React Query hook's `error` branch can render a friendly empty
+ * state (admin-required for 403) instead of crashing.
+ */
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/core/api/fetcher", () => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock("@/core/config", () => ({
+  getBackendBaseURL: () => "",
+}));
+
+import { fetch as fetcher } from "@/core/api/fetcher";
+import {
+  MCPConfigRequestError,
+  loadMCPConfig,
+  updateMCPConfig,
+} from "@/core/mcp/api";
+
+const mockedFetch = vi.mocked(fetcher);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("loadMCPConfig", () => {
+  test("returns parsed config on 200", async () => {
+    const config = { mcp_servers: { foo: { enabled: true } } };
+    mockedFetch.mockResolvedValueOnce(jsonResponse(200, config));
+    await expect(loadMCPConfig()).resolves.toEqual(config);
+  });
+
+  test("throws MCPConfigRequestError with isAdminRequired on 403 (issue #3527)", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse(403, {
+        detail: "Admin privileges required to manage MCP configuration.",
+      }),
+    );
+    await expect(loadMCPConfig()).rejects.toMatchObject({
+      name: "MCPConfigRequestError",
+      status: 403,
+      isAdminRequired: true,
+      message: "Admin privileges required to manage MCP configuration.",
+    });
+  });
+
+  test("throws MCPConfigRequestError with isAdminRequired=false on non-403 errors", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      new Response("", { status: 500, statusText: "Internal Server Error" }),
+    );
+    await expect(loadMCPConfig()).rejects.toMatchObject({
+      name: "MCPConfigRequestError",
+      status: 500,
+      isAdminRequired: false,
+      message: "Failed to load MCP configuration",
+    });
+  });
+
+  test("the rejected value is an instance of MCPConfigRequestError", async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse(403, { detail: "nope" }));
+    await expect(loadMCPConfig()).rejects.toBeInstanceOf(MCPConfigRequestError);
+  });
+});
+
+describe("updateMCPConfig", () => {
+  test("returns parsed body on 200", async () => {
+    mockedFetch.mockResolvedValueOnce(jsonResponse(200, { ok: true }));
+    await expect(updateMCPConfig({ mcp_servers: {} })).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  test("throws MCPConfigRequestError with isAdminRequired on 403", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse(403, {
+        detail: "Admin privileges required to manage MCP configuration.",
+      }),
+    );
+    await expect(updateMCPConfig({ mcp_servers: {} })).rejects.toMatchObject({
+      name: "MCPConfigRequestError",
+      status: 403,
+      isAdminRequired: true,
+      message: "Admin privileges required to manage MCP configuration.",
+    });
+  });
+
+  test("falls back to generic message on non-403 errors", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      new Response("", { status: 500, statusText: "Internal Server Error" }),
+    );
+    await expect(updateMCPConfig({ mcp_servers: {} })).rejects.toMatchObject({
+      name: "MCPConfigRequestError",
+      status: 500,
+      isAdminRequired: false,
+      message: "Failed to update MCP configuration",
+    });
+  });
+});

--- a/frontend/tests/unit/core/mcp/hooks.test.ts
+++ b/frontend/tests/unit/core/mcp/hooks.test.ts
@@ -1,0 +1,84 @@
+import { QueryClient } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/core/api/fetcher", () => ({
+  fetch: vi.fn(),
+}));
+
+import { fetch } from "@/core/api/fetcher";
+import { MCPConfigRequestError, loadMCPConfig } from "@/core/mcp/api";
+
+const mockedFetch = vi.mocked(fetch);
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retryDelay: 0,
+      },
+    },
+  });
+}
+
+describe("useMCPConfig retry policy", () => {
+  beforeEach(() => {
+    mockedFetch.mockReset();
+  });
+
+  it("does not retry when loadMCPConfig throws MCPConfigRequestError (403)", async () => {
+    mockedFetch.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Forbidden" }),
+    } as Response);
+
+    const client = makeClient();
+    await expect(
+      client.fetchQuery({
+        queryKey: ["mcpConfig"],
+        queryFn: () => loadMCPConfig(),
+        retry: (count, error) =>
+          !(error instanceof MCPConfigRequestError) && count < 3,
+      }),
+    ).rejects.toBeInstanceOf(MCPConfigRequestError);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries up to 3 times on generic errors", async () => {
+    mockedFetch.mockRejectedValue(new Error("network down"));
+
+    const client = makeClient();
+    await expect(
+      client.fetchQuery({
+        queryKey: ["mcpConfig"],
+        queryFn: () => loadMCPConfig(),
+        retry: (count, error) =>
+          !(error instanceof MCPConfigRequestError) && count < 3,
+      }),
+    ).rejects.toThrow("network down");
+
+    // initial + 3 retries = 4 calls
+    expect(mockedFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not retry on MCPConfigRequestError 5xx either (deterministic typed error)", async () => {
+    mockedFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ detail: "Boom" }),
+    } as Response);
+
+    const client = makeClient();
+    await expect(
+      client.fetchQuery({
+        queryKey: ["mcpConfig"],
+        queryFn: () => loadMCPConfig(),
+        retry: (count, error) =>
+          !(error instanceof MCPConfigRequestError) && count < 3,
+      }),
+    ).rejects.toBeInstanceOf(MCPConfigRequestError);
+
+    expect(mockedFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Fixes #3527

## Why

Reported in #3527: a regular (non-admin) user opening Settings → Tools immediately hits

```
Runtime TypeError: Cannot convert undefined or null to object
  at MCPServerList (tool-settings-page.tsx:45)
```

Root cause has two layers, both confirmed in the issue thread:

1. `GET /api/mcp/config` is admin-only and returns `403 {detail: "Admin privileges required to manage MCP configuration."}` for non-admin users.
2. `loadMCPConfig()` did not check `response.ok` and cast the 403 body straight into `MCPConfig`. `config.mcp_servers` was therefore `undefined`, and `Object.entries(undefined)` crashed at render time.

Every non-admin user hits this on every visit, so the settings page is effectively broken for them.

## What changed

From a user's perspective:

- Non-admin users opening Settings → Tools no longer see a runtime crash. They see a friendly message: "Admin privileges are required to manage MCP tools." (with the corresponding zh-CN copy).
- Admin users with no MCP servers configured now see "No MCP tools configured." instead of an empty container.
- Admin users with MCP servers configured see the same UI as before — no behavior change for them.

Under the hood, `loadMCPConfig` / `updateMCPConfig` no longer silently turn non-2xx error bodies into a parsed `MCPConfig`; they throw a typed `MCPConfigRequestError` that carries the HTTP status and an `isAdminRequired` flag, so the UI renders the empty state from the server's response signal rather than guessing from a local user-role check.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

The regression is pinned by a new contract test on the API client: `frontend/tests/unit/core/mcp/api.test.ts`. It asserts that a 403 response from `/api/mcp/config` is surfaced as `MCPConfigRequestError({status: 403, isAdminRequired: true})` instead of being silently parsed as `MCPConfig`. The test is newly introduced (no equivalent existed on `main`), so a green-on-main / red-on-branch flip isn't applicable; instead, the test directly fails if the `response.ok` check or the `MCPConfigRequestError` wrapping in `api.ts` is removed, which is the exact pre-fix behavior on `main` that caused #3527.

Manually verified with a non-admin login against `make docker-start`: Settings → Tools now renders the friendly "Admin privileges are required to manage MCP tools." empty state, no `Cannot convert undefined or null to object` in the console.

## Validation

Ran in `frontend/`:

- `pnpm format:write` — clean, only newly edited files were touched.
- `pnpm lint` — clean (no warnings or errors).
- `pnpm typecheck` — clean (`tsc --noEmit` no errors).
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — succeeded, route table printed normally.
- `pnpm test` — **32 files, 303 tests passed, 0 failed**. The 7 new cases in `tests/unit/core/mcp/api.test.ts` are included.

No backend files changed, so backend checks were not run.
