### PR TITLE
fix: allow unauthenticated access to mock case study pages

### DIFF
--- a/frontend/src/app/workspace/layout.tsx
+++ b/frontend/src/app/workspace/layout.tsx
@@ -11,7 +11,18 @@ export const dynamic = "force-dynamic";
 
 export default async function WorkspaceLayout({
   children,
-}: Readonly<{ children: React.ReactNode }>) {
+  searchParams,
+}: Readonly<{
+  children: React.ReactNode;
+  searchParams?: Promise<{ mock?: string }>;
+}>) {
+  // Allow unauthenticated access to mock case study pages (public demos).
+  // The chat page reads ?mock=true and renders in read-only demo mode.
+  const params = await searchParams;
+  if (params?.mock === "true") {
+    return <WorkspaceContent>{children}</WorkspaceContent>;
+  }
+
   const result = await getServerSideUser();
 
   switch (result.tag) {


### PR DESCRIPTION
## Why

Public case study cards on the landing page link to `/workspace/chats/{threadId}?mock=true`, intended as public demos. But the workspace layout's server-side auth guard redirects unauthenticated visitors to `/login` before the chat page can read the `mock=true` flag, making the demos unreachable without authentication.

## What changed

The workspace layout now accepts `searchParams` and checks for `mock=true` before running the auth guard. When `mock=true` is present, children render directly inside `WorkspaceContent` (sidebar, layout) without requiring authentication. The chat page already handles `isMock` mode gracefully — read-only, no backend calls.

## Surface area

- [x] **Frontend UI** — workspace layout auth guard

## Bug fix verification

Bug: unauthenticated users visiting a case study link get redirected to `/login` instead of seeing the mock chat page.
Fix: `searchParams.mock === "true"` bypasses the auth guard, letting the chat page render in mock mode.

## Validation

- `pnpm typecheck` — passes
- `pnpm test` — 111/111 tests pass
- `pnpm format:write` — no changes needed
- `pnpm lint` — passes

## AI assistance

**Tool(s) used:** Claude Code (OpenClaw)

**How you used it:** AI wrote the implementation based on issue analysis. I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
