### PR TITLE
fix(middleware): prevent title middleware from streaming tokens

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, NotRequired, override
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
 from langgraph.config import get_config
+from langgraph.constants import TAG_NOSTREAM
 from langgraph.runtime import Runtime
 
 from deerflow.agents.middlewares.dynamic_context_middleware import is_dynamic_context_reminder
@@ -140,7 +141,11 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             parent = {}
         config = {**parent}
         config["run_name"] = "title_agent"
-        config["tags"] = [*(config.get("tags") or []), "middleware:title"]
+        config["tags"] = [
+            *(config.get("tags") or []),
+            "middleware:title",
+            TAG_NOSTREAM,
+        ]
         return config
 
     def _generate_title_result(self, state: TitleMiddlewareState) -> dict | None:

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.constants import TAG_NOSTREAM
 
 from deerflow.agents.middlewares import title_middleware as title_middleware_module
 from deerflow.agents.middlewares.dynamic_context_middleware import _DYNAMIC_CONTEXT_REMINDER_KEY
@@ -113,8 +114,21 @@ class TestTitleMiddlewareCoreLogic:
         model.ainvoke.assert_awaited_once()
         assert model.ainvoke.await_args.kwargs["config"] == {
             "run_name": "title_agent",
-            "tags": ["middleware:title"],
+            "tags": ["middleware:title", TAG_NOSTREAM],
         }
+
+    def test_title_model_config_preserves_parent_tags_and_adds_nostream(self, monkeypatch):
+        middleware = TitleMiddleware()
+        monkeypatch.setattr(
+            title_middleware_module,
+            "get_config",
+            MagicMock(return_value={"tags": ["parent"]}),
+        )
+
+        config = middleware._get_runnable_config()
+
+        assert config["run_name"] == "title_agent"
+        assert config["tags"] == ["parent", "middleware:title", TAG_NOSTREAM]
 
     def test_generate_title_uses_explicit_app_config_without_global_config(self, monkeypatch):
         title_config = TitleConfig(enabled=True, model_name="title-model", max_chars=20)


### PR DESCRIPTION
## Why

The title-generation LLM call runs inside a LangGraph middleware hook and is captured by the `messages` stream. This can make the generated title briefly flash as a phantom assistant message in the frontend chat before it is overwritten by the next `values` state.


## What changed

- Title-generation LLM calls are now tagged with LangGraph `TAG_NOSTREAM`.
- The existing `middleware:title` tag is preserved so title calls are still attributed correctly.
- Added regression coverage to verify title model calls include the nostream tag while preserving parent runnable tags.


## Screenshots / Recording

N/A. This is a backend streaming behavior fix. No frontend UI code changed.


## Bug fix verification

- Test path:
  - `backend/tests/test_title_middleware_core_logic.py`
- Verification:
  - The regression test verifies that title-generation LLM calls are tagged with `TAG_NOSTREAM`, while preserving existing runnable tags.


## Validation

```bash
cd backend
python -m pytest tests/test_title_middleware_core_logic.py
python -m ruff check packages/harness/deerflow/agents/middlewares/title_middleware.py tests/test_title_middleware_core_logic.py


## AI assistance

Tool(s) used: Codex
How you used it: Used Codex to help trace the LangGraph streaming path and identify why title-generation tokens could enter the message stream. Codex also helped draft the focused backend fix and regression test; I reviewed and verified the final changes.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

