### PR TITLE
feat: add introduction documentation pages in English and Chinese

### DIFF
--- a/frontend/src/content/en/index.mdx
+++ b/frontend/src/content/en/index.mdx
@@ -37,7 +37,7 @@ Start with the Harness section. This path is for teams who want to integrate Dee
 
 Start with the App section. This path is for teams who want to run DeerFlow as a complete application and understand how to configure, operate, and use it in practice.
 
-- [DeerFlow App](./docs/app)
+- [DeerFlow App](./docs/application)
 - [Quick Start](./docs/app/quick-start)
 - [Deployment Guide](./docs/app/deployment-guide)
 - [Workspace Usage](./docs/app/workspace-usage)
@@ -91,5 +91,5 @@ The Reference section is for detailed lookup material, including configuration, 
 
 - If you are **evaluating the project**, start with [Introduction](./docs/introduction).
 - If you are **building your own agent system**, start with [DeerFlow Harness](./docs/harness).
-- If you are **deploying DeerFlow for users**, start with [DeerFlow App](./docs/app).
+- If you are **deploying DeerFlow for users**, start with [DeerFlow App](./docs/application).
 - If you want to **learn by doing**, go to [Tutorials](./docs/tutorials).

--- a/frontend/src/content/en/introduction/_meta.ts
+++ b/frontend/src/content/en/introduction/_meta.ts
@@ -1,6 +1,9 @@
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
+  index: {
+    title: "Introduction",
+  },
   "why-deerflow": {
     title: "Why DeerFlow",
   },

--- a/frontend/src/content/en/introduction/index.mdx
+++ b/frontend/src/content/en/introduction/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Introduction
+description: DeerFlow is a runtime harness for building long-horizon agent systems with skills, memory, tools, and sandboxed execution.
+---
+
+import { Cards } from "nextra/components";
+
+# Introduction
+
+Welcome to DeerFlow!
+
+DeerFlow is a framework for building and operating agent systems. Rather than treating an AI agent as a simple text generator or a hardcoded workflow graph, DeerFlow provides a robust **runtime harness** that packages the core components required for agents to perform meaningful, long-horizon work.
+
+## What is DeerFlow?
+
+DeerFlow bridges the gap between raw LLMs and production-ready agent workflows. It focuses on the capabilities necessary to complete complex tasks:
+
+- **Long-Horizon Planning**: Keeping agents on-track and coherent across multiple reasoning cycles and tool invocations.
+- **Decomposition via Subagents**: Breaking complex work into parallel, isolated tasks that don't overwhelm the main agent's context window.
+- **Sandboxed Execution**: Giving agents a safe, isolated filesystem environment where they can write files, run tests, and execute code.
+- **Modular Skills & Tools**: Loading capabilities dynamically so the agent's core stays general while adapting to specific workloads (e.g. deep research or data analysis).
+- **Persistent Memory & Context Engineering**: Managing what the agent remembers, summarizes, or forgets across turns and sessions.
+
+## Section Contents
+
+To help you build the right mental model before diving into implementation:
+
+<Cards num={3}>
+  <Cards.Card title="Why DeerFlow" href="/docs/introduction/why-deerflow" />
+  <Cards.Card title="Core Concepts" href="/docs/introduction/core-concepts" />
+  <Cards.Card title="Harness vs App" href="/docs/introduction/harness-vs-app" />
+</Cards>

--- a/frontend/src/content/zh/introduction/_meta.ts
+++ b/frontend/src/content/zh/introduction/_meta.ts
@@ -1,6 +1,9 @@
 import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
+  index: {
+    title: "简介",
+  },
   "why-deerflow": {
     title: "为什么选择 DeerFlow",
   },

--- a/frontend/src/content/zh/introduction/index.mdx
+++ b/frontend/src/content/zh/introduction/index.mdx
@@ -1,0 +1,32 @@
+---
+title: 简介
+description: DeerFlow 是一个运行时 Harness，用于构建支持技能、记忆、工具和沙箱执行的长时序 Agent 系统。
+---
+a
+import { Cards } from "nextra/components";
+
+# 简介
+
+欢迎来到 DeerFlow！
+
+DeerFlow 是一个用于构建和运行 Agent 系统的框架。与将 AI Agent 视为简单的文本生成器或硬编码的工作流图不同，DeerFlow 提供了一个强大的 **运行时 Harness**，打包了 Agent 执行有意义的长时序工作所需的核心组件。
+
+## 什么是 DeerFlow？
+
+DeerFlow 弥补了原生 LLM 与生产级 Agent 工作流之间的差距。它专注于完成复杂任务所需的关键能力：
+
+- **长时序规划**：在多个推理周期和工具调用中保持 Agent 处于正轨并连贯。
+- **通过子 Agent 进行任务拆解**：将复杂工作拆分为并行的、隔离的子任务，避免使主 Agent 的上下文窗口过载。
+- **沙箱化执行**：为 Agent 提供安全、隔离的文件系统环境，使其能够写入文件、运行测试并执行代码。
+- **模块化技能与工具**：动态加载能力，在保持 Agent 核心通用的同时适应特定工作负载（例如深度研究或数据分析）。
+- **持久化记忆与上下文工程**：管理 Agent 在不同轮次和会话之间记住、总结或遗忘的内容。
+
+## 章节内容
+
+在深入具体实现之前，建议阅读以下内容以建立正确的思维模型：
+
+<Cards num={3}>
+  <Cards.Card title="为什么选择 DeerFlow" href="/docs/introduction/why-deerflow" />
+  <Cards.Card title="核心概念" href="/docs/introduction/core-concepts" />
+  <Cards.Card title="Harness 与应用" href="/docs/introduction/harness-vs-app" />
+</Cards>


### PR DESCRIPTION
add introduction documentation pages in English and Chinese and update application path references
## Surface area

Fixes https://github.com/bytedance/deer-flow/issues/3676

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change


