### PR TITLE
fix(claude): coalesce non-consecutive system messages before Anthropic request

### DIFF
--- a/backend/packages/harness/deerflow/models/claude_provider.py
+++ b/backend/packages/harness/deerflow/models/claude_provider.py
@@ -26,7 +26,7 @@ from typing import Any
 
 import anthropic
 from langchain_anthropic import ChatAnthropic
-from langchain_core.messages import BaseMessage
+from langchain_core.messages import BaseMessage, SystemMessage
 from pydantic import PrivateAttr
 
 logger = logging.getLogger(__name__)
@@ -39,6 +39,39 @@ THINKING_BUDGET_RATIO = 0.8
 # Override with ANTHROPIC_BILLING_HEADER env var if the hardcoded version drifts.
 _DEFAULT_BILLING_HEADER = "x-anthropic-billing-header: cc_version=2.1.85.351; cc_entrypoint=cli; cch=6c6d5;"
 OAUTH_BILLING_HEADER = os.environ.get("ANTHROPIC_BILLING_HEADER", _DEFAULT_BILLING_HEADER)
+
+
+def _coalesce_system_messages(messages: list[BaseMessage]) -> list[BaseMessage]:
+    """Merge non-leading system messages into one leading SystemMessage.
+
+    Anthropic accepts system content only as a single leading block. Several
+    DeerFlow middleware paths (skill activation, summarization message removal,
+    midnight date reminders) can leave a SystemMessage stranded mid-conversation,
+    which makes langchain_anthropic raise "Received multiple non-consecutive
+    system messages." Returns the input unchanged when the system messages
+    already form a front-anchored block (the common case), so normal requests
+    stay byte-for-byte identical.
+    """
+    system_idxs = [i for i, m in enumerate(messages) if isinstance(m, SystemMessage)]
+    if system_idxs == list(range(len(system_idxs))):
+        return messages
+
+    blocks: list[Any] = []
+    others: list[BaseMessage] = []
+    for message in messages:
+        if isinstance(message, SystemMessage):
+            content = message.content
+            if isinstance(content, str):
+                if content:
+                    blocks.append({"type": "text", "text": content})
+            elif isinstance(content, list):
+                blocks.extend(b if isinstance(b, dict) else {"type": "text", "text": str(b)} for b in content)
+        else:
+            others.append(message)
+
+    if not blocks:
+        return others
+    return [SystemMessage(content=blocks), *others]
 
 
 class ClaudeChatModel(ChatAnthropic):
@@ -139,7 +172,12 @@ class ClaudeChatModel(ChatAnthropic):
         **kwargs: Any,
     ) -> dict:
         """Override to inject prompt caching, thinking budget, and OAuth billing."""
-        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        # Anthropic requires all system content as one leading block; coalesce
+        # defensively so stray mid-conversation SystemMessages don't blow up
+        # _format_messages with "multiple non-consecutive system messages".
+        messages = self._convert_input(input_).to_messages()
+        coalesced = _coalesce_system_messages(messages)
+        payload = super()._get_request_payload(input_ if coalesced is messages else coalesced, stop=stop, **kwargs)
 
         if self._is_oauth:
             self._apply_oauth_billing(payload)

--- a/backend/tests/test_claude_provider_system_coalesce.py
+++ b/backend/tests/test_claude_provider_system_coalesce.py
@@ -1,0 +1,137 @@
+"""Tests for non-consecutive system message coalescing in ClaudeChatModel.
+
+Regression test for the Anthropic-only error "Received multiple non-consecutive
+system messages." raised by ``langchain_anthropic._format_messages`` when a
+``SystemMessage`` is left mid-conversation (e.g. by skill activation,
+summarization message removal, or midnight date reminders). The provider now
+folds all system content into a single leading block before formatting, so any
+message shape stays valid for the Anthropic Messages API.
+"""
+
+from unittest import mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+from deerflow.models.claude_provider import ClaudeChatModel
+
+
+def _make_model() -> ClaudeChatModel:
+    """Minimal non-OAuth ClaudeChatModel instance without network calls."""
+    with mock.patch.object(ClaudeChatModel, "model_post_init"):
+        model = ClaudeChatModel(model="claude-sonnet-4-6", anthropic_api_key="sk-ant-fake-token")  # type: ignore[call-arg]
+    # model_post_init is mocked, so initialize the PrivateAttr fields it would
+    # normally set (otherwise pydantic's __pydantic_private__ stays None).
+    model._is_oauth = False
+    model._oauth_access_token = ""
+    return model
+
+
+@pytest.fixture()
+def model() -> ClaudeChatModel:
+    return _make_model()
+
+
+def _system_text(system: object) -> str:
+    """Flatten a payload ``system`` value (str or list of blocks) to plain text."""
+    if isinstance(system, str):
+        return system
+    if isinstance(system, list):
+        return "\n".join(b.get("text", "") for b in system if isinstance(b, dict))
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Regression: the failing shape must not raise (red on main, green here)
+# ---------------------------------------------------------------------------
+
+
+def test_non_consecutive_system_messages_do_not_raise(model):
+    """A SystemMessage stranded after human/AI turns previously raised ValueError."""
+    messages = [
+        SystemMessage(content="MAIN PROMPT"),
+        HumanMessage(content="hi"),
+        AIMessage(content="hello"),
+        SystemMessage(content="LATE SYSTEM"),  # stranded mid-conversation
+        HumanMessage(content="more"),
+    ]
+
+    payload = model._get_request_payload(messages, stop=None)
+
+    text = _system_text(payload["system"])
+    assert "MAIN PROMPT" in text  # both system instructions survive the merge
+    assert "LATE SYSTEM" in text
+    assert len(payload["messages"]) == 3  # the three non-system turns remain
+
+
+def test_front_anchored_systems_still_work(model):
+    messages = [
+        SystemMessage(content="MAIN"),
+        SystemMessage(content="DATE"),
+        HumanMessage(content="hi"),
+    ]
+
+    payload = model._get_request_payload(messages, stop=None)
+
+    text = _system_text(payload["system"])
+    assert "MAIN" in text
+    assert "DATE" in text
+
+
+# ---------------------------------------------------------------------------
+# _coalesce_system_messages unit behavior
+# ---------------------------------------------------------------------------
+
+
+def test_coalesce_merges_non_leading_system_messages():
+    from deerflow.models.claude_provider import _coalesce_system_messages
+
+    messages = [
+        SystemMessage(content="A"),
+        HumanMessage(content="h1"),
+        SystemMessage(content="B"),
+        AIMessage(content="a1"),
+        SystemMessage(content="C"),
+        HumanMessage(content="h2"),
+    ]
+
+    result = _coalesce_system_messages(messages)
+
+    assert isinstance(result[0], SystemMessage)
+    assert sum(isinstance(m, SystemMessage) for m in result) == 1
+    assert [b["text"] for b in result[0].content] == ["A", "B", "C"]
+    # Non-system messages keep their original relative order.
+    assert [type(m).__name__ for m in result[1:]] == ["HumanMessage", "AIMessage", "HumanMessage"]
+
+
+@pytest.mark.parametrize(
+    "messages",
+    [
+        [],
+        [HumanMessage(content="hi")],
+        [SystemMessage(content="only")],
+        [SystemMessage(content="a"), SystemMessage(content="b"), HumanMessage(content="hi")],
+    ],
+)
+def test_coalesce_leaves_valid_shapes_untouched(messages):
+    from deerflow.models.claude_provider import _coalesce_system_messages
+
+    # Front-anchored (or absent) system messages are already valid for Anthropic;
+    # the helper returns the exact same object so normal requests never drift.
+    assert _coalesce_system_messages(messages) is messages
+
+
+def test_coalesce_preserves_list_content_blocks():
+    from deerflow.models.claude_provider import _coalesce_system_messages
+
+    block = {"type": "text", "text": "structured", "cache_control": {"type": "ephemeral"}}
+    messages = [
+        SystemMessage(content="lead"),
+        HumanMessage(content="hi"),
+        SystemMessage(content=[block]),
+    ]
+
+    result = _coalesce_system_messages(messages)
+
+    assert result[0].content[0] == {"type": "text", "text": "lead"}
+    assert result[0].content[1] == block  # original block dict preserved verbatim


### PR DESCRIPTION
## Why

Running DeerFlow against a Claude model (e.g. Opus 4.8) fails with `LLM request failed: Received multiple non-consecutive system messages.` once a turn has a `SystemMessage` outside the leading block. Anthropic accepts system content only as a single leading block, so `langchain_anthropic._format_messages` raises as soon as it meets a second, non-consecutive system message. Several middleware paths produce that shape — summarization removing messages around an injected reminder, the midnight date-update reminder, or skill content — and it reproduces reliably with the `skill-creator` workflow (activate a skill, run a few tool calls; the next model call throws). It's Anthropic-specific: OpenAI-style providers tolerate mid-list system messages, so it only surfaces on Claude models.

## What changed

`ClaudeChatModel` now folds all system messages into a single leading
`SystemMessage` before the request is formatted — but only when they aren't already a front-anchored block. Valid requests are returned unchanged (same list object), so there's no behavior drift for the common case. Claude requests now succeed regardless of where middleware placed system content.

## Surface area

- [x] **Agents / LangGraph** — model-call path: system-message formatting in the Claude provider

## Bug fix verification

- Test: `backend/tests/test_claude_provider_system_coalesce.py::test_non_consecutive_system_messages_do_not_raise`
- Red on `main`, green on this branch: **yes**. On `main`, `_get_request_payload` with a `SystemMessage` stranded after human/AI turns raises `ValueError: Received multiple non-consecutive system messages.`; with the fix it returns a payload whose single leading `system` block carries both instructions.

## Validation

Run in the backend dev container:
- `ruff check` + `ruff format` on the changed files — clean
- `python -m pytest tests/test_claude_provider_system_coalesce.py tests/test_claude_provider_oauth_billing.py` — **19 passed**
- Live end-to-end: a real Claude Opus 4.8 request containing non-consecutive system messages now succeeds and honors both system instructions (previously errored).

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code root-caused the failure to `langchain_anthropic._format_messages`, implemented the coalescing fix in `ClaudeChatModel`, and wrote the regression test. A human reviewed the diff and ran the validation above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.