### PR TITLE
chore: remove deprecated zero-caller sandbox_from_runtime

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1122,35 +1122,6 @@ def is_local_sandbox(runtime: Runtime | None) -> bool:
     return sandbox_id == "local" or sandbox_id.startswith("local:")
 
 
-def sandbox_from_runtime(runtime: Runtime | None = None) -> Sandbox:
-    """Extract sandbox instance from tool runtime.
-
-    DEPRECATED: Use ensure_sandbox_initialized() for lazy initialization support.
-    This function assumes sandbox is already initialized and will raise error if not.
-
-    Raises:
-        SandboxRuntimeError: If runtime is not available or sandbox state is missing.
-        SandboxNotFoundError: If sandbox with the given ID cannot be found.
-    """
-    if runtime is None:
-        raise SandboxRuntimeError("Tool runtime not available")
-    if runtime.state is None:
-        raise SandboxRuntimeError("Tool runtime state not available")
-    sandbox_state = runtime.state.get("sandbox")
-    if sandbox_state is None:
-        raise SandboxRuntimeError("Sandbox state not initialized in runtime")
-    sandbox_id = sandbox_state.get("sandbox_id")
-    if sandbox_id is None:
-        raise SandboxRuntimeError("Sandbox ID not found in state")
-    sandbox = get_sandbox_provider().get(sandbox_id)
-    if sandbox is None:
-        raise SandboxNotFoundError(f"Sandbox with ID '{sandbox_id}' not found", sandbox_id=sandbox_id)
-
-    if runtime.context is not None:
-        runtime.context["sandbox_id"] = sandbox_id  # Ensure sandbox_id is in context for downstream use
-    return sandbox
-
-
 def ensure_sandbox_initialized(runtime: Runtime | None = None) -> Sandbox:
     """Ensure sandbox is initialized, acquiring lazily if needed.
 


### PR DESCRIPTION
### Summary

Removes `packages/harness/deerflow/sandbox/tools.py:sandbox_from_runtime` — explicitly marked `DEPRECATED: Use ensure_sandbox_initialized()` in its own docstring, with **no callers anywhere** in the repo and no export. `ensure_sandbox_initialized` (sync) and `ensure_sandbox_initialized_async` are the live replacements (they add lazy initialization).

Follow-up to #3748 / #3749 (the unused private helpers landed there; this deprecated public function is split out on its own since it's an API-surface removal).

### Verification

- `grep` confirms the name now appears nowhere in the codebase; `ensure_sandbox_initialized` is intact.
- `ruff check` / `ruff format --check` clean; `py_compile` OK.
- Diff is a single function deletion (29 lines), no other changes.
