### PR TITLE
fix(scripts): make stop reaps repo-owned nginx on macOS

### DIFF
--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -203,8 +203,12 @@ _is_repo_nginx_pid() {
     local args
 
     command=$(ps -p "$pid" -o comm= 2>/dev/null) || return 1
+    # On macOS nginx rewrites argv[0] (e.g. "nginx: master process ..." or
+    # "nginx: worker process"), and `ps -o comm=` returns that rewritten string
+    # rather than the executable basename. Accept the macOS form as well so
+    # `make stop` actually reaps repo-owned nginx processes here.
     case "$command" in
-        nginx|*/nginx) ;;
+        nginx|*/nginx|nginx:*) ;;
         *) return 1 ;;
     esac
 


### PR DESCRIPTION
## Summary

- `scripts/serve.sh`: accept the macOS-rewritten `argv[0]` form (`nginx:*`) in `_is_repo_nginx_pid` so `make stop` actually kills repo-owned nginx on macOS.

Fixes #3758.

## Why

On macOS, `_is_repo_nginx_pid()` rejected every nginx process — including the ones the repo itself just started. As a consequence `_kill_repo_nginx()` was a no-op on macOS, `make stop` left nginx running on port 2026, and the next `make start` aborted with:

```
✗ Nginx cannot start because port 2026 is already in use.
```

nginx master/worker processes rewrite their own `argv[0]` after fork (`nginx: master process …` / `nginx: worker process`). On macOS, `ps -p PID -o comm=` returns that rewritten string rather than the executable basename, so the previous `case nginx|*/nginx)` never matched. Linux is unaffected because the kernel's `comm` field is the executable basename and is not influenced by `argv[0]` rewrites.

## Change

```diff
 _is_repo_nginx_pid() {
     ...
     command=$(ps -p "$pid" -o comm= 2>/dev/null) || return 1
+    # On macOS nginx rewrites argv[0] (e.g. "nginx: master process ..." or
+    # "nginx: worker process"), and `ps -o comm=` returns that rewritten string
+    # rather than the executable basename. Accept the macOS form as well so
+    # `make stop` actually reaps repo-owned nginx processes here.
     case "$command" in
-        nginx|*/nginx) ;;
+        nginx|*/nginx|nginx:*) ;;
         *) return 1 ;;
     esac
```

The downstream `args` case and `_is_deerflow_pid` fallback still gate ownership, so a Homebrew system nginx or any other unrelated nginx on the machine is not at risk.

## Test plan

End-to-end repro + verification (full repro details, including a self-contained probe script that sources the helper verbatim, are in #3758).

- [x] **Before patch (upstream `main` `debb0fd`, macOS):** spawn an unrelated nginx via the conf at `/tmp/repro/nginx.conf`, then call upstream's `_kill_repo_nginx` with `kill` overridden to print instead of execute. The function emitted **zero** kill calls and the nginx remained alive. `_is_repo_nginx_pid` returned non-zero for both the master (`nginx: master process …`) and worker (`nginx: worker process`).
- [x] **After patch (this branch):** the same probe against the same nginx now prints `[would kill -9] -9 <master_pid>` and `_is_repo_nginx_pid` matches both master and worker.
- [x] Real workflow (`make start-daemon` → `make stop` → `make start`) on macOS no longer leaves nginx running on port 2026 between cycles.
- [x] No-op on Linux (the new `nginx:*` arm is additive; Linux `ps -o comm=` continues to return `nginx`).

## Risk

- Same kill-target ownership invariants as before (the `args`/`_is_deerflow_pid` checks immediately following the case statement are unchanged).
- The Ctrl+C path on a foreground `make start` was already working because SIGINT goes to the whole process group; this change only affects code paths that go through the helper (daemon mode, terminal closed, SIGTERM, CI without TTY signal forwarding).