### PR TITLE
Add rvLLM as an OpenAI-compatible inference stack (RvllmChatModel)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ INFOQUEST_API_KEY=your-infoquest-api-key
 # MINIMAX_API_KEY=your-minimax-api-key  # OpenAI-compatible, see https://platform.minimax.io
 # STEPFUN_API_KEY=your-stepfun-api-key  # OpenAI-compatible, see https://platform.stepfun.com
 # VLLM_API_KEY=your-vllm-api-key  # OpenAI-compatible
+# RVLLM_API_KEY=your-rvllm-api-key  # OpenAI-compatible, native Rust rvllm-server (https://github.com/m0at/rvllm)
 # FEISHU_APP_ID=your-feishu-app-id
 # FEISHU_APP_SECRET=your-feishu-app-secret
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
          extra_body:
            chat_template_kwargs:
              enable_thinking: true
+
+     - name: gemma-4-e4b-it-rvllm
+       display_name: Gemma 4 E4B (rvLLM)
+       use: deerflow.models.rvllm_provider:RvllmChatModel
+       model: gemma-4-e4b-it
+       api_key: $RVLLM_API_KEY
+       base_url: http://localhost:18086/v1
+       temperature: 0
    ```
 
    OpenRouter and similar OpenAI-compatible gateways should be configured with `langchain_openai:ChatOpenAI` plus `base_url`. If you prefer a provider-specific environment variable name, point `api_key` at that variable explicitly (for example `api_key: $OPENROUTER_API_KEY`).
@@ -164,6 +172,8 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
    To route OpenAI models through `/v1/responses`, keep using `langchain_openai:ChatOpenAI` and set `use_responses_api: true` with `output_version: responses/v1`.
 
    For vLLM 0.19.0, use `deerflow.models.vllm_provider:VllmChatModel`. For Qwen-style reasoning models, DeerFlow toggles reasoning with `extra_body.chat_template_kwargs.enable_thinking` and preserves vLLM's non-standard `reasoning` field across multi-turn tool-call conversations. Legacy `thinking` configs are normalized automatically for backward compatibility. Reasoning models may also require the server to be started with `--reasoning-parser ...`. If your local vLLM deployment accepts any non-empty API key, you can still set `VLLM_API_KEY` to a placeholder value.
+
+   For rvLLM, use `deerflow.models.rvllm_provider:RvllmChatModel`. rvLLM is a native Rust `rvllm-server` exposing an OpenAI-compatible API; it serves greedy models with server-side MTP speculative decoding, so the provider defaults to deterministic decoding (`temperature: 0`) to keep agent runs reproducible — set `temperature` explicitly to opt into sampling. As with vLLM, if your local rvllm-server accepts any non-empty API key you can set `RVLLM_API_KEY` to a placeholder value. See [m0at/rvllm](https://github.com/m0at/rvllm).
 
    CLI-backed provider examples:
 

--- a/backend/packages/harness/deerflow/models/rvllm_provider.py
+++ b/backend/packages/harness/deerflow/models/rvllm_provider.py
@@ -1,0 +1,41 @@
+"""Custom rvLLM provider built on top of LangChain ChatOpenAI.
+
+rvLLM (https://github.com/m0at/rvllm) is a native Rust inference server that
+speaks the OpenAI-compatible API through ``rvllm-server``. It serves greedy
+models with server-side MTP speculative decoding: a small drafter proposes K
+tokens, the target verifies them in a single forward pass, and a greedy
+accept/reject keeps the emitted tokens *identical* to plain greedy decoding.
+Speculation changes throughput only, never the output (rvLLM's "identity
+guarantee").
+
+Because rvllm-server is greedy by default, this provider defaults to
+deterministic decoding (``temperature=0``) so multi-step agent trajectories are
+reproducible across runs. Callers can still opt into sampling by setting
+``temperature`` explicitly on the model config. The endpoint is otherwise a
+plain OpenAI-compatible chat-completions API, so the rest of ChatOpenAI's
+behavior (tool calls, streaming, usage accounting) is inherited unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_openai import ChatOpenAI
+
+
+class RvllmChatModel(ChatOpenAI):
+    """ChatOpenAI variant tuned for rvllm-server's greedy identity guarantee."""
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    def __init__(self, **kwargs: Any) -> None:
+        # rvllm-server is greedy by default and its speculative decode preserves
+        # greedy token identity, so default to deterministic decoding unless the
+        # caller explicitly opts into sampling. An explicit ``temperature``
+        # (including a non-zero value) always wins.
+        kwargs.setdefault("temperature", 0.0)
+        super().__init__(**kwargs)
+
+    @property
+    def _llm_type(self) -> str:
+        return "rvllm-openai-compatible"

--- a/backend/tests/test_rvllm_provider.py
+++ b/backend/tests/test_rvllm_provider.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from langchain_core.messages import HumanMessage
+
+from deerflow.models.rvllm_provider import RvllmChatModel
+
+
+def _make_model(**kwargs) -> RvllmChatModel:
+    params = {
+        "model": "gemma-4-e4b-it",
+        "api_key": "dummy",
+        "base_url": "http://localhost:18086/v1",
+    }
+    params.update(kwargs)
+    return RvllmChatModel(**params)
+
+
+def test_rvllm_provider_llm_type():
+    assert _make_model()._llm_type == "rvllm-openai-compatible"
+
+
+def test_rvllm_provider_defaults_to_greedy_decoding():
+    # rvllm-server's spec decode preserves greedy token identity, so the
+    # provider keeps agent runs deterministic by default.
+    assert _make_model().temperature == 0.0
+
+
+def test_rvllm_provider_preserves_explicit_temperature():
+    assert _make_model(temperature=0.7).temperature == 0.7
+
+
+def test_rvllm_provider_emits_greedy_temperature_in_request_payload():
+    payload = _make_model()._get_request_payload([HumanMessage(content="Hello")])
+    assert payload["temperature"] == 0.0

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -463,6 +463,22 @@ models:
   #       chat_template_kwargs:
   #         enable_thinking: true
 
+  # Example: rvLLM (native Rust rvllm-server, OpenAI-compatible)
+  # rvLLM serves greedy models with server-side MTP speculative decoding; the
+  # provider defaults to deterministic decoding (temperature: 0) so agent runs
+  # stay reproducible. See https://github.com/m0at/rvllm
+  # - name: gemma-4-e4b-it-rvllm
+  #   display_name: Gemma 4 E4B (rvLLM)
+  #   use: deerflow.models.rvllm_provider:RvllmChatModel
+  #   model: gemma-4-e4b-it
+  #   api_key: $RVLLM_API_KEY
+  #   base_url: http://localhost:18086/v1
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #   temperature: 0
+  #   supports_vision: false
+
 
   # Example: Qwen3-Coder deployed on MindIE Engine
   # - name: Qwen3_Coder_480B_MindIE


### PR DESCRIPTION
## What

Adds **rvLLM** as an additional inference stack alongside the existing vLLM provider.

[rvLLM](https://github.com/m0at/rvllm) is a native Rust inference server (`rvllm-server`) that exposes an OpenAI-compatible API and serves greedy models with server-side **MTP speculative decoding** — a small drafter proposes K tokens, the target verifies them in one forward pass, and a greedy accept/reject keeps the emitted tokens identical to plain greedy decoding. Speculation changes throughput only, never the output (an "identity guarantee").

Because `rvllm-server` is greedy by default, `RvllmChatModel` defaults to deterministic decoding (`temperature=0`) so multi-step agent trajectories are reproducible across runs. An explicit `temperature` (including a non-zero value) always wins. The endpoint is otherwise plain OpenAI-compatible, so tool calls, streaming, and usage accounting are inherited from `ChatOpenAI` unchanged.

## Changes

- `deerflow/models/rvllm_provider.py` — `RvllmChatModel`, a thin `ChatOpenAI` subclass that defaults to greedy decoding and reports `_llm_type = "rvllm-openai-compatible"`.
- `tests/test_rvllm_provider.py` — covers the greedy default, explicit-temperature override, request-payload temperature, and `_llm_type`.
- `README.md`, `config.example.yaml`, `.env.example` — document the provider right after the vLLM entry, mirroring its format (`RVLLM_API_KEY`, `base_url`, `use: deerflow.models.rvllm_provider:RvllmChatModel`).

## Usage

```yaml
models:
  - name: gemma-4-e4b-it-rvllm
    display_name: Gemma 4 E4B (rvLLM)
    use: deerflow.models.rvllm_provider:RvllmChatModel
    model: gemma-4-e4b-it
    api_key: $RVLLM_API_KEY
    base_url: http://localhost:18086/v1
    temperature: 0
```

## Tests

`uv run pytest tests/test_rvllm_provider.py` → 4 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)