### PR TITLE
fix: preserve mcpInterceptors when toggling skills (#3773)

### DIFF
--- a/backend/app/gateway/routers/skills.py
+++ b/backend/app/gateway/routers/skills.py
@@ -325,6 +325,7 @@ async def update_skill(skill_name: str, request: SkillUpdateRequest, config: App
         extensions_config.skills[skill_name] = SkillStateConfig(enabled=request.enabled)
 
         config_data = {
+            **{k: v for k, v in extensions_config.model_dump(by_alias=True, exclude_none=True).items() if k not in ("mcpServers", "skills")},
             "mcpServers": {name: server.model_dump() for name, server in extensions_config.mcp_servers.items()},
             "skills": {name: {"enabled": skill_config.enabled} for name, skill_config in extensions_config.skills.items()},
         }

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -1039,6 +1039,7 @@ class DeerFlowClient:
         extensions_config.skills[name] = SkillStateConfig(enabled=enabled)
 
         config_data = {
+            **{k: v for k, v in extensions_config.model_dump(by_alias=True, exclude_none=True).items() if k not in ("mcpServers", "skills")},
             "mcpServers": {n: s.model_dump() for n, s in extensions_config.mcp_servers.items()},
             "skills": {n: {"enabled": sc.enabled} for n, sc in extensions_config.skills.items()},
         }

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -203,6 +203,9 @@ class RunJournal(BaseCallbackHandler):
                 for m in reversed(batch):
                     if isinstance(m, HumanMessage) and m.name != "summary" and m.additional_kwargs.get("hide_from_ui") is not True:
                         caller = self._identify_caller(tags)
+                        # Skip messages from middleware (e.g., summarization)
+                        if caller.startswith("middleware:"):
+                            continue
                         self.set_first_human_message(m.text)
                         self._put(
                             event_type="llm.human.input",


### PR DESCRIPTION
Fixes #3773. When saving extensions_config.json after skill toggle, include all top-level extension fields.