### PR TITLE
fix: preserve LangGraph resume command

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -18,6 +18,7 @@ from typing import Any
 from fastapi import HTTPException, Request
 from langchain_core.messages import BaseMessage
 from langchain_core.messages.utils import convert_to_messages
+from langgraph.types import Command
 
 from app.gateway.deps import get_checkpointer, get_run_context, get_run_manager, get_stream_bridge
 from app.gateway.internal_auth import INTERNAL_SYSTEM_ROLE, get_trusted_internal_owner_user_id
@@ -456,7 +457,11 @@ async def start_run(
             logger.warning("Failed to upsert thread_meta for %s (non-fatal)", sanitize_log_param(thread_id))
 
         agent_factory = resolve_agent_factory(body.assistant_id)
-        graph_input = normalize_input(body.input)
+        command = getattr(body, "command", None)
+        if command and command.get("resume") is not None:
+            graph_input = Command(resume=command["resume"])
+        else:
+            graph_input = normalize_input(body.input)
         config = build_run_config(thread_id, body.config, body.metadata, assistant_id=body.assistant_id)
         await apply_checkpoint_to_run_config(config, body=body, thread_id=thread_id, request=request)
 

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -612,6 +612,89 @@ def test_inject_authenticated_user_context_skips_internal_role():
     assert config["context"]["user_id"] == "channel-user-7"
 
 
+async def _capture_start_run_graph_input(body):
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.store.memory import InMemoryStore
+
+    from app.gateway.services import start_run
+    from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
+    from deerflow.runtime import RunManager
+    from deerflow.runtime.runs.store.memory import MemoryRunStore
+
+    run_manager = RunManager(store=MemoryRunStore())
+    state = SimpleNamespace(
+        stream_bridge=SimpleNamespace(),
+        run_manager=run_manager,
+        checkpointer=InMemorySaver(),
+        store=InMemoryStore(),
+        run_event_store=SimpleNamespace(),
+        run_events_config=None,
+        thread_store=MemoryThreadMetaStore(InMemoryStore()),
+    )
+    request = SimpleNamespace(
+        headers={},
+        state=SimpleNamespace(),
+        app=SimpleNamespace(state=state),
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_run_agent(*args, **kwargs):
+        captured["graph_input"] = kwargs["graph_input"]
+
+    with (
+        patch("app.gateway.services.resolve_agent_factory", return_value=object()),
+        patch("app.gateway.services.run_agent", side_effect=fake_run_agent),
+    ):
+        record = await start_run(body, "thread-command-test", request)
+        await record.task
+
+    return captured["graph_input"]
+
+
+def test_start_run_translates_resume_command_to_langgraph_command(_stub_app_config):
+    import asyncio
+
+    from langgraph.types import Command
+
+    from app.gateway.routers.thread_runs import RunCreateRequest
+
+    graph_input = asyncio.run(
+        _capture_start_run_graph_input(
+            RunCreateRequest(
+                input=None,
+                command={"resume": {"answer": "approved"}},
+            )
+        )
+    )
+
+    assert isinstance(graph_input, Command)
+    assert graph_input.resume == {"answer": "approved"}
+
+
+def test_start_run_uses_normalized_input_without_command(_stub_app_config):
+    import asyncio
+
+    from langchain_core.messages import HumanMessage
+
+    from app.gateway.routers.thread_runs import RunCreateRequest
+
+    graph_input = asyncio.run(
+        _capture_start_run_graph_input(
+            RunCreateRequest(
+                input={"messages": [{"role": "human", "content": "hi"}]},
+                command=None,
+            )
+        )
+    )
+
+    assert isinstance(graph_input, dict)
+    assert isinstance(graph_input["messages"][0], HumanMessage)
+    assert graph_input["messages"][0].content == "hi"
+
+
 def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
     import asyncio
     from types import SimpleNamespace


### PR DESCRIPTION
Closes #3720

## Why

Resume requests sent through the LangGraph-compatible runs API already accept `command`, but `start_run()` only used `body.input` when constructing the graph input.

As a result, requests like `{"command": {"resume": ...}}` silently dropped the resume value, so resumed graphs could restart from checkpoint without delivering the value back to `interrupt()`.

## What changed

- `start_run()` now converts `body.command.resume` into `langgraph.types.Command(resume=...)` before launching the graph.
- Normal `input` handling is unchanged when no resume command is provided.
- Added regression coverage for both resume-command and normal-input paths.

## Surface area

- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend-only bug fix.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_gateway_services.py::test_start_run_translates_resume_command_to_langgraph_command`
- The regression test verifies that `command.resume` reaches `run_agent` as a real LangGraph `Command` instead of being dropped.

## Validation

```bash
cd backend && uv run pytest tests/test_gateway_services.py
cd backend && uv run ruff check app tests/test_gateway_services.py
cd backend && uv run ruff format --check app tests/test_gateway_services.py