### PR TITLE
fix(frontend): reset new chat on client-side navigation

### DIFF
--- a/frontend/src/components/workspace/chats/use-thread-chat.ts
+++ b/frontend/src/components/workspace/chats/use-thread-chat.ts
@@ -27,6 +27,9 @@ export function resetThreadChatAfterDelete(detail: ThreadChatResetDetail) {
 export function useThreadChat() {
   const { thread_id: threadIdFromPath } = useParams<{ thread_id: string }>();
   const pathname = usePathname();
+  // Render-time values use the committed browser URL. The sync effect below
+  // intentionally watches the reactive pathname so client navigation still
+  // schedules a reset when window.location is stale during render.
   const actualPathname =
     typeof window === "undefined" ? pathname : window.location.pathname;
   const isNewPath = actualPathname.endsWith("/new");
@@ -65,11 +68,9 @@ export function useThreadChat() {
       return;
     }
     newThreadIdRef.current = null;
-    // Guard: after history.replaceState updates the URL from /chats/new to
-    // /chats/{UUID}, Next.js useParams may still return the stale "new" value
-    // because replaceState does not trigger router updates.  Avoid propagating
-    // this invalid thread ID to downstream hooks (e.g. useStream), which would
-    // cause a 422 from LangGraph Server.
+    // Native history updates the canonical pathname but preserves the route
+    // tree, so useParams may still return the stale "new" value. Avoid passing
+    // it to downstream hooks (e.g. useStream), which would cause a 422.
     if (threadIdFromPath === "new") {
       return;
     }

--- a/frontend/src/components/workspace/chats/use-thread-chat.ts
+++ b/frontend/src/components/workspace/chats/use-thread-chat.ts
@@ -57,7 +57,7 @@ export function useThreadChat() {
   }, []);
 
   useEffect(() => {
-    if (isNewPath) {
+    if (pathname.endsWith("/new")) {
       const nextThreadId = newThreadIdRef.current ?? uuid();
       newThreadIdRef.current = nextThreadId;
       setIsNewThreadState(true);
@@ -75,7 +75,7 @@ export function useThreadChat() {
     }
     setIsNewThreadState(false);
     setThreadIdState(threadIdFromPath);
-  }, [isNewPath, threadIdFromPath]);
+  }, [pathname, threadIdFromPath]);
 
   useEffect(() => {
     const handleReset = (event: Event) => {

--- a/frontend/tests/e2e/thread-history.spec.ts
+++ b/frontend/tests/e2e/thread-history.spec.ts
@@ -202,6 +202,43 @@ test.describe("Thread history", () => {
     await expect(page.getByPlaceholder(/how can i assist you/i)).toBeVisible();
   });
 
+  test("new chat resets immediately after a history-only thread URL update", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page);
+
+    await page.goto("/workspace/chats/new");
+    const textarea = page.getByPlaceholder(/how can i assist you/i);
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+    await textarea.fill("Message that must disappear in the next new chat");
+    await textarea.press("Enter");
+    await expect(page.getByText("Hello from DeerFlow!")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // A newly created chat changes the URL with history.replaceState so the
+    // active stream is not remounted. Reproduce that history-only transition:
+    // the canonical pathname becomes the UUID while useParams can stay "new".
+    await page.evaluate((threadId) => {
+      history.replaceState(null, "", `/workspace/chats/${threadId}`);
+    }, MOCK_THREAD_ID);
+
+    const newChatLink = page.locator(
+      "[data-sidebar='sidebar'] a[href='/workspace/chats/new']",
+    );
+    await expect(page).toHaveURL(
+      new RegExp(`/workspace/chats/${MOCK_THREAD_ID}$`),
+    );
+    await expect(newChatLink).toHaveAttribute("data-active", "false");
+
+    // One click must reset the chat without a second click or unrelated UI
+    // interaction forcing another render.
+    await newChatLink.click();
+    await expect(page).toHaveURL(/\/workspace\/chats\/new$/);
+    await expect(page.getByText("Hello from DeerFlow!")).toHaveCount(0);
+    await expect(textarea).toBeVisible();
+  });
+
   test("deleting the active newly created chat returns to the new chat screen", async ({
     page,
   }) => {


### PR DESCRIPTION
Drive the chat reset effect with Next.js's reactive pathname instead of the render-time window.location-derived flag.

During App Router transitions, window.location may still point to the previous thread until commit, leaving chat state stale until another UI interaction triggers a render. Preserve the stale 'new' param guard so created thread UUIDs are not overwritten.


## Why

After the first message creates a thread, DeerFlow updates the URL with `history.replaceState()` to avoid remounting the active chat. This can leave `useParams().thread_id` as `"new"` while the browser URL points to the created thread.

When **New Chat** was clicked, React could render before `window.location.pathname` was updated. As a result, `isNewPath` remained `false` and the reset effect did not run.

From the user's perspective, clicking **New Chat** appeared to do nothing: the page continued showing the previous conversation. A second click or another UI interaction triggered a re-render and completed the reset.


## What changed

- Drive the chat synchronization effect with Next.js's reactive pathname.
- Determine the new-chat destination from pathname inside the effect.
- Add a Playwright regression test covering the history-only URL transition used after thread creation.
- Verify that one New Chat click clears the previous conversation without requiring a second click or unrelated UI interaction.


## Bug fix verification

- Test path that reproduces the bug:
    - `frontend/tests/e2e/thread-history.spec.ts`
    - `Thread history › new chat resets immediately after a history-only thread URL update`

- Did it go red on main and green on this branch? yes
- Red result on the old implementation:
    - The URL changed to `/workspace/chats/new`.
    - `Hello from DeerFlow!` remained visible.
    - The assertion expected 0 matching messages but received 1.

- Green result on this branch:
    - The URL changed to `/workspace/chats/new`.
    - The previous message disappeared after one click.
    - No second click or unrelated UI interaction was required.


## Validation

Commands actually run from `frontend/`:
```bash
pnpm format
pnpm lint
pnpm typecheck
BETTER_AUTH_SECRET=local-dev-secret pnpm build
pnpm test
pnpm test:e2e -- --reporter=line
```

Results:
- Prettier: passed.
- ESLint: passed with 0 errors and 2 pre-existing warnings in unrelated files.
- TypeScript: passed.
- Production build: passed with one pre-existing Turbopack NFT tracing warning.
- Vitest: 34 test files passed, 328 tests passed.
- Playwright E2E: 49 tests passed.
- Regression test:
    - Red on the old implementation.
    - Green on the fixed implementation.


## AI assistance

**Tool(s) used:** Codex
- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

