### PR TITLE
fix(runtime): bridge runtime user_id onto current-user ContextVar in run worker (#3724)

### DIFF
--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -32,7 +32,12 @@ if TYPE_CHECKING:
 from deerflow.config.app_config import AppConfig
 from deerflow.runtime.serialization import serialize
 from deerflow.runtime.stream_bridge import StreamBridge
-from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.runtime.user_context import (
+    get_current_user,
+    get_effective_user_id,
+    reset_current_user,
+    set_current_user,
+)
 from deerflow.tracing import inject_langfuse_metadata
 
 from .manager import RunManager, RunRecord
@@ -43,6 +48,11 @@ logger = logging.getLogger(__name__)
 
 # Valid stream_mode values for LangGraph's graph.astream()
 _VALID_LG_MODES = {"values", "updates", "checkpoints", "tasks", "debug", "messages", "custom"}
+
+
+@dataclass(frozen=True)
+class _RunUser:
+    id: str
 
 
 def _build_runtime_context(
@@ -153,6 +163,7 @@ async def run_agent(
     llm_error_fallback_message: str | None = None
 
     journal = None
+    run_user_token = None
 
     # Track whether "events" was requested but skipped
     if "events" in requested_modes:
@@ -225,6 +236,16 @@ async def run_agent(
         # runtime-internal channel; user code must not depend on the key name.
         if journal is not None:
             runtime_ctx["__run_journal"] = journal
+        # Bridge ``runtime.context['user_id']`` onto the current-user ContextVar so
+        # legacy consumers that resolve identity via ``get_effective_user_id()``
+        # (e.g. sandbox mount resolution) align with the run's owner. Skip when the
+        # ContextVar already carries the same id to avoid downgrading a full ``User``
+        # (with role/oauth attributes) to an id-only stub.
+        runtime_user_id = runtime_ctx.get("user_id")
+        if runtime_user_id:
+            current_user = get_current_user()
+            if current_user is None or str(current_user.id) != str(runtime_user_id):
+                run_user_token = set_current_user(_RunUser(id=str(runtime_user_id)))
         _install_runtime_context(config, runtime_ctx)
         runtime = Runtime(context=cast(Any, runtime_ctx), store=store)
         config.setdefault("configurable", {})["__pregel_runtime"] = runtime
@@ -433,7 +454,11 @@ async def run_agent(
             except Exception:
                 logger.debug("Failed to update thread_meta status for %s (non-fatal)", thread_id)
 
-        await bridge.publish_end(run_id)
+        try:
+            await bridge.publish_end(run_id)
+        finally:
+            if run_user_token is not None:
+                reset_current_user(run_user_token)
         asyncio.create_task(bridge.cleanup(run_id, delay=60))
 
 

--- a/backend/tests/test_run_worker_rollback.py
+++ b/backend/tests/test_run_worker_rollback.py
@@ -105,6 +105,113 @@ async def test_run_agent_threads_explicit_app_config_into_config_only_factory():
     bridge.cleanup.assert_awaited_once_with(record.run_id, delay=60)
 
 
+@pytest.mark.no_auto_user
+@pytest.mark.anyio
+async def test_run_agent_installs_runtime_user_for_sandbox_mounts(tmp_path, monkeypatch):
+    from deerflow.community.aio_sandbox.aio_sandbox_provider import AioSandboxProvider
+    from deerflow.config.paths import Paths
+    from deerflow.runtime.user_context import DEFAULT_USER_ID, get_effective_user_id
+
+    run_manager = RunManager()
+    record = await run_manager.create("thread-3724")
+    bridge = SimpleNamespace(
+        publish=AsyncMock(),
+        publish_end=AsyncMock(),
+        cleanup=AsyncMock(),
+    )
+    paths = Paths(base_dir=tmp_path)
+    captured: dict[str, object] = {}
+
+    import deerflow.community.aio_sandbox.aio_sandbox_provider as aio_mod
+
+    monkeypatch.delenv("DEER_FLOW_HOST_BASE_DIR", raising=False)
+    monkeypatch.setattr(aio_mod, "get_paths", lambda: paths)
+
+    assert get_effective_user_id() == DEFAULT_USER_ID
+
+    class DummyAgent:
+        metadata: dict[str, object] = {}
+
+        async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+            mounts = AioSandboxProvider._get_thread_mounts("thread-3724")
+            captured["outputs_mount"] = next(host for host, container, _ in mounts if container == "/mnt/user-data/outputs")
+            captured["effective_user_id"] = get_effective_user_id()
+            yield {"messages": []}
+
+    def factory(*, config):
+        captured["factory_effective_user_id"] = get_effective_user_id()
+        return DummyAgent()
+
+    await run_agent(
+        bridge,
+        run_manager,
+        record,
+        ctx=RunContext(checkpointer=None),
+        agent_factory=factory,
+        graph_input={},
+        config={"context": {"user_id": "ou_123456"}},
+    )
+    await asyncio.sleep(0)
+
+    expected_outputs = paths.host_sandbox_outputs_dir("thread-3724", user_id="ou_123456")
+    assert captured["factory_effective_user_id"] == "ou_123456"
+    assert captured["effective_user_id"] == "ou_123456"
+    assert captured["outputs_mount"] == expected_outputs
+    assert get_effective_user_id() == DEFAULT_USER_ID
+    bridge.publish_end.assert_awaited_once_with(record.run_id)
+    bridge.cleanup.assert_awaited_once_with(record.run_id, delay=60)
+
+
+@pytest.mark.no_auto_user
+@pytest.mark.anyio
+async def test_run_agent_preserves_existing_user_when_id_matches():
+    from deerflow.runtime.user_context import (
+        get_current_user,
+        reset_current_user,
+        set_current_user,
+    )
+
+    run_manager = RunManager()
+    record = await run_manager.create("thread-match")
+    bridge = SimpleNamespace(
+        publish=AsyncMock(),
+        publish_end=AsyncMock(),
+        cleanup=AsyncMock(),
+    )
+    captured: dict[str, object] = {}
+
+    full_user = SimpleNamespace(id="ou_match", system_role="member")
+    token = set_current_user(full_user)
+
+    class DummyAgent:
+        metadata: dict[str, object] = {}
+
+        async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+            captured["in_run_user"] = get_current_user()
+            yield {"messages": []}
+
+    def factory(*, config):
+        return DummyAgent()
+
+    try:
+        await run_agent(
+            bridge,
+            run_manager,
+            record,
+            ctx=RunContext(checkpointer=None),
+            agent_factory=factory,
+            graph_input={},
+            config={"context": {"user_id": "ou_match"}},
+        )
+        await asyncio.sleep(0)
+        # The same-id full user object must survive the run without being
+        # downgraded to an id-only stub.
+        assert captured["in_run_user"] is full_user
+        assert get_current_user() is full_user
+    finally:
+        reset_current_user(token)
+
+
 @pytest.mark.anyio
 async def test_run_agent_marks_llm_error_fallback_as_error_status():
     run_manager = RunManager()


### PR DESCRIPTION
## Summary

Fixes #3724 — artifact file delivery fails because the sandbox mount and artifact resolution disagree on `user_id`.

Sandbox mount resolution (and several other legacy callers) resolve identity via `get_effective_user_id()`, which reads the current-user `ContextVar`. On dispatch paths where that `ContextVar` does not carry the run owner — e.g. IM/channel runs and internal runs scheduled outside the request task — the agent writes artifact files under `users/default/...`, while delivery looks them up under `users/{platform_user_id}/...`. The result is that generated files are produced but never found at delivery time, so attachments are silently dropped.

## Change

`run_agent` already builds a `runtime.context` dict that carries `user_id` (stamped by the gateway / channel manager). This PR bridges that value onto the current-user `ContextVar` for the duration of the run, so legacy `get_effective_user_id()` consumers (sandbox mounts, uploads, memory, etc.) resolve the same owner that delivery uses.

- Install `runtime.context["user_id"]` onto the `ContextVar` at run start, right after the runtime context is assembled.
- Reset it in the `finally` block (wrapping `publish_end`) so the run-scoped identity never leaks into the background `cleanup` task.
- Skip installation when the `ContextVar` already holds the same id, to avoid downgrading a full `User` object (with role / oauth attributes) to an id-only stub — relevant for the authenticated web path where the middleware already set a complete `User`.

No behaviour change for the web path (the ContextVar already matches); the fix targets the channel / internal dispatch paths where the ContextVar was unset.

## Tests

- New regression test `test_run_agent_installs_runtime_user_for_sandbox_mounts`: asserts the sandbox outputs mount resolves to `users/{runtime_user_id}/...` during the run, and that the ContextVar is reset to `DEFAULT_USER_ID` afterwards.
- New regression test `test_run_agent_preserves_existing_user_when_id_matches`: asserts a pre-existing full `User` with the same id is preserved (not downgraded to a stub).

Verified locally:

- `uv run pytest tests/test_run_worker_rollback.py tests/test_worker_langfuse_metadata.py tests/test_channel_file_attachments.py tests/test_aio_sandbox_provider.py 'tests/test_channels.py::TestResolveRunParamsUserId' -q` → 97 passed
- `uv run pytest tests/test_gateway_services.py tests/test_user_context.py tests/test_stateless_runs_owner_isolation.py -q` → 67 passed
- `uv run ruff check ...` → All checks passed
