### PR TITLE
fix(skills): preserve extension config on toggle

### DIFF
--- a/backend/app/gateway/routers/skills.py
+++ b/backend/app/gateway/routers/skills.py
@@ -324,10 +324,19 @@ async def update_skill(skill_name: str, request: SkillUpdateRequest, config: App
         extensions_config = get_extensions_config()
         extensions_config.skills[skill_name] = SkillStateConfig(enabled=request.enabled)
 
-        config_data = {
-            "mcpServers": {name: server.model_dump() for name, server in extensions_config.mcp_servers.items()},
-            "skills": {name: {"enabled": skill_config.enabled} for name, skill_config in extensions_config.skills.items()},
-        }
+        raw_servers: dict | None = None
+        raw_other_keys: dict = {}
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                raw_data = json.load(f)
+            raw_servers = raw_data.get("mcpServers", {})
+            for key, value in raw_data.items():
+                if key not in ("mcpServers", "skills"):
+                    raw_other_keys[key] = value
+
+        config_data = dict(raw_other_keys)
+        config_data["mcpServers"] = raw_servers if raw_servers is not None else {name: server.model_dump() for name, server in extensions_config.mcp_servers.items()}
+        config_data["skills"] = {name: {"enabled": skill_config.enabled} for name, skill_config in extensions_config.skills.items()}
 
         with open(config_path, "w", encoding="utf-8") as f:
             json.dump(config_data, f, indent=2)

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -1038,10 +1038,19 @@ class DeerFlowClient:
         extensions_config = get_extensions_config()
         extensions_config.skills[name] = SkillStateConfig(enabled=enabled)
 
-        config_data = {
-            "mcpServers": {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()},
-            "skills": {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()},
-        }
+        raw_servers: dict | None = None
+        raw_other_keys: dict = {}
+        if config_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                raw_data = json.load(f)
+            raw_servers = raw_data.get("mcpServers", {})
+            for key, value in raw_data.items():
+                if key not in ("mcpServers", "skills"):
+                    raw_other_keys[key] = value
+
+        config_data = dict(raw_other_keys)
+        config_data["mcpServers"] = raw_servers if raw_servers is not None else {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()}
+        config_data["skills"] = {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()}
 
         self._atomic_write_json(config_path, config_data)
 

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1284,6 +1284,60 @@ class TestSkillsManagement:
         finally:
             tmp_path.unlink()
 
+    def test_update_skill_preserves_extension_top_level_keys(self, client):
+        skill = self._make_skill(enabled=True)
+        updated_skill = self._make_skill(enabled=False)
+
+        ext_config = MagicMock()
+        resolved_server = MagicMock()
+        resolved_server.model_dump.return_value = {
+            "enabled": False,
+            "type": "stdio",
+            "command": "echo",
+            "args": ["demo-a"],
+            "env": {"DEMO_TOKEN": "resolved-token"},
+        }
+        ext_config.mcp_servers = {"demo-a": resolved_server}
+        ext_config.skills = {}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "mcpInterceptors": ["demo.module:builder"],
+                    "customExtension": {"enabled": True},
+                    "mcpServers": {
+                        "demo-a": {
+                            "enabled": False,
+                            "type": "stdio",
+                            "command": "echo",
+                            "args": ["demo-a"],
+                            "env": {"DEMO_TOKEN": "$DEMO_TOKEN"},
+                        }
+                    },
+                    "skills": {},
+                },
+                f,
+            )
+            tmp_path = Path(f.name)
+
+        try:
+            with (
+                patch("deerflow.skills.storage.local_skill_storage.LocalSkillStorage.load_skills", side_effect=[[skill], [updated_skill]]),
+                patch("deerflow.client.ExtensionsConfig.resolve_config_path", return_value=tmp_path),
+                patch("deerflow.client.get_extensions_config", return_value=ext_config),
+                patch("deerflow.client.reload_extensions_config"),
+            ):
+                result = client.update_skill("test-skill", enabled=False)
+
+            assert result["enabled"] is False
+            saved = json.loads(tmp_path.read_text(encoding="utf-8"))
+            assert saved["mcpInterceptors"] == ["demo.module:builder"]
+            assert saved["customExtension"] == {"enabled": True}
+            assert saved["mcpServers"]["demo-a"]["env"] == {"DEMO_TOKEN": "$DEMO_TOKEN"}
+            assert saved["skills"] == {"test-skill": {"enabled": False}}
+        finally:
+            tmp_path.unlink()
+
     def test_update_skill_not_found(self, client):
         with patch("deerflow.skills.storage.local_skill_storage.LocalSkillStorage.load_skills", return_value=[]):
             with pytest.raises(ValueError, match="not found"):

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -435,3 +435,67 @@ def test_update_skill_refreshes_prompt_cache_before_return(monkeypatch, tmp_path
     assert response.json()["enabled"] is False
     assert refresh_calls == ["refresh"]
     assert json.loads(config_path.read_text(encoding="utf-8")) == {"mcpServers": {}, "skills": {"demo-skill": {"enabled": False}}}
+
+
+def test_update_skill_preserves_extension_top_level_keys(monkeypatch, tmp_path):
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "mcpInterceptors": ["demo.module:builder"],
+                "customExtension": {"enabled": True},
+                "mcpServers": {
+                    "demo-a": {
+                        "enabled": False,
+                        "type": "stdio",
+                        "command": "echo",
+                        "args": ["demo-a"],
+                        "env": {"DEMO_TOKEN": "$DEMO_TOKEN"},
+                    }
+                },
+                "skills": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    calls = iter(
+        [
+            [_make_skill("demo-skill", enabled=True)],
+            [_make_skill("demo-skill", enabled=False)],
+        ]
+    )
+
+    def _load_skills(*, enabled_only: bool):
+        return next(calls)
+
+    async def _refresh():
+        return None
+
+    mcp_server = SimpleNamespace(
+        model_dump=lambda: {
+            "enabled": False,
+            "type": "stdio",
+            "command": "echo",
+            "args": ["demo-a"],
+            "env": {"DEMO_TOKEN": "resolved-token"},
+        }
+    )
+    mock_storage = SimpleNamespace(load_skills=_load_skills)
+    monkeypatch.setattr("app.gateway.routers.skills.get_or_new_skill_storage", lambda **kwargs: mock_storage)
+    monkeypatch.setattr("app.gateway.routers.skills.get_extensions_config", lambda: SimpleNamespace(mcp_servers={"demo-a": mcp_server}, skills={}))
+    monkeypatch.setattr("app.gateway.routers.skills.reload_extensions_config", lambda: None)
+    monkeypatch.setattr(skills_router.ExtensionsConfig, "resolve_config_path", staticmethod(lambda: config_path))
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_skills_system_prompt_cache_async", _refresh)
+
+    app = _make_test_app(SimpleNamespace())
+
+    with TestClient(app) as client:
+        response = client.put("/api/skills/demo-skill", json={"enabled": False})
+
+    assert response.status_code == 200
+    written = json.loads(config_path.read_text(encoding="utf-8"))
+    assert written["mcpInterceptors"] == ["demo.module:builder"]
+    assert written["customExtension"] == {"enabled": True}
+    assert written["mcpServers"]["demo-a"]["env"] == {"DEMO_TOKEN": "$DEMO_TOKEN"}
+    assert written["skills"] == {"demo-skill": {"enabled": False}}


### PR DESCRIPTION
<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Closes #3773

## Why
Toggling a skill in Settings rewrites `extensions_config.json`. The previous
save path only emitted `mcpServers` and `skills`, so supported top-level
extension fields such as `mcpInterceptors` were silently removed.

The same path could also re-dump MCP server config from the resolved
`ExtensionsConfig`, which risks replacing raw `$VAR` placeholders in MCP server
environment values with resolved values.


## What changed
- Skill enable/disable saves now preserve top-level extension fields outside
  `mcpServers` and `skills`.
- Skill enable/disable saves now preserve the raw on-disk `mcpServers` block
  when the config file already exists, matching the MCP config update path and
  keeping `$VAR` placeholders intact.
- The Python client `update_skill()` path now follows the same preservation
  behavior as the Gateway route.
- Added regression coverage for both the Gateway route and Python client.

## Surface area
- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable. This is a backend config persistence fix with no UI change.
## Bug fix verification

- Test path that reproduces the bug:
  - `backend/tests/test_skills_custom_router.py::test_update_skill_preserves_extension_top_level_keys`
  - `backend/tests/test_client.py::TestSkillsManagement::test_update_skill_preserves_extension_top_level_keys`
- Did it go red on `main` and green on this branch? yes. The previous save path
  dropped `mcpInterceptors`; this branch preserves it and also keeps raw
  `$VAR` MCP env placeholders.


## Validation


Checks after the final fix:

```bash
cd backend
make lint
make test
```

Additional CI-style checks run earlier on this branch:

```bash
cd backend && uv lock --check
cd backend && make test-blocking-io
cd backend && PYTHONPATH=. uv run pytest tests/test_replay_golden.py -v

cd frontend && pnpm test
cd frontend && pnpm format
cd frontend && pnpm lint
cd frontend && pnpm typecheck
cd frontend && BETTER_AUTH_SECRET=local-dev-secret pnpm build
cd frontend && CI=1 pnpm exec playwright test -c playwright.real-backend.config.ts
cd frontend && CI=1 SKIP_ENV_VALIDATION=1 pnpm exec playwright test
```


## AI assistance


**Tool(s) used:** codex

**How you used it:** AI-assisted testing and code review assistance

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
