### PR TITLE
fix(serialization): strip base64 image data from streamed values events

### DIFF
--- a/backend/packages/harness/deerflow/runtime/serialization.py
+++ b/backend/packages/harness/deerflow/runtime/serialization.py
@@ -133,11 +133,14 @@ def serialize(obj: Any, *, mode: str = "") -> Any:
     """Serialize LangChain objects with mode-specific handling.
 
     * ``messages`` — obj is ``(message_chunk, metadata_dict)``
-    * ``values`` — obj is the full state dict; ``__pregel_*`` keys stripped
+    * ``values`` — obj is the full state dict; ``__pregel_*`` keys stripped and
+      base64 ``data:`` image blocks dropped from hide_from_ui messages
     * everything else — recursive ``model_dump()`` / ``dict()`` fallback
     """
     if mode == "messages":
         return serialize_messages_tuple(obj)
     if mode == "values":
-        return serialize_channel_values(obj) if isinstance(obj, dict) else serialize_lc_object(obj)
+        # ``values`` snapshots stream the full state to the frontend, so they
+        # must drop base64 image payloads the same way the REST endpoints do.
+        return serialize_channel_values_for_api(obj) if isinstance(obj, dict) else serialize_lc_object(obj)
     return serialize_lc_object(obj)

--- a/backend/tests/test_serialization.py
+++ b/backend/tests/test_serialization.py
@@ -328,3 +328,32 @@ def test_serialize_channel_values_for_api_no_messages():
 
     result = serialize_channel_values_for_api({"title": "empty"})
     assert result == {"title": "empty"}
+
+
+def test_serialize_values_mode_strips_base64_from_hidden_messages():
+    """The SSE stream emits ``values`` snapshots of the full state, so it must
+    strip base64 image data from hide_from_ui messages just like the REST
+    endpoints do — otherwise the same payload leaks over the stream."""
+    import json
+
+    from deerflow.runtime.serialization import serialize
+
+    state = {
+        "messages": [
+            _make_msg(
+                [
+                    {"type": "text", "text": "context"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,iVBOR..."},
+                    },
+                ],
+                hide_from_ui=True,
+            ),
+        ],
+    }
+    result = serialize(state, mode="values")
+    # the hidden message survives (count/order preserved) but the data: block is gone
+    assert len(result["messages"]) == 1
+    assert "data:image/png;base64" not in json.dumps(result)
+    assert result["messages"][0]["content"] == [{"type": "text", "text": "context"}]


### PR DESCRIPTION
## Why

`#3535` stopped the REST endpoints from leaking base64 image data to the frontend: `ViewImageMiddleware` stores full base64 image payloads inside `hide_from_ui` human messages, and the wait/history/state endpoints now run those through `serialize_channel_values_for_api`, which drops the `data:` image blocks.

The SSE streaming path was missed. With the default stream mode (`values`), the worker publishes full-state snapshots via `serialize(chunk, mode="values")`, and that branch still went through `serialize_channel_values` (no stripping). So the exact payload `#3535` removed from the REST responses was still streamed to the frontend over SSE on every `values` event.

## What changed

`serialize(..., mode="values")` now routes through `serialize_channel_values_for_api` instead of `serialize_channel_values`, so streamed state snapshots drop base64 `data:` image blocks from `hide_from_ui` messages, matching the REST endpoints. Message count and ordering are preserved; non-hidden messages and `https://` image URLs are left untouched. `serialize()` is only used by the gateway SSE publisher, so persisted/internal serialization is unaffected.

## Surface area

- [x] **Backend API** — SSE event / response shape (`values` stream events)
- [ ] **Default behavior change** — no opt-in change; this removes data that was never meant to reach the client

## Bug fix verification

Before: a run whose state contains a `hide_from_ui` human message with a `data:image/...;base64,...` block streams that base64 to the client in every `values` SSE event.

After: the `values` event keeps the message (count/order intact) but the base64 `data:` image block is gone; `https://` image URLs and non-hidden messages are still sent.

## Validation

- Added `test_serialize_values_mode_strips_base64_from_hidden_messages` in `backend/tests/test_serialization.py`, alongside the existing `serialize_channel_values_for_api` / `strip_data_url_image_blocks` tests from #3535.
- `ruff check` and `ruff format --check` pass on the changed files.
- I reproduced the leak and confirmed the fix with a standalone load of `serialization.py` (it only depends on `typing`): on `main`, `serialize(state, mode="values")` keeps the base64; with the change it is stripped while `__pregel_*` keys, non-hidden messages, and `https` URLs are preserved. The full `make test` suite needs the backend workspace env (langgraph etc.), so I rely on CI to run the pytest test end to end.

## AI assistance

**Tool:** Claude Code.
**How:** It helped trace the streaming serialization path and spot that it was the unfixed sibling of #3535, and drafted the one-line fix and the test. I reviewed the serialization module, confirmed `serialize()` is used only by the SSE publisher (not persistence), and verified the behavior with the standalone reproduction above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
