### PR TITLE
fix: allow valid heredoc commands in sandbox audit

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py
@@ -150,8 +150,9 @@ def _classify_single_command(command: str) -> str:
             if pattern.search(joined):
                 return "block"
     except ValueError:
-        # shlex.split fails on unclosed quotes — treat as suspicious
-        return "block"
+        # Heredocs and other multiline shell forms may be valid bash but
+        # unparseable by shlex. Raw high-risk patterns were already checked.
+        pass
 
     for pattern in _MEDIUM_RISK_PATTERNS:
         if pattern.search(normalized):

--- a/backend/tests/test_sandbox_audit_middleware.py
+++ b/backend/tests/test_sandbox_audit_middleware.py
@@ -183,19 +183,12 @@ class TestClassifyCommand:
     def test_safe_classified_as_pass(self, cmd):
         assert _classify_command(cmd) == "pass", f"Expected 'pass' for: {cmd!r}"
 
-    def test_benign_heredoc_classified_as_pass(self):
-        cmd = """python3 << 'PYEOF'
-from PIL import Image
-img = Image.open('/mnt/user-data/uploads/image.jpg')
-print(img.size)
-PYEOF"""
+    def test_unparseable_heredoc_classified_as_pass(self):
+        cmd = "python3 << 'EOF'\necho it's fine\nEOF"
         assert _classify_command(cmd) == "pass"
 
-    def test_heredoc_with_high_risk_pattern_still_blocks(self):
-        cmd = """python3 << 'PYEOF'
-print('inspect first')
-PYEOF
-cat /etc/shadow"""
+    def test_unparseable_heredoc_with_high_risk_pattern_still_blocks(self):
+        cmd = "python3 << 'EOF'\necho it's fine\ncat /etc/shadow\nEOF"
         assert _classify_command(cmd) == "block"
 
     # --- Compound commands: sub-command splitting ---

--- a/backend/tests/test_sandbox_audit_middleware.py
+++ b/backend/tests/test_sandbox_audit_middleware.py
@@ -183,6 +183,21 @@ class TestClassifyCommand:
     def test_safe_classified_as_pass(self, cmd):
         assert _classify_command(cmd) == "pass", f"Expected 'pass' for: {cmd!r}"
 
+    def test_benign_heredoc_classified_as_pass(self):
+        cmd = """python3 << 'PYEOF'
+from PIL import Image
+img = Image.open('/mnt/user-data/uploads/image.jpg')
+print(img.size)
+PYEOF"""
+        assert _classify_command(cmd) == "pass"
+
+    def test_heredoc_with_high_risk_pattern_still_blocks(self):
+        cmd = """python3 << 'PYEOF'
+print('inspect first')
+PYEOF
+cat /etc/shadow"""
+        assert _classify_command(cmd) == "block"
+
     # --- Compound commands: sub-command splitting ---
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3774

## Why

`SandboxAuditMiddleware` was blocking valid multiline heredoc commands such as Python image/file analysis snippets.

These commands are valid bash, but `shlex.split()` can raise `ValueError` on heredoc or multiline input. The previous handler treated any `ValueError` as suspicious and returned `block`, which caused legitimate image analysis and file inspection commands to fail.

The issue and maintainer review confirmed this was over-conservative: high-risk patterns are already scanned on the normalized raw command before the `shlex.split()` path, so falling through on `ValueError` keeps the primary high-risk guard in place.

## What changed

- Valid heredoc / multiline commands that `shlex` cannot parse are no longer automatically blocked.
- The middleware still scans the raw normalized command for high-risk patterns before attempting `shlex.split()`.
- Added regression tests for:
  - a benign Python heredoc command, which now passes classification
  - a heredoc command whose shell portion contains a high-risk pattern, which still blocks

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. This is a backend middleware classification fix with regression tests.

## Bug fix verification

Test path that reproduces the bug:

- `backend/tests/test_sandbox_audit_middleware.py::TestClassifyCommand::test_benign_heredoc_classified_as_pass`
- `backend/tests/test_sandbox_audit_middleware.py::TestClassifyCommand::test_heredoc_with_high_risk_pattern_still_blocks`


## Validation

From `backend/`:

```bash
uv run pytest tests/test_sandbox_audit_middleware.py
uv run ruff check packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py tests/test_sandbox_audit_middleware.py
uv run ruff format --check packages/harness/deerflow/agents/middlewares/sandbox_audit_middleware.py tests/test_sandbox_audit_middleware.py
Additional git validation from repo root:
git diff --check
Results:
149 passed
ruff check: all checks passed
ruff format --check: 2 files already formatted
git diff --check: no whitespace errors