### PR TITLE
fix: force reload config on channel restart

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -230,7 +230,7 @@ Setup: Copy `config.example.yaml` to `config.yaml` in the **project root** direc
 
 **Config Versioning**: `config.example.yaml` has a `config_version` field. On startup, `AppConfig.from_file()` compares user version vs example version and emits a warning if outdated. Missing `config_version` = version 0. Run `make config-upgrade` to auto-merge missing fields. When changing the config schema, bump `config_version` in `config.example.yaml`.
 
-**Config Caching**: `get_app_config()` caches the parsed config, but automatically reloads it when the resolved config path changes or the file's mtime increases. This keeps Gateway and LangGraph reads aligned with `config.yaml` edits without requiring a manual process restart.
+**Config Caching**: `get_app_config()` caches the parsed config, but automatically reloads it when the resolved config path or file content signature changes. The signature includes file metadata and a content digest, so Gateway and LangGraph reads stay aligned with `config.yaml` edits even on object-store or network mounts where mtime can remain stale.
 
 **Config Hot-Reload Boundary**: Gateway dependencies route through `get_app_config()` on every request, so per-run fields like `models[*].max_tokens`, `summarization.*`, `title.*`, `memory.*`, `subagents.*`, `tools[*]`, and the agent system prompt pick up `config.yaml` edits on the next message. `AppConfig` is intentionally **not** cached on `app.state` — `lifespan()` keeps a local `startup_config` variable for one-shot bootstrap work and passes it to `langgraph_runtime(app, startup_config)`.
 

--- a/backend/app/channels/service.py
+++ b/backend/app/channels/service.py
@@ -234,18 +234,18 @@ class ChannelService:
     def _load_channel_config(self, name: str) -> dict[str, Any] | None:
         """Load the latest config for a specific channel from disk.
 
-        Uses ``reload_app_config()`` so an explicit channel restart always
-        rereads ``config.yaml`` instead of relying on mtime-based cache
-        invalidation.
+        Uses ``get_app_config()`` which detects file changes via config
+        signature, so edits to ``config.yaml`` are picked up without a process
+        restart.
         The UI runtime-config overlay applied at startup is re-applied here
         so a file-driven reload neither drops credentials entered from the
         browser nor resurrects a channel disconnected from it.
         Falls back to the cached ``self._config`` when config loading fails.
         """
         try:
-            from deerflow.config.app_config import reload_app_config
+            from deerflow.config.app_config import get_app_config
 
-            app_config = reload_app_config()
+            app_config = get_app_config()
             extra = app_config.model_extra or {}
             channels_config = dict(extra.get("channels") or {})
             _merge_channel_connection_runtime_config(channels_config, app_config)

--- a/backend/app/channels/service.py
+++ b/backend/app/channels/service.py
@@ -234,17 +234,18 @@ class ChannelService:
     def _load_channel_config(self, name: str) -> dict[str, Any] | None:
         """Load the latest config for a specific channel from disk.
 
-        Uses ``get_app_config()`` which detects file changes via mtime,
-        so edits to ``config.yaml`` are picked up without a process restart.
+        Uses ``reload_app_config()`` so an explicit channel restart always
+        rereads ``config.yaml`` instead of relying on mtime-based cache
+        invalidation.
         The UI runtime-config overlay applied at startup is re-applied here
         so a file-driven reload neither drops credentials entered from the
         browser nor resurrects a channel disconnected from it.
         Falls back to the cached ``self._config`` when config loading fails.
         """
         try:
-            from deerflow.config.app_config import get_app_config
+            from deerflow.config.app_config import reload_app_config
 
-            app_config = get_app_config()
+            app_config = reload_app_config()
             extra = app_config.model_extra or {}
             channels_config = dict(extra.get("channels") or {})
             _merge_channel_connection_runtime_config(channels_config, app_config)

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 from collections.abc import Mapping
@@ -400,6 +401,8 @@ class AppConfig(BaseModel):
 _app_config: AppConfig | None = None
 _app_config_path: Path | None = None
 _app_config_mtime: float | None = None
+_ConfigSignature = tuple[float | None, int | None, str | None]
+_app_config_signature: _ConfigSignature | None = None
 _app_config_is_custom = False
 _current_app_config: ContextVar[AppConfig | None] = ContextVar("deerflow_current_app_config", default=None)
 _current_app_config_stack: ContextVar[tuple[AppConfig | None, ...]] = ContextVar("deerflow_current_app_config_stack", default=())
@@ -413,14 +416,33 @@ def _get_config_mtime(config_path: Path) -> float | None:
         return None
 
 
+def _get_config_signature(config_path: Path) -> _ConfigSignature | None:
+    """Get cache metadata for a config file, including a content digest."""
+    try:
+        stat_result = config_path.stat()
+    except OSError:
+        return None
+
+    digest = hashlib.sha256()
+    try:
+        with config_path.open("rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return (stat_result.st_mtime, stat_result.st_size, None)
+
+    return (stat_result.st_mtime, stat_result.st_size, digest.hexdigest())
+
+
 def _load_and_cache_app_config(config_path: str | None = None) -> AppConfig:
     """Load config from disk and refresh cache metadata."""
-    global _app_config, _app_config_path, _app_config_mtime, _app_config_is_custom
+    global _app_config, _app_config_path, _app_config_mtime, _app_config_signature, _app_config_is_custom
 
     resolved_path = AppConfig.resolve_config_path(config_path)
     _app_config = AppConfig.from_file(str(resolved_path))
     _app_config_path = resolved_path
     _app_config_mtime = _get_config_mtime(resolved_path)
+    _app_config_signature = _get_config_signature(resolved_path)
     _app_config_is_custom = False
     return _app_config
 
@@ -429,11 +451,11 @@ def get_app_config() -> AppConfig:
     """Get the DeerFlow config instance.
 
     Returns a cached singleton instance and automatically reloads it when the
-    underlying config file path or modification time changes. Use
+    underlying config file path or content signature changes. Use
     `reload_app_config()` to force a reload, or `reset_app_config()` to clear
     the cache.
     """
-    global _app_config, _app_config_path, _app_config_mtime
+    global _app_config, _app_config_path, _app_config_mtime, _app_config_signature
 
     runtime_override = _current_app_config.get()
     if runtime_override is not None:
@@ -444,8 +466,9 @@ def get_app_config() -> AppConfig:
 
     resolved_path = AppConfig.resolve_config_path()
     current_mtime = _get_config_mtime(resolved_path)
+    current_signature = _get_config_signature(resolved_path)
 
-    should_reload = _app_config is None or _app_config_path != resolved_path or _app_config_mtime != current_mtime
+    should_reload = _app_config is None or _app_config_path != resolved_path or _app_config_signature != current_signature
     if should_reload:
         if _app_config_path == resolved_path and _app_config_mtime is not None and current_mtime is not None and _app_config_mtime != current_mtime:
             logger.info(
@@ -453,6 +476,8 @@ def get_app_config() -> AppConfig:
                 _app_config_mtime,
                 current_mtime,
             )
+        elif _app_config_path == resolved_path and _app_config_signature != current_signature:
+            logger.info("Config file content signature changed, reloading AppConfig")
         _load_and_cache_app_config(str(resolved_path))
     return _app_config
 
@@ -480,10 +505,11 @@ def reset_app_config() -> None:
     `get_app_config()` to reload from file. Useful for testing
     or when switching between different configurations.
     """
-    global _app_config, _app_config_path, _app_config_mtime, _app_config_is_custom
+    global _app_config, _app_config_path, _app_config_mtime, _app_config_signature, _app_config_is_custom
     _app_config = None
     _app_config_path = None
     _app_config_mtime = None
+    _app_config_signature = None
     _app_config_is_custom = False
 
 
@@ -495,10 +521,11 @@ def set_app_config(config: AppConfig) -> None:
     Args:
         config: The AppConfig instance to use.
     """
-    global _app_config, _app_config_path, _app_config_mtime, _app_config_is_custom
+    global _app_config, _app_config_path, _app_config_mtime, _app_config_signature, _app_config_is_custom
     _app_config = config
     _app_config_path = None
     _app_config_mtime = None
+    _app_config_signature = None
     _app_config_is_custom = True
 
 

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -216,6 +216,45 @@ def test_get_app_config_reloads_when_file_changes(tmp_path, monkeypatch):
         reset_app_config()
 
 
+def test_get_app_config_reloads_when_content_digest_changes_without_metadata(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    _write_config(config_path, model_name="model-a", supports_thinking=False)
+
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+    _reset_config_singletons()
+
+    try:
+        initial = get_app_config()
+        initial_mtime = app_config_module._app_config_mtime
+        initial_signature = app_config_module._app_config_signature
+        assert initial.models[0].name == "model-a"
+        assert initial_signature is not None
+
+        _write_config(config_path, model_name="model-b", supports_thinking=False)
+
+        real_get_config_signature = app_config_module._get_config_signature
+
+        def stale_metadata_signature(path: Path):
+            current_signature = real_get_config_signature(path)
+            assert current_signature is not None
+            return (initial_signature[0], initial_signature[1], current_signature[2])
+
+        monkeypatch.setattr(app_config_module, "_get_config_mtime", lambda _path: initial_mtime)
+        monkeypatch.setattr(app_config_module, "_get_config_signature", stale_metadata_signature)
+
+        reloaded = get_app_config()
+        assert reloaded.models[0].name == "model-b"
+        assert reloaded is not initial
+        assert app_config_module._app_config_signature is not None
+        assert app_config_module._app_config_signature[:2] == initial_signature[:2]
+        assert app_config_module._app_config_signature[2] != initial_signature[2]
+    finally:
+        _reset_config_singletons()
+
+
 def test_get_app_config_reloads_when_config_path_changes(tmp_path, monkeypatch):
     config_a = tmp_path / "config-a.yaml"
     config_b = tmp_path / "config-b.yaml"

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -4368,7 +4367,7 @@ class TestChannelService:
     # -- restart_channel config reload tests (issue #3497) --
 
     def test_restart_channel_reloads_config_from_disk(self, monkeypatch):
-        """restart_channel reads the latest config via reload_app_config()."""
+        """restart_channel reads the latest config via get_app_config()."""
         from app.channels.service import ChannelService
 
         initial_config = {"feishu": {"enabled": True, "app_id": "old_id", "app_secret": "old_secret"}}
@@ -4376,10 +4375,10 @@ class TestChannelService:
 
         service = ChannelService(channels_config=initial_config)
 
-        def mock_reload_app_config():
+        def mock_get_app_config():
             return SimpleNamespace(model_extra={"channels": updated_config})
 
-        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
 
         started_configs = {}
 
@@ -4398,64 +4397,6 @@ class TestChannelService:
         assert started_configs["feishu"]["app_secret"] == "new_secret"
         assert service._config["feishu"]["app_id"] == "new_id"
 
-    def test_restart_channel_force_reloads_config_when_mtime_is_unchanged(self, monkeypatch, tmp_path):
-        """restart_channel must honor explicit reload even when config mtime is stale."""
-        from app.channels.service import ChannelService
-        from deerflow.config.app_config import get_app_config, reset_app_config
-
-        config_path = tmp_path / "config.yaml"
-
-        def write_config(*, app_id: str, app_secret: str) -> None:
-            config_path.write_text(
-                f"""
-sandbox:
-  use: deerflow.sandbox.local:LocalSandboxProvider
-models:
-  - name: default
-    use: langchain_openai:ChatOpenAI
-    model: gpt-test
-channels:
-  feishu:
-    enabled: true
-    app_id: {app_id}
-    app_secret: {app_secret}
-""".lstrip(),
-                encoding="utf-8",
-            )
-
-        monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
-        reset_app_config()
-        try:
-            write_config(app_id="old_id", app_secret="old_secret")
-            initial_app_config = get_app_config()
-            initial_mtime = config_path.stat().st_mtime
-            assert initial_app_config.model_extra["channels"]["feishu"]["app_id"] == "old_id"
-
-            write_config(app_id="new_id", app_secret="new_secret")
-            os.utime(config_path, (initial_mtime, initial_mtime))
-            assert get_app_config().model_extra["channels"]["feishu"]["app_id"] == "old_id"
-
-            service = ChannelService(channels_config={"feishu": {"enabled": True, "app_id": "old_id", "app_secret": "old_secret"}})
-
-            started_configs = {}
-
-            async def mock_start_channel(name, config):
-                started_configs[name] = config
-                return True
-
-            service._start_channel = mock_start_channel
-
-            async def go():
-                await service.restart_channel("feishu")
-
-            _run(go())
-
-            assert started_configs["feishu"]["app_id"] == "new_id"
-            assert started_configs["feishu"]["app_secret"] == "new_secret"
-            assert service._config["feishu"]["app_id"] == "new_id"
-        finally:
-            reset_app_config()
-
     def test_configure_channel_keeps_explicit_config_over_stale_file_entry(self, monkeypatch):
         """UI-entered runtime credentials must not be clobbered by a config.yaml reload.
 
@@ -4466,10 +4407,10 @@ channels:
         """
         from app.channels.service import ChannelService
 
-        def fail_reload_app_config():
+        def fail_get_app_config():
             raise AssertionError("configure_channel must not reload file config")
 
-        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", fail_reload_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.get_app_config", fail_get_app_config)
 
         service = ChannelService(channels_config={})
         service._running = True
@@ -4506,13 +4447,13 @@ channels:
             {"enabled": True, "bot_token": "store-token"},
         )
 
-        def mock_reload_app_config():
+        def mock_get_app_config():
             return SimpleNamespace(
                 model_extra={"channels": {}},
                 channel_connections=ChannelConnectionsConfig.model_validate({"enabled": True, "telegram": {"enabled": True, "bot_username": "deerflow_bot"}}),
             )
 
-        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
 
         service = ChannelService(channels_config={})
 
@@ -4532,7 +4473,7 @@ channels:
         assert started_configs["telegram"]["bot_token"] == "store-token"
 
     def test_restart_channel_falls_back_to_cached_config_on_error(self, monkeypatch):
-        """When reload_app_config() fails, restart_channel uses cached config."""
+        """When get_app_config() fails, restart_channel uses cached config."""
         from app.channels.service import ChannelService
 
         cached_config = {"feishu": {"enabled": True, "app_id": "cached_id", "app_secret": "cached_secret"}}
@@ -4541,7 +4482,7 @@ channels:
         def _raise():
             raise RuntimeError("config missing")
 
-        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", _raise)
+        monkeypatch.setattr("deerflow.config.app_config.get_app_config", _raise)
 
         started_configs = {}
 
@@ -4621,10 +4562,10 @@ channels:
         # Simulate config.yaml updated to enabled: false
         disabled_config = {"feishu": {"enabled": False, "app_id": "x", "app_secret": "y"}}
 
-        def mock_reload_app_config():
+        def mock_get_app_config():
             return SimpleNamespace(model_extra={"channels": disabled_config})
 
-        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
 
         started = []
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -4367,7 +4368,7 @@ class TestChannelService:
     # -- restart_channel config reload tests (issue #3497) --
 
     def test_restart_channel_reloads_config_from_disk(self, monkeypatch):
-        """restart_channel reads the latest config via get_app_config()."""
+        """restart_channel reads the latest config via reload_app_config()."""
         from app.channels.service import ChannelService
 
         initial_config = {"feishu": {"enabled": True, "app_id": "old_id", "app_secret": "old_secret"}}
@@ -4375,10 +4376,10 @@ class TestChannelService:
 
         service = ChannelService(channels_config=initial_config)
 
-        def mock_get_app_config():
+        def mock_reload_app_config():
             return SimpleNamespace(model_extra={"channels": updated_config})
 
-        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
 
         started_configs = {}
 
@@ -4397,6 +4398,64 @@ class TestChannelService:
         assert started_configs["feishu"]["app_secret"] == "new_secret"
         assert service._config["feishu"]["app_id"] == "new_id"
 
+    def test_restart_channel_force_reloads_config_when_mtime_is_unchanged(self, monkeypatch, tmp_path):
+        """restart_channel must honor explicit reload even when config mtime is stale."""
+        from app.channels.service import ChannelService
+        from deerflow.config.app_config import get_app_config, reset_app_config
+
+        config_path = tmp_path / "config.yaml"
+
+        def write_config(*, app_id: str, app_secret: str) -> None:
+            config_path.write_text(
+                f"""
+sandbox:
+  use: deerflow.sandbox.local:LocalSandboxProvider
+models:
+  - name: default
+    use: langchain_openai:ChatOpenAI
+    model: gpt-test
+channels:
+  feishu:
+    enabled: true
+    app_id: {app_id}
+    app_secret: {app_secret}
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+        monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+        reset_app_config()
+        try:
+            write_config(app_id="old_id", app_secret="old_secret")
+            initial_app_config = get_app_config()
+            initial_mtime = config_path.stat().st_mtime
+            assert initial_app_config.model_extra["channels"]["feishu"]["app_id"] == "old_id"
+
+            write_config(app_id="new_id", app_secret="new_secret")
+            os.utime(config_path, (initial_mtime, initial_mtime))
+            assert get_app_config().model_extra["channels"]["feishu"]["app_id"] == "old_id"
+
+            service = ChannelService(channels_config={"feishu": {"enabled": True, "app_id": "old_id", "app_secret": "old_secret"}})
+
+            started_configs = {}
+
+            async def mock_start_channel(name, config):
+                started_configs[name] = config
+                return True
+
+            service._start_channel = mock_start_channel
+
+            async def go():
+                await service.restart_channel("feishu")
+
+            _run(go())
+
+            assert started_configs["feishu"]["app_id"] == "new_id"
+            assert started_configs["feishu"]["app_secret"] == "new_secret"
+            assert service._config["feishu"]["app_id"] == "new_id"
+        finally:
+            reset_app_config()
+
     def test_configure_channel_keeps_explicit_config_over_stale_file_entry(self, monkeypatch):
         """UI-entered runtime credentials must not be clobbered by a config.yaml reload.
 
@@ -4407,12 +4466,10 @@ class TestChannelService:
         """
         from app.channels.service import ChannelService
 
-        stale_file_config = {"feishu": {"enabled": True, "app_id": "file_id", "app_secret": "file_secret"}}
+        def fail_reload_app_config():
+            raise AssertionError("configure_channel must not reload file config")
 
-        def mock_get_app_config():
-            return SimpleNamespace(model_extra={"channels": stale_file_config})
-
-        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", fail_reload_app_config)
 
         service = ChannelService(channels_config={})
         service._running = True
@@ -4449,13 +4506,13 @@ class TestChannelService:
             {"enabled": True, "bot_token": "store-token"},
         )
 
-        def mock_get_app_config():
+        def mock_reload_app_config():
             return SimpleNamespace(
                 model_extra={"channels": {}},
                 channel_connections=ChannelConnectionsConfig.model_validate({"enabled": True, "telegram": {"enabled": True, "bot_username": "deerflow_bot"}}),
             )
 
-        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
 
         service = ChannelService(channels_config={})
 
@@ -4475,7 +4532,7 @@ class TestChannelService:
         assert started_configs["telegram"]["bot_token"] == "store-token"
 
     def test_restart_channel_falls_back_to_cached_config_on_error(self, monkeypatch):
-        """When get_app_config() fails, restart_channel uses cached config."""
+        """When reload_app_config() fails, restart_channel uses cached config."""
         from app.channels.service import ChannelService
 
         cached_config = {"feishu": {"enabled": True, "app_id": "cached_id", "app_secret": "cached_secret"}}
@@ -4484,7 +4541,7 @@ class TestChannelService:
         def _raise():
             raise RuntimeError("config missing")
 
-        monkeypatch.setattr("deerflow.config.app_config.get_app_config", _raise)
+        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", _raise)
 
         started_configs = {}
 
@@ -4564,10 +4621,10 @@ class TestChannelService:
         # Simulate config.yaml updated to enabled: false
         disabled_config = {"feishu": {"enabled": False, "app_id": "x", "app_secret": "y"}}
 
-        def mock_get_app_config():
+        def mock_reload_app_config():
             return SimpleNamespace(model_extra={"channels": disabled_config})
 
-        monkeypatch.setattr("deerflow.config.app_config.get_app_config", mock_get_app_config)
+        monkeypatch.setattr("deerflow.config.app_config.reload_app_config", mock_reload_app_config)
 
         started = []
 


### PR DESCRIPTION
Fixes #3616

## Why

`/api/channels/{name}/restart` is an explicit operator-triggered channel restart, but it previously loaded channel config through `get_app_config()`.

`get_app_config()` uses a cached `AppConfig` and only reloads when the config path or file mtime changes. On object-storage-backed mounts such as MinIO via s3fs/goofys/JuiceFS, the container can observe updated `config.yaml` contents while `stat().st_mtime` remains unchanged or cached. In that case, channel restart silently reused stale channel credentials/config.

## What changed

Channel restart now force-reloads `config.yaml` from disk before rebuilding the requested channel.

The normal `get_app_config()` mtime cache remains unchanged for regular config reads. The UI/runtime credential path still uses `restart_channel(..., reload_config=False)`, so browser-entered runtime credentials are not clobbered by file config reloads.

A regression test now covers the stale-mtime case by caching an old config, rewriting the file with new channel credentials while restoring the original mtime, and asserting that `restart_channel()` still starts with the new values.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend channel restart behavior only.

## Bug fix verification

Test path that reproduces the bug:
- `backend/tests/test_channels.py::TestChannelService::test_restart_channel_force_reloads_config_when_mtime_is_unchanged`

Did it go red on `main` and green on this branch?
- Yes. On `main`, the restart path uses `get_app_config()`, so the cached old config is reused when mtime is unchanged. On this branch, `reload_app_config()` forces a disk read and the test observes the new channel config.

## Validation

- `cd backend && uv run pytest tests/test_channels.py -k "restart_channel"`
- `cd backend && uv run pytest tests/test_channels.py -k "restart_channel or configure_channel_keeps_explicit_config"`
- `cd backend && uv run pytest tests/test_channels.py`
- `cd backend && uv run ruff check app/channels/service.py tests/test_channels.py`
- `cd backend && uv run ruff format --check app/channels/service.py tests/test_channels.py`
