### PR TITLE
fix: make local-dev (make dev) work on non-root / NFS hosts

### DIFF
--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -1,3 +1,7 @@
+# Global error_log (main context). Without this, nginx opens its compiled-in
+# default (/var/log/nginx/error.log) at startup before reaching the http-block
+# error_log, which fails with permission denied when run as a non-root user.
+error_log logs/nginx-error.log warn;
 events {
     worker_connections 1024;
 }

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -105,7 +105,7 @@ _is_deerflow_pid() {
         return 0
     fi
 
-    files=$(lsof -p "$pid" 2>/dev/null) || return 1
+    files=$(lsof -b -w -p "$pid" 2>/dev/null) || return 1
     while IFS= read -r root; do
         [ -n "$root" ] || continue
         case "$files" in
@@ -122,7 +122,7 @@ _report_reclaimed_ports() {
     for port in 8001 3000 2026; do
         for pid in $(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null); do
             _is_deerflow_pid "$pid" || continue
-            files=$(lsof -p "$pid" 2>/dev/null)
+            files=$(lsof -b -w -p "$pid" 2>/dev/null)
             case "$files" in *"$REPO_ROOT"/*) continue ;; esac  # this worktree — normal
             owner=""
             while IFS= read -r root; do


### PR DESCRIPTION
## Why

Bringing up the **local (non-Docker) dev workflow** (`make dev`) on a Linux host where the home/working tree lives on a network filesystem (NFS/autofs) and the user is non-root, two issues make the stack fail to start:

1. `make dev` / `make stop` **hang forever** at `Stopping all services...`.
2. Once that's worked around, nginx **fails to start** on port 2026.

Both are environment issues in the dev tooling, not the app — but they block the documented "Option 2: Local Development" path in `CONTRIBUTING.md` on a common setup (NFS home dirs, unprivileged user).

## What changed

- **`make dev` no longer hangs during cleanup on NFS hosts.** The port/process reaping in `scripts/serve.sh` enumerated each candidate process's open files with `lsof -p <pid>`, which blocks indefinitely on network mounts. It now uses `lsof -b -w -p <pid>` (avoid kernel blocking calls + suppress the resulting warnings). Behavior is unchanged on local filesystems.
- **Local-dev nginx now starts as a non-root user.** `nginx.local.conf` only set `error_log` inside `http {}`; nginx opens its compiled-in default error log (`/var/log/nginx/error.log` on Debian/Ubuntu builds) at startup *before* reaching that directive, which isn't writable by a normal user and aborts with `[emerg] ... Permission denied`. A global `error_log logs/nginx-error.log warn;` is now declared so logging resolves under the repo-local `logs/` dir (via the existing `-p $REPO_ROOT`).

No application, API, or frontend behavior changes — these only affect the local dev launcher.

## Surface area

- [x] **Sandbox** — `docker/` or sandboxed execution  <!-- docker/nginx/nginx.local.conf -->
- [x] **Docs / tests / CI only** — no runtime behavior change  <!-- closest fit for scripts/serve.sh dev tooling; no app runtime change -->

Also touches `scripts/serve.sh` (local dev launcher). No change to backend/frontend runtime.

## Bug fix verification

These are environment-specific shell/nginx-startup bugs (NFS-blocking `lsof`, non-root nginx default-log path) that aren't cheap to encode as an automated red test in CI (CI runs as root on a local FS, so neither failure reproduces there). Verified manually instead:

- **lsof hang:** reproduced `make dev` hanging at `Stopping all services...` on an NFS home; confirmed the stuck process was `lsof -p <pid>`. After the change, cleanup returns immediately.
- **nginx:** reproduced `[emerg] open() "/var/log/nginx/error.log" failed (13: Permission denied)` as a non-root user; after the change `nginx -t -c docker/nginx/nginx.local.conf -p "$PWD"` passes and nginx binds 2026.

## Validation

- `make check`, `make install`, `make doctor` — all pass.
- `make dev` — full stack comes up: Gateway (8001), Frontend (3000), Nginx (2026); `GET http://localhost:2026/` returns `200`.
- `make stop` — tears down cleanly and returns immediately (previously hung).
- `nginx -t -c docker/nginx/nginx.local.conf -p "$PWD"` — syntax OK.
- Backend/frontend lint+test suites not run: no Python or TypeScript files changed (only a shell script and an nginx config).

## AI assistance

**Tool(s) used:** Claude Code (Claude Opus 4.8)

**How you used it:** Both failures were diagnosed and the fixes authored with Claude Code during a real local-dev bring-up, then verified by running the full `make dev` stack successfully. The diff is small (two `lsof` flag additions and one nginx directive) and was reviewed by a human before submitting.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
