### PR TITLE
fix(memory): filter hide_from_ui HumanMessages from memory builder

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/message_processing.py
+++ b/backend/packages/harness/deerflow/agents/memory/message_processing.py
@@ -61,6 +61,13 @@ def filter_messages_for_memory(messages: list[Any]) -> list[Any]:
         msg_type = getattr(msg, "type", None)
 
         if msg_type == "human":
+            # Middleware-injected hidden messages (e.g. TodoMiddleware.todo_reminder,
+            # ViewImageMiddleware, p0 DynamicContextMiddleware.__memory) carry
+            # hide_from_ui and must never reach the memory-updating LLM — otherwise
+            # framework-internal text pollutes long-term memory (and the p0 __memory
+            # payload could trigger a self-amplification loop).
+            if getattr(msg, "additional_kwargs", {}).get("hide_from_ui"):
+                continue
             content_str = extract_message_text(msg)
             if "<uploaded_files>" in content_str:
                 stripped = _UPLOAD_BLOCK_RE.sub("", content_str).strip()

--- a/backend/tests/test_memory_upload_filtering.py
+++ b/backend/tests/test_memory_upload_filtering.py
@@ -133,6 +133,58 @@ class TestFilterMessagesForMemory:
         assert "/mnt/user-data/uploads/" not in all_content
         assert "<uploaded_files>" not in all_content
 
+    # --- hide_from_ui messages are excluded ---
+
+    def test_hide_from_ui_human_message_is_excluded(self):
+        """Middleware-injected hidden HumanMessages (TodoMiddleware.todo_reminder,
+        ViewImageMiddleware, p0 DynamicContextMiddleware.__memory) must never reach
+        the memory-updating LLM."""
+        hidden_reminder = HumanMessage(
+            content="<system_reminder>\nYour todo list from earlier is no longer visible.\n</system_reminder>",
+            additional_kwargs={"hide_from_ui": True, "name": "todo_reminder"},
+        )
+        msgs = [
+            _human("What is the capital of France?"),
+            _ai("The capital of France is Paris."),
+            hidden_reminder,  # should be skipped
+            _ai("Is there anything else I can help with?"),  # should be kept
+        ]
+        result = filter_messages_for_memory(msgs)
+
+        human_contents = [m.content for m in result if m.type == "human"]
+        assert len(human_contents) == 1
+        assert "What is the capital of France?" in human_contents[0]
+        assert not any("todo list" in c for c in human_contents)
+        assert not any(m.additional_kwargs.get("hide_from_ui") for m in result if m.type == "human")
+
+    def test_p0_memory_payload_is_excluded(self):
+        """The p0 DynamicContextMiddleware.__memory HumanMessage carries extracted
+        memory facts back to the memory LLM; feeding it again risks a
+        self-amplification loop, so it must be filtered out."""
+        memory_payload = HumanMessage(
+            content="<memory>User prefers concise answers</memory>",
+            additional_kwargs={"hide_from_ui": True},
+        )
+        msgs = [
+            _human("Help me with Python."),
+            _ai("Sure."),
+            memory_payload,  # should be skipped
+        ]
+        result = filter_messages_for_memory(msgs)
+
+        human_contents = [m.content for m in result if m.type == "human"]
+        assert len(human_contents) == 1
+        assert "Help me with Python." in human_contents[0]
+        assert not any("<memory>" in c for c in human_contents)
+
+    def test_hide_from_ui_false_is_preserved(self):
+        """Messages without hide_from_ui (or with it set to False) are kept."""
+        visible_msg = HumanMessage(content="Visible message", additional_kwargs={"hide_from_ui": False})
+        msgs = [visible_msg, _ai("Reply.")]
+        result = filter_messages_for_memory(msgs)
+        assert len(result) == 2
+        assert result[0].content == "Visible message"
+
 
 # ===========================================================================
 # detect_correction


### PR DESCRIPTION
Closes #3695

## Why

`filter_messages_for_memory` keeps every `HumanMessage` by type but never checks `additional_kwargs["hide_from_ui"]`. Middleware-injected hidden messages — `TodoMiddleware.todo_reminder`, `ViewImageMiddleware`, and the p0 `DynamicContextMiddleware.__memory` — are fed to the memory-updating LLM as if they were real user input, polluting `memory.json` with framework-internal text.

The `__memory` case is especially dangerous: it carries extracted memory facts back to the memory-updating LLM, risking a self-amplification loop where a fact is re-asserted across runs even after its source turn is gone.

## What changed

`filter_messages_for_memory` now skips `HumanMessage`s with `additional_kwargs["hide_from_ui"]`, consistent with the frontend's `isHiddenFromUIMessage` (`core/messages/utils.ts`) and the input-box filtering added in #3662. Normal messages (without the flag, or with it set to `False`) are kept unchanged.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path: `backend/tests/test_memory_upload_filtering.py`
  - `test_hide_from_ui_human_message_is_excluded` — verifies `todo_reminder`-style hidden messages are skipped
  - `test_p0_memory_payload_is_excluded` — verifies `__memory` payload is excluded (prevents amplification loop)
  - `test_hide_from_ui_false_is_preserved` — verifies normal messages (without the flag) are kept
- Did it go red on `main` and green on this branch? yes — the bug is reproducible on `main` without the fix (hidden messages leak into filtered output); all three new tests pass on this branch.
- Note: the tests are newly added in this PR (they did not exist on `main`), so "red on main" means the bug behavior is present, not that a pre-existing test failed.

## Validation

- Backend: `cd backend && make lint && make test`
  - `ruff check` + `ruff format --check`: all green
  - `pytest tests/test_memory_upload_filtering.py`: 29 passed (including 3 new `hide_from_ui` tests)
  - `pytest tests/test_harness_boundary.py`: 1 passed

## AI assistance

**Tool(s) used:** VSCode(GLM-5.2)

**How you used it:** AI identified the bug through codebase audit, wrote the fix and test cases, verified in Docker container. Human reviewed every line and validated the reproduction scenario.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
