### PR TITLE
fix(token-budget): acquire _lock in _apply, before_agent, _clear_run_state, and _drain_pending_warnings

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/token_budget_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/token_budget_middleware.py
@@ -96,31 +96,33 @@ class TokenBudgetMiddleware(AgentMiddleware[AgentState]):
         return str(id(runtime))
 
     def _clear_run_state(self, run_id: str) -> None:
-        self._warned.pop(run_id, None)
-        self._pending_warnings.pop(run_id, None)
-        self._seen_messages.pop(run_id, None)
-        self._cumulative_usage.pop(run_id, None)
+        with self._lock:
+            self._warned.pop(run_id, None)
+            self._pending_warnings.pop(run_id, None)
+            self._seen_messages.pop(run_id, None)
+            self._cumulative_usage.pop(run_id, None)
 
     @override
     def before_agent(self, state: AgentState, runtime: Runtime) -> None:
         if not self._config.enabled:
             return
 
-        # Mark all old messages from previous runss as 'seen' so they don't count toward THIS run's budget
+        # Mark all old messages from previous runs as 'seen' so they don't count toward THIS run's budget
         messages = state.get("messages", [])
         if not messages:
             return
 
         run_id = self._get_run_id(runtime)
-        seen = self._seen_messages.setdefault(run_id, {})
-        self._cumulative_usage.setdefault(run_id, TokenUsage())
+        with self._lock:
+            seen = self._seen_messages.setdefault(run_id, {})
+            self._cumulative_usage.setdefault(run_id, TokenUsage())
 
-        for msg in messages:
-            if isinstance(msg, AIMessage) and msg.id and hasattr(msg, "usage_metadata"):
-                usage = msg.usage_metadata or {}
-                input_tokens = usage.get("input_tokens", 0)
-                output_tokens = usage.get("output_tokens", 0)
-                seen[msg.id] = (input_tokens, output_tokens)
+            for msg in messages:
+                if isinstance(msg, AIMessage) and msg.id and hasattr(msg, "usage_metadata"):
+                    usage = msg.usage_metadata or {}
+                    input_tokens = usage.get("input_tokens", 0)
+                    output_tokens = usage.get("output_tokens", 0)
+                    seen[msg.id] = (input_tokens, output_tokens)
 
     @override
     async def abefore_agent(self, state: AgentState, runtime: Runtime) -> None:
@@ -182,67 +184,68 @@ class TokenBudgetMiddleware(AgentMiddleware[AgentState]):
 
         run_id = self._get_run_id(runtime)
 
-        seen = self._seen_messages.setdefault(run_id, {})
-        usage_accum = self._cumulative_usage.setdefault(run_id, TokenUsage())
+        with self._lock:
+            seen = self._seen_messages.setdefault(run_id, {})
+            usage_accum = self._cumulative_usage.setdefault(run_id, TokenUsage())
 
-        for msg in messages:
-            if isinstance(msg, AIMessage) and msg.id and hasattr(msg, "usage_metadata"):
-                usage = msg.usage_metadata or {}
+            for msg in messages:
+                if isinstance(msg, AIMessage) and msg.id and hasattr(msg, "usage_metadata"):
+                    usage = msg.usage_metadata or {}
 
-                input_tokens = usage.get("input_tokens", 0)
-                output_tokens = usage.get("output_tokens", 0)
+                    input_tokens = usage.get("input_tokens", 0)
+                    output_tokens = usage.get("output_tokens", 0)
 
-                # Check what previously recorded for this exact message
-                prev_input, prev_output = seen.get(msg.id, (0, 0))
+                    # Check what previously recorded for this exact message
+                    prev_input, prev_output = seen.get(msg.id, (0, 0))
 
-                # Calculate if any new tokens were added (handles retroactive subagent tokens)
-                diff_input = max(0, input_tokens - prev_input)
-                diff_output = max(0, output_tokens - prev_output)
+                    # Calculate if any new tokens were added (handles retroactive subagent tokens)
+                    diff_input = max(0, input_tokens - prev_input)
+                    diff_output = max(0, output_tokens - prev_output)
 
-                if diff_input > 0 or diff_output > 0:
-                    usage_accum.input += diff_input
-                    usage_accum.output += diff_output
-                    usage_accum.total += diff_input + diff_output
-                    seen[msg.id] = (input_tokens, output_tokens)
+                    if diff_input > 0 or diff_output > 0:
+                        usage_accum.input += diff_input
+                        usage_accum.output += diff_output
+                        usage_accum.total += diff_input + diff_output
+                        seen[msg.id] = (input_tokens, output_tokens)
 
-        if usage_accum.total <= 0:
+            if usage_accum.total <= 0:
+                return None
+
+            fractions = [("total", usage_accum.total, self._config.max_tokens)]
+            if self._config.max_input_tokens:
+                fractions.append(("input", usage_accum.input, self._config.max_input_tokens))
+            if self._config.max_output_tokens:
+                fractions.append(("output", usage_accum.output, self._config.max_output_tokens))
+
+            highest_fraction = 0.0
+            trigger_reason = ""
+            trigger_used = 0
+            trigger_budget = 0
+
+            for reason, used, limit in fractions:
+                frac = used / limit
+                if frac > highest_fraction:
+                    highest_fraction = frac
+                    trigger_reason = reason
+                    trigger_used = used
+                    trigger_budget = limit
+
+            if highest_fraction >= self._config.hard_stop_threshold:
+                logger.warning("Token budget hard stop triggered for run %s: %s limit exceeded", run_id, trigger_reason)
+                stop_text = _BUDGET_EXCEEDED_MSG.format(reason=trigger_reason, used=trigger_used, budget=trigger_budget)
+                return self._build_hard_stop_update(last_msg, stop_text)
+
+            if highest_fraction >= self._config.warn_threshold and not self._warned.get(run_id, False):
+                self._warned[run_id] = True
+                percent = highest_fraction * 100
+                warn_text = _BUDGET_WARNING_MSG.format(reason=trigger_reason, used=trigger_used, budget=trigger_budget, percent=percent)
+                logger.info("Token budget warning triggered for run %s: %s limit at %.1f%%", run_id, trigger_reason, percent)
+                # queue warning for wrap_model_call
+                warnings = self._pending_warnings.setdefault(run_id, [])
+                warnings.append(warn_text)
+                return None
+
             return None
-
-        fractions = [("total", usage_accum.total, self._config.max_tokens)]
-        if self._config.max_input_tokens:
-            fractions.append(("input", usage_accum.input, self._config.max_input_tokens))
-        if self._config.max_output_tokens:
-            fractions.append(("output", usage_accum.output, self._config.max_output_tokens))
-
-        highest_fraction = 0.0
-        trigger_reason = ""
-        trigger_used = 0
-        trigger_budget = 0
-
-        for reason, used, limit in fractions:
-            frac = used / limit
-            if frac > highest_fraction:
-                highest_fraction = frac
-                trigger_reason = reason
-                trigger_used = used
-                trigger_budget = limit
-
-        if highest_fraction >= self._config.hard_stop_threshold:
-            logger.warning("Token budget hard stop triggered for run %s: %s limit exceeded", run_id, trigger_reason)
-            stop_text = _BUDGET_EXCEEDED_MSG.format(reason=trigger_reason, used=trigger_used, budget=trigger_budget)
-            return self._build_hard_stop_update(last_msg, stop_text)
-
-        if highest_fraction >= self._config.warn_threshold and not self._warned.get(run_id, False):
-            self._warned[run_id] = True
-            percent = highest_fraction * 100
-            warn_text = _BUDGET_WARNING_MSG.format(reason=trigger_reason, used=trigger_used, budget=trigger_budget, percent=percent)
-            logger.info("Token budget warning triggered for run %s: %s limit at %.1f%%", run_id, trigger_reason, percent)
-            # queue warning for wrap_model_call
-            warnings = self._pending_warnings.setdefault(run_id, [])
-            warnings.append(warn_text)
-            return None
-
-        return None
 
     @override
     def after_model(self, state: AgentState, runtime: Runtime) -> dict | None:
@@ -257,7 +260,8 @@ class TokenBudgetMiddleware(AgentMiddleware[AgentState]):
             return []
 
         run_id = self._get_run_id(runtime)
-        warnings = self._pending_warnings.pop(run_id, None)
+        with self._lock:
+            warnings = self._pending_warnings.pop(run_id, None)
         return warnings or []
 
     def _inject_warnings(self, request: ModelRequest, warnings: list[str]) -> ModelRequest:

--- a/frontend/src/content/zh/introduction/index.mdx
+++ b/frontend/src/content/zh/introduction/index.mdx
@@ -2,7 +2,6 @@
 title: 简介
 description: DeerFlow 是一个运行时 Harness，用于构建支持技能、记忆、工具和沙箱执行的长时序 Agent 系统。
 ---
-a
 import { Cards } from "nextra/components";
 
 # 简介


### PR DESCRIPTION
## Why

`TokenBudgetMiddleware` defines `self._lock = threading.Lock()` in `__init__` and acquires it only in `reset()`. The four methods that mutate per-run state — `before_agent`, `_apply`, `_clear_run_state`, and `_drain_pending_warnings` — all access the same `BoundedDict` structures (`_seen_messages`, `_cumulative_usage`, `_warned`, `_pending_warnings`) without holding the lock.

LangGraph can call `after_model` concurrently for parallel agent nodes that share the same run. That means two `_apply()` calls can interleave on the same `usage_accum` object, producing a lost-update race on `usage_accum.input += diff_input`. The budget counter silently under-counts, so hard-stop and warn thresholds may never fire.

The second change removes a stray bare `a` character in `frontend/src/content/zh/introduction/index.mdx` (line 5) that renders as visible literal text on the Chinese introduction documentation page.

## What changed

- `before_agent`: shared-state mutations (`setdefault`, loop writes to `seen`) now run under `with self._lock:`
- `_apply`: the entire per-run accumulation + threshold evaluation block now runs under `with self._lock:`
- `_clear_run_state`: the four `pop` calls now run under `with self._lock:` (was unprotected even though `after_agent` calls it while `_apply` may still be running)
- `_drain_pending_warnings`: the `pop` from `_pending_warnings` now runs under `with self._lock:` (prevents a TOCTOU race with `_apply`'s `append`)
- Also fixed a typo in an inline comment: `previous runss` → `previous runs`
- `frontend/src/content/zh/introduction/index.mdx`: removed stray `a` between front matter `---` and the first `import` statement

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A — backend threading fix and a one-line doc file correction.

## Bug fix verification

A minimal reproducer would spin up two threads calling `_apply()` concurrently with the same `run_id` and assert the final `usage_accum.total` equals the sum of both threads' token deltas (currently it under-counts non-deterministically). Writing that test requires internal access to a `Runtime` stub; I can add it if the team provides a test harness fixture for `Runtime`. In the meantime:

- The race is deterministic by inspection: `usage_accum.input += diff_input` is a read-modify-write on a plain Python `int` attribute, which CPython's GIL does not protect across object attribute access in LangGraph's async task scheduling.
- The fix is mechanical: add `with self._lock:` around all four unprotected mutation sites, matching the pattern already used in `reset()`.

## Validation

```
python3 -m ruff check backend/packages/harness/deerflow/agents/middlewares/token_budget_middleware.py
# All checks passed!

python3 -m ruff format --check backend/packages/harness/deerflow/agents/middlewares/token_budget_middleware.py
# 1 file already formatted
```

Full `make lint && make test` requires `uv` and the full dependency graph which I could not install locally. The change is purely additive (`with self._lock:` wrapping) with no logic changes — the same `if`/`for`/`+=` expressions run, just under the mutex that was already present for `reset()`.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Used Claude Code to analyze the middleware source, identify the unprotected mutation sites by comparing `reset()` (which uses the lock) against `_apply()` and `before_agent()` (which do not), and generate the `with self._lock:` wrapping. I read every line of the diff and verified the lock scope covers all four mutation paths.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.