### PR TITLE
fix(frontend): render full content for multi-part AI messages

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -259,7 +259,13 @@ export function extractTextFromMessage(message: Message) {
   }
   if (Array.isArray(message.content)) {
     return message.content
-      .map((content) => (content.type === "text" ? content.text : ""))
+      .map((content) =>
+        typeof content === "string"
+          ? content
+          : content.type === "text"
+            ? content.text
+            : "",
+      )
       .join("\n")
       .trim();
   }
@@ -323,6 +329,9 @@ export function extractContentFromMessage(message: Message) {
   if (Array.isArray(message.content)) {
     return message.content
       .map((content) => {
+        if (typeof content === "string") {
+          return content;
+        }
         switch (content.type) {
           case "text":
             return content.text;

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -43,6 +43,8 @@ export function textOfMessage(message: Message) {
   if (typeof message.content === "string") {
     return message.content;
   } else if (Array.isArray(message.content)) {
+    // Flat join ("") for single-line consumers (input box, titles); the rendered
+    // body uses extractContentFromMessage, which joins multi-part content with "\n".
     const text = message.content
       .map((part) =>
         typeof part === "string" ? part : part.type === "text" ? part.text : "",

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -43,11 +43,12 @@ export function textOfMessage(message: Message) {
   if (typeof message.content === "string") {
     return message.content;
   } else if (Array.isArray(message.content)) {
-    for (const part of message.content) {
-      if (part.type === "text") {
-        return part.text;
-      }
-    }
+    const text = message.content
+      .map((part) =>
+        typeof part === "string" ? part : part.type === "text" ? part.text : "",
+      )
+      .join("");
+    return text.length > 0 ? text : null;
   }
   return null;
 }

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 
 import {
   extractContentFromMessage,
+  extractTextFromMessage,
   extractReasoningContentFromMessage,
   getAssistantTurnCopyData,
   getAssistantTurnUsageMessages,
@@ -507,4 +508,36 @@ test("keeps streaming assistant hidden when a hidden control message follows it"
       ),
     ),
   ).toBe(true);
+});
+
+describe("multi-part content with bare-string continuations", () => {
+  // Gemini streams the first content block as a {type:"text"} object carrying
+  // the thinking signature, then emits continuation deltas as plain strings.
+  // LangChain's Python merge_content preserves these as bare-string elements,
+  // so the finalized message content is [{type:"text", ...}, "...rest..."].
+  const geminiMessage = {
+    id: "ai-1",
+    type: "ai",
+    content: [
+      {
+        type: "text",
+        text: "First block carrying the signature.",
+        extras: { signature: "abc123" },
+        index: 0,
+      },
+      "Continuation streamed as a bare string.",
+    ],
+  } as unknown as Message;
+
+  test("extractContentFromMessage includes the bare-string parts", () => {
+    expect(extractContentFromMessage(geminiMessage)).toBe(
+      "First block carrying the signature.\nContinuation streamed as a bare string.",
+    );
+  });
+
+  test("extractTextFromMessage includes the bare-string parts", () => {
+    expect(extractTextFromMessage(geminiMessage)).toBe(
+      "First block carrying the signature.\nContinuation streamed as a bare string.",
+    );
+  });
 });

--- a/frontend/tests/unit/core/threads/utils.test.ts
+++ b/frontend/tests/unit/core/threads/utils.test.ts
@@ -1,6 +1,11 @@
+import type { Message } from "@langchain/langgraph-sdk";
 import { expect, test } from "vitest";
 
-import { channelSourceOfThread, pathOfThread } from "@/core/threads/utils";
+import {
+  channelSourceOfThread,
+  pathOfThread,
+  textOfMessage,
+} from "@/core/threads/utils";
 
 test("uses standard chat route when thread has no agent context", () => {
   expect(pathOfThread("thread-123")).toBe("/workspace/chats/thread-123");
@@ -80,4 +85,36 @@ test("ignores threads without valid IM channel source metadata", () => {
       },
     }),
   ).toBeNull();
+});
+
+test("textOfMessage concatenates object and bare-string content parts", () => {
+  // Gemini's finalized shape: first signed {type:text} block + bare-string
+  // continuation. textOfMessage joins flat ("") for single-line consumers.
+  const message = {
+    id: "ai-1",
+    type: "ai",
+    content: [
+      {
+        type: "text",
+        text: "First block.",
+        extras: { signature: "abc123" },
+        index: 0,
+      },
+      " Continuation as a bare string.",
+    ],
+  } as unknown as Message;
+
+  expect(textOfMessage(message)).toBe(
+    "First block. Continuation as a bare string.",
+  );
+});
+
+test("textOfMessage returns null when array content has no text", () => {
+  const message = {
+    id: "ai-1",
+    type: "ai",
+    content: [{ type: "image_url", image_url: "https://example.com/x.png" }],
+  } as unknown as Message;
+
+  expect(textOfMessage(message)).toBeNull();
 });


### PR DESCRIPTION
Fixes #1000

## Why

AI messages were truncated in the chat UI — only the first few words rendered (the rest of a long reply silently disappeared). This was reported in #1000 with Gemini 2.5 Pro and misdiagnosed there as a backend checkpoint/serialization issue. It is actually a frontend rendering bug: the full content does reach the client.

## What changed

AI messages whose `content` is a mixed array (an object `{type:"text"}` block followed by bare-string continuations) now render their full text instead of just the first block.

Root cause: Gemini streams the first content block as a `{type:"text"}` object carrying the thinking `signature`, then emits continuation deltas as plain strings. LangChain's Python `merge_content` preserves these as bare-string elements, so the finalized message content is `[{type:"text", ...}, "…rest of the reply…"]`. The frontend content extractors only kept elements where `content.type === "text"`, mapping the bare strings to `""` and dropping them.

The streaming render looked fine because the JS SDK's `mergeContent` wraps trailing strings into `{type:"text"}` objects; the truncation appeared only after the final `values`/state snapshot (backend-shaped content) replaced the live message.

Fix: handle bare-string parts in `extractContentFromMessage`, `extractTextFromMessage` (`core/messages/utils.ts`), and `textOfMessage` (`core/threads/utils.ts`). Object-only content is unchanged.

## Surface area

- [x] **Frontend UI** — message rendering under `frontend/`

## Bug fix verification

No automated regression test added in this PR; verified manually by reloading an affected Gemini thread (truncated before, full after). Happy to add a unit test in `frontend/tests/unit/core/messages/utils.test.ts` covering the mixed `[{type:text}, "string"]` shape if preferred.

## Validation

```
cd frontend && pnpm format && pnpm lint && pnpm typecheck
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Traced the SSE stream and `/history` payloads to localize the truncation, compared the JS vs Python `merge_content` behavior to explain the stream-vs-finalized discrepancy, and applied the fix to the leaf content extractors. Reviewed every line and verified locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
