### PR TITLE
fix(channel): unsubscribe channel listeners by equality

### DIFF
--- a/backend/app/channels/message_bus.py
+++ b/backend/app/channels/message_bus.py
@@ -172,7 +172,7 @@ class MessageBus:
 
     def unsubscribe_outbound(self, callback: OutboundCallback) -> None:
         """Remove a previously registered outbound callback."""
-        self._outbound_listeners = [cb for cb in self._outbound_listeners if cb is not callback]
+        self._outbound_listeners = [cb for cb in self._outbound_listeners if cb != callback]
 
     async def publish_outbound(self, msg: OutboundMessage) -> None:
         """Dispatch an outbound message to all registered listeners."""

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -148,6 +148,27 @@ class TestMessageBus:
 
         _run(go())
 
+    def test_unsubscribe_outbound_removes_fresh_bound_method_reference(self):
+        bus = MessageBus()
+        received = []
+
+        class Handler:
+            async def callback(self, msg):
+                received.append((self, msg))
+
+        handler = Handler()
+        other_handler = Handler()
+
+        async def go():
+            bus.subscribe_outbound(handler.callback)
+            bus.subscribe_outbound(other_handler.callback)
+            bus.unsubscribe_outbound(handler.callback)
+            out = OutboundMessage(channel_name="test", chat_id="c1", thread_id="t1", text="reply")
+            await bus.publish_outbound(out)
+            assert received == [(other_handler, out)]
+
+        _run(go())
+
     def test_outbound_error_does_not_crash(self):
         bus = MessageBus()
 


### PR DESCRIPTION
Fixes #3607

## Why

Hot-restarting a channel could leave its old outbound listener registered on the shared `MessageBus`.

For Feishu, this showed up as duplicate replies after calling `/api/channels/feishu/restart`: each restart added one more listener, so one outbound message could be sent multiple times. The root cause is that channel implementations subscribe and unsubscribe bound methods like `self._on_outbound`, and Python creates a fresh bound-method object on each access.

## What changed

Outbound listener unsubscribe now compares callbacks by equality instead of identity.

This lets `MessageBus.unsubscribe_outbound()` correctly remove the listener for the same channel instance even when the bound method object is accessed again during `stop()`, while keeping listeners from other channel instances intact.

A regression test covers the bound-method unsubscribe case.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend channel lifecycle fix only.

## Bug fix verification

Test path that reproduces the bug:
- `backend/tests/test_channels.py::TestMessageBus::test_unsubscribe_outbound_removes_fresh_bound_method_reference`

Did it go red on `main` and green on this branch?
- Yes. The test encodes the fresh bound-method access pattern that `is not` fails to unsubscribe correctly.

## Validation

- `cd backend && uv run pytest tests/test_channels.py -k "MessageBus or restart_channel"`
- `cd backend && uv run ruff check app/channels tests/test_channels.py`
- `cd backend && uv run pytest tests/test_channels.py tests/test_channel_connections_router.py`
- `cd backend && uv run ruff format --check app/channels tests/test_channels.py`
