### PR TITLE
fix(makefile):fix the per-commit hooks installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,8 @@ install:
 	@echo "Installing frontend dependencies..."
 	@cd frontend && pnpm install
 	@echo "Installing pre-commit hooks..."
-        @$(BACKEND_UV_RUN) --with pre-commit pre-commit install
+	@uv tool install pre-commit
+	@pre-commit install --overwrite
 	@echo "✓ All dependencies installed"
 	@echo ""
 	@echo "=========================================="


### PR DESCRIPTION
  Install pre-commit as a stable uv tool. Avoid `uv run --with pre-commit`: that runs
  from a throwaway temp env whose Python gets baked into .git/hooks/pre-commit and is
  gone by the next commit, leaving the hook broken. A tool install bakes a permanent path.


