### PR TITLE
Lock sandbox provider lifecycle

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
+++ b/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 from abc import ABC, abstractmethod
 
 from deerflow.config import get_app_config
@@ -55,6 +56,7 @@ class SandboxProvider(ABC):
 
 
 _default_sandbox_provider: SandboxProvider | None = None
+_provider_lock = threading.RLock()
 
 
 def get_sandbox_provider(**kwargs) -> SandboxProvider:
@@ -68,9 +70,11 @@ def get_sandbox_provider(**kwargs) -> SandboxProvider:
     """
     global _default_sandbox_provider
     if _default_sandbox_provider is None:
-        config = get_app_config()
-        cls = resolve_class(config.sandbox.use, SandboxProvider)
-        _default_sandbox_provider = cls(**kwargs)
+        with _provider_lock:
+            if _default_sandbox_provider is None:
+                config = get_app_config()
+                cls = resolve_class(config.sandbox.use, SandboxProvider)
+                _default_sandbox_provider = cls(**kwargs)
     return _default_sandbox_provider
 
 
@@ -90,8 +94,9 @@ def reset_sandbox_provider() -> None:
     Use `shutdown_sandbox_provider()` for proper cleanup.
     """
     global _default_sandbox_provider
-    if _default_sandbox_provider is not None:
-        _default_sandbox_provider.reset()
+    with _provider_lock:
+        if _default_sandbox_provider is not None:
+            _default_sandbox_provider.reset()
         _default_sandbox_provider = None
 
 
@@ -103,10 +108,11 @@ def shutdown_sandbox_provider() -> None:
     is shutting down or when you need to completely reset the sandbox system.
     """
     global _default_sandbox_provider
-    if _default_sandbox_provider is not None:
-        if hasattr(_default_sandbox_provider, "shutdown"):
-            _default_sandbox_provider.shutdown()
-        _default_sandbox_provider = None
+    with _provider_lock:
+        if _default_sandbox_provider is not None:
+            if hasattr(_default_sandbox_provider, "shutdown"):
+                _default_sandbox_provider.shutdown()
+            _default_sandbox_provider = None
 
 
 def set_sandbox_provider(provider: SandboxProvider) -> None:
@@ -118,4 +124,5 @@ def set_sandbox_provider(provider: SandboxProvider) -> None:
         provider: The SandboxProvider instance to use.
     """
     global _default_sandbox_provider
-    _default_sandbox_provider = provider
+    with _provider_lock:
+        _default_sandbox_provider = provider

--- a/backend/tests/test_sandbox_provider_lifecycle.py
+++ b/backend/tests/test_sandbox_provider_lifecycle.py
@@ -1,0 +1,59 @@
+import threading
+import time
+
+import deerflow.sandbox.sandbox_provider as sandbox_provider
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.sandbox_provider import SandboxProvider
+
+
+class SlowSandboxProvider(SandboxProvider):
+    instances_created = 0
+    instances_lock = threading.Lock()
+
+    def __init__(self):
+        time.sleep(0.05)
+        with self.instances_lock:
+            type(self).instances_created += 1
+
+    def acquire(self, thread_id: str | None = None) -> str:
+        return "sandbox-id"
+
+    def get(self, sandbox_id: str) -> Sandbox | None:
+        return None
+
+    def release(self, sandbox_id: str) -> None:
+        pass
+
+
+class SandboxConfig:
+    use = "SlowSandboxProvider"
+
+
+class AppConfig:
+    sandbox = SandboxConfig()
+
+
+def test_get_sandbox_provider_initializes_singleton_once_under_concurrent_access(monkeypatch):
+    sandbox_provider.reset_sandbox_provider()
+    SlowSandboxProvider.instances_created = 0
+    monkeypatch.setattr(sandbox_provider, "get_app_config", lambda: AppConfig())
+    monkeypatch.setattr(sandbox_provider, "resolve_class", lambda *args: SlowSandboxProvider)
+
+    providers: list[SandboxProvider] = []
+    start = threading.Event()
+
+    def get_provider() -> None:
+        start.wait()
+        providers.append(sandbox_provider.get_sandbox_provider())
+
+    threads = [threading.Thread(target=get_provider) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+
+    start.set()
+
+    for thread in threads:
+        thread.join()
+
+    assert len({id(provider) for provider in providers}) == 1
+    assert SlowSandboxProvider.instances_created == 1


### PR DESCRIPTION
## Summary
- add a shared lifecycle lock around the sandbox provider singleton
- guard creation, reset, shutdown, and explicit test injection with the same lock
- add a concurrent-access regression test that previously created multiple providers

Closes #3721

## Root cause
`get_sandbox_provider()` used an unsynchronized check-then-create flow. Concurrent cold-start callers could all observe `_default_sandbox_provider is None`, construct separate provider instances, and then overwrite the global. For providers with constructor side effects, the losing instances can leave orphaned background resources.

## Validation
- `uv run pytest tests/test_sandbox_provider_lifecycle.py` -> passed
- `uv run ruff check tests/test_sandbox_provider_lifecycle.py packages/harness/deerflow/sandbox/sandbox_provider.py` -> passed
- `uv run pytest tests/test_sandbox_provider_lifecycle.py tests/test_local_sandbox_encoding.py tests/test_sandbox_tools_security.py --basetemp ./.pytest-tmp` -> 128 passed, 1 upstream dependency warning