### PR TITLE
perf(models): index assistant-payload signature matching (O(P×A) → O(P+A))

### DIFF
--- a/backend/packages/harness/deerflow/models/assistant_payload_replay.py
+++ b/backend/packages/harness/deerflow/models/assistant_payload_replay.py
@@ -9,6 +9,7 @@ decide which fields to restore.
 from __future__ import annotations
 
 import json
+from collections import defaultdict
 from collections.abc import Callable, Sequence
 from typing import Any
 
@@ -33,10 +34,23 @@ def restore_assistant_payloads(
     assistant_payloads = [m for m in payload_messages if m.get("role") == "assistant"]
     used_ai_indexes: set[int] = set()
 
+    # Index unused AI messages by signature so the unique-match lookup is O(1)
+    # per payload instead of rescanning every AI message (O(P*A) -> O(P+A)).
+    signature_by_index: list[tuple[str, str] | None] = [_ai_signature(m) for m in ai_messages]
+    unused_by_signature: dict[tuple[str, str], set[int]] = defaultdict(set)
+    for index, signature in enumerate(signature_by_index):
+        if signature is not None:
+            unused_by_signature[signature].add(index)
+
     for ordinal, payload_msg in enumerate(assistant_payloads):
-        ai_msg = _match_ai_message(payload_msg, ai_messages, used_ai_indexes, ordinal)
-        if ai_msg is not None:
-            restore(payload_msg, ai_msg)
+        ai_index = _match_ai_index(payload_msg, ai_messages, used_ai_indexes, unused_by_signature, ordinal)
+        if ai_index is None:
+            continue
+        used_ai_indexes.add(ai_index)
+        signature = signature_by_index[ai_index]
+        if signature is not None:
+            unused_by_signature[signature].discard(ai_index)
+        restore(payload_msg, ai_messages[ai_index])
 
 
 def restore_additional_kwargs_field(payload_msg: dict[str, Any], orig_msg: AIMessage, field_name: str) -> None:
@@ -51,25 +65,27 @@ def restore_reasoning_content(payload_msg: dict[str, Any], orig_msg: AIMessage) 
     restore_additional_kwargs_field(payload_msg, orig_msg, "reasoning_content")
 
 
-def _match_ai_message(
+def _match_ai_index(
     payload_msg: dict[str, Any],
     ai_messages: Sequence[AIMessage],
     used_ai_indexes: set[int],
+    unused_by_signature: dict[tuple[str, str], set[int]],
     fallback_ordinal: int,
-) -> AIMessage | None:
+) -> int | None:
+    """Return the index of the AI message to restore onto ``payload_msg`` (or None).
+
+    Prefers an unambiguous signature match — exactly one *unused* AI message
+    shares the payload's content/tool-call signature — looked up in O(1) via
+    ``unused_by_signature``; otherwise falls back to the next unused AI message
+    at or after the payload's ordinal. Pure: the caller records consumption.
+    """
     payload_key = _assistant_signature(payload_msg)
     if payload_key is not None:
-        matches = [index for index, ai_msg in enumerate(ai_messages) if index not in used_ai_indexes and _ai_signature(ai_msg) == payload_key]
-        if len(matches) == 1:
-            used_ai_indexes.add(matches[0])
-            return ai_messages[matches[0]]
+        candidates = unused_by_signature.get(payload_key)
+        if candidates is not None and len(candidates) == 1:
+            return next(iter(candidates))
 
-    fallback_index = _next_unused_index_at_or_after(len(ai_messages), used_ai_indexes, fallback_ordinal)
-    if fallback_index is not None:
-        used_ai_indexes.add(fallback_index)
-        return ai_messages[fallback_index]
-
-    return None
+    return _next_unused_index_at_or_after(len(ai_messages), used_ai_indexes, fallback_ordinal)
 
 
 def _next_unused_index_at_or_after(count: int, used_ai_indexes: set[int], start: int) -> int | None:

--- a/backend/tests/test_assistant_payload_replay.py
+++ b/backend/tests/test_assistant_payload_replay.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import copy
+import random
+
 from langchain_core.messages import AIMessage, HumanMessage
 
 from deerflow.models.assistant_payload_replay import (
+    _ai_signature,
+    _assistant_signature,
+    _next_unused_index_at_or_after,
     restore_additional_kwargs_field,
     restore_assistant_payloads,
     restore_reasoning_content,
@@ -164,3 +170,74 @@ def test_restore_assistant_payloads_does_not_wrap_to_earlier_unused_message():
 
     assert payload_messages[0]["reasoning_content"] == "unique-thought"
     assert "reasoning_content" not in payload_messages[1]
+
+
+# ---------------------------------------------------------------------------
+# Parity: the O(P+A) signature-indexed matcher must behave exactly like the
+# original O(P*A) linear-scan implementation across fuzzed inputs.
+# ---------------------------------------------------------------------------
+
+
+def _reference_restore(payload_messages, original_messages, restore):
+    """The original O(P*A) implementation, kept as a parity oracle."""
+    if len(payload_messages) == len(original_messages):
+        for payload_msg, orig_msg in zip(payload_messages, original_messages):
+            if payload_msg.get("role") == "assistant" and isinstance(orig_msg, AIMessage):
+                restore(payload_msg, orig_msg)
+        return
+
+    ai_messages = [m for m in original_messages if isinstance(m, AIMessage)]
+    assistant_payloads = [m for m in payload_messages if m.get("role") == "assistant"]
+    used: set[int] = set()
+    for ordinal, payload_msg in enumerate(assistant_payloads):
+        payload_key = _assistant_signature(payload_msg)
+        chosen = None
+        if payload_key is not None:
+            matches = [i for i, m in enumerate(ai_messages) if i not in used and _ai_signature(m) == payload_key]
+            if len(matches) == 1:
+                chosen = matches[0]
+        if chosen is None:
+            chosen = _next_unused_index_at_or_after(len(ai_messages), used, ordinal)
+        if chosen is not None:
+            used.add(chosen)
+            restore(payload_msg, ai_messages[chosen])
+
+
+def _random_case(rng):
+    contents = ["", "a", "b"]
+    tool_ids = ["x", "y"]
+    originals = []
+    marker = 0
+    for _ in range(rng.randint(0, 6)):
+        if rng.random() < 0.3:
+            originals.append(HumanMessage(content="user"))
+            continue
+        tool_calls = [{"id": f"call_{rng.choice(tool_ids)}", "name": "t", "args": {}}] if rng.random() < 0.35 else []
+        # Unique reasoning marker per AI message so the restored value identifies
+        # exactly which AI message was matched.
+        originals.append(AIMessage(content=rng.choice(contents), additional_kwargs={"reasoning_content": f"r{marker}"}, tool_calls=tool_calls))
+        marker += 1
+
+    payloads = []
+    for _ in range(rng.randint(0, 6)):
+        if rng.random() < 0.3:
+            payloads.append({"role": "user", "content": rng.choice(contents)})
+            continue
+        payload = {"role": "assistant", "content": rng.choice(contents)}
+        if rng.random() < 0.35:
+            payload["tool_calls"] = [{"id": f"call_{rng.choice(tool_ids)}", "type": "function", "function": {"name": "t", "arguments": "{}"}}]
+        payloads.append(payload)
+    return payloads, originals
+
+
+def _restored_markers(impl, payloads, originals):
+    local = copy.deepcopy(payloads)
+    impl(local, originals, _restore_reasoning)
+    return [pm.get("reasoning_content") for pm in local]
+
+
+def test_restore_assistant_payloads_parity_with_reference():
+    rng = random.Random(20260622)
+    for _ in range(2000):
+        payloads, originals = _random_case(rng)
+        assert _restored_markers(restore_assistant_payloads, payloads, originals) == _restored_markers(_reference_restore, payloads, originals)


### PR DESCRIPTION
## Why

`restore_assistant_payloads` re-attaches provider fields (e.g. `reasoning_content`) onto serialized assistant payloads. When the serialized payload length differs from the original message list (dropped/reordered messages), it falls back to signature matching — and for **each** assistant payload it **rescanned every original AIMessage**:

```python
matches = [index for index, ai_msg in enumerate(ai_messages)
           if index not in used_ai_indexes and _ai_signature(ai_msg) == payload_key]
if len(matches) == 1:
    ...
```

That's **O(P × A)** (P = assistant payloads, A = AIMessages, both grow with conversation length), recomputed on the relevant provider requests (vLLM/MiniMax/DeepSeek/StepFun reasoning replay, OpenAI tool-call signatures).

## What changed

The rule — restore only when **exactly one *unused*** AIMessage shares the payload's signature — is equivalent to *"that signature's unused-index bucket has size 1"*. So build a `signature → unused indexes` map once (O(A)) and look it up per payload in **O(1)**, removing each index from its bucket as it's consumed. The positional fallback (`_next_unused_index_at_or_after`) is unchanged.

**O(P × A) → O(P + A)** for the signature path. Behavior is identical.

## Surface area

Internal optimization under `backend/packages/harness/deerflow/models/`. No API or behavior change.

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Validation

`cd backend && make lint` — clean.

`tests/test_assistant_payload_replay.py` + `tests/test_patched_*` — 56 passed. All existing replay tests (unique content/tool-call/structured signature, ambiguous→positional, forward-scan, no-wrap-to-earlier) stay green; added:
- `test_restore_assistant_payloads_parity_with_reference` — **2000 fuzzed scenarios** (mixed AI/Human, colliding/empty/tool-call signatures, divergent lengths) asserting the new matcher restores byte-for-byte the same fields as a kept copy of the original O(P×A) implementation.

## AI assistance

**Tool(s) used:** Claude Code (Claude Opus 4.8)

**How you used it:** AI identified the per-payload rescan, proved the "exactly one unused match" rule equals a size-1 signature bucket, implemented the O(1) indexed lookup (positional fallback untouched), and wrote the fuzz parity test; I reviewed the equivalence argument and ran the suite before opening.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
