### PR TITLE
fix(middleware): fix positional fallback consuming unrelated todo when same-content list is exhausted

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/token_usage_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/token_usage_middleware.py
@@ -90,14 +90,14 @@ def _build_todo_actions(previous_todos: list[Todo], next_todos: list[Todo]) -> l
 
         previous_match: Todo | None = None
         content_matches = previous_by_content.get(content)
-        if content_matches:
+        if content_matches is not None:
             while content_matches and content_matches[0][0] in matched_previous_indices:
                 content_matches.pop(0)
             if content_matches:
                 previous_index, previous_match = content_matches.pop(0)
                 matched_previous_indices.add(previous_index)
-
-        if previous_match is None and index < len(previous_todos) and index not in matched_previous_indices:
+        elif index < len(previous_todos) and index not in matched_previous_indices:
+            # Positional fallback: only when content was never in previous
             previous_match = previous_todos[index]
             matched_previous_indices.add(index)
 


### PR DESCRIPTION
When `next_todos` contains the same content string twice, the first match pops from `previous_by_content[content]`, leaving an empty list. The second match sees the empty list (falsy), and the positional fallback would unconditionally consume `previous_todos[index]` even when it holds a completely different entry.

Fix: use `is not None` instead of truthiness check to distinguish "content was never in previous" (None) from "all content matches consumed" (empty list). Change the positional fallback to `elif` so it only fires when the key was never in `previous_by_content`.