### PR TITLE
fix(uploads): offload blocking filesystem IO in file upload

### DIFF
--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -1,5 +1,6 @@
 """Upload router for handling file uploads."""
 
+import asyncio
 import logging
 import os
 import stat
@@ -163,6 +164,28 @@ def _cleanup_uploaded_paths(paths: list[os.PathLike[str] | str]) -> None:
             logger.warning("Failed to clean up upload path after rejected request: %s", path, exc_info=True)
 
 
+def _finalize_uploads_for_sandbox(
+    written_paths: list,
+    sandbox_sync_targets: list,
+    sandbox,
+    sync_to_sandbox: bool,
+) -> None:
+    """Grant sandbox-readable perms and optionally sync files into the sandbox.
+
+    Uploaded files are created 0o600; in Docker sandbox mode the sandbox process
+    runs as a non-root user and needs group/other read bits, and (when not
+    bind-mounted) the bytes must be pushed via ``sandbox.update_file``. The
+    ``lstat``/``chmod``, the ``read_bytes``, and the sandbox write are all
+    blocking filesystem IO, so the caller runs this whole step in a worker thread.
+    """
+    for file_path in written_paths:
+        _make_file_sandbox_readable(file_path)
+    if sync_to_sandbox:
+        for file_path, virtual_path in sandbox_sync_targets:
+            _make_file_sandbox_writable(file_path)
+            sandbox.update_file(virtual_path, file_path.read_bytes())
+
+
 async def _write_upload_file_with_limits(
     file: UploadFile,
     *,
@@ -173,7 +196,10 @@ async def _write_upload_file_with_limits(
     total_size: int,
 ) -> tuple[os.PathLike[str] | str, int, int]:
     file_size = 0
-    file_path, fh = open_upload_file_no_symlink(uploads_dir, display_filename)
+    # Open / per-chunk write / close / unlink are blocking filesystem IO and must
+    # stay off the event loop; the chunk read is genuinely async (UploadFile) and
+    # stays on the loop, so the size-limit checks still short-circuit mid-stream.
+    file_path, fh = await asyncio.to_thread(open_upload_file_no_symlink, uploads_dir, display_filename)
     try:
         while chunk := await file.read(UPLOAD_CHUNK_SIZE):
             file_size += len(chunk)
@@ -182,16 +208,16 @@ async def _write_upload_file_with_limits(
                 raise HTTPException(status_code=413, detail=f"File too large: {display_filename}")
             if total_size > max_total_size:
                 raise HTTPException(status_code=413, detail="Total upload size too large")
-            fh.write(chunk)
+            await asyncio.to_thread(fh.write, chunk)
     except Exception:
-        fh.close()
+        await asyncio.to_thread(fh.close)
         try:
-            os.unlink(file_path)
+            await asyncio.to_thread(os.unlink, file_path)
         except FileNotFoundError:
             pass
         raise
     else:
-        fh.close()
+        await asyncio.to_thread(fh.close)
     return file_path, file_size, total_size
 
 
@@ -308,7 +334,7 @@ async def upload_files(
             uploaded_files.append(file_info)
 
         except HTTPException as e:
-            _cleanup_uploaded_paths(written_paths)
+            await asyncio.to_thread(_cleanup_uploaded_paths, written_paths)
             raise e
         except UnsafeUploadPathError as e:
             logger.warning("Skipping upload with unsafe destination %s: %s", file.filename, e)
@@ -316,23 +342,13 @@ async def upload_files(
             continue
         except Exception as e:
             logger.error(f"Failed to upload {file.filename}: {e}")
-            _cleanup_uploaded_paths(written_paths)
+            await asyncio.to_thread(_cleanup_uploaded_paths, written_paths)
             raise HTTPException(status_code=500, detail=f"Failed to upload {file.filename}: {str(e)}")
 
-    # Uploaded files are created with 0o600 permissions (owner read/write only).
-    # In Docker sandbox deployments the gateway writes as root but the sandbox
-    # process runs as a non-root user (typically UID 1000).  Without group/other
-    # read bits the sandbox cannot access the files — whether the uploads
-    # directory is bind-mounted into the container or synced via
-    # sandbox.update_file.  Always add group/other read bits so every sandbox
-    # configuration can read the uploaded content.
-    for file_path in written_paths:
-        _make_file_sandbox_readable(file_path)
-
-    if sync_to_sandbox:
-        for file_path, virtual_path in sandbox_sync_targets:
-            _make_file_sandbox_writable(file_path)
-            sandbox.update_file(virtual_path, file_path.read_bytes())
+    # Grant sandbox-readable perms and (optionally) push bytes into the sandbox.
+    # All of this is blocking filesystem IO, so run it in a worker thread; see
+    # _finalize_uploads_for_sandbox for why the read bits / byte sync are needed.
+    await asyncio.to_thread(_finalize_uploads_for_sandbox, written_paths, sandbox_sync_targets, sandbox, sync_to_sandbox)
 
     message = f"Successfully uploaded {len(uploaded_files)} file(s)"
     if skipped_files:

--- a/backend/tests/blocking_io/test_uploads_router.py
+++ b/backend/tests/blocking_io/test_uploads_router.py
@@ -1,0 +1,69 @@
+"""Regression anchor: writing an uploaded file must not block the event loop.
+
+``_write_upload_file_with_limits`` is the core of ``POST /api/.../uploads``: it
+opens the destination file, streams the ``UploadFile`` in chunks, and writes each
+chunk to disk while enforcing size limits. The chunk *read* is genuinely async
+(Starlette runs it in a threadpool); the open / per-chunk ``write`` / ``close`` /
+cleanup ``unlink`` are blocking filesystem IO that the function offloads via
+``asyncio.to_thread``. If any of that regresses back onto the event loop, the
+strict Blockbuster gate raises ``BlockingError`` and this test fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from pathlib import Path
+
+import pytest
+from starlette.datastructures import UploadFile
+
+from app.gateway.routers.uploads import _write_upload_file_with_limits
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_write_upload_file_does_not_block_event_loop(tmp_path: Path) -> None:
+    uploads_dir = tmp_path / "uploads"
+    await asyncio.to_thread(uploads_dir.mkdir, parents=True, exist_ok=True)
+
+    # Multi-chunk payload so the chunked read/write loop actually iterates.
+    payload = b"deerflow-upload-anchor-" * 4096  # ~90 KB, spans several chunks
+    upload = UploadFile(filename="anchor.bin", file=io.BytesIO(payload))
+
+    file_path, file_size, total_size = await _write_upload_file_with_limits(
+        upload,
+        uploads_dir=uploads_dir,
+        display_filename="anchor.bin",
+        max_single_file_size=10 * 1024 * 1024,
+        max_total_size=10 * 1024 * 1024,
+        total_size=0,
+    )
+
+    assert file_size == len(payload)
+    assert total_size == len(payload)
+    written = await asyncio.to_thread(Path(file_path).read_bytes)
+    assert written == payload
+
+
+async def test_write_upload_file_over_limit_cleans_up_without_blocking(tmp_path: Path) -> None:
+    """The 413 path closes the handle and unlinks the partial file — also off-loop."""
+    uploads_dir = tmp_path / "uploads"
+    await asyncio.to_thread(uploads_dir.mkdir, parents=True, exist_ok=True)
+
+    payload = b"x" * (256 * 1024)
+    upload = UploadFile(filename="too-big.bin", file=io.BytesIO(payload))
+
+    with pytest.raises(Exception):  # HTTPException 413  # noqa: B017
+        await _write_upload_file_with_limits(
+            upload,
+            uploads_dir=uploads_dir,
+            display_filename="too-big.bin",
+            max_single_file_size=1024,  # force "File too large" mid-stream
+            max_total_size=10 * 1024 * 1024,
+            total_size=0,
+        )
+
+    # Partial file was unlinked on the error path.
+    leftovers = await asyncio.to_thread(lambda: list(uploads_dir.iterdir()))
+    assert leftovers == []


### PR DESCRIPTION
## Why

`POST /api/threads/{id}/uploads` (`upload_files`) ran its filesystem workload on the event loop:

- `_write_upload_file_with_limits` — opens the destination file and writes the upload **chunk-by-chunk** (`fh.write`), plus the on-error `close`/`unlink`
- `_cleanup_uploaded_paths` — `os.unlink` of partial files on a rejected request
- the sandbox-readable `chmod` (`os.lstat`/`os.chmod`), the `file_path.read_bytes()`, and the `sandbox.update_file` sync

The chunk *read* is genuinely async (Starlette runs `UploadFile.read` in a threadpool); everything else is blocking IO that stalls the loop for the whole upload. `make detect-blocking-io` flags 5 calls here — same class as #3457 / #3529 / #3551 / #3552.

## What changed

Offload the blocking work via `asyncio.to_thread`:

- **Write loop:** `open_upload_file_no_symlink`, each per-chunk `fh.write`, `close`, and the cleanup `unlink` are offloaded. The async chunk read stays on the loop, so the `max_single_file_size` / `max_total_size` checks still short-circuit mid-stream exactly as before.
- **Cleanup:** the two `_cleanup_uploaded_paths(...)` calls are offloaded.
- **Sandbox finalize:** a new `_finalize_uploads_for_sandbox` helper folds the sandbox-readable `chmod` loop + the `read_bytes` + `sandbox.update_file` sync into a single worker hop.

Behavior, size limits, error codes (413 / 500 / `UnsafeUploadPathError` skip), and the partial-file cleanup semantics are all unchanged.

## Surface area

- [x] **Backend** — `app/gateway/routers/uploads.py` + new `tests/blocking_io` anchor. No API / schema / response change.

## Validation

- New `tests/blocking_io/test_uploads_router.py` anchor (multi-chunk happy path + mid-stream 413 cleanup) under the strict Blockbuster gate, verified **red→green** (removing the offload fails with `BlockingError`) → **2 passed**
- Full `tests/blocking_io` suite → **18 passed**
- Existing upload behavior suites (`test_uploads_router`, `test_uploads_manager`, `test_uploads_middleware_core_logic`, `test_memory_upload_filtering`) → **126 passed**
- `make detect-blocking-io` → `uploads.py` no longer reported
- `ruff check` + `ruff format --check` → clean

## AI assistance

**Tool(s) used:** Claude Code (Claude Opus 4.8)

**How you used it:** AI located the finding via `make detect-blocking-io`, implemented the `asyncio.to_thread` offloads (per-chunk write loop keeping the async read + size limits on the loop; folding the sandbox finalize into one worker hop), and wrote the gate anchor. I reviewed the change.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
