### PR TITLE
fix(backend): persist partial answer when a run is interrupted mid-stream (#3403)

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -281,6 +281,7 @@ CORS is same-origin by default when requests enter through nginx on port 2026. S
 - `RunManager.get()` is async; direct callers must `await` it.
 - When a persistent `RunStore` is configured, `get()` and `list_by_thread()` hydrate historical runs from the store. In-memory records win for the same `run_id` so task, abort, and stream-control state stays attached to active local runs.
 - `cancel()` and `create_or_reject(..., multitask_strategy="interrupt"|"rollback")` persist interrupted status through `RunStore.update_status()`, matching normal `set_status()` transitions.
+- On an `interrupt` cancel (not `rollback`), `run_agent` persists the partial answer streamed so far as an `llm.ai.response` run event (flagged `interrupted`) before flushing the journal, so the half-finished message survives a refresh. `RunJournal.on_llm_end` never fires for a cancelled-mid-stream LLM call, so the worker accumulates streamed `messages`-mode AI chunks by id and hands the not-yet-completed ones to `RunJournal.record_interrupted_ai_messages()` (issue #3403).
 - Store-only hydrated runs are readable history. If the current worker has no in-memory task/control state for that run, cancellation APIs can return 409 because this worker cannot stop the task.
 - `POST /wait` (both thread-scoped and `/api/runs/wait`) drains the stream bridge via `wait_for_run_completion()` instead of bare `await record.task`, so it honours the run's `on_disconnect` setting and cancels the background run on real client disconnect rather than returning a stale checkpoint (issue #3265).
 

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -82,6 +82,12 @@ class RunJournal(BaseCallbackHandler):
         self._counted_external_source_ids: set[str] = set()
         self._counted_message_llm_run_ids: set[str] = set()
 
+        # Message ids already persisted by on_llm_end (a completed LLM call) and
+        # by record_interrupted_ai_messages (a cancelled-mid-stream partial), so
+        # an interrupt never re-writes a message that already reached the store.
+        self._completed_message_ids: set[str] = set()
+        self._partial_message_ids: set[str] = set()
+
         # Convenience fields
         self._last_ai_msg: str | None = None
         self._first_human_msg: str | None = None
@@ -261,6 +267,12 @@ class RunJournal(BaseCallbackHandler):
         for message in messages:
             caller = self._identify_caller(tags)
 
+            # Remember the id so an interrupt does not re-persist this message
+            # as a "partial" — on_llm_end means the call completed in full.
+            completed_id = getattr(message, "id", None)
+            if completed_id:
+                self._completed_message_ids.add(completed_id)
+
             # Latency
             rid = str(run_id)
             start = self._llm_start_times.pop(rid, None)
@@ -331,6 +343,55 @@ class RunJournal(BaseCallbackHandler):
 
         if messages:
             self._counted_message_llm_run_ids.add(str(run_id))
+
+    def record_interrupted_ai_messages(self, chunks: Any) -> int:
+        """Persist partial AI answers from a cancelled-mid-stream run (#3403).
+
+        A user interrupt stops streaming before the in-flight LLM call finishes,
+        so ``on_llm_end`` — the only callback that writes an AI message event —
+        never fires for it. The partial text was already streamed to the UI but
+        would vanish on refresh because history is rebuilt from ``run_events``.
+
+        ``chunks`` are the accumulated ``AIMessageChunk`` objects the worker
+        merged from the ``messages`` stream. Each not-yet-persisted, non-empty
+        partial is written in the same ``llm.ai.response`` / ``category=message``
+        shape ``on_llm_end`` uses (so history rebuilds it identically), flagged
+        ``interrupted``. Returns the number of partials written.
+        """
+        from langchain_core.messages import AIMessage
+
+        written = 0
+        for chunk in chunks:
+            message_id = getattr(chunk, "id", None)
+            if message_id and (message_id in self._completed_message_ids or message_id in self._partial_message_ids):
+                continue
+
+            additional_kwargs = dict(getattr(chunk, "additional_kwargs", {}) or {})
+            content = getattr(chunk, "content", None) or ""
+            # Nothing the user actually saw — skip empty tool-call-only chunks.
+            if not content and not additional_kwargs.get("reasoning_content"):
+                continue
+
+            # Keep the user-visible text and reasoning; drop partial tool calls,
+            # whose arguments may be truncated mid-JSON and are not resumable.
+            message = AIMessage(
+                content=content,
+                id=message_id,
+                additional_kwargs=additional_kwargs,
+                response_metadata=dict(getattr(chunk, "response_metadata", {}) or {}),
+            )
+
+            if message_id:
+                self._partial_message_ids.add(message_id)
+            self._put(
+                event_type="llm.ai.response",
+                category="message",
+                content=message.model_dump(),
+                metadata={"caller": "lead_agent", "interrupted": True},
+            )
+            self._record_message_summary(message, caller="lead_agent")
+            written += 1
+        return written
 
     def on_llm_error(self, error: BaseException, *, run_id: UUID, **kwargs: Any) -> None:
         self._llm_start_times.pop(str(run_id), None)

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -151,6 +151,10 @@ async def run_agent(
     pre_run_snapshot: dict[str, Any] | None = None
     snapshot_capture_failed = False
     llm_error_fallback_message: str | None = None
+    # AI message chunks accumulated from the stream so a user interrupt can
+    # persist the partial answer already shown in the UI (issue #3403). Defined
+    # up here so the finally block can read it even if streaming never started.
+    partial_ai_chunks: dict[str, Any] = {}
 
     journal = None
 
@@ -314,6 +318,7 @@ async def run_agent(
                     logger.info("Run %s abort requested — stopping", run_id)
                     break
                 llm_error_fallback_message = llm_error_fallback_message or _extract_llm_error_fallback_message(chunk)
+                _accumulate_partial_ai_chunk(single_mode, chunk, partial_ai_chunks)
                 sse_event = _lg_mode_to_sse_event(single_mode)
                 await bridge.publish(run_id, sse_event, serialize(chunk, mode=single_mode))
         else:
@@ -333,6 +338,7 @@ async def run_agent(
                     continue
 
                 llm_error_fallback_message = llm_error_fallback_message or _extract_llm_error_fallback_message(chunk)
+                _accumulate_partial_ai_chunk(mode, chunk, partial_ai_chunks)
                 sse_event = _lg_mode_to_sse_event(mode)
                 await bridge.publish(run_id, sse_event, serialize(chunk, mode=mode))
 
@@ -400,6 +406,18 @@ async def run_agent(
     finally:
         # Flush any buffered journal events and persist completion data
         if journal is not None:
+            # On a user interrupt (but not a rollback, which discards the run),
+            # persist the partial answer streamed so far so it survives a page
+            # refresh instead of vanishing — on_llm_end never fired for the
+            # cancelled-mid-stream call (issue #3403).
+            if partial_ai_chunks and record.abort_event.is_set() and record.abort_action != "rollback":
+                try:
+                    written = journal.record_interrupted_ai_messages(partial_ai_chunks.values())
+                    if written:
+                        logger.info("Run %s: persisted %d interrupted partial message(s)", run_id, written)
+                except Exception:
+                    logger.warning("Failed to persist interrupted partial messages for run %s", run_id, exc_info=True)
+
             try:
                 await journal.flush()
             except Exception:
@@ -691,3 +709,26 @@ def _unpack_stream_item(
 
     # Fallback: single-element output from first mode
     return lg_modes[0] if lg_modes else None, item
+
+
+def _accumulate_partial_ai_chunk(mode: str | None, chunk: Any, accum: dict[str, Any]) -> None:
+    """Merge a streamed ``messages``-mode AI chunk into *accum* keyed by message id.
+
+    Lets a user interrupt persist the partial answer that was already streamed
+    to the UI (issue #3403). ``messages`` mode yields ``(message_chunk, meta)``;
+    consecutive ``AIMessageChunk``s for one response share an ``id`` and merge
+    with ``+`` to rebuild the partial message (content, reasoning, metadata).
+    Only AI chunks are accumulated; tool results have their own end callbacks.
+    """
+    if mode != "messages":
+        return
+    from langchain_core.messages import AIMessageChunk
+
+    message = chunk[0] if isinstance(chunk, (tuple, list)) and chunk else chunk
+    if not isinstance(message, AIMessageChunk):
+        return
+    message_id = getattr(message, "id", None)
+    if not message_id:
+        return
+    existing = accum.get(message_id)
+    accum[message_id] = message if existing is None else existing + message

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -819,6 +819,86 @@ class TestProgressSnapshots:
         assert snapshots[-1]["last_ai_message"] == "First"
 
 
+class TestInterruptedPartialMessages:
+    """Tests for record_interrupted_ai_messages (cancelled-mid-stream persistence, #3403)."""
+
+    @pytest.mark.anyio
+    async def test_persists_partial_ai_message(self, journal_setup):
+        from langchain_core.messages import AIMessageChunk
+
+        j, store = journal_setup
+        chunk = AIMessageChunk(content="partial answer so f", id="msg-1")
+        written = j.record_interrupted_ai_messages([chunk])
+        await j.flush()
+
+        assert written == 1
+        messages = await store.list_messages("t1")
+        assert len(messages) == 1
+        assert messages[0]["event_type"] == "llm.ai.response"
+        assert messages[0]["content"]["type"] == "ai"
+        assert messages[0]["content"]["content"] == "partial answer so f"
+        assert messages[0]["content"]["id"] == "msg-1"
+        assert messages[0]["metadata"]["interrupted"] is True
+
+    @pytest.mark.anyio
+    async def test_skips_message_already_completed_via_on_llm_end(self, journal_setup):
+        from langchain_core.messages import AIMessageChunk
+
+        j, store = journal_setup
+        # A completed call recorded the message in full — do not re-persist a partial.
+        response = _make_llm_response("Full answer")
+        response.generations[0][0].message.id = "msg-done"
+        j.on_llm_end(response, run_id=uuid4(), parent_run_id=None, tags=["lead_agent"])
+
+        written = j.record_interrupted_ai_messages([AIMessageChunk(content="Full ans", id="msg-done")])
+        await j.flush()
+
+        assert written == 0
+        messages = await store.list_messages("t1")
+        # Only the completed message, not a duplicate partial.
+        assert [m["content"]["content"] for m in messages] == ["Full answer"]
+
+    @pytest.mark.anyio
+    async def test_skips_empty_chunk(self, journal_setup):
+        from langchain_core.messages import AIMessageChunk
+
+        j, store = journal_setup
+        # Tool-call-only chunk with no visible text and no reasoning — nothing to restore.
+        written = j.record_interrupted_ai_messages([AIMessageChunk(content="", id="msg-empty")])
+        await j.flush()
+
+        assert written == 0
+        assert await store.list_messages("t1") == []
+
+    @pytest.mark.anyio
+    async def test_keeps_reasoning_only_chunk(self, journal_setup):
+        from langchain_core.messages import AIMessageChunk
+
+        j, store = journal_setup
+        # The user saw streamed thinking before cancelling, even with no final text.
+        chunk = AIMessageChunk(content="", id="msg-think", additional_kwargs={"reasoning_content": "let me think"})
+        written = j.record_interrupted_ai_messages([chunk])
+        await j.flush()
+
+        assert written == 1
+        messages = await store.list_messages("t1")
+        assert messages[0]["content"]["additional_kwargs"]["reasoning_content"] == "let me think"
+
+    @pytest.mark.anyio
+    async def test_dedups_repeated_partial(self, journal_setup):
+        from langchain_core.messages import AIMessageChunk
+
+        j, store = journal_setup
+        chunk = AIMessageChunk(content="partial", id="msg-dup")
+        assert j.record_interrupted_ai_messages([chunk]) == 1
+        # A second emit for the same id (e.g. both abort branches firing) is a no-op.
+        assert j.record_interrupted_ai_messages([chunk]) == 0
+        await j.flush()
+
+        messages = await store.list_messages("t1")
+        assert len(messages) == 1
+
+
 class TestChatModelStartHumanMessage:
     """Tests for on_chat_model_start extracting the first human message."""
 

--- a/backend/tests/test_worker_partial_persist.py
+++ b/backend/tests/test_worker_partial_persist.py
@@ -1,0 +1,52 @@
+"""Tests for the worker's partial-AI-chunk accumulation (cancelled-mid-stream persistence, #3403).
+
+``_accumulate_partial_ai_chunk`` collects streamed ``messages``-mode AI chunks so a
+user interrupt can persist the partial answer that was already shown in the UI.
+"""
+
+from langchain_core.messages import AIMessageChunk, ToolMessageChunk
+
+from deerflow.runtime.runs.worker import _accumulate_partial_ai_chunk
+
+
+def test_accumulates_chunks_by_id():
+    accum: dict = {}
+    # messages mode yields (message_chunk, metadata) tuples.
+    _accumulate_partial_ai_chunk("messages", (AIMessageChunk(content="Hel", id="m1"), {}), accum)
+    _accumulate_partial_ai_chunk("messages", (AIMessageChunk(content="lo", id="m1"), {}), accum)
+
+    assert set(accum) == {"m1"}
+    assert accum["m1"].content == "Hello"
+
+
+def test_separate_ids_are_kept_apart():
+    accum: dict = {}
+    _accumulate_partial_ai_chunk("messages", (AIMessageChunk(content="a", id="m1"), {}), accum)
+    _accumulate_partial_ai_chunk("messages", (AIMessageChunk(content="b", id="m2"), {}), accum)
+
+    assert accum["m1"].content == "a"
+    assert accum["m2"].content == "b"
+
+
+def test_ignores_non_messages_mode():
+    accum: dict = {}
+    _accumulate_partial_ai_chunk("values", {"messages": [AIMessageChunk(content="x", id="m1")]}, accum)
+    assert accum == {}
+
+
+def test_ignores_non_ai_chunk():
+    accum: dict = {}
+    _accumulate_partial_ai_chunk("messages", (ToolMessageChunk(content="r", tool_call_id="c1", id="t1"), {}), accum)
+    assert accum == {}
+
+
+def test_ignores_chunk_without_id():
+    accum: dict = {}
+    _accumulate_partial_ai_chunk("messages", (AIMessageChunk(content="x", id=None), {}), accum)
+    assert accum == {}
+
+
+def test_handles_bare_chunk_without_metadata_tuple():
+    accum: dict = {}
+    _accumulate_partial_ai_chunk("messages", AIMessageChunk(content="x", id="m1"), accum)
+    assert accum["m1"].content == "x"


### PR DESCRIPTION
### Summary

Fixes #3403 — when a user cancels a streaming response midway, the partial AI answer shown in the UI disappears after a refresh.

**Root cause:** thread history is rebuilt from the `run_events` store, but `RunJournal` only writes an AI message on `on_llm_end`. A cancel stops streaming mid-generation, so `on_llm_end` never fires for the in-flight LLM call and its partial text — already streamed to the client — is never persisted. (The `>` blockquote framing in the issue thread aside, this is the data-consistency gap the maintainer pointed at.)

### What changes

- `run_agent` (`runtime/runs/worker.py`) accumulates streamed `messages`-mode AI chunks by message id during the stream (consecutive `AIMessageChunk`s for one response merge with `+`).
- On an **interrupt** cancel — but **not** a `rollback`, which intentionally discards the run — the worker hands the not-yet-completed partials to the new `RunJournal.record_interrupted_ai_messages()`, right before flushing the journal in the `finally` block.
- `record_interrupted_ai_messages()` writes each partial in the **same** `llm.ai.response` / `category="message"` shape that `on_llm_end` produces (so history rebuilds it identically), flagged `interrupted: true`. It skips ids already completed via `on_llm_end` (tracked in a new `_completed_message_ids` set) and dedups its own writes, so nothing is duplicated. Incomplete tool calls are dropped (their args may be truncated mid-JSON); user-visible text and reasoning content are kept.

No new storage layer is introduced — the reporter's suggested "store run_events for unfinished turns" is exactly the existing `run_events` mechanism; this just fills the partial in on interrupt. Normal (non-cancelled) runs are unaffected.

### Testing

- `tests/test_run_journal.py::TestInterruptedPartialMessages` — persists a partial; skips a message already completed via `on_llm_end`; skips empty chunks; keeps reasoning-only chunks; dedups repeated emits.
- `tests/test_worker_partial_persist.py` — chunk accumulation by id, merge of same-id chunks, and ignoring of non-`messages` modes / non-AI chunks / id-less chunks.
- All 11 new tests pass; `ruff check` and `ruff format --check` clean on the changed files.

> Note: a handful of pre-existing tests in `test_run_journal.py` / `test_run_worker_rollback.py` fail in my sandbox due to a `langgraph` version mismatch (`No module named 'langgraph.runtime'`); I confirmed they fail identically on `main` without this change, so they're unrelated to this PR.
