### PR TITLE
feat(compaction): add Headroom context compaction middleware

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -212,6 +212,7 @@ Lead-agent middlewares are assembled in strict append order across `packages/har
 8. **ToolErrorHandlingMiddleware** - Converts tool exceptions into error `ToolMessage`s so the run can continue instead of aborting
 9. **SkillActivationMiddleware** - Detects strict `/skill-name task` syntax on the latest real user message, resolves only enabled and runtime-allowed skills, reads `SKILL.md` from trusted skill storage, injects the skill body as hidden current-turn model context, and records a `middleware:skill_activation` audit event with skill name, category, path, and content hash
 10. **SummarizationMiddleware** - Context reduction when approaching token limits (optional, if enabled)
+10b. **HeadroomCompactionMiddleware** - Non-destructive per-call message compression via the optional `headroom-ai` package (optional, if `compaction.enabled`). Runs in `wrap_model_call` and only rewrites the request copy of the messages (`request.override(messages=...)`); persisted state keeps full originals, so it is reversible. Content is compressed in place; message count and `tool_calls` are always preserved (falls back to originals on any shape change or error). No-op when `headroom-ai` is not installed. Also added to the subagent runtime chain.
 11. **TodoListMiddleware** - Task tracking with `write_todos` tool (optional, if plan_mode)
 12. **TokenUsageMiddleware** - Records token usage metrics when token tracking is enabled (optional); subagent usage is cached by `tool_call_id` only while token usage is enabled and merged back into the dispatching AIMessage by message position rather than message id
 13. **TitleMiddleware** - Auto-generates thread title after first complete exchange and normalizes structured message content before prompting the title model
@@ -502,6 +503,7 @@ Returns `{}` when Langfuse is not in the enabled providers — LangSmith-only de
 - `skills.path` / `skills.container_path` - Host and container paths to skills directory
 - `title` - Auto-title generation (enabled, max_words, max_chars, prompt_template)
 - `summarization` - Context summarization (enabled, trigger conditions, keep policy)
+- `compaction` - Headroom context compaction (enabled, model, model_limit, min_total_tokens, min_tokens_to_compress, protect_recent, compress_user_messages, compress_system_messages, target_ratio, savings_profile, fail_open). Optional `headroom-ai` dependency; no-op when absent
 - `subagents.enabled` - Master switch for subagent delegation
 - `memory` - Memory system (enabled, storage_path, debounce_seconds, model_name, max_facts, fact_confidence_threshold, injection_enabled, max_injection_tokens)
 
@@ -645,6 +647,18 @@ Automatic conversation summarization when approaching token limits:
 
 See [docs/summarization.md](docs/summarization.md) for details.
 
+### Context Compaction (Headroom)
+
+Non-destructive, per-call message compression for large tool outputs / logs / RAG chunks:
+- Configured in `config.yaml` under `compaction` key (disabled by default)
+- Powered by the optional `headroom-ai` package — install with `pip install "deerflow-harness[compaction]"`; the middleware is a transparent no-op when the package is absent
+- Implemented by `HeadroomCompactionMiddleware` (`agents/middlewares/compaction_middleware.py`) in `wrap_model_call`: only the request copy of the messages is shrunk via `request.override(...)`, so checkpointed state is untouched and the operation is reversible
+- Complementary to summarization: compaction shrinks message *content* in place (preserving count + `tool_calls`), while summarization reduces *history*. Both can be enabled together
+- Wired into both the lead agent (`build_middlewares`, after summarization) and the subagent runtime (`build_subagent_runtime_middlewares`)
+- Tests: `tests/test_compaction_config.py`, `tests/test_compaction_middleware.py` (use a `compress_fn` injection seam, so they never import the heavy ML stack)
+
+See [docs/compaction.md](docs/compaction.md) for details.
+
 ### Vision Support
 
 For models with `supports_vision: true`:
@@ -669,4 +683,5 @@ See `docs/` directory for detailed documentation:
 - [FILE_UPLOAD.md](docs/FILE_UPLOAD.md) - File upload feature
 - [PATH_EXAMPLES.md](docs/PATH_EXAMPLES.md) - Path types and usage
 - [summarization.md](docs/summarization.md) - Context summarization
+- [compaction.md](docs/compaction.md) - Headroom context compaction
 - [plan_mode_usage.md](docs/plan_mode_usage.md) - Plan mode with TodoList

--- a/backend/docs/compaction.md
+++ b/backend/docs/compaction.md
@@ -1,0 +1,134 @@
+# Context Compaction (Headroom)
+
+DeerFlow can compress the message history sent to the LLM on every model call —
+primarily large **tool outputs, logs, search results, and RAG chunks** — using
+the [Headroom](https://github.com/chopratejas/headroom) compression layer. The
+goal is the same answers for a fraction of the tokens.
+
+Compaction is **disabled by default** and depends on the optional `headroom-ai`
+package. When the package is not installed, the middleware is a transparent
+no-op, so enabling the config on a host without Headroom is safe.
+
+## Compaction vs. Summarization
+
+DeerFlow ships two complementary context-reduction features. They solve
+different problems and can be enabled together.
+
+| | **Summarization** | **Compaction (Headroom)** |
+|---|---|---|
+| What it reduces | Conversation *history* (old turns) | Message *content* (large tool outputs) |
+| Mechanism | LLM-generated summary replaces old messages | ML/heuristic compression of text in place |
+| Touches persisted state? | **Yes** — rewrites `ThreadState.messages` | **No** — only the per-call request copy |
+| Reversible? | No (originals are summarized away) | **Yes** (full originals stay in the checkpointer) |
+| Extra LLM call? | Yes | No |
+| Where it runs | `before_model` | `wrap_model_call` |
+| Config key | `summarization` | `compaction` |
+
+A common setup: enable compaction to keep individual tool results small on every
+turn, and enable summarization to collapse very long histories once they cross a
+token threshold.
+
+## How it works
+
+`HeadroomCompactionMiddleware`
+(`packages/harness/deerflow/agents/middlewares/compaction_middleware.py`) runs
+inside the model-call boundary:
+
+1. On each model call it takes the request's messages and, if their estimated
+   token count exceeds `min_total_tokens`, hands a flat `{role, content}` view to
+   Headroom's `compress()`.
+2. Any compressed **string** content is mapped back onto the *original* LangChain
+   message objects via `model_copy(update={"content": ...})`. Message IDs,
+   `tool_calls`, and `additional_kwargs` are preserved exactly, so AI/Tool call
+   pairing is never broken.
+3. The middleware forwards a new request via `request.override(messages=...)`.
+   The persisted `ThreadState` is **not** modified — the full, original messages
+   remain in the checkpointer, making compaction fully reversible.
+4. If Headroom ever returns a different message count (e.g. a history-dropping
+   transform), or if anything raises, the middleware conservatively falls back to
+   the original messages. History reduction is left to summarization.
+
+The middleware is wired into both the **lead agent** (after summarization) and
+the **subagent runtime**.
+
+## Installation
+
+```bash
+# from backend/
+uv pip install "deerflow-harness[compaction]"
+# or directly
+pip install headroom-ai
+```
+
+## Configuration
+
+Configured in `config.yaml` under the `compaction` key:
+
+```yaml
+compaction:
+  enabled: false
+
+  # Model name Headroom uses for token counting / context sizing.
+  # null = resolve from the active model at call time (falls back to a default).
+  model: null
+  model_limit: 200000
+
+  # Only run compaction once the estimated history exceeds this many tokens.
+  min_total_tokens: 4000
+
+  # Per-message floor: messages below this estimate are never compressed.
+  min_tokens_to_compress: 250
+
+  # Leave the most recent N messages uncompressed (the active conversation).
+  protect_recent: 4
+
+  # User/system messages are left byte-exact by default; only tool/assistant
+  # content is compressed. Flip these on for document/RAG-style workloads.
+  compress_user_messages: false
+  compress_system_messages: false
+
+  # Keep-ratio hint for Headroom's text compressor (e.g. 0.5 keeps ~50%).
+  # null lets Headroom decide (most aggressive). Named profiles like "agent-90"
+  # can be set via savings_profile instead.
+  target_ratio: null
+  savings_profile: null
+
+  # If true, compaction errors are swallowed and originals are sent unchanged.
+  fail_open: true
+```
+
+### Field reference
+
+| Field | Default | Description |
+|---|---|---|
+| `enabled` | `false` | Master switch. No-op if `headroom-ai` is not installed. |
+| `model` | `null` | Model name for Headroom's tokenizer. `null` resolves from the active model, falling back to a default. |
+| `model_limit` | `200000` | Context window (tokens) Headroom assumes. |
+| `min_total_tokens` | `4000` | Skip compaction below this estimated history size (keeps short chats prefix-cache-friendly). |
+| `min_tokens_to_compress` | `250` | Per-message floor below which a message is never compressed. |
+| `protect_recent` | `4` | Number of most-recent messages left uncompressed. |
+| `compress_user_messages` | `false` | Also compress user/human messages. |
+| `compress_system_messages` | `false` | Compress system messages embedded in history. |
+| `target_ratio` | `null` | Keep-ratio hint (0.0–1.0) for the text compressor. |
+| `savings_profile` | `null` | Named Headroom savings profile (e.g. `agent-90`). |
+| `fail_open` | `true` | Swallow compaction errors and send originals unchanged. |
+
+## Operational notes
+
+- **Cache friendliness.** Because compaction rewrites message content, it can
+  reduce prefix-cache hit rates on the provider side. `min_total_tokens` and
+  `protect_recent` exist to keep small/recent context stable. Tune them up if you
+  rely heavily on provider prompt caching.
+- **Token accounting.** Token usage reported by `TokenUsageMiddleware` reflects
+  what the model actually received (the compacted request), so savings show up in
+  your usage metrics directly.
+- **Observability.** When compaction changes content it logs an info line with
+  the estimated tokens saved and compression ratio.
+
+## Tests
+
+- `tests/test_compaction_config.py` — config validation and `AppConfig` wiring.
+- `tests/test_compaction_middleware.py` — gating, non-destructive behaviour,
+  structure preservation, fail-open/closed, the optional-dependency no-op path,
+  model-name resolution, and the async path. These use a `compress_fn` injection
+  seam and never import the heavy `headroom-ai` ML stack.

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -317,6 +317,14 @@ def build_middlewares(
     if summarization_middleware is not None:
         middlewares.append(summarization_middleware)
 
+    # Add Headroom context compaction (non-destructive per-call message compression).
+    # Registered after summarization so it compresses the post-summary, post-budget
+    # message copy handed to the model without mutating persisted state.
+    if resolved_app_config.compaction.enabled:
+        from deerflow.agents.middlewares.compaction_middleware import HeadroomCompactionMiddleware
+
+        middlewares.append(HeadroomCompactionMiddleware.from_app_config(resolved_app_config))
+
     # Add TodoList middleware if plan mode is enabled
     cfg = _get_runtime_config(config)
     is_plan_mode = cfg.get("is_plan_mode", False)

--- a/backend/packages/harness/deerflow/agents/middlewares/compaction_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/compaction_middleware.py
@@ -1,0 +1,254 @@
+"""Headroom context compaction middleware.
+
+Compresses the message history handed to the LLM — primarily large tool
+outputs, logs, and search results — at the model-call boundary, using the
+optional `Headroom <https://github.com/chopratejas/headroom>`_ library.
+
+Design notes
+------------
+* **Non-destructive.** Compaction happens inside ``wrap_model_call`` via
+  ``request.override(messages=...)``. Only the *request copy* of the messages is
+  shrunk; the persisted ``ThreadState`` keeps the full originals, so the
+  operation is reversible and never loses tool provenance. This is the opposite
+  of :class:`DeerFlowSummarizationMiddleware`, which rewrites state. The two are
+  complementary.
+
+* **Content-only, structure-preserving.** We hand Headroom a flat
+  ``{role, content}`` view of the messages and map any compressed *string*
+  content back onto the original LangChain message objects by position
+  (``model_copy(update=...)``). Message IDs, ``tool_calls``, and
+  ``additional_kwargs`` are therefore preserved exactly, keeping AI/Tool call
+  pairing intact for the provider. If Headroom ever returns a different message
+  count (e.g. a history-dropping transform), we conservatively fall back to the
+  originals — DeerFlow's own summarization owns history reduction.
+
+* **Optional dependency.** When ``headroom-ai`` is not installed the middleware
+  is a transparent pass-through (warned once). Enabling the config on a host
+  without Headroom is safe and simply does nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
+
+from deerflow.config.compaction_config import CompactionConfig
+
+logger = logging.getLogger(__name__)
+
+# Resolved lazily on first use: (compress_callable, CompressConfig_type) or (None, None).
+_HEADROOM: tuple[Callable[..., Any] | None, type | None] | None = None
+
+_DEFAULT_MODEL = "gpt-4o"
+_CHARS_PER_TOKEN = 4  # Coarse estimate, only used to gate cheap/expensive work.
+
+
+def _load_headroom() -> tuple[Callable[..., Any] | None, type | None]:
+    """Import Headroom's ``compress`` API lazily, caching the (failed) result.
+
+    Returns ``(None, None)`` and warns once when ``headroom-ai`` is not
+    installed so that an enabled config degrades to a no-op instead of crashing.
+    """
+    global _HEADROOM
+    if _HEADROOM is not None:
+        return _HEADROOM
+    try:
+        from headroom import CompressConfig, compress
+
+        _HEADROOM = (compress, CompressConfig)
+    except Exception as exc:  # ImportError or transitive import failures
+        logger.warning(
+            "Context compaction is enabled but the 'headroom-ai' package could not be imported (%s). Compaction is disabled for this process; install it with `pip install headroom-ai`.",
+            exc,
+        )
+        _HEADROOM = (None, None)
+    return _HEADROOM
+
+
+def _role_of(message: BaseMessage) -> str:
+    """Map a LangChain message to a Headroom/OpenAI role string."""
+    if isinstance(message, SystemMessage):
+        return "system"
+    if isinstance(message, HumanMessage):
+        return "user"
+    if isinstance(message, AIMessage):
+        return "assistant"
+    if isinstance(message, ToolMessage):
+        return "tool"
+    return getattr(message, "type", "user")
+
+
+def _estimate_tokens(messages: list[BaseMessage]) -> int:
+    """Cheap char-based token estimate used only to gate compaction work."""
+    chars = 0
+    for msg in messages:
+        content = msg.content
+        if isinstance(content, str):
+            chars += len(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, str):
+                    chars += len(part)
+                elif isinstance(part, dict) and isinstance(part.get("text"), str):
+                    chars += len(part["text"])
+    return chars // _CHARS_PER_TOKEN
+
+
+class HeadroomCompactionMiddleware(AgentMiddleware[AgentState]):
+    """Compress message content with Headroom just before each model call."""
+
+    def __init__(
+        self,
+        config: CompactionConfig | None = None,
+        *,
+        compress_fn: Callable[..., Any] | None = None,
+        compress_config_cls: type | None = None,
+    ) -> None:
+        """Create the middleware.
+
+        Parameters
+        ----------
+        config:
+            Compaction settings. Defaults to a disabled :class:`CompactionConfig`.
+        compress_fn / compress_config_cls:
+            Dependency-injection seam for tests — supply a fake ``compress``
+            callable (and optional config type) so the middleware can be
+            exercised without the heavy ``headroom-ai`` ML stack installed.
+        """
+        super().__init__()
+        self._config = config if config is not None else CompactionConfig()
+        self._compress_fn = compress_fn
+        self._compress_config_cls = compress_config_cls
+
+    @classmethod
+    def from_app_config(cls, app_config: Any) -> HeadroomCompactionMiddleware:
+        compaction = getattr(app_config, "compaction", None)
+        if isinstance(compaction, CompactionConfig):
+            return cls(config=compaction)
+        return cls()
+
+    # -- model call hooks --------------------------------------------------
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        compacted = self._compact_request(request)
+        return handler(compacted if compacted is not None else request)
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        # Headroom compression can be CPU-heavy (ML inference), so keep it off the
+        # event loop. _compact_request only reads request.messages and builds new
+        # message objects — no async state is touched — so a worker thread is safe.
+        if self._config.enabled:
+            compacted = await asyncio.to_thread(self._compact_request, request)
+        else:
+            compacted = None
+        return await handler(compacted if compacted is not None else request)
+
+    # -- internals ---------------------------------------------------------
+
+    def _compact_request(self, request: ModelRequest) -> ModelRequest | None:
+        """Return a request with compacted messages, or ``None`` to pass through."""
+        if not self._config.enabled:
+            return None
+
+        messages = getattr(request, "messages", None)
+        if not isinstance(messages, list) or not messages:
+            return None
+
+        if _estimate_tokens(messages) < self._config.min_total_tokens:
+            return None
+
+        compress_fn, compress_config_cls = self._resolve_compress()
+        if compress_fn is None:
+            return None
+
+        try:
+            new_messages = self._compact_messages(messages, request, compress_fn, compress_config_cls)
+        except Exception:
+            if self._config.fail_open:
+                logger.debug("Context compaction failed; sending original messages.", exc_info=True)
+                return None
+            raise
+
+        if new_messages is None:
+            return None
+        return request.override(messages=new_messages)
+
+    def _resolve_compress(self) -> tuple[Callable[..., Any] | None, type | None]:
+        if self._compress_fn is not None:
+            return self._compress_fn, self._compress_config_cls
+        return _load_headroom()
+
+    def _compact_messages(
+        self,
+        messages: list[BaseMessage],
+        request: ModelRequest,
+        compress_fn: Callable[..., Any],
+        compress_config_cls: type | None,
+    ) -> list[BaseMessage] | None:
+        """Run Headroom and map compressed string content back onto originals."""
+        payload = [{"role": _role_of(msg), "content": msg.content} for msg in messages]
+
+        kwargs: dict[str, Any] = {
+            "model": self._resolve_model_name(request),
+            "model_limit": self._config.model_limit,
+        }
+        if compress_config_cls is not None:
+            kwargs["config"] = compress_config_cls(
+                compress_user_messages=self._config.compress_user_messages,
+                compress_system_messages=self._config.compress_system_messages,
+                protect_recent=self._config.protect_recent,
+                min_tokens_to_compress=self._config.min_tokens_to_compress,
+                target_ratio=self._config.target_ratio,
+                savings_profile=self._config.savings_profile,
+            )
+
+        result = compress_fn(payload, **kwargs)
+        compressed = getattr(result, "messages", None)
+        if not isinstance(compressed, list) or len(compressed) != len(messages):
+            # Different shape (e.g. history dropped) — leave history reduction to
+            # summarization and pass the originals through unchanged.
+            return None
+
+        changed = False
+        rebuilt: list[BaseMessage] = []
+        for original, new in zip(messages, compressed, strict=True):
+            new_content = new.get("content") if isinstance(new, dict) else None
+            if isinstance(new_content, str) and isinstance(original.content, str) and new_content != original.content:
+                rebuilt.append(original.model_copy(update={"content": new_content}))
+                changed = True
+            else:
+                rebuilt.append(original)
+
+        if not changed:
+            return None
+
+        saved = getattr(result, "tokens_saved", 0)
+        if saved:
+            logger.info("Context compaction saved ~%s tokens (ratio %.2f).", saved, getattr(result, "compression_ratio", 0.0))
+        return rebuilt
+
+    def _resolve_model_name(self, request: ModelRequest) -> str:
+        """Best-effort model-name string for Headroom's tokenizer."""
+        if self._config.model:
+            return self._config.model
+        model = getattr(request, "model", None)
+        for attr in ("model_name", "model", "model_id", "deployment_name"):
+            value = getattr(model, attr, None)
+            if isinstance(value, str) and value:
+                return value
+        return _DEFAULT_MODEL

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -236,6 +236,13 @@ def build_subagent_runtime_middlewares(
 
         middlewares.append(DeferredToolFilterMiddleware(deferred_setup.deferred_names, deferred_setup.catalog_hash))
 
+    # Headroom context compaction — subagents read large tool outputs too, so they
+    # benefit from the same non-destructive per-call message compression.
+    if app_config.compaction.enabled:
+        from deerflow.agents.middlewares.compaction_middleware import HeadroomCompactionMiddleware
+
+        middlewares.append(HeadroomCompactionMiddleware.from_app_config(app_config))
+
     # Same provider safety-termination guard the lead agent uses — subagents
     # are equally exposed to truncated tool_calls returned with
     # finish_reason=content_filter (and friends), and the bad call would then

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -13,6 +13,7 @@ from deerflow.config.acp_config import ACPAgentConfig, load_acp_config_from_dict
 from deerflow.config.agents_api_config import AgentsApiConfig, load_agents_api_config_from_dict
 from deerflow.config.channel_connections_config import ChannelConnectionsConfig
 from deerflow.config.checkpointer_config import CheckpointerConfig, load_checkpointer_config_from_dict
+from deerflow.config.compaction_config import CompactionConfig
 from deerflow.config.database_config import DatabaseConfig
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_config_from_dict
@@ -108,6 +109,7 @@ class AppConfig(BaseModel):
     skill_evolution: SkillEvolutionConfig = Field(default_factory=SkillEvolutionConfig, description="Agent-managed skill evolution configuration")
     extensions: ExtensionsConfig = Field(default_factory=ExtensionsConfig, description="Extensions configuration (MCP servers and skills state)")
     tool_output: ToolOutputConfig = Field(default_factory=ToolOutputConfig, description="Tool output budget protection configuration")
+    compaction: CompactionConfig = Field(default_factory=CompactionConfig, description="Headroom context compaction configuration (non-destructive per-call message compression)")
     tool_search: ToolSearchConfig = Field(default_factory=ToolSearchConfig, description="Tool search / deferred loading configuration")
     title: TitleConfig = Field(default_factory=TitleConfig, description="Automatic title generation configuration")
     summarization: SummarizationConfig = Field(default_factory=SummarizationConfig, description="Conversation summarization configuration")

--- a/backend/packages/harness/deerflow/config/compaction_config.py
+++ b/backend/packages/harness/deerflow/config/compaction_config.py
@@ -1,0 +1,84 @@
+"""Configuration for Headroom-based context compaction.
+
+Context compaction compresses the message history sent to the LLM — primarily
+large tool outputs, logs, and search results — *just before* each model call,
+using the optional `Headroom <https://github.com/chopratejas/headroom>`_
+library (``pip install headroom-ai``).
+
+Unlike :class:`~deerflow.config.summarization_config.SummarizationConfig`, which
+*rewrites persisted state* by replacing old turns with an LLM-generated summary,
+compaction is **non-destructive**: it only shrinks the copy of the messages
+handed to the model for a single call. The full, original history stays in the
+checkpointer untouched, so compaction is fully reversible and never loses tool
+provenance. The two features are complementary and may both be enabled.
+
+Headroom is an optional dependency. When it is not installed the middleware is a
+transparent pass-through (logged once at startup), so enabling this config on a
+host without ``headroom-ai`` is safe and simply does nothing.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CompactionConfig(BaseModel):
+    """Config section for Headroom context compaction.
+
+    Compaction runs inside the model-call boundary (``wrap_model_call``) and only
+    rewrites the request copy of the messages — it never mutates checkpointed
+    state. Content is compressed in place; the message count and tool-call
+    structure are always preserved (if Headroom ever returns a different shape,
+    the middleware falls back to passing the originals through unchanged).
+    """
+
+    enabled: bool = Field(
+        default=False,
+        description="Enable Headroom context compaction. Requires the optional 'headroom-ai' package; when it is missing the middleware is a no-op.",
+    )
+    model: str | None = Field(
+        default=None,
+        description="Model name Headroom uses for token counting / context sizing. None = resolve from the active model at call time, falling back to a sensible default.",
+    )
+    model_limit: int = Field(
+        default=200_000,
+        gt=0,
+        description="Context window (tokens) Headroom assumes for the target model.",
+    )
+    min_total_tokens: int = Field(
+        default=4_000,
+        ge=0,
+        description="Only run compaction once the estimated message-history token count exceeds this. Keeps short conversations untouched (and cache-friendly).",
+    )
+    min_tokens_to_compress: int = Field(
+        default=250,
+        ge=0,
+        description="Per-message floor: messages estimated below this many tokens are never compressed.",
+    )
+    protect_recent: int = Field(
+        default=4,
+        ge=0,
+        description="Number of most-recent messages left uncompressed (the active conversation). 0 compresses everything.",
+    )
+    compress_user_messages: bool = Field(
+        default=False,
+        description="Also compress user/human messages. Default False — for agent workloads user turns are usually small and worth preserving verbatim.",
+    )
+    compress_system_messages: bool = Field(
+        default=False,
+        description="Compress system messages embedded in the history. Default False to keep instructions/tool definitions byte-exact.",
+    )
+    target_ratio: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Keep-ratio hint for Headroom's text compressor (e.g. 0.5 keeps ~50%). None lets Headroom decide (most aggressive).",
+    )
+    savings_profile: str | None = Field(
+        default=None,
+        description="Named Headroom savings profile to apply (e.g. 'agent-90'). None uses the default pipeline.",
+    )
+    fail_open: bool = Field(
+        default=True,
+        description="If True, any error during compaction is swallowed and the original messages are sent unchanged. Set False to surface compaction errors.",
+    )

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -40,6 +40,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Context compaction via Headroom (non-destructive per-call message compression).
+# Optional because it pulls in an ML compression stack; the middleware degrades
+# to a no-op when this extra is not installed.
+compaction = ["headroom-ai>=0.1.0"]
 ollama = ["langchain-ollama>=0.3.0"]
 postgres = [
     "asyncpg>=0.29",

--- a/backend/tests/test_compaction_config.py
+++ b/backend/tests/test_compaction_config.py
@@ -1,0 +1,68 @@
+"""Unit tests for CompactionConfig and its AppConfig registration."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from deerflow.config.compaction_config import CompactionConfig
+
+
+class TestCompactionConfigDefaults:
+    def test_disabled_by_default(self):
+        cfg = CompactionConfig()
+        assert cfg.enabled is False
+        assert cfg.fail_open is True
+        assert cfg.protect_recent == 4
+        assert cfg.model is None
+        assert cfg.min_total_tokens == 4_000
+
+    def test_round_trips_through_dict(self):
+        cfg = CompactionConfig(enabled=True, target_ratio=0.5, protect_recent=2, savings_profile="agent-90")
+        restored = CompactionConfig(**cfg.model_dump())
+        assert restored == cfg
+
+
+class TestCompactionConfigValidation:
+    def test_target_ratio_bounds(self):
+        with pytest.raises(ValidationError):
+            CompactionConfig(target_ratio=1.5)
+        with pytest.raises(ValidationError):
+            CompactionConfig(target_ratio=-0.1)
+        # In-range values are accepted.
+        assert CompactionConfig(target_ratio=0.0).target_ratio == 0.0
+        assert CompactionConfig(target_ratio=1.0).target_ratio == 1.0
+
+    def test_model_limit_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            CompactionConfig(model_limit=0)
+
+    def test_negative_floors_rejected(self):
+        with pytest.raises(ValidationError):
+            CompactionConfig(protect_recent=-1)
+        with pytest.raises(ValidationError):
+            CompactionConfig(min_total_tokens=-1)
+
+
+class TestAppConfigRegistration:
+    def test_app_config_has_compaction_default(self):
+        from deerflow.config.app_config import AppConfig
+        from deerflow.config.sandbox_config import SandboxConfig
+
+        cfg = AppConfig(sandbox=SandboxConfig(use="test"))
+        assert isinstance(cfg.compaction, CompactionConfig)
+        assert cfg.compaction.enabled is False
+
+    def test_app_config_parses_compaction_section(self):
+        from deerflow.config.app_config import AppConfig
+        from deerflow.config.sandbox_config import SandboxConfig
+
+        cfg = AppConfig.model_validate(
+            {
+                "sandbox": SandboxConfig(use="test").model_dump(),
+                "compaction": {"enabled": True, "target_ratio": 0.6, "min_total_tokens": 1000},
+            }
+        )
+        assert cfg.compaction.enabled is True
+        assert cfg.compaction.target_ratio == 0.6
+        assert cfg.compaction.min_total_tokens == 1000

--- a/backend/tests/test_compaction_middleware.py
+++ b/backend/tests/test_compaction_middleware.py
@@ -1,0 +1,282 @@
+"""Unit tests for HeadroomCompactionMiddleware.
+
+These never import the heavy ``headroom-ai`` package: the middleware exposes a
+``compress_fn`` injection seam, and the Headroom loader is monkeypatched where
+the no-dependency path is under test.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from langchain.agents.middleware.types import ModelRequest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from deerflow.agents.middlewares.compaction_middleware import HeadroomCompactionMiddleware
+from deerflow.config.compaction_config import CompactionConfig
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    messages: list[dict[str, Any]]
+    tokens_saved: int = 0
+    compression_ratio: float = 0.0
+    transforms_applied: list[str] = field(default_factory=list)
+
+
+class _FakeConfig:
+    """Stand-in for headroom.CompressConfig that just records kwargs."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+def _shrinking_compress(threshold: int = 50):
+    """Return a fake ``compress`` that truncates long string content in place."""
+
+    def _compress(payload, *, model, model_limit, config=None):
+        out = []
+        saved = 0
+        for msg in payload:
+            content = msg.get("content")
+            if isinstance(content, str) and len(content) > threshold:
+                saved += len(content) - len("COMPRESSED")
+                out.append({**msg, "content": "COMPRESSED"})
+            else:
+                out.append(dict(msg))
+        return _FakeResult(messages=out, tokens_saved=saved // 4, compression_ratio=0.5)
+
+    return _compress
+
+
+def _request(messages, model=None):
+    return ModelRequest(model=model, messages=messages, tools=[], state={})
+
+
+def _mw(config: CompactionConfig, compress_fn=None):
+    return HeadroomCompactionMiddleware(
+        config=config,
+        compress_fn=compress_fn,
+        compress_config_cls=_FakeConfig,
+    )
+
+
+def _capture_handler(box):
+    def handler(req):
+        box["request"] = req
+        return []
+
+    return handler
+
+
+_BIG = "x" * 4000  # > min_tokens_to_compress and pushes history over the gate
+
+
+# ---------------------------------------------------------------------------
+# Disabled / gating
+# ---------------------------------------------------------------------------
+
+
+class TestGating:
+    def test_disabled_passes_through(self):
+        mw = _mw(CompactionConfig(enabled=False), compress_fn=_shrinking_compress())
+        box: dict = {}
+        mw.wrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t")]), _capture_handler(box))
+        assert box["request"].messages[0].content == _BIG  # untouched
+
+    def test_below_min_total_tokens_passes_through(self):
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=10_000), compress_fn=_shrinking_compress())
+        box: dict = {}
+        req = _request([ToolMessage(content=_BIG, tool_call_id="t")])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+    def test_empty_messages_passes_through(self):
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress())
+        box: dict = {}
+        req = _request([])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+
+# ---------------------------------------------------------------------------
+# Compaction behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCompaction:
+    def test_compresses_string_content(self):
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress())
+        box: dict = {}
+        req = _request([ToolMessage(content=_BIG, tool_call_id="t1")])
+        mw.wrap_model_call(req, _capture_handler(box))
+
+        forwarded = box["request"]
+        assert forwarded is not req  # a new request was forwarded
+        assert forwarded.messages[0].content == "COMPRESSED"
+
+    def test_original_messages_not_mutated(self):
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress())
+        original = ToolMessage(content=_BIG, tool_call_id="t1")
+        req = _request([original])
+        mw.wrap_model_call(req, _capture_handler({}))
+        # Non-destructive: the original message object keeps its full content.
+        assert original.content == _BIG
+
+    def test_preserves_tool_calls_and_ids(self):
+        ai = AIMessage(
+            content=_BIG,
+            id="ai-1",
+            tool_calls=[{"name": "bash", "args": {"cmd": "ls"}, "id": "call-1", "type": "tool_call"}],
+        )
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress())
+        box: dict = {}
+        mw.wrap_model_call(_request([ai]), _capture_handler(box))
+
+        out = box["request"].messages[0]
+        assert out.content == "COMPRESSED"
+        assert out.id == "ai-1"
+        assert out.tool_calls == ai.tool_calls
+
+    def test_no_change_passes_original_request(self):
+        # All content short → fake compress returns identical strings → no override.
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress(threshold=10_000))
+        box: dict = {}
+        req = _request([ToolMessage(content=_BIG, tool_call_id="t1")])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+    def test_count_mismatch_passes_through(self):
+        def dropping_compress(payload, *, model, model_limit, config=None):
+            return _FakeResult(messages=payload[1:])  # drops one → shape mismatch
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=dropping_compress)
+        box: dict = {}
+        req = _request([HumanMessage(content=_BIG), ToolMessage(content=_BIG, tool_call_id="t1")])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+    def test_list_content_preserved(self):
+        # Multimodal/list content is never mapped back even if compress touches it.
+        def mangle(payload, *, model, model_limit, config=None):
+            out = [dict(m) for m in payload]
+            out[0]["content"] = "SHOULD_NOT_APPLY"
+            return _FakeResult(messages=out, tokens_saved=1)
+
+        multimodal = HumanMessage(content=[{"type": "text", "text": _BIG}])
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=mangle)
+        box: dict = {}
+        mw.wrap_model_call(_request([multimodal]), _capture_handler(box))
+        # No string change applied → original request forwarded unchanged.
+        assert box["request"].messages[0].content == multimodal.content
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_fail_open_swallows_errors(self):
+        def boom(payload, **kwargs):
+            raise RuntimeError("kompress exploded")
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0, fail_open=True), compress_fn=boom)
+        box: dict = {}
+        req = _request([ToolMessage(content=_BIG, tool_call_id="t1")])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+    def test_fail_closed_raises(self):
+        def boom(payload, **kwargs):
+            raise RuntimeError("kompress exploded")
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0, fail_open=False), compress_fn=boom)
+        with pytest.raises(RuntimeError):
+            mw.wrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t1")]), _capture_handler({}))
+
+
+# ---------------------------------------------------------------------------
+# Optional dependency fallback
+# ---------------------------------------------------------------------------
+
+
+class TestOptionalDependency:
+    def test_noop_when_headroom_unavailable(self, monkeypatch):
+        import deerflow.agents.middlewares.compaction_middleware as mod
+
+        monkeypatch.setattr(mod, "_load_headroom", lambda: (None, None))
+        # No compress_fn injected → middleware must resolve via _load_headroom.
+        mw = HeadroomCompactionMiddleware(CompactionConfig(enabled=True, min_total_tokens=0))
+        box: dict = {}
+        req = _request([ToolMessage(content=_BIG, tool_call_id="t1")])
+        mw.wrap_model_call(req, _capture_handler(box))
+        assert box["request"] is req
+
+
+# ---------------------------------------------------------------------------
+# Model name resolution
+# ---------------------------------------------------------------------------
+
+
+class TestModelNameResolution:
+    def test_explicit_config_model_wins(self):
+        captured: dict = {}
+
+        def spy(payload, *, model, model_limit, config=None):
+            captured["model"] = model
+            return _FakeResult(messages=[dict(m) for m in payload])
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0, model="claude-x"), compress_fn=spy)
+        mw.wrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t")]), _capture_handler({}))
+        assert captured["model"] == "claude-x"
+
+    def test_resolves_from_request_model_attr(self):
+        captured: dict = {}
+
+        def spy(payload, *, model, model_limit, config=None):
+            captured["model"] = model
+            return _FakeResult(messages=[dict(m) for m in payload])
+
+        class _Model:
+            model_name = "gpt-from-binding"
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=spy)
+        mw.wrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t")], model=_Model()), _capture_handler({}))
+        assert captured["model"] == "gpt-from-binding"
+
+    def test_falls_back_to_default(self):
+        captured: dict = {}
+
+        def spy(payload, *, model, model_limit, config=None):
+            captured["model"] = model
+            return _FakeResult(messages=[dict(m) for m in payload])
+
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=spy)
+        mw.wrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t")]), _capture_handler({}))
+        assert captured["model"] == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# Async path
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncPath:
+    @pytest.mark.anyio
+    async def test_awrap_model_call_compresses(self):
+        mw = _mw(CompactionConfig(enabled=True, min_total_tokens=0), compress_fn=_shrinking_compress())
+        box: dict = {}
+
+        async def handler(req):
+            box["request"] = req
+            return []
+
+        await mw.awrap_model_call(_request([ToolMessage(content=_BIG, tool_call_id="t1")]), handler)
+        assert box["request"].messages[0].content == "COMPRESSED"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -238,6 +238,21 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-grep-cli"
+version = "0.42.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/f9/cf0347fe62c76c2af727a7c8e94a146891248dbc58973dc603fd38ef19e1/ast_grep_cli-0.42.3.tar.gz", hash = "sha256:81c08507cc3e9b18afdf417b704a8bd3e0bf0d956b2c5e62332e747e554adc70", size = 232405, upload-time = "2026-05-19T15:35:55.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/76/3fa41358a8be5c1ce3ec90eb5830ad48f26f1fa3582c2a3933078a42d95a/ast_grep_cli-0.42.3-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:ea4c65222d2794c0d1d9165d5d77464e94e51d91209968040fbf2eb3e6a4ac50", size = 15230449, upload-time = "2026-05-19T15:35:45.282Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/61/5dffed31617d49f81010869fe370524e22fdc9270c9012c40e26fbb8043e/ast_grep_cli-0.42.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ae81004c465b5a53585e50acc6a700fee16c51a5b8cd38938854def2bc03bd2c", size = 7618415, upload-time = "2026-05-19T15:35:41.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3d/80d1333089033a49514017536ee90a5b0c13afb93b6f12520740c4b9d31f/ast_grep_cli-0.42.3-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:52394e24b3caf00266e41b894561fdd250668c56f4879f11102b0c0dc9d559dc", size = 7458512, upload-time = "2026-05-19T15:35:43.218Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/a3e40d49b32a6ec545efbe2be1d0ebabe5fa3abe2dcc8588577fd2fb2741/ast_grep_cli-0.42.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:0a23ff5bcbeac165a44b1bb3a9c14270cdfea4916fe62364b4c3cf8a64910b1c", size = 7755883, upload-time = "2026-05-19T15:35:49.555Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/f2fa0760eefe5765365ad65e46b8e561cac4b40607c62c03854b2fe73000/ast_grep_cli-0.42.3-py3-none-win32.whl", hash = "sha256:650ea2b65b7059603a5d0872d85ce976cdc8173bfb7994648a9dab1b5caee568", size = 7350210, upload-time = "2026-05-19T15:35:47.399Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/6fe4212243a7ebb3d997203a213e1ad60ca15426121f90fb6e23b1bf31c3/ast_grep_cli-0.42.3-py3-none-win_amd64.whl", hash = "sha256:e3dd282b60c547e916b0e77a33a01131b2a52a488cf44960547c64cffe09a444", size = 7802569, upload-time = "2026-05-19T15:35:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/67679a13c82068bb31617d1c79c9e9e9205fbec24b5a3d3bae256b307da0/ast_grep_cli-0.42.3-py3-none-win_arm64.whl", hash = "sha256:4bccbfa124eae9d7ee437505fa4d26b5de6348a8c4e68b39ecb016af5c7871e2", size = 7505695, upload-time = "2026-05-19T15:35:51.662Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -867,6 +882,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+compaction = [
+    { name = "headroom-ai" },
+]
 ollama = [
     { name = "langchain-ollama" },
 ]
@@ -893,6 +911,7 @@ requires-dist = [
     { name = "duckdb", specifier = ">=1.4.4" },
     { name = "exa-py", specifier = ">=1.0.0" },
     { name = "firecrawl-py", specifier = ">=1.15.0" },
+    { name = "headroom-ai", marker = "extra == 'compaction'", specifier = ">=0.1.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "kubernetes", specifier = ">=30.0.0" },
     { name = "langchain", specifier = ">=1.2.15" },
@@ -922,7 +941,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
-provides-extras = ["ollama", "postgres", "pymupdf"]
+provides-extras = ["compaction", "ollama", "postgres", "pymupdf"]
 
 [[package]]
 name = "defusedxml"
@@ -1092,6 +1111,56 @@ wheels = [
 ]
 
 [[package]]
+name = "fastuuid"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
+    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
+    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
+    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
+    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/dc/be6cbe99670cd6e4ad387123647cb08e0c32975e223f82551e914c5568a6/filelock-3.29.4.tar.gz", hash = "sha256:10cdb3656fc44541cdf30652a93fb10ec6b05325620eb316bd26893e4201538a", size = 63028, upload-time = "2026-06-13T16:12:00.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/37/a065dc3bd6e49423a6532c642ca7378d3f467b1ef44c2800c937af7f9739/filelock-3.29.4-py3-none-any.whl", hash = "sha256:dac1648087d5115554850d113e7dd8c83ab2d38e3435dde2d4f163847e57b767", size = 42757, upload-time = "2026-06-13T16:11:59.582Z" },
+]
+
+[[package]]
 name = "filetype"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1219,6 +1288,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
 ]
 
 [[package]]
@@ -1426,6 +1504,58 @@ wheels = [
 ]
 
 [[package]]
+name = "headroom-ai"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-grep-cli" },
+    { name = "click" },
+    { name = "litellm" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/0c/a63eb36cd9d9ccf151e3a95e314eef7db061f773d7bb48033ebd0d776a07/headroom_ai-0.25.0.tar.gz", hash = "sha256:6b6c9959f3fcde95ff271698393c4a43c40522155aaa5cc6754ecd9ad56048ca", size = 1726277, upload-time = "2026-06-12T06:48:07.025Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/6f/190fbbddf5e3b501cddb02bc0fb58137a2fb237c95f5e2a24aa0f1a77f52/headroom_ai-0.25.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0d4c24a5e6d86c2a6375833bbe3e47a87b7283ca82cf69d3df627448c2391ee", size = 16178093, upload-time = "2026-06-12T06:47:59.311Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/82/1777348063c59a3201cfed71ff7acb89c4f07b5855864ee9c9a5b6c54506/headroom_ai-0.25.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b05abbc899db1938d5161946f88f3407345ea7035928fee7c5effaef1523e4f5", size = 18237600, upload-time = "2026-06-12T06:48:02.364Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/cb/84969342e34fda736e8a8aa0bf614b46ffc2a4129011b7c66142faee26d0/headroom_ai-0.25.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:202ae31f937e8993339441b363a2e47ebbf43502e22a447b2c643d390856f4dc", size = 17361595, upload-time = "2026-06-12T06:48:04.868Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/05/24/5e0c28f80371c17d49fed004597d9d132cb75c1f6f53db2cb95f459d2312/hf_xet-1.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:3474760d10e3bb6f92ff3f024fcb00c0b3e4001e9b035c7483e49a5dd17aa70f", size = 4069676, upload-time = "2026-06-08T23:02:26.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/17/261ba565b6a4d960fb478f61fdf919c0be5824645aaf1c319eca660c1611/hf_xet-1.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6762d89b9e3267dfd502b29b2a327b4525f33b17e7b509a78d94e2151a30ce30", size = 3838509, upload-time = "2026-06-08T23:02:28.573Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/44/7ffdc2e184b0d41fc0f683ba3936ef669ab63cf242cf36ef50e57d683668/hf_xet-1.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bf67e6ed10260cef62e852789dc91ebb03f382d5bdc4b1dbeb64763ea275e7d6", size = 4505881, upload-time = "2026-06-08T23:02:30.257Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b6/788060d5aa4d5e671f1a31bf69624c314eb2d8babab3aa562f9e5d53444e/hf_xet-1.5.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c6b6cd08ca095058780b50b8ce4d6cbf6787bcf27841705d58a9d32246e3e47a", size = 4292995, upload-time = "2026-06-08T23:02:31.993Z" },
+    { url = "https://files.pythonhosted.org/packages/22/93/c5540cbd6b55529b7dc42f6734e88cebee21aefbea34128b66229df56c57/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e1af0de8ca6f190d4294a28b88023db64a1e2d1d719cab044baf75bec569e7a9", size = 4491570, upload-time = "2026-06-08T23:02:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f3/9d8ceab30f44f36c1679b1b8683054c71a0dadc787dbf07421891742d3ca/hf_xet-1.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4f561cbbb92f80960772059864b7fb07eae879adde1b2e781ec6f86f6ac26c59", size = 4711565, upload-time = "2026-06-08T23:02:35.454Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/54/27ed9a5e2cc583b4df82f75a03a4df8dbf55f5a9fa1f47f1fadfb20dbeac/hf_xet-1.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:e7dbb40617410f432182d918e37c12303fe6700fd6aa6c5964e30a535a4461d6", size = 4017343, upload-time = "2026-06-08T23:02:37.14Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/12/ecb2fc8d45e767580e3a37faa97cb895608b614965567efb4f18cff67e27/hf_xet-1.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:6071d5ccb4d8d2cbd5fea5cc798da4f0ba3f44e25369591c4e89a4987050e61d", size = 3845716, upload-time = "2026-06-08T23:02:39.073Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "html5lib"
 version = "1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1510,6 +1640,26 @@ wheels = [
 ]
 
 [[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+]
+
+[[package]]
 name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1558,6 +1708,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
 
 [[package]]
@@ -2082,6 +2244,29 @@ wheels = [
 ]
 
 [[package]]
+name = "litellm"
+version = "1.89.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "click" },
+    { name = "fastuuid" },
+    { name = "httpx" },
+    { name = "importlib-metadata" },
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "tiktoken" },
+    { name = "tokenizers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/4b/15d4cb75f054933c1f19bcfd5683e139cdf792099b995ae55916b26094dc/litellm-1.89.0.tar.gz", hash = "sha256:eb1910a23497044b4375a0500c65f4c60d291a575d7b679c7566a5df9b9a5fcb", size = 14062606, upload-time = "2026-06-13T23:45:53.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/86/49cf94af8c51cacc15fd9bff1e6f9de1fb07ab10b8bb09961675ab389af4/litellm-1.89.0-py3-none-any.whl", hash = "sha256:63b33e2de386ab2a83fed7ed852c755e59d461a21b16c79fc17993f1b8c3d154", size = 15475805, upload-time = "2026-06-13T23:45:46.037Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2201,6 +2386,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ed/3c/a58418d2af00f2da60d4a51e18cd0311307b72d48d2fffec36a97b4a5e44/mammoth-1.11.0.tar.gz", hash = "sha256:a0f59e442f34d5b6447f4b0999306cbf3e67aaabfa8cb516f878fb1456744637", size = 53142, upload-time = "2025-09-19T10:35:20.373Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ca/54/2e39566a131b13f6d8d193f974cb6a34e81bb7cc2fa6f7e03de067b36588/mammoth-1.11.0-py2.py3-none-any.whl", hash = "sha256:c077ab0d450bd7c0c6ecd529a23bf7e0fa8190c929e28998308ff4eada3f063b", size = 54752, upload-time = "2025-09-19T10:35:18.699Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -2350,6 +2547,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -3823,6 +4029,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3935,6 +4154,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -4208,6 +4436,33 @@ wheels = [
 ]
 
 [[package]]
+name = "tokenizers"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/39/b87a87d5bb9470610b80a2d31df42fcffeaf35118b8b97952b2aff598cc7/tokenizers-0.23.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e03d6ffcbe0d56ee9c1ccd070e70a13fa750727c0277e138152acbc0252c2224", size = 3146732, upload-time = "2026-04-27T14:43:15.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6a/068ed9f6e444c9d7e9d55ce134181325700f3d7f30410721bdc8f848d727/tokenizers-0.23.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e0948bbb1ac1d7cdfc9fb6d62c596e3b7550036ad60ecd654a66ad273326324e", size = 3054954, upload-time = "2026-04-27T14:43:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/36/e006edf031154cba92b8416057d92c3abe3635e4c4b0aa0b5b9bb39dde70/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1bf13402aff9bc533c89cb849ec3b412dc3fbeacc9744840e423d7bf3f7dc0e3", size = 3374081, upload-time = "2026-04-27T14:43:01.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/7735d226f9c7f874a6bee5e3f27fb25ecabdf207d37b8cf45286d0795893/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f836ca703b89ae07919a309f9651f7a88fd5a33d5f718ba5ad0870ec0256bad6", size = 3247641, upload-time = "2026-04-27T14:43:03.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d9/24827036f6e21297bfffda0768e58eb6096a4f411e932964a01707857931/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae848657742035523fdf261773630cb819a26995fcd3d9ecae0c1daf6e5a4959", size = 3585624, upload-time = "2026-04-27T14:43:10.664Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/22f3582b3a4f49358293a5206e25317621ee4526bfe9cdaa0f07a12e770e/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b09e85775d5187941e7bab30e941b4134ab4a7dd8c68e783d231fb7ca27c51", size = 3844062, upload-time = "2026-04-27T14:43:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/65/b8f8814eef95800f20721384136d9a1d22241d50b2874357cb70542c392f/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea5a0ce170074329faaa8ea3f6400ecde604b6678192688533af80980daae71a", size = 3460098, upload-time = "2026-04-27T14:43:08.854Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d5/1353e5f677ec27c2494fb6a6725e82d56c985f53e90ec511369e7e4f02c6/tokenizers-0.23.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5075b405006415ea148a992d093699c66eb01952bf59f4d5727089a98bda45a4", size = 3346235, upload-time = "2026-04-27T14:43:12.377Z" },
+    { url = "https://files.pythonhosted.org/packages/71/89/39b6b8fc073fb6d413d0147aa333dc7eff7be65639ac9d19930a0b21bf33/tokenizers-0.23.1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:56f3a77de629917652f876294dc9fe6bad4a0c43bc229dc72e59bb23a0f4729a", size = 3426398, upload-time = "2026-04-27T14:43:07.264Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/80/127c854da64827e5b79264ce524993a90dddcb320e5cd42412c5c02f9e8a/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d10a6d957ef01896dc274e890eee27d41bd0e74ef31e60616f0fc311345184e", size = 9823279, upload-time = "2026-04-27T14:43:17.222Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ba/44c2502feb1a058f096ddfb4e0996ef3225a01a388e1a9b094e91689fe93/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1974288a609c343774f1b897c8b482c791ab17b75ab5c8c2b1737565c1d82288", size = 9644986, upload-time = "2026-04-27T14:43:19.45Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c1/464019a9fb059870bfe4eebb4ba12208f3042035e258bf5e782906bd3847/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:120468fb4c24faf0543c835a4fabafa4deb3f20a035c9b6e83d0b553a97615d4", size = 9976181, upload-time = "2026-04-27T14:43:21.463Z" },
+    { url = "https://files.pythonhosted.org/packages/79/94/3ac1432bda31626071e9b6a12709b97ae05131c804b94c8f3ac622c5da32/tokenizers-0.23.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e3d8f40ea6268047de7046906326abed5134f27d4e8447b23763afe5808c8a96", size = 10113853, upload-time = "2026-04-27T14:43:23.617Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/dd/631b21433c771b1382535326f0eca80b9c9cee2e64961dd993bc9ac4669e/tokenizers-0.23.1-cp310-abi3-win32.whl", hash = "sha256:93120a930b919416da7cd10a2f606ac9919cc69cacae7980fa2140e277660948", size = 2536263, upload-time = "2026-04-27T14:43:29.888Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/2553f72aaf65a2797d4229e37fa7fbe38ffbf3e32912d31bdd78b3323e59/tokenizers-0.23.1-cp310-abi3-win_amd64.whl", hash = "sha256:e7bfaf995c1bdbbd21d13539decb6650967013759318627d85daeb7881af16b7", size = 2798223, upload-time = "2026-04-27T14:43:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/2b/2be299bab55fc595e3d38567edb1a87f86e594842968fa9515a07bdcf422/tokenizers-0.23.1-cp310-abi3-win_arm64.whl", hash = "sha256:a26197957d8e4425dfba746315f3c425ea00cfa8367c5fbc4ec73447893dcea9", size = 2664127, upload-time = "2026-04-27T14:43:26.949Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4226,6 +4481,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 12
+config_version: 13
 
 # ============================================================================
 # Logging
@@ -1049,6 +1049,52 @@ summarization:
     - read
     - view
     - cat
+
+# ============================================================================
+# Context Compaction (Headroom)
+# ============================================================================
+# Non-destructive, per-call message compression powered by the optional
+# "headroom-ai" package. Unlike summarization (which rewrites persisted state
+# with an LLM-generated summary), compaction only shrinks the *copy* of the
+# messages handed to the model for a single call — primarily large tool
+# outputs, logs, and search results. The full history stays in the checkpointer
+# untouched, so it is fully reversible. Summarization and compaction are
+# complementary and can both be enabled.
+#
+# Requires: pip install "deerflow-harness[compaction]"  (or  headroom-ai)
+# When the package is absent the middleware is a transparent no-op.
+compaction:
+  enabled: false
+
+  # Model name Headroom uses for token counting / context sizing.
+  # null = resolve from the active model at call time (falls back to a default).
+  model: null
+  model_limit: 200000
+
+  # Only run compaction once the estimated history exceeds this many tokens —
+  # keeps short conversations untouched and prefix-cache-friendly.
+  min_total_tokens: 4000
+
+  # Per-message floor: messages estimated below this many tokens are never compressed.
+  min_tokens_to_compress: 250
+
+  # Leave the most recent N messages uncompressed (the active conversation).
+  protect_recent: 4
+
+  # By default user and system messages are left byte-exact; only tool/assistant
+  # content is compressed. Flip these on for document/RAG-style workloads.
+  compress_user_messages: false
+  compress_system_messages: false
+
+  # Keep-ratio hint for Headroom's text compressor (e.g. 0.5 keeps ~50%).
+  # null lets Headroom decide (most aggressive). Named profiles like "agent-90"
+  # can be set via savings_profile instead.
+  target_ratio: null
+  savings_profile: null
+
+  # If true, any error during compaction is swallowed and the original messages
+  # are sent unchanged. Set false to surface compaction errors.
+  fail_open: true
 
 # ============================================================================
 # Memory Configuration


### PR DESCRIPTION
Compress the message history sent to the LLM — primarily large tool outputs, logs, and search results — at the model-call boundary using the optional `headroom-ai` package.

Design:
- Non-destructive: runs in `wrap_model_call` and only rewrites the request copy of the messages via `request.override(...)`. Persisted ThreadState keeps full originals, so it is reversible. Complementary to (not a replacement for) SummarizationMiddleware.
- Structure-preserving: only string content is mapped back onto the original LangChain messages, so message IDs and tool_calls are intact. Any message-count change or error falls back to the originals (fail_open).
- Optional dependency: transparent no-op when `headroom-ai` is absent; middleware is only added to the chain when `compaction.enabled`.
- Event-loop safe: async hook offloads compression via asyncio.to_thread.

Wiring: lead agent (after summarization) + subagent runtime. Config: new `compaction` section in AppConfig / config.example.yaml (config_version 12 -> 13). New `[compaction]` extra (headroom-ai). Docs: backend/docs/compaction.md + CLAUDE.md.
Tests: test_compaction_config.py, test_compaction_middleware.py (use a compress_fn injection seam; never import the heavy ML stack).

<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - The trigger — what made you write this? A bug you hit, a feature you need,
         tech debt, or a prod issue?
       - The pain being addressed — user-facing problem, or what it unblocks.
     For non-trivial features, please open an issue/discussion first to align on
     scope before writing code. -->


## What changed

<!-- Describe the change from a user's / caller's perspective, not as a code diff. e.g.:
       - "Settings now has a 'Custom endpoint' field, off by default"
       - "Backend /api/chat gains a `stream` flag, defaults to false"
       - "Default model changed from X to Y — existing users notice on first run" -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

<!-- If you checked "Frontend UI", attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip (delete) this section if this PR is not a bug fix.

     Bugs should be encoded as a failing test that goes red before the fix.
     Confirm:
       - Test path that reproduces the bug:
       - Did it go red on `main` and green on this branch? (yes / no)
       - If a red test wasn't cheap to write, explain why and what you did instead. -->


## Validation

<!-- What you actually ran. Run at least the checks for the area you changed:
       Backend:   cd backend  && make lint && make test
       Frontend:  cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test
       Frontend E2E (if you touched frontend/): cd frontend && make test-e2e -->


## AI assistance

<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
     welcome. Disclosing it just helps reviewers calibrate how closely to read the
     diff. Please fill all three; don't delete the section. -->

**Tool(s) used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, or "none" -->

**How you used it:** <!-- e.g. "generated the module from a spec", "autocomplete only",
     "AI wrote tests, I wrote the impl". A prompt or conversation link is great too. -->

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

