### PR TITLE
fix(frontend): resolve stale subagent running state after stop

### DIFF
--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -30,7 +30,7 @@ import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
 import type { Subtask } from "@/core/tasks";
 import { useUpdateSubtask } from "@/core/tasks/context";
 import {
-  getPendingSubtaskStatus,
+  derivePendingSubtaskStatus,
   parseSubtaskResult,
 } from "@/core/tasks/subtask-result";
 import type { AgentThreadState } from "@/core/threads";
@@ -183,6 +183,7 @@ export function MessageList({
   const updateSubtask = useUpdateSubtask();
   const messages = thread.messages;
   const groupedMessages = getMessageGroups(messages);
+  const lastGroupIndex = groupedMessages.length - 1;
   const turnUsageMessagesByGroupIndex =
     getAssistantTurnUsageMessages(groupedMessages);
   const tokenDebugSteps = useMemo(
@@ -279,10 +280,7 @@ export function MessageList({
         {groupedMessages.map((group, groupIndex) => {
           const turnUsageMessages = turnUsageMessagesByGroupIndex[groupIndex];
           const groupIsLoading =
-            thread.isLoading &&
-            !groupedMessages
-              .slice(groupIndex + 1)
-              .some((nextGroup) => nextGroup.type === "human");
+            thread.isLoading && groupIndex === lastGroupIndex;
 
           if (group.type === "human" || group.type === "assistant") {
             return (
@@ -367,13 +365,17 @@ export function MessageList({
               if (message.type === "ai") {
                 for (const toolCall of message.tool_calls ?? []) {
                   if (toolCall.name === "task") {
-                    const status = getPendingSubtaskStatus(
-                      toolCall.id,
+                    const taskId = toolCall.id;
+                    if (!taskId) {
+                      continue;
+                    }
+                    const status = derivePendingSubtaskStatus(
+                      taskId,
                       group.messages,
                       groupIsLoading,
                     );
                     const task: Subtask = {
-                      id: toolCall.id!,
+                      id: taskId,
                       subagent_type: toolCall.args.subagent_type,
                       description: toolCall.args.description,
                       prompt: toolCall.args.prompt,
@@ -430,14 +432,14 @@ export function MessageList({
               } else if (message.id) {
                 subagentDebugMessageIds.push(message.id);
               }
-              const taskIds = message.tool_calls
-                ?.filter((toolCall) => toolCall.name === "task")
-                .map((toolCall) => toolCall.id);
+              const taskIds = message.tool_calls?.flatMap((toolCall) =>
+                toolCall.name === "task" && toolCall.id ? [toolCall.id] : [],
+              );
               for (const taskId of taskIds ?? []) {
                 results.push(
                   <SubtaskCard
                     key={"task-group-" + taskId}
-                    taskId={taskId!}
+                    taskId={taskId}
                     isLoading={groupIsLoading}
                   />,
                 );

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -29,7 +29,10 @@ import {
 import { useRehypeSplitWordsIntoSpans } from "@/core/rehype";
 import type { Subtask } from "@/core/tasks";
 import { useUpdateSubtask } from "@/core/tasks/context";
-import { parseSubtaskResult } from "@/core/tasks/subtask-result";
+import {
+  getPendingSubtaskStatus,
+  parseSubtaskResult,
+} from "@/core/tasks/subtask-result";
 import type { AgentThreadState } from "@/core/threads";
 import { cn } from "@/lib/utils";
 
@@ -275,6 +278,11 @@ export function MessageList({
         />
         {groupedMessages.map((group, groupIndex) => {
           const turnUsageMessages = turnUsageMessagesByGroupIndex[groupIndex];
+          const groupIsLoading =
+            thread.isLoading &&
+            !groupedMessages
+              .slice(groupIndex + 1)
+              .some((nextGroup) => nextGroup.type === "human");
 
           if (group.type === "human" || group.type === "assistant") {
             return (
@@ -359,12 +367,20 @@ export function MessageList({
               if (message.type === "ai") {
                 for (const toolCall of message.tool_calls ?? []) {
                   if (toolCall.name === "task") {
+                    const status = getPendingSubtaskStatus(
+                      toolCall.id,
+                      group.messages,
+                      groupIsLoading,
+                    );
                     const task: Subtask = {
                       id: toolCall.id!,
                       subagent_type: toolCall.args.subagent_type,
                       description: toolCall.args.description,
                       prompt: toolCall.args.prompt,
-                      status: "in_progress",
+                      status,
+                      ...(status === "failed"
+                        ? { error: t.subtasks.failed }
+                        : {}),
                     };
                     updateSubtask(task);
                     tasks.add(task);
@@ -402,7 +418,7 @@ export function MessageList({
                   <MessageGroup
                     key={"thinking-group-" + message.id}
                     messages={[message]}
-                    isLoading={thread.isLoading}
+                    isLoading={groupIsLoading}
                     tokenDebugSteps={tokenDebugSteps.filter(
                       (step) => step.messageId === message.id,
                     )}
@@ -422,7 +438,7 @@ export function MessageList({
                   <SubtaskCard
                     key={"task-group-" + taskId}
                     taskId={taskId!}
-                    isLoading={thread.isLoading}
+                    isLoading={groupIsLoading}
                   />,
                 );
               }

--- a/frontend/src/core/tasks/context.tsx
+++ b/frontend/src/core/tasks/context.tsx
@@ -1,6 +1,17 @@
-import { createContext, useCallback, useContext, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import type { Subtask } from "./types";
+
+function isTerminalSubtaskStatus(status: Subtask["status"] | undefined) {
+  return status === "completed" || status === "failed";
+}
 
 export interface SubtaskContextValue {
   tasks: Record<string, Subtask>;
@@ -40,14 +51,45 @@ export function useSubtask(id: string) {
 
 export function useUpdateSubtask() {
   const { tasks, setTasks } = useSubtaskContext();
+  const shouldNotifyAfterRenderRef = useRef(false);
+  // No deps: must run after every render to check the ref set during render.
+  useEffect(() => {
+    if (!shouldNotifyAfterRenderRef.current) {
+      return;
+    }
+    shouldNotifyAfterRenderRef.current = false;
+    setTasks({ ...tasks });
+  });
+
   const updateSubtask = useCallback(
     (task: Partial<Subtask> & { id: string }) => {
-      tasks[task.id] = { ...tasks[task.id], ...task } as Subtask;
+      const previous = tasks[task.id];
+      const previousStatus = previous?.status;
+      // MessageList writes the pending task tool-call state before parsing the
+      // matching ToolMessage in the same render. Keep terminal results stable
+      // across the next render so the refresh notification does not loop.
+      const next = {
+        ...previous,
+        ...task,
+        ...(task.status === "in_progress" &&
+        isTerminalSubtaskStatus(previousStatus)
+          ? { status: previousStatus }
+          : {}),
+      } as Subtask;
+
+      const becameTerminal =
+        isTerminalSubtaskStatus(next.status) && previousStatus !== next.status;
+
+      tasks[task.id] = next;
+
       if (task.latestMessage) {
         setTasks({ ...tasks });
+      } else if (becameTerminal) {
+        shouldNotifyAfterRenderRef.current = true;
       }
     },
     [tasks, setTasks],
   );
+
   return updateSubtask;
 }

--- a/frontend/src/core/tasks/subtask-result.ts
+++ b/frontend/src/core/tasks/subtask-result.ts
@@ -1,3 +1,5 @@
+import type { Message } from "@langchain/langgraph-sdk";
+
 import type { Subtask } from "./types";
 
 export type SubtaskStatus = Subtask["status"];
@@ -122,6 +124,29 @@ export function parseSubtaskResult(
     update.result = fromText.result;
   }
   return update;
+}
+
+export function hasSubtaskToolResult(
+  toolCallId: string | undefined,
+  messages: Message[],
+) {
+  if (!toolCallId) {
+    return false;
+  }
+  return messages.some(
+    (message) => message.type === "tool" && message.tool_call_id === toolCallId,
+  );
+}
+
+export function getPendingSubtaskStatus(
+  toolCallId: string | undefined,
+  messages: Message[],
+  isCurrentTurnLoading: boolean,
+): SubtaskStatus {
+  if (isCurrentTurnLoading || hasSubtaskToolResult(toolCallId, messages)) {
+    return "in_progress";
+  }
+  return "failed";
 }
 
 function parseFromText(trimmed: string): SubtaskResultUpdate {

--- a/frontend/src/core/tasks/subtask-result.ts
+++ b/frontend/src/core/tasks/subtask-result.ts
@@ -138,7 +138,7 @@ export function hasSubtaskToolResult(
   );
 }
 
-export function getPendingSubtaskStatus(
+export function derivePendingSubtaskStatus(
   toolCallId: string | undefined,
   messages: Message[],
   isCurrentTurnLoading: boolean,

--- a/frontend/tests/e2e/subtask-card.spec.ts
+++ b/frontend/tests/e2e/subtask-card.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+import { mockLangGraphAPI, MOCK_THREAD_ID } from "./utils/mock-api";
+
+const STOPPED_TASK_DESCRIPTION = "Research stopped reload regression";
+const STOPPED_TASK_PROMPT =
+  "Investigate why the stopped subtask card should not remain running after reload.";
+
+const stoppedSubtaskMessages = [
+  {
+    type: "human",
+    id: "msg-human-stopped-subtask",
+    content: [
+      {
+        type: "text",
+        text: "Start a subtask and then stop before the task tool returns.",
+      },
+    ],
+  },
+  {
+    type: "ai",
+    id: "msg-ai-stopped-subtask",
+    content: "",
+    additional_kwargs: {},
+    response_metadata: {},
+    tool_calls: [
+      {
+        id: "call-stopped-subtask",
+        name: "task",
+        args: {
+          subagent_type: "general-purpose",
+          description: STOPPED_TASK_DESCRIPTION,
+          prompt: STOPPED_TASK_PROMPT,
+        },
+        type: "tool_call",
+      },
+    ],
+    invalid_tool_calls: [],
+  },
+];
+
+test.describe("Subtask card", () => {
+  test("shows failed after a stopped task thread is reloaded", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: MOCK_THREAD_ID,
+          title: "Stopped subtask",
+          updated_at: "2026-06-18T12:00:00Z",
+          messages: stoppedSubtaskMessages,
+        },
+      ],
+    });
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await page.reload();
+
+    await expect(page.getByText(STOPPED_TASK_DESCRIPTION)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("Subtask failed")).toBeVisible();
+    await expect(page.getByText("Running subtask")).toHaveCount(0);
+  });
+});

--- a/frontend/tests/unit/core/tasks/subtask-result.test.ts
+++ b/frontend/tests/unit/core/tasks/subtask-result.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
   SUBAGENT_ERROR_KEY,
   SUBAGENT_STATUS_KEY,
-  getPendingSubtaskStatus,
+  derivePendingSubtaskStatus,
   hasSubtaskToolResult,
   parseSubtaskResult,
 } from "@/core/tasks/subtask-result";
@@ -165,11 +165,11 @@ describe("hasSubtaskToolResult", () => {
   });
 });
 
-describe("getPendingSubtaskStatus", () => {
+describe("derivePendingSubtaskStatus", () => {
   it("keeps a task in progress while its own assistant turn is loading", () => {
     const messages = [{ type: "ai" }] as Message[];
 
-    expect(getPendingSubtaskStatus("call_task_1", messages, true)).toBe(
+    expect(derivePendingSubtaskStatus("call_task_1", messages, true)).toBe(
       "in_progress",
     );
   });
@@ -177,7 +177,7 @@ describe("getPendingSubtaskStatus", () => {
   it("does not revive an earlier unfinished task during a later turn", () => {
     const messages = [{ type: "ai" }] as Message[];
 
-    expect(getPendingSubtaskStatus("call_task_1", messages, false)).toBe(
+    expect(derivePendingSubtaskStatus("call_task_1", messages, false)).toBe(
       "failed",
     );
   });
@@ -188,7 +188,7 @@ describe("getPendingSubtaskStatus", () => {
       { type: "tool", tool_call_id: "call_task_1" },
     ] as Message[];
 
-    expect(getPendingSubtaskStatus("call_task_1", messages, false)).toBe(
+    expect(derivePendingSubtaskStatus("call_task_1", messages, false)).toBe(
       "in_progress",
     );
   });

--- a/frontend/tests/unit/core/tasks/subtask-result.test.ts
+++ b/frontend/tests/unit/core/tasks/subtask-result.test.ts
@@ -1,11 +1,14 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import type { Message } from "@langchain/langgraph-sdk";
 import { describe, expect, it } from "vitest";
 
 import {
   SUBAGENT_ERROR_KEY,
   SUBAGENT_STATUS_KEY,
+  getPendingSubtaskStatus,
+  hasSubtaskToolResult,
   parseSubtaskResult,
 } from "@/core/tasks/subtask-result";
 
@@ -139,6 +142,55 @@ describe("parseSubtaskResult", () => {
     const parsed = parseSubtaskResult("   Task Succeeded. Result: ok   ");
     expect(parsed.status).toBe("completed");
     expect(parsed.result).toBe("ok");
+  });
+});
+
+describe("hasSubtaskToolResult", () => {
+  it("matches a task tool call to its ToolMessage", () => {
+    const messages = [
+      { type: "ai" },
+      { type: "tool", tool_call_id: "call_task_1" },
+    ] as Message[];
+
+    expect(hasSubtaskToolResult("call_task_1", messages)).toBe(true);
+  });
+
+  it("returns false when a task tool call has no ToolMessage", () => {
+    const messages = [
+      { type: "ai" },
+      { type: "tool", tool_call_id: "call_other" },
+    ] as Message[];
+
+    expect(hasSubtaskToolResult("call_task_1", messages)).toBe(false);
+  });
+});
+
+describe("getPendingSubtaskStatus", () => {
+  it("keeps a task in progress while its own assistant turn is loading", () => {
+    const messages = [{ type: "ai" }] as Message[];
+
+    expect(getPendingSubtaskStatus("call_task_1", messages, true)).toBe(
+      "in_progress",
+    );
+  });
+
+  it("does not revive an earlier unfinished task during a later turn", () => {
+    const messages = [{ type: "ai" }] as Message[];
+
+    expect(getPendingSubtaskStatus("call_task_1", messages, false)).toBe(
+      "failed",
+    );
+  });
+
+  it("leaves result parsing to the ToolMessage path when a result exists", () => {
+    const messages = [
+      { type: "ai" },
+      { type: "tool", tool_call_id: "call_task_1" },
+    ] as Message[];
+
+    expect(getPendingSubtaskStatus("call_task_1", messages, false)).toBe(
+      "in_progress",
+    );
   });
 });
 


### PR DESCRIPTION
Subtask cards were recreated from task tool calls as in_progress whenever the thread was loading. If a user stopped a run before the task tool returned a ToolMessage, the card could remain running after reload, and could flip back to running when a later user turn started streaming.

Derive pending subtask state from the current assistant turn instead of the global thread loading flag. A task now stays in progress only while its own turn is loading or while a matching ToolMessage exists for result parsing; otherwise it is marked failed.

Add unit coverage for task ToolMessage matching and for the later-turn loading regression.

Fixes #3638

## Why

Subtask cards are built from `task` tool calls in the message history. Before this change, each discovered `task` call was recreated as `in_progress` unless a matching ToolMessage later updated it.

When a user stops a run before the `task` tool returns, the history can contain the task tool call without a matching ToolMessage. That left the subtask card stuck in "Running subtask" after stop or reload.

There was also a second edge case: if a later user turn started streaming, the global `thread.isLoading` flag could make an earlier stopped subtask appear to be running again.


## What changed

- Added helpers to detect whether a subtask tool call has a matching ToolMessage and derive its pending UI status.
- Scoped subtask loading state to the current assistant message group instead of the whole thread.
- Mark unfinished subtasks as `failed` when their own assistant turn is no longer loading and no ToolMessage exists.
- Added unit tests for ToolMessage matching and the later-turn loading regression.


## Bug fix verification

Reproduced from code path:

1. A `task` tool call creates a subtask card.
2. User stops the run before a ToolMessage is produced.
3. The message history contains the task tool call without a matching ToolMessage.
4. The old logic recreated the subtask as `in_progress`.
5. The new logic marks it `failed` once that assistant turn is no longer loading.
6. Starting a later user turn no longer revives the earlier stopped subtask.


## Validation

- `pnpm vitest run tests/unit/core/tasks/subtask-result.test.ts`
- `pnpm lint`
- `pnpm format`
- `pnpm format:write`
- `pnpm check`


## AI assistance
use: claude code
- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.