### PR TITLE
feat: add conversation scheduled runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,22 @@ DeerFlow supports configurable MCP servers and skills to extend its capabilities
 For HTTP/SSE MCP servers, OAuth token flows are supported (`client_credentials`, `refresh_token`).
 See the [MCP Server Guide](backend/docs/MCP_SERVER.md) for detailed instructions.
 
+#### Scheduled Runs
+
+DeerFlow can let the lead agent create one-time scheduled tasks from a conversation with the built-in `schedule_task` tool. Enable the Gateway scheduler when you want prompts such as "tomorrow at 18:00 run the backup check" to persist a task and run it later in the same thread.
+
+Scheduled runs require `database.backend` to be `sqlite` or `postgres`; `memory` persistence is rejected because tasks would be lost on restart. The first implementation supports one-time tasks only.
+When a Web-created scheduled run completes, the Gateway emits a thread-scoped SSE invalidation event so an open conversation can refresh its run history and show the new assistant message.
+
+```yaml
+scheduler:
+  enabled: true
+  poll_interval_seconds: 5.0
+  max_concurrent_runs: 2
+  claim_ttl_seconds: 300
+  misfire_grace_time_seconds: 300
+```
+
 #### IM Channels
 
 DeerFlow supports receiving tasks from messaging apps. Channels auto-start when configured — no public IP required for any of them.
@@ -595,6 +611,8 @@ Users can explicitly activate an enabled skill for a single turn by starting the
 When you install `.skill` archives through the Gateway, DeerFlow accepts standard optional frontmatter metadata such as `version`, `author`, and `compatibility` instead of rejecting otherwise valid external skills.
 
 Tools follow the same philosophy. DeerFlow comes with a core toolset — web search, web fetch, file operations, bash execution — and supports custom tools via MCP servers and Python functions. Swap anything. Add anything.
+
+The lead agent also includes a `schedule_task` tool for one-time scheduled runs when the Gateway scheduler is enabled. The model converts the user's natural-language time into an ISO-8601 datetime; DeerFlow persists the task, runs it later in the same thread, and sends a channel notification when the task originated from an IM integration.
 
 Gateway-generated follow-up suggestions now normalize both plain-string model output and block/list-style rich content before parsing the JSON array response, so provider-specific content wrappers do not silently drop suggestions.
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -234,7 +234,7 @@ Setup: Copy `config.example.yaml` to `config.yaml` in the **project root** direc
 
 **Config Hot-Reload Boundary**: Gateway dependencies route through `get_app_config()` on every request, so per-run fields like `models[*].max_tokens`, `summarization.*`, `title.*`, `memory.*`, `subagents.*`, `tools[*]`, and the agent system prompt pick up `config.yaml` edits on the next message. `AppConfig` is intentionally **not** cached on `app.state` — `lifespan()` keeps a local `startup_config` variable for one-shot bootstrap work and passes it to `langgraph_runtime(app, startup_config)`.
 
-Infrastructure fields are **restart-required**. The authoritative list lives in `packages/harness/deerflow/config/reload_boundary.py::STARTUP_ONLY_FIELDS` and is mirrored by the standardised `"startup-only:"` prefix on the corresponding `Field(description=...)` in `AppConfig`, so IDE hover on those fields surfaces the reason inline (no need to context-switch into this table). Currently registered: `database`, `checkpointer`, `run_events`, `stream_bridge`, `sandbox`, `log_level`, `channels`, `channel_connections`. Adding a new restart-required field requires updating the registry; drift is pinned by `tests/test_reload_boundary.py`.
+Infrastructure fields are **restart-required**. The authoritative list lives in `packages/harness/deerflow/config/reload_boundary.py::STARTUP_ONLY_FIELDS` and is mirrored by the standardised `"startup-only:"` prefix on the corresponding `Field(description=...)` in `AppConfig`, so IDE hover on those fields surfaces the reason inline (no need to context-switch into this table). Currently registered: `database`, `checkpointer`, `run_events`, `stream_bridge`, `sandbox`, `log_level`, `channels`, `channel_connections`, `scheduler`. Adding a new restart-required field requires updating the registry; drift is pinned by `tests/test_reload_boundary.py`.
 
 Configuration priority:
 1. Explicit `config_path` argument
@@ -273,9 +273,10 @@ CORS is same-origin by default when requests enter through nginx on port 2026. S
 | **Threads** (`/api/threads/{id}`) | `DELETE /` - remove DeerFlow-managed local thread data after LangGraph thread deletion; unexpected failures are logged server-side and return a generic 500 detail |
 | **Artifacts** (`/api/threads/{id}/artifacts`) | `GET /{path}` - serve artifacts; active content types (`text/html`, `application/xhtml+xml`, `image/svg+xml`) are always forced as download attachments to reduce XSS risk; `?download=true` still forces download for other file types |
 | **Suggestions** (`/api/threads/{id}/suggestions`) | `POST /` - generate follow-up questions; rich list/block model content is normalized and inline reasoning (`<think>...</think>`, including unclosed/truncated blocks from reasoning models like MiniMax-M3) is stripped before JSON parsing |
-| **Thread Runs** (`/api/threads/{id}/runs`) | `POST /` - create background run; `POST /stream` - create + SSE stream; `POST /wait` - create + block; `GET /` - list runs; `GET /{rid}` - run details; `POST /{rid}/cancel` - cancel; `GET /{rid}/join` - join SSE; `GET /{rid}/messages` - paginated messages `{data, has_more}`; `GET /{rid}/events` - full event stream; `GET /../messages` - thread messages with feedback; `GET /../token-usage` - aggregate tokens |
+| **Thread Runs** (`/api/threads/{id}/runs`) | `POST /` - create background run; `POST /stream` - create + SSE stream; `POST /wait` - create + block; `GET /` - list runs; `GET /{rid}` - run details; `POST /{rid}/cancel` - cancel; `GET /{rid}/join` - join SSE; `GET /{rid}/messages` - paginated messages `{data, has_more}`; `GET /{rid}/events` - full event stream; `GET /../events` - thread-level browser invalidation SSE; `GET /../messages` - thread messages with feedback; `GET /../token-usage` - aggregate tokens |
 | **Feedback** (`/api/threads/{id}/runs/{rid}/feedback`) | `PUT /` - upsert feedback; `DELETE /` - delete user feedback; `POST /` - create feedback; `GET /` - list feedback; `GET /stats` - aggregate stats; `DELETE /{fid}` - delete specific |
 | **Runs** (`/api/runs`) | `POST /stream` - stateless run + SSE; `POST /wait` - stateless run + block; `GET /{rid}/messages` - paginated messages by run_id `{data, has_more}` (cursor: `after_seq`/`before_seq`); `GET /{rid}/feedback` - list feedback by run_id |
+| **Scheduled Tasks** (`/api/scheduled-tasks`) | `GET /` - list current user's scheduled tasks; `GET /{id}` - task details; `DELETE /{id}` - cancel an active task |
 
 **RunManager / RunStore contract**:
 - `RunManager.get()` is async; direct callers must `await` it.
@@ -285,6 +286,16 @@ CORS is same-origin by default when requests enter through nginx on port 2026. S
 - `POST /wait` (both thread-scoped and `/api/runs/wait`) drains the stream bridge via `wait_for_run_completion()` instead of bare `await record.task`, so it honours the run's `on_disconnect` setting and cancels the background run on real client disconnect rather than returning a stale checkpoint (issue #3265).
 
 Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runtime, all other `/api/*` → Gateway REST APIs.
+
+### Scheduled Runs (`app/scheduler/` + `deerflow.persistence.scheduled_tasks`)
+
+The first scheduled-run implementation supports one-time tasks created by the built-in `schedule_task` tool. Keep the layer split strict:
+
+- Harness owns the data model, repository, and tool (`deerflow.persistence.scheduled_tasks`, `deerflow.tools.builtins.schedule_task_tool`). It never imports `app.*`.
+- App owns execution (`app.scheduler.service`). Gateway starts `ScheduledRunService` at lifespan only when `scheduler.enabled` is true and a SQL database backend is available.
+- The service polls `scheduled_tasks` for due `active` rows, claims each row with a DB lease, starts a normal `RunManager`/`run_agent()` execution in the original `thread_id`, then marks the task `completed`, `failed`, or `missed`.
+- Tasks created from IM channels persist channel routing metadata from `ChannelManager`'s run context. On completion, `ScheduledRunService` sends an `OutboundMessage` through the active channel if available. Web-created tasks write the result into the thread checkpoint/history and publish a thread-scoped SSE invalidation through `app.gateway.thread_events` so open browser conversations refresh their run history.
+- `scheduler.*` is restart-required because the polling loop and semaphore are built once during Gateway startup.
 
 ### Sandbox System (`packages/harness/deerflow/sandbox/`)
 
@@ -325,6 +336,7 @@ Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runti
    - `present_files` - Make output files visible to user (only `/mnt/user-data/outputs`)
    - `ask_clarification` - Request clarification (intercepted by ClarificationMiddleware → interrupts)
    - `view_image` - Read image as base64 (added only if model supports vision)
+   - `schedule_task` - Create a one-time scheduled run in the current thread (requires SQL persistence and Gateway scheduler)
    - `setup_agent` - Bootstrap-only: persist a brand-new custom agent's `SOUL.md` and `config.yaml`. Bound only when `is_bootstrap=True`.
    - `update_agent` - Custom-agent-only: persist self-updates to the current agent's `SOUL.md` / `config.yaml` from inside a normal chat (partial update + atomic write). Bound when `agent_name` is set and `is_bootstrap=False`.
 4. **Subagent tool** (if enabled):

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -788,7 +788,20 @@ class ChannelManager:
         # For browser-connected IM channels, prefer the DeerFlow account that
         # owns the connection. Preserve the raw platform user under
         # ``channel_user_id`` for platform-facing lookups and audits.
-        run_context_identity: dict[str, Any] = {"thread_id": thread_id}
+        run_context_identity: dict[str, Any] = {
+            "thread_id": thread_id,
+            "assistant_id": assistant_id,
+            "channel_name": msg.channel_name,
+            "channel_chat_id": msg.chat_id,
+        }
+        if msg.topic_id:
+            run_context_identity["channel_topic_id"] = msg.topic_id
+        if msg.thread_ts:
+            run_context_identity["channel_thread_ts"] = msg.thread_ts
+        if msg.connection_id:
+            run_context_identity["channel_connection_id"] = msg.connection_id
+        if msg.owner_user_id:
+            run_context_identity["channel_owner_user_id"] = msg.owner_user_id
         owner_user_id = _effective_owner_user_id(msg)
         if owner_user_id:
             run_context_identity["user_id"] = _safe_user_id_for_run(owner_user_id)

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -23,6 +23,7 @@ from app.gateway.routers import (
     memory,
     models,
     runs,
+    scheduled_tasks,
     skills,
     suggestions,
     thread_runs,
@@ -210,6 +211,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Initialize LangGraph runtime components (StreamBridge, RunManager, checkpointer, store)
     async with langgraph_runtime(app, startup_config):
         logger.info("LangGraph runtime initialised")
+        from app.gateway.thread_events import ThreadEventHub
+
+        app.state.thread_event_hub = ThreadEventHub()
 
         # Check admin bootstrap state and migrate orphan threads after admin exists.
         # Must run AFTER langgraph_runtime so app.state.store is available for thread migration
@@ -224,7 +228,36 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         except Exception:
             logger.exception("No IM channels configured or channel service failed to start")
 
+        # Start scheduled-run service when enabled.
+        try:
+            from app.scheduler.service import start_scheduler_service
+
+            await start_scheduler_service(app, startup_config)
+        except Exception:
+            logger.exception("Scheduled-run service failed to start")
+
         yield
+
+        # Stop scheduled-run service before runtime teardown.
+        try:
+            from app.scheduler.service import stop_scheduler_service
+
+            await asyncio.wait_for(
+                stop_scheduler_service(),
+                timeout=_SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning(
+                "Scheduled-run service shutdown exceeded %.1fs; proceeding with worker exit.",
+                _SHUTDOWN_HOOK_TIMEOUT_SECONDS,
+            )
+        except Exception:
+            logger.exception("Failed to stop scheduled-run service")
+
+        try:
+            await app.state.thread_event_hub.close()
+        except Exception:
+            logger.exception("Failed to close thread event hub")
 
         # Stop channel service on shutdown (bounded to prevent worker hang)
         try:
@@ -384,6 +417,9 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
 
     # Suggestions API is mounted at /api/threads/{thread_id}/suggestions
     app.include_router(suggestions.router)
+
+    # Scheduled task API is mounted at /api/scheduled-tasks
+    app.include_router(scheduled_tasks.router)
 
     # User-facing IM channel connection API is mounted at /api/channels
     app.include_router(channel_connections.router)

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -74,6 +74,7 @@ async def _drain_inflight_runs(run_manager: RunManager) -> None:
 if TYPE_CHECKING:
     from app.gateway.auth.local_provider import LocalAuthProvider
     from app.gateway.auth.repositories.sqlite import SQLiteUserRepository
+    from app.gateway.thread_events import ThreadEventHub
     from deerflow.persistence.thread_meta.base import ThreadMetaStore
     from deerflow.runtime import RunRecord
 
@@ -260,6 +261,7 @@ get_checkpointer: Callable[[Request], Checkpointer] = _require("checkpointer", "
 get_run_event_store: Callable[[Request], RunEventStore] = _require("run_event_store", "Run event store")
 get_feedback_repo: Callable[[Request], FeedbackRepository] = _require("feedback_repo", "Feedback")
 get_run_store: Callable[[Request], RunStore] = _require("run_store", "Run store")
+get_thread_event_hub: Callable[[Request], ThreadEventHub] = _require("thread_event_hub", "Thread event hub")
 
 
 def get_store(request: Request):

--- a/backend/app/gateway/routers/scheduled_tasks.py
+++ b/backend/app/gateway/routers/scheduled_tasks.py
@@ -1,0 +1,80 @@
+"""Scheduled task management endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from app.gateway.deps import get_current_user
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_tasks import ScheduledTaskRepository
+
+router = APIRouter(prefix="/api/scheduled-tasks", tags=["scheduled-tasks"])
+
+
+class ScheduledTaskResponse(BaseModel):
+    id: str
+    owner_user_id: str
+    thread_id: str
+    assistant_id: str
+    agent_name: str | None = None
+    title: str | None = None
+    prompt: str
+    schedule_type: str
+    run_at: str
+    timezone: str
+    status: str
+    last_run_id: str | None = None
+    last_error: str | None = None
+    channel_name: str | None = None
+    chat_id: str | None = None
+    topic_id: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: str
+    updated_at: str
+
+
+class ScheduledTaskListResponse(BaseModel):
+    tasks: list[ScheduledTaskResponse]
+
+
+def _repo() -> ScheduledTaskRepository:
+    sf = get_session_factory()
+    if sf is None:
+        raise HTTPException(status_code=503, detail="Scheduled tasks require sqlite or postgres database backend")
+    return ScheduledTaskRepository(sf)
+
+
+@router.get("", response_model=ScheduledTaskListResponse)
+async def list_scheduled_tasks(
+    request: Request,
+    thread_id: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> ScheduledTaskListResponse:
+    user_id = await get_current_user(request)
+    tasks = await _repo().list(user_id=user_id, thread_id=thread_id, limit=limit)
+    return ScheduledTaskListResponse(tasks=[ScheduledTaskResponse(**task) for task in tasks])
+
+
+@router.get("/{task_id}", response_model=ScheduledTaskResponse)
+async def get_scheduled_task(task_id: str, request: Request) -> ScheduledTaskResponse:
+    user_id = await get_current_user(request)
+    task = await _repo().get(task_id, user_id=user_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Scheduled task {task_id} not found")
+    return ScheduledTaskResponse(**task)
+
+
+@router.delete("/{task_id}", response_model=ScheduledTaskResponse)
+async def cancel_scheduled_task(task_id: str, request: Request) -> ScheduledTaskResponse:
+    user_id = await get_current_user(request)
+    repo = _repo()
+    cancelled = await repo.cancel(task_id, user_id=user_id)
+    if not cancelled:
+        raise HTTPException(status_code=404, detail=f"Active scheduled task {task_id} not found")
+    task = await repo.get(task_id, user_id=user_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"Scheduled task {task_id} not found")
+    return ScheduledTaskResponse(**task)

--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -12,6 +12,7 @@ works without modification.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Any, Literal
 
@@ -20,9 +21,18 @@ from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from app.gateway.authz import require_permission
-from app.gateway.deps import get_checkpointer, get_current_user, get_feedback_repo, get_run_event_store, get_run_manager, get_run_store, get_stream_bridge
+from app.gateway.deps import (
+    get_checkpointer,
+    get_current_user,
+    get_feedback_repo,
+    get_run_event_store,
+    get_run_manager,
+    get_run_store,
+    get_stream_bridge,
+    get_thread_event_hub,
+)
 from app.gateway.pagination import trim_run_message_page
-from app.gateway.services import sse_consumer, start_run, wait_for_run_completion
+from app.gateway.services import format_sse, sse_consumer, start_run, wait_for_run_completion
 from deerflow.runtime import RunRecord, RunStatus, serialize_channel_values
 
 logger = logging.getLogger(__name__)
@@ -109,14 +119,40 @@ def _cancel_conflict_detail(run_id: str, record: RunRecord) -> str:
     return f"Run {run_id} is not cancellable (status: {record.status.value})"
 
 
+def _json_safe_run_payload(value: Any) -> Any:
+    """Return JSON-safe run metadata for API responses.
+
+    In-flight runtime config can contain process-local objects such as
+    ``Runtime`` or ``RunJournal``. Those are useful while executing a graph but
+    must never leak into the LangGraph-compatible runs list response.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text.startswith("__") or key_text == "callbacks":
+                continue
+            result[key_text] = _json_safe_run_payload(item)
+        return result
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_run_payload(item) for item in value]
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return str(value)
+
+
 def _record_to_response(record: RunRecord) -> RunResponse:
     return RunResponse(
         run_id=record.run_id,
         thread_id=record.thread_id,
         assistant_id=record.assistant_id,
         status=record.status.value,
-        metadata=record.metadata,
-        kwargs=record.kwargs,
+        metadata=_json_safe_run_payload(record.metadata),
+        kwargs=_json_safe_run_payload(record.kwargs),
         multitask_strategy=record.multitask_strategy,
         created_at=record.created_at,
         updated_at=record.updated_at,
@@ -336,6 +372,44 @@ async def stream_existing_run(
 # ---------------------------------------------------------------------------
 
 
+@router.get("/{thread_id}/events")
+@require_permission("runs", "read", owner_check=True)
+async def stream_thread_events(thread_id: str, request: Request) -> StreamingResponse:
+    """Stream thread-scoped browser notifications via SSE.
+
+    This stream carries invalidation signals, not durable conversation data.
+    Clients should refresh the canonical thread/run APIs after receiving an
+    event such as ``scheduled_run_completed``.
+    """
+    hub = get_thread_event_hub(request)
+    user_id = await get_current_user(request)
+
+    async def event_consumer():
+        async with hub.subscribe(thread_id, user_id) as queue:
+            yield format_sse("ready", {"thread_id": thread_id})
+            while True:
+                if await request.is_disconnected():
+                    return
+                try:
+                    item = await asyncio.wait_for(queue.get(), timeout=15)
+                except TimeoutError:
+                    yield ": heartbeat\n\n"
+                    continue
+                if item is None:
+                    return
+                yield format_sse(item.event, item.data, event_id=item.id)
+
+    return StreamingResponse(
+        event_consumer(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.get("/{thread_id}/messages")
 @require_permission("runs", "read", owner_check=True)
 async def list_thread_messages(
@@ -396,6 +470,12 @@ async def list_run_messages(
     Response: { data: [...], has_more: bool }
     """
     event_store = get_run_event_store(request)
+    run_mgr = getattr(request.app.state, "run_manager", None)
+    run_source = None
+    if run_mgr is not None:
+        user_id = await get_current_user(request)
+        record = await run_mgr.get(run_id, user_id=user_id)
+        run_source = record.metadata.get("source") if record is not None else None
     rows = await event_store.list_messages_by_run(
         thread_id,
         run_id,
@@ -404,6 +484,11 @@ async def list_run_messages(
         after_seq=after_seq,
     )
     data, has_more = trim_run_message_page(rows, limit=limit, after_seq=after_seq)
+    if run_source:
+        for row in data:
+            metadata = row.setdefault("metadata", {})
+            if isinstance(metadata, dict):
+                metadata.setdefault("source", run_source)
     return {"data": data, "has_more": has_more}
 
 

--- a/backend/app/gateway/thread_events.py
+++ b/backend/app/gateway/thread_events.py
@@ -1,0 +1,81 @@
+"""In-process thread event fan-out for browser notifications."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+
+@dataclass(frozen=True)
+class ThreadEvent:
+    event: str
+    data: dict[str, Any]
+    id: str = field(default_factory=lambda: uuid4().hex)
+
+
+ThreadEventQueue = asyncio.Queue[ThreadEvent | None]
+
+
+class ThreadEventHub:
+    """Small SSE fan-out hub keyed by thread and owner user.
+
+    Events are intentionally ephemeral. Durable conversation state remains in
+    run/checkpoint storage; this hub only wakes active browser sessions so they
+    can refresh the authoritative thread history.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: defaultdict[tuple[str, str | None], set[ThreadEventQueue]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+
+    @asynccontextmanager
+    async def subscribe(self, thread_id: str, user_id: str | None) -> AsyncIterator[ThreadEventQueue]:
+        queue: ThreadEventQueue = asyncio.Queue(maxsize=100)
+        key = (thread_id, user_id)
+        async with self._lock:
+            self._subscribers[key].add(queue)
+        try:
+            yield queue
+        finally:
+            async with self._lock:
+                queues = self._subscribers.get(key)
+                if queues is not None:
+                    queues.discard(queue)
+                    if not queues:
+                        self._subscribers.pop(key, None)
+
+    async def publish(
+        self,
+        thread_id: str,
+        event: str,
+        data: dict[str, Any],
+        *,
+        user_id: str | None,
+    ) -> None:
+        item = ThreadEvent(event=event, data=data)
+        async with self._lock:
+            queues = list(self._subscribers.get((thread_id, user_id), set()))
+        for queue in queues:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            queue.put_nowait(item)
+
+    async def close(self) -> None:
+        async with self._lock:
+            queues = [queue for group in self._subscribers.values() for queue in group]
+            self._subscribers.clear()
+        for queue in queues:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            queue.put_nowait(None)

--- a/backend/app/scheduler/__init__.py
+++ b/backend/app/scheduler/__init__.py
@@ -1,0 +1,1 @@
+"""Scheduled-run service package."""

--- a/backend/app/scheduler/service.py
+++ b/backend/app/scheduler/service.py
@@ -1,0 +1,293 @@
+"""Gateway-local scheduler for conversation-created one-time runs."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import FastAPI
+from langchain_core.messages import AIMessage, BaseMessage
+
+from app.channels.message_bus import OutboundMessage
+from deerflow.config.app_config import AppConfig
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_tasks import ScheduledTaskRepository
+from deerflow.runtime import ConflictError, DisconnectMode, RunContext, RunStatus, run_agent
+from deerflow.runtime.user_context import reset_current_user, set_current_user
+
+logger = logging.getLogger(__name__)
+
+
+class ScheduledRunService:
+    def __init__(self, app: FastAPI, config: AppConfig, repository: ScheduledTaskRepository) -> None:
+        self._app = app
+        self._config = config
+        self._repo = repository
+        self._running = False
+        self._loop_task: asyncio.Task | None = None
+        self._semaphore = asyncio.Semaphore(config.scheduler.max_concurrent_runs)
+
+    async def start(self) -> None:
+        if self._running:
+            return
+        self._running = True
+        self._loop_task = asyncio.create_task(self._poll_loop())
+        logger.info("ScheduledRunService started")
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._loop_task is not None:
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
+            self._loop_task = None
+        logger.info("ScheduledRunService stopped")
+
+    async def _poll_loop(self) -> None:
+        interval = self._config.scheduler.poll_interval_seconds
+        while self._running:
+            try:
+                await self._dispatch_due_tasks()
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Scheduled task polling failed")
+            await asyncio.sleep(interval)
+
+    async def _dispatch_due_tasks(self) -> None:
+        now = datetime.now(UTC)
+        due = await self._repo.list_due(now=now, limit=self._config.scheduler.max_concurrent_runs * 4)
+        for task in due:
+            asyncio.create_task(self._execute_if_claimed(task["id"]))
+
+    async def _execute_if_claimed(self, task_id: str) -> None:
+        async with self._semaphore:
+            now = datetime.now(UTC)
+            task = await self._repo.claim_due(task_id, now=now, lease_seconds=self._config.scheduler.claim_ttl_seconds)
+            if task is None:
+                return
+            grace = self._config.scheduler.misfire_grace_time_seconds
+            run_at = datetime.fromisoformat(str(task["run_at"]))
+            if run_at.tzinfo is None:
+                run_at = run_at.replace(tzinfo=UTC)
+            if grace >= 0 and (now - run_at.astimezone(UTC)).total_seconds() > grace:
+                await self._repo.mark_missed(task_id, error="Scheduled task missed its grace window.")
+                await self._notify_thread_event(
+                    task,
+                    "scheduled_run_missed",
+                    status="missed",
+                    error="Scheduled task missed its grace window.",
+                )
+                return
+            await self._execute_task(task)
+
+    async def _execute_task(self, task: dict[str, Any]) -> None:
+        run_id: str | None = None
+        try:
+            record = await self._start_agent_run(task)
+            run_id = record.run_id
+            if record.task is not None:
+                await record.task
+            if record.status == RunStatus.success:
+                await self._repo.mark_completed(task["id"], run_id=run_id)
+                await self._notify_thread_event(task, "scheduled_run_completed", status="completed", run_id=run_id)
+                await self._notify_channel(task, await self._extract_latest_response_async(task["thread_id"]))
+            else:
+                error = record.error or f"Scheduled run finished with status {record.status.value}"
+                await self._repo.mark_failed(task["id"], error=error, run_id=run_id)
+                await self._notify_thread_event(task, "scheduled_run_failed", status="failed", run_id=run_id, error=error)
+                await self._notify_channel(task, f"Scheduled task failed: {error}")
+        except ConflictError as exc:
+            error = f"Thread is busy: {exc}"
+            await self._repo.mark_failed(task["id"], error=error, run_id=run_id)
+            await self._notify_thread_event(task, "scheduled_run_failed", status="failed", run_id=run_id, error=error)
+            await self._notify_channel(task, f"Scheduled task could not start because the thread is busy: {exc}")
+        except Exception as exc:
+            logger.exception("Scheduled task %s failed", task.get("id"))
+            await self._repo.mark_failed(task["id"], error=str(exc), run_id=run_id)
+            await self._notify_thread_event(task, "scheduled_run_failed", status="failed", run_id=run_id, error=str(exc))
+            await self._notify_channel(task, f"Scheduled task failed: {exc}")
+
+    async def _start_agent_run(self, task: dict[str, Any]):
+        from app.gateway.services import build_run_config, merge_run_context_overrides, normalize_input, resolve_agent_factory
+
+        thread_id = str(task["thread_id"])
+        assistant_id = str(task.get("assistant_id") or "lead_agent")
+        owner_user_id = str(task["owner_user_id"])
+        prompt = self._build_scheduled_prompt(task)
+        body_input = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": prompt,
+                    "additional_kwargs": {"hide_from_ui": True},
+                }
+            ]
+        }
+        metadata = {"scheduled_task_id": task["id"], "source": "scheduled_task"}
+        config = build_run_config(thread_id, None, metadata, assistant_id=assistant_id)
+        context: dict[str, Any] = {"user_id": owner_user_id}
+        if task.get("agent_name"):
+            context["agent_name"] = task["agent_name"]
+        merge_run_context_overrides(config, context)
+
+        run_mgr = self._app.state.run_manager
+        record = await run_mgr.create_or_reject(
+            thread_id,
+            assistant_id,
+            on_disconnect=DisconnectMode.continue_,
+            metadata=metadata,
+            kwargs={"input": body_input, "config": copy.deepcopy(config)},
+            multitask_strategy="reject",
+            user_id=owner_user_id,
+        )
+
+        token = set_current_user(SimpleNamespace(id=owner_user_id))
+        try:
+            run_ctx = RunContext(
+                checkpointer=self._app.state.checkpointer,
+                store=getattr(self._app.state, "store", None),
+                event_store=getattr(self._app.state, "run_event_store", None),
+                run_events_config=getattr(self._app.state, "run_events_config", None),
+                thread_store=getattr(self._app.state, "thread_store", None),
+                app_config=self._config,
+            )
+            record.task = asyncio.create_task(
+                run_agent(
+                    self._app.state.stream_bridge,
+                    run_mgr,
+                    record,
+                    ctx=run_ctx,
+                    agent_factory=resolve_agent_factory(assistant_id),
+                    graph_input=normalize_input(body_input),
+                    config=config,
+                    stream_modes=["values"],
+                )
+            )
+            return record
+        finally:
+            reset_current_user(token)
+
+    @staticmethod
+    def _build_scheduled_prompt(task: dict[str, Any]) -> str:
+        title = task.get("title")
+        prefix = f"Scheduled task '{title}' is due." if title else "Scheduled task is due."
+        return f"{prefix}\n\n{task['prompt']}"
+
+    async def _extract_latest_response_async(self, thread_id: str) -> str:
+        checkpoint_tuple = await self._app.state.checkpointer.aget_tuple({"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}})
+        if checkpoint_tuple is None:
+            return "Scheduled task completed."
+        channel_values = getattr(checkpoint_tuple, "checkpoint", {}).get("channel_values", {})
+        messages = channel_values.get("messages", [])
+        for message in reversed(messages):
+            if isinstance(message, AIMessage):
+                return _message_content_to_text(message.content) or "Scheduled task completed."
+            if isinstance(message, BaseMessage) and getattr(message, "type", "") == "ai":
+                return _message_content_to_text(message.content) or "Scheduled task completed."
+        return "Scheduled task completed."
+
+    async def _notify_channel(self, task: dict[str, Any], text: str | None) -> None:
+        channel_name = task.get("channel_name")
+        chat_id = task.get("chat_id")
+        if not channel_name or not chat_id:
+            return
+        from app.channels.service import get_channel_service
+
+        service = get_channel_service()
+        channel = service.get_channel(str(channel_name)) if service else None
+        if channel is None:
+            logger.info("Scheduled task %s completed without active channel %s", task.get("id"), channel_name)
+            return
+        await channel.send(
+            OutboundMessage(
+                channel_name=str(channel_name),
+                chat_id=str(chat_id),
+                thread_id=str(task["thread_id"]),
+                text=text or "Scheduled task completed.",
+                thread_ts=str(task["thread_ts"]) if task.get("thread_ts") else None,
+                connection_id=str(task["connection_id"]) if task.get("connection_id") else None,
+                owner_user_id=str(task["owner_user_id"]),
+                metadata={"scheduled_task_id": task["id"]},
+            )
+        )
+
+    async def _notify_thread_event(
+        self,
+        task: dict[str, Any],
+        event: str,
+        *,
+        status: str,
+        run_id: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        hub = getattr(self._app.state, "thread_event_hub", None)
+        if hub is None:
+            return
+        data = {
+            "type": event,
+            "scheduled_task_id": task["id"],
+            "thread_id": task["thread_id"],
+            "status": status,
+            "run_id": run_id,
+        }
+        if error:
+            data["error"] = error
+        await hub.publish(
+            str(task["thread_id"]),
+            event,
+            data,
+            user_id=str(task["owner_user_id"]) if task.get("owner_user_id") else None,
+        )
+
+
+def _message_content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+            elif isinstance(item, dict) and isinstance(item.get("content"), str):
+                parts.append(item["content"])
+        return "\n".join(part for part in parts if part).strip()
+    return str(content) if content is not None else ""
+
+
+_scheduler_service: ScheduledRunService | None = None
+
+
+def get_scheduler_service() -> ScheduledRunService | None:
+    return _scheduler_service
+
+
+async def start_scheduler_service(app: FastAPI, app_config: AppConfig) -> ScheduledRunService | None:
+    global _scheduler_service
+    if not app_config.scheduler.enabled:
+        logger.info("ScheduledRunService disabled by config")
+        return None
+    if _scheduler_service is not None:
+        return _scheduler_service
+    sf = get_session_factory()
+    if sf is None:
+        logger.warning("ScheduledRunService requires sqlite or postgres database backend; not starting")
+        return None
+    _scheduler_service = ScheduledRunService(app, app_config, ScheduledTaskRepository(sf))
+    await _scheduler_service.start()
+    return _scheduler_service
+
+
+async def stop_scheduler_service() -> None:
+    global _scheduler_service
+    if _scheduler_service is not None:
+        await _scheduler_service.stop()
+        _scheduler_service = None

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -241,6 +241,7 @@ tools:
 - `write_file` - Write file contents
 - `str_replace` - String replacement in files
 - `bash` - Execute bash commands
+- `schedule_task` - Create one-time scheduled conversation runs when the scheduler is enabled
 
 ### Sandbox
 
@@ -302,6 +303,23 @@ sandbox:
 When you configure `sandbox.mounts`, DeerFlow exposes those `container_path` values in the agent prompt so the agent can discover and operate on mounted directories directly instead of assuming everything must live under `/mnt/user-data`.
 
 For bare-metal Docker sandbox runs that use localhost, DeerFlow binds the sandbox HTTP port to `127.0.0.1` by default so it is not exposed on every host interface. Docker-outside-of-Docker deployments that connect through `host.docker.internal` keep the broad legacy bind for compatibility. Set `DEER_FLOW_SANDBOX_BIND_HOST` explicitly if your deployment needs a different bind address.
+
+### Scheduler
+
+Enable conversation-created one-time scheduled runs:
+
+```yaml
+scheduler:
+  enabled: false
+  poll_interval_seconds: 5.0
+  max_concurrent_runs: 2
+  claim_ttl_seconds: 300
+  misfire_grace_time_seconds: 300
+```
+
+The scheduler is disabled by default. When enabled, Gateway starts a local polling service that executes due `schedule_task` entries in their original conversation thread. Scheduled tasks require `database.backend` to be `sqlite` or `postgres`; memory persistence is rejected because it cannot survive Gateway restarts.
+
+The first scheduler implementation supports one-time tasks only. Recurring schedules should be modeled in a later feature.
 
 ### Skills
 

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -24,6 +24,7 @@ from deerflow.config.run_events_config import RunEventsConfig
 from deerflow.config.runtime_paths import existing_project_file
 from deerflow.config.safety_finish_reason_config import SafetyFinishReasonConfig
 from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.config.scheduler_config import SchedulerConfig
 from deerflow.config.skill_evolution_config import SkillEvolutionConfig
 from deerflow.config.skills_config import SkillsConfig
 from deerflow.config.stream_bridge_config import StreamBridgeConfig, load_stream_bridge_config_from_dict
@@ -126,6 +127,13 @@ class AppConfig(BaseModel):
     )
     loop_detection: LoopDetectionConfig = Field(default_factory=LoopDetectionConfig, description="Loop detection middleware configuration")
     safety_finish_reason: SafetyFinishReasonConfig = Field(default_factory=SafetyFinishReasonConfig, description="Provider safety-filter finish_reason interception middleware configuration")
+    scheduler: SchedulerConfig = Field(
+        default_factory=SchedulerConfig,
+        description=format_field_description(
+            "scheduler",
+            field_doc="Conversation-created scheduled run service configuration.",
+        ),
+    )
     model_config = ConfigDict(extra="allow")
     database: DatabaseConfig = Field(
         default_factory=DatabaseConfig,

--- a/backend/packages/harness/deerflow/config/reload_boundary.py
+++ b/backend/packages/harness/deerflow/config/reload_boundary.py
@@ -59,6 +59,7 @@ STARTUP_ONLY_FIELDS: dict[str, str] = {
     "channel_connections": (
         "start_channel_service() wires the connection repository and channel workers once at startup, and the channel-connections router caches the merged provider config on app.state; channel_connections.* edits need a restart."
     ),
+    "scheduler": ("start_scheduler_service() is invoked once during startup; scheduled-run polling intervals, concurrency limits, and enablement are not rebuilt when scheduler.* changes."),
 }
 
 

--- a/backend/packages/harness/deerflow/config/scheduler_config.py
+++ b/backend/packages/harness/deerflow/config/scheduler_config.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class SchedulerConfig(BaseModel):
+    """Configuration for conversation-created scheduled runs."""
+
+    enabled: bool = Field(default=False, description="Whether Gateway starts the scheduled-run service.")
+    poll_interval_seconds: float = Field(default=5.0, ge=0.5, description="How often the service checks for due tasks.")
+    max_concurrent_runs: int = Field(default=2, ge=1, description="Maximum scheduled runs executed concurrently by this Gateway process.")
+    claim_ttl_seconds: int = Field(default=300, ge=30, description="How long a running-task lease stays valid before another worker may reclaim it.")
+    misfire_grace_time_seconds: int = Field(default=300, ge=0, description="How late a one-time task may run before it is marked missed.")

--- a/backend/packages/harness/deerflow/persistence/models/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/models/__init__.py
@@ -23,6 +23,7 @@ from deerflow.persistence.channel_connections.model import (
 from deerflow.persistence.feedback.model import FeedbackRow
 from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.persistence.run.model import RunRow
+from deerflow.persistence.scheduled_tasks.model import ScheduledTaskRow
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.persistence.user.model import UserRow
 
@@ -34,6 +35,7 @@ __all__ = [
     "FeedbackRow",
     "RunEventRow",
     "RunRow",
+    "ScheduledTaskRow",
     "ThreadMetaRow",
     "UserRow",
 ]

--- a/backend/packages/harness/deerflow/persistence/scheduled_tasks/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_tasks/__init__.py
@@ -1,0 +1,19 @@
+from deerflow.persistence.scheduled_tasks.sql import (
+    ACTIVE,
+    CANCELLED,
+    COMPLETED,
+    FAILED,
+    MISSED,
+    RUNNING,
+    ScheduledTaskRepository,
+)
+
+__all__ = [
+    "ACTIVE",
+    "CANCELLED",
+    "COMPLETED",
+    "FAILED",
+    "MISSED",
+    "RUNNING",
+    "ScheduledTaskRepository",
+]

--- a/backend/packages/harness/deerflow/persistence/scheduled_tasks/model.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_tasks/model.py
@@ -1,0 +1,52 @@
+"""ORM model for conversation-created scheduled runs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class ScheduledTaskRow(Base):
+    __tablename__ = "scheduled_tasks"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    owner_user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    thread_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    assistant_id: Mapped[str] = mapped_column(String(128), nullable=False, default="lead_agent")
+    agent_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    title: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    schedule_type: Mapped[str] = mapped_column(String(16), nullable=False, default="once")
+    run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    timezone: Mapped[str] = mapped_column(String(64), nullable=False, default="UTC")
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active", index=True)
+    lease_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True, index=True)
+    last_run_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    channel_name: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    chat_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    topic_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    thread_ts: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    channel_user_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    connection_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    owner_channel_user_id: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=_utc_now)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=_utc_now, onupdate=_utc_now)
+
+    __table_args__ = (
+        Index("idx_scheduled_tasks_due", "status", "run_at"),
+        Index("idx_scheduled_tasks_owner_thread", "owner_user_id", "thread_id"),
+    )

--- a/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
@@ -1,0 +1,199 @@
+"""SQL repository for scheduled runs."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import and_, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.scheduled_tasks.model import ScheduledTaskRow
+from deerflow.runtime.user_context import AUTO, _AutoSentinel, resolve_user_id
+from deerflow.utils.time import coerce_iso
+
+ACTIVE = "active"
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+CANCELLED = "cancelled"
+MISSED = "missed"
+
+
+class ScheduledTaskRepository:
+    """Persistence facade for one-time scheduled runs."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sf = session_factory
+
+    @staticmethod
+    def _new_id() -> str:
+        return uuid.uuid4().hex
+
+    @staticmethod
+    def _coerce_datetime(value: datetime) -> datetime:
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
+
+    @staticmethod
+    def _row_to_dict(row: ScheduledTaskRow) -> dict[str, Any]:
+        data = row.to_dict()
+        data["metadata"] = data.pop("metadata_json") or {}
+        for key in ("run_at", "lease_until", "created_at", "updated_at"):
+            value = data.get(key)
+            if isinstance(value, datetime):
+                data[key] = coerce_iso(value)
+        return data
+
+    async def create_once(
+        self,
+        *,
+        owner_user_id: str,
+        thread_id: str,
+        prompt: str,
+        run_at: datetime,
+        timezone: str = "UTC",
+        assistant_id: str = "lead_agent",
+        agent_name: str | None = None,
+        title: str | None = None,
+        channel_name: str | None = None,
+        chat_id: str | None = None,
+        topic_id: str | None = None,
+        thread_ts: str | None = None,
+        channel_user_id: str | None = None,
+        connection_id: str | None = None,
+        owner_channel_user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        row = ScheduledTaskRow(
+            id=self._new_id(),
+            owner_user_id=owner_user_id,
+            thread_id=thread_id,
+            assistant_id=assistant_id or "lead_agent",
+            agent_name=agent_name,
+            title=title,
+            prompt=prompt,
+            schedule_type="once",
+            run_at=self._coerce_datetime(run_at),
+            timezone=timezone or "UTC",
+            status=ACTIVE,
+            channel_name=channel_name,
+            chat_id=chat_id,
+            topic_id=topic_id,
+            thread_ts=thread_ts,
+            channel_user_id=channel_user_id,
+            connection_id=connection_id,
+            owner_channel_user_id=owner_channel_user_id,
+            metadata_json=dict(metadata or {}),
+        )
+        async with self._sf() as session:
+            session.add(row)
+            await session.commit()
+            await session.refresh(row)
+            return self._row_to_dict(row)
+
+    async def get(
+        self,
+        task_id: str,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> dict[str, Any] | None:
+        resolved_user_id = resolve_user_id(user_id, method_name="ScheduledTaskRepository.get")
+        async with self._sf() as session:
+            row = await session.get(ScheduledTaskRow, task_id)
+            if row is None:
+                return None
+            if resolved_user_id is not None and row.owner_user_id != resolved_user_id:
+                return None
+            return self._row_to_dict(row)
+
+    async def list(
+        self,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+        thread_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        resolved_user_id = resolve_user_id(user_id, method_name="ScheduledTaskRepository.list")
+        stmt = select(ScheduledTaskRow).order_by(ScheduledTaskRow.created_at.desc()).limit(limit)
+        if resolved_user_id is not None:
+            stmt = stmt.where(ScheduledTaskRow.owner_user_id == resolved_user_id)
+        if thread_id:
+            stmt = stmt.where(ScheduledTaskRow.thread_id == thread_id)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._row_to_dict(row) for row in result.scalars()]
+
+    async def cancel(
+        self,
+        task_id: str,
+        *,
+        user_id: str | None | _AutoSentinel = AUTO,
+    ) -> bool:
+        resolved_user_id = resolve_user_id(user_id, method_name="ScheduledTaskRepository.cancel")
+        stmt = update(ScheduledTaskRow).where(ScheduledTaskRow.id == task_id).where(ScheduledTaskRow.status.in_([ACTIVE, RUNNING])).values(status=CANCELLED, lease_until=None, updated_at=datetime.now(UTC))
+        if resolved_user_id is not None:
+            stmt = stmt.where(ScheduledTaskRow.owner_user_id == resolved_user_id)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            await session.commit()
+            return bool(result.rowcount)
+
+    async def list_due(self, *, now: datetime, limit: int = 50) -> list[dict[str, Any]]:
+        now = self._coerce_datetime(now)
+        claimable_status = or_(
+            ScheduledTaskRow.status == ACTIVE,
+            and_(ScheduledTaskRow.status == RUNNING, ScheduledTaskRow.lease_until < now),
+        )
+        stmt = select(ScheduledTaskRow).where(claimable_status).where(ScheduledTaskRow.run_at <= now).order_by(ScheduledTaskRow.run_at.asc()).limit(limit)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._row_to_dict(row) for row in result.scalars()]
+
+    async def claim_due(self, task_id: str, *, now: datetime, lease_seconds: int) -> dict[str, Any] | None:
+        now = self._coerce_datetime(now)
+        lease_until = now + timedelta(seconds=lease_seconds)
+        async with self._sf() as session:
+            stmt = (
+                update(ScheduledTaskRow)
+                .where(ScheduledTaskRow.id == task_id)
+                .where(
+                    or_(
+                        ScheduledTaskRow.status == ACTIVE,
+                        and_(ScheduledTaskRow.status == RUNNING, ScheduledTaskRow.lease_until < now),
+                    )
+                )
+                .values(status=RUNNING, lease_until=lease_until, updated_at=now, last_error=None)
+            )
+            result = await session.execute(stmt)
+            if not result.rowcount:
+                await session.rollback()
+                return None
+            await session.commit()
+            row = await session.get(ScheduledTaskRow, task_id)
+            return self._row_to_dict(row) if row else None
+
+    async def mark_completed(self, task_id: str, *, run_id: str | None = None) -> None:
+        await self._mark_terminal(task_id, COMPLETED, run_id=run_id)
+
+    async def mark_failed(self, task_id: str, *, error: str, run_id: str | None = None) -> None:
+        await self._mark_terminal(task_id, FAILED, error=error, run_id=run_id)
+
+    async def mark_missed(self, task_id: str, *, error: str) -> None:
+        await self._mark_terminal(task_id, MISSED, error=error)
+
+    async def _mark_terminal(self, task_id: str, status: str, *, error: str | None = None, run_id: str | None = None) -> None:
+        values: dict[str, Any] = {
+            "status": status,
+            "lease_until": None,
+            "updated_at": datetime.now(UTC),
+        }
+        if error is not None:
+            values["last_error"] = error[:4000]
+        if run_id is not None:
+            values["last_run_id"] = run_id
+        async with self._sf() as session:
+            await session.execute(update(ScheduledTaskRow).where(ScheduledTaskRow.id == task_id).values(**values))
+            await session.commit()

--- a/backend/packages/harness/deerflow/tools/builtins/__init__.py
+++ b/backend/packages/harness/deerflow/tools/builtins/__init__.py
@@ -1,5 +1,6 @@
 from .clarification_tool import ask_clarification_tool
 from .present_file_tool import present_file_tool
+from .schedule_task_tool import schedule_task
 from .setup_agent_tool import setup_agent
 from .task_tool import task_tool
 from .update_agent_tool import update_agent
@@ -9,6 +10,7 @@ __all__ = [
     "setup_agent",
     "update_agent",
     "present_file_tool",
+    "schedule_task",
     "ask_clarification_tool",
     "view_image_tool",
     "task_tool",

--- a/backend/packages/harness/deerflow/tools/builtins/schedule_task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/schedule_task_tool.py
@@ -1,0 +1,137 @@
+"""Built-in tool for creating one-time scheduled runs from a conversation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from langchain_core.messages import ToolMessage
+from langchain_core.tools import tool
+from langgraph.types import Command
+
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.scheduled_tasks import ScheduledTaskRepository
+from deerflow.runtime.user_context import resolve_runtime_user_id
+from deerflow.tools.types import Runtime
+
+
+def _error(tool_call_id: str, message: str) -> Command:
+    return Command(update={"messages": [ToolMessage(content=f"Error: {message}", tool_call_id=tool_call_id, status="error")]})
+
+
+def _parse_run_at(value: str, timezone: str) -> datetime:
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(raw)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo(timezone))
+    return parsed.astimezone(UTC)
+
+
+def _resolve_fire_at(
+    *,
+    run_at: str | None,
+    timezone: str,
+    delay_seconds: int | None,
+    now: datetime,
+) -> datetime | str:
+    has_run_at = isinstance(run_at, str) and bool(run_at.strip())
+    has_delay = delay_seconds is not None
+    if has_run_at == has_delay:
+        return "Provide exactly one of run_at or delay_seconds."
+    if has_delay:
+        if not isinstance(delay_seconds, int) or delay_seconds <= 0:
+            return "delay_seconds must be a positive integer."
+        return now + timedelta(seconds=delay_seconds)
+    try:
+        return _parse_run_at(str(run_at), timezone)
+    except ValueError as exc:
+        return f"run_at must be an ISO-8601 datetime: {exc}"
+
+
+@tool("schedule_task", parse_docstring=True)
+async def schedule_task(
+    runtime: Runtime,
+    task_prompt: str,
+    run_at: str | None = None,
+    title: str | None = None,
+    timezone: str = "UTC",
+    delay_seconds: int | None = None,
+    schedule_type: Literal["once"] = "once",
+) -> Command:
+    """Schedule a one-time DeerFlow run in the current conversation.
+
+    Use this when the user asks DeerFlow to run a task once at a future time.
+    For relative requests such as "in 3 minutes", pass delay_seconds instead of
+    calculating the clock time yourself. For absolute requests such as "tomorrow
+    at 18:00", convert the user's natural language time into an ISO-8601
+    datetime before calling this tool. The first version supports one-time tasks
+    only; do not use it for recurring schedules.
+
+    Args:
+        task_prompt: The instruction DeerFlow should execute when the task fires.
+        run_at: Future ISO-8601 datetime. Include an offset when known, e.g. "2026-06-14T18:00:00+08:00". Required unless delay_seconds is provided.
+        title: Optional short label for the scheduled task.
+        timezone: IANA timezone used when run_at has no offset, e.g. "Asia/Shanghai".
+        delay_seconds: Relative delay in seconds from the server's current time. Use this for "in N minutes/hours" requests.
+        schedule_type: Must be "once"; recurring schedules are not supported yet.
+    """
+    tool_call_id = runtime.tool_call_id
+    context = runtime.context if isinstance(runtime.context, dict) else {}
+    thread_id = context.get("thread_id")
+    if not isinstance(thread_id, str) or not thread_id.strip():
+        return _error(tool_call_id, "Cannot schedule a task without a current thread_id.")
+
+    app_config = context.get("app_config")
+    scheduler_config = getattr(app_config, "scheduler", None)
+    if scheduler_config is not None and not getattr(scheduler_config, "enabled", False):
+        return _error(tool_call_id, "Scheduled tasks are disabled. Set scheduler.enabled=true in config.yaml and restart Gateway.")
+
+    if schedule_type != "once":
+        return _error(tool_call_id, "Recurring schedules are not supported yet. Create a one-time scheduled task instead.")
+
+    prompt = task_prompt.strip()
+    if not prompt:
+        return _error(tool_call_id, "task_prompt must not be empty.")
+
+    try:
+        ZoneInfo(timezone)
+    except ZoneInfoNotFoundError:
+        return _error(tool_call_id, f"Unknown timezone '{timezone}'. Use an IANA timezone such as 'UTC' or 'Asia/Shanghai'.")
+
+    now = datetime.now(UTC)
+    fire_at = _resolve_fire_at(run_at=run_at, timezone=timezone, delay_seconds=delay_seconds, now=now)
+    if isinstance(fire_at, str):
+        return _error(tool_call_id, fire_at)
+
+    if fire_at <= now:
+        return _error(tool_call_id, "run_at must be in the future.")
+
+    session_factory = get_session_factory()
+    if session_factory is None:
+        return _error(tool_call_id, "Scheduled tasks require database.backend to be sqlite or postgres; memory persistence cannot survive restarts.")
+
+    owner_user_id = resolve_runtime_user_id(runtime)
+    repo = ScheduledTaskRepository(session_factory)
+    task = await repo.create_once(
+        owner_user_id=owner_user_id,
+        thread_id=thread_id,
+        prompt=prompt,
+        run_at=fire_at,
+        timezone=timezone,
+        assistant_id=str(context.get("assistant_id") or "lead_agent"),
+        agent_name=str(context.get("agent_name")) if context.get("agent_name") else None,
+        title=title.strip() if isinstance(title, str) and title.strip() else None,
+        channel_name=str(context.get("channel_name")) if context.get("channel_name") else None,
+        chat_id=str(context.get("channel_chat_id")) if context.get("channel_chat_id") else None,
+        topic_id=str(context.get("channel_topic_id")) if context.get("channel_topic_id") else None,
+        thread_ts=str(context.get("channel_thread_ts")) if context.get("channel_thread_ts") else None,
+        channel_user_id=str(context.get("channel_user_id")) if context.get("channel_user_id") else None,
+        connection_id=str(context.get("channel_connection_id")) if context.get("channel_connection_id") else None,
+        owner_channel_user_id=str(context.get("channel_owner_user_id")) if context.get("channel_owner_user_id") else None,
+        metadata={"created_by": "schedule_task"},
+    )
+    content = f"Scheduled task {task['id']} for {task['run_at']}."
+    return Command(update={"messages": [ToolMessage(content=content, tool_call_id=tool_call_id)]})

--- a/backend/packages/harness/deerflow/tools/tools.py
+++ b/backend/packages/harness/deerflow/tools/tools.py
@@ -6,7 +6,7 @@ from deerflow.config import get_app_config
 from deerflow.config.app_config import AppConfig
 from deerflow.reflection import resolve_variable
 from deerflow.sandbox.security import is_host_bash_allowed
-from deerflow.tools.builtins import ask_clarification_tool, present_file_tool, task_tool, view_image_tool
+from deerflow.tools.builtins import ask_clarification_tool, present_file_tool, schedule_task, task_tool, view_image_tool
 from deerflow.tools.mcp_metadata import tag_mcp_tool
 from deerflow.tools.sync import make_sync_tool_wrapper
 
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 BUILTIN_TOOLS = [
     present_file_tool,
     ask_clarification_tool,
+    schedule_task,
 ]
 
 SUBAGENT_TOOLS = [

--- a/backend/tests/test_scheduled_tasks.py
+++ b/backend/tests/test_scheduled_tasks.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.gateway.routers.thread_runs import _record_to_response
+from app.gateway.thread_events import ThreadEventHub
+from deerflow.persistence.base import Base
+from deerflow.persistence.scheduled_tasks import ACTIVE, CANCELLED, COMPLETED, RUNNING, ScheduledTaskRepository
+from deerflow.persistence.scheduled_tasks.model import ScheduledTaskRow
+from deerflow.runtime import DisconnectMode, RunRecord, RunStatus
+from deerflow.tools.builtins.schedule_task_tool import _resolve_fire_at
+
+
+@pytest_asyncio.fixture()
+async def scheduled_task_repo():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=[ScheduledTaskRow.__table__])
+    try:
+        yield ScheduledTaskRepository(async_sessionmaker(engine, expire_on_commit=False))
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_and_list_scheduled_task_is_user_scoped(scheduled_task_repo: ScheduledTaskRepository):
+    run_at = datetime.now(UTC) + timedelta(minutes=5)
+    created = await scheduled_task_repo.create_once(
+        owner_user_id="user-a",
+        thread_id="thread-1",
+        prompt="Run the backup check",
+        run_at=run_at,
+        title="Backup",
+    )
+
+    assert created["status"] == ACTIVE
+    assert created["thread_id"] == "thread-1"
+    assert created["title"] == "Backup"
+
+    own_tasks = await scheduled_task_repo.list(user_id="user-a")
+    other_tasks = await scheduled_task_repo.list(user_id="user-b")
+
+    assert [task["id"] for task in own_tasks] == [created["id"]]
+    assert other_tasks == []
+
+
+@pytest.mark.asyncio
+async def test_claim_due_task_is_atomic(scheduled_task_repo: ScheduledTaskRepository):
+    now = datetime.now(UTC)
+    created = await scheduled_task_repo.create_once(
+        owner_user_id="user-a",
+        thread_id="thread-1",
+        prompt="Run the backup check",
+        run_at=now - timedelta(seconds=1),
+    )
+
+    due = await scheduled_task_repo.list_due(now=now)
+    assert [task["id"] for task in due] == [created["id"]]
+
+    claimed = await scheduled_task_repo.claim_due(created["id"], now=now, lease_seconds=60)
+    claimed_again = await scheduled_task_repo.claim_due(created["id"], now=now, lease_seconds=60)
+
+    assert claimed is not None
+    assert claimed["status"] == RUNNING
+    assert claimed_again is None
+
+
+@pytest.mark.asyncio
+async def test_expired_running_task_can_be_reclaimed(scheduled_task_repo: ScheduledTaskRepository):
+    first_now = datetime.now(UTC)
+    created = await scheduled_task_repo.create_once(
+        owner_user_id="user-a",
+        thread_id="thread-1",
+        prompt="Run the backup check",
+        run_at=first_now - timedelta(seconds=1),
+    )
+
+    assert await scheduled_task_repo.claim_due(created["id"], now=first_now, lease_seconds=1) is not None
+    later = first_now + timedelta(seconds=2)
+
+    due = await scheduled_task_repo.list_due(now=later)
+    reclaimed = await scheduled_task_repo.claim_due(created["id"], now=later, lease_seconds=60)
+
+    assert [task["id"] for task in due] == [created["id"]]
+    assert reclaimed is not None
+    assert reclaimed["status"] == RUNNING
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_complete_status_transitions(scheduled_task_repo: ScheduledTaskRepository):
+    run_at = datetime.now(UTC) + timedelta(minutes=5)
+    first = await scheduled_task_repo.create_once(
+        owner_user_id="user-a",
+        thread_id="thread-1",
+        prompt="Run the backup check",
+        run_at=run_at,
+    )
+    second = await scheduled_task_repo.create_once(
+        owner_user_id="user-a",
+        thread_id="thread-1",
+        prompt="Run the report",
+        run_at=run_at,
+    )
+
+    assert await scheduled_task_repo.cancel(first["id"], user_id="user-a") is True
+    assert await scheduled_task_repo.cancel(first["id"], user_id="user-a") is False
+    cancelled = await scheduled_task_repo.get(first["id"], user_id="user-a")
+    assert cancelled is not None
+    assert cancelled["status"] == CANCELLED
+
+    await scheduled_task_repo.mark_completed(second["id"], run_id="run-1")
+    completed = await scheduled_task_repo.get(second["id"], user_id="user-a")
+    assert completed is not None
+    assert completed["status"] == COMPLETED
+    assert completed["last_run_id"] == "run-1"
+
+
+@pytest.mark.asyncio
+async def test_thread_event_hub_fans_out_by_thread_and_user():
+    hub = ThreadEventHub()
+
+    async with (
+        hub.subscribe("thread-1", "user-a") as own_queue,
+        hub.subscribe("thread-1", "user-b") as other_user_queue,
+        hub.subscribe("thread-2", "user-a") as other_thread_queue,
+    ):
+        await hub.publish(
+            "thread-1",
+            "scheduled_run_completed",
+            {"scheduled_task_id": "task-1"},
+            user_id="user-a",
+        )
+
+        event = await asyncio.wait_for(own_queue.get(), timeout=1)
+        assert event is not None
+        assert event.event == "scheduled_run_completed"
+        assert event.data["scheduled_task_id"] == "task-1"
+        assert other_user_queue.empty()
+        assert other_thread_queue.empty()
+
+
+def test_run_response_filters_runtime_only_kwargs():
+    record = RunRecord(
+        run_id="run-1",
+        thread_id="thread-1",
+        assistant_id="lead_agent",
+        status=RunStatus.success,
+        on_disconnect=DisconnectMode.continue_,
+        kwargs={
+            "config": {
+                "configurable": {
+                    "thread_id": "thread-1",
+                    "__pregel_runtime": object(),
+                },
+                "callbacks": [object()],
+            }
+        },
+    )
+
+    response = _record_to_response(record)
+
+    assert response.kwargs == {"config": {"configurable": {"thread_id": "thread-1"}}}
+
+
+def test_schedule_task_resolves_relative_delay_from_server_time():
+    now = datetime(2026, 6, 14, 10, 0, tzinfo=UTC)
+
+    fire_at = _resolve_fire_at(
+        run_at=None,
+        timezone="Asia/Shanghai",
+        delay_seconds=180,
+        now=now,
+    )
+
+    assert fire_at == now + timedelta(seconds=180)
+
+
+def test_schedule_task_requires_exactly_one_time_source():
+    now = datetime(2026, 6, 14, 10, 0, tzinfo=UTC)
+
+    assert (
+        _resolve_fire_at(
+            run_at="2026-06-14T18:00:00+08:00",
+            timezone="Asia/Shanghai",
+            delay_seconds=60,
+            now=now,
+        )
+        == "Provide exactly one of run_at or delay_seconds."
+    )

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,7 +15,7 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 12
+config_version: 13
 
 # ============================================================================
 # Logging
@@ -1165,6 +1165,20 @@ run_events:
   backend: memory
   max_trace_content: 10240
   track_token_usage: true
+
+# ============================================================================
+# Scheduled Runs Configuration
+# ============================================================================
+# Lets the lead agent create one-time scheduled tasks from a conversation via
+# the built-in `schedule_task` tool. Requires database.backend to be sqlite or
+# postgres so tasks survive Gateway restarts. The first implementation supports
+# one-time tasks only; recurring schedules are planned separately.
+scheduler:
+  enabled: false
+  poll_interval_seconds: 5.0
+  max_concurrent_runs: 2
+  claim_ttl_seconds: 300
+  misfire_grace_time_seconds: 300
 
 # ============================================================================
 # User-Owned IM Channel Connections

--- a/frontend/src/app/workspace/chats/[thread_id]/layout.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/layout.tsx
@@ -3,6 +3,8 @@ import { DEMO_THREAD_IDS } from "@/core/threads/static-demo";
 
 import { ChatProviders } from "./providers";
 
+export const dynamicParams = true;
+
 export function generateStaticParams() {
   if (!isStaticWebsiteOnly()) {
     return [];

--- a/frontend/src/app/workspace/chats/new/page.tsx
+++ b/frontend/src/app/workspace/chats/new/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import ChatPage from "../[thread_id]/page";
+import { ChatProviders } from "../[thread_id]/providers";
+
+export default function NewChatPage() {
+  return (
+    <ChatProviders>
+      <ChatPage />
+    </ChatProviders>
+  );
+}

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -153,6 +153,30 @@ type RunMessagesPageResponse = {
   hasMore?: boolean;
 };
 
+type ThreadEventPayload = {
+  run_id?: string | null;
+  status?: string;
+  thread_id?: string;
+  type?: string;
+};
+
+function isDisplayableRunMessage(message: RunMessage) {
+  if (message.metadata.caller?.startsWith("middleware:")) {
+    return false;
+  }
+  if (
+    message.metadata.source === "scheduled_task" &&
+    message.content.type === "human"
+  ) {
+    return false;
+  }
+  return !isHiddenFromUIMessage(message.content);
+}
+
+function isDisplayableScheduledRunMessage(message: RunMessage) {
+  return isDisplayableRunMessage(message) && message.content.type === "ai";
+}
+
 export function runMessagesPageHasMore(result: RunMessagesPageResponse) {
   return result.has_more ?? result.hasMore ?? false;
 }
@@ -193,6 +217,16 @@ export function buildRunMessagesUrl(
   if (beforeSeq !== undefined) {
     url.searchParams.set("before_seq", String(beforeSeq));
   }
+  return normalizedBaseUrl ? url.toString() : `${url.pathname}${url.search}`;
+}
+
+export function buildThreadEventsUrl(baseUrl: string, threadId: string) {
+  const normalizedBaseUrl = baseUrl.replace(/\/$/, "");
+  const path = `/api/threads/${encodeURIComponent(threadId)}/events`;
+  const url = new URL(
+    `${normalizedBaseUrl}${path}`,
+    typeof window !== "undefined" ? window.location.origin : "http://localhost",
+  );
   return normalizedBaseUrl ? url.toString() : `${url.pathname}${url.search}`;
 }
 
@@ -421,6 +455,7 @@ export function useThreadStream({
   const [liveMessagesThreadId, setLiveMessagesThreadId] = useState<
     string | null
   >(null);
+  const [backgroundMessages, setBackgroundMessages] = useState<Message[]>([]);
   const [isUploading, setIsUploading] = useState(false);
   // Track the thread ID that is currently streaming to handle thread changes during streaming
   const [onStreamThreadId, setOnStreamThreadId] = useState(() => threadId);
@@ -494,6 +529,94 @@ export function useThreadStream({
 
   const queryClient = useQueryClient();
   const updateSubtask = useUpdateSubtask();
+
+  useEffect(() => {
+    if (isMock || !onStreamThreadId || typeof window === "undefined") {
+      return;
+    }
+
+    const subscribedThreadId = onStreamThreadId;
+    const source = new EventSource(
+      buildThreadEventsUrl(getBackendBaseURL(), subscribedThreadId),
+      { withCredentials: true },
+    );
+
+    const refreshThreadHistory = () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["thread", subscribedThreadId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ["threads", "search"] });
+      void queryClient.invalidateQueries({
+        queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: threadTokenUsageQueryKey(subscribedThreadId),
+      });
+    };
+
+    const fetchRunMessages = async (runId: string) => {
+      const url = buildRunMessagesUrl(
+        getBackendBaseURL(),
+        subscribedThreadId,
+        runId,
+      );
+      const result: RunMessagesPageResponse = await fetch(url, {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }).then((res) => res.json());
+      const messages = result.data
+        .filter(isDisplayableScheduledRunMessage)
+        .map((m) => m.content);
+      if (messages.length > 0) {
+        setBackgroundMessages((prev) =>
+          dedupeMessagesByIdentity([...prev, ...messages]),
+        );
+      }
+    };
+
+    const handleScheduledRunEvent = (event: MessageEvent<string>) => {
+      refreshThreadHistory();
+      let payload: ThreadEventPayload | null = null;
+      try {
+        payload = JSON.parse(event.data) as ThreadEventPayload;
+      } catch {
+        payload = null;
+      }
+      const runId = payload?.run_id;
+      if (typeof runId === "string" && runId.length > 0) {
+        void fetchRunMessages(runId).catch((error: unknown) => {
+          console.warn("[deer-flow] Failed to load scheduled run messages", error);
+        });
+      }
+    };
+
+    source.addEventListener("ready", refreshThreadHistory);
+    source.addEventListener("scheduled_run_completed", handleScheduledRunEvent);
+    source.addEventListener("scheduled_run_failed", handleScheduledRunEvent);
+    source.addEventListener("scheduled_run_missed", handleScheduledRunEvent);
+
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) {
+        return;
+      }
+      console.warn(
+        `[deer-flow] Thread event stream interrupted for ${subscribedThreadId}; browser will retry.`,
+      );
+    };
+
+    return () => {
+      source.removeEventListener("ready", refreshThreadHistory);
+      source.removeEventListener(
+        "scheduled_run_completed",
+        handleScheduledRunEvent,
+      );
+      source.removeEventListener("scheduled_run_failed", handleScheduledRunEvent);
+      source.removeEventListener("scheduled_run_missed", handleScheduledRunEvent);
+      source.close();
+    };
+  }, [isMock, onStreamThreadId, queryClient]);
 
   const thread = useStream<AgentThreadState>({
     client: getAPIClient(isMock),
@@ -722,6 +845,7 @@ export function useThreadStream({
     sendInFlightRef.current = false;
     messagesRef.current = [];
     summarizedRef.current = new Set<string>();
+    setBackgroundMessages([]);
     pendingUsageBaselineMessageIdsRef.current = new Set();
     prevHumanMsgCountRef.current =
       latestMessageCountsRef.current.humanMessageCount;
@@ -994,11 +1118,23 @@ export function useThreadStream({
     prevHumanMsgCountRef.current,
     humanMessageCount,
   );
+  const visibleMessageIds = new Set(
+    [...visibleHistory, ...persistedMessages]
+      .map(messageIdentity)
+      .filter((id): id is string => Boolean(id)),
+  );
+  const pendingBackgroundMessages = backgroundMessages.filter((message) => {
+    const identity = messageIdentity(message);
+    return !identity || !visibleMessageIds.has(identity);
+  });
 
   const mergedMessages = mergeMessages(
     visibleHistory,
     persistedMessages,
-    visibleOptimisticMessages,
+    dedupeMessagesByIdentity([
+      ...pendingBackgroundMessages,
+      ...visibleOptimisticMessages,
+    ]),
   );
   const pendingUsageMessages = thread.isLoading
     ? getMessagesAfterBaseline(
@@ -1112,7 +1248,7 @@ export function useThreadHistory(
           return;
         }
         const _messages = result.data
-          .filter((m) => !m.metadata.caller?.startsWith("middleware:"))
+          .filter(isDisplayableRunMessage)
           .map((m) => m.content);
         setMessages((prev) =>
           dedupeMessagesByIdentity([..._messages, ...prev]),

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -29,6 +29,7 @@ export interface RunMessage {
   content: Message;
   metadata: {
     caller: string;
+    source?: string;
   };
   created_at: string;
 }


### PR DESCRIPTION
Refs #3525

## Why

This PR adds the first phase of conversation-created scheduled runs.

The issue asks DeerFlow to support scheduled tasks from a conversation. Without this, users cannot ask the agent to run a reminder or follow-up task at a future time, and browser users need to manually refresh to see scheduled results.

This implementation focuses on one-time scheduled runs first, keeping recurring schedules out of scope for a follow-up discussion.

## What changed

- Added a built-in `schedule_task` tool for creating one-time scheduled tasks from the current conversation.
- Added persistent scheduled task storage backed by the existing sqlite/postgres persistence layer.
- Added a Gateway-local scheduler service that polls due tasks, claims them with a DB lease, and executes them through the normal DeerFlow run path.
- Added thread-scoped SSE events so the web chat can refresh scheduled run results without requiring a browser refresh.
- Added scheduled task management APIs for listing, reading, and cancelling scheduled tasks.
- Added support for relative delays via `delay_seconds`, so requests like "remind me in 3 minutes" do not require the model to know the current clock time.
- Hid internal scheduled-run trigger messages from the chat UI to avoid exposing scheduler prompts to users.
- Fixed `/workspace/chats/new` routing so users can reliably open a new chat route.
- Added scheduler configuration, documentation, and regression tests.

The scheduler is disabled by default:

```yaml
scheduler:
  enabled: false
It requires database.backend to be sqlite or postgres because scheduled tasks need durable persistence.
## Surface area
```

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

<img width="2014" height="918" alt="image" src="https://github.com/user-attachments/assets/5915cf49-6a91-4cb2-b1a9-a70adc65a243" />
<img width="1852" height="934" alt="image" src="https://github.com/user-attachments/assets/7edeca1e-bc5b-4d64-b991-5ea253583215" />


## Bug fix verification

N/A - this is primarily a feature PR.

## Validation

Ran:

```bash
cd backend && uv run ruff check app packages/harness/deerflow tests/test_scheduled_tasks.py
cd backend && uv run ruff format --check app packages/harness/deerflow tests/test_scheduled_tasks.py
cd backend && uv run pytest
cd frontend && pnpm check
git diff --cached --check

Results:
Backend full test suite: 4392 passed, 16 skipped
Backend ruff check: passed
Backend ruff format check: passed
Frontend lint/typecheck: passed
Cached diff whitespace check: passed