### PR TITLE
fix: add MCP tools cache reset endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -113,6 +113,7 @@ FastAPI application providing REST endpoints for frontend integration:
 |-------|---------|
 | `GET /api/models` | List available LLM models |
 | `GET/PUT /api/mcp/config` | Manage MCP server configurations |
+| `POST /api/mcp/cache/reset` | Reset cached MCP tools so they reload on next use |
 | `GET/PUT /api/skills` | List and manage skills |
 | `POST /api/skills/install` | Install skill from `.skill` archive |
 | `GET /api/memory` | Retrieve memory data |

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -281,13 +281,14 @@ async def get_mcp_configuration(request: Request) -> McpConfigResponse:
     "/mcp/cache/reset",
     response_model=McpCacheResetResponse,
     summary="Reset MCP Tools Cache",
-    description="Reset cached MCP tools and sessions so tools are reloaded on next use.",
+    description=("Reset cached MCP tools and pooled sessions process-wide so tools are reloaded on next use. This affects all threads and users in the current Gateway process."),
 )
 async def reset_mcp_tools_cache_endpoint(request: Request) -> McpCacheResetResponse:
-    """Reset cached MCP tools and persistent sessions.
+    """Reset cached MCP tools and persistent sessions process-wide.
 
     The next agent run or tool lookup will reload tools from the configured MCP
-    servers. This avoids relying on extensions_config.json mtime changes.
+    servers. This affects all threads and users in the current Gateway process,
+    and avoids relying on extensions_config.json mtime changes.
     """
     await _require_admin_user(request)
     reset_mcp_tools_cache()

--- a/backend/app/gateway/routers/mcp.py
+++ b/backend/app/gateway/routers/mcp.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
 from deerflow.config.extensions_config import ExtensionsConfig, get_extensions_config, reload_extensions_config
+from deerflow.mcp.cache import reset_mcp_tools_cache
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api", tags=["mcp"])
@@ -67,6 +68,13 @@ class McpConfigUpdateRequest(BaseModel):
         ...,
         description="Map of MCP server name to configuration",
     )
+
+
+class McpCacheResetResponse(BaseModel):
+    """Response model for resetting the MCP tools cache."""
+
+    success: bool = Field(description="Whether the MCP tools cache was reset")
+    message: str = Field(description="Human-readable reset status")
 
 
 _MASKED_VALUE = "***"
@@ -269,6 +277,26 @@ async def get_mcp_configuration(request: Request) -> McpConfigResponse:
     return McpConfigResponse(mcp_servers=servers)
 
 
+@router.post(
+    "/mcp/cache/reset",
+    response_model=McpCacheResetResponse,
+    summary="Reset MCP Tools Cache",
+    description="Reset cached MCP tools and sessions so tools are reloaded on next use.",
+)
+async def reset_mcp_tools_cache_endpoint(request: Request) -> McpCacheResetResponse:
+    """Reset cached MCP tools and persistent sessions.
+
+    The next agent run or tool lookup will reload tools from the configured MCP
+    servers. This avoids relying on extensions_config.json mtime changes.
+    """
+    await _require_admin_user(request)
+    reset_mcp_tools_cache()
+    return McpCacheResetResponse(
+        success=True,
+        message="MCP tools cache reset. Tools will reload on next use.",
+    )
+
+
 @router.put(
     "/mcp/config",
     response_model=McpConfigResponse,
@@ -363,6 +391,7 @@ async def update_mcp_configuration(request: Request, body: McpConfigUpdateReques
         # agent runtime lives in Gateway, so this keeps API reads and tool
         # execution aligned after extensions_config.json changes.
         reloaded_config = reload_extensions_config()
+        reset_mcp_tools_cache()
         servers = {name: _mask_server_config(McpServerConfigResponse(**server.model_dump())) for name, server in reloaded_config.mcp_servers.items()}
         return McpConfigResponse(mcp_servers=servers)
 

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -299,6 +299,25 @@ deployment needs additional trusted launchers.
 }
 ```
 
+#### Reset MCP Tools Cache
+
+Clear cached MCP tools and persistent MCP sessions. Tools are loaded again from
+configured MCP servers on the next agent run or tool lookup.
+
+```http
+POST /api/mcp/cache/reset
+```
+
+Requires an authenticated admin session.
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "MCP tools cache reset. Tools will reload on next use."
+}
+```
+
 ### Skills
 
 #### List Skills

--- a/backend/docs/API.md
+++ b/backend/docs/API.md
@@ -301,8 +301,9 @@ deployment needs additional trusted launchers.
 
 #### Reset MCP Tools Cache
 
-Clear cached MCP tools and persistent MCP sessions. Tools are loaded again from
-configured MCP servers on the next agent run or tool lookup.
+Clear cached MCP tools and persistent MCP sessions process-wide. This affects
+all threads and users in the current Gateway process. Tools are loaded again
+from configured MCP servers on the next agent run or tool lookup.
 
 ```http
 POST /api/mcp/cache/reset

--- a/backend/docs/ARCHITECTURE.md
+++ b/backend/docs/ARCHITECTURE.md
@@ -427,17 +427,17 @@ SKILL.md Format:
 ### Configuration Reload
 
 ```
-1. Client updates MCP config
+1. Client updates MCP config or requests a cache reset
    PUT /api/mcp/config
+   POST /api/mcp/cache/reset
 
-2. Gateway writes extensions_config.json
-   - Updates mcpServers section
-   - File mtime changes
+2. Gateway updates runtime state
+   - PUT writes extensions_config.json and reloads configuration
+   - Both endpoints reset the MCP tools cache and persistent sessions
 
-3. MCP Manager detects change
-   - get_cached_mcp_tools() checks mtime
-   - If changed: reinitializes MCP client
-   - Loads updated server configurations
+3. MCP Manager reloads on next use
+   - get_cached_mcp_tools() lazily reinitializes MCP tools
+   - Loads current server configurations and tool lists
 
 4. Next agent run uses new tools
 ```

--- a/backend/tests/test_auth_middleware.py
+++ b/backend/tests/test_auth_middleware.py
@@ -33,6 +33,7 @@ def test_public_paths(path: str):
     [
         "/api/models",
         "/api/mcp/config",
+        "/api/mcp/cache/reset",
         "/api/memory",
         "/api/skills",
         "/api/threads/123",
@@ -147,6 +148,10 @@ def _make_app():
 
     @app.put("/api/mcp/config")
     async def mcp_put():
+        return {"ok": True}
+
+    @app.post("/api/mcp/cache/reset")
+    async def mcp_cache_reset():
         return {"ok": True}
 
     @app.delete("/api/threads/abc")
@@ -357,6 +362,11 @@ def test_protected_path_with_junk_cookie_rejected(client):
 
 def test_protected_post_no_cookie_returns_401(client):
     res = client.post("/api/threads/abc/runs/stream")
+    assert res.status_code == 401
+
+
+def test_mcp_cache_reset_post_no_cookie_returns_401(client):
+    res = client.post("/api/mcp/cache/reset")
     assert res.status_code == 401
 
 

--- a/backend/tests/test_mcp_config_secrets.py
+++ b/backend/tests/test_mcp_config_secrets.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException
 
+from app.gateway.routers import mcp as mcp_router
 from app.gateway.routers.mcp import (
     _MCP_STDIO_COMMAND_ALLOWLIST_ENV,
     McpConfigUpdateRequest,
@@ -21,6 +22,8 @@ from app.gateway.routers.mcp import (
     _merge_preserving_secrets,
     _require_admin_user,
     _validate_mcp_update_request,
+    reset_mcp_tools_cache_endpoint,
+    update_mcp_configuration,
 )
 
 # ---------------------------------------------------------------------------
@@ -337,6 +340,71 @@ async def test_mcp_config_requires_admin_user():
         await _require_admin_user(_request_with_role("user"))
 
     assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_reset_mcp_tools_cache_endpoint_requires_admin_user(monkeypatch):
+    called = False
+
+    def fake_reset_mcp_tools_cache():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(mcp_router, "reset_mcp_tools_cache", fake_reset_mcp_tools_cache)
+
+    response = await reset_mcp_tools_cache_endpoint(_request_with_role("admin"))
+
+    assert called is True
+    assert response.success is True
+    assert "next use" in response.message
+
+    with pytest.raises(HTTPException) as exc_info:
+        await reset_mcp_tools_cache_endpoint(_request_with_role("user"))
+
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_update_mcp_configuration_resets_tools_cache(monkeypatch, tmp_path):
+    reset_calls = 0
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text('{"mcpServers": {}, "skills": {}}', encoding="utf-8")
+
+    current_config = SimpleNamespace(skills={}, mcp_servers={})
+    reloaded_config = SimpleNamespace(
+        mcp_servers={
+            "github": McpServerConfigResponse(
+                type="stdio",
+                command="npx",
+                args=["-y", "@modelcontextprotocol/server-github"],
+            )
+        }
+    )
+
+    def fake_reset_mcp_tools_cache():
+        nonlocal reset_calls
+        reset_calls += 1
+
+    monkeypatch.setattr(mcp_router.ExtensionsConfig, "resolve_config_path", lambda: config_path)
+    monkeypatch.setattr(mcp_router, "get_extensions_config", lambda: current_config)
+    monkeypatch.setattr(mcp_router, "reload_extensions_config", lambda: reloaded_config)
+    monkeypatch.setattr(mcp_router, "reset_mcp_tools_cache", fake_reset_mcp_tools_cache)
+
+    response = await update_mcp_configuration(
+        _request_with_role("admin"),
+        McpConfigUpdateRequest(
+            mcp_servers={
+                "github": McpServerConfigResponse(
+                    type="stdio",
+                    command="npx",
+                    args=["-y", "@modelcontextprotocol/server-github"],
+                )
+            }
+        ),
+    )
+
+    assert reset_calls == 1
+    assert list(response.mcp_servers) == ["github"]
 
 
 def test_validate_mcp_update_allows_default_npx_stdio_command(monkeypatch):


### PR DESCRIPTION
Fixes #3586
Fixes #3588

## Why

MCP tools are cached and previously relied on `extensions_config.json` mtime changes to become stale.

That breaks when an MCP server adds tools without changing the config file, and it is especially unreliable for MinIO/FUSE-mounted config files where writes may not update the mtime visible inside the container.

## What changed

- Added an admin-only `POST /api/mcp/cache/reset` endpoint.
- The endpoint calls the existing `reset_mcp_tools_cache()` helper so MCP tools and persistent sessions are cleared, then tools reload on next use.
- Updated `PUT /api/mcp/config` to explicitly reset the MCP tools cache after reloading config.
- Updated MCP API, architecture, and backend README docs.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A, backend API only.

## Bug fix verification

Test path that reproduces the bug:
- `backend/tests/test_mcp_config_secrets.py`
- `backend/tests/test_auth_middleware.py`

Did it go red on `main` and green on this branch?
- Not run on `main`; tests were added to cover the new endpoint and explicit cache reset behavior.

## Validation

- `cd backend && uv run pytest tests/test_mcp_config_secrets.py tests/test_auth_middleware.py tests/test_mcp_session_pool.py::test_reset_mcp_tools_cache_from_running_loop_is_bounded`
  - 85 passed
- `cd backend && make lint`
  - passed
- `cd backend && make test`
  - 4388 passed, 16 skipped
