### PR TITLE
feat(setup): ask custom OpenAI-compatible users about thinking support

### DIFF
--- a/scripts/setup_wizard.py
+++ b/scripts/setup_wizard.py
@@ -38,6 +38,7 @@ def main() -> int:
             yellow,
         )
         from wizard.writer import write_config_yaml, write_env_file
+        from wizard.providers import OPENAI_COMPAT_THINKING_CONFIG
 
         project_root = Path(__file__).resolve().parents[1]
         config_path = project_root / "config.yaml"
@@ -82,6 +83,9 @@ def main() -> int:
 
         print_header(f"Step {total_steps}/{total_steps} · Writing configuration")
 
+        extra_model_config = llm.provider.extra_config_for(llm.model_name) or {}
+        if llm.provider.base_url_prompt and llm.supports_thinking:
+            extra_model_config.update(OPENAI_COMPAT_THINKING_CONFIG)
         write_config_yaml(
             config_path,
             provider_use=llm.provider.use,
@@ -89,7 +93,7 @@ def main() -> int:
             display_name=f"{llm.provider.display_name} / {llm.model_name}",
             api_key_field=llm.provider.api_key_field,
             env_var=llm.provider.env_var,
-            extra_model_config=llm.provider.extra_config_for(llm.model_name) or None,
+            extra_model_config=extra_model_config or None,
             base_url=llm.base_url,
             search_use=search_provider.use if search_provider else None,
             search_tool_name=search_provider.tool_name if search_provider else "web_search",

--- a/scripts/wizard/steps/llm.py
+++ b/scripts/wizard/steps/llm.py
@@ -9,6 +9,7 @@ from wizard.ui import (
     ask_choice,
     ask_secret,
     ask_text,
+    ask_yes_no,
     print_header,
     print_info,
     print_success,
@@ -21,6 +22,7 @@ class LLMStepResult:
     model_name: str
     api_key: str | None
     base_url: str | None = None
+    supports_thinking: bool = False
 
 
 def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
@@ -52,6 +54,9 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
         if provider.model_prompt:
             model_name = ask_text(provider.model_prompt, default=model_name)
 
+    # Ask about thinking support for custom OpenAI-compatible gateways
+    supports_thinking = _ask_thinking_support(provider)
+
     if provider.auth_hint:
         print_header(f"{step_label} · Authentication")
         print_info(provider.auth_hint)
@@ -61,6 +66,7 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
             model_name=model_name,
             api_key=api_key,
             base_url=base_url,
+            supports_thinking=supports_thinking,
         )
 
     print_header(f"{step_label} · Enter your API Key")
@@ -77,4 +83,21 @@ def run_llm_step(step_label: str = "Step 1/3") -> LLMStepResult:
         model_name=model_name,
         api_key=api_key,
         base_url=base_url,
+        supports_thinking=supports_thinking,
     )
+
+
+def _ask_thinking_support(provider: LLMProvider) -> bool:
+    """Ask the user whether their OpenAI-compatible model supports thinking/reasoning.
+
+    Only prompted for custom gateway providers (those with base_url_prompt) where
+    the thinking capability is ambiguous.
+    """
+    if not provider.base_url_prompt:
+        return False
+    print_header("Thinking / Reasoning support")
+    print_info(
+        "Some OpenAI-compatible models (e.g. DeepSeek Reasoner, Claude Sonnet 4) "
+        "support thinking/reasoning output, which can improve complex reasoning tasks."
+    )
+    return ask_yes_no("Does this model support thinking/reasoning output?", default=False)


### PR DESCRIPTION
## Summary

When configuring the **Other OpenAI-compatible** provider in `make setup`, the wizard now asks whether the model supports thinking/reasoning output. If the user confirms, the generated config.yaml includes `supports_thinking: true` and `when_thinking_enabled`/`when_thinking_disabled` blocks.

Built-in providers (OpenAI, Anthropic, DeepSeek, etc.) are not affected - they already have pre-configured thinking support.

## Changes
- `scripts/wizard/steps/llm.py`: Add `ask_yes_no` prompt for thinking support after base_url entry; add `supports_thinking` field to `LLMStepResult`
- `scripts/setup_wizard.py`: Merge `OPENAI_COMPAT_THINKING_CONFIG` into extra model config when user confirms thinking support

Fixes #3162