### PR TITLE
fix(gateway): Added thread_id in new-API context 

### DIFF
--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -252,6 +252,7 @@ def build_run_config(
                 context = dict(context_value)
             else:
                 raise ValueError("request config 'context' must be a mapping or null.")
+            context["thread_id"] = thread_id
             config["context"] = context
         else:
             configurable = {"thread_id": thread_id}

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -705,8 +705,24 @@ def test_build_run_config_with_context():
     )
     assert "context" in config
     assert config["context"]["user_id"] == "u-42"
+    assert config["context"]["thread_id"] == "thread-1"
     assert "configurable" not in config
     assert config["recursion_limit"] == 100
+
+
+def test_build_run_config_context_injects_thread_id():
+    from app.gateway.services import build_run_config
+
+    config = build_run_config(
+        "T-deadbeef-42",
+        {"context": {"user_id": "u-1", "thinking_enabled": True}},
+        None,
+    )
+
+    assert config["context"]["user_id"] == "u-1"
+    assert config["context"]["thinking_enabled"] is True
+    assert config["context"]["thread_id"] == "T-deadbeef-42"
+    assert "configurable" not in config
 
 
 def test_build_run_config_null_context_becomes_empty_context():
@@ -715,7 +731,7 @@ def test_build_run_config_null_context_becomes_empty_context():
 
     config = build_run_config("thread-1", {"context": None}, None)
 
-    assert config["context"] == {}
+    assert config["context"] == {"thread_id": "thread-1"}
     assert "configurable" not in config
 
 


### PR DESCRIPTION
Fixes #3728 

## Why

`build_run_config()` injects the gateway-resolved `thread_id` only when requests use the legacy configurable API shape.

Modern LangGraph SDK clients use the `context` API by default. On that code path, `thread_id` is never injected into the runtime configuration, causing downstream middleware to be unable to resolve the current thread. This can lead to incorrect thread scoping and, in the case of `thread_data_middleware`, runtime failures when a thread ID is required.

## What changed

- Inject the gateway-resolved `thread_id` into `config["context"]` when requests use the LangGraph 0.6+ context API.
- Preserve existing behavior for legacy configurable requests.
- Add regression tests covering context-based request configurations.

As a result, middleware can consistently resolve `thread_id` regardless of which supported request configuration shape is used.

## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

<!-- If you checked "Frontend UI", attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip (delete) this section if this PR is not a bug fix.

     Bugs should be encoded as a failing test that goes red before the fix.
     Confirm:
       - Test path that reproduces the bug:
       - Did it go red on `main` and green on this branch? (yes / no)
       - If a red test wasn't cheap to write, explain why and what you did instead. -->

### Test path that reproduces the bug:

Regression tests added for `build_run_config()` covering context-based request configurations.

### Did it go red on main and green on this branch?

Yes.

On main, context-based requests did not receive an injected `thread_id`, causing downstream readers to resolve None.

On this branch, `thread_id` is injected into the active context container and is correctly resolved by downstream middleware.


## Validation

<!-- What you actually ran. Run at least the checks for the area you changed:
       Backend:   cd backend  && make lint && make test
       Frontend:  cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test
       Frontend E2E (if you touched frontend/): cd frontend && make test-e2e -->
        Ran: cd backend && make test
        Ran: python -m pytest tests/test_gateway_services.py 


## AI assistance

<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
     welcome. Disclosing it just helps reviewers calibrate how closely to read the
     diff. Please fill all three; don't delete the section. -->

**Tool(s) used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, or "none" -->Github CoPilot, ChatGPT

**How you used it:** <!-- e.g. "generated the module from a spec", "autocomplete only",
     "AI wrote tests, I wrote the impl". A prompt or conversation link is great too. --> ChatGPT helped me frame this PR language properly. Used Copilot to implement the changes. All code changes were reviewed and verified before submission.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

