### PR TITLE
docs: define durable workflow runtime stack

### DIFF
--- a/backend/docs/DURABLE_WORKFLOW_CORE_RFC.md
+++ b/backend/docs/DURABLE_WORKFLOW_CORE_RFC.md
@@ -1,0 +1,262 @@
+# RFC: Native Durable Workflow Runtime Layer For DeerFlow Core
+
+Status: upstream submission draft
+Date: 2026-06-29
+
+This RFC frames the product and runtime direction for a native Durable Workflow
+Runtime Layer in DeerFlow core. The implementation can still be reviewed as
+separate PR groups, but the design should be evaluated as one coherent runtime
+foundation for real-world agent work.
+
+## Summary
+
+DeerFlow should add a native Durable Workflow Runtime Layer in core.
+
+The goal is not to replace LangGraph, and not to turn DeerFlow into a clone of
+Temporal, Restate, or Hatchet. The goal is to give DeerFlow a configurable,
+native workflow runtime foundation for human-agent collaboration, multi-agent
+coordination, observability, recovery, and daily work operations.
+
+## Why DeerFlow Needs This In Core
+
+For agents to be useful in daily work, users need more than a single chat turn
+or a single run.
+
+In real work, humans and agents need to understand:
+
+- which work was received;
+- which workflow or run is active;
+- which work is waiting for human input;
+- which work completed;
+- which work failed or lost execution after a gateway restart;
+- what happened over time;
+- how an external request, DeerFlow thread, run, checkpoint, and event timeline
+  relate to each other.
+
+Workflow is the shared control surface between humans and agents. Without
+durable workflow identity and lifecycle, an agent system easily stays at the
+level of personal assistance or one-off automation. It is much harder to use it
+as a reliable work system for individuals, small teams, or larger deployments.
+
+## Multi-Agent Work Needs Durable Workflow
+
+DeerFlow already positions itself as a super agent harness with sub-agents,
+skills, memory, sandbox execution, channels, and long-running tasks. That makes
+durable workflow identity more important, not less.
+
+When users create multiple agents, each agent may have different skills, roles,
+tools, and operating characteristics. A lead or coordinator agent needs a
+runtime-level way to:
+
+- delegate work to other agents;
+- know which agent is handling which part of the work;
+- track parallel branches;
+- support workflows that loop through several attempts;
+- know which step is waiting for a human, another agent, or an external system;
+- detect when a delegated agent failed, stopped, or did not return a result;
+- retry or resume without losing the whole work context.
+
+Without durable workflow state, the lead agent can get stuck when a child agent
+dies or when one branch never completes. It also becomes much harder to improve
+individual agents, because operators cannot see where the work got stuck, which
+agent owned it, which input caused the failure, or which loop needs redesign.
+
+Durable workflow state gives DeerFlow better operational visibility: where the
+work is, who or what is handling it, which step failed, what can be retried, and
+which agent needs improvement.
+
+## Current Gap In Agent Systems
+
+Many agent systems focus primarily on personal-assistant use cases. When users
+want to apply agents to team work or daily operations, they often need to add an
+external workflow engine such as Temporal, Restate, or Hatchet.
+
+Those systems are powerful, especially for large teams and complex production
+infrastructure. But for individuals, small teams, and open-source users, making
+an external workflow engine mandatory creates a high adoption cost:
+
+- more infrastructure;
+- more integration work;
+- more operational complexity;
+- slower experimentation;
+- harder adoption for smaller communities.
+
+DeerFlow can fill this gap with a native Durable Workflow Runtime Layer in core:
+close enough to DeerFlow's agent runtime to be useful out of the box, and
+generic enough for different deployments to configure and extend.
+
+## Existing DeerFlow Runtime Foundation
+
+DeerFlow already has a strong LangGraph-based runtime foundation:
+
+- LangGraph checkpointer for graph/thread checkpoint state.
+- LangGraph store for runtime and cross-thread memory.
+- RunManager / RunRepository for run identity, status, cancellation, and
+  multitask behavior.
+- RunEventStore for ordered run event streams.
+- Gateway execution through process-local asyncio tasks and agent streaming.
+- Channel adapters for external message sources.
+
+The gap is not LangGraph checkpointing.
+
+LangGraph should continue to own graph execution, checkpoint state, checkpoint
+writes, interrupt payloads, graph-local memory, and resume mechanics.
+
+The missing layer is a DeerFlow-owned durable workflow runtime layer so every
+external message, API request, dashboard request, or delegated agent task can
+have stable identity, idempotency, runtime refs, status, event timeline, and
+recovery visibility.
+
+## Proposed Core Layer
+
+Add a native Durable Workflow Runtime Layer in DeerFlow core, configurable and
+feature-gated, with these foundation primitives:
+
+- `workflow_id`
+- `external_message_ref`
+- source/channel metadata
+- `thread_id`
+- `run_id`
+- checkpoint refs
+- `idempotency_key`
+- workflow status
+- append-only workflow events
+- created/updated timestamps
+- generic metadata
+
+The runtime layer owns:
+
+- durable workflow intake;
+- idempotent create-or-get;
+- workflow refs bound to existing DeerFlow runs;
+- workflow event projection over the existing RunEventStore;
+- recovery visibility for orphaned active workflows;
+- waiting/resume refs for human-in-the-loop workflows;
+- worker lease primitives when deployments need scaled execution, without
+  requiring every deployment to run a separate worker service.
+
+The layer can later grow toward:
+
+- multi-agent delegation records;
+- branch/child workflow visibility;
+- clearer retries, loops, waits, and resume refs;
+- worker leasing/concurrency controls;
+- richer timelines and operator-facing recovery hints;
+- clean integration boundaries so users are not locked out of external workflow
+  engines when they need them.
+
+## Value For DeerFlow Users And The Community
+
+A native durable workflow layer helps DeerFlow apply to real work:
+
+- Personal users can manage workflows that last longer than one chat turn.
+- Small teams can use DeerFlow immediately without starting with Temporal,
+  Restate, or Hatchet.
+- Operators can inspect status and history after a gateway restart.
+- Integration developers get one intake contract for API, dashboard, and
+  channel messages.
+- Multi-agent builders get a foundation for lead-agent delegation, branch
+  tracking, retry/resume, and failure analysis.
+- Maintainers get a clear core abstraction for later modules such as Work Module
+  and WorkBoard.
+- Enterprise teams can still integrate Temporal, Restate, or Hatchet when they
+  need stronger orchestration, because DeerFlow core does not lock users into a
+  single execution model.
+
+## Added Value: Work Module And WorkBoard
+
+Work Module and WorkBoard should not be required for the Durable Workflow
+Runtime Layer to work. They are added value once DeerFlow has durable workflow
+identity, lifecycle, refs, and events.
+
+For individuals or small teams, WorkBoard can provide a simple built-in work
+management surface inside DeerFlow. It can act as a lightweight PM tool for
+teams that do not already have a dedicated system.
+
+For teams that already use Trello, ClickUp, Jira, Plane, or internal systems,
+Work Module can provide shared work primitives and external refs so those teams
+can build their own integrations more cleanly.
+
+Durable Workflow Runtime Layer is the foundation. Work Module standardizes work
+objects above it. WorkBoard gives users a simple built-in surface to use those
+objects immediately.
+
+## LangGraph Boundary
+
+This proposal does not replace LangGraph durability.
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint state;
+- checkpoint writes;
+- interrupt payloads;
+- graph-local memory;
+- replay/resume mechanics.
+
+DeerFlow Durable Workflow Runtime Layer owns:
+
+- workflow intake identity;
+- idempotency;
+- source/channel refs;
+- deterministic run/checkpoint binding records;
+- workflow status projection;
+- workflow lifecycle events;
+- recovery visibility;
+- human-agent and multi-agent observability.
+
+DeerFlow workflow rows store refs to LangGraph state, not checkpoint payloads.
+
+## Relationship To Temporal, Restate, And Hatchet
+
+Temporal, Restate, and Hatchet are useful systems for durable execution,
+retries, leases, idempotency, and recovery at larger scale.
+
+DeerFlow core should still have its own native Durable Workflow Runtime Layer so
+users can begin using durable agent work without external infrastructure.
+
+This does not block larger teams from integrating Temporal, Restate, or Hatchet
+when they need them. DeerFlow only needs clear identity, lifecycle, refs, and
+event boundaries so users are not locked into one operational model.
+
+## Non-goals
+
+This RFC does not propose:
+
+- full deterministic replay like Temporal;
+- durable handler replay like Restate;
+- a DAG builder or visual workflow definition engine;
+- a hard dependency on any external workflow engine;
+- a hard dependency on Work Module or WorkBoard;
+- domain-specific PM semantics;
+- AICOS-specific concepts.
+
+## Submission And Review Shape
+
+The implementation should be submitted as a package that shows the complete
+runtime value, but reviewed in two clear groups.
+
+For the current open GitHub PRs, the Core Runtime Package maps to:
+
+- **PR 1 / #3813: RFC and runtime contracts.**
+- **PR 2 / #3814: Workflow store and lifecycle events.**
+- **PR 3 / #3815: Workflow read APIs and timeline projection.**
+- **PR 4 / #3816: Existing run wrapper and trace UI.**
+- **PR 5 / #3848: Recovery and orphan reconciliation.**
+
+This is the first landing target because normal DeerFlow runs become
+inspectable durable workflows without requiring Work Module or WorkBoard. PR
+#3814 intentionally keeps store and events together for the current submission
+so the package is not split into tiny, low-context fragments. If maintainers
+prefer a finer split, #3814 can be split into separate store and event PRs
+before final review.
+
+PR 6-10 form the Hardening/Scale Package: deterministic binding,
+channel/dashboard intake adoption, waiting/resume refs, and worker-readiness.
+The current open branches cover those areas; exact numbering can be adjusted if
+maintainers ask to split one hardening item further.
+
+Code should remain split into small, reviewable PRs. The submit narrative should
+not be split into tiny unrelated fragments: maintainers need to see the
+end-to-end durable core value and the explicit boundary around what the core is
+not trying to become.

--- a/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
+++ b/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
@@ -1,4 +1,4 @@
-# Durable Workflow Frontdoor
+# Durable Workflow Runtime Frontdoor
 
 Status: architecture decision draft
 Date: 2026-06-26
@@ -6,10 +6,11 @@ Scope: DeerFlow backend gateway, runtime, persistence, and channel adapters
 
 ## Decision
 
-DeerFlow should add a native, minimal durable workflow frontdoor for every
-inbound message that may invoke an agent. The first layer should be a DeerFlow
-owned workflow envelope and ledger, not a hard dependency on AICOS, Restate,
-Temporal, or any product-specific task model.
+DeerFlow should add a native Durable Workflow Runtime Layer in core for inbound
+messages, run requests, dashboard requests, and delegated agent tasks that may
+invoke an agent. The first core surface should be a DeerFlow-owned workflow
+envelope and ledger, not a hard dependency on AICOS, Restate, Temporal, Hatchet,
+or any product-specific task model.
 
 The frontdoor provides stable intake identity, idempotency, routing/binding
 metadata, run/checkpoint references, and queryable workflow status. LangGraph
@@ -17,8 +18,10 @@ continues to own graph execution state, checkpoint values, graph-local memory,
 interrupt semantics, and replay from checkpoints. DeerFlow owns generic intake,
 run orchestration, channel routing, and event correlation.
 
-External workflow engines such as Restate or Temporal should be optional
-adapters above this interface, not a required DeerFlow core dependency.
+External workflow engines such as Restate, Temporal, or Hatchet must not be a
+required DeerFlow core dependency. The runtime layer should keep clean identity,
+lifecycle, refs, and event boundaries so users are not locked out of those
+systems when their deployments need them.
 
 Scalable DeerFlow deployments should add a small native workflow leasing layer
 to this envelope. Leasing gives DeerFlow a horizontal worker contract without
@@ -28,9 +31,9 @@ another worker recover it when the lease expires.
 
 For deployments that need durable work management, this frontdoor can later be
 paired with an optional DeerFlow Work Module. The frontdoor remains the generic
-intake and runtime-dispatch layer; the Work module would add reusable work unit,
-acceptance criterion, gate, artifact reference, review, and external PM-tool
-binding schemas.
+intake and runtime-dispatch layer; the Work module would add reusable Work Unit
+records, acceptance criteria, gates, artifact references, review metadata, and
+external refs that make deployment-owned PM integrations easier to build.
 
 ## Current Architecture Summary
 
@@ -77,9 +80,9 @@ Temporal and Restate solve a different boundary: durable orchestration replay.
 Temporal workflows must be deterministic and push non-deterministic operations
 such as API/LLM calls into activities. Restate journals steps, side effects,
 timers, and service calls so handlers can replay without duplicating completed
-effects. These are valuable optional execution adapters, but making either
-mandatory would raise DeerFlow's deployment bar and entangle the core runtime
-with a specific orchestrator.
+effects. These are valuable external systems, but making either mandatory would
+raise DeerFlow's deployment bar and entangle the core runtime with a specific
+execution engine.
 
 Hatchet is useful as a scale and worker model reference. Its durable execution
 docs separate ordinary task execution from durable tasks that checkpoint when
@@ -135,8 +138,8 @@ From Restate:
 - dedupe repeated submissions by identity/idempotency key;
 - distinguish retryable errors from terminal errors;
 - model external waits as durable workflow state, not as an in-memory future;
-- optionally support Restate as an execution adapter later, where Restate owns
-  its execution log and DeerFlow owns workflow/run/checkpoint refs.
+- keep boundaries clean enough that deployments can integrate Restate later if
+  they need durable handler execution outside DeerFlow core.
 
 From Temporal:
 
@@ -155,12 +158,12 @@ From Hatchet:
 - make waits and child work visible as durable state;
 - persist completed step/task refs so retries do not need to guess what already
   happened;
-- keep DAG/workflow-builder concerns separate from the minimal intake ledger.
+- keep DAG/workflow-builder concerns separate from the core runtime layer.
 
 The practical result is a small DeerFlow schema made of a mutable workflow
 projection plus append-only lifecycle facts. LangGraph remains the durable graph
-runtime. Optional engines can wrap DeerFlow, but DeerFlow still has a native
-frontdoor that every deployment can run.
+runtime. DeerFlow still has a native frontdoor that every deployment can run,
+while users remain free to integrate external workflow engines when needed.
 
 ## Boundary Rules
 
@@ -193,11 +196,11 @@ DeerFlow runtime core must not know integration-specific names such as Gate,
 Evidence, Review, Runtime Invocation, AICOS, OpenClaw, Restate, or Temporal.
 It also must not require the Work Module to run durable workflows.
 
-The optional Work Module intentionally sits between DeerFlow runtime core and
-external integrations. It provides generic community primitives such as Work
-Units and Work Gates, while adapter packages map those primitives to Jira
-issues, Trello cards, ClickUp tasks, Plane issues, Lark tasks/docs, or AICOS-X
-records.
+The optional Work Module intentionally sits above DeerFlow runtime core. It
+provides generic community primitives such as Work Units and Work Gates, plus
+external refs that make it easier for teams to connect Jira issues, Trello
+cards, ClickUp tasks, Plane issues, Lark tasks/docs, internal systems, or other
+work records without making those integrations DeerFlow core.
 
 ## Core Primitive: Workflow Envelope
 
@@ -229,7 +232,7 @@ Minimum fields:
 - `lease_owner`: worker/process id that currently owns execution.
 - `lease_expires_at`: time after which another worker may recover/claim it.
 - `error`: short error summary.
-- `metadata`: JSON for adapter/runtime extension data.
+- `metadata`: JSON for source/runtime extension data.
 - `created_at`, `updated_at`.
 
 The envelope stores refs and summaries. It must not copy LangGraph checkpoint
@@ -280,7 +283,7 @@ This table is not a copy of `RunEventStore`. It records DeerFlow workflow facts
 and points at run event sequence numbers where graph execution details already
 exist. UI timelines can merge workflow events and run events at query time.
 
-## Minimal Durable Schema
+## Durable Runtime Schema
 
 The first scalable schema should be intentionally small:
 
@@ -308,8 +311,8 @@ LangGraph checkpoints/checkpoint_writes/store
 
 Do not add a `workflow_steps` table in the first native layer. Step-level
 durability is already owned by LangGraph for graph nodes and can later be owned
-by an optional Restate/Temporal/Hatchet adapter for deployments that need
-deterministic code replay beyond LangGraph checkpoints.
+by an external workflow engine in deployments that need deterministic code
+replay beyond LangGraph checkpoints.
 
 Do not add a separate `workflow_runtime_bindings` table until DeerFlow needs
 one workflow to fan out into multiple runs or runtimes. The first model can bind
@@ -336,7 +339,7 @@ Routing should be deterministic before the agent is invoked:
    rules make that deterministic.
 5. If multiple valid candidates exist, persist the candidates in workflow
    metadata and pass the ambiguity to the agent or human flow. Do not guess in
-   the adapter.
+   channel/source-specific code.
 
 This resolver is intentionally not a semantic classifier. Semantic intent
 belongs in the agent or integration layer.
@@ -415,13 +418,13 @@ On startup:
 - workflows with expired leases and an active/local run should keep the run as
   source of truth until the run reaches a terminal state;
 - workflows that were only `received` or `bound` before a run was created can
-  be retried only when the idempotency key, input refs, and adapter policy make
+  be retried only when the idempotency key, input refs, and source policy make
   retry safe;
 - retry/resume policies must be explicit per workflow kind/source.
 
-Future Restate/Temporal adapters can provide stronger execution replay by
-driving DeerFlow through the same workflow envelope and marking their own
-orchestrator refs in metadata.
+Deployments that require stronger execution replay can integrate external
+workflow engines around the same DeerFlow identity, lifecycle, refs, and event
+boundaries.
 
 ## Human-In-The-Loop
 
@@ -466,20 +469,17 @@ ordered so that cutting later PRs still leaves a useful durable runtime prefix.
 9. Waiting, resume, and human-in-the-loop refs.
 10. Worker pool readiness.
 
-## First Implementation Slice
+## Review Grouping
 
-The first safe slice is PR 1 plus the persistence skeleton for PR 2:
+Submit the implementation as one coherent durable runtime package with two
+explicit review groups:
 
-- add this design doc;
-- add generic workflow status/kind/source enums;
-- add a `workflows` ORM model and Alembic migration;
-- add a small repository/store API with idempotent create-or-get by
-  idempotency key;
-- add lease/attempt fields so later PRs can scale workers horizontally without
-  another schema break;
-- add unit tests for idempotent create, binding updates, status updates, and
-  list filters;
-- do not change any gateway or channel runtime behavior yet.
+- PR 1-5: Core Runtime Package. Contracts, store, events, read APIs/trace, and
+  run endpoint compatibility wrappers, plus recovery/orphan reconciliation.
+- PR 6-10: Hardening/Scale Package. Deterministic binding, channel/dashboard
+  intake, waiting/resume refs, and worker readiness.
 
-This gives downstream PRs a stable table and API surface without changing the
-current run endpoints or channel dispatch path.
+The code stays split into reviewable PRs. The submit narrative should show the
+end-to-end native Durable Workflow Runtime Layer so maintainers can evaluate the
+core value without requiring Work Module, WorkBoard, PM connectors, or external
+workflow engines.

--- a/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
+++ b/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
@@ -1,0 +1,485 @@
+# Durable Workflow Frontdoor
+
+Status: architecture decision draft
+Date: 2026-06-26
+Scope: DeerFlow backend gateway, runtime, persistence, and channel adapters
+
+## Decision
+
+DeerFlow should add a native, minimal durable workflow frontdoor for every
+inbound message that may invoke an agent. The first layer should be a DeerFlow
+owned workflow envelope and ledger, not a hard dependency on AICOS, Restate,
+Temporal, or any product-specific task model.
+
+The frontdoor provides stable intake identity, idempotency, routing/binding
+metadata, run/checkpoint references, and queryable workflow status. LangGraph
+continues to own graph execution state, checkpoint values, graph-local memory,
+interrupt semantics, and replay from checkpoints. DeerFlow owns generic intake,
+run orchestration, channel routing, and event correlation.
+
+External workflow engines such as Restate or Temporal should be optional
+adapters above this interface, not a required DeerFlow core dependency.
+
+Scalable DeerFlow deployments should add a small native workflow leasing layer
+to this envelope. Leasing gives DeerFlow a horizontal worker contract without
+claiming full durable code replay: a worker can atomically claim an eligible
+workflow, bind it to a LangGraph thread/run, renew or finish the lease, and let
+another worker recover it when the lease expires.
+
+For deployments that need durable work management, this frontdoor can later be
+paired with an optional DeerFlow Work Module. The frontdoor remains the generic
+intake and runtime-dispatch layer; the Work module would add reusable work unit,
+acceptance criterion, gate, artifact reference, review, and external PM-tool
+binding schemas.
+
+## Current Architecture Summary
+
+DeerFlow already has the foundation for durable agent runtime behavior:
+
+- LangGraph checkpointer persists thread-scoped graph state by `thread_id`,
+  `checkpoint_ns`, and `checkpoint_id`.
+- LangGraph store persists runtime/application memory outside graph state.
+- `RunManager` creates process-local `RunRecord` objects and persists run
+  metadata through `RunStore`.
+- `RunRepository` stores `run_id`, `thread_id`, status, model, token usage,
+  first/last messages, and run kwargs/metadata.
+- `RunEventStore` stores an ordered event stream keyed by
+  `(thread_id, run_id, seq)`.
+- `run_agent()` executes `agent.astream(...)` in an `asyncio.Task`, writes run
+  status transitions, publishes stream bridge events, and flushes `RunJournal`
+  events.
+- Gateway endpoints (`/runs`, `/threads/{thread_id}/runs`) call `start_run()`
+  directly.
+- Channel adapters normalize platform events into `InboundMessage`; the
+  channel manager resolves/creates a DeerFlow thread, then calls
+  `client.runs.wait()` or `client.runs.stream()`.
+
+The important current limitation is that the executing run task is process
+local. A persisted `pending` or `running` row does not imply an executor still
+exists after gateway restart. Startup reconciliation explicitly marks orphaned
+active runs as `error` for SQLite-backed deployments instead of pretending they
+are resumable.
+
+## Research Notes
+
+LangGraph persistence separates thread-scoped checkpointers from cross-thread
+stores. Checkpointers are the right owner for graph state snapshots,
+conversation continuity, human-in-the-loop, time travel, and fault tolerance.
+They require a stable `thread_id` and can reference concrete checkpoints by
+`checkpoint_id`.
+
+LangGraph interrupts pause graph execution, persist graph state through the
+checkpointer, and resume by invoking the same thread with `Command(resume=...)`.
+Interrupt side effects before the interrupt must be idempotent because the
+node can restart when resumed.
+
+Temporal and Restate solve a different boundary: durable orchestration replay.
+Temporal workflows must be deterministic and push non-deterministic operations
+such as API/LLM calls into activities. Restate journals steps, side effects,
+timers, and service calls so handlers can replay without duplicating completed
+effects. These are valuable optional execution adapters, but making either
+mandatory would raise DeerFlow's deployment bar and entangle the core runtime
+with a specific orchestrator.
+
+Hatchet is useful as a scale and worker model reference. Its durable execution
+docs separate ordinary task execution from durable tasks that checkpoint when
+they wait or spawn children. Its DAG model persists each completed task result
+so retries can avoid re-running succeeded parts, and its platform emphasizes
+worker slots, concurrency, priority, retries, and observability. DeerFlow should
+borrow those operational primitives at the workflow-envelope layer, while still
+leaving graph execution and checkpoint state inside LangGraph.
+
+OpenAI Agents SDK tracing and handoffs are useful compatibility concepts:
+trace/group IDs and spans map naturally to workflow/run/event correlation,
+while handoffs show how multi-agent delegation can remain tool-like and
+runtime-owned. They do not replace DeerFlow's need for an intake ledger.
+
+Dust-style platforms are useful as product pattern evidence: many surfaces
+(web, Slack, Teams, API, browser extension) can call the same agent layer with
+selected knowledge sources and tools. DeerFlow should generalize that as
+surface-agnostic intake and routing, not as a Dust-specific feature.
+
+References:
+
+- https://docs.langchain.com/oss/python/langgraph/persistence
+- https://docs.langchain.com/oss/python/langgraph/checkpointers
+- https://docs.langchain.com/oss/python/langgraph/interrupts
+- https://docs.temporal.io/workflow-definition
+- https://docs.restate.dev/foundations/key-concepts
+- https://docs.hatchet.run/v1/durable-execution
+- https://docs.hatchet.run/v1/durable-tasks
+- https://docs.hatchet.run/v1/directed-acyclic-graphs
+- https://openai.github.io/openai-agents-python/tracing/
+- https://openai.github.io/openai-agents-python/handoffs/
+- https://docs.dust.tt/docs/intro
+
+## Schema Lessons From Durable Workflow Systems
+
+The schema should borrow the smallest durable ideas from LangGraph, Restate,
+Temporal, and Hatchet without turning DeerFlow into another workflow engine.
+
+From LangGraph:
+
+- use `thread_id`, `checkpoint_ns`, and `checkpoint_id` as refs into graph
+  state;
+- never copy checkpoint `values` into DeerFlow workflow rows;
+- remember that a checkpoint snapshot already has `metadata`, `created_at`,
+  `parent_config`, `tasks`, and `next` for graph-local replay and inspection;
+- rely on LangGraph checkpoint writes/pending writes for graph node recovery
+  inside a super-step;
+- use interrupts/resume as the primary graph-local human-in-the-loop primitive.
+
+From Restate:
+
+- keep a durable identity before handler execution starts;
+- dedupe repeated submissions by identity/idempotency key;
+- distinguish retryable errors from terminal errors;
+- model external waits as durable workflow state, not as an in-memory future;
+- optionally support Restate as an execution adapter later, where Restate owns
+  its execution log and DeerFlow owns workflow/run/checkpoint refs.
+
+From Temporal:
+
+- separate stable `workflow_id` from per-attempt/per-run execution identity;
+- use append-only event history concepts for observability and recovery
+  decisions;
+- keep workers stateless enough that another worker can pick up eligible work;
+- treat calls to LLMs, databases, channels, and PM tools as external effects
+  that require idempotency or a durable result record;
+- avoid putting critical execution data only in searchable/memo metadata.
+
+From Hatchet:
+
+- expose worker-facing lease/claim/concurrency primitives without requiring
+  full deterministic replay in core;
+- make waits and child work visible as durable state;
+- persist completed step/task refs so retries do not need to guess what already
+  happened;
+- keep DAG/workflow-builder concerns separate from the minimal intake ledger.
+
+The practical result is a small DeerFlow schema made of a mutable workflow
+projection plus append-only lifecycle facts. LangGraph remains the durable graph
+runtime. Optional engines can wrap DeerFlow, but DeerFlow still has a native
+frontdoor that every deployment can run.
+
+## Boundary Rules
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint values and checkpoint writes;
+- graph-local memory and interrupt/resume mechanics;
+- replay from a checkpoint.
+
+DeerFlow core owns:
+
+- generic workflow intake identity;
+- source/channel metadata;
+- deterministic conversation/thread binding records;
+- run creation and cancellation orchestration;
+- workflow-to-run/checkpoint references;
+- workflow event projection over `RunEventStore`;
+- restart reconciliation and orphan status visibility.
+
+Integrations own:
+
+- domain-specific work semantics;
+- task/goal/work-unit lifecycle;
+- approval policies and business gates;
+- evidence/artifact acceptance rules;
+- semantic completion beyond "the DeerFlow run ended".
+
+DeerFlow runtime core must not know integration-specific names such as Gate,
+Evidence, Review, Runtime Invocation, AICOS, OpenClaw, Restate, or Temporal.
+It also must not require the Work Module to run durable workflows.
+
+The optional Work Module intentionally sits between DeerFlow runtime core and
+external integrations. It provides generic community primitives such as Work
+Units and Work Gates, while adapter packages map those primitives to Jira
+issues, Trello cards, ClickUp tasks, Plane issues, Lark tasks/docs, or AICOS-X
+records.
+
+## Core Primitive: Workflow Envelope
+
+The workflow envelope is a generic record for one inbound message or command
+that may cause an agent invocation.
+
+Minimum fields:
+
+- `workflow_id`: DeerFlow-generated durable identity.
+- `workflow_kind`: `message`, `command`, `resume`, `handoff`, or `other`.
+- `source_type`: `api`, `dashboard`, `channel`, `agent_session`, or `other`.
+- `source`: provider/surface name such as `slack`, `telegram`, `dashboard`, or
+  `api`.
+- `external_message_ref`: stable external message/event id when one exists.
+- `conversation_ref`: external conversation/session/channel id.
+- `thread_ref`: external topic/thread/reply id.
+- `sender_ref`: external user/account/bot id.
+- `thread_id`: DeerFlow LangGraph thread id, once resolved.
+- `run_id`: DeerFlow run id, once created.
+- `checkpoint_ns`: checkpoint namespace, usually `""` for the root graph.
+- `checkpoint_id`: checkpoint ref when the workflow targets or observes one.
+- `idempotency_key`: caller or adapter supplied stable key.
+- `status`: `received`, `bound`, `claimed`, `run_created`, `running`, `waiting`,
+  `succeeded`, `failed`, `cancelled`, `orphaned`, or `ignored`.
+- `attempt_count`: how many times DeerFlow has claimed or attempted the
+  workflow.
+- `max_attempts`: retry ceiling for safe retry policies.
+- `next_attempt_at`: earliest time the workflow can be claimed again.
+- `lease_owner`: worker/process id that currently owns execution.
+- `lease_expires_at`: time after which another worker may recover/claim it.
+- `error`: short error summary.
+- `metadata`: JSON for adapter/runtime extension data.
+- `created_at`, `updated_at`.
+
+The envelope stores refs and summaries. It must not copy LangGraph checkpoint
+state values or large raw transcripts.
+
+## Core Primitive: Workflow Event
+
+The workflow row is the latest projection. A separate append-only event table
+should record workflow lifecycle facts that are useful for audit, recovery, and
+UI timelines.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Suggested event types:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+This table is not a copy of `RunEventStore`. It records DeerFlow workflow facts
+and points at run event sequence numbers where graph execution details already
+exist. UI timelines can merge workflow events and run events at query time.
+
+## Minimal Durable Schema
+
+The first scalable schema should be intentionally small:
+
+```text
+workflows
+  durable intake identity
+  source refs and idempotency key
+  current status projection
+  worker lease and retry metadata
+  LangGraph thread/checkpoint refs
+  DeerFlow run refs
+  compact error/metadata
+
+workflow_events
+  append-only workflow lifecycle facts
+  refs to run_events, checkpoints, and external ids
+  compact payload summaries
+
+run_events
+  existing DeerFlow execution stream
+
+LangGraph checkpoints/checkpoint_writes/store
+  existing graph state and graph-local memory
+```
+
+Do not add a `workflow_steps` table in the first native layer. Step-level
+durability is already owned by LangGraph for graph nodes and can later be owned
+by an optional Restate/Temporal/Hatchet adapter for deployments that need
+deterministic code replay beyond LangGraph checkpoints.
+
+Do not add a separate `workflow_runtime_bindings` table until DeerFlow needs
+one workflow to fan out into multiple runs or runtimes. The first model can bind
+the current `thread_id`, `run_id`, and checkpoint refs directly on `workflows`,
+with richer execution attempts represented later by the optional Work module's
+`runtime_invocations`.
+
+Human waits can begin as `status = waiting` plus checkpoint/interrupt metadata.
+If this becomes too overloaded, add a focused `workflow_waits` or
+`workflow_signals` table later with `wait_id`, `workflow_id`, `wait_type`,
+`status`, `resume_id`, `expires_at`, and `metadata`.
+
+## Deterministic Binding Resolver
+
+Routing should be deterministic before the agent is invoked:
+
+1. Respect explicit request fields (`thread_id`, `checkpoint_id`, selected
+   assistant/agent, explicit external refs).
+2. Resolve channel conversation mappings using existing channel connection and
+   conversation stores.
+3. Detect explicit references in message text only when their syntax is
+   unambiguous and generic, such as a DeerFlow thread/run/workflow id.
+4. Bind to an active thread/run only when the source conversation and binding
+   rules make that deterministic.
+5. If multiple valid candidates exist, persist the candidates in workflow
+   metadata and pass the ambiguity to the agent or human flow. Do not guess in
+   the adapter.
+
+This resolver is intentionally not a semantic classifier. Semantic intent
+belongs in the agent or integration layer.
+
+## Scalable Execution Model
+
+The native DeerFlow layer should be a durable intake and dispatch ledger, not a
+second graph engine. The scalable path is:
+
+```text
+surface/API/channel
+  -> workflow intake row (idempotent)
+  -> deterministic binding resolver
+  -> workflow lease claim
+  -> LangGraph run creation
+  -> LangGraph checkpointer/store/run_events
+  -> workflow status projection
+```
+
+Core primitives needed for scale:
+
+- `create_or_get`: idempotent intake.
+- `claim_next`: atomically lease an eligible workflow for one worker.
+- `bind_runtime`: attach `thread_id`, `run_id`, and checkpoint refs after run
+  creation.
+- `update_status`: complete, fail, wait, cancel, or orphan the workflow.
+- `release_for_retry`: clear a lease, increment/reuse retry metadata, and set
+  `next_attempt_at`.
+- `recover_expired_leases`: mark or requeue workflows whose lease owner died.
+
+The first implementation can keep run execution in the gateway process. A later
+worker pool can use the same store API to claim workflows from Postgres without
+changing public intake semantics.
+
+This design intentionally does not provide Temporal/Restate-style deterministic
+code replay in core. DeerFlow should replay at three safer boundaries instead:
+
+1. API/channel retries dedupe at `workflow.idempotency_key`.
+2. Workflow dispatch retries re-enter before LangGraph run creation, or after a
+   known terminal/orphaned run state.
+3. LangGraph graph resume uses `thread_id` and checkpoint/interrupt refs.
+
+Any side effect outside those boundaries must be idempotent or pushed into a
+tool/runtime layer that records its own durable result.
+
+## Runtime Binding
+
+Workflow rows bind to DeerFlow runtime refs:
+
+```text
+workflow_id
+  -> thread_id
+  -> run_id
+  -> checkpoint_ns/checkpoint_id refs
+  -> run_events(thread_id, run_id, seq)
+```
+
+Run events remain the source event stream for graph execution observations.
+Workflow timeline APIs should project from workflow status changes plus
+`RunEventStore` rows. The projection should include links/correlation, not
+duplicate every run event into a second canonical stream.
+
+## Recovery Semantics
+
+The initial native layer does not make process-local `asyncio.Task` execution
+durable across gateway restarts.
+
+On startup:
+
+- orphaned `pending`/`running` runs remain explicitly marked as `error` under
+  current run reconciliation;
+- workflows bound to those runs should be marked `orphaned` or `failed` with a
+  recovery hint;
+- workflows with expired leases and no run can be requeued when their
+  idempotency key and source policy make retry safe;
+- workflows with expired leases and an active/local run should keep the run as
+  source of truth until the run reaches a terminal state;
+- workflows that were only `received` or `bound` before a run was created can
+  be retried only when the idempotency key, input refs, and adapter policy make
+  retry safe;
+- retry/resume policies must be explicit per workflow kind/source.
+
+Future Restate/Temporal adapters can provide stronger execution replay by
+driving DeerFlow through the same workflow envelope and marking their own
+orchestrator refs in metadata.
+
+## Human-In-The-Loop
+
+LangGraph interrupts should remain the primary graph-local HITL primitive.
+DeerFlow workflow records should add:
+
+- a durable `waiting` status for workflows whose run reached an interrupt or
+  requires user input;
+- references to the relevant `thread_id`, `run_id`, and checkpoint config;
+- a generic pending-input record or metadata block that stores prompt summary,
+  interrupt id(s), source, and resume route;
+- `Command(resume=...)` intake through the same workflow frontdoor.
+
+The human decision semantics remain outside DeerFlow unless they are generic
+approval/resume mechanics.
+
+## Observability
+
+DeerFlow should expose workflow observability without requiring an integration:
+
+- list workflows by status, source, thread, run, and updated time;
+- get one workflow envelope;
+- get workflow timeline projected from workflow lifecycle plus run events;
+- show idempotency and external refs;
+- surface orphan/retry/recovery hints;
+- correlate workflow rows to run rows and checkpoint refs.
+
+## PR Stack
+
+Detailed implementation order lives in
+[Durable Workflow Runtime Plan](DURABLE_WORKFLOW_RUNTIME_PLAN.md). The stack is
+ordered so that cutting later PRs still leaves a useful durable runtime prefix.
+
+1. Runtime architecture and shared contracts.
+2. Workflow envelope schema/store/idempotency/lease tests.
+3. Workflow events append-only lifecycle log.
+4. Runtime read APIs and observability.
+5. Existing run endpoint compatibility wrapper.
+6. Recovery/reconciliation for orphaned workflows/runs.
+7. Deterministic binding resolver.
+8. Channel/dashboard intake adoption.
+9. Waiting, resume, and human-in-the-loop refs.
+10. Worker pool readiness.
+
+## First Implementation Slice
+
+The first safe slice is PR 1 plus the persistence skeleton for PR 2:
+
+- add this design doc;
+- add generic workflow status/kind/source enums;
+- add a `workflows` ORM model and Alembic migration;
+- add a small repository/store API with idempotent create-or-get by
+  idempotency key;
+- add lease/attempt fields so later PRs can scale workers horizontally without
+  another schema break;
+- add unit tests for idempotent create, binding updates, status updates, and
+  list filters;
+- do not change any gateway or channel runtime behavior yet.
+
+This gives downstream PRs a stable table and API surface without changing the
+current run endpoints or channel dispatch path.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -1,0 +1,286 @@
+# Durable Workflow PR Stack
+
+Status: working stack
+Date: 2026-06-26
+
+This stack is ordered for upstream review. PR 1-5 is the first community-visible
+milestone: existing DeerFlow run APIs keep their current behavior, but each run
+also has durable workflow identity, idempotency, lifecycle events, and an
+inspectable trace.
+
+## Review Principles
+
+- Keep the Durable Workflow Runtime layer generic. Do not introduce AICOS, PM
+  tool, visual designer, board, or external-orchestrator concepts into that
+  runtime layer.
+- Keep module boundaries explicit. Durable Workflow Runtime, Work Module, and
+  WorkBoard are separately gated by `modules.*` config and should not require
+  each other except for WorkBoard depending on the Work Module API.
+- LangGraph remains owner of graph execution, checkpoint state, graph-local
+  memory, interrupts, and resume semantics.
+- DeerFlow owns intake identity, workflow status projection, idempotency,
+  run/checkpoint references, channel/API routing, and runtime observability.
+- The optional DeerFlow Work Module may map workflow ids to generic Work Units,
+  and external adapters may map those Work Units to domain task/card/issue
+  systems. Those mappings live outside this runtime stack.
+
+## PR 1: Runtime Architecture And Shared Contracts
+
+Purpose: align vocabulary before schema and API changes.
+
+Scope:
+
+- Add `DURABLE_WORKFLOW_RUNTIME_PLAN.md`.
+- Add `DURABLE_WORKFLOW_FRONTDOOR.md`.
+- Link both docs from the backend docs index.
+- Define shared identity names: `workflow_id`, `workflow_event_id`,
+  `thread_id`, `run_id`, `checkpoint_ns`, `checkpoint_id`,
+  `workflow_definition_id`, and `workflow_run_id`.
+- Define status and event contracts.
+
+Acceptance:
+
+- No runtime behavior changes.
+- Docs clearly separate runtime workflow identity from future visual workflow
+  definitions and future work unit modules.
+
+Suggested checks:
+
+```bash
+git diff --check
+```
+
+## PR 2: Workflow Envelope Schema And Store
+
+Purpose: persist the minimal durable frontdoor envelope.
+
+Scope:
+
+- Add runtime workflow enums and `WorkflowStore`.
+- Add in-memory workflow store.
+- Add SQLAlchemy workflow repository.
+- Add `workflows` ORM model and migration.
+- Wire gateway dependency so production uses SQL store when a DB session
+  factory exists, otherwise memory store.
+
+Acceptance:
+
+- `create_or_get` dedupes by `(source_type, source, idempotency_key)`.
+- Store supports `get`, `list`, `bind_runtime`, `update_status`,
+  `claim_next`, and `release_for_retry`.
+- Existing run APIs still behave the same before wrapper adoption.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py \
+  tests/test_persistence_scaffold.py -q
+```
+
+## PR 3: Workflow Events
+
+Purpose: add append-only lifecycle facts for audit and recovery decisions.
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event` and `list_events` to workflow stores.
+- Keep workflow events separate from `RunEventStore`.
+- Ensure migrations are idempotent when legacy `create_all` already created
+  tables.
+
+Acceptance:
+
+- Event `seq` is monotonic per workflow.
+- Events can exist before a run exists.
+- No checkpoint values are copied into workflow event rows.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_workflows_router.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py -q
+```
+
+## PR 4: Durable Run Trace API And UI
+
+Purpose: make the runtime value visible without requiring WorkBoard, PM
+adapters, or an external workflow engine.
+
+Scope:
+
+- Add read-only workflow endpoints:
+  - `GET /api/workflows`
+  - `GET /api/workflows/{workflow_id}`
+  - `GET /api/workflows/{workflow_id}/events`
+  - `GET /api/workflows/by-run/{run_id}`
+  - `GET /api/workflows/{workflow_id}/timeline`
+- Timeline merges workflow lifecycle events and run events at query time.
+- Add a compact workspace Trace trigger for the latest run in a chat.
+
+Acceptance:
+
+- A user can open a chat and inspect the latest run trace.
+- A developer can find `workflow_id` from `run_id`.
+- Timeline includes both workflow events and existing run events.
+- Endpoint additions do not change existing run API responses.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflows_router.py \
+  tests/test_gateway_services.py -q
+
+cd ../frontend
+CI=true pnpm run check
+```
+
+## PR 5: Run API Wrapper And Status Projection
+
+Purpose: route existing run creation through workflow intake while preserving
+client compatibility.
+
+Scope:
+
+- Wrap `/api/runs/*` and `/api/threads/{thread_id}/runs*` creation paths.
+- Create a workflow envelope before run creation.
+- Bind `thread_id`, `run_id`, `checkpoint_ns`, and `checkpoint_id`.
+- Project run lifecycle to workflow status:
+  - `running`
+  - `succeeded`
+  - `failed`
+  - `cancelled`
+- Append lifecycle events:
+  - `workflow.received`
+  - `workflow.deduped`
+  - `workflow.run_created`
+  - `workflow.run_started`
+  - `workflow.succeeded`
+  - `workflow.failed`
+  - `workflow.cancelled`
+
+Acceptance:
+
+- Old clients can ignore workflows entirely.
+- Duplicate idempotency keys do not create duplicate bound runs.
+- Workflow terminal status matches the bound run terminal status.
+- Trace UI shows terminal status on new runs.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -q
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff check .
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff format --check .
+
+cd ../frontend
+CI=true pnpm run check
+NEXT_PUBLIC_BACKEND_BASE_URL=http://127.0.0.1:18081 \
+NEXT_PUBLIC_LANGGRAPH_BASE_URL=http://127.0.0.1:18081/api \
+DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://127.0.0.1:18081 \
+DEER_FLOW_TRUSTED_ORIGINS=http://127.0.0.1:13001,http://localhost:13001 \
+DEER_FLOW_AUTH_DISABLED=1 \
+pnpm exec next build
+```
+
+## Post-Milestone PRs
+
+These should come after PR 1-5, so the foundation is already visible and
+testable.
+
+### PR 6: Recovery And Orphan Reconciliation
+
+- Reconcile active workflows with existing run reconciliation at gateway
+  startup.
+- Mark `running` / `run_created` workflows as `orphaned` when process-local
+  execution was lost.
+- Add recovery hints in timeline responses.
+
+### PR 7: Deterministic Binding Resolver
+
+- Normalize explicit thread/run/checkpoint/source bindings.
+- Persist ambiguous candidates instead of guessing.
+- Give channel adapters a generic binding contract.
+
+### PR 8: Channel And Dashboard Intake Adoption
+
+- Route Slack/Discord/Telegram-style adapters through workflow intake.
+- Use stable external message ids as idempotency keys.
+- Keep channel UX compatible.
+
+### PR 9: Durable Waiting And Resume Refs
+
+- Represent LangGraph interrupt waits as durable workflow state.
+- Route resume commands through workflow intake.
+- Keep actual interrupt payloads in LangGraph checkpoint state.
+
+### PR 10: Worker Pool Readiness
+
+- Add worker identity and lease renewal.
+- Add a claim loop abstraction behind a feature flag.
+- Keep gateway process execution as the default mode.
+
+## Next Module Tracks
+
+The following tracks should remain separate from the runtime PRs:
+
+- Work Module: generic Work Unit records and external PM mappings.
+- WorkBoard: built-in board UI for deployments without a PM tool.
+- Workflow Designer: visual workflow definition authoring and versioning.
+- Optional orchestrator adapters: Restate, Temporal, Hatchet integration
+  examples, not hard dependencies.
+
+## Module PRs After Runtime
+
+These PRs depend on the runtime identity/event foundation but should not be
+required for a minimal durable runtime deployment.
+
+### PR 11: Work Module Schema And API
+
+- Add `DEERFLOW_WORK_MODULE.md`.
+- Add `work_units` and `work_events` schema/migration.
+- Add memory and SQL stores.
+- Add `/api/work-units` CRUD and event list endpoints.
+- Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
+
+### PR 12: WorkBoard MVP
+
+- Add `/workspace/work`.
+- Show Trello-style columns over `work_units.status`.
+- Create local work units.
+- Show runtime-driven status projection; local human-created work starts in
+  `backlog`.
+- Link cards to chat threads and workflow traces when refs exist.
+
+### PR 13: External PM Binding Contract
+
+- Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
+  objects.
+- Add external ref/url/source conventions.
+- Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
+
+### PR 14: Work Gates And Criteria
+
+- Add acceptance criteria and lightweight human gates.
+- Link gates to runtime `waiting` workflows where appropriate.
+- Keep LangGraph interrupt payloads in LangGraph checkpoint state.
+
+### PR 15: Agent Workflow Definition Plane
+
+- Add Agent Workflow DSL schema/validation.
+- Add definition/version persistence.
+- Add visual designer under a feature flag.
+- Compile from DeerFlow DSL to LangGraph/runtime plans, not from editor JSON.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -43,9 +43,36 @@ Draft upstream PRs currently opened from this roadmap:
   memory, interrupts, and resume semantics.
 - DeerFlow owns intake identity, workflow status projection, idempotency,
   run/checkpoint references, channel/API routing, and runtime observability.
+- StreamBridge backends own live run-event delivery to connected clients.
+  Durable workflow state should not depend on a particular StreamBridge backend.
 - The optional DeerFlow Work Module may map workflow ids to generic Work Units,
   and external adapters may map those Work Units to domain task/card/issue
   systems. Those mappings live outside this runtime stack.
+
+## Redis StreamBridge Alignment
+
+The Redis StreamBridge proposals in upstream discussion address a different
+layer from this durable workflow runtime stack. They make live run streaming
+work across multiple gateway workers by moving `StreamBridge` from an
+in-process queue to Redis Streams. That is a runtime transport and reconnect
+improvement, not a canonical workflow ledger.
+
+The durable workflow layer remains compatible with either `memory` or `redis`
+StreamBridge:
+
+- `StreamBridge` delivers recent run events to SSE clients and may use bounded
+  retention, replay cursors, TTLs, and terminal reconciliation.
+- `RunEventStore` remains the durable low-level run event source.
+- `WorkflowStore` and `workflow_events` remain the durable intake, identity,
+  lifecycle, idempotency, and recovery projection.
+- Workflow timelines merge workflow events with `RunEventStore` rows at query
+  time instead of copying Redis stream entries.
+
+If a Redis StreamBridge lands before this stack, the run wrapper PR should
+rebase around gateway service and thread-run router changes, preserve
+cross-process stream capability checks, and continue to treat Redis Streams as
+an optional live transport. If the durable workflow stack lands first, Redis
+StreamBridge can be added underneath it without changing workflow schema.
 
 ## PR 1: Runtime Architecture And Shared Contracts
 

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -31,6 +31,42 @@ Draft upstream PRs currently opened from this roadmap:
 - #3818: agent-facing Work Unit tools.
 - #3819: WorkBoard MVP.
 
+## Current Progress
+
+The runtime foundation has reached the first upstream discussion point:
+
+- PR 1-5 are open as draft PRs and form the first mergeable runtime wave.
+- PR 1-5 are intentionally useful without Work Module, WorkBoard, channel
+  adapters, visual workflow design, Redis StreamBridge, Restate, Temporal, or
+  Hatchet.
+- Work Module, Agent Work Unit Tools, and WorkBoard are also open as draft PRs
+  to demonstrate practical value, but they should remain downstream of runtime
+  identity and separately gated.
+
+The next runtime work that is not yet represented by open implementation PRs is
+PR 6-10: recovery/orphan reconciliation, deterministic binding resolver,
+channel/dashboard intake adoption, durable waiting/resume refs, and worker pool
+readiness.
+
+The next module work that is not yet ready for upstream review is external PM
+binding, work gates/criteria, and the workflow definition/designer plane.
+
+## Plan Updates
+
+The plan should be adjusted in three ways:
+
+- Treat PR 1-5 as the first review wave and keep later runtime PRs separate.
+  This gives maintainers a small durable workflow core to evaluate before
+  horizontal worker semantics or channel intake expand the surface area.
+- Keep Work Module before WorkBoard, and keep Agent Work Unit Tools before
+  WorkBoard. WorkBoard should be an observer and operator surface over Work
+  Units; agents should update Work Units by calling tools so the database, board
+  UI, and chat claims cannot drift.
+- Keep Redis StreamBridge as a compatible transport layer, not as a dependency
+  of durable workflow state. This avoids coupling workflow durability to Redis
+  stream TTL/bounded replay behavior while still supporting multi-worker SSE
+  once that upstream track lands.
+
 ## Review Principles
 
 - Keep the Durable Workflow Runtime layer generic. Do not introduce AICOS, PM
@@ -308,22 +344,7 @@ Current draft: #3817.
 - Add `/api/work-units` CRUD and event list endpoints.
 - Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
 
-### PR 12: WorkBoard MVP
-
-Current draft: #3819.
-
-- Add `/workspace/work`.
-- Show Trello-style columns over `work_units.status`.
-- Create local work units.
-- Show runtime-driven status projection; local human-created work starts in
-  `backlog`.
-- Link cards to chat threads and workflow traces when refs exist.
-- Support the practical operating model where long-running contribution work,
-  such as a stack of upstream PRs, can be represented as Work Units assigned
-  to agents and tracked through backlog, ready, running, waiting, review, done,
-  and closed states.
-
-### PR 12b: Agent Work Unit Tools
+### PR 12: Agent Work Unit Tools
 
 Current draft: #3818.
 
@@ -333,20 +354,36 @@ Current draft: #3818.
 - Keep WorkBoard thin: the board observes and chats, while agent/runtime tools
   mutate Work Unit state.
 
-### PR 13: External PM Binding Contract
+### PR 13: WorkBoard MVP
+
+Current draft: #3819.
+
+- Add `/workspace/work`.
+- Show Trello-style columns over `work_units.status`.
+- Create local work units in `backlog` only.
+- Show runtime-driven status projection.
+- Link cards to chat threads and workflow traces when refs exist.
+- Support the practical operating model where long-running contribution work,
+  such as a stack of upstream PRs, can be represented as Work Units assigned
+  to agents and tracked through backlog, ready, running, waiting, review, done,
+  and closed states.
+- Avoid direct human status mutation as the default flow. Humans create and
+  review Work Units; agents/runtimes move status through Work Unit tools.
+
+### PR 14: External PM Binding Contract
 
 - Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
   objects.
 - Add external ref/url/source conventions.
 - Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
 
-### PR 14: Work Gates And Criteria
+### PR 15: Work Gates And Criteria
 
 - Add acceptance criteria and lightweight human gates.
 - Link gates to runtime `waiting` workflows where appropriate.
 - Keep LangGraph interrupt payloads in LangGraph checkpoint state.
 
-### PR 15: Agent Workflow Definition Plane
+### PR 16: Agent Workflow Definition Plane
 
 - Add Agent Workflow DSL schema/validation.
 - Add definition/version persistence.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -1,12 +1,35 @@
 # Durable Workflow PR Stack
 
 Status: working stack
-Date: 2026-06-26
+Date: 2026-06-27
 
 This stack is ordered for upstream review. PR 1-5 is the first community-visible
 milestone: existing DeerFlow run APIs keep their current behavior, but each run
 also has durable workflow identity, idempotency, lifecycle events, and an
 inspectable trace.
+
+The roadmap continues beyond the runtime layer because durable workflow
+identity is most useful when operators can assign, observe, and recover real
+work. The follow-up module track keeps that product value visible while
+preserving the runtime boundary:
+
+- runtime core PRs make every run/workflow traceable and recoverable;
+- Work Module PRs add generic Work Units that can map to Jira, ClickUp, Plane,
+  Trello, Lark, GitHub Issues, or internal PM tools;
+- WorkBoard PRs add a built-in Kanban surface for teams that do not already
+  have a PM system connected;
+- workflow design PRs add authoring/versioning for repeatable agent workflows
+  after the runtime and work primitives are stable.
+
+Draft upstream PRs currently opened from this roadmap:
+
+- #3813: runtime architecture docs.
+- #3814: durable workflow store/schema/events.
+- #3815: workflow read APIs and timeline projection.
+- #3816: run wrapper and workflow trace binding.
+- #3817: generic Work Module core.
+- #3818: agent-facing Work Unit tools.
+- #3819: WorkBoard MVP.
 
 ## Review Principles
 
@@ -250,6 +273,8 @@ required for a minimal durable runtime deployment.
 
 ### PR 11: Work Module Schema And API
 
+Current draft: #3817.
+
 - Add `DEERFLOW_WORK_MODULE.md`.
 - Add `work_units` and `work_events` schema/migration.
 - Add memory and SQL stores.
@@ -258,12 +283,28 @@ required for a minimal durable runtime deployment.
 
 ### PR 12: WorkBoard MVP
 
+Current draft: #3819.
+
 - Add `/workspace/work`.
 - Show Trello-style columns over `work_units.status`.
 - Create local work units.
 - Show runtime-driven status projection; local human-created work starts in
   `backlog`.
 - Link cards to chat threads and workflow traces when refs exist.
+- Support the practical operating model where long-running contribution work,
+  such as a stack of upstream PRs, can be represented as Work Units assigned
+  to agents and tracked through backlog, ready, running, waiting, review, done,
+  and closed states.
+
+### PR 12b: Agent Work Unit Tools
+
+Current draft: #3818.
+
+- Add a general `work_units` tool for create/list/get/update_status.
+- Scope tool access by runtime user identity.
+- Require agents to call a tool before claiming Work Unit status changed.
+- Keep WorkBoard thin: the board observes and chats, while agent/runtime tools
+  mutate Work Unit state.
 
 ### PR 13: External PM Binding Contract
 

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -3,74 +3,43 @@
 Status: working stack
 Date: 2026-06-27
 
-This stack is ordered for upstream review. PR 1-5 is the first community-visible
-milestone: existing DeerFlow run APIs keep their current behavior, but each run
-also has durable workflow identity, idempotency, lifecycle events, and an
-inspectable trace.
+This stack is ordered for upstream review as one coherent Durable Workflow
+Runtime package, split into two review groups:
 
-The roadmap continues beyond the runtime layer because durable workflow
-identity is most useful when operators can assign, observe, and recover real
-work. The follow-up module track keeps that product value visible while
-preserving the runtime boundary:
+- PR 1-5: Core Runtime Package. Existing DeerFlow run APIs keep their current
+  behavior, but each run also has durable workflow identity, idempotency,
+  lifecycle events, an inspectable trace, and explicit orphan recovery
+  visibility.
+- PR 6-10: Hardening/Scale Package. Deterministic binding, channel/dashboard
+  intake, waiting/resume refs, and worker-readiness show the production path
+  while remaining separable from the first landing target.
 
-- runtime core PRs make every run/workflow traceable and recoverable;
-- Work Module PRs add generic Work Units that can map to Jira, ClickUp, Plane,
-  Trello, Lark, GitHub Issues, or internal PM tools;
-- WorkBoard PRs add a built-in Kanban surface for teams that do not already
-  have a PM system connected;
-- workflow design PRs add authoring/versioning for repeatable agent workflows
-  after the runtime and work primitives are stable.
+The submit narrative should show why the native Durable Workflow Runtime Layer
+belongs in DeerFlow core. The code should remain split so maintainers can review
+and land smaller pieces if needed.
 
-Draft upstream PRs currently opened from this roadmap:
+## Current GitHub PR Mapping
 
-- #3813: runtime architecture docs.
-- #3814: durable workflow store/schema/events.
-- #3815: workflow read APIs and timeline projection.
-- #3816: run wrapper and workflow trace binding.
-- #3817: generic Work Module core.
-- #3818: agent-facing Work Unit tools.
-- #3819: WorkBoard MVP.
+The current open PRs intentionally keep the first submit package substantial
+instead of splitting every primitive into tiny PRs:
 
-## Current Progress
+- PR 1 / #3813: RFC and runtime contracts.
+- PR 2 / #3814: workflow store and lifecycle events.
+- PR 3 / #3815: workflow read APIs and timeline projection.
+- PR 4 / #3816: existing run wrapper and trace UI.
+- PR 5 / #3848: recovery and orphan reconciliation.
 
-The runtime foundation has reached the first upstream discussion point:
+#3814 combines the store and event foundation for the current submission. If
+maintainers prefer a finer split, separate #3814 into a store PR and an event PR
+before final review.
 
-- PR 1-5 are open as draft PRs and form the first mergeable runtime wave.
-- PR 1-5 are intentionally useful without Work Module, WorkBoard, channel
-  adapters, visual workflow design, Redis StreamBridge, Restate, Temporal, or
-  Hatchet.
-- Work Module, Agent Work Unit Tools, and WorkBoard are also open as draft PRs
-  to demonstrate practical value, but they should remain downstream of runtime
-  identity and separately gated.
-
-The next runtime work that is not yet represented by open implementation PRs is
-PR 6-10: recovery/orphan reconciliation, deterministic binding resolver,
-channel/dashboard intake adoption, durable waiting/resume refs, and worker pool
-readiness.
-
-The next module work that is not yet ready for upstream review is external PM
-binding, work gates/criteria, and the workflow definition/designer plane.
-
-## Plan Updates
-
-The plan should be adjusted in three ways:
-
-- Treat PR 1-5 as the first review wave and keep later runtime PRs separate.
-  This gives maintainers a small durable workflow core to evaluate before
-  horizontal worker semantics or channel intake expand the surface area.
-- Keep Work Module before WorkBoard, and keep Agent Work Unit Tools before
-  WorkBoard. WorkBoard should be an observer and operator surface over Work
-  Units; agents should update Work Units by calling tools so the database, board
-  UI, and chat claims cannot drift.
-- Keep Redis StreamBridge as a compatible transport layer, not as a dependency
-  of durable workflow state. This avoids coupling workflow durability to Redis
-  stream TTL/bounded replay behavior while still supporting multi-worker SSE
-  once that upstream track lands.
+For current upstream review state, CLA/RFC blockers, and instructions for
+future agents, see `DEERFLOW_X_UPSTREAM_REVIEW_HANDOFF.md`.
 
 ## Review Principles
 
 - Keep the Durable Workflow Runtime layer generic. Do not introduce AICOS, PM
-  tool, visual designer, board, or external-orchestrator concepts into that
+  tool, visual designer, board, or external workflow engine concepts into that
   runtime layer.
 - Keep module boundaries explicit. Durable Workflow Runtime, Work Module, and
   WorkBoard are separately gated by `modules.*` config and should not require
@@ -79,36 +48,10 @@ The plan should be adjusted in three ways:
   memory, interrupts, and resume semantics.
 - DeerFlow owns intake identity, workflow status projection, idempotency,
   run/checkpoint references, channel/API routing, and runtime observability.
-- StreamBridge backends own live run-event delivery to connected clients.
-  Durable workflow state should not depend on a particular StreamBridge backend.
-- The optional DeerFlow Work Module may map workflow ids to generic Work Units,
-  and external adapters may map those Work Units to domain task/card/issue
-  systems. Those mappings live outside this runtime stack.
-
-## Redis StreamBridge Alignment
-
-The Redis StreamBridge proposals in upstream discussion address a different
-layer from this durable workflow runtime stack. They make live run streaming
-work across multiple gateway workers by moving `StreamBridge` from an
-in-process queue to Redis Streams. That is a runtime transport and reconnect
-improvement, not a canonical workflow ledger.
-
-The durable workflow layer remains compatible with either `memory` or `redis`
-StreamBridge:
-
-- `StreamBridge` delivers recent run events to SSE clients and may use bounded
-  retention, replay cursors, TTLs, and terminal reconciliation.
-- `RunEventStore` remains the durable low-level run event source.
-- `WorkflowStore` and `workflow_events` remain the durable intake, identity,
-  lifecycle, idempotency, and recovery projection.
-- Workflow timelines merge workflow events with `RunEventStore` rows at query
-  time instead of copying Redis stream entries.
-
-If a Redis StreamBridge lands before this stack, the run wrapper PR should
-rebase around gateway service and thread-run router changes, preserve
-cross-process stream capability checks, and continue to treat Redis Streams as
-an optional live transport. If the durable workflow stack lands first, Redis
-StreamBridge can be added underneath it without changing workflow schema.
+- The optional DeerFlow Work Module may map workflow ids to generic Work Units.
+  Work Module should define enough external-ref metadata for teams to build PM
+  integrations later, but this stack does not implement Jira, ClickUp, Plane,
+  Trello, or Lark bindings.
 
 ## PR 1: Runtime Architecture And Shared Contracts
 
@@ -118,7 +61,9 @@ Scope:
 
 - Add `DURABLE_WORKFLOW_RUNTIME_PLAN.md`.
 - Add `DURABLE_WORKFLOW_FRONTDOOR.md`.
-- Link both docs from the backend docs index.
+- Add `DURABLE_WORKFLOW_CORE_RFC.md` as the English package RFC/background
+  anchor.
+- Link these docs from the backend docs index.
 - Define shared identity names: `workflow_id`, `workflow_event_id`,
   `thread_id`, `run_id`, `checkpoint_ns`, `checkpoint_id`,
   `workflow_definition_id`, and `workflow_run_id`.
@@ -136,9 +81,10 @@ Suggested checks:
 git diff --check
 ```
 
-## PR 2: Workflow Envelope Schema And Store
+## PR 2: Workflow Envelope Schema, Store, And Events
 
-Purpose: persist the minimal durable frontdoor envelope.
+Purpose: persist the durable runtime frontdoor envelope and append-only
+lifecycle facts.
 
 Scope:
 
@@ -146,6 +92,9 @@ Scope:
 - Add in-memory workflow store.
 - Add SQLAlchemy workflow repository.
 - Add `workflows` ORM model and migration.
+- Add `workflow_events` ORM model and migration.
+- Add `append_event` and `list_events` to workflow stores.
+- Keep workflow events separate from `RunEventStore`.
 - Wire gateway dependency so production uses SQL store when a DB session
   factory exists, otherwise memory store.
 
@@ -153,7 +102,10 @@ Acceptance:
 
 - `create_or_get` dedupes by `(source_type, source, idempotency_key)`.
 - Store supports `get`, `list`, `bind_runtime`, `update_status`,
-  `claim_next`, and `release_for_retry`.
+  `claim_next`, `release_for_retry`, `append_event`, and `list_events`.
+- Event `seq` is monotonic per workflow.
+- Events can exist before a run exists.
+- No checkpoint values are copied into workflow event rows.
 - Existing run APIs still behave the same before wrapper adoption.
 
 Suggested checks:
@@ -168,55 +120,25 @@ PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
   tests/test_persistence_scaffold.py -q
 ```
 
-## PR 3: Workflow Events
-
-Purpose: add append-only lifecycle facts for audit and recovery decisions.
-
-Scope:
-
-- Add `workflow_events` ORM model and migration.
-- Add `append_event` and `list_events` to workflow stores.
-- Keep workflow events separate from `RunEventStore`.
-- Ensure migrations are idempotent when legacy `create_all` already created
-  tables.
-
-Acceptance:
-
-- Event `seq` is monotonic per workflow.
-- Events can exist before a run exists.
-- No checkpoint values are copied into workflow event rows.
-
-Suggested checks:
-
-```bash
-cd backend
-PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
-  tests/test_workflow_repository.py \
-  tests/test_workflows_router.py \
-  tests/test_persistence_bootstrap.py \
-  tests/test_persistence_bootstrap_concurrency.py \
-  tests/test_persistence_bootstrap_regression.py -q
-```
-
-## PR 4: Durable Run Trace API And UI
+## PR 3: Durable Run Trace APIs
 
 Purpose: make the runtime value visible without requiring WorkBoard, PM
-adapters, or an external workflow engine.
+integrations, or an external workflow engine.
 
 Scope:
 
 - Add read-only workflow endpoints:
+  - `GET /api/modules`
   - `GET /api/workflows`
   - `GET /api/workflows/{workflow_id}`
   - `GET /api/workflows/{workflow_id}/events`
   - `GET /api/workflows/by-run/{run_id}`
   - `GET /api/workflows/{workflow_id}/timeline`
 - Timeline merges workflow lifecycle events and run events at query time.
-- Add a compact workspace Trace trigger for the latest run in a chat.
+- Add frontend API hooks for module flags and workflow trace data.
 
 Acceptance:
 
-- A user can open a chat and inspect the latest run trace.
 - A developer can find `workflow_id` from `run_id`.
 - Timeline includes both workflow events and existing run events.
 - Endpoint additions do not change existing run API responses.
@@ -233,7 +155,7 @@ cd ../frontend
 CI=true pnpm run check
 ```
 
-## PR 5: Run API Wrapper And Status Projection
+## PR 4: Run API Wrapper, Status Projection, And Trace UI
 
 Purpose: route existing run creation through workflow intake while preserving
 client compatibility.
@@ -282,61 +204,99 @@ DEER_FLOW_AUTH_DISABLED=1 \
 pnpm exec next build
 ```
 
-## Post-Milestone PRs
+## PR 5: Recovery And Orphan Reconciliation
 
-These should come after PR 1-5, so the foundation is already visible and
-testable.
+Purpose: make restart behavior explicit for workflow records bound to
+process-local runs.
 
-### PR 6: Recovery And Orphan Reconciliation
+Scope:
 
 - Reconcile active workflows with existing run reconciliation at gateway
   startup.
 - Mark `running` / `run_created` workflows as `orphaned` when process-local
   execution was lost.
 - Add recovery hints in timeline responses.
+- Extend memory and SQL stores with recovery helpers.
 
-### PR 7: Deterministic Binding Resolver
+Acceptance:
+
+- Restart behavior is explicit and queryable.
+- No workflow is silently left `running` without an owner.
+- PR 1-4 remain useful if this PR is reviewed separately.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_gateway_run_recovery.py \
+  tests/test_workflow_repository.py -q
+```
+
+## PR 6-10: Hardening/Scale Package
+
+These PRs should be submitted as the second review group after PR 1-5. The
+current open branches cover deterministic binding, channel/dashboard intake,
+waiting/resume refs, and worker readiness. Exact numbering can be adjusted if
+maintainers ask to split one hardening item further.
+
+### PR 6: Deterministic Binding Resolver
+
+Status: implemented in `codex/deerflow-durable-binding-resolver`.
 
 - Normalize explicit thread/run/checkpoint/source bindings.
 - Persist ambiguous candidates instead of guessing.
 - Give channel adapters a generic binding contract.
 
-### PR 8: Channel And Dashboard Intake Adoption
+### PR 7: Channel And Dashboard Intake Adoption
+
+Status: implemented in `codex/deerflow-durable-channel-intake`.
 
 - Route Slack/Discord/Telegram-style adapters through workflow intake.
 - Use stable external message ids as idempotency keys.
 - Keep channel UX compatible.
 
-### PR 9: Durable Waiting And Resume Refs
+### PR 8: Durable Waiting And Resume Refs
+
+Status: implemented in `codex/deerflow-durable-waiting-resume`.
 
 - Represent LangGraph interrupt waits as durable workflow state.
 - Route resume commands through workflow intake.
 - Keep actual interrupt payloads in LangGraph checkpoint state.
 
-### PR 10: Worker Pool Readiness
+### PR 9: Worker Pool Readiness
+
+Status: implemented in `codex/deerflow-workflow-worker-readiness`.
 
 - Add worker identity and lease renewal.
-- Add a claim loop abstraction behind a feature flag.
+- Prepare the store contract for future worker processes without enabling a
+  separate worker pool by default.
 - Keep gateway process execution as the default mode.
+
+### PR 10: Optional Split Point
+
+If maintainers want exactly ten PRs, split either waiting/resume or worker
+readiness into two smaller hardening PRs during final packaging. Do not create a
+new conceptual dependency just to fill a number.
 
 ## Next Module Tracks
 
 The following tracks should remain separate from the runtime PRs:
 
-- Work Module: generic Work Unit records and external PM mappings.
+- Work Module: generic Work Unit records with external-ref fields that let teams
+  build PM integrations later.
 - WorkBoard: built-in board UI for deployments without a PM tool.
 - Workflow Designer: visual workflow definition authoring and versioning.
-- Optional orchestrator adapters: Restate, Temporal, Hatchet integration
-  examples, not hard dependencies.
+- External workflow engines: users remain free to integrate Temporal, Restate,
+  or Hatchet when they need stronger orchestration, but that is not DeerFlow
+  core value or a hard dependency.
 
 ## Module PRs After Runtime
 
 These PRs depend on the runtime identity/event foundation but should not be
-required for a minimal durable runtime deployment.
+required for the Durable Workflow Runtime Layer to work.
 
 ### PR 11: Work Module Schema And API
-
-Current draft: #3817.
 
 - Add `DEERFLOW_WORK_MODULE.md`.
 - Add `work_units` and `work_events` schema/migration.
@@ -344,38 +304,35 @@ Current draft: #3817.
 - Add `/api/work-units` CRUD and event list endpoints.
 - Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
 
-### PR 12: Agent Work Unit Tools
+### PR 12: Work Unit Agent Tools
 
-Current draft: #3818.
-
-- Add a general `work_units` tool for create/list/get/update_status.
-- Scope tool access by runtime user identity.
-- Require agents to call a tool before claiming Work Unit status changed.
-- Keep WorkBoard thin: the board observes and chats, while agent/runtime tools
-  mutate Work Unit state.
+- Expose the generic `work_units` tool only when
+  `modules.work.global_tools_enabled=true`; keep runtime-bound `work_unit`
+  tools available for a single attached work unit.
+- Let agents create, list, inspect, and update Work Units through the generic
+  Work Module store.
+- Keep runtime-bound `work_unit` status updates scoped to the attached Work
+  Unit.
+- Record agent actions as `work_events`.
+- WorkBoard and PM integrations are not required for this PR to be useful.
 
 ### PR 13: WorkBoard MVP
 
-Current draft: #3819.
-
 - Add `/workspace/work`.
 - Show Trello-style columns over `work_units.status`.
-- Create local work units in `backlog` only.
-- Show runtime-driven status projection.
+- Create local work units.
+- Show runtime-driven status projection; local human-created work starts in
+  `backlog`.
 - Link cards to chat threads and workflow traces when refs exist.
-- Support the practical operating model where long-running contribution work,
-  such as a stack of upstream PRs, can be represented as Work Units assigned
-  to agents and tracked through backlog, ready, running, waiting, review, done,
-  and closed states.
-- Avoid direct human status mutation as the default flow. Humans create and
-  review Work Units; agents/runtimes move status through Work Unit tools.
 
-### PR 14: External PM Binding Contract
+### PR 14: External Work Binding Contract
 
-- Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
+- Define external-ref mapping for Jira/Trello/ClickUp/Plane/Lark-style work
   objects.
 - Add external ref/url/source conventions.
-- Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
+- Keep credentials, webhooks, sync cursors, and conflict policy outside
+  DeerFlow core.
+- Do not implement concrete PM connectors in the core stack.
 
 ### PR 15: Work Gates And Criteria
 

--- a/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
+++ b/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
@@ -4,12 +4,11 @@ Status: implementation plan
 Date: 2026-06-26
 Scope: first-priority PR stack for DeerFlow durable workflow runtime, shared identity, workflow events, and runtime adoption
 
-## Relationship To Platform Plan
+## Relationship To DeerFlow Runtime
 
 This plan is the focused execution track for the Durable Workflow Runtime plane
-in [Durable Agent Platform Plan](DURABLE_AGENT_PLATFORM_PLAN.md). It should land
-before the Agent Workflow Definition, Compiler/Run Binding, Work Module,
-WorkBoard, and PM adapter tracks depend on it.
+in DeerFlow core. It should land before the Agent Workflow Definition,
+Compiler/Run Binding, Work Module, and WorkBoard tracks depend on it.
 
 The runtime layer is the shared foundation because it gives all later modules a
 stable way to answer:
@@ -40,7 +39,8 @@ Standardize these names before expanding module surface area:
 - `checkpoint_id`: LangGraph checkpoint ref.
 - `step_id`: designed workflow node/step id; reserved for later projection.
 - `work_unit_id`: generic task/card/issue id; Work module, not runtime core.
-- `external_binding_id`: PM/external object mapping id; Work module/adapters.
+- `external_binding_id`: external object mapping id; Work module or
+  deployment-owned integrations.
 
 Runtime core owns `workflow_id` and `workflow_event_id`. It may store refs to
 the other ids, but it must not require the modules that own them.
@@ -115,7 +115,7 @@ DeerFlow runtime owns:
 
 The runtime layer stores refs to LangGraph state, never checkpoint payloads.
 
-## Minimal Data Model
+## Core Data Model
 
 ### `workflows`
 
@@ -210,10 +210,22 @@ development.
 ## PR Stack
 
 The stack is ordered so later PRs are optional expansions. If review stops at a
-given prefix, the runtime should still be useful at that maturity level. The
-first upstream-ready community demo should include PR 1 through PR 5: by then a
-normal DeerFlow run has a durable workflow identity, idempotent intake, and a
-visible run trace that explains what happened.
+given prefix, the runtime should still be useful at that maturity level.
+
+Submit the work as one coherent Durable Workflow Runtime package, but make the
+review groups explicit:
+
+- PR 1-5: Core Runtime Package. A normal DeerFlow run has durable workflow
+  identity, idempotent intake, lifecycle events, a visible run trace, and
+  explicit orphan recovery visibility.
+- PR 6-10: Hardening/Scale Package. Binding, channel/dashboard intake,
+  waiting/resume, and worker readiness show the production path while remaining
+  separable from the first landing target.
+
+For the current open GitHub PRs, #3814 combines workflow store and lifecycle
+events, and #3848 is the fifth Core Runtime Package PR for recovery/orphan
+reconciliation. If maintainers prefer a finer split, #3814 can be separated
+into store and event PRs before final review.
 
 - PR 1-2: schema/store foundation.
 - PR 1-3: durable envelope plus lifecycle events.
@@ -240,15 +252,17 @@ the benefit during normal chat/run usage:
   without copying LangGraph checkpoint payloads.
 
 This milestone is still runtime-only. It intentionally does not include Work
-Units, WorkBoard, PM adapters, visual workflow design, or an external durable
-engine dependency.
+Units, WorkBoard, PM integrations, visual workflow design, or an external
+workflow engine dependency.
 
 ### PR 1: Runtime Architecture and Shared Contracts
 
 Scope:
 
+- Add `DURABLE_WORKFLOW_CORE_RFC.md` as the English package RFC/background
+  anchor.
 - Add this plan.
-- Link it from the platform plan and docs index.
+- Link it from the RFC/frontdoor docs and docs index.
 - Align terminology with `DURABLE_WORKFLOW_FRONTDOOR.md`.
 
 Acceptance:
@@ -258,41 +272,30 @@ Acceptance:
 - docs define initial runtime statuses and event contract;
 - no runtime behavior changes.
 
-### PR 2: Workflow Envelope Schema and Store
+### PR 2: Workflow Envelope Schema, Store, And Events
 
 Scope:
 
 - Add runtime enums for workflow kind/source/status.
 - Add `workflows` ORM model and migration.
+- Add `workflow_events` ORM model and migration.
 - Add in-memory and SQL store implementations.
 - Implement `create_or_get`, `get`, `list`, `update_status`,
-  `bind_runtime`, `claim_next`, and `release_for_retry`.
+  `bind_runtime`, `claim_next`, `release_for_retry`, `append_event`, and
+  `list_events`.
 - Wire store dependency without changing endpoint behavior.
 
 Acceptance:
 
 - idempotent create returns existing workflow for duplicate key;
 - lease claim is atomic under SQL store;
+- event seq is monotonic per workflow;
+- timeline can include workflow events even before a run exists;
+- no run event duplication;
 - existing run APIs and channels behave unchanged;
 - tests cover memory and SQL store behavior.
 
-### PR 3: Workflow Events
-
-Scope:
-
-- Add `workflow_events` ORM model and migration.
-- Add `append_event`.
-- Emit events for create/dedupe/status/bind/claim/retry.
-- Add event list and timeline projection helpers.
-
-Acceptance:
-
-- every projection mutation can append a lifecycle fact;
-- event seq is monotonic per workflow;
-- timeline can include workflow events even before a run exists;
-- no run event duplication.
-
-### PR 4: Durable Run Trace APIs
+### PR 3: Durable Run Trace APIs
 
 Scope:
 
@@ -313,7 +316,7 @@ Acceptance:
 - one workflow timeline correlates workflow lifecycle events with run events;
 - endpoint additions do not alter existing run API compatibility.
 
-### PR 5: Run API Compatibility Wrapper and Status Projection
+### PR 4: Run API Compatibility Wrapper and Status Projection
 
 Scope:
 
@@ -334,7 +337,7 @@ Acceptance:
 - workflow terminal status matches the bound run terminal status;
 - tests cover direct run creation.
 
-### PR 6: Recovery and Reconciliation
+### PR 5: Recovery and Reconciliation
 
 Scope:
 
@@ -349,14 +352,14 @@ Acceptance:
 - no workflow is silently left `running` without an owner;
 - automatic retry is conservative and policy-driven.
 
-### PR 7: Deterministic Binding Resolver
+### PR 6: Deterministic Binding Resolver
 
 Scope:
 
 - Add generic resolver for explicit `thread_id`, external conversation refs,
   checkpoint refs, and active run binding.
 - Record ambiguous candidates in metadata.
-- Do not use semantic guessing in adapters.
+- Do not use semantic guessing in channel/source-specific code.
 
 Acceptance:
 
@@ -364,7 +367,7 @@ Acceptance:
 - unambiguous channel conversation mappings bind deterministically;
 - ambiguous cases are persisted and surfaced, not guessed.
 
-### PR 8: Channel and Dashboard Intake Adoption
+### PR 7: Channel and Dashboard Intake Adoption
 
 Scope:
 
@@ -378,7 +381,7 @@ Acceptance:
 - channel retries dedupe by stable external event/message ids;
 - channel behavior remains compatible for users.
 
-### PR 9: Waiting, Resume, and Human-In-The-Loop Refs
+### PR 8: Waiting, Resume, and Human-In-The-Loop Refs
 
 Scope:
 
@@ -394,7 +397,7 @@ Acceptance:
 - resume creates/uses a durable workflow envelope;
 - LangGraph remains owner of interrupt/resume state.
 
-### PR 10: Worker Pool Readiness
+### PR 9: Worker Pool Readiness
 
 Scope:
 
@@ -407,30 +410,34 @@ Acceptance:
 
 - Postgres deployments have a clear horizontal worker contract;
 - local SQLite/default deployments remain simple;
-- no mandatory external orchestrator dependency.
+- no mandatory external workflow engine dependency.
 
-## First Implementation Slice
+### PR 10: Optional Split Point
 
-The safest first implementation slice is PR 1 plus PR 2 without runtime
-adoption:
+If maintainers want exactly ten PRs, split either waiting/resume or worker
+readiness into two smaller hardening PRs during final packaging. Do not create a
+new conceptual dependency just to fill a number.
+
+## Review Grouping
+
+The safest first code landing target is PR 1-5 as the Core Runtime Package:
 
 - docs and shared contracts;
 - `workflows` schema/store;
 - idempotent create;
-- lease primitives;
+- lifecycle events;
 - run/checkpoint binding fields;
-- focused repository tests.
+- read APIs and timeline projection;
+- existing run API compatibility wrapper;
+- recovery/orphan reconciliation;
+- focused repository, router, and gateway tests.
 
-This creates the durable foundation without changing existing run/channel
-behavior. PR 3 should follow quickly because `workflow_events` is the audit and
-timeline foundation for enterprise operation.
+This is not too small: maintainers can see the end-to-end value during normal
+chat/run usage without installing Work Module or WorkBoard.
 
-For the first community-visible stack, continue through PR 5 before opening the
-main upstream discussion. PR 4 makes the runtime inspectable as a Durable Run
-Trace. PR 5 makes existing DeerFlow run APIs update that trace through terminal
-status. PR 6 and later are important for production hardening, but PR 1-5 is
-the smallest stack that lets a normal user see value without installing a Work
-Module, WorkBoard, or external orchestrator.
+PR 6-10 should be submitted as the Hardening/Scale Package. It is important for
+production confidence, but it can be reviewed after the core package if
+maintainers want staged landing.
 
 ## Defer Explicitly
 
@@ -440,7 +447,7 @@ Do not include in the runtime-first stack:
 - visual designer UI;
 - Work Unit schemas;
 - WorkBoard;
-- PM adapters;
+- PM connector implementations;
 - Restate/Temporal/Hatchet dependencies;
 - AICOS-X concepts;
 - checkpoint value copies;

--- a/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
+++ b/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
@@ -1,0 +1,450 @@
+# Durable Workflow Runtime Plan
+
+Status: implementation plan
+Date: 2026-06-26
+Scope: first-priority PR stack for DeerFlow durable workflow runtime, shared identity, workflow events, and runtime adoption
+
+## Relationship To Platform Plan
+
+This plan is the focused execution track for the Durable Workflow Runtime plane
+in [Durable Agent Platform Plan](DURABLE_AGENT_PLATFORM_PLAN.md). It should land
+before the Agent Workflow Definition, Compiler/Run Binding, Work Module,
+WorkBoard, and PM adapter tracks depend on it.
+
+The runtime layer is the shared foundation because it gives all later modules a
+stable way to answer:
+
+- what external request/message arrived;
+- whether it was already accepted;
+- which DeerFlow thread/run/checkpoint it bound to;
+- who claimed execution;
+- whether it is running, waiting, terminal, retryable, or orphaned;
+- which lifecycle and run events explain what happened.
+
+## Core Standardization Goals
+
+### Shared Identity Model
+
+Standardize these names before expanding module surface area:
+
+- `workflow_id`: durable frontdoor envelope id for one inbound command/message.
+- `workflow_event_id`: append-only lifecycle fact id.
+- `workflow_definition_id`: design-time workflow definition id; not owned by
+  this runtime plan, but reserved now to avoid name collisions.
+- `workflow_definition_version`: immutable design snapshot version/id.
+- `workflow_run_id`: execution of a designed workflow; later compiler/run
+  binding plane.
+- `thread_id`: LangGraph/DeerFlow thread id.
+- `run_id`: DeerFlow run id.
+- `checkpoint_ns`: LangGraph checkpoint namespace.
+- `checkpoint_id`: LangGraph checkpoint ref.
+- `step_id`: designed workflow node/step id; reserved for later projection.
+- `work_unit_id`: generic task/card/issue id; Work module, not runtime core.
+- `external_binding_id`: PM/external object mapping id; Work module/adapters.
+
+Runtime core owns `workflow_id` and `workflow_event_id`. It may store refs to
+the other ids, but it must not require the modules that own them.
+
+### Status Contracts
+
+Initial workflow statuses:
+
+- `received`: intake persisted, not yet resolved/claimed.
+- `bound`: deterministic thread/checkpoint binding resolved.
+- `claimed`: worker/process lease acquired.
+- `run_created`: DeerFlow run row created.
+- `running`: bound run is executing.
+- `waiting`: run/workflow is paused for interrupt, human input, external event,
+  or safe retry time.
+- `succeeded`: terminal success.
+- `failed`: terminal failure.
+- `cancelled`: terminal cancellation.
+- `orphaned`: previous executor is gone and automatic safe resume is not known.
+- `ignored`: accepted and intentionally not executed.
+
+These statuses are a public runtime contract. Later modules can project their
+own statuses from them, but should not redefine runtime meaning.
+
+### Event Contract
+
+`workflows` is the mutable latest projection. `workflow_events` is the
+append-only lifecycle log.
+
+`workflow_events` should record DeerFlow runtime facts such as:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+It should reference `run_events` by `(thread_id, run_id, run_event_seq)` rather
+than copying low-level execution events. Timeline APIs merge workflow lifecycle
+facts with `RunEventStore` rows at query time.
+
+### LangGraph Boundary
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint state values;
+- checkpoint writes and pending writes;
+- graph-local memory;
+- interrupt/resume mechanics;
+- replay from checkpoints.
+
+DeerFlow runtime owns:
+
+- intake identity;
+- idempotency;
+- source/channel refs;
+- deterministic thread/run/checkpoint binding records;
+- worker lease and retry metadata;
+- startup reconciliation;
+- lifecycle events and runtime correlation.
+
+The runtime layer stores refs to LangGraph state, never checkpoint payloads.
+
+## Minimal Data Model
+
+### `workflows`
+
+Purpose: durable intake envelope and latest runtime projection.
+
+Minimum fields:
+
+- `workflow_id`
+- `workflow_kind`
+- `source_type`
+- `source`
+- `external_message_ref`
+- `conversation_ref`
+- `thread_ref`
+- `sender_ref`
+- `idempotency_key`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `status`
+- `attempt_count`
+- `max_attempts`
+- `next_attempt_at`
+- `lease_owner`
+- `lease_expires_at`
+- `error`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+Indexes:
+
+- unique idempotency scope, initially `(source_type, source, idempotency_key)`
+  when `idempotency_key` is present;
+- `(status, next_attempt_at, lease_expires_at)` for claiming/recovery;
+- `(thread_id, run_id)`;
+- `(source_type, source, conversation_ref)`;
+- `updated_at`.
+
+### `workflow_events`
+
+Purpose: append-only lifecycle facts for audit, recovery, and timeline APIs.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Indexes:
+
+- unique `(workflow_id, seq)`;
+- `(workflow_id, created_at)`;
+- `(thread_id, run_id, run_event_seq)`;
+- `(event_type, created_at)`.
+
+## Store Contracts
+
+The runtime store should work with in-memory tests, SQLite local dev, and
+Postgres production.
+
+Required methods:
+
+- `create_or_get`: idempotent intake.
+- `append_event`: append a lifecycle event with monotonic per-workflow seq.
+- `get`: fetch workflow projection.
+- `list`: filter by status, source, thread, run, and updated time.
+- `update_status`: mutate projection and append lifecycle event.
+- `bind_runtime`: attach `thread_id`, `run_id`, checkpoint refs.
+- `claim_next`: atomically lease eligible workflow.
+- `renew_lease`: extend active ownership for long execution.
+- `release_for_retry`: clear lease and schedule next attempt.
+- `mark_orphaned`: terminal or recoverable orphan projection.
+- `timeline`: merge workflow events and run events.
+
+Postgres should use row-level locking and `SKIP LOCKED` for `claim_next`. SQLite
+can use a conservative transaction path suitable for local/single-process
+development.
+
+## PR Stack
+
+The stack is ordered so later PRs are optional expansions. If review stops at a
+given prefix, the runtime should still be useful at that maturity level. The
+first upstream-ready community demo should include PR 1 through PR 5: by then a
+normal DeerFlow run has a durable workflow identity, idempotent intake, and a
+visible run trace that explains what happened.
+
+- PR 1-2: schema/store foundation.
+- PR 1-3: durable envelope plus lifecycle events.
+- PR 1-4: observable Durable Run Trace for operators and users.
+- PR 1-5: existing run APIs create and update workflow envelopes.
+- PR 1-6: restart/orphan behavior is production-visible.
+- PR 1-8: universal API/dashboard/channel frontdoor.
+- PR 1-9: durable human-in-the-loop.
+- PR 1-10: horizontal worker readiness.
+
+### Community Value Milestone
+
+The first PR stack proposed upstream should not stop at invisible primitives.
+It should include enough surface area that a DeerFlow user or operator can see
+the benefit during normal chat/run usage:
+
+- every run created through existing run APIs has a `workflow_id`;
+- repeated client/channel retries with the same idempotency key do not create a
+  duplicate run;
+- the workflow can be found from `run_id` or `thread_id`;
+- the trace shows intake, run creation, running state, and terminal
+  success/failure/cancellation;
+- the trace links workflow lifecycle events with the existing run event stream
+  without copying LangGraph checkpoint payloads.
+
+This milestone is still runtime-only. It intentionally does not include Work
+Units, WorkBoard, PM adapters, visual workflow design, or an external durable
+engine dependency.
+
+### PR 1: Runtime Architecture and Shared Contracts
+
+Scope:
+
+- Add this plan.
+- Link it from the platform plan and docs index.
+- Align terminology with `DURABLE_WORKFLOW_FRONTDOOR.md`.
+
+Acceptance:
+
+- docs distinguish `workflow_id`, `workflow_definition_id`, and
+  `workflow_run_id`;
+- docs define initial runtime statuses and event contract;
+- no runtime behavior changes.
+
+### PR 2: Workflow Envelope Schema and Store
+
+Scope:
+
+- Add runtime enums for workflow kind/source/status.
+- Add `workflows` ORM model and migration.
+- Add in-memory and SQL store implementations.
+- Implement `create_or_get`, `get`, `list`, `update_status`,
+  `bind_runtime`, `claim_next`, and `release_for_retry`.
+- Wire store dependency without changing endpoint behavior.
+
+Acceptance:
+
+- idempotent create returns existing workflow for duplicate key;
+- lease claim is atomic under SQL store;
+- existing run APIs and channels behave unchanged;
+- tests cover memory and SQL store behavior.
+
+### PR 3: Workflow Events
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event`.
+- Emit events for create/dedupe/status/bind/claim/retry.
+- Add event list and timeline projection helpers.
+
+Acceptance:
+
+- every projection mutation can append a lifecycle fact;
+- event seq is monotonic per workflow;
+- timeline can include workflow events even before a run exists;
+- no run event duplication.
+
+### PR 4: Durable Run Trace APIs
+
+Scope:
+
+- Add read-only gateway endpoints for workflow envelopes and run traces.
+- Add filters by status, source, thread, run, and updated time.
+- Add a timeline endpoint that merges workflow lifecycle facts with existing
+  `RunEventStore` rows at query time.
+- Add run-to-workflow lookup so existing clients can discover the durable
+  workflow for a run.
+- Include idempotency/source refs, runtime refs, terminal status, and recovery
+  hints in responses.
+
+Acceptance:
+
+- operators can query active, waiting, failed, orphaned, and terminal
+  workflows;
+- users and developers can inspect a normal chat/run and see the durable trace;
+- one workflow timeline correlates workflow lifecycle events with run events;
+- endpoint additions do not alter existing run API compatibility.
+
+### PR 5: Run API Compatibility Wrapper and Status Projection
+
+Scope:
+
+- Wrap existing `/runs` and `/threads/{thread_id}/runs` paths with workflow
+  intake when enabled.
+- Create workflow envelope before `start_run`.
+- Bind `thread_id`, `run_id`, and checkpoint refs after run creation.
+- Project run lifecycle into workflow lifecycle (`running`, `succeeded`,
+  `failed`, `cancelled`) without making LangGraph checkpoint state secondary.
+- Preserve existing request/response behavior for clients.
+
+Acceptance:
+
+- old clients can ignore `workflow_id`;
+- new clients can find the workflow for a created run;
+- duplicate idempotency keys do not create duplicate runs when policy says
+  dedupe;
+- workflow terminal status matches the bound run terminal status;
+- tests cover direct run creation.
+
+### PR 6: Recovery and Reconciliation
+
+Scope:
+
+- Reconcile active workflow envelopes with existing run reconciliation.
+- Mark orphaned workflows explicitly when process-local execution was lost.
+- Requeue only workflows that are safe by idempotency/source policy.
+- Record `lease_expired`, `orphaned`, and `retry_scheduled` events.
+
+Acceptance:
+
+- restart behavior is explicit and queryable;
+- no workflow is silently left `running` without an owner;
+- automatic retry is conservative and policy-driven.
+
+### PR 7: Deterministic Binding Resolver
+
+Scope:
+
+- Add generic resolver for explicit `thread_id`, external conversation refs,
+  checkpoint refs, and active run binding.
+- Record ambiguous candidates in metadata.
+- Do not use semantic guessing in adapters.
+
+Acceptance:
+
+- explicit thread/checkpoint ids win;
+- unambiguous channel conversation mappings bind deterministically;
+- ambiguous cases are persisted and surfaced, not guessed.
+
+### PR 8: Channel and Dashboard Intake Adoption
+
+Scope:
+
+- Route channel adapters through workflow intake.
+- Route dashboard/API chat messages through workflow intake where applicable.
+- Normalize source refs and idempotency keys for channels.
+
+Acceptance:
+
+- Slack/Discord/Telegram-style messages produce workflow envelopes;
+- channel retries dedupe by stable external event/message ids;
+- channel behavior remains compatible for users.
+
+### PR 9: Waiting, Resume, and Human-In-The-Loop Refs
+
+Scope:
+
+- Add generic waiting metadata conventions for LangGraph interrupts and external
+  human input.
+- Route resume messages through workflow intake.
+- Bind resume workflows to `thread_id`, checkpoint refs, and parent workflow
+  metadata.
+
+Acceptance:
+
+- interrupted runs surface as `waiting`;
+- resume creates/uses a durable workflow envelope;
+- LangGraph remains owner of interrupt/resume state.
+
+### PR 10: Worker Pool Readiness
+
+Scope:
+
+- Add lease renewal.
+- Add configurable worker identity.
+- Add claim loop abstraction behind feature flag or internal API.
+- Keep gateway process execution as the default path.
+
+Acceptance:
+
+- Postgres deployments have a clear horizontal worker contract;
+- local SQLite/default deployments remain simple;
+- no mandatory external orchestrator dependency.
+
+## First Implementation Slice
+
+The safest first implementation slice is PR 1 plus PR 2 without runtime
+adoption:
+
+- docs and shared contracts;
+- `workflows` schema/store;
+- idempotent create;
+- lease primitives;
+- run/checkpoint binding fields;
+- focused repository tests.
+
+This creates the durable foundation without changing existing run/channel
+behavior. PR 3 should follow quickly because `workflow_events` is the audit and
+timeline foundation for enterprise operation.
+
+For the first community-visible stack, continue through PR 5 before opening the
+main upstream discussion. PR 4 makes the runtime inspectable as a Durable Run
+Trace. PR 5 makes existing DeerFlow run APIs update that trace through terminal
+status. PR 6 and later are important for production hardening, but PR 1-5 is
+the smallest stack that lets a normal user see value without installing a Work
+Module, WorkBoard, or external orchestrator.
+
+## Defer Explicitly
+
+Do not include in the runtime-first stack:
+
+- Agent Workflow DSL persistence;
+- visual designer UI;
+- Work Unit schemas;
+- WorkBoard;
+- PM adapters;
+- Restate/Temporal/Hatchet dependencies;
+- AICOS-X concepts;
+- checkpoint value copies;
+- generic deterministic code replay.
+
+These become easier and cleaner after the runtime identity, status, event, and
+binding contracts are stable.

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -17,6 +17,9 @@ This directory contains detailed documentation for the DeerFlow backend.
 | Document | Description |
 |----------|-------------|
 | [STREAMING.md](STREAMING.md) | Token-level streaming design: Gateway vs DeerFlowClient paths, `stream_mode` semantics, per-id dedup |
+| [DURABLE_WORKFLOW_RUNTIME_PLAN.md](DURABLE_WORKFLOW_RUNTIME_PLAN.md) | Runtime-first PR plan for workflow identity, status, events, idempotency, lease, and recovery |
+| [DURABLE_WORKFLOW_FRONTDOOR.md](DURABLE_WORKFLOW_FRONTDOOR.md) | Durable workflow intake/frontdoor architecture and PR stack |
+| [DURABLE_WORKFLOW_PR_STACK.md](DURABLE_WORKFLOW_PR_STACK.md) | Prefix-safe upstream PR sequence for durable runtime, recovery, intake, and worker readiness |
 | [FILE_UPLOAD.md](FILE_UPLOAD.md) | File upload functionality |
 | [PATH_EXAMPLES.md](PATH_EXAMPLES.md) | Path types and usage examples |
 | [SANDBOX_MEMORY_PROFILING.md](SANDBOX_MEMORY_PROFILING.md) | Sandbox memory baseline and runtime comparison guide |
@@ -52,6 +55,9 @@ docs/
 ├── summarization.md           # Summarization feature
 ├── plan_mode_usage.md         # Plan mode feature
 ├── STREAMING.md               # Token-level streaming design
+├── DURABLE_WORKFLOW_RUNTIME_PLAN.md # Runtime-first durable workflow PR plan
+├── DURABLE_WORKFLOW_FRONTDOOR.md # Durable workflow frontdoor design
+├── DURABLE_WORKFLOW_PR_STACK.md # Prefix-safe durable runtime PR sequence
 ├── AUTO_TITLE_GENERATION.md   # Title generation
 ├── TITLE_GENERATION_IMPLEMENTATION.md  # Title implementation details
 └── TODO.md                    # Roadmap and issues

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -17,6 +17,7 @@ This directory contains detailed documentation for the DeerFlow backend.
 | Document | Description |
 |----------|-------------|
 | [STREAMING.md](STREAMING.md) | Token-level streaming design: Gateway vs DeerFlowClient paths, `stream_mode` semantics, per-id dedup |
+| [DURABLE_WORKFLOW_CORE_RFC.md](DURABLE_WORKFLOW_CORE_RFC.md) | Upstream RFC draft for a native Durable Workflow Runtime Layer in DeerFlow core |
 | [DURABLE_WORKFLOW_RUNTIME_PLAN.md](DURABLE_WORKFLOW_RUNTIME_PLAN.md) | Runtime-first PR plan for workflow identity, status, events, idempotency, lease, and recovery |
 | [DURABLE_WORKFLOW_FRONTDOOR.md](DURABLE_WORKFLOW_FRONTDOOR.md) | Durable workflow intake/frontdoor architecture and PR stack |
 | [DURABLE_WORKFLOW_PR_STACK.md](DURABLE_WORKFLOW_PR_STACK.md) | Prefix-safe upstream PR sequence for durable runtime, recovery, intake, and worker readiness |
@@ -55,6 +56,7 @@ docs/
 ├── summarization.md           # Summarization feature
 ├── plan_mode_usage.md         # Plan mode feature
 ├── STREAMING.md               # Token-level streaming design
+├── DURABLE_WORKFLOW_CORE_RFC.md # Upstream durable workflow core RFC draft
 ├── DURABLE_WORKFLOW_RUNTIME_PLAN.md # Runtime-first durable workflow PR plan
 ├── DURABLE_WORKFLOW_FRONTDOOR.md # Durable workflow frontdoor design
 ├── DURABLE_WORKFLOW_PR_STACK.md # Prefix-safe durable runtime PR sequence


### PR DESCRIPTION
## Summary

This is PR 1 of the Native Durable Workflow Runtime Layer package for DeerFlow
core. It is the RFC/background and shared-contract anchor for the
implementation stack.

It adds:

- `DURABLE_WORKFLOW_CORE_RFC.md`, the upstream RFC draft for a native Durable
  Workflow Runtime Layer in DeerFlow core.
- Runtime identity vocabulary: `workflow_id`, `workflow_event_id`, `thread_id`,
  `run_id`, checkpoint refs, and future definition/run ids.
- LangGraph vs DeerFlow ownership boundaries.
- Workflow status and lifecycle event contracts.
- The grouped review plan:
  - PR 1-5: Core Runtime Package.
  - PR 6-10: Hardening/Scale Package.

The RFC is not submitted as a standalone request. It should be reviewed
together with the implementation package so maintainers can see the end-to-end
durable core value while still reviewing small PRs.

## Core Position

DeerFlow should own durable workflow identity, lifecycle, refs, status,
idempotency, event projection, and recovery visibility for agent work.

LangGraph remains the owner of graph execution, checkpoint state, checkpoint
writes, interrupts, graph-local memory, and resume mechanics.

This does not add Work Module, WorkBoard, PM connector implementations, or a
hard dependency on Temporal, Restate, Hatchet, AICOS, or any external workflow
engine.

## Package Context

- PR 1: RFC and runtime contracts. This PR.
- PR 2: Workflow store and lifecycle events: #3814.
- PR 3: Workflow read APIs and timeline projection: #3815.
- PR 4: Existing run wrapper and trace UI: #3816.
- PR 5: Recovery/orphan reconciliation: #3848.

PR 6-10 should remain the Hardening/Scale Package: deterministic binding,
channel/dashboard intake, waiting/resume refs, and worker readiness.

Work Module and WorkBoard PRs are follow-up added-value modules after the
runtime direction is accepted.

## Validation

- `git diff --check`
