### PR TITLE
fix(middleware): fix positional fallback consuming unrelated todo when same-content list is exhausted

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/token_usage_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/token_usage_middleware.py
@@ -97,7 +97,7 @@ def _build_todo_actions(previous_todos: list[Todo], next_todos: list[Todo]) -> l
                 previous_index, previous_match = content_matches.pop(0)
                 matched_previous_indices.add(previous_index)
 
-        if previous_match is None and index < len(previous_todos) and index not in matched_previous_indices:
+        if previous_match is None and content not in previous_by_content and index < len(previous_todos) and index not in matched_previous_indices:
             previous_match = previous_todos[index]
             matched_previous_indices.add(index)
 

--- a/backend/tests/test_token_usage_middleware.py
+++ b/backend/tests/test_token_usage_middleware.py
@@ -296,6 +296,4 @@ class TestBuildTodoActions:
             {"content": "A", "status": "completed"},
         ]
         actions = _build_todo_actions(previous, next_todos)
-        assert any(
-            a.get("kind") == "todo_remove" and a.get("content") == "B" for a in actions
-        ), f"Expected todo_remove for B but got: {actions}"
+        assert any(a.get("kind") == "todo_remove" and a.get("content") == "B" for a in actions), f"Expected todo_remove for B but got: {actions}"

--- a/backend/tests/test_token_usage_middleware.py
+++ b/backend/tests/test_token_usage_middleware.py
@@ -9,6 +9,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from deerflow.agents.middlewares.token_usage_middleware import (
     TOKEN_USAGE_ATTRIBUTION_KEY,
     TokenUsageMiddleware,
+    _build_todo_actions,
 )
 
 
@@ -279,3 +280,22 @@ class TestTokenUsageMiddleware:
             "output_tokens": 12,
             "total_tokens": 42,
         }
+
+
+class TestBuildTodoActions:
+    def test_duplicate_content_emits_todo_remove(self):
+        """When next_todos has duplicate content entries that exhaust previous_by_content,
+        the positional fallback must not consume an unrelated previous todo as matched.
+        The unrelated previous entry should still produce a todo_remove action."""
+        previous = [
+            {"content": "A", "status": "pending"},
+            {"content": "B", "status": "pending"},
+        ]
+        next_todos = [
+            {"content": "A", "status": "in_progress"},
+            {"content": "A", "status": "completed"},
+        ]
+        actions = _build_todo_actions(previous, next_todos)
+        assert any(
+            a.get("kind") == "todo_remove" and a.get("content") == "B" for a in actions
+        ), f"Expected todo_remove for B but got: {actions}"


### PR DESCRIPTION
When `next_todos` contains the same content string twice (e.g. two `"A"` entries), the first match pops from `previous_by_content["A"]`, leaving an empty list. The second `"A"` sees that empty list, treats it as falsy, and sets `previous_match = None`. The positional fallback then fires unconditionally — consuming `previous_todos[index]` even when it holds a completely different entry (e.g. `"B"`). That marks `"B"` as matched, so the final loop never emits a `todo_remove` action for it.

**Trigger case:**
```python
previous_todos = [{'content': 'A', 'status': 'pending'}, {'content': 'B', 'status': 'pending'}]
next_todos     = [{'content': 'A', 'status': 'in_progress'}, {'content': 'A', 'status': 'completed'}]
# Expected: [todo_start for A, todo_complete for second A, todo_remove for B]
# Actual:   [todo_start for A, todo_update for A]  — B silently disappears
```

**Fix:** guard the positional fallback with `content not in previous_by_content` so it only fires when the content was genuinely absent from previous (never in the map at all), not when the same-content list happened to be exhausted by earlier iterations.

**Regression test** added to `backend/tests/test_token_usage_middleware.py` covering this exact scenario — all 9 tests pass.
