### PR TITLE
chore: remove standalone LangGraph Server remnants from agent docs (#3304)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,9 +94,9 @@ make dev
 Behavior:
 
 - Stops existing local services first.
-- Starts LangGraph (`2024`), Gateway (`8001`), Frontend (`3000`), nginx (`2026`).
+- Starts Gateway (`8001`, with the embedded LangGraph-compatible runtime), Frontend (`3000`), nginx (`2026`). There is no standalone LangGraph service.
 - Unified app endpoint: `http://localhost:2026`.
-- Logs: `logs/langgraph.log`, `logs/gateway.log`, `logs/frontend.log`, `logs/nginx.log`.
+- Logs: `logs/gateway.log`, `logs/frontend.log`, `logs/nginx.log`.
 
 Stop services:
 

--- a/backend/packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py
@@ -201,7 +201,7 @@ class SandboxAuditMiddleware(AgentMiddleware[ThreadState]):
     1. **Command classification**: regex + shlex analysis grades commands as
        high-risk (block), medium-risk (warn), or safe (pass).
     2. **Audit log**: every bash call is recorded as a structured JSON entry
-       via the standard logger (visible in langgraph.log).
+       via the standard logger (visible in gateway.log).
 
     High-risk commands (e.g. ``rm -rf /``, ``curl url | bash``) are blocked:
     the handler is not called and an error ``ToolMessage`` is returned so the

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -147,3 +147,14 @@ def test_gateway_runtime_docs_do_not_reference_transition_modes():
         assert "./scripts/deploy.sh --gateway" not in content, path
         assert "docker compose --profile gateway" not in content, path
         assert "`/api/langgraph/*` → LangGraph" not in content, path
+
+
+def test_agent_instruction_docs_do_not_reference_standalone_langgraph_server():
+    """Agent/Copilot instruction docs must describe only the Gateway-embedded
+    runtime — no standalone LangGraph service, port 2024, or langgraph.log."""
+    content = _read(".github/copilot-instructions.md")
+
+    assert "langgraph.log" not in content
+    assert "localhost:2024" not in content
+    assert "127.0.0.1:2024" not in content
+    assert "Starts LangGraph" not in content


### PR DESCRIPTION
### Summary

Follow-up to #3301 / #3344 for issue #3304. The standard runtime is Gateway-embedded — there is **no standalone LangGraph service** — but two stale references still pointed contributors/agents at the old standalone setup and had slipped past the `test_gateway_runtime_cleanup.py` guard:

- **`.github/copilot-instructions.md`** described `make dev` as *"Starts LangGraph (`2024`), Gateway (`8001`), …"* and listed `logs/langgraph.log` in the log paths.
- **`SandboxAuditMiddleware`** docstring said the bash audit log is *"visible in langgraph.log"*.

### What changes

- `.github/copilot-instructions.md`: describe only the Gateway-embedded topology (Gateway `8001` with the embedded LangGraph-compatible runtime; no standalone LangGraph service); drop `logs/langgraph.log`.
- `sandbox_audit_middleware.py`: docstring now references `gateway.log`.
- `test_gateway_runtime_cleanup.py`: new `test_agent_instruction_docs_do_not_reference_standalone_langgraph_server` pins `.github/copilot-instructions.md` so `langgraph.log` / `:2024` / `Starts LangGraph` can't reappear.

### Scope / safety

Stays strictly within the **safe** scope of #3304. It does **not** touch the maintainer-gated pieces — `backend/app/gateway/langgraph_auth.py`, `backend/tests/test_langgraph_auth.py`, `auth.path` in `backend/langgraph.json`, or the `langgraph-api` / `langgraph-cli` / `langgraph-runtime-inmem` dependencies — which the issue says require confirming that direct standalone LangGraph Server / Studio support is no longer needed.

Acceptance criteria honored: standard Gateway runtime unchanged, `/api/langgraph/*` compatibility untouched, only standalone-server docs/comments removed, guard test extended.

### Testing

- `test_gateway_runtime_cleanup.py` — 12 passed (incl. the new guard).
- `ruff check` / `ruff format --check` clean.
