### PR TITLE
fix(config): coerce null object config sections to their defaults

### DIFF
--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -7,7 +7,7 @@ from typing import Any, Self
 
 import yaml
 from dotenv import load_dotenv
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from deerflow.config.acp_config import ACPAgentConfig, load_acp_config_from_dict
 from deerflow.config.agents_api_config import AgentsApiConfig, load_agents_api_config_from_dict
@@ -156,20 +156,28 @@ class AppConfig(BaseModel):
         ),
     )
 
-    @field_validator("models", "tools", "tool_groups", mode="before")
+    @model_validator(mode="before")
     @classmethod
-    def _coerce_null_list_sections(cls, value: Any) -> Any:
-        """Treat a present-but-empty config section as an empty list.
+    def _drop_null_config_sections(cls, data: Any) -> Any:
+        """Treat a present-but-null config section as absent so its default applies.
 
         Commenting out every entry under a top-level YAML key — e.g. ``models:``
-        with only comments beneath it, exactly as shipped in
-        ``config.example.yaml`` — makes PyYAML parse the value as ``None``.
-        Without this, the documented ``cp config.example.yaml config.yaml``
-        first-run flow crashes with an opaque ``Input should be a valid list``
-        pydantic error. Coercing ``None`` to ``[]`` keeps that flow working and
-        matches the field's own ``default_factory=list``.
+        (a list) or ``memory:`` (an object), with only comments beneath it as
+        shipped throughout ``config.example.yaml`` — makes PyYAML parse the value
+        as ``None``. Without this, the documented ``cp config.example.yaml
+        config.yaml`` first-run flow crashes with an opaque ``Input should be a
+        valid list`` / ``valid dictionary`` pydantic error for that section.
+
+        Dropping the ``None`` lets each field fall back to its default: list
+        sections become ``[]`` via ``default_factory=list`` and object sections
+        get their default config. This generalizes the earlier list-only
+        handling (and the ``database`` special-case in ``from_file``) to every
+        section. Required sections without a default (``sandbox``) intentionally
+        still error when null — there is nothing to fall back to.
         """
-        return [] if value is None else value
+        if isinstance(data, dict):
+            return {key: value for key, value in data.items() if value is not None}
+        return data
 
     @classmethod
     def resolve_config_path(cls, config_path: str | None = None) -> Path:

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -171,9 +171,11 @@ class AppConfig(BaseModel):
         Dropping the ``None`` lets each field fall back to its default: list
         sections become ``[]`` via ``default_factory=list`` and object sections
         get their default config. This generalizes the earlier list-only
-        handling (and the ``database`` special-case in ``from_file``) to every
-        section. Required sections without a default (``sandbox``) intentionally
-        still error when null — there is nothing to fall back to.
+        handling to every section that defines a default. The ``database``
+        section is independent and still owned by ``_apply_database_defaults``
+        (in ``from_file``), which applies concrete defaults beyond null-coercion.
+        Required sections without a default (``sandbox``) intentionally still
+        error when null — there is nothing to fall back to.
         """
         if isinstance(data, dict):
             return {key: value for key, value in data.items() if value is not None}

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -170,6 +170,41 @@ def test_app_config_coerces_commented_out_list_sections(tmp_path, monkeypatch):
     assert config.tool_groups == []
 
 
+def test_app_config_coerces_commented_out_object_sections(tmp_path, monkeypatch):
+    """Commenting out every entry under an object key makes PyYAML parse it as None.
+
+    Same documented ``cp config.example.yaml config.yaml`` flow as the list
+    sections: object sections (memory, summarization, ...) must fall back to
+    their defaults instead of raising ``Input should be a valid dictionary``.
+    """
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+                "memory": None,
+                "summarization": None,
+                "guardrails": None,
+                "tool_output": None,
+                "run_events": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+
+    config = AppConfig.from_file(str(config_path))
+
+    # Each present-but-null object section falls back to its default config.
+    assert config.memory is not None
+    assert config.summarization is not None
+    assert config.guardrails is not None
+    assert config.tool_output is not None
+    assert config.run_events is not None
+
+
 def test_app_config_warns_when_no_models_configured(tmp_path, monkeypatch, caplog):
     config_path = tmp_path / "config.yaml"
     extensions_path = tmp_path / "extensions_config.json"

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -197,12 +197,30 @@ def test_app_config_coerces_commented_out_object_sections(tmp_path, monkeypatch)
 
     config = AppConfig.from_file(str(config_path))
 
-    # Each present-but-null object section falls back to its default config.
-    assert config.memory is not None
-    assert config.summarization is not None
-    assert config.guardrails is not None
-    assert config.tool_output is not None
-    assert config.run_events is not None
+    # Each present-but-null object section falls back to a real default config
+    # object of the expected type (not merely non-None).
+    assert type(config.memory).__name__ == "MemoryConfig"
+    assert type(config.summarization).__name__ == "SummarizationConfig"
+    assert type(config.guardrails).__name__ == "GuardrailsConfig"
+    assert type(config.tool_output).__name__ == "ToolOutputConfig"
+    assert type(config.run_events).__name__ == "RunEventsConfig"
+
+
+def test_app_config_null_required_section_still_errors(tmp_path, monkeypatch):
+    """A present-but-null *required* section still errors.
+
+    ``sandbox`` has no default, so dropping a ``sandbox: null`` key leaves the
+    required field absent — there is nothing to fall back to (per
+    ``_drop_null_config_sections``), unlike the optional object sections above.
+    """
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    config_path.write_text(yaml.safe_dump({"sandbox": None}), encoding="utf-8")
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+
+    with pytest.raises(ValidationError):
+        AppConfig.from_file(str(config_path))
 
 
 def test_app_config_warns_when_no_models_configured(tmp_path, monkeypatch, caplog):


### PR DESCRIPTION
## Why

#3434 made commented-out **list** sections (`models` / `tools` / `tool_groups`) parse as `[]` instead of crashing — but the same scenario still crashes for **object** sections. Commenting out every key under e.g. `memory:`, `summarization:`, `guardrails:`, `tool_output:` or `run_events:` makes PyYAML parse the value as `None`, and `AppConfig` then raises an opaque `Input should be a valid dictionary` for that section. This breaks the documented `cp config.example.yaml config.yaml` first-run flow (the exact flow #3434 fixed), since `config.example.yaml` ships those object sections and a user disabling one by commenting out its body hits the crash.

Repro on `main`: a config containing `memory:` (null) fails to load with a `ValidationError`.

## What changed

No change for valid configs. A present-but-null section now falls back to its default instead of crashing: a `model_validator(mode="before")` drops `None`-valued top-level sections so each field uses its default (list sections → `[]` via `default_factory`, object sections → their default config). This **generalizes** the previous list-only `field_validator` (now removed as subsumed) and the `database` special-case in `from_file` to every section. Required sections with no default (`sandbox`) still error when null — there is nothing to fall back to.

## Surface area

Internal config loading (`packages/harness/deerflow/config/app_config.py`) — no frontend, endpoint, agent, sandbox, skills, or dependency change; robustness fix for malformed/partial `config.yaml`.

## Bug fix verification

- Test: `backend/tests/test_app_config_reload.py::test_app_config_coerces_commented_out_object_sections`.
- Red on `main` / green on branch: **yes** — on `main`, `AppConfig.from_file` of a config with a null object section raises `ValidationError`; the new test reproduces that and passes on this branch. The existing `test_app_config_coerces_commented_out_list_sections` (#3434) still passes, confirming the generalization preserves list-section behavior.

## Validation

In `backend/`:

- `uv run pytest tests/test_app_config_reload.py` → **12 passed**.
- `uv run ruff check` + `uv run ruff format --check` on the changed files → clean.

## AI assistance

**Tool(s) used:** Claude Code

**How:** Used to spot that #3434's null-section handling was list-only, reproduce the object-section crash, generalize the coercion via a `model_validator`, and add the regression test. I reviewed every line and verified locally with the test + ruff runs above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
