### PR TITLE
fix(channels): add operational guardrails

### DIFF
--- a/backend/app/channels/dingtalk.py
+++ b/backend/app/channels/dingtalk.py
@@ -376,12 +376,12 @@ class DingTalkChannel(Channel):
                 return
 
             logger.info(
-                "[DingTalk] parsed message: conv_type=%s, msg_id=%s, sender=%s(%s), text_len=%d",
+                "[DingTalk] parsed message: conv_type=%s, msg_id=%s, sender=%s(%s), text=%r",
                 conversation_type,
                 msg_id,
                 sender_staff_id,
                 sender_nick,
-                len(text or ""),
+                text[:100],
             )
 
             connect_code = extract_connect_code(text)

--- a/backend/app/channels/dingtalk.py
+++ b/backend/app/channels/dingtalk.py
@@ -376,12 +376,12 @@ class DingTalkChannel(Channel):
                 return
 
             logger.info(
-                "[DingTalk] parsed message: conv_type=%s, msg_id=%s, sender=%s(%s), text=%r",
+                "[DingTalk] parsed message: conv_type=%s, msg_id=%s, sender=%s(%s), text_len=%d",
                 conversation_type,
                 msg_id,
                 sender_staff_id,
                 sender_nick,
-                text[:100],
+                len(text or ""),
             )
 
             connect_code = extract_connect_code(text)

--- a/backend/app/channels/feishu.py
+++ b/backend/app/channels/feishu.py
@@ -837,14 +837,14 @@ class FeishuChannel(Channel):
             text = text.strip()
 
             logger.info(
-                "[Feishu] parsed message: chat_id=%s, msg_id=%s, root_id=%s, parent_id=%s, thread_id=%s, sender=%s, text=%r",
+                "[Feishu] parsed message: chat_id=%s, msg_id=%s, root_id=%s, parent_id=%s, thread_id=%s, sender=%s, text_len=%d",
                 chat_id,
                 msg_id,
                 root_id,
                 parent_id,
                 feishu_thread_id,
                 sender_id,
-                text[:100] if text else "",
+                len(text or ""),
             )
 
             if not (text or files_list):

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -62,6 +62,9 @@ MESSAGE_STREAM_EVENTS = ("messages-tuple", "messages")
 THREAD_BUSY_MESSAGE = "This conversation is already processing another request. Please wait for it to finish and try again."
 BOUND_IDENTITY_REQUIRED_MESSAGE = "Connect this channel from DeerFlow Settings, complete the in-channel connect step, then send your message again."
 BOUND_IDENTITY_UNAVAILABLE_MESSAGE = "Channel connection verification is temporarily unavailable. Please try again later or contact the DeerFlow operator."
+INBOUND_DEDUPE_TTL_SECONDS = 10 * 60
+INBOUND_DEDUPE_MAX_ENTRIES = 4096
+INBOUND_DEDUPE_METADATA_KEYS = ("event_id", "message_id", "msg_id", "client_msg_id", "client_id")
 
 CHANNEL_CAPABILITIES = {
     "dingtalk": {"supports_streaming": False},
@@ -774,6 +777,7 @@ class ChannelManager:
         self._semaphore: asyncio.Semaphore | None = None
         self._running = False
         self._task: asyncio.Task | None = None
+        self._recent_inbound_events: dict[tuple[str, str, str, str], float] = {}
 
     @staticmethod
     def _channel_supports_streaming(channel_name: str) -> bool:
@@ -920,14 +924,73 @@ class ChannelManager:
                 break
 
             logger.info(
-                "[Manager] received inbound: channel=%s, chat_id=%s, type=%s, text=%r",
+                "[Manager] received inbound: channel=%s, chat_id=%s, type=%s, text_len=%d, files=%d",
                 msg.channel_name,
                 msg.chat_id,
                 msg.msg_type.value,
-                msg.text[:100] if msg.text else "",
+                len(msg.text or ""),
+                len(msg.files),
             )
+            if self._is_duplicate_inbound(msg):
+                continue
             task = asyncio.create_task(self._handle_message(msg))
             task.add_done_callback(self._log_task_error)
+
+    @staticmethod
+    def _inbound_dedupe_key(msg: InboundMessage) -> tuple[str, str, str, str] | None:
+        metadata = msg.metadata or {}
+        message_id = None
+        for key in INBOUND_DEDUPE_METADATA_KEYS:
+            value = metadata.get(key)
+            if value:
+                message_id = str(value)
+                break
+        if message_id is None:
+            raw_message = metadata.get("raw_message")
+            if isinstance(raw_message, Mapping):
+                for key in INBOUND_DEDUPE_METADATA_KEYS:
+                    value = raw_message.get(key)
+                    if value:
+                        message_id = str(value)
+                        break
+        if message_id is None:
+            return None
+
+        workspace_id = (
+            msg.workspace_id
+            or metadata.get("workspace_id")
+            or metadata.get("team_id")
+            or metadata.get("guild_id")
+            or metadata.get("aibotid")
+            or ""
+        )
+        return (msg.channel_name, str(workspace_id), msg.chat_id, message_id)
+
+    def _is_duplicate_inbound(self, msg: InboundMessage) -> bool:
+        key = self._inbound_dedupe_key(msg)
+        if key is None:
+            return False
+
+        now = time.monotonic()
+        for seen_key, seen_at in list(self._recent_inbound_events.items()):
+            if now - seen_at > INBOUND_DEDUPE_TTL_SECONDS:
+                self._recent_inbound_events.pop(seen_key, None)
+        if len(self._recent_inbound_events) > INBOUND_DEDUPE_MAX_ENTRIES:
+            overflow = len(self._recent_inbound_events) - INBOUND_DEDUPE_MAX_ENTRIES
+            for seen_key in list(self._recent_inbound_events)[:overflow]:
+                self._recent_inbound_events.pop(seen_key, None)
+
+        if key in self._recent_inbound_events:
+            logger.info(
+                "[Manager] duplicate inbound ignored: channel=%s, chat_id=%s, message_id=%s",
+                msg.channel_name,
+                msg.chat_id,
+                key[-1],
+            )
+            return True
+
+        self._recent_inbound_events[key] = now
+        return False
 
     @staticmethod
     def _log_task_error(task: asyncio.Task) -> None:
@@ -1169,7 +1232,7 @@ class ChannelManager:
             )
             return
 
-        logger.info("[Manager] invoking runs.wait(thread_id=%s, text=%r)", thread_id, msg.text[:100])
+        logger.info("[Manager] invoking runs.wait(thread_id=%s, text_len=%d)", thread_id, len(msg.text or ""))
         run_kwargs: dict[str, Any] = {
             "input": {"messages": [human_message]},
             "config": run_config,
@@ -1236,7 +1299,7 @@ class ChannelManager:
         run_context: dict[str, Any],
         human_message: dict[str, Any],
     ) -> None:
-        logger.info("[Manager] invoking runs.stream(thread_id=%s, text=%r)", thread_id, msg.text[:100])
+        logger.info("[Manager] invoking runs.stream(thread_id=%s, text_len=%d)", thread_id, len(msg.text or ""))
 
         last_values: dict[str, Any] | list | None = None
         streamed_buffers: dict[str, str] = {}

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -956,14 +956,7 @@ class ChannelManager:
         if message_id is None:
             return None
 
-        workspace_id = (
-            msg.workspace_id
-            or metadata.get("workspace_id")
-            or metadata.get("team_id")
-            or metadata.get("guild_id")
-            or metadata.get("aibotid")
-            or ""
-        )
+        workspace_id = msg.workspace_id or metadata.get("workspace_id") or metadata.get("team_id") or metadata.get("guild_id") or metadata.get("aibotid") or ""
         return (msg.channel_name, str(workspace_id), msg.chat_id, message_id)
 
     def _is_duplicate_inbound(self, msg: InboundMessage) -> bool:

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -7,6 +7,7 @@ import logging
 import mimetypes
 import re
 import time
+from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,7 +65,10 @@ BOUND_IDENTITY_REQUIRED_MESSAGE = "Connect this channel from DeerFlow Settings, 
 BOUND_IDENTITY_UNAVAILABLE_MESSAGE = "Channel connection verification is temporarily unavailable. Please try again later or contact the DeerFlow operator."
 INBOUND_DEDUPE_TTL_SECONDS = 10 * 60
 INBOUND_DEDUPE_MAX_ENTRIES = 4096
-INBOUND_DEDUPE_METADATA_KEYS = ("event_id", "message_id", "msg_id", "client_msg_id", "client_id")
+# Only server-stable provider message ids: client-generated ids (client_msg_id,
+# client_id) are not guaranteed identical across a provider's own redelivery, so
+# keying dedupe on them would miss exactly the retries we want to absorb.
+INBOUND_DEDUPE_METADATA_KEYS = ("event_id", "message_id", "msg_id")
 
 CHANNEL_CAPABILITIES = {
     "dingtalk": {"supports_streaming": False},
@@ -777,7 +781,10 @@ class ChannelManager:
         self._semaphore: asyncio.Semaphore | None = None
         self._running = False
         self._task: asyncio.Task | None = None
-        self._recent_inbound_events: dict[tuple[str, str, str, str], float] = {}
+        # Insertion order == chronological (keys are never re-inserted), so an
+        # OrderedDict lets us evict expired/overflow entries from the front in
+        # O(k) instead of scanning all entries on every inbound message.
+        self._recent_inbound_events: OrderedDict[tuple[str, str, str, str], float] = OrderedDict()
 
     @staticmethod
     def _channel_supports_streaming(channel_name: str) -> bool:
@@ -923,6 +930,14 @@ class ChannelManager:
             except asyncio.CancelledError:
                 break
 
+            # Dedupe before logging "received" so a provider retrying an event N
+            # times does not log N accepts; duplicates are logged once as ignored.
+            # Note: this manager-level dedupe only guards the agent run / final
+            # answer. Provider adapters may emit ack side-effects (a "Working on
+            # it…" reply, an "eyes" reaction) before publish_inbound, so those are
+            # intentionally not deduped here.
+            if self._is_duplicate_inbound(msg):
+                continue
             logger.info(
                 "[Manager] received inbound: channel=%s, chat_id=%s, type=%s, text_len=%d, files=%d",
                 msg.channel_name,
@@ -931,8 +946,6 @@ class ChannelManager:
                 len(msg.text or ""),
                 len(msg.files),
             )
-            if self._is_duplicate_inbound(msg):
-                continue
             task = asyncio.create_task(self._handle_message(msg))
             task.add_done_callback(self._log_task_error)
 
@@ -970,13 +983,16 @@ class ChannelManager:
             return False
 
         now = time.monotonic()
-        for seen_key, seen_at in list(self._recent_inbound_events.items()):
-            if now - seen_at > INBOUND_DEDUPE_TTL_SECONDS:
-                self._recent_inbound_events.pop(seen_key, None)
-        if len(self._recent_inbound_events) > INBOUND_DEDUPE_MAX_ENTRIES:
-            overflow = len(self._recent_inbound_events) - INBOUND_DEDUPE_MAX_ENTRIES
-            for seen_key in list(self._recent_inbound_events)[:overflow]:
-                self._recent_inbound_events.pop(seen_key, None)
+        # Entries are in chronological insertion order, so expired ones cluster at
+        # the front: pop from the front until we hit a still-live entry.
+        while self._recent_inbound_events:
+            _, oldest_at = next(iter(self._recent_inbound_events.items()))
+            if now - oldest_at > INBOUND_DEDUPE_TTL_SECONDS:
+                self._recent_inbound_events.popitem(last=False)
+            else:
+                break
+        while len(self._recent_inbound_events) > INBOUND_DEDUPE_MAX_ENTRIES:
+            self._recent_inbound_events.popitem(last=False)
 
         if key in self._recent_inbound_events:
             logger.info(

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -956,7 +956,12 @@ class ChannelManager:
         if message_id is None:
             return None
 
-        workspace_id = msg.workspace_id or metadata.get("workspace_id") or metadata.get("team_id") or metadata.get("guild_id") or metadata.get("aibotid") or ""
+        # Fail closed: without a workspace/team/guild identifier we cannot tell two
+        # workspaces apart (e.g. Slack channel ids are not globally unique), so
+        # skip dedupe rather than risk collapsing distinct workspaces' messages.
+        workspace_id = msg.workspace_id or metadata.get("workspace_id") or metadata.get("team_id") or metadata.get("guild_id") or metadata.get("aibotid")
+        if not workspace_id:
+            return None
         return (msg.channel_name, str(workspace_id), msg.chat_id, message_id)
 
     def _is_duplicate_inbound(self, msg: InboundMessage) -> bool:
@@ -984,6 +989,18 @@ class ChannelManager:
 
         self._recent_inbound_events[key] = now
         return False
+
+    def _release_inbound_dedupe_key(self, msg: InboundMessage) -> None:
+        """Drop a recorded dedupe key so a provider redelivery can be reprocessed.
+
+        Called only on transient/unexpected handling failures: the key was
+        recorded on receipt so retries arriving *while* the message is being
+        handled are still deduped, but if handling fails we must not turn a
+        recoverable error into a TTL-long black hole for the same message_id.
+        """
+        key = self._inbound_dedupe_key(msg)
+        if key is not None:
+            self._recent_inbound_events.pop(key, None)
 
     @staticmethod
     def _log_task_error(task: asyncio.Task) -> None:
@@ -1035,6 +1052,10 @@ class ChannelManager:
                 msg.channel_name,
                 msg.chat_id,
             )
+            # Transient/unexpected failure: release the dedupe key so a provider
+            # redelivery of the same message can recover instead of being dropped
+            # for the dedupe TTL.
+            self._release_inbound_dedupe_key(msg)
             await self._send_error(msg, "An internal error occurred. Please try again.")
 
     # -- chat handling -----------------------------------------------------

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -312,7 +312,7 @@ class SlackChannel(Channel):
                 asyncio.run_coroutine_threadsafe(
                     self._bind_connection_from_connect_code(
                         event=event,
-                        team_id=str(team_id or event.get("team") or ""),
+                        team_id=str(team_id or ""),
                         code=connect_code,
                     ),
                     self._loop,
@@ -337,7 +337,8 @@ class SlackChannel(Channel):
             msg_type=msg_type,
             thread_ts=thread_ts,
             metadata={
-                "team_id": team_id or event.get("team"),
+                # team_id is already resolved (payload team_id/team, else event team) by the caller.
+                "team_id": team_id,
                 "message_id": event.get("ts"),
                 "client_msg_id": event.get("client_msg_id"),
             },

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -90,15 +90,8 @@ class SlackChannel(Channel):
         bot_token = self.config.get("bot_token", "")
         app_token = self.config.get("app_token", "")
 
-        if self._connection_repo is not None and self.config.get("event_delivery") == "http":
-            if not bot_token:
-                logger.error("Slack HTTP Events mode requires bot_token")
-                return
-            await self._initialize_operator_web_client(str(bot_token))
-            self._loop = asyncio.get_event_loop()
-            self._running = True
-            self.bus.subscribe_outbound(self._on_outbound)
-            logger.info("Slack channel started in HTTP Events mode")
+        if self.config.get("event_delivery") == "http":
+            logger.error("Slack HTTP Events mode is not supported by this channel adapter; use Socket Mode with app_token")
             return
 
         if not bot_token or not app_token:
@@ -343,6 +336,11 @@ class SlackChannel(Channel):
             text=text,
             msg_type=msg_type,
             thread_ts=thread_ts,
+            metadata={
+                "team_id": team_id or event.get("team"),
+                "message_id": event.get("ts"),
+                "client_msg_id": event.get("client_msg_id"),
+            },
         )
         inbound.topic_id = thread_ts
 

--- a/backend/app/channels/telegram.py
+++ b/backend/app/channels/telegram.py
@@ -503,6 +503,7 @@ class TelegramChannel(Channel):
             text=text,
             msg_type=InboundMessageType.COMMAND,
             thread_ts=msg_id,
+            metadata={"message_id": msg_id},
         )
         inbound.topic_id = topic_id
         inbound = await self._attach_connection_identity(inbound)
@@ -546,6 +547,7 @@ class TelegramChannel(Channel):
             text=text,
             msg_type=InboundMessageType.CHAT,
             thread_ts=msg_id,
+            metadata={"message_id": msg_id},
         )
         inbound.topic_id = topic_id
         inbound = await self._attach_connection_identity(inbound)

--- a/backend/app/channels/wechat.py
+++ b/backend/app/channels/wechat.py
@@ -600,7 +600,8 @@ class WechatChannel(Channel):
             return
 
         context_token = str(raw_message.get("context_token") or "").strip()
-        thread_ts = context_token or str(raw_message.get("client_id") or raw_message.get("msg_id") or "").strip() or None
+        message_id = str(raw_message.get("message_id") or raw_message.get("msg_id") or raw_message.get("client_id") or "").strip()
+        thread_ts = context_token or message_id or None
 
         if context_token:
             self._context_tokens_by_chat[chat_id] = context_token
@@ -627,6 +628,7 @@ class WechatChannel(Channel):
             metadata={
                 "context_token": context_token,
                 "ilink_user_id": chat_id,
+                "message_id": message_id,
                 "ref_msg": self._extract_ref_message(raw_message),
                 "raw_message": raw_message,
             },

--- a/backend/app/channels/wechat.py
+++ b/backend/app/channels/wechat.py
@@ -600,8 +600,7 @@ class WechatChannel(Channel):
             return
 
         context_token = str(raw_message.get("context_token") or "").strip()
-        message_id = str(raw_message.get("message_id") or raw_message.get("msg_id") or raw_message.get("client_id") or "").strip()
-        thread_ts = context_token or message_id or None
+        thread_ts = context_token or str(raw_message.get("client_id") or raw_message.get("msg_id") or "").strip() or None
 
         if context_token:
             self._context_tokens_by_chat[chat_id] = context_token
@@ -628,7 +627,7 @@ class WechatChannel(Channel):
             metadata={
                 "context_token": context_token,
                 "ilink_user_id": chat_id,
-                "message_id": message_id,
+                "message_id": str(raw_message.get("message_id") or raw_message.get("msg_id") or "").strip(),
                 "ref_msg": self._extract_ref_message(raw_message),
                 "raw_message": raw_message,
             },

--- a/backend/app/channels/wecom.py
+++ b/backend/app/channels/wecom.py
@@ -313,7 +313,11 @@ class WeComChannel(Channel):
             msg_type=inbound_type,
             thread_ts=msg_id,
             files=files or [],
-            metadata={"aibotid": body.get("aibotid"), "chattype": body.get("chattype")},
+            metadata={
+                "aibotid": body.get("aibotid"),
+                "chattype": body.get("chattype"),
+                "message_id": msg_id,
+            },
         )
         inbound.topic_id = user_id  # keep the same thread
 

--- a/backend/app/gateway/routers/channel_connections.py
+++ b/backend/app/gateway/routers/channel_connections.py
@@ -24,6 +24,7 @@ router = APIRouter(prefix="/api/channels", tags=["channel-connections"])
 logger = logging.getLogger(__name__)
 
 _STATE_TTL_SECONDS = 600
+_MAX_PENDING_CONNECT_CODES_PER_PROVIDER = 5
 _MASKED_CREDENTIAL_VALUE = "********"
 
 
@@ -332,12 +333,26 @@ async def _create_state(
     owner_user_id: str,
     provider: str,
 ) -> str:
+    now = datetime.now(UTC)
+    await repo.delete_expired_oauth_states(now=now)
+    pending_count = await repo.count_oauth_states(
+        owner_user_id=owner_user_id,
+        provider=provider,
+        active_only=True,
+        now=now,
+    )
+    if pending_count >= _MAX_PENDING_CONNECT_CODES_PER_PROVIDER:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many pending channel connection codes. Wait for existing codes to expire or use one of them.",
+        )
+
     state = _new_binding_code()
     await repo.create_oauth_state(
         owner_user_id=owner_user_id,
         provider=provider,
         state=state,
-        expires_at=datetime.now(UTC) + timedelta(seconds=_STATE_TTL_SECONDS),
+        expires_at=now + timedelta(seconds=_STATE_TTL_SECONDS),
     )
     return state
 

--- a/backend/app/gateway/routers/channel_connections.py
+++ b/backend/app/gateway/routers/channel_connections.py
@@ -334,26 +334,22 @@ async def _create_state(
     provider: str,
 ) -> str:
     now = datetime.now(UTC)
-    await repo.delete_expired_oauth_states(now=now)
-    pending_count = await repo.count_oauth_states(
-        owner_user_id=owner_user_id,
-        provider=provider,
-        active_only=True,
-        now=now,
-    )
-    if pending_count >= _MAX_PENDING_CONNECT_CODES_PER_PROVIDER:
-        raise HTTPException(
-            status_code=429,
-            detail="Too many pending channel connection codes. Wait for existing codes to expire or use one of them.",
-        )
-
     state = _new_binding_code()
-    await repo.create_oauth_state(
+    # Atomic delete-expired + count + insert so concurrent connect POSTs from one
+    # owner cannot each see count < cap and all insert past the cap.
+    inserted = await repo.create_oauth_state_within_cap(
         owner_user_id=owner_user_id,
         provider=provider,
         state=state,
         expires_at=now + timedelta(seconds=_STATE_TTL_SECONDS),
+        max_pending=_MAX_PENDING_CONNECT_CODES_PER_PROVIDER,
+        now=now,
     )
+    if not inserted:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many pending channel connection codes. Wait for existing codes to expire or use one of them.",
+        )
     return state
 
 

--- a/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
+++ b/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
@@ -279,15 +279,39 @@ class ChannelConnectionRepository:
             session.add(row)
             await session.commit()
 
-    async def count_oauth_states(self, *, owner_user_id: str, provider: str) -> int:
+    async def delete_expired_oauth_states(self, *, now: datetime | None = None) -> int:
+        current_time = now or datetime.now(UTC)
+        async with self.session_factory() as session:
+            result = await session.execute(delete(ChannelOAuthStateRow).where(ChannelOAuthStateRow.expires_at < current_time))
+            await session.commit()
+            return int(result.rowcount or 0)
+
+    async def count_oauth_states(
+        self,
+        *,
+        owner_user_id: str,
+        provider: str,
+        active_only: bool = False,
+        now: datetime | None = None,
+    ) -> int:
+        current_time = now or datetime.now(UTC)
+        conditions = [
+            ChannelOAuthStateRow.owner_user_id == owner_user_id,
+            ChannelOAuthStateRow.provider == provider,
+        ]
+        if active_only:
+            conditions.extend(
+                [
+                    ChannelOAuthStateRow.consumed_at.is_(None),
+                    ChannelOAuthStateRow.expires_at >= current_time,
+                ]
+            )
+
         async with self.session_factory() as session:
             result = await session.execute(
                 select(func.count())
                 .select_from(ChannelOAuthStateRow)
-                .where(
-                    ChannelOAuthStateRow.owner_user_id == owner_user_id,
-                    ChannelOAuthStateRow.provider == provider,
-                )
+                .where(*conditions)
             )
             return int(result.scalar_one())
 

--- a/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
+++ b/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
@@ -308,11 +308,7 @@ class ChannelConnectionRepository:
             )
 
         async with self.session_factory() as session:
-            result = await session.execute(
-                select(func.count())
-                .select_from(ChannelOAuthStateRow)
-                .where(*conditions)
-            )
+            result = await session.execute(select(func.count()).select_from(ChannelOAuthStateRow).where(*conditions))
             return int(result.scalar_one())
 
     async def consume_oauth_state(

--- a/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
+++ b/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
@@ -308,10 +308,19 @@ class ChannelConnectionRepository:
         current_time = now or datetime.now(UTC)
         async with self.session_factory() as session:
             await self._serialize_oauth_owner_scope(session, owner_user_id, provider)
-            # Issue a write first: this prunes expired rows and, on SQLite,
-            # takes the database write lock so the count below cannot race a
-            # concurrent inserter between count and commit.
-            await session.execute(delete(ChannelOAuthStateRow).where(ChannelOAuthStateRow.expires_at < current_time))
+            # Prune only this owner/provider's expired codes (the ones that affect
+            # this cap), not every user's — avoids a global DELETE on each connect
+            # POST. Issuing this write first also takes the SQLite database write
+            # lock so the count below cannot race a concurrent inserter between
+            # count and commit. Stale codes for other owners are pruned globally
+            # by consume_oauth_state / delete_expired_oauth_states.
+            await session.execute(
+                delete(ChannelOAuthStateRow).where(
+                    ChannelOAuthStateRow.owner_user_id == owner_user_id,
+                    ChannelOAuthStateRow.provider == provider,
+                    ChannelOAuthStateRow.expires_at < current_time,
+                )
+            )
             pending = await session.execute(
                 select(func.count())
                 .select_from(ChannelOAuthStateRow)

--- a/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
+++ b/backend/packages/harness/deerflow/persistence/channel_connections/sql.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from cryptography.fernet import Fernet, InvalidToken
-from sqlalchemy import delete, func, select, update
+from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -278,6 +278,89 @@ class ChannelConnectionRepository:
         async with self.session_factory() as session:
             session.add(row)
             await session.commit()
+
+    async def create_oauth_state_within_cap(
+        self,
+        *,
+        owner_user_id: str,
+        provider: str,
+        state: str,
+        expires_at: datetime,
+        max_pending: int,
+        now: datetime | None = None,
+        code_verifier: str | None = None,
+        nonce_hash: str | None = None,
+        redirect_after: str | None = None,
+        requested_scopes: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Atomically enforce the per-(owner, provider) pending cap, then insert.
+
+        delete-expired + count + insert run in a single transaction serialized
+        per (owner, provider), so concurrent connect requests cannot each
+        observe ``count < max_pending`` and all insert (which would leak past
+        the cap). PostgreSQL takes a transaction-scoped advisory lock; SQLite
+        serializes writers through the write lock the leading DELETE acquires.
+
+        Returns ``True`` when the row was inserted, ``False`` when the cap is
+        already reached.
+        """
+        current_time = now or datetime.now(UTC)
+        async with self.session_factory() as session:
+            await self._serialize_oauth_owner_scope(session, owner_user_id, provider)
+            # Issue a write first: this prunes expired rows and, on SQLite,
+            # takes the database write lock so the count below cannot race a
+            # concurrent inserter between count and commit.
+            await session.execute(delete(ChannelOAuthStateRow).where(ChannelOAuthStateRow.expires_at < current_time))
+            pending = await session.execute(
+                select(func.count())
+                .select_from(ChannelOAuthStateRow)
+                .where(
+                    ChannelOAuthStateRow.owner_user_id == owner_user_id,
+                    ChannelOAuthStateRow.provider == provider,
+                    ChannelOAuthStateRow.consumed_at.is_(None),
+                    ChannelOAuthStateRow.expires_at >= current_time,
+                )
+            )
+            if int(pending.scalar_one()) >= max_pending:
+                await session.rollback()
+                return False
+            session.add(
+                ChannelOAuthStateRow(
+                    state_hash=self.hash_state(state),
+                    owner_user_id=owner_user_id,
+                    provider=provider,
+                    code_verifier_encrypted=self._encrypt_optional_secret(code_verifier),
+                    nonce_hash=nonce_hash,
+                    redirect_after=redirect_after,
+                    requested_scopes_json=list(requested_scopes or []),
+                    metadata_json=dict(metadata or {}),
+                    expires_at=expires_at,
+                )
+            )
+            await session.commit()
+            return True
+
+    async def _serialize_oauth_owner_scope(self, session: AsyncSession, owner_user_id: str, provider: str) -> None:
+        """Serialize concurrent pending-cap transactions for one (owner, provider).
+
+        On PostgreSQL this takes a transaction-scoped advisory lock so concurrent
+        issuers run their count+insert one at a time. On SQLite the leading
+        DELETE in the caller's transaction already acquires the database write
+        lock, which serializes writers, so no extra lock is required.
+        """
+        try:
+            dialect = session.bind.dialect.name if session.bind is not None else ""
+        except Exception:
+            dialect = ""
+        if dialect == "postgresql":
+            await session.execute(text("SELECT pg_advisory_xact_lock(:lock_key)"), {"lock_key": self._oauth_scope_lock_key(owner_user_id, provider)})
+
+    @staticmethod
+    def _oauth_scope_lock_key(owner_user_id: str, provider: str) -> int:
+        digest = hashlib.sha256(f"{owner_user_id}\x00{provider}".encode()).digest()
+        # 63-bit non-negative key for pg_advisory_xact_lock(bigint).
+        return int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
 
     async def delete_expired_oauth_states(self, *, now: datetime | None = None) -> int:
         current_time = now or datetime.now(UTC)

--- a/backend/tests/test_channel_connections_repository.py
+++ b/backend/tests/test_channel_connections_repository.py
@@ -247,6 +247,26 @@ class TestChannelConnectionRepository:
         assert [state.state_hash for state in states] == [repo.hash_state("active-state")]
 
     @pytest.mark.anyio
+    async def test_count_oauth_states_active_only_and_delete_expired(self, repo):
+        now = datetime.now(UTC)
+        await repo.create_oauth_state(
+            owner_user_id="alice",
+            provider="slack",
+            state="expired-state",
+            expires_at=now - timedelta(minutes=1),
+        )
+        await repo.create_oauth_state(
+            owner_user_id="alice",
+            provider="slack",
+            state="active-state",
+            expires_at=now + timedelta(minutes=5),
+        )
+
+        assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 1
+        assert await repo.delete_expired_oauth_states(now=now) == 1
+        assert await repo.count_oauth_states(owner_user_id="alice", provider="slack") == 1
+
+    @pytest.mark.anyio
     async def test_consume_oauth_state_is_one_time_even_under_concurrent_consumers(self, repo):
         import anyio
 

--- a/backend/tests/test_channel_connections_repository.py
+++ b/backend/tests/test_channel_connections_repository.py
@@ -277,22 +277,15 @@ class TestChannelConnectionRepository:
         expires = now + timedelta(minutes=5)
 
         for i in range(3):
-            inserted = await repo.create_oauth_state_within_cap(
-                owner_user_id="alice", provider="slack", state=f"code-{i}", expires_at=expires, max_pending=3, now=now
-            )
+            inserted = await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state=f"code-{i}", expires_at=expires, max_pending=3, now=now)
             assert inserted is True
 
         # Cap reached: the next issuance is rejected and nothing is inserted.
-        assert (
-            await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state="code-over", expires_at=expires, max_pending=3, now=now)
-            is False
-        )
+        assert await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state="code-over", expires_at=expires, max_pending=3, now=now) is False
         assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 3
 
         # Expired rows are pruned and free up capacity; a different owner is unaffected.
-        assert (
-            await repo.create_oauth_state_within_cap(owner_user_id="bob", provider="slack", state="bob-1", expires_at=expires, max_pending=3, now=now) is True
-        )
+        assert await repo.create_oauth_state_within_cap(owner_user_id="bob", provider="slack", state="bob-1", expires_at=expires, max_pending=3, now=now) is True
 
     @pytest.mark.anyio
     async def test_create_oauth_state_within_cap_ignores_expired_rows(self, repo):
@@ -301,9 +294,7 @@ class TestChannelConnectionRepository:
         for i in range(3):
             await repo.create_oauth_state(owner_user_id="alice", provider="slack", state=f"old-{i}", expires_at=now - timedelta(minutes=1))
 
-        inserted = await repo.create_oauth_state_within_cap(
-            owner_user_id="alice", provider="slack", state="fresh", expires_at=now + timedelta(minutes=5), max_pending=3, now=now
-        )
+        inserted = await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state="fresh", expires_at=now + timedelta(minutes=5), max_pending=3, now=now)
         assert inserted is True
         assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 1
 
@@ -317,9 +308,7 @@ class TestChannelConnectionRepository:
         results: list[bool] = []
 
         async def issue(state: str) -> None:
-            results.append(
-                await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state=state, expires_at=expires, max_pending=3, now=now)
-            )
+            results.append(await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state=state, expires_at=expires, max_pending=3, now=now))
 
         async with anyio.create_task_group() as tg:
             for i in range(8):

--- a/backend/tests/test_channel_connections_repository.py
+++ b/backend/tests/test_channel_connections_repository.py
@@ -265,6 +265,11 @@ class TestChannelConnectionRepository:
         assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 1
         assert await repo.delete_expired_oauth_states(now=now) == 1
         assert await repo.count_oauth_states(owner_user_id="alice", provider="slack") == 1
+        # Pin that the surviving row is the active one (an inverted expiry
+        # predicate would delete the active row, still return 1, and pass above).
+        async with repo.session_factory() as session:
+            survivors = (await session.execute(select(ChannelOAuthStateRow))).scalars().all()
+        assert [row.state_hash for row in survivors] == [repo.hash_state("active-state")]
 
     @pytest.mark.anyio
     async def test_create_oauth_state_within_cap_enforces_pending_cap(self, repo):

--- a/backend/tests/test_channel_connections_repository.py
+++ b/backend/tests/test_channel_connections_repository.py
@@ -267,6 +267,63 @@ class TestChannelConnectionRepository:
         assert await repo.count_oauth_states(owner_user_id="alice", provider="slack") == 1
 
     @pytest.mark.anyio
+    async def test_create_oauth_state_within_cap_enforces_pending_cap(self, repo):
+        now = datetime.now(UTC)
+        expires = now + timedelta(minutes=5)
+
+        for i in range(3):
+            inserted = await repo.create_oauth_state_within_cap(
+                owner_user_id="alice", provider="slack", state=f"code-{i}", expires_at=expires, max_pending=3, now=now
+            )
+            assert inserted is True
+
+        # Cap reached: the next issuance is rejected and nothing is inserted.
+        assert (
+            await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state="code-over", expires_at=expires, max_pending=3, now=now)
+            is False
+        )
+        assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 3
+
+        # Expired rows are pruned and free up capacity; a different owner is unaffected.
+        assert (
+            await repo.create_oauth_state_within_cap(owner_user_id="bob", provider="slack", state="bob-1", expires_at=expires, max_pending=3, now=now) is True
+        )
+
+    @pytest.mark.anyio
+    async def test_create_oauth_state_within_cap_ignores_expired_rows(self, repo):
+        now = datetime.now(UTC)
+        # Three already-expired rows must not count against the cap.
+        for i in range(3):
+            await repo.create_oauth_state(owner_user_id="alice", provider="slack", state=f"old-{i}", expires_at=now - timedelta(minutes=1))
+
+        inserted = await repo.create_oauth_state_within_cap(
+            owner_user_id="alice", provider="slack", state="fresh", expires_at=now + timedelta(minutes=5), max_pending=3, now=now
+        )
+        assert inserted is True
+        assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 1
+
+    @pytest.mark.anyio
+    async def test_create_oauth_state_within_cap_does_not_leak_under_concurrency(self, repo):
+        """Concurrent issuance for one owner cannot push past the cap (willem #1)."""
+        import anyio
+
+        now = datetime.now(UTC)
+        expires = now + timedelta(minutes=5)
+        results: list[bool] = []
+
+        async def issue(state: str) -> None:
+            results.append(
+                await repo.create_oauth_state_within_cap(owner_user_id="alice", provider="slack", state=state, expires_at=expires, max_pending=3, now=now)
+            )
+
+        async with anyio.create_task_group() as tg:
+            for i in range(8):
+                tg.start_soon(issue, f"code-{i}")
+
+        assert sum(1 for ok in results if ok) == 3
+        assert await repo.count_oauth_states(owner_user_id="alice", provider="slack", active_only=True, now=now) == 3
+
+    @pytest.mark.anyio
     async def test_consume_oauth_state_is_one_time_even_under_concurrent_consumers(self, repo):
         import anyio
 

--- a/backend/tests/test_channel_connections_router.py
+++ b/backend/tests/test_channel_connections_router.py
@@ -504,6 +504,27 @@ def test_connect_slack_returns_binding_command_and_persists_state(tmp_path):
     anyio.run(repo.close)
 
 
+def test_connect_binding_code_caps_pending_states_per_provider(tmp_path):
+    import anyio
+
+    repo = anyio.run(_make_repo, tmp_path)
+    app = _make_app(_enabled_connections_config(), repo, _channels_config())
+
+    with TestClient(app) as client:
+        responses = [client.post("/api/channels/slack/connect") for _ in range(6)]
+
+    assert [response.status_code for response in responses[:5]] == [200, 200, 200, 200, 200]
+    assert responses[5].status_code == 429
+    assert "Too many pending channel connection codes" in responses[5].json()["detail"]
+
+    async def count_states():
+        return await repo.count_oauth_states(owner_user_id=str(_user().id), provider="slack")
+
+    assert anyio.run(count_states) == 5
+
+    anyio.run(repo.close)
+
+
 def test_connect_discord_returns_binding_command_and_persists_state(tmp_path):
     import anyio
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -836,6 +836,78 @@ class TestChannelManager:
 
         _run(go())
 
+    def test_inbound_dedupe_key_fails_closed_without_workspace(self):
+        """Without a workspace identifier, skip dedupe instead of collapsing workspaces (willem #3)."""
+        from app.channels.manager import ChannelManager
+
+        with_workspace = InboundMessage(
+            channel_name="slack",
+            chat_id="C1",
+            user_id="U1",
+            text="x",
+            metadata={"team_id": "T1", "message_id": "m1"},
+        )
+        assert ChannelManager._inbound_dedupe_key(with_workspace) == ("slack", "T1", "C1", "m1")
+
+        without_workspace = InboundMessage(
+            channel_name="slack",
+            chat_id="C1",
+            user_id="U1",
+            text="x",
+            metadata={"message_id": "m1"},
+        )
+        assert ChannelManager._inbound_dedupe_key(without_workspace) is None
+
+    def test_dispatch_loop_releases_dedupe_key_when_handling_fails(self):
+        """A transient handling failure must not black-hole a provider redelivery (ShenAC #1)."""
+        from app.channels.manager import ChannelManager
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+            client = _make_mock_langgraph_client()
+            attempts = {"n": 0}
+
+            async def flaky_wait(*args, **kwargs):
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise RuntimeError("transient gateway 503")
+                return {"messages": [{"type": "human", "content": "hi"}, {"type": "ai", "content": "recovered"}]}
+
+            client.runs.wait = AsyncMock(side_effect=flaky_wait)
+            manager._client = client
+
+            outbound_received: list[OutboundMessage] = []
+
+            async def capture_outbound(msg: OutboundMessage) -> None:
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="slack",
+                chat_id="C123",
+                user_id="U123",
+                text="hello",
+                metadata={"team_id": "T123", "message_id": "m-1"},
+            )
+
+            # First delivery fails transiently; the dedupe key must be released.
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: attempts["n"] == 1 and len(outbound_received) >= 1)
+
+            # Provider redelivers the same message_id: it must be reprocessed, not dropped.
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: attempts["n"] == 2)
+            await asyncio.sleep(0.05)
+            await manager.stop()
+
+            assert attempts["n"] == 2
+
+        _run(go())
+
     def test_handle_chat_outbound_preserves_inbound_metadata(self):
         """DingTalk (and similar) need inbound metadata on outbound sends (e.g. sender_staff_id)."""
         from app.channels.manager import ChannelManager

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -800,12 +800,12 @@ class TestChannelManager:
 
         _run(go())
 
-    def test_dispatch_loop_dedupes_stable_provider_message_id(self):
+    def test_dispatch_loop_dedupes_stable_provider_message_id(self, tmp_path):
         from app.channels.manager import ChannelManager
 
         async def go():
             bus = MessageBus()
-            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            store = ChannelStore(path=tmp_path / "store.json")
             manager = ChannelManager(bus=bus, store=store)
             manager._client = _make_mock_langgraph_client()
             outbound_received: list[OutboundMessage] = []
@@ -816,23 +816,35 @@ class TestChannelManager:
             bus.subscribe_outbound(capture_outbound)
             await manager.start()
 
-            inbound = InboundMessage(
-                channel_name="slack",
-                chat_id="C123",
-                user_id="U123",
-                text="sensitive prompt",
-                topic_id="1710000000.000100",
-                metadata={"team_id": "T123", "message_id": "1710000000.000200"},
-            )
-            await bus.publish_inbound(inbound)
-            await bus.publish_inbound(inbound)
+            def _slack_inbound(message_id: str) -> InboundMessage:
+                # Distinct objects per publish, like a real provider redelivery.
+                return InboundMessage(
+                    channel_name="slack",
+                    chat_id="C123",
+                    user_id="U123",
+                    text="sensitive prompt",
+                    topic_id="1710000000.000100",
+                    metadata={"team_id": "T123", "message_id": message_id},
+                )
+
+            # Same stable message_id delivered twice -> processed once.
+            await bus.publish_inbound(_slack_inbound("1710000000.000200"))
+            await bus.publish_inbound(_slack_inbound("1710000000.000200"))
             await _wait_for(lambda: manager._client.runs.wait.call_count == 1 and len(outbound_received) == 1)
             await asyncio.sleep(0.05)
-            await manager.stop()
-
             assert manager._client.threads.create.call_count == 1
             assert manager._client.runs.wait.call_count == 1
             assert len(outbound_received) == 1
+
+            # Negative control: a *different* message_id must still be processed,
+            # so an over-dedupe regression (dropping distinct messages) is caught.
+            await bus.publish_inbound(_slack_inbound("1710000000.000999"))
+            await _wait_for(lambda: manager._client.runs.wait.call_count == 2 and len(outbound_received) == 2)
+            await asyncio.sleep(0.05)
+            await manager.stop()
+
+            assert manager._client.runs.wait.call_count == 2
+            assert len(outbound_received) == 2
 
         _run(go())
 
@@ -858,13 +870,13 @@ class TestChannelManager:
         )
         assert ChannelManager._inbound_dedupe_key(without_workspace) is None
 
-    def test_dispatch_loop_releases_dedupe_key_when_handling_fails(self):
+    def test_dispatch_loop_releases_dedupe_key_when_handling_fails(self, tmp_path):
         """A transient handling failure must not black-hole a provider redelivery (ShenAC #1)."""
         from app.channels.manager import ChannelManager
 
         async def go():
             bus = MessageBus()
-            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            store = ChannelStore(path=tmp_path / "store.json")
             manager = ChannelManager(bus=bus, store=store)
             client = _make_mock_langgraph_client()
             attempts = {"n": 0}

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -800,6 +800,42 @@ class TestChannelManager:
 
         _run(go())
 
+    def test_dispatch_loop_dedupes_stable_provider_message_id(self):
+        from app.channels.manager import ChannelManager
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+            manager._client = _make_mock_langgraph_client()
+            outbound_received: list[OutboundMessage] = []
+
+            async def capture_outbound(msg: OutboundMessage) -> None:
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="slack",
+                chat_id="C123",
+                user_id="U123",
+                text="sensitive prompt",
+                topic_id="1710000000.000100",
+                metadata={"team_id": "T123", "message_id": "1710000000.000200"},
+            )
+            await bus.publish_inbound(inbound)
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: manager._client.runs.wait.call_count == 1 and len(outbound_received) == 1)
+            await asyncio.sleep(0.05)
+            await manager.stop()
+
+            assert manager._client.threads.create.call_count == 1
+            assert manager._client.runs.wait.call_count == 1
+            assert len(outbound_received) == 1
+
+        _run(go())
+
     def test_handle_chat_outbound_preserves_inbound_metadata(self):
         """DingTalk (and similar) need inbound metadata on outbound sends (e.g. sender_staff_id)."""
         from app.channels.manager import ChannelManager
@@ -3752,7 +3788,7 @@ class TestWeComChannel:
             assert inbound.thread_ts == "msg-1"
             assert inbound.topic_id == "user-1"
             assert inbound.files == files
-            assert inbound.metadata == {"aibotid": "bot-1", "chattype": "single"}
+            assert inbound.metadata == {"aibotid": "bot-1", "chattype": "single", "message_id": "msg-1"}
             assert channel._ws_frames["msg-1"] is frame
             assert channel._ws_stream_ids["msg-1"] == "stream-1"
 

--- a/backend/tests/test_slack_channel_connections.py
+++ b/backend/tests/test_slack_channel_connections.py
@@ -98,24 +98,13 @@ def test_slack_send_uses_connection_bot_token_when_connection_id_is_present():
     anyio.run(go)
 
 
-def test_slack_http_events_mode_initializes_operator_web_client(monkeypatch):
+def test_slack_http_events_mode_is_rejected(monkeypatch, caplog):
     import anyio
 
     from app.channels.slack import SlackChannel
 
-    class FakeWebClient:
-        def __init__(self, token: str) -> None:
-            self.token = token
-            self.messages: list[dict] = []
-
-        def auth_test(self):
-            return {"user_id": "B-http"}
-
-        def chat_postMessage(self, **kwargs):
-            self.messages.append(kwargs)
-
     slack_sdk = ModuleType("slack_sdk")
-    slack_sdk.WebClient = FakeWebClient
+    slack_sdk.WebClient = object
     socket_mode = ModuleType("slack_sdk.socket_mode")
     socket_mode.SocketModeClient = object
     response = ModuleType("slack_sdk.socket_mode.response")
@@ -134,21 +123,11 @@ def test_slack_http_events_mode_initializes_operator_web_client(monkeypatch):
             },
         )
 
-        await channel.start()
-        assert channel._running is True
-        assert channel._web_client is not None
-        assert channel._web_client.token == "xoxb-operator"
-        assert channel._bot_user_id == "B-http"
+        with caplog.at_level("ERROR", logger="app.channels.slack"):
+            await channel.start()
 
-        await channel._post_connection_reply("C123", "Slack connected to DeerFlow.", "1710000000.000100")
-
-        assert channel._web_client.messages == [
-            {
-                "channel": "C123",
-                "text": "Slack connected to DeerFlow.",
-                "thread_ts": "1710000000.000100",
-            }
-        ]
-        await channel.stop()
+        assert channel._running is False
+        assert channel._web_client is None
+        assert "Slack HTTP Events mode is not supported" in caplog.text
 
     anyio.run(go)

--- a/backend/tests/test_slack_channel_connections.py
+++ b/backend/tests/test_slack_channel_connections.py
@@ -118,6 +118,10 @@ def test_slack_http_events_mode_is_rejected(monkeypatch, caplog):
             bus=MessageBus(),
             config={
                 "bot_token": "xoxb-operator",
+                # Provide app_token too so the missing-token early return cannot
+                # fire before the HTTP-mode guard — otherwise the state assertions
+                # below would hold even if the guard were deleted.
+                "app_token": "xapp-token",
                 "event_delivery": "http",
                 "connection_repo": MagicMock(),
             },


### PR DESCRIPTION
Closes #3544

# Summary

- Add a bounded inbound dedupe cache in `ChannelManager` keyed by provider/workspace/chat/stable message ID.
- Add missing stable `message_id` metadata for Slack, Telegram, WeChat, and WeCom inbound messages.
- Cap pending connect-code issuance per owner/provider and clear expired OAuth state before counting active pending codes.
- Remove message text snippets from manager and provider parsing logs; log text length and metadata instead.
- Reject unsupported Slack `event_delivery="http"` mode clearly instead of starting a partially functional adapter.

# Tests

- `uv run pytest tests/test_channels.py tests/test_channel_connections_router.py tests/test_channel_connections_repository.py tests/test_slack_channel_connections.py -q`
- `uv run ruff check app/channels/manager.py app/channels/slack.py app/channels/telegram.py app/channels/wechat.py app/channels/wecom.py app/channels/feishu.py app/channels/dingtalk.py app/gateway/routers/channel_connections.py packages/harness/deerflow/persistence/channel_connections/sql.py tests/test_channels.py tests/test_channel_connections_router.py tests/test_channel_connections_repository.py tests/test_slack_channel_connections.py`
- Pre-commit backend lint

# Notes

The inbound dedupe intentionally only uses stable provider message IDs from metadata. It does not guess based on `thread_ts`, because threaded platforms can legitimately reuse thread/root IDs for multiple user messages.

