### PR TITLE
fix(sandbox): return actionable hint when read_file hits a binary file

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1665,6 +1665,12 @@ def read_file_tool(
         return f"Error: Permission denied reading file: {requested_path}"
     except IsADirectoryError:
         return f"Error: Path is a directory, not a file: {requested_path}"
+    except UnicodeDecodeError:
+        return (
+            f"Error: cannot read '{requested_path}' as text — it appears to be a binary file "
+            "(e.g. .xlsx, .pdf, or an image). read_file only supports UTF-8 text. Use bash with a "
+            "suitable library instead (pandas/openpyxl for spreadsheets), or view_image for images."
+        )
     except Exception as e:
         return f"Error: Unexpected error reading file: {_sanitize_error(e, runtime)}"
 

--- a/backend/tests/test_read_file_tool_binary.py
+++ b/backend/tests/test_read_file_tool_binary.py
@@ -1,0 +1,65 @@
+"""read_file tool behaviour on binary files.
+
+``read_file`` decodes with UTF-8. Binary uploads (``.xlsx``, images, ...) raise
+``UnicodeDecodeError`` deep in the sandbox layer, which previously surfaced to
+the model as a vague ``Unexpected error reading file`` message. The model could
+not tell that the file was binary, so it retried ``read_file`` instead of
+switching to ``bash`` + pandas/openpyxl — burning LLM round-trips. These tests
+pin the actionable error contract and guard the normal text path.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from deerflow.sandbox.local.local_sandbox import LocalSandbox
+from deerflow.sandbox.tools import read_file_tool
+
+
+def _local_runtime(tmp_path: Path) -> SimpleNamespace:
+    for sub in ("workspace", "uploads", "outputs"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    thread_data = {
+        "workspace_path": str(tmp_path / "workspace"),
+        "uploads_path": str(tmp_path / "uploads"),
+        "outputs_path": str(tmp_path / "outputs"),
+    }
+    return SimpleNamespace(
+        state={"sandbox": {"sandbox_id": "local:t1"}, "thread_data": thread_data},
+        context={"thread_id": "t1"},
+    )
+
+
+def test_read_file_tool_binary_file_returns_actionable_hint(tmp_path, monkeypatch) -> None:
+    runtime = _local_runtime(tmp_path)
+    # .xlsx is a zip container: header bytes PK\x03\x04 plus a non-UTF-8 byte 0x82
+    # that makes strict UTF-8 decoding fail (the exact byte seen in the field logs).
+    (tmp_path / "uploads" / "data.xlsx").write_bytes(b"PK\x03\x04\x14\x00\x00\x00\x08\x00\x82\x6a\xb1\x55")
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+
+    result = read_file_tool.func(
+        runtime=runtime,
+        description="read uploaded excel",
+        path="/mnt/user-data/uploads/data.xlsx",
+    )
+
+    assert "Unexpected error" not in result, result
+    assert "binary" in result.lower(), result
+    # The model must be steered to bash + pandas/openpyxl, not another read_file.
+    assert "bash" in result.lower(), result
+
+
+def test_read_file_tool_text_file_unaffected(tmp_path, monkeypatch) -> None:
+    runtime = _local_runtime(tmp_path)
+    (tmp_path / "uploads" / "notes.txt").write_text("hello 你好\nsecond line", encoding="utf-8")
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+
+    result = read_file_tool.func(
+        runtime=runtime,
+        description="read notes",
+        path="/mnt/user-data/uploads/notes.txt",
+    )
+
+    assert "hello 你好" in result, result
+    assert "binary" not in result.lower(), result


### PR DESCRIPTION
Relates to #3598

## Why

While investigating the slowdown in #3598, a recurring failure loop surfaced: when the agent calls `read_file` on a binary upload (`.xlsx`, images, ...), the tool returns a vague `Error: Unexpected error reading file: UnicodeDecodeError: ...`. The model can't tell the file is binary, so it retries `read_file` instead of switching to `bash` + pandas/openpyxl — burning LLM round-trips and bloating context with repeated failures, which compounds latency.

Long-standing bug (not a recent regression); reproduces on `main`.

## What changed

`read_file` on a non-UTF-8 (binary) file now returns an actionable message instead of a generic one:

> Error: cannot read '<path>' as text — it appears to be a binary file (e.g. .xlsx, .pdf, or an image). read_file only supports UTF-8 text. Use bash with a suitable library instead (pandas/openpyxl for spreadsheets), or view_image for images.

The model is steered to the right tool in one turn rather than looping on `read_file`. Text files are unaffected.

## Surface area

- [x] **Sandbox** — sandboxed execution (`read_file` tool error handling)

## Bug fix verification

- Test path: `backend/tests/test_read_file_tool_binary.py`
- Red on `main` / green on this branch? **yes** — `test_read_file_tool_binary_file_returns_actionable_hint` goes red on `main` (returns `Unexpected error reading file: UnicodeDecodeError: ... byte 0x82 ...`, matching the field logs) and green here.
- Root cause: `UnicodeDecodeError` is a `ValueError` subclass, **not** `OSError`, so it bypassed the typed handlers in `read_file_tool` and fell through to the generic `except`. The async tool reuses the sync `.func`, so a single handler covers both.

## Validation

```
cd backend && make lint && make test
```
- Sandbox / encoding / truncation suites: **152 passed**.
- Full-repo `ruff check .` + `ruff format --check .`: clean.
- Real tool-chain check: `read_file_tool.func` on a real `.xlsx` (real `LocalSandbox`, `/mnt/user-data/uploads/...` virtual path) returns the binary hint; a UTF-8 text file still returns its contents.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Root-caused the failure from the issue logs (incl. confirming the exception-hierarchy bug that bypassed the typed handlers), wrote the failing test first (TDD), then the minimal `except UnicodeDecodeError` handler. I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
