### PR TITLE
chore(deps): sync uv.lock with groundroute extra

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -922,7 +922,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "tiktoken", specifier = ">=0.8.0" },
 ]
-provides-extras = ["ollama", "postgres", "pymupdf"]
+provides-extras = ["groundroute", "ollama", "postgres", "pymupdf"]
 
 [[package]]
 name = "defusedxml"


### PR DESCRIPTION
## Summary
- `backend/packages/harness/pyproject.toml` declares an empty `groundroute` optional-dependency extra (added in #3675), but `backend/uv.lock` was not regenerated alongside it, so its `provides-extras` for the `deerflow-harness` package was left out of sync.
- Ran `uv lock` to reconcile the lock file. The only change is the `deerflow-harness` `provides-extras` line, which now includes `groundroute`.

## Test plan
- [ ] `cd backend && uv lock --check` reports the lock is up to date
- [ ] `uv sync` resolves cleanly
