### PR TITLE
fix: preserve sandbox reducer in middleware state

### DIFF
--- a/backend/packages/harness/deerflow/agents/thread_state.py
+++ b/backend/packages/harness/deerflow/agents/thread_state.py
@@ -39,6 +39,9 @@ def merge_sandbox(existing: SandboxState | None, new: SandboxState | None) -> Sa
     raise ValueError(f"Conflicting sandbox state updates: {existing_id!r} != {new_id!r}")
 
 
+SandboxStateField = Annotated[NotRequired[SandboxState | None], merge_sandbox]
+
+
 def merge_artifacts(existing: list[str] | None, new: list[str] | None) -> list[str]:
     """Reducer for artifacts list - merges and deduplicates artifacts."""
     if existing is None:
@@ -106,7 +109,7 @@ def merge_promoted(existing: PromotedTools | None, new: PromotedTools | None) ->
 
 
 class ThreadState(AgentState):
-    sandbox: Annotated[NotRequired[SandboxState | None], merge_sandbox]
+    sandbox: SandboxStateField
     thread_data: NotRequired[ThreadDataState | None]
     title: NotRequired[str | None]
     artifacts: Annotated[list[str], merge_artifacts]

--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import replace as dc_replace
-from typing import Annotated, NotRequired, override
+from typing import NotRequired, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
@@ -11,7 +11,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
 
-from deerflow.agents.thread_state import SandboxState, ThreadDataState, merge_sandbox
+from deerflow.agents.thread_state import SandboxStateField, ThreadDataState
 from deerflow.sandbox import get_sandbox_provider
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class SandboxMiddlewareState(AgentState):
     """Compatible with the `ThreadState` schema."""
 
-    sandbox: Annotated[NotRequired[SandboxState | None], merge_sandbox]
+    sandbox: SandboxStateField
     thread_data: NotRequired[ThreadDataState | None]
 
 

--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import replace as dc_replace
-from typing import NotRequired, override
+from typing import Annotated, NotRequired, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
@@ -11,7 +11,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
 
-from deerflow.agents.thread_state import SandboxState, ThreadDataState
+from deerflow.agents.thread_state import SandboxState, ThreadDataState, merge_sandbox
 from deerflow.sandbox import get_sandbox_provider
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 class SandboxMiddlewareState(AgentState):
     """Compatible with the `ThreadState` schema."""
 
-    sandbox: NotRequired[SandboxState | None]
+    sandbox: Annotated[NotRequired[SandboxState | None], merge_sandbox]
     thread_data: NotRequired[ThreadDataState | None]
 
 

--- a/backend/tests/test_sandbox_middleware.py
+++ b/backend/tests/test_sandbox_middleware.py
@@ -11,7 +11,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
 
-from deerflow.agents.thread_state import merge_sandbox
+from deerflow.agents.thread_state import ThreadState
 from deerflow.sandbox.middleware import SandboxMiddleware, SandboxMiddlewareState
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import SandboxProvider, reset_sandbox_provider, set_sandbox_provider
@@ -92,11 +92,12 @@ class _AsyncOnlyProvider(SandboxProvider):
         return None
 
 
-def test_sandbox_middleware_state_preserves_sandbox_reducer() -> None:
-    """Middleware-local schema must keep ThreadState.sandbox merge semantics."""
-    hints = get_type_hints(SandboxMiddlewareState, include_extras=True)
+def test_sandbox_middleware_state_matches_thread_state_sandbox_field() -> None:
+    """Middleware-local schema must not drift from ThreadState.sandbox."""
+    middleware_hints = get_type_hints(SandboxMiddlewareState, include_extras=True)
+    thread_hints = get_type_hints(ThreadState, include_extras=True)
 
-    assert merge_sandbox in hints["sandbox"].__metadata__
+    assert middleware_hints["sandbox"] == thread_hints["sandbox"]
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_sandbox_middleware.py
+++ b/backend/tests/test_sandbox_middleware.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import get_type_hints
 
 import pytest
 from langchain.agents.middleware import AgentMiddleware
@@ -10,7 +11,8 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
 
-from deerflow.sandbox.middleware import SandboxMiddleware
+from deerflow.agents.thread_state import merge_sandbox
+from deerflow.sandbox.middleware import SandboxMiddleware, SandboxMiddlewareState
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import SandboxProvider, reset_sandbox_provider, set_sandbox_provider
 from deerflow.sandbox.search import GrepMatch
@@ -88,6 +90,13 @@ class _AsyncOnlyProvider(SandboxProvider):
     def release(self, sandbox_id: str) -> None:
         self.released_ids.append(sandbox_id)
         return None
+
+
+def test_sandbox_middleware_state_preserves_sandbox_reducer() -> None:
+    """Middleware-local schema must keep ThreadState.sandbox merge semantics."""
+    hints = get_type_hints(SandboxMiddlewareState, include_extras=True)
+
+    assert merge_sandbox in hints["sandbox"].__metadata__
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fixes #3628

## Why

Subagent sandbox tools can lazily initialize the same sandbox within the same LangGraph step. When multiple tool calls emit the same `sandbox` state update concurrently, LangGraph should merge those idempotent writes through `merge_sandbox` instead of treating `sandbox` as a last-value channel and raising `INVALID_CONCURRENT_GRAPH_UPDATE`.

## What changed

`SandboxMiddlewareState.sandbox` now keeps the same `merge_sandbox` reducer as `ThreadState.sandbox`, so concurrent writes of the same `sandbox_id` merge safely while conflicting sandbox ids still fail closed.
SandboxStateField alias
Added a regression test to ensure the middleware-local state schema preserves the sandbox reducer.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend-only bug fix.

## Bug fix verification

- Test path that reproduces the bug:
  - `backend/tests/test_sandbox_middleware.py::test_sandbox_middleware_state_matches_thread_state_sandbox_field`
  - Existing reducer behavior is covered by `backend/tests/test_thread_state_reducers.py`
- Did it go red on `main` and green on this branch? No. I added schema-level regression coverage for the reducer wiring because reproducing the full concurrent LangGraph subagent step in a small unit test would require heavier graph orchestration.
- The test verifies the exact regression point: `SandboxMiddlewareState.sandbox` must carry `merge_sandbox` metadata.

## Validation

```shell
cd backend && uv run pytest tests/test_sandbox_middleware.py tests/test_thread_state_reducers.py
cd backend && uv run ruff check packages/harness/deerflow/sandbox/middleware.py tests/test_sandbox_middleware.py tests/test_thread_state_reducers.py
cd backend && uv run ruff format --check packages/harness/deerflow/sandbox/middleware.py tests/test_sandbox_middleware.py tests/test_thread_state_reducers.py
git diff --check