### PR TITLE
fix(frontend): preserve artifacts during streaming updates

### DIFF
--- a/frontend/src/components/workspace/chats/chat-box.tsx
+++ b/frontend/src/components/workspace/chats/chat-box.tsx
@@ -44,13 +44,20 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
 
   const [autoSelectFirstArtifact, setAutoSelectFirstArtifact] = useState(true);
   useEffect(() => {
+    const threadArtifacts = Array.isArray(thread.values.artifacts)
+      ? thread.values.artifacts
+      : undefined;
+
     if (threadIdRef.current !== threadId) {
       threadIdRef.current = threadId;
       deselect();
+      setArtifacts([]);
     }
 
     // Update artifacts from the current thread
-    setArtifacts(thread.values.artifacts);
+    if (threadArtifacts) {
+      setArtifacts(threadArtifacts);
+    }
 
     // DO NOT automatically deselect the artifact when switching threads, because the artifacts auto discovering is not work now.
     // if (
@@ -64,9 +71,9 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
       env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" &&
       autoSelectFirstArtifact
     ) {
-      if (thread?.values?.artifacts?.length > 0) {
+      if (threadArtifacts && threadArtifacts.length > 0) {
         setAutoSelectFirstArtifact(false);
-        selectArtifact(thread.values.artifacts[0]!);
+        selectArtifact(threadArtifacts[0]!);
       }
     }
   }, [
@@ -149,7 +156,7 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
                   <XIcon />
                 </Button>
               </div>
-              {thread.values.artifacts?.length === 0 ? (
+              {artifacts.length === 0 ? (
                 <ConversationEmptyState
                   icon={<FilesIcon />}
                   title="No artifact selected"
@@ -163,7 +170,7 @@ const ChatBox: React.FC<{ children: React.ReactNode; threadId: string }> = ({
                   <main className="min-h-0 grow">
                     <ArtifactFileList
                       className="max-w-(--container-width-sm) p-4 pt-12"
-                      files={thread.values.artifacts ?? []}
+                      files={artifacts}
                       threadId={threadId}
                     />
                   </main>

--- a/frontend/src/core/threads/types.ts
+++ b/frontend/src/core/threads/types.ts
@@ -5,7 +5,7 @@ import type { Todo } from "../todos";
 export interface AgentThreadState extends Record<string, unknown> {
   title: string;
   messages: Message[];
-  artifacts: string[];
+  artifacts?: string[];
   todos?: Todo[];
 }
 

--- a/frontend/tests/e2e/artifact-stream-state.spec.ts
+++ b/frontend/tests/e2e/artifact-stream-state.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test, type Route } from "@playwright/test";
+
+import { mockLangGraphAPI } from "./utils/mock-api";
+
+const THREAD_ID = "00000000-0000-0000-0000-000000003788";
+const RUN_ID = "00000000-0000-0000-0000-000000003789";
+const ARTIFACT_PATH = "/artifact-fixtures/report.md";
+const THREAD_MESSAGES = [
+  {
+    type: "human",
+    id: "msg-human-artifact",
+    content: [{ type: "text", text: "Create a markdown report" }],
+  },
+  {
+    type: "ai",
+    id: "msg-ai-artifact",
+    content: "Created a markdown report.",
+  },
+];
+
+function streamWithoutArtifacts(route: Route) {
+  const events = [
+    {
+      event: "metadata",
+      data: { run_id: RUN_ID, thread_id: THREAD_ID },
+    },
+    {
+      event: "values",
+      data: {
+        messages: [
+          {
+            type: "human",
+            id: "msg-human-artifact-follow-up",
+            content: [{ type: "text", text: "Continue" }],
+          },
+          {
+            type: "ai",
+            id: "msg-ai-artifact-follow-up",
+            content: "Updated response while the artifact list is omitted.",
+          },
+        ],
+      },
+    },
+  ];
+
+  return route.fulfill({
+    status: 200,
+    contentType: "text/event-stream",
+    body: events
+      .map((event) => {
+        return `event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`;
+      })
+      .join(""),
+  });
+}
+
+test("keeps artifact trigger after stream values omit artifacts", async ({
+  page,
+}) => {
+  mockLangGraphAPI(page, {
+    threads: [
+      {
+        thread_id: THREAD_ID,
+        title: "Artifact stream state",
+        artifacts: [ARTIFACT_PATH],
+        messages: THREAD_MESSAGES,
+      },
+    ],
+  });
+
+  await page.route("**/api/langgraph/threads/*/runs/stream", (route) => {
+    return streamWithoutArtifacts(route);
+  });
+
+  await page.goto(`/workspace/chats/${THREAD_ID}`);
+
+  const artifactTrigger = page.getByRole("button", { name: /artifacts/i });
+  await expect(artifactTrigger).toBeVisible({ timeout: 15_000 });
+
+  const textarea = page.getByPlaceholder(/how can i assist you/i);
+  await textarea.fill("Continue");
+  await textarea.press("Enter");
+
+  await expect(
+    page.getByText("Updated response while the artifact list is omitted."),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(artifactTrigger).toBeVisible();
+
+  await artifactTrigger.click();
+
+  const artifactsPanel = page.locator("#artifacts");
+  await expect(artifactsPanel.getByText("report.md")).toBeVisible();
+  await artifactsPanel.getByText("report.md").click();
+
+  await expect(artifactsPanel.getByRole("combobox")).toContainText("report.md");
+});


### PR DESCRIPTION
Fixes #3788

## Why

During LangGraph streaming, `thread.values` can arrive as a partial update without `artifacts`.

`ChatBox` previously wrote `thread.values.artifacts` into `ArtifactsContext` unconditionally. When a later same-thread stream update omitted `artifacts`, the existing artifact list was cleared, causing the top Files button to disappear and the artifact header dropdown to lose its file option.

This PR only fixes the #3788 streaming-state bug. The #3198 follow-up about keeping all presented files in the dropdown is intentionally left out of scope.

## What changed

- Preserve existing artifact state when a same-thread streaming update omits `thread.values.artifacts`.
- Clear artifact state on real thread switches to avoid leaking files across conversations.
- Mark `AgentThreadState.artifacts` as optional to match runtime partial stream values.
- Add a focused Playwright regression for a stream update that omits `artifacts` after artifacts already exist.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

<img width="2814" height="1490" alt="image" src="https://github.com/user-attachments/assets/e23b1d18-85dd-46b0-9517-ec09bdd841ca" />
Note on the file dropdown:

The dropdown itself is working after the artifact is selected from the generated file card. The remaining difference during the auto-open streaming preview is caused by the preview using the temporary `write-file:` artifact path, which renders the in-progress file title directly instead of the normal file `<Select>`.

This PR fixes the #3788 regression where the Files button and artifact options were cleared by partial streaming updates. The title/rendering behavior for auto-opened `write-file:` previews is covered separately by the related PR, so this PR intentionally avoids changing that area to prevent scope overlap.


## Bug fix verification

Test path that reproduces the bug:

frontend/tests/e2e/artifact-stream-state.spec.ts

Did it go red on `main` and green on this branch?

The test encodes the #3788 failure mode: artifacts exist first, then a later same-thread stream `values` event omits `artifacts`.

On this branch, the test passes and confirms:
- the Files button remains visible
- the artifact panel still lists `report.md`
- the artifact header combobox still shows `report.md`

## Validation

Ran:

- git diff --check
- pnpm --dir frontend typecheck
- pnpm --dir frontend lint
- pnpm --dir frontend test:e2e -- artifact-stream-state.spec.ts

Results:

- git diff --check: passed
- pnpm --dir frontend typecheck: passed
- pnpm --dir frontend lint: passed with 0 errors and 4 pre-existing warnings
- pnpm --dir frontend test:e2e -- artifact-stream-state.spec.ts: passed, 1 passed



