### PR TITLE
chore(ci): enforce uv.lock is in sync

### DIFF
--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -23,6 +23,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Check uv.lock is in sync
+        working-directory: backend
+        run: uv lock --check
+
       - name: Install dependencies
         working-directory: backend
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,12 @@ repos:
         language: system
         types_or: [python]
         files: ^backend/
+      - id: uv-lock-check
+        name: uv lock check
+        entry: bash -c 'cd backend && uv lock --check'
+        language: system
+        pass_filenames: false
+        files: ^backend/(pyproject\.toml|uv\.lock|packages/harness/pyproject\.toml)$
 
   # Frontend: eslint + prettier (must run from frontend/ for node_modules resolution)
   - repo: local


### PR DESCRIPTION
## Summary
Add a `uv lock --check` guard in two places so a stale `uv.lock` can't be committed unnoticed (as happened with the `groundroute` extra, fixed in #3678):

- **pre-commit**: a local `uv-lock-check` hook, scoped to the backend `pyproject.toml` files and `uv.lock` so it only runs when a manifest or the lock is staged.
- **CI**: a "Check uv.lock is in sync" step in the `lint-backend` job, run **before** `uv sync` — `uv sync` regenerates the lock when out of sync, so the check must run first to catch drift instead of masking it.

## Note
This PR branches off `main`, where `uv.lock` is currently out of sync. The new CI check will fail here until #3678 (the lock sync) merges. Merge #3678 first, then rebase this branch.

## Test plan
- [ ] CI `lint-backend` runs the new "Check uv.lock is in sync" step
- [ ] `pre-commit run uv-lock-check --files backend/uv.lock` passes when the lock is in sync and fails when it is stale
