### PR TITLE
fix: prevent incomplete user directories from shadowing global agents

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -152,7 +152,13 @@ async def check_agent_name(name: str) -> dict:
     # Treat the name as taken if either the per-user path or the legacy shared
     # path holds an agent — picking a name that collides with an unmigrated
     # legacy agent would shadow the legacy entry once migration runs.
-    available = not paths.user_agent_dir(user_id, normalized).exists() and not paths.agent_dir(normalized).exists()
+    # Require config.yaml to confirm a genuine agent directory (see #3390),
+    # not a leftover from memory/storage writes (memory.json only).
+    user_agent_path = paths.user_agent_dir(user_id, normalized)
+    user_has_agent = user_agent_path.exists() and (user_agent_path / "config.yaml").exists()
+    legacy_agent_path = paths.agent_dir(normalized)
+    legacy_has_agent = legacy_agent_path.exists() and (legacy_agent_path / "config.yaml").exists()
+    available = not user_has_agent and not legacy_has_agent
     return {"available": available, "name": normalized}
 
 


### PR DESCRIPTION
Fixes #3625

## Why

When a user starts a conversation with a global agent, memory/storage operations write a memory.json to the user's per-user agent directory. After refresh, any attempt to create an agent with the same name was blocked because check_agent_name returned available=false based solely on directory existence.

This also prevented proper fallback to the global agent in some edge cases because an incomplete user directory (memory.json only, no config.yaml) was treated as a valid agent.

## What changed

Changed check_agent_name to require config.yaml presence, consistent with resolve_agent_dir. A directory with only memory.json from conversation memory writes is no longer treated as a valid agent.

Specifically:
- backend/app/gateway/routers/agents.py: check_agent_name now verifies config.yaml exists in the user and legacy agent directories, not just that the directory exists.

## Surface area

- [ ] Frontend UI
- [x] Backend API — check_agent_name endpoint
- [ ] Agents / LangGraph
- [ ] Sandbox
- [ ] Skills
- [ ] Dependencies
- [ ] Default behavior change
- [x] Docs / tests / CI only

## Validation

- Backend: `cd backend && make lint && make test`
- Manual testing of check_agent_name with incomplete agent directories.

## AI assistance

**Tool(s) used:** Claude Code / Hermes Agent
**How you used it:** Fix implementation based on issue root cause analysis.
- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.