### PR TITLE
fix( frontend) :notification permission refresh

### DIFF
--- a/frontend/src/components/workspace/settings/notification-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/notification-settings-page.tsx
@@ -54,6 +54,7 @@ export function NotificationSettingsPage() {
           <div>{t.settings.notification.description}</div>
           <div>
             <Switch
+              aria-label={t.settings.notification.title}
               disabled={permission !== "granted"}
               checked={
                 permission === "granted" && settings.notification.enabled

--- a/frontend/src/core/notification/hooks.ts
+++ b/frontend/src/core/notification/hooks.ts
@@ -24,7 +24,7 @@ export function useNotification(): UseNotificationReturn {
     useState<NotificationPermission>("default");
   const [isSupported, setIsSupported] = useState(false);
 
-  const lastNotificationTime = useRef<Date>(new Date());
+  const lastNotificationTime = useRef<number | null>(null);
 
   useEffect(() => {
     // Check if browser supports Notification API
@@ -60,19 +60,25 @@ export function useNotification(): UseNotificationReturn {
         return;
       }
 
+      const currentPermission = Notification.permission;
+      if (currentPermission !== permission) {
+        setPermission(currentPermission);
+      }
+
+      if (currentPermission !== "granted") {
+        console.warn("Notification permission not granted");
+        return;
+      }
+
+      const now = Date.now();
       if (
-        new Date().getTime() - lastNotificationTime.current.getTime() <
-        1000
+        lastNotificationTime.current !== null &&
+        now - lastNotificationTime.current < 1000
       ) {
         console.warn("Notification sent too soon");
         return;
       }
-      lastNotificationTime.current = new Date();
-
-      if (permission !== "granted") {
-        console.warn("Notification permission not granted");
-        return;
-      }
+      lastNotificationTime.current = now;
 
       const notification = new Notification(title, options);
 

--- a/frontend/tests/e2e/settings-notification.spec.ts
+++ b/frontend/tests/e2e/settings-notification.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { mockLangGraphAPI } from "./utils/mock-api";
+
+declare global {
+  interface Window {
+    __deerflowNotifications?: Array<{ title: string; body?: string }>;
+  }
+}
+
+async function installNotificationMock(
+  page: Page,
+  initialPermission: NotificationPermission = "default",
+) {
+  await page.addInitScript((permission) => {
+    window.__deerflowNotifications = [];
+
+    class MockNotification {
+      static permission: NotificationPermission = permission;
+
+      static async requestPermission(): Promise<NotificationPermission> {
+        MockNotification.permission = "granted";
+        return "granted";
+      }
+
+      onclick: (() => void) | null = null;
+      onerror: ((error: Event) => void) | null = null;
+      closed = false;
+
+      constructor(title: string, options?: NotificationOptions) {
+        window.__deerflowNotifications?.push({
+          title,
+          body: options?.body,
+        });
+      }
+
+      close() {
+        this.closed = true;
+      }
+    }
+
+    Object.defineProperty(window, "Notification", {
+      configurable: true,
+      value: MockNotification,
+    });
+  }, initialPermission);
+}
+
+async function openNotificationSettings(page: Page) {
+  await page.goto("/workspace/chats/new");
+  const sidebar = page.locator("[data-sidebar='sidebar']");
+  await sidebar.getByRole("button", { name: /Settings and more/ }).click();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
+  const dialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole("button", { name: "Notification" }).click();
+  return dialog;
+}
+
+test.describe("Notification settings", () => {
+  test("can request permission and send the first test notification immediately", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page);
+    await installNotificationMock(page);
+
+    const dialog = await openNotificationSettings(page);
+    await dialog
+      .getByRole("button", { name: "Request notification permission" })
+      .click();
+
+    await expect(
+      dialog.getByRole("switch", { name: "Notification" }),
+    ).toBeChecked();
+
+    await dialog
+      .getByRole("button", { name: "Send test notification" })
+      .click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__deerflowNotifications ?? []))
+      .toEqual([
+        {
+          title: "DeerFlow",
+          body: "This is a test notification.",
+        },
+      ]);
+  });
+
+  test("sends a completion notification when chat finishes while the page is unfocused", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page);
+    await installNotificationMock(page, "granted");
+    await page.addInitScript(() => {
+      Document.prototype.hasFocus = () => false;
+    });
+
+    await page.goto("/workspace/chats/new");
+
+    const textarea = page.getByPlaceholder(/how can i assist you/i);
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+    await textarea.fill("Run a one minute task");
+    await textarea.press("Enter");
+
+    await expect
+      .poll(() => page.evaluate(() => window.__deerflowNotifications ?? []))
+      .toEqual([
+        {
+          title: "New Chat",
+          body: "Hello from DeerFlow!",
+        },
+      ]);
+  });
+});

--- a/frontend/tests/unit/core/notification/hooks.test.ts
+++ b/frontend/tests/unit/core/notification/hooks.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test, rs } from "@rstest/core";
+
+type NotificationInstance = {
+  onclick: (() => void) | null;
+  onerror: ((error: Event) => void) | null;
+  close: () => void;
+};
+
+async function loadNotificationHook({
+  browserPermission = "granted",
+  hookPermission = "granted",
+}: {
+  browserPermission?: NotificationPermission;
+  hookPermission?: NotificationPermission;
+} = {}) {
+  const notifications: Array<{
+    title: string;
+    options: NotificationOptions | undefined;
+    instance: NotificationInstance;
+  }> = [];
+
+  class MockNotification implements NotificationInstance {
+    static permission: NotificationPermission = browserPermission;
+    static requestPermission = rs.fn(async () => {
+      MockNotification.permission = "granted";
+      return "granted" as const;
+    });
+
+    onclick: (() => void) | null = null;
+    onerror: ((error: Event) => void) | null = null;
+    close = rs.fn();
+
+    constructor(title: string, options?: NotificationOptions) {
+      notifications.push({ title, options, instance: this });
+    }
+  }
+
+  rs.resetModules();
+  rs.doMock("react", () => ({
+    useCallback: <T extends (...args: never[]) => unknown>(callback: T) =>
+      callback,
+    useEffect: () => undefined,
+    useRef: <T>(initialValue: T) => ({ current: initialValue }),
+    useState: <T>(initialValue: T) => {
+      if (initialValue === "default") {
+        return [hookPermission, rs.fn()] as const;
+      }
+      if (initialValue === false) {
+        return [true, rs.fn()] as const;
+      }
+      return [initialValue, rs.fn()] as const;
+    },
+  }));
+  rs.doMock("@/core/settings", () => ({
+    useLocalSettings: () => [
+      {
+        notification: { enabled: true },
+        tokenUsage: { headerTotal: true, inlineMode: "per_turn" },
+        context: {
+          model_name: undefined,
+          mode: undefined,
+          reasoning_effort: undefined,
+        },
+      },
+      rs.fn(),
+    ],
+  }));
+  rs.stubGlobal("window", { focus: rs.fn() });
+  rs.stubGlobal("Notification", MockNotification);
+
+  const { useNotification } = await import("@/core/notification/hooks");
+
+  return {
+    notifications,
+    useNotification,
+  };
+}
+
+afterEach(() => {
+  rs.doUnmock("react");
+  rs.doUnmock("@/core/settings");
+  rs.unstubAllGlobals();
+  rs.resetModules();
+});
+
+describe("useNotification", () => {
+  test("allows the first notification immediately after the hook is created", async () => {
+    const { notifications, useNotification } = await loadNotificationHook();
+    const { showNotification } = useNotification();
+
+    showNotification("Finished", { body: "Conversation finished" });
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]?.title).toBe("Finished");
+    expect(notifications[0]?.options?.body).toBe("Conversation finished");
+  });
+
+  test("rate limits only after a notification has been sent", async () => {
+    const { notifications, useNotification } = await loadNotificationHook();
+    const { showNotification } = useNotification();
+
+    showNotification("First");
+    showNotification("Second");
+
+    expect(notifications.map((notification) => notification.title)).toEqual([
+      "First",
+    ]);
+  });
+
+  test("uses the browser's current permission when another hook requested it", async () => {
+    const { notifications, useNotification } = await loadNotificationHook({
+      browserPermission: "granted",
+      hookPermission: "default",
+    });
+    const { showNotification } = useNotification();
+
+    showNotification("Finished elsewhere");
+
+    expect(notifications.map((notification) => notification.title)).toEqual([
+      "Finished elsewhere",
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes #3767

## Why

Browser notifications could be skipped after a user enabled notification permission in Settings.

The root cause is that `useNotification()` stores permission state per hook instance. When Settings requests permission, another hook instance used by the chat/agent page can still hold the stale `"default"` state and refuse to send notifications until the page is refreshed.

There was also a first-notification timing edge case: `lastNotificationTime` was initialized at hook creation time, so a valid notification sent immediately after the hook mounted could be incorrectly throttled.



## What changed


- Notification sending now reads the browser's current `Notification.permission` before deciding whether to send.
- The hook syncs its local permission state if the browser permission has changed.
- First notification throttling now only applies after a notification has actually been sent.
- Added unit tests covering:
  - first notification can be sent immediately;
  - rate limiting starts only after a successful send;
  - browser permission changes from another hook instance are respected.
- Added Playwright coverage for notification settings/test-notification behavior.
- Added an accessible label to the notification settings switch.


## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — notifications now use the browser's latest permission state when sending
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

N/A. This is a notification behavior fix; the visible Settings UI is unchanged.
## Bug fix verification
Test path that reproduces the bug:

- `frontend/tests/unit/core/notification/hooks.test.ts`

Before the fix, the notification hook tests fail against the old behavior:

- the first notification can be rejected as `Notification sent too soon`;
- a hook instance can keep stale `"default"` permission after another hook grants browser permission.

After the fix, the same tests pass.

## Validation

cd frontend && pnpm test tests/unit/core/notification/hooks.test.ts
cd frontend && pnpm typecheck

## AI assistance


**Tool(s) used:** codex

**How you used it:** AI helps with testing and code review.

-  I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

