### PR TITLE
fix: ignore middleware prompts in run journal input

### DIFF
--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -197,12 +197,12 @@ class RunJournal(BaseCallbackHandler):
             [len(batch) for batch in messages],
         )
 
-        # Capture the first human message sent to any LLM in this run.
-        if not self._first_human_msg and messages:
+        # Capture the first user message sent to the lead agent in this run.
+        caller = self._identify_caller(tags)
+        if caller == "lead_agent" and not self._first_human_msg and messages:
             for batch in reversed(messages):
                 for m in reversed(batch):
                     if isinstance(m, HumanMessage) and m.name != "summary" and m.additional_kwargs.get("hide_from_ui") is not True:
-                        caller = self._identify_caller(tags)
                         self.set_first_human_message(m.text)
                         self._put(
                             event_type="llm.human.input",

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -925,6 +925,57 @@ class TestChatModelStartHumanMessage:
         assert human_events[0]["content"]["content"] == "Real question"
 
     @pytest.mark.anyio
+    async def test_summarization_prompt_does_not_capture_first_human_message(self, journal_setup):
+        """Internal summarization prompts must not replace the run's real user input."""
+        from langchain_core.messages import HumanMessage
+
+        j, store = journal_setup
+        summarization_prompt = HumanMessage(
+            content="<role>\nContext Extraction Assistant\n</role>\n\n<primary_objective>\nExtract context...",
+        )
+        j.on_chat_model_start(
+            {},
+            [[summarization_prompt]],
+            run_id=uuid4(),
+            tags=["middleware:summarize"],
+        )
+        j.on_chat_model_start(
+            {},
+            [[HumanMessage(content="Real user follow-up")]],
+            run_id=uuid4(),
+            tags=["lead_agent"],
+        )
+        await j.flush()
+
+        assert j._first_human_msg == "Real user follow-up"
+        assert j.get_completion_data()["message_count"] == 1
+        events = await store.list_events("t1", "r1")
+        human_events = [e for e in events if e["event_type"] == "llm.human.input"]
+        assert len(human_events) == 1
+        assert human_events[0]["content"]["content"] == "Real user follow-up"
+        assert human_events[0]["metadata"]["caller"] == "lead_agent"
+
+    @pytest.mark.anyio
+    @pytest.mark.parametrize("tags", [["middleware:summarize"], ["subagent:research"]])
+    async def test_non_lead_human_prompts_are_not_captured_as_user_input(self, journal_setup, tags):
+        """Only lead-agent LLM starts create UI-facing human input events."""
+        from langchain_core.messages import HumanMessage
+
+        j, store = journal_setup
+        j.on_chat_model_start(
+            {},
+            [[HumanMessage(content="Internal prompt")]],
+            run_id=uuid4(),
+            tags=tags,
+        )
+        await j.flush()
+
+        assert j._first_human_msg is None
+        assert j.get_completion_data()["message_count"] == 0
+        events = await store.list_events("t1", "r1")
+        assert not any(e["event_type"] == "llm.human.input" for e in events)
+
+    @pytest.mark.anyio
     async def test_only_first_human_message_captured(self, journal_setup):
         """Subsequent on_chat_model_start calls do not overwrite the first message."""
         from langchain_core.messages import HumanMessage


### PR DESCRIPTION
Fixes #3776

## Why

RunJournal currently captures the first `HumanMessage` sent to any LLM call as the run's `llm.human.input` and `first_human_message`.

When summarization runs before the lead agent call, its internal prompt is tagged as `middleware:summarize` but still arrives as a normal unnamed `HumanMessage`. That lets the summarization prompt replace the real user input in persisted run events and run metadata, which can make chat history show the wrong latest user message.

## What changed

- RunJournal now only records UI-facing human input from `lead_agent` LLM calls.
- Internal middleware and subagent prompts no longer create `llm.human.input` events or populate `first_human_message`.
- Existing safeguards for `name == "summary"` and `hide_from_ui=True` are preserved for lead-agent prompts.
- Added regression coverage for a summarization prompt arriving before the real user prompt.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. Backend runtime persistence fix only.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_run_journal.py::TestChatModelStartHumanMessage::test_summarization_prompt_does_not_capture_first_human_message`
- Did it go red on `main` and green on this branch? yes
- The regression test sends a `middleware:summarize` `HumanMessage` before the real `lead_agent` user prompt and verifies only the real user prompt is recorded as `llm.human.input`.

## Validation

- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_run_journal.py -q`
- `cd backend && UV_CACHE_DIR=/tmp/uv-cache make lint`
- `git diff --check`

Also ran full backend pytest:

- `cd backend && UV_CACHE_DIR=/tmp/uv-cache uv run pytest`

Result: `5064 passed, 19 skipped, 4 failed`. The 4 failures are in `tests/test_client_live.py` and are caused by live LLM provider connection / circuit breaker errors, unrelated to this RunJournal change.

