### PR TITLE
fix(mcp): isolate tool discovery failures per server

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -615,9 +615,20 @@ async def get_mcp_tools() -> list[BaseTool]:
             tool_name_prefix=True,
         )
 
-        # Get all tools from all servers (discovers tool definitions via
-        # temporary sessions – the persistent-session wrapping is applied below).
-        tools = await client.get_tools()
+        async def load_server_tools(server_name: str) -> list[BaseTool]:
+            try:
+                return await client.get_tools(server_name=server_name)
+            except Exception as e:
+                logger.warning(
+                    f"Skipping MCP server '{server_name}' after tool discovery failed: {e}",
+                    exc_info=True,
+                )
+                return []
+
+        # Get tools from each server independently so one broken MCP server does
+        # not prevent healthy servers from contributing their tools.
+        tools_by_server = await asyncio.gather(*(load_server_tools(name) for name in servers_config))
+        tools = [tool for server_tools in tools_by_server for tool in server_tools]
         logger.info(f"Successfully loaded {len(tools)} tool(s) from MCP servers")
 
         # Wrap each tool with persistent-session logic.

--- a/backend/tests/test_mcp_session_pool.py
+++ b/backend/tests/test_mcp_session_pool.py
@@ -889,7 +889,15 @@ async def test_http_transport_tools_not_pooled():
         patch("langchain_mcp_adapters.sessions.create_session", return_value=mock_cm),
     ):
         mock_client_instance = MockClient.return_value
-        mock_client_instance.get_tools = AsyncMock(return_value=[http_tool, stdio_tool])
+
+        async def get_tools_for_server(*, server_name: str | None = None):
+            if server_name == "myserver":
+                return [http_tool]
+            if server_name == "playwright":
+                return [stdio_tool]
+            raise AssertionError(f"unexpected server_name: {server_name}")
+
+        mock_client_instance.get_tools = AsyncMock(side_effect=get_tools_for_server)
 
         tools = await get_mcp_tools()
 

--- a/backend/tests/test_mcp_sync_wrapper.py
+++ b/backend/tests/test_mcp_sync_wrapper.py
@@ -53,6 +53,46 @@ def test_mcp_tool_sync_wrapper_generation():
         assert result == "result: 42"
 
 
+def test_mcp_tool_loading_skips_failed_server():
+    """A broken MCP server should not drop tools from healthy servers."""
+
+    async def mock_coro(x: int):
+        return f"result: {x}"
+
+    good_tool = StructuredTool(
+        name="good-server_search",
+        description="search from healthy server",
+        args_schema=MockArgs,
+        func=None,
+        coroutine=mock_coro,
+    )
+
+    async def get_tools_for_server(*, server_name: str | None = None):
+        if server_name == "good-server":
+            return [good_tool]
+        if server_name == "bad-server":
+            raise RuntimeError("SSE endpoint returned text/html")
+        raise AssertionError(f"unexpected server_name: {server_name}")
+
+    mock_client_instance = MagicMock()
+    mock_client_instance.get_tools = AsyncMock(side_effect=get_tools_for_server)
+
+    with (
+        patch("langchain_mcp_adapters.client.MultiServerMCPClient", return_value=mock_client_instance),
+        patch("deerflow.config.extensions_config.ExtensionsConfig.from_file", return_value=MagicMock(model_extra={})),
+        patch("deerflow.mcp.tools.build_servers_config", return_value={"good-server": {}, "bad-server": {}}),
+        patch("deerflow.mcp.tools.get_initial_oauth_headers", new_callable=AsyncMock, return_value={}),
+        patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=None),
+        patch("deerflow.mcp.tools.logger.warning") as mock_warning,
+    ):
+        tools = asyncio.run(get_mcp_tools())
+
+    assert [tool.name for tool in tools] == ["good-server_search"]
+    assert tools[0].func is not None
+    mock_warning.assert_called_once()
+    assert "bad-server" in mock_warning.call_args[0][0]
+
+
 def test_mcp_tool_sync_wrapper_in_running_loop():
     """Test the shared sync wrapper from production code."""
 


### PR DESCRIPTION
Fixes #3762

## Why

MCP tool discovery currently fails all-or-nothing when multiple MCP servers are configured. If one enabled server is invalid or returns an unexpected response, `MultiServerMCPClient.get_tools()` raises for the whole batch, and DeerFlow returns no MCP tools at all.

This means one broken MCP server can prevent other healthy MCP servers from being loaded, which is the user-facing issue reported in #3762.

## What changed

- MCP tool discovery now loads tools per configured server instead of as one all-server batch.
- If one MCP server fails during tool discovery, DeerFlow logs a warning with that server name and skips only that server.
- Tools from healthy MCP servers continue to load and go through the existing wrapping/sync behavior unchanged.
- Added a regression test covering one healthy MCP server plus one failing MCP server.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend MCP loading behavior only.

## Bug fix verification

- Test path that reproduces the bug:
  - `backend/tests/test_mcp_sync_wrapper.py::test_mcp_tool_loading_skips_failed_server`
- Did it go red on `main` and green on this branch?
  - Yes. The old all-server discovery path would return no tools when one server raises; this branch keeps the healthy server's tool.
- If a red test wasn't cheap to write, explain why and what you did instead.
  - N/A. A focused regression test was added.

## Validation

```bash
cd backend && uv run pytest tests/test_mcp_custom_interceptors.py tests/test_mcp_sync_wrapper.py tests/test_mcp_session_pool.py -q
cd backend && uv run pytest tests/test_mcp*.py -q
cd backend && uv run ruff check packages/harness/deerflow/mcp/tools.py tests/test_mcp_custom_interceptors.py tests/test_mcp_sync_wrapper.py tests/test_mcp_session_pool.py
cd backend && uv run ruff format --check packages/harness/deerflow/mcp/tools.py tests/test_mcp_custom_interceptors.py tests/test_mcp_sync_wrapper.py tests/test_mcp_session_pool.py
git diff --check

Results:
Targeted tests: 53 passed
MCP test suite: 152 passed
Ruff check: passed
Ruff format check: passed
Diff whitespace check: passed