### PR TITLE
fix(deps): sync cryptography constraint to >=48.0.1

### DIFF
--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "sqlalchemy[asyncio]>=2.0,<3.0",
     "aiosqlite>=0.19",
     "alembic>=1.13",
-    "cryptography>=43.0.0",
+    "cryptography>=48.0.1",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `cryptography` constraint in `backend/packages/harness/pyproject.toml` from `>=43.0.0` to `>=48.0.1` to match what's already locked in `uv.lock`.

## Why
Dependabot security update #3620 bumped `cryptography` to 48.0.1 in `uv.lock`, but left the harness manifest at `>=43.0.0`. The dependency is declared in the uv **workspace member** `packages/harness`, not in `backend/pyproject.toml` where Dependabot discovers the manifest — so the source constraint never got updated. The result: `uv lock` kept rewriting the recorded `requires-dist` specifier, making the lockfile appear perpetually out of date.

This aligns the source constraint with the locked version. `uv.lock` is unchanged (it already records `>=48.0.1`), and `uv lock --check` now passes cleanly.

## Test plan
- [x] `cd backend && uv lock --check` passes with no diff
