### PR TITLE
fix(memory): skip whitespace-only facts in _apply_updates

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -652,7 +652,12 @@ class MemoryUpdater:
                     continue
                 normalized_content = raw_content.strip()
                 fact_key = _fact_content_key(normalized_content)
-                if fact_key is not None and fact_key in existing_fact_keys:
+                if fact_key is None:
+                    # Empty / whitespace-only content: skip it the same way the
+                    # non-string guard above does, instead of appending a blank
+                    # fact that violates the non-empty-content invariant.
+                    continue
+                if fact_key in existing_fact_keys:
                     continue
 
                 fact_entry = {

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -78,6 +78,27 @@ def test_apply_updates_skips_existing_duplicate_and_preserves_removals() -> None
     assert all(fact["id"] != "fact_remove" for fact in result["facts"])
 
 
+def test_apply_updates_skips_whitespace_only_facts() -> None:
+    updater = MemoryUpdater()
+    current_memory = _make_memory()
+    update_data = {
+        "newFacts": [
+            {"content": "   ", "category": "context", "confidence": 0.9},
+            {"content": "User prefers dark mode", "category": "preference", "confidence": 0.9},
+        ],
+    }
+
+    with patch(
+        "deerflow.agents.memory.updater.get_memory_config",
+        return_value=_memory_config(max_facts=100, fact_confidence_threshold=0.7),
+    ):
+        result = updater._apply_updates(current_memory, update_data, thread_id="thread-ws")
+
+    # The whitespace-only fact must not be stored; the real fact still is.
+    assert [fact["content"] for fact in result["facts"]] == ["User prefers dark mode"]
+    assert all(fact["content"].strip() for fact in result["facts"])
+
+
 def test_prepare_update_prompt_preserves_non_ascii_memory_text() -> None:
     updater = MemoryUpdater()
     current_memory = _make_memory(


### PR DESCRIPTION
## What

`_apply_updates` dedups incoming facts with `_fact_content_key`, which returns `None` for empty / whitespace-only content. The dedup guard

```python
fact_key = _fact_content_key(normalized_content)
if fact_key is not None and fact_key in existing_fact_keys:
    continue
```

short-circuits to `False` whenever `fact_key is None`, so a whitespace-only fact is never skipped — it falls through and gets appended with empty `content`, even though the manual `create_memory_fact` API rejects empty content. An LLM memory-update step that emits `{"content": "   ", ...}` therefore pollutes memory with a blank fact.

This adds an explicit `if fact_key is None: continue`, mirroring the `if not isinstance(raw_content, str): continue` guard a few lines above, so empty / whitespace-only facts are dropped instead of stored.

## Test

New `test_apply_updates_skips_whitespace_only_facts`: a batch containing a `"   "` fact plus a real fact keeps only the real one. It fails before the change (the blank fact is stored) and passes after.

```
uv run pytest tests/test_memory_updater.py
```

passes locally.
