### PR TITLE
fix(frontend): remove deprecated baseUrl for TypeScript 6 compatibility

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,8 +26,7 @@
       }
     ],
     "incremental": true,
-    /* Path Aliases */
-    "baseUrl": ".",
+    /* Path Aliases (baseUrl removed — TS 6.0; paths are relative to this file) */
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Removes deprecated `baseUrl` from `frontend/tsconfig.json` to fix the TypeScript 6.0 deprecation warning (`TS5101`).

Path aliases continue to work via explicit `paths` entries relative to the tsconfig file:

```json
"paths": {
  "@/*": ["./src/*"]
}
```

This matches the [TypeScript 6.0 migration guidance](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html): `baseUrl` is deprecated in TS 6 and will stop functioning in TS 7.0.

## Test plan

- [x] Verified `tsc --noEmit` no longer reports `TS5101` for `baseUrl` with TypeScript 6.0.3
- [x] Existing `@/*` import paths unchanged (`./src/*` mapping preserved)

Made with [Cursor](https://cursor.com)