### PR TITLE
feat(work): add work board workspace

### DIFF
--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -29,6 +29,7 @@ from app.gateway.routers import (
     thread_runs,
     threads,
     uploads,
+    work_units,
     workflows,
 )
 from deerflow.config import app_config as deerflow_app_config
@@ -225,6 +226,13 @@ def _openapi_tags(config: AppConfig) -> list[dict[str, str]]:
             {
                 "name": "workflows",
                 "description": "Durable workflow runtime envelopes and lifecycle events",
+            }
+        )
+    if config.modules.work.enabled and config.modules.work.api_enabled:
+        tags.append(
+            {
+                "name": "work-units",
+                "description": "Generic work units for agent and PM-tool integration",
             }
         )
     return tags
@@ -436,6 +444,10 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     # Durable workflow runtime read API
     if startup_config.modules.durable_workflows.api_enabled:
         app.include_router(workflows.router)
+
+    # Generic work unit API
+    if startup_config.modules.work.enabled and startup_config.modules.work.api_enabled:
+        app.include_router(work_units.router)
 
     @app.get("/health", tags=["health"])
     async def health_check() -> dict[str, str]:

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -22,12 +22,14 @@ from app.gateway.routers import (
     mcp,
     memory,
     models,
+    modules,
     runs,
     skills,
     suggestions,
     thread_runs,
     threads,
     uploads,
+    workflows,
 )
 from deerflow.config import app_config as deerflow_app_config
 from deerflow.config.app_config import apply_logging_level
@@ -159,6 +161,75 @@ async def _migrate_orphaned_threads(store, admin_user_id: str) -> int:
     return migrated
 
 
+def _openapi_tags(config: AppConfig) -> list[dict[str, str]]:
+    tags = [
+        {
+            "name": "models",
+            "description": "Operations for querying available AI models and their configurations",
+        },
+        {
+            "name": "mcp",
+            "description": "Manage Model Context Protocol (MCP) server configurations",
+        },
+        {
+            "name": "memory",
+            "description": "Access and manage global memory data for personalized conversations",
+        },
+        {
+            "name": "skills",
+            "description": "Manage skills and their configurations",
+        },
+        {
+            "name": "artifacts",
+            "description": "Access and download thread artifacts and generated files",
+        },
+        {
+            "name": "uploads",
+            "description": "Upload and manage user files for threads",
+        },
+        {
+            "name": "threads",
+            "description": "Manage DeerFlow thread-local filesystem data",
+        },
+        {
+            "name": "agents",
+            "description": "Create and manage custom agents with per-agent config and prompts",
+        },
+        {
+            "name": "suggestions",
+            "description": "Generate follow-up question suggestions for conversations",
+        },
+        {
+            "name": "channels",
+            "description": "Manage IM channel integrations (Feishu, Slack, Telegram)",
+        },
+        {
+            "name": "modules",
+            "description": "Public optional module feature flags",
+        },
+        {
+            "name": "assistants-compat",
+            "description": "LangGraph Platform-compatible assistants API (stub)",
+        },
+        {
+            "name": "runs",
+            "description": "LangGraph Platform-compatible runs lifecycle (create, stream, cancel)",
+        },
+        {
+            "name": "health",
+            "description": "Health check and system status endpoints",
+        },
+    ]
+    if config.modules.durable_workflows.api_enabled:
+        tags.append(
+            {
+                "name": "workflows",
+                "description": "Durable workflow runtime envelopes and lifecycle events",
+            }
+        )
+    return tags
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan handler."""
@@ -257,6 +328,7 @@ def create_app() -> FastAPI:
         Configured FastAPI application instance.
     """
     config = get_gateway_config()
+    startup_config = get_app_config()
     docs_url = "/docs" if config.enable_docs else None
     redoc_url = "/redoc" if config.enable_docs else None
     openapi_url = "/openapi.json" if config.enable_docs else None
@@ -287,60 +359,7 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
         docs_url=docs_url,
         redoc_url=redoc_url,
         openapi_url=openapi_url,
-        openapi_tags=[
-            {
-                "name": "models",
-                "description": "Operations for querying available AI models and their configurations",
-            },
-            {
-                "name": "mcp",
-                "description": "Manage Model Context Protocol (MCP) server configurations",
-            },
-            {
-                "name": "memory",
-                "description": "Access and manage global memory data for personalized conversations",
-            },
-            {
-                "name": "skills",
-                "description": "Manage skills and their configurations",
-            },
-            {
-                "name": "artifacts",
-                "description": "Access and download thread artifacts and generated files",
-            },
-            {
-                "name": "uploads",
-                "description": "Upload and manage user files for threads",
-            },
-            {
-                "name": "threads",
-                "description": "Manage DeerFlow thread-local filesystem data",
-            },
-            {
-                "name": "agents",
-                "description": "Create and manage custom agents with per-agent config and prompts",
-            },
-            {
-                "name": "suggestions",
-                "description": "Generate follow-up question suggestions for conversations",
-            },
-            {
-                "name": "channels",
-                "description": "Manage IM channel integrations (Feishu, Slack, Telegram)",
-            },
-            {
-                "name": "assistants-compat",
-                "description": "LangGraph Platform-compatible assistants API (stub)",
-            },
-            {
-                "name": "runs",
-                "description": "LangGraph Platform-compatible runs lifecycle (create, stream, cancel)",
-            },
-            {
-                "name": "health",
-                "description": "Health check and system status endpoints",
-            },
-        ],
+        openapi_tags=_openapi_tags(startup_config),
     )
 
     # Auth: reject unauthenticated requests to non-public paths (fail-closed safety net)
@@ -390,6 +409,9 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     # Suggestions API is mounted at /api/threads/{thread_id}/suggestions
     app.include_router(suggestions.router)
 
+    # Public module feature flags are mounted at /api/modules
+    app.include_router(modules.router)
+
     # User-facing IM channel connection API is mounted at /api/channels
     app.include_router(channel_connections.router)
 
@@ -410,6 +432,10 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
 
     # Stateless Runs API (stream/wait without a pre-existing thread)
     app.include_router(runs.router)
+
+    # Durable workflow runtime read API
+    if startup_config.modules.durable_workflows.api_enabled:
+        app.include_router(workflows.router)
 
     @app.get("/health", tags=["health"])
     async def health_check() -> dict[str, str]:

--- a/backend/app/gateway/authz.py
+++ b/backend/app/gateway/authz.py
@@ -58,6 +58,11 @@ class Permissions:
     RUNS_READ = "runs:read"
     RUNS_CANCEL = "runs:cancel"
 
+    # Work module
+    WORK_READ = "work:read"
+    WORK_CREATE = "work:create"
+    WORK_UPDATE = "work:update"
+
 
 class AuthContext:
     """Authentication context for the current request.
@@ -116,6 +121,9 @@ _ALL_PERMISSIONS: list[str] = [
     Permissions.RUNS_CREATE,
     Permissions.RUNS_READ,
     Permissions.RUNS_CANCEL,
+    Permissions.WORK_READ,
+    Permissions.WORK_CREATE,
+    Permissions.WORK_UPDATE,
 ]
 
 

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -31,6 +31,7 @@ from deerflow.persistence.feedback import FeedbackRepository
 from deerflow.runtime import RunContext, RunManager, StreamBridge
 from deerflow.runtime.events.store.base import RunEventStore
 from deerflow.runtime.runs.store.base import RunStore
+from deerflow.runtime.workflows.store.base import WorkflowStore
 
 logger = logging.getLogger(__name__)
 
@@ -190,11 +191,19 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.persistence.run import RunRepository
 
             app.state.run_store = RunRepository(sf)
+            if config.modules.durable_workflows.enabled:
+                from deerflow.persistence.workflow import WorkflowRepository
+
+                app.state.workflow_store = WorkflowRepository(sf)
             app.state.feedback_repo = FeedbackRepository(sf)
         else:
             from deerflow.runtime.runs.store.memory import MemoryRunStore
 
             app.state.run_store = MemoryRunStore()
+            if config.modules.durable_workflows.enabled:
+                from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+                app.state.workflow_store = MemoryWorkflowStore()
             app.state.feedback_repo = None
 
         from deerflow.persistence.thread_meta import make_thread_store
@@ -260,6 +269,7 @@ get_checkpointer: Callable[[Request], Checkpointer] = _require("checkpointer", "
 get_run_event_store: Callable[[Request], RunEventStore] = _require("run_event_store", "Run event store")
 get_feedback_repo: Callable[[Request], FeedbackRepository] = _require("feedback_repo", "Feedback")
 get_run_store: Callable[[Request], RunStore] = _require("run_store", "Run store")
+get_workflow_store: Callable[[Request], WorkflowStore] = _require("workflow_store", "Workflow store")
 
 
 def get_store(request: Request):

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -31,6 +31,7 @@ from deerflow.persistence.feedback import FeedbackRepository
 from deerflow.runtime import RunContext, RunManager, StreamBridge
 from deerflow.runtime.events.store.base import RunEventStore
 from deerflow.runtime.runs.store.base import RunStore
+from deerflow.work.units.store.base import WorkUnitStore
 from deerflow.runtime.workflows.store.base import WorkflowStore
 
 logger = logging.getLogger(__name__)
@@ -191,6 +192,10 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.persistence.run import RunRepository
 
             app.state.run_store = RunRepository(sf)
+            if config.modules.work.enabled:
+                from deerflow.persistence.work_units import WorkUnitRepository
+
+                app.state.work_unit_store = WorkUnitRepository(sf)
             if config.modules.durable_workflows.enabled:
                 from deerflow.persistence.workflow import WorkflowRepository
 
@@ -200,6 +205,10 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.runtime.runs.store.memory import MemoryRunStore
 
             app.state.run_store = MemoryRunStore()
+            if config.modules.work.enabled:
+                from deerflow.work.units.store.memory import MemoryWorkUnitStore
+
+                app.state.work_unit_store = MemoryWorkUnitStore()
             if config.modules.durable_workflows.enabled:
                 from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
@@ -270,6 +279,7 @@ get_run_event_store: Callable[[Request], RunEventStore] = _require("run_event_st
 get_feedback_repo: Callable[[Request], FeedbackRepository] = _require("feedback_repo", "Feedback")
 get_run_store: Callable[[Request], RunStore] = _require("run_store", "Run store")
 get_workflow_store: Callable[[Request], WorkflowStore] = _require("workflow_store", "Workflow store")
+get_work_unit_store: Callable[[Request], WorkUnitStore] = _require("work_unit_store", "Work unit store")
 
 
 def get_store(request: Request):

--- a/backend/app/gateway/routers/__init__.py
+++ b/backend/app/gateway/routers/__init__.py
@@ -1,3 +1,15 @@
-from . import artifacts, assistants_compat, mcp, models, skills, suggestions, thread_runs, threads, uploads
+from . import artifacts, assistants_compat, mcp, models, modules, skills, suggestions, thread_runs, threads, uploads, workflows
 
-__all__ = ["artifacts", "assistants_compat", "mcp", "models", "skills", "suggestions", "threads", "thread_runs", "uploads"]
+__all__ = [
+    "artifacts",
+    "assistants_compat",
+    "mcp",
+    "models",
+    "modules",
+    "skills",
+    "suggestions",
+    "threads",
+    "thread_runs",
+    "uploads",
+    "workflows",
+]

--- a/backend/app/gateway/routers/__init__.py
+++ b/backend/app/gateway/routers/__init__.py
@@ -1,4 +1,4 @@
-from . import artifacts, assistants_compat, mcp, models, modules, skills, suggestions, thread_runs, threads, uploads, workflows
+from . import artifacts, assistants_compat, mcp, models, modules, skills, suggestions, thread_runs, threads, uploads, work_units, workflows
 
 __all__ = [
     "artifacts",
@@ -11,5 +11,6 @@ __all__ = [
     "threads",
     "thread_runs",
     "uploads",
+    "work_units",
     "workflows",
 ]

--- a/backend/app/gateway/routers/modules.py
+++ b/backend/app/gateway/routers/modules.py
@@ -1,0 +1,18 @@
+"""Read-only module feature flags."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.gateway.deps import get_config
+
+router = APIRouter(prefix="/api/modules", tags=["modules"])
+
+
+@router.get("")
+async def get_modules() -> dict:
+    """Return public feature gates for optional DeerFlow modules."""
+    modules = get_config().modules
+    return {
+        "durable_workflows": modules.durable_workflows.model_dump(),
+    }

--- a/backend/app/gateway/routers/modules.py
+++ b/backend/app/gateway/routers/modules.py
@@ -15,4 +15,5 @@ async def get_modules() -> dict:
     modules = get_config().modules
     return {
         "durable_workflows": modules.durable_workflows.model_dump(),
+        "work": modules.work.model_dump(),
     }

--- a/backend/app/gateway/routers/work_units.py
+++ b/backend/app/gateway/routers/work_units.py
@@ -78,12 +78,19 @@ def _validate_enum_field(field: str, value: str | None, enum_cls: type) -> str |
 
 
 def _validate_work_unit_fields(values: dict[str, Any]) -> dict[str, Any]:
+    for field in ("title", "status", "priority", "source_type"):
+        if field in values and values[field] is None:
+            raise HTTPException(status_code=400, detail=f"{field} cannot be null")
     if "status" in values:
         values["status"] = _validate_enum_field("status", values.get("status"), WorkUnitStatus)
     if "priority" in values:
         values["priority"] = _validate_enum_field("priority", values.get("priority"), WorkUnitPriority)
     if "source_type" in values:
         values["source_type"] = _validate_enum_field("source_type", values.get("source_type"), WorkUnitSourceType)
+    if "labels" in values and values["labels"] is None:
+        values["labels"] = []
+    if "metadata" in values and values["metadata"] is None:
+        values["metadata"] = {}
     return values
 
 

--- a/backend/app/gateway/routers/work_units.py
+++ b/backend/app/gateway/routers/work_units.py
@@ -1,0 +1,197 @@
+"""Generic work unit endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from app.gateway.authz import require_permission
+from app.gateway.deps import get_work_unit_store
+from app.gateway.internal_auth import get_trusted_internal_owner_user_id
+from deerflow.work.units.schemas import WorkUnitPriority, WorkUnitSourceType, WorkUnitStatus
+
+router = APIRouter(prefix="/api/work-units", tags=["work-units"])
+
+
+class WorkUnitCreateRequest(BaseModel):
+    title: str = Field(min_length=1, max_length=300)
+    description: str | None = None
+    status: str = "backlog"
+    priority: str = "P2"
+    assignee_ref: str | None = None
+    reporter_ref: str | None = None
+    due_at: str | None = None
+    workflow_id: str | None = None
+    thread_id: str | None = None
+    run_id: str | None = None
+    source_type: str = "local"
+    source: str | None = None
+    external_type: str | None = None
+    external_ref: str | None = None
+    external_url: str | None = None
+    labels: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    work_unit_id: str | None = None
+
+
+class WorkUnitUpdateRequest(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=300)
+    description: str | None = None
+    status: str | None = None
+    priority: str | None = None
+    assignee_ref: str | None = None
+    reporter_ref: str | None = None
+    due_at: str | None = None
+    workflow_id: str | None = None
+    thread_id: str | None = None
+    run_id: str | None = None
+    source_type: str | None = None
+    source: str | None = None
+    external_type: str | None = None
+    external_ref: str | None = None
+    external_url: str | None = None
+    labels: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def _changed_fields(payload: WorkUnitUpdateRequest) -> dict[str, Any]:
+    return payload.model_dump(exclude_unset=True)
+
+
+def _enum_values(enum_cls: type) -> set[str]:
+    return {item.value for item in enum_cls}
+
+
+def _validate_enum_field(field: str, value: str | None, enum_cls: type) -> str | None:
+    if value is None:
+        return None
+    normalized = value.lower() if field in {"status", "source_type"} else value
+    allowed = _enum_values(enum_cls)
+    if normalized not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid {field}: {value}. Allowed values: {', '.join(sorted(allowed))}",
+        )
+    return normalized
+
+
+def _validate_work_unit_fields(values: dict[str, Any]) -> dict[str, Any]:
+    if "status" in values:
+        values["status"] = _validate_enum_field("status", values.get("status"), WorkUnitStatus)
+    if "priority" in values:
+        values["priority"] = _validate_enum_field("priority", values.get("priority"), WorkUnitPriority)
+    if "source_type" in values:
+        values["source_type"] = _validate_enum_field("source_type", values.get("source_type"), WorkUnitSourceType)
+    return values
+
+
+def _owner_user_id(request: Request) -> str | None:
+    internal_owner = get_trusted_internal_owner_user_id(request)
+    if internal_owner:
+        return internal_owner
+    user = getattr(request.state, "user", None)
+    user_id = getattr(user, "id", None)
+    return str(user_id) if user_id is not None else None
+
+
+@router.get("")
+@require_permission("work", "read")
+async def list_work_units(
+    request: Request,
+    status: str | None = Query(default=None),
+    workflow_id: str | None = Query(default=None),
+    thread_id: str | None = Query(default=None),
+    run_id: str | None = Query(default=None),
+    source_type: str | None = Query(default=None),
+    source: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> dict:
+    """List generic work units for board and PM-adapter views."""
+    store = get_work_unit_store(request)
+    rows = await store.list(
+        status=status,
+        workflow_id=workflow_id,
+        thread_id=thread_id,
+        run_id=run_id,
+        source_type=source_type,
+        source=source,
+        user_id=_owner_user_id(request),
+        limit=limit,
+    )
+    return {"data": rows}
+
+
+@router.post("")
+@require_permission("work", "create")
+async def create_work_unit(payload: WorkUnitCreateRequest, request: Request) -> dict:
+    """Create a local or externally-mapped work unit."""
+    store = get_work_unit_store(request)
+    values = _validate_work_unit_fields(payload.model_dump())
+    row = await store.create(**values, user_id=_owner_user_id(request))
+    await store.append_event(
+        row["work_unit_id"],
+        event_type="work_unit.created",
+        actor_ref=payload.reporter_ref or _owner_user_id(request),
+        workflow_id=row.get("workflow_id"),
+        run_id=row.get("run_id"),
+        content={"title": row["title"], "status": row["status"], "priority": row["priority"]},
+    )
+    return row
+
+
+@router.get("/{work_unit_id}")
+@require_permission("work", "read")
+async def get_work_unit(work_unit_id: str, request: Request) -> dict:
+    """Fetch one work unit."""
+    store = get_work_unit_store(request)
+    row = await store.get(work_unit_id, user_id=_owner_user_id(request))
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Work unit {work_unit_id} not found")
+    return row
+
+
+@router.patch("/{work_unit_id}")
+@require_permission("work", "update")
+async def update_work_unit(work_unit_id: str, payload: WorkUnitUpdateRequest, request: Request) -> dict:
+    """Update a work unit projection."""
+    changes = _changed_fields(payload)
+    if not changes:
+        raise HTTPException(status_code=400, detail="No work unit fields provided")
+    changes = _validate_work_unit_fields(changes)
+    store = get_work_unit_store(request)
+    owner_user_id = _owner_user_id(request)
+    previous = await store.get(work_unit_id, user_id=owner_user_id)
+    if previous is None:
+        raise HTTPException(status_code=404, detail=f"Work unit {work_unit_id} not found")
+    row = await store.update(work_unit_id, user_id=owner_user_id, **changes)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Work unit {work_unit_id} not found")
+
+    event_type = "work_unit.status_changed" if "status" in changes and changes["status"] != previous.get("status") else "work_unit.updated"
+    await store.append_event(
+        work_unit_id,
+        event_type=event_type,
+        workflow_id=row.get("workflow_id"),
+        run_id=row.get("run_id"),
+        content={"changes": changes, "previous_status": previous.get("status"), "status": row.get("status")},
+    )
+    return row
+
+
+@router.get("/{work_unit_id}/events")
+@require_permission("work", "read")
+async def list_work_events(
+    work_unit_id: str,
+    request: Request,
+    event_type: list[str] | None = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=1000),
+) -> dict:
+    """List work unit activity events."""
+    store = get_work_unit_store(request)
+    item = await store.get(work_unit_id, user_id=_owner_user_id(request))
+    if item is None:
+        raise HTTPException(status_code=404, detail=f"Work unit {work_unit_id} not found")
+    events = await store.list_events(work_unit_id, event_types=event_type, limit=limit)
+    return {"work_unit": item, "events": events}

--- a/backend/app/gateway/routers/workflows.py
+++ b/backend/app/gateway/routers/workflows.py
@@ -1,0 +1,153 @@
+"""Durable workflow runtime read endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from app.gateway.authz import require_permission
+from app.gateway.deps import get_run_event_store, get_run_store, get_workflow_store
+
+router = APIRouter(prefix="/api/workflows", tags=["workflows"])
+
+
+def _workflow_timeline_event(row: dict) -> dict:
+    return {
+        "kind": "workflow_event",
+        "seq": row.get("seq"),
+        "event_type": row.get("event_type"),
+        "category": row.get("category"),
+        "created_at": row.get("created_at"),
+        "thread_id": row.get("thread_id"),
+        "run_id": row.get("run_id"),
+        "checkpoint_ns": row.get("checkpoint_ns"),
+        "checkpoint_id": row.get("checkpoint_id"),
+        "run_event_seq": row.get("run_event_seq"),
+        "content": row.get("content"),
+        "metadata": row.get("metadata") or {},
+    }
+
+
+def _run_timeline_event(row: dict) -> dict:
+    return {
+        "kind": "run_event",
+        "seq": row.get("seq"),
+        "event_type": row.get("event_type"),
+        "category": row.get("category"),
+        "created_at": row.get("created_at"),
+        "thread_id": row.get("thread_id"),
+        "run_id": row.get("run_id"),
+        "content": row.get("content"),
+        "metadata": row.get("metadata") or {},
+    }
+
+
+def _timeline_sort_key(row: dict) -> tuple[str, int, int]:
+    created_at = str(row.get("created_at") or "")
+    kind_order = 0 if row.get("kind") == "workflow_event" else 1
+    seq = row.get("seq")
+    return created_at, kind_order, int(seq) if isinstance(seq, int) else 0
+
+
+@router.get("")
+@require_permission("runs", "read")
+async def list_workflows(
+    request: Request,
+    status: str | None = Query(default=None),
+    source_type: str | None = Query(default=None),
+    source: str | None = Query(default=None),
+    thread_id: str | None = Query(default=None),
+    run_id: str | None = Query(default=None),
+    user_id: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> dict:
+    """List durable workflow envelopes."""
+    store = get_workflow_store(request)
+    rows = await store.list(
+        status=status,
+        source_type=source_type,
+        source=source,
+        thread_id=thread_id,
+        run_id=run_id,
+        user_id=user_id,
+        limit=limit,
+    )
+    return {"data": rows}
+
+
+@router.get("/by-run/{run_id}")
+@require_permission("runs", "read")
+async def get_workflow_by_run(run_id: str, request: Request, thread_id: str | None = Query(default=None)) -> dict:
+    """Fetch the durable workflow envelope bound to a DeerFlow run."""
+    store = get_workflow_store(request)
+    rows = await store.list(thread_id=thread_id, run_id=run_id, limit=2)
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"Workflow for run {run_id} not found")
+    return rows[0]
+
+
+@router.get("/{workflow_id}")
+@require_permission("runs", "read")
+async def get_workflow(workflow_id: str, request: Request, user_id: str | None = Query(default=None)) -> dict:
+    """Fetch one durable workflow envelope."""
+    store = get_workflow_store(request)
+    row = await store.get(workflow_id, user_id=user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+    return row
+
+
+@router.get("/{workflow_id}/events")
+@require_permission("runs", "read")
+async def list_workflow_events(
+    workflow_id: str,
+    request: Request,
+    event_type: list[str] | None = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=1000),
+) -> dict:
+    """List append-only lifecycle events for one workflow."""
+    store = get_workflow_store(request)
+    workflow = await store.get(workflow_id)
+    if workflow is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+    rows = await store.list_events(workflow_id, event_types=event_type, limit=limit)
+    return {"workflow": workflow, "events": rows}
+
+
+@router.get("/{workflow_id}/timeline")
+@require_permission("runs", "read")
+async def get_workflow_timeline(
+    workflow_id: str,
+    request: Request,
+    include_run_events: bool = Query(default=True),
+    limit: int = Query(default=500, ge=1, le=1000),
+) -> dict:
+    """Return a durable run trace merged from workflow and run events."""
+    store = get_workflow_store(request)
+    workflow = await store.get(workflow_id)
+    if workflow is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+
+    workflow_events = await store.list_events(workflow_id, limit=limit)
+    run_events: list[dict] = []
+    thread_id = workflow.get("thread_id")
+    run_id = workflow.get("run_id")
+    if include_run_events and thread_id and run_id:
+        run_event_store = get_run_event_store(request)
+        run_events = await run_event_store.list_events(thread_id, run_id, limit=limit)
+
+    run = None
+    if run_id:
+        run_store = get_run_store(request)
+        run = await run_store.get(run_id)
+
+    timeline = [_workflow_timeline_event(row) for row in workflow_events]
+    timeline.extend(_run_timeline_event(row) for row in run_events)
+    timeline.sort(key=_timeline_sort_key)
+
+    return {
+        "workflow": workflow,
+        "run": run,
+        "timeline": timeline[:limit],
+        "workflow_events": workflow_events,
+        "run_events": run_events,
+    }

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -20,7 +20,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.messages.utils import convert_to_messages
 from langgraph.types import Command
 
-from app.gateway.deps import get_checkpointer, get_run_context, get_run_manager, get_stream_bridge
+from app.gateway.deps import get_checkpointer, get_run_context, get_run_manager, get_stream_bridge, get_workflow_store
 from app.gateway.internal_auth import INTERNAL_SYSTEM_ROLE, get_trusted_internal_owner_user_id
 from app.gateway.utils import sanitize_log_param
 from deerflow.config.app_config import get_app_config
@@ -353,6 +353,189 @@ async def apply_checkpoint_to_run_config(
 # ---------------------------------------------------------------------------
 
 
+def _request_workflow_idempotency_key(request: Request) -> str | None:
+    return request.headers.get("Idempotency-Key") or request.headers.get("X-Idempotency-Key")
+
+
+def _request_user_id(request: Request, owner_user_id: str | None) -> str | None:
+    if owner_user_id:
+        return owner_user_id
+    user = getattr(request.state, "user", None)
+    user_id = getattr(user, "id", None)
+    return str(user_id) if user_id is not None else None
+
+
+def _workflow_kind_for_run(body: Any) -> str:
+    command = getattr(body, "command", None)
+    if isinstance(command, Mapping) and command.get("resume") is not None:
+        return "resume"
+    return "message"
+
+
+def _auto_workflow_envelopes_enabled() -> bool:
+    modules = get_app_config().modules
+    return modules.durable_workflows.enabled and modules.durable_workflows.auto_envelope_for_runs
+
+
+async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, owner_user_id: str | None) -> dict[str, Any]:
+    workflow_store = get_workflow_store(request)
+    idempotency_key = _request_workflow_idempotency_key(request)
+    external_message_ref = request.headers.get("X-External-Message-Ref")
+    route_path = str(getattr(getattr(request, "url", None), "path", None) or "/api/runs")
+    method = str(getattr(request, "method", None) or "POST")
+    workflow, created = await workflow_store.create_or_get(
+        workflow_kind=_workflow_kind_for_run(body),
+        source_type="api",
+        source=route_path,
+        idempotency_key=idempotency_key,
+        external_message_ref=external_message_ref,
+        conversation_ref=thread_id,
+        thread_ref=thread_id,
+        sender_ref=_request_user_id(request, owner_user_id),
+        user_id=_request_user_id(request, owner_user_id),
+        thread_id=thread_id,
+        status="received",
+        metadata={
+            "assistant_id": getattr(body, "assistant_id", None),
+            "route": route_path,
+            "method": method,
+        },
+    )
+    if not created and workflow.get("run_id"):
+        await workflow_store.append_event(
+            workflow["workflow_id"],
+            event_type="workflow.deduped",
+            idempotency_key=idempotency_key,
+            metadata={"existing_run_id": workflow.get("run_id")},
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=f"Workflow {workflow['workflow_id']} is already bound to run {workflow['run_id']}",
+        )
+
+    await workflow_store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.received" if created else "workflow.deduped",
+        idempotency_key=idempotency_key,
+        content={"thread_id": thread_id, "source": route_path},
+    )
+    return workflow
+
+
+async def _mark_run_workflow_failed(request: Request, workflow_id: str, *, error: str) -> None:
+    workflow_store = get_workflow_store(request)
+    await workflow_store.update_status(workflow_id, "failed", error=error)
+    await workflow_store.append_event(workflow_id, event_type="workflow.failed", metadata={"error": error})
+
+
+async def _bind_run_workflow(
+    request: Request,
+    workflow_id: str,
+    *,
+    thread_id: str,
+    run_id: str,
+    checkpoint_ns: str | None,
+    checkpoint_id: str | None,
+) -> None:
+    workflow_store = get_workflow_store(request)
+    await workflow_store.bind_runtime(
+        workflow_id,
+        thread_id=thread_id,
+        run_id=run_id,
+        checkpoint_ns=checkpoint_ns,
+        checkpoint_id=checkpoint_id,
+        status="run_created",
+    )
+    await workflow_store.append_event(
+        workflow_id,
+        event_type="workflow.run_created",
+        category="runtime",
+        thread_id=thread_id,
+        run_id=run_id,
+        checkpoint_ns=checkpoint_ns,
+        checkpoint_id=checkpoint_id,
+    )
+
+
+def _workflow_status_for_run_status(status: RunStatus) -> tuple[str, str] | None:
+    if status == RunStatus.running:
+        return "running", "workflow.run_started"
+    if status == RunStatus.success:
+        return "succeeded", "workflow.succeeded"
+    if status in (RunStatus.error, RunStatus.timeout):
+        return "failed", "workflow.failed"
+    if status == RunStatus.interrupted:
+        return "cancelled", "workflow.cancelled"
+    return None
+
+
+async def _project_run_workflow_status(
+    request: Request,
+    workflow_id: str,
+    record: RunRecord,
+    *,
+    status: str,
+    event_type: str,
+    error: str | None = None,
+) -> None:
+    workflow_store = get_workflow_store(request)
+    metadata = {"run_status": record.status.value}
+    if error:
+        metadata["error"] = error
+    await workflow_store.update_status(workflow_id, status, error=error, metadata=metadata)
+    await workflow_store.append_event(
+        workflow_id,
+        event_type=event_type,
+        category="runtime",
+        thread_id=record.thread_id,
+        run_id=record.run_id,
+        metadata=metadata,
+    )
+
+
+async def _run_agent_with_workflow_projection(
+    request: Request,
+    workflow_id: str,
+    bridge: StreamBridge,
+    run_mgr: RunManager,
+    record: RunRecord,
+    **run_agent_kwargs: Any,
+) -> None:
+    await _project_run_workflow_status(
+        request,
+        workflow_id,
+        record,
+        status="running",
+        event_type="workflow.run_started",
+    )
+    escaped_error: BaseException | None = None
+    try:
+        await run_agent(bridge, run_mgr, record, **run_agent_kwargs)
+    except BaseException as exc:
+        escaped_error = exc
+        raise
+    finally:
+        projection = _workflow_status_for_run_status(record.status)
+        if escaped_error is not None and projection is None:
+            await _project_run_workflow_status(
+                request,
+                workflow_id,
+                record,
+                status="failed",
+                event_type="workflow.failed",
+                error=str(escaped_error),
+            )
+        elif projection is not None and projection[0] != "running":
+            await _project_run_workflow_status(
+                request,
+                workflow_id,
+                record,
+                status=projection[0],
+                event_type=projection[1],
+                error=record.error,
+            )
+
+
 async def start_run(
     body: Any,
     thread_id: str,
@@ -417,6 +600,11 @@ async def start_run(
         if not allowed:
             raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")
 
+    workflow_id: str | None = None
+    if _auto_workflow_envelopes_enabled():
+        workflow = await _create_run_workflow(body, thread_id, request, owner_user_id=owner_user_id)
+        workflow_id = workflow["workflow_id"]
+
     owner_context_token = set_current_user(SimpleNamespace(id=owner_user_id)) if owner_user_id else None
     try:
         try:
@@ -431,8 +619,12 @@ async def start_run(
                 user_id=owner_user_id,
             )
         except ConflictError as exc:
+            if workflow_id is not None:
+                await _mark_run_workflow_failed(request, workflow_id, error=str(exc))
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except UnsupportedStrategyError as exc:
+            if workflow_id is not None:
+                await _mark_run_workflow_failed(request, workflow_id, error=str(exc))
             raise HTTPException(status_code=501, detail=str(exc)) from exc
 
         # Upsert thread metadata so the thread appears in /threads/search,
@@ -465,6 +657,16 @@ async def start_run(
             graph_input = normalize_input(body.input)
         config = build_run_config(thread_id, body.config, body.metadata, assistant_id=body.assistant_id)
         await apply_checkpoint_to_run_config(config, body=body, thread_id=thread_id, request=request)
+        configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+        if workflow_id is not None:
+            await _bind_run_workflow(
+                request,
+                workflow_id,
+                thread_id=thread_id,
+                run_id=record.run_id,
+                checkpoint_ns=str(configurable.get("checkpoint_ns")) if configurable.get("checkpoint_ns") is not None else None,
+                checkpoint_id=str(configurable.get("checkpoint_id")) if configurable.get("checkpoint_id") is not None else None,
+            )
 
         # Merge DeerFlow-specific context overrides into both ``configurable`` and ``context``.
         # The ``context`` field is a custom extension for the langgraph-compat layer
@@ -475,21 +677,36 @@ async def start_run(
 
         stream_modes = normalize_stream_modes(body.stream_mode)
 
-        task = asyncio.create_task(
-            run_agent(
-                bridge,
-                run_mgr,
-                record,
-                ctx=run_ctx,
-                agent_factory=agent_factory,
-                graph_input=graph_input,
-                config=config,
-                stream_modes=stream_modes,
-                stream_subgraphs=body.stream_subgraphs,
-                interrupt_before=body.interrupt_before,
-                interrupt_after=body.interrupt_after,
-            )
+        run_agent_kwargs = dict(
+            ctx=run_ctx,
+            agent_factory=agent_factory,
+            graph_input=graph_input,
+            config=config,
+            stream_modes=stream_modes,
+            stream_subgraphs=body.stream_subgraphs,
+            interrupt_before=body.interrupt_before,
+            interrupt_after=body.interrupt_after,
         )
+        if workflow_id is not None:
+            task = asyncio.create_task(
+                _run_agent_with_workflow_projection(
+                    request,
+                    workflow_id,
+                    bridge,
+                    run_mgr,
+                    record,
+                    **run_agent_kwargs,
+                )
+            )
+        else:
+            task = asyncio.create_task(
+                run_agent(
+                    bridge,
+                    run_mgr,
+                    record,
+                    **run_agent_kwargs,
+                )
+            )
         record.task = task
 
         # Title sync is handled by worker.py's finally block which reads the

--- a/backend/docs/DEERFLOW_WORK_MODULE.md
+++ b/backend/docs/DEERFLOW_WORK_MODULE.md
@@ -166,7 +166,17 @@ visual workflow designer is not accepted.
 - Add a runtime-bound Work Unit tool so agents must call a tool before claiming
   a status change.
 
-### Work PR 2: WorkBoard MVP
+### Work PR 2: Agent Tools
+
+- Expose a global `work_units` tool when the Work Module is enabled.
+- Let agents create, list, inspect, and update generic work units through the
+  same store/API contract as external PM adapters.
+- Keep runtime-bound `work_unit` updates scoped to the work unit attached by
+  the calling surface.
+- Record tool writes as `work_events` so UI and adapters can audit agent
+  actions.
+
+### Work PR 3: WorkBoard MVP
 
 - Add `/workspace/work` route.
 - Show board columns by status.
@@ -174,13 +184,13 @@ visual workflow designer is not accepted.
 - Let agent/runtime updates move status through the Work Unit tool/API.
 - Link to thread/run/workflow trace when refs exist.
 
-### Work PR 3: External PM Binding Contract
+### Work PR 4: External PM Binding Contract
 
 - Add adapter interface docs and sync metadata conventions.
 - Add import/export examples for Trello/Jira/Plane-style objects.
 - No hard dependency on a PM vendor.
 
-### Work PR 4: Gates And Criteria
+### Work PR 5: Gates And Criteria
 
 - Add acceptance criteria and lightweight human gates.
 - Link gates to durable workflow `waiting` states where applicable.
@@ -191,7 +201,7 @@ visual workflow designer is not accepted.
 The smallest useful demo is Work PR 1-3:
 
 1. Create a work unit from the WorkBoard.
-2. Move it across board statuses.
+2. Ask the assigned agent to inspect or update it through the Work Unit tool.
 3. Attach a `workflow_id` or `run_id` from a normal DeerFlow chat.
 4. Open the workflow trace from the work unit.
 

--- a/backend/docs/DEERFLOW_WORK_MODULE.md
+++ b/backend/docs/DEERFLOW_WORK_MODULE.md
@@ -1,0 +1,199 @@
+# DeerFlow Work Module
+
+Status: architecture decision
+Date: 2026-06-26
+Scope: generic work unit schema, workflow linkage, agent tool boundary, and PM-tool adapter boundary
+
+## Decision
+
+DeerFlow should add an optional Work Module after the Durable Workflow Runtime
+foundation. The module gives teams a small, generic way to track operational
+work that can be performed by humans, agents, or both. It should stay easy to
+map to external PM tools such as Jira, Trello, ClickUp, Plane, Lark, GitHub
+Issues, or enterprise work management systems.
+
+The Work Module should not be part of the minimal Durable Workflow Runtime
+Layer. Runtime workflow identity, idempotency, status, and event correlation
+must work without work units. Work units sit above the runtime and may link to
+workflow envelopes, DeerFlow threads, runs, artifacts, and external objects.
+
+Use `work_unit` as the canonical DeerFlow core term. Integrations may call the
+same concept a task, card, issue, ticket, work unit, or request.
+
+## Boundary
+
+Durable Workflow Runtime owns:
+
+- `workflow_id`;
+- intake/source/idempotency metadata;
+- workflow lifecycle status;
+- workflow events and run event correlation;
+- thread/run/checkpoint refs.
+
+Work Module owns:
+
+- `work_unit_id`;
+- title, description/objective, status, priority, assignee, due date, labels;
+- work-to-work links;
+- acceptance criteria and lightweight gates;
+- external PM object bindings;
+- optional links to workflow/thread/run refs;
+- work unit events for audit and board activity.
+
+The future WorkBoard application owns:
+
+- visual board/list views over Work Module records;
+- local backlog capture UX;
+- status projection and review UX over runtime/adapter updates;
+- filters and trace links;
+- no separate task schema.
+
+## Module Gates
+
+The Work Module is an optional layer over DeerFlow's runtime:
+
+```yaml
+modules:
+  durable_workflows:
+    enabled: true
+    api_enabled: true
+    auto_envelope_for_runs: true
+  work:
+    enabled: true
+    api_enabled: true
+```
+
+- `durable_workflows.enabled=false` preserves the legacy run path with no
+  automatic workflow envelope.
+- `work.enabled=false` disables Work Unit store construction and Work Unit API
+  exposure.
+- A future WorkBoard UI can depend on Work Module, but Work Module must not
+  depend on WorkBoard.
+
+The first implementation keeps Work tables in DeerFlow's normal database
+migration chain. When the module is disabled those tables are inert; API, store,
+and UI surfaces are not mounted. A separate migration namespace can be added
+later if upstream maintainers want a zero-table footprint for disabled modules.
+
+PM adapters own:
+
+- mapping external task/card/issue/ticket fields to `work_units`;
+- sync cursors and conflict policy;
+- external webhooks and credentials;
+- tool-specific custom fields.
+
+## Core Schema
+
+### `work_units`
+
+Minimum fields:
+
+- `work_unit_id`: DeerFlow-generated id.
+- `title`: short human-readable title.
+- `description`: optional Markdown/plain text body.
+- `status`: `backlog`, `ready`, `in_progress`, `blocked`, `review`, `done`,
+  `closed`, or `cancelled`.
+- `priority`: `P0`, `P1`, `P2`, `P3`, or `P4`.
+- `assignee_ref`: optional user/team/external assignee ref.
+- `reporter_ref`: optional source reporter ref.
+- `due_at`: optional target date.
+- `workflow_id`: optional Durable Workflow Runtime link.
+- `thread_id`: optional DeerFlow thread link.
+- `run_id`: optional DeerFlow run link.
+- `source_type`: `local`, `pm_tool`, `channel`, `api`, or `other`.
+- `source`: provider/system name.
+- `external_type`: optional provider object type such as `jira_issue`,
+  `trello_card`, `clickup_task`, or `plane_issue`.
+- `external_ref`: provider object id/key.
+- `external_url`: provider object URL.
+- `labels`: JSON string array.
+- `metadata`: JSON extension object.
+- `created_at`, `updated_at`.
+
+Indexes:
+
+- `(status, updated_at)`;
+- `(priority, updated_at)`;
+- `(workflow_id)`;
+- `(thread_id, run_id)`;
+- `(source_type, source, external_ref)` unique when `external_ref` exists.
+
+### `work_events`
+
+Minimum fields:
+
+- `work_event_id`;
+- `work_unit_id`;
+- `seq`;
+- `event_type`;
+- `actor_ref`;
+- `workflow_id`;
+- `run_id`;
+- `content`;
+- `metadata`;
+- `created_at`.
+
+Use this for board activity and adapter sync audit, not for LangGraph
+checkpoint state.
+
+### Later Tables
+
+Keep the first PR small. Add these only when workflows need them:
+
+- `work_unit_links`: relates work units with `blocks`, `blocked_by`,
+  `duplicates`, `relates_to`, `parent`, `child`.
+- `work_unit_criteria`: acceptance criteria or completion checks.
+- `work_gates`: pending approvals/human decisions linked to work units and
+  workflow waits.
+- `external_object_bindings`: richer adapter binding metadata and sync state.
+
+## PR Sequence
+
+Work Module PRs should follow the runtime PRs. They are useful even if the
+visual workflow designer is not accepted.
+
+### Work PR 1: Core Module
+
+- Add this document.
+- Add `work_units` and `work_events` models/migrations.
+- Add memory and SQL repositories.
+- Add tests for create/list/update/link-to-workflow.
+- Add `GET /api/work-units`.
+- Add `POST /api/work-units`.
+- Add `GET /api/work-units/{work_unit_id}`.
+- Add `PATCH /api/work-units/{work_unit_id}`.
+- Add `GET /api/work-units/{work_unit_id}/events`.
+- Add a runtime-bound Work Unit tool so agents must call a tool before claiming
+  a status change.
+
+### Work PR 2: WorkBoard MVP
+
+- Add `/workspace/work` route.
+- Show board columns by status.
+- Create local backlog work units.
+- Let agent/runtime updates move status through the Work Unit tool/API.
+- Link to thread/run/workflow trace when refs exist.
+
+### Work PR 3: External PM Binding Contract
+
+- Add adapter interface docs and sync metadata conventions.
+- Add import/export examples for Trello/Jira/Plane-style objects.
+- No hard dependency on a PM vendor.
+
+### Work PR 4: Gates And Criteria
+
+- Add acceptance criteria and lightweight human gates.
+- Link gates to durable workflow `waiting` states where applicable.
+- Keep LangGraph interrupt payloads in LangGraph checkpoints.
+
+## Local Demo Path
+
+The smallest useful demo is Work PR 1-3:
+
+1. Create a work unit from the WorkBoard.
+2. Move it across board statuses.
+3. Attach a `workflow_id` or `run_id` from a normal DeerFlow chat.
+4. Open the workflow trace from the work unit.
+
+This proves the product value without needing Jira/Trello credentials, a visual
+designer, or an external orchestrator.

--- a/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
+++ b/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
@@ -1,0 +1,485 @@
+# Durable Workflow Frontdoor
+
+Status: architecture decision draft
+Date: 2026-06-26
+Scope: DeerFlow backend gateway, runtime, persistence, and channel adapters
+
+## Decision
+
+DeerFlow should add a native, minimal durable workflow frontdoor for every
+inbound message that may invoke an agent. The first layer should be a DeerFlow
+owned workflow envelope and ledger, not a hard dependency on AICOS, Restate,
+Temporal, or any product-specific task model.
+
+The frontdoor provides stable intake identity, idempotency, routing/binding
+metadata, run/checkpoint references, and queryable workflow status. LangGraph
+continues to own graph execution state, checkpoint values, graph-local memory,
+interrupt semantics, and replay from checkpoints. DeerFlow owns generic intake,
+run orchestration, channel routing, and event correlation.
+
+External workflow engines such as Restate or Temporal should be optional
+adapters above this interface, not a required DeerFlow core dependency.
+
+Scalable DeerFlow deployments should add a small native workflow leasing layer
+to this envelope. Leasing gives DeerFlow a horizontal worker contract without
+claiming full durable code replay: a worker can atomically claim an eligible
+workflow, bind it to a LangGraph thread/run, renew or finish the lease, and let
+another worker recover it when the lease expires.
+
+For deployments that need durable work management, this frontdoor can later be
+paired with an optional DeerFlow Work Module. The frontdoor remains the generic
+intake and runtime-dispatch layer; the Work module would add reusable work unit,
+acceptance criterion, gate, artifact reference, review, and external PM-tool
+binding schemas.
+
+## Current Architecture Summary
+
+DeerFlow already has the foundation for durable agent runtime behavior:
+
+- LangGraph checkpointer persists thread-scoped graph state by `thread_id`,
+  `checkpoint_ns`, and `checkpoint_id`.
+- LangGraph store persists runtime/application memory outside graph state.
+- `RunManager` creates process-local `RunRecord` objects and persists run
+  metadata through `RunStore`.
+- `RunRepository` stores `run_id`, `thread_id`, status, model, token usage,
+  first/last messages, and run kwargs/metadata.
+- `RunEventStore` stores an ordered event stream keyed by
+  `(thread_id, run_id, seq)`.
+- `run_agent()` executes `agent.astream(...)` in an `asyncio.Task`, writes run
+  status transitions, publishes stream bridge events, and flushes `RunJournal`
+  events.
+- Gateway endpoints (`/runs`, `/threads/{thread_id}/runs`) call `start_run()`
+  directly.
+- Channel adapters normalize platform events into `InboundMessage`; the
+  channel manager resolves/creates a DeerFlow thread, then calls
+  `client.runs.wait()` or `client.runs.stream()`.
+
+The important current limitation is that the executing run task is process
+local. A persisted `pending` or `running` row does not imply an executor still
+exists after gateway restart. Startup reconciliation explicitly marks orphaned
+active runs as `error` for SQLite-backed deployments instead of pretending they
+are resumable.
+
+## Research Notes
+
+LangGraph persistence separates thread-scoped checkpointers from cross-thread
+stores. Checkpointers are the right owner for graph state snapshots,
+conversation continuity, human-in-the-loop, time travel, and fault tolerance.
+They require a stable `thread_id` and can reference concrete checkpoints by
+`checkpoint_id`.
+
+LangGraph interrupts pause graph execution, persist graph state through the
+checkpointer, and resume by invoking the same thread with `Command(resume=...)`.
+Interrupt side effects before the interrupt must be idempotent because the
+node can restart when resumed.
+
+Temporal and Restate solve a different boundary: durable orchestration replay.
+Temporal workflows must be deterministic and push non-deterministic operations
+such as API/LLM calls into activities. Restate journals steps, side effects,
+timers, and service calls so handlers can replay without duplicating completed
+effects. These are valuable optional execution adapters, but making either
+mandatory would raise DeerFlow's deployment bar and entangle the core runtime
+with a specific orchestrator.
+
+Hatchet is useful as a scale and worker model reference. Its durable execution
+docs separate ordinary task execution from durable tasks that checkpoint when
+they wait or spawn children. Its DAG model persists each completed task result
+so retries can avoid re-running succeeded parts, and its platform emphasizes
+worker slots, concurrency, priority, retries, and observability. DeerFlow should
+borrow those operational primitives at the workflow-envelope layer, while still
+leaving graph execution and checkpoint state inside LangGraph.
+
+OpenAI Agents SDK tracing and handoffs are useful compatibility concepts:
+trace/group IDs and spans map naturally to workflow/run/event correlation,
+while handoffs show how multi-agent delegation can remain tool-like and
+runtime-owned. They do not replace DeerFlow's need for an intake ledger.
+
+Dust-style platforms are useful as product pattern evidence: many surfaces
+(web, Slack, Teams, API, browser extension) can call the same agent layer with
+selected knowledge sources and tools. DeerFlow should generalize that as
+surface-agnostic intake and routing, not as a Dust-specific feature.
+
+References:
+
+- https://docs.langchain.com/oss/python/langgraph/persistence
+- https://docs.langchain.com/oss/python/langgraph/checkpointers
+- https://docs.langchain.com/oss/python/langgraph/interrupts
+- https://docs.temporal.io/workflow-definition
+- https://docs.restate.dev/foundations/key-concepts
+- https://docs.hatchet.run/v1/durable-execution
+- https://docs.hatchet.run/v1/durable-tasks
+- https://docs.hatchet.run/v1/directed-acyclic-graphs
+- https://openai.github.io/openai-agents-python/tracing/
+- https://openai.github.io/openai-agents-python/handoffs/
+- https://docs.dust.tt/docs/intro
+
+## Schema Lessons From Durable Workflow Systems
+
+The schema should borrow the smallest durable ideas from LangGraph, Restate,
+Temporal, and Hatchet without turning DeerFlow into another workflow engine.
+
+From LangGraph:
+
+- use `thread_id`, `checkpoint_ns`, and `checkpoint_id` as refs into graph
+  state;
+- never copy checkpoint `values` into DeerFlow workflow rows;
+- remember that a checkpoint snapshot already has `metadata`, `created_at`,
+  `parent_config`, `tasks`, and `next` for graph-local replay and inspection;
+- rely on LangGraph checkpoint writes/pending writes for graph node recovery
+  inside a super-step;
+- use interrupts/resume as the primary graph-local human-in-the-loop primitive.
+
+From Restate:
+
+- keep a durable identity before handler execution starts;
+- dedupe repeated submissions by identity/idempotency key;
+- distinguish retryable errors from terminal errors;
+- model external waits as durable workflow state, not as an in-memory future;
+- optionally support Restate as an execution adapter later, where Restate owns
+  its execution log and DeerFlow owns workflow/run/checkpoint refs.
+
+From Temporal:
+
+- separate stable `workflow_id` from per-attempt/per-run execution identity;
+- use append-only event history concepts for observability and recovery
+  decisions;
+- keep workers stateless enough that another worker can pick up eligible work;
+- treat calls to LLMs, databases, channels, and PM tools as external effects
+  that require idempotency or a durable result record;
+- avoid putting critical execution data only in searchable/memo metadata.
+
+From Hatchet:
+
+- expose worker-facing lease/claim/concurrency primitives without requiring
+  full deterministic replay in core;
+- make waits and child work visible as durable state;
+- persist completed step/task refs so retries do not need to guess what already
+  happened;
+- keep DAG/workflow-builder concerns separate from the minimal intake ledger.
+
+The practical result is a small DeerFlow schema made of a mutable workflow
+projection plus append-only lifecycle facts. LangGraph remains the durable graph
+runtime. Optional engines can wrap DeerFlow, but DeerFlow still has a native
+frontdoor that every deployment can run.
+
+## Boundary Rules
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint values and checkpoint writes;
+- graph-local memory and interrupt/resume mechanics;
+- replay from a checkpoint.
+
+DeerFlow core owns:
+
+- generic workflow intake identity;
+- source/channel metadata;
+- deterministic conversation/thread binding records;
+- run creation and cancellation orchestration;
+- workflow-to-run/checkpoint references;
+- workflow event projection over `RunEventStore`;
+- restart reconciliation and orphan status visibility.
+
+Integrations own:
+
+- domain-specific work semantics;
+- task/goal/work-unit lifecycle;
+- approval policies and business gates;
+- evidence/artifact acceptance rules;
+- semantic completion beyond "the DeerFlow run ended".
+
+DeerFlow runtime core must not know integration-specific names such as Gate,
+Evidence, Review, Runtime Invocation, AICOS, OpenClaw, Restate, or Temporal.
+It also must not require the Work Module to run durable workflows.
+
+The optional Work Module intentionally sits between DeerFlow runtime core and
+external integrations. It provides generic community primitives such as Work
+Units and Work Gates, while adapter packages map those primitives to Jira
+issues, Trello cards, ClickUp tasks, Plane issues, Lark tasks/docs, or AICOS-X
+records.
+
+## Core Primitive: Workflow Envelope
+
+The workflow envelope is a generic record for one inbound message or command
+that may cause an agent invocation.
+
+Minimum fields:
+
+- `workflow_id`: DeerFlow-generated durable identity.
+- `workflow_kind`: `message`, `command`, `resume`, `handoff`, or `other`.
+- `source_type`: `api`, `dashboard`, `channel`, `agent_session`, or `other`.
+- `source`: provider/surface name such as `slack`, `telegram`, `dashboard`, or
+  `api`.
+- `external_message_ref`: stable external message/event id when one exists.
+- `conversation_ref`: external conversation/session/channel id.
+- `thread_ref`: external topic/thread/reply id.
+- `sender_ref`: external user/account/bot id.
+- `thread_id`: DeerFlow LangGraph thread id, once resolved.
+- `run_id`: DeerFlow run id, once created.
+- `checkpoint_ns`: checkpoint namespace, usually `""` for the root graph.
+- `checkpoint_id`: checkpoint ref when the workflow targets or observes one.
+- `idempotency_key`: caller or adapter supplied stable key.
+- `status`: `received`, `bound`, `claimed`, `run_created`, `running`, `waiting`,
+  `succeeded`, `failed`, `cancelled`, `orphaned`, or `ignored`.
+- `attempt_count`: how many times DeerFlow has claimed or attempted the
+  workflow.
+- `max_attempts`: retry ceiling for safe retry policies.
+- `next_attempt_at`: earliest time the workflow can be claimed again.
+- `lease_owner`: worker/process id that currently owns execution.
+- `lease_expires_at`: time after which another worker may recover/claim it.
+- `error`: short error summary.
+- `metadata`: JSON for adapter/runtime extension data.
+- `created_at`, `updated_at`.
+
+The envelope stores refs and summaries. It must not copy LangGraph checkpoint
+state values or large raw transcripts.
+
+## Core Primitive: Workflow Event
+
+The workflow row is the latest projection. A separate append-only event table
+should record workflow lifecycle facts that are useful for audit, recovery, and
+UI timelines.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Suggested event types:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+This table is not a copy of `RunEventStore`. It records DeerFlow workflow facts
+and points at run event sequence numbers where graph execution details already
+exist. UI timelines can merge workflow events and run events at query time.
+
+## Minimal Durable Schema
+
+The first scalable schema should be intentionally small:
+
+```text
+workflows
+  durable intake identity
+  source refs and idempotency key
+  current status projection
+  worker lease and retry metadata
+  LangGraph thread/checkpoint refs
+  DeerFlow run refs
+  compact error/metadata
+
+workflow_events
+  append-only workflow lifecycle facts
+  refs to run_events, checkpoints, and external ids
+  compact payload summaries
+
+run_events
+  existing DeerFlow execution stream
+
+LangGraph checkpoints/checkpoint_writes/store
+  existing graph state and graph-local memory
+```
+
+Do not add a `workflow_steps` table in the first native layer. Step-level
+durability is already owned by LangGraph for graph nodes and can later be owned
+by an optional Restate/Temporal/Hatchet adapter for deployments that need
+deterministic code replay beyond LangGraph checkpoints.
+
+Do not add a separate `workflow_runtime_bindings` table until DeerFlow needs
+one workflow to fan out into multiple runs or runtimes. The first model can bind
+the current `thread_id`, `run_id`, and checkpoint refs directly on `workflows`,
+with richer execution attempts represented later by the optional Work module's
+`runtime_invocations`.
+
+Human waits can begin as `status = waiting` plus checkpoint/interrupt metadata.
+If this becomes too overloaded, add a focused `workflow_waits` or
+`workflow_signals` table later with `wait_id`, `workflow_id`, `wait_type`,
+`status`, `resume_id`, `expires_at`, and `metadata`.
+
+## Deterministic Binding Resolver
+
+Routing should be deterministic before the agent is invoked:
+
+1. Respect explicit request fields (`thread_id`, `checkpoint_id`, selected
+   assistant/agent, explicit external refs).
+2. Resolve channel conversation mappings using existing channel connection and
+   conversation stores.
+3. Detect explicit references in message text only when their syntax is
+   unambiguous and generic, such as a DeerFlow thread/run/workflow id.
+4. Bind to an active thread/run only when the source conversation and binding
+   rules make that deterministic.
+5. If multiple valid candidates exist, persist the candidates in workflow
+   metadata and pass the ambiguity to the agent or human flow. Do not guess in
+   the adapter.
+
+This resolver is intentionally not a semantic classifier. Semantic intent
+belongs in the agent or integration layer.
+
+## Scalable Execution Model
+
+The native DeerFlow layer should be a durable intake and dispatch ledger, not a
+second graph engine. The scalable path is:
+
+```text
+surface/API/channel
+  -> workflow intake row (idempotent)
+  -> deterministic binding resolver
+  -> workflow lease claim
+  -> LangGraph run creation
+  -> LangGraph checkpointer/store/run_events
+  -> workflow status projection
+```
+
+Core primitives needed for scale:
+
+- `create_or_get`: idempotent intake.
+- `claim_next`: atomically lease an eligible workflow for one worker.
+- `bind_runtime`: attach `thread_id`, `run_id`, and checkpoint refs after run
+  creation.
+- `update_status`: complete, fail, wait, cancel, or orphan the workflow.
+- `release_for_retry`: clear a lease, increment/reuse retry metadata, and set
+  `next_attempt_at`.
+- `recover_expired_leases`: mark or requeue workflows whose lease owner died.
+
+The first implementation can keep run execution in the gateway process. A later
+worker pool can use the same store API to claim workflows from Postgres without
+changing public intake semantics.
+
+This design intentionally does not provide Temporal/Restate-style deterministic
+code replay in core. DeerFlow should replay at three safer boundaries instead:
+
+1. API/channel retries dedupe at `workflow.idempotency_key`.
+2. Workflow dispatch retries re-enter before LangGraph run creation, or after a
+   known terminal/orphaned run state.
+3. LangGraph graph resume uses `thread_id` and checkpoint/interrupt refs.
+
+Any side effect outside those boundaries must be idempotent or pushed into a
+tool/runtime layer that records its own durable result.
+
+## Runtime Binding
+
+Workflow rows bind to DeerFlow runtime refs:
+
+```text
+workflow_id
+  -> thread_id
+  -> run_id
+  -> checkpoint_ns/checkpoint_id refs
+  -> run_events(thread_id, run_id, seq)
+```
+
+Run events remain the source event stream for graph execution observations.
+Workflow timeline APIs should project from workflow status changes plus
+`RunEventStore` rows. The projection should include links/correlation, not
+duplicate every run event into a second canonical stream.
+
+## Recovery Semantics
+
+The initial native layer does not make process-local `asyncio.Task` execution
+durable across gateway restarts.
+
+On startup:
+
+- orphaned `pending`/`running` runs remain explicitly marked as `error` under
+  current run reconciliation;
+- workflows bound to those runs should be marked `orphaned` or `failed` with a
+  recovery hint;
+- workflows with expired leases and no run can be requeued when their
+  idempotency key and source policy make retry safe;
+- workflows with expired leases and an active/local run should keep the run as
+  source of truth until the run reaches a terminal state;
+- workflows that were only `received` or `bound` before a run was created can
+  be retried only when the idempotency key, input refs, and adapter policy make
+  retry safe;
+- retry/resume policies must be explicit per workflow kind/source.
+
+Future Restate/Temporal adapters can provide stronger execution replay by
+driving DeerFlow through the same workflow envelope and marking their own
+orchestrator refs in metadata.
+
+## Human-In-The-Loop
+
+LangGraph interrupts should remain the primary graph-local HITL primitive.
+DeerFlow workflow records should add:
+
+- a durable `waiting` status for workflows whose run reached an interrupt or
+  requires user input;
+- references to the relevant `thread_id`, `run_id`, and checkpoint config;
+- a generic pending-input record or metadata block that stores prompt summary,
+  interrupt id(s), source, and resume route;
+- `Command(resume=...)` intake through the same workflow frontdoor.
+
+The human decision semantics remain outside DeerFlow unless they are generic
+approval/resume mechanics.
+
+## Observability
+
+DeerFlow should expose workflow observability without requiring an integration:
+
+- list workflows by status, source, thread, run, and updated time;
+- get one workflow envelope;
+- get workflow timeline projected from workflow lifecycle plus run events;
+- show idempotency and external refs;
+- surface orphan/retry/recovery hints;
+- correlate workflow rows to run rows and checkpoint refs.
+
+## PR Stack
+
+Detailed implementation order lives in
+[Durable Workflow Runtime Plan](DURABLE_WORKFLOW_RUNTIME_PLAN.md). The stack is
+ordered so that cutting later PRs still leaves a useful durable runtime prefix.
+
+1. Runtime architecture and shared contracts.
+2. Workflow envelope schema/store/idempotency/lease tests.
+3. Workflow events append-only lifecycle log.
+4. Runtime read APIs and observability.
+5. Existing run endpoint compatibility wrapper.
+6. Recovery/reconciliation for orphaned workflows/runs.
+7. Deterministic binding resolver.
+8. Channel/dashboard intake adoption.
+9. Waiting, resume, and human-in-the-loop refs.
+10. Worker pool readiness.
+
+## First Implementation Slice
+
+The first safe slice is PR 1 plus the persistence skeleton for PR 2:
+
+- add this design doc;
+- add generic workflow status/kind/source enums;
+- add a `workflows` ORM model and Alembic migration;
+- add a small repository/store API with idempotent create-or-get by
+  idempotency key;
+- add lease/attempt fields so later PRs can scale workers horizontally without
+  another schema break;
+- add unit tests for idempotent create, binding updates, status updates, and
+  list filters;
+- do not change any gateway or channel runtime behavior yet.
+
+This gives downstream PRs a stable table and API surface without changing the
+current run endpoints or channel dispatch path.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -1,0 +1,286 @@
+# Durable Workflow PR Stack
+
+Status: working stack
+Date: 2026-06-26
+
+This stack is ordered for upstream review. PR 1-5 is the first community-visible
+milestone: existing DeerFlow run APIs keep their current behavior, but each run
+also has durable workflow identity, idempotency, lifecycle events, and an
+inspectable trace.
+
+## Review Principles
+
+- Keep the Durable Workflow Runtime layer generic. Do not introduce AICOS, PM
+  tool, visual designer, board, or external-orchestrator concepts into that
+  runtime layer.
+- Keep module boundaries explicit. Durable Workflow Runtime, Work Module, and
+  WorkBoard are separately gated by `modules.*` config and should not require
+  each other except for WorkBoard depending on the Work Module API.
+- LangGraph remains owner of graph execution, checkpoint state, graph-local
+  memory, interrupts, and resume semantics.
+- DeerFlow owns intake identity, workflow status projection, idempotency,
+  run/checkpoint references, channel/API routing, and runtime observability.
+- The optional DeerFlow Work Module may map workflow ids to generic Work Units,
+  and external adapters may map those Work Units to domain task/card/issue
+  systems. Those mappings live outside this runtime stack.
+
+## PR 1: Runtime Architecture And Shared Contracts
+
+Purpose: align vocabulary before schema and API changes.
+
+Scope:
+
+- Add `DURABLE_WORKFLOW_RUNTIME_PLAN.md`.
+- Add `DURABLE_WORKFLOW_FRONTDOOR.md`.
+- Link both docs from the backend docs index.
+- Define shared identity names: `workflow_id`, `workflow_event_id`,
+  `thread_id`, `run_id`, `checkpoint_ns`, `checkpoint_id`,
+  `workflow_definition_id`, and `workflow_run_id`.
+- Define status and event contracts.
+
+Acceptance:
+
+- No runtime behavior changes.
+- Docs clearly separate runtime workflow identity from future visual workflow
+  definitions and future work unit modules.
+
+Suggested checks:
+
+```bash
+git diff --check
+```
+
+## PR 2: Workflow Envelope Schema And Store
+
+Purpose: persist the minimal durable frontdoor envelope.
+
+Scope:
+
+- Add runtime workflow enums and `WorkflowStore`.
+- Add in-memory workflow store.
+- Add SQLAlchemy workflow repository.
+- Add `workflows` ORM model and migration.
+- Wire gateway dependency so production uses SQL store when a DB session
+  factory exists, otherwise memory store.
+
+Acceptance:
+
+- `create_or_get` dedupes by `(source_type, source, idempotency_key)`.
+- Store supports `get`, `list`, `bind_runtime`, `update_status`,
+  `claim_next`, and `release_for_retry`.
+- Existing run APIs still behave the same before wrapper adoption.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py \
+  tests/test_persistence_scaffold.py -q
+```
+
+## PR 3: Workflow Events
+
+Purpose: add append-only lifecycle facts for audit and recovery decisions.
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event` and `list_events` to workflow stores.
+- Keep workflow events separate from `RunEventStore`.
+- Ensure migrations are idempotent when legacy `create_all` already created
+  tables.
+
+Acceptance:
+
+- Event `seq` is monotonic per workflow.
+- Events can exist before a run exists.
+- No checkpoint values are copied into workflow event rows.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_workflows_router.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py -q
+```
+
+## PR 4: Durable Run Trace API And UI
+
+Purpose: make the runtime value visible without requiring WorkBoard, PM
+adapters, or an external workflow engine.
+
+Scope:
+
+- Add read-only workflow endpoints:
+  - `GET /api/workflows`
+  - `GET /api/workflows/{workflow_id}`
+  - `GET /api/workflows/{workflow_id}/events`
+  - `GET /api/workflows/by-run/{run_id}`
+  - `GET /api/workflows/{workflow_id}/timeline`
+- Timeline merges workflow lifecycle events and run events at query time.
+- Add a compact workspace Trace trigger for the latest run in a chat.
+
+Acceptance:
+
+- A user can open a chat and inspect the latest run trace.
+- A developer can find `workflow_id` from `run_id`.
+- Timeline includes both workflow events and existing run events.
+- Endpoint additions do not change existing run API responses.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflows_router.py \
+  tests/test_gateway_services.py -q
+
+cd ../frontend
+CI=true pnpm run check
+```
+
+## PR 5: Run API Wrapper And Status Projection
+
+Purpose: route existing run creation through workflow intake while preserving
+client compatibility.
+
+Scope:
+
+- Wrap `/api/runs/*` and `/api/threads/{thread_id}/runs*` creation paths.
+- Create a workflow envelope before run creation.
+- Bind `thread_id`, `run_id`, `checkpoint_ns`, and `checkpoint_id`.
+- Project run lifecycle to workflow status:
+  - `running`
+  - `succeeded`
+  - `failed`
+  - `cancelled`
+- Append lifecycle events:
+  - `workflow.received`
+  - `workflow.deduped`
+  - `workflow.run_created`
+  - `workflow.run_started`
+  - `workflow.succeeded`
+  - `workflow.failed`
+  - `workflow.cancelled`
+
+Acceptance:
+
+- Old clients can ignore workflows entirely.
+- Duplicate idempotency keys do not create duplicate bound runs.
+- Workflow terminal status matches the bound run terminal status.
+- Trace UI shows terminal status on new runs.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -q
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff check .
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff format --check .
+
+cd ../frontend
+CI=true pnpm run check
+NEXT_PUBLIC_BACKEND_BASE_URL=http://127.0.0.1:18081 \
+NEXT_PUBLIC_LANGGRAPH_BASE_URL=http://127.0.0.1:18081/api \
+DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://127.0.0.1:18081 \
+DEER_FLOW_TRUSTED_ORIGINS=http://127.0.0.1:13001,http://localhost:13001 \
+DEER_FLOW_AUTH_DISABLED=1 \
+pnpm exec next build
+```
+
+## Post-Milestone PRs
+
+These should come after PR 1-5, so the foundation is already visible and
+testable.
+
+### PR 6: Recovery And Orphan Reconciliation
+
+- Reconcile active workflows with existing run reconciliation at gateway
+  startup.
+- Mark `running` / `run_created` workflows as `orphaned` when process-local
+  execution was lost.
+- Add recovery hints in timeline responses.
+
+### PR 7: Deterministic Binding Resolver
+
+- Normalize explicit thread/run/checkpoint/source bindings.
+- Persist ambiguous candidates instead of guessing.
+- Give channel adapters a generic binding contract.
+
+### PR 8: Channel And Dashboard Intake Adoption
+
+- Route Slack/Discord/Telegram-style adapters through workflow intake.
+- Use stable external message ids as idempotency keys.
+- Keep channel UX compatible.
+
+### PR 9: Durable Waiting And Resume Refs
+
+- Represent LangGraph interrupt waits as durable workflow state.
+- Route resume commands through workflow intake.
+- Keep actual interrupt payloads in LangGraph checkpoint state.
+
+### PR 10: Worker Pool Readiness
+
+- Add worker identity and lease renewal.
+- Add a claim loop abstraction behind a feature flag.
+- Keep gateway process execution as the default mode.
+
+## Next Module Tracks
+
+The following tracks should remain separate from the runtime PRs:
+
+- Work Module: generic Work Unit records and external PM mappings.
+- WorkBoard: built-in board UI for deployments without a PM tool.
+- Workflow Designer: visual workflow definition authoring and versioning.
+- Optional orchestrator adapters: Restate, Temporal, Hatchet integration
+  examples, not hard dependencies.
+
+## Module PRs After Runtime
+
+These PRs depend on the runtime identity/event foundation but should not be
+required for a minimal durable runtime deployment.
+
+### PR 11: Work Module Schema And API
+
+- Add `DEERFLOW_WORK_MODULE.md`.
+- Add `work_units` and `work_events` schema/migration.
+- Add memory and SQL stores.
+- Add `/api/work-units` CRUD and event list endpoints.
+- Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
+
+### PR 12: WorkBoard MVP
+
+- Add `/workspace/work`.
+- Show Trello-style columns over `work_units.status`.
+- Create local work units.
+- Show runtime-driven status projection; local human-created work starts in
+  `backlog`.
+- Link cards to chat threads and workflow traces when refs exist.
+
+### PR 13: External PM Binding Contract
+
+- Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
+  objects.
+- Add external ref/url/source conventions.
+- Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
+
+### PR 14: Work Gates And Criteria
+
+- Add acceptance criteria and lightweight human gates.
+- Link gates to runtime `waiting` workflows where appropriate.
+- Keep LangGraph interrupt payloads in LangGraph checkpoint state.
+
+### PR 15: Agent Workflow Definition Plane
+
+- Add Agent Workflow DSL schema/validation.
+- Add definition/version persistence.
+- Add visual designer under a feature flag.
+- Compile from DeerFlow DSL to LangGraph/runtime plans, not from editor JSON.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -256,7 +256,17 @@ required for a minimal durable runtime deployment.
 - Add `/api/work-units` CRUD and event list endpoints.
 - Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
 
-### PR 12: WorkBoard MVP
+### PR 12: Work Unit Agent Tools
+
+- Expose `work_units` when `modules.work.enabled=true`.
+- Let agents create, list, inspect, and update Work Units through the generic
+  Work Module store.
+- Keep runtime-bound `work_unit` status updates scoped to the attached Work
+  Unit.
+- Record agent actions as `work_events`.
+- WorkBoard and PM adapters are not required for this PR to be useful.
+
+### PR 13: WorkBoard MVP
 
 - Add `/workspace/work`.
 - Show Trello-style columns over `work_units.status`.
@@ -265,20 +275,20 @@ required for a minimal durable runtime deployment.
   `backlog`.
 - Link cards to chat threads and workflow traces when refs exist.
 
-### PR 13: External PM Binding Contract
+### PR 14: External PM Binding Contract
 
 - Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
   objects.
 - Add external ref/url/source conventions.
 - Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
 
-### PR 14: Work Gates And Criteria
+### PR 15: Work Gates And Criteria
 
 - Add acceptance criteria and lightweight human gates.
 - Link gates to runtime `waiting` workflows where appropriate.
 - Keep LangGraph interrupt payloads in LangGraph checkpoint state.
 
-### PR 15: Agent Workflow Definition Plane
+### PR 16: Agent Workflow Definition Plane
 
 - Add Agent Workflow DSL schema/validation.
 - Add definition/version persistence.

--- a/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
+++ b/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
@@ -1,0 +1,450 @@
+# Durable Workflow Runtime Plan
+
+Status: implementation plan
+Date: 2026-06-26
+Scope: first-priority PR stack for DeerFlow durable workflow runtime, shared identity, workflow events, and runtime adoption
+
+## Relationship To Platform Plan
+
+This plan is the focused execution track for the Durable Workflow Runtime plane
+in [Durable Agent Platform Plan](DURABLE_AGENT_PLATFORM_PLAN.md). It should land
+before the Agent Workflow Definition, Compiler/Run Binding, Work Module,
+WorkBoard, and PM adapter tracks depend on it.
+
+The runtime layer is the shared foundation because it gives all later modules a
+stable way to answer:
+
+- what external request/message arrived;
+- whether it was already accepted;
+- which DeerFlow thread/run/checkpoint it bound to;
+- who claimed execution;
+- whether it is running, waiting, terminal, retryable, or orphaned;
+- which lifecycle and run events explain what happened.
+
+## Core Standardization Goals
+
+### Shared Identity Model
+
+Standardize these names before expanding module surface area:
+
+- `workflow_id`: durable frontdoor envelope id for one inbound command/message.
+- `workflow_event_id`: append-only lifecycle fact id.
+- `workflow_definition_id`: design-time workflow definition id; not owned by
+  this runtime plan, but reserved now to avoid name collisions.
+- `workflow_definition_version`: immutable design snapshot version/id.
+- `workflow_run_id`: execution of a designed workflow; later compiler/run
+  binding plane.
+- `thread_id`: LangGraph/DeerFlow thread id.
+- `run_id`: DeerFlow run id.
+- `checkpoint_ns`: LangGraph checkpoint namespace.
+- `checkpoint_id`: LangGraph checkpoint ref.
+- `step_id`: designed workflow node/step id; reserved for later projection.
+- `work_unit_id`: generic task/card/issue id; Work module, not runtime core.
+- `external_binding_id`: PM/external object mapping id; Work module/adapters.
+
+Runtime core owns `workflow_id` and `workflow_event_id`. It may store refs to
+the other ids, but it must not require the modules that own them.
+
+### Status Contracts
+
+Initial workflow statuses:
+
+- `received`: intake persisted, not yet resolved/claimed.
+- `bound`: deterministic thread/checkpoint binding resolved.
+- `claimed`: worker/process lease acquired.
+- `run_created`: DeerFlow run row created.
+- `running`: bound run is executing.
+- `waiting`: run/workflow is paused for interrupt, human input, external event,
+  or safe retry time.
+- `succeeded`: terminal success.
+- `failed`: terminal failure.
+- `cancelled`: terminal cancellation.
+- `orphaned`: previous executor is gone and automatic safe resume is not known.
+- `ignored`: accepted and intentionally not executed.
+
+These statuses are a public runtime contract. Later modules can project their
+own statuses from them, but should not redefine runtime meaning.
+
+### Event Contract
+
+`workflows` is the mutable latest projection. `workflow_events` is the
+append-only lifecycle log.
+
+`workflow_events` should record DeerFlow runtime facts such as:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+It should reference `run_events` by `(thread_id, run_id, run_event_seq)` rather
+than copying low-level execution events. Timeline APIs merge workflow lifecycle
+facts with `RunEventStore` rows at query time.
+
+### LangGraph Boundary
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint state values;
+- checkpoint writes and pending writes;
+- graph-local memory;
+- interrupt/resume mechanics;
+- replay from checkpoints.
+
+DeerFlow runtime owns:
+
+- intake identity;
+- idempotency;
+- source/channel refs;
+- deterministic thread/run/checkpoint binding records;
+- worker lease and retry metadata;
+- startup reconciliation;
+- lifecycle events and runtime correlation.
+
+The runtime layer stores refs to LangGraph state, never checkpoint payloads.
+
+## Minimal Data Model
+
+### `workflows`
+
+Purpose: durable intake envelope and latest runtime projection.
+
+Minimum fields:
+
+- `workflow_id`
+- `workflow_kind`
+- `source_type`
+- `source`
+- `external_message_ref`
+- `conversation_ref`
+- `thread_ref`
+- `sender_ref`
+- `idempotency_key`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `status`
+- `attempt_count`
+- `max_attempts`
+- `next_attempt_at`
+- `lease_owner`
+- `lease_expires_at`
+- `error`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+Indexes:
+
+- unique idempotency scope, initially `(source_type, source, idempotency_key)`
+  when `idempotency_key` is present;
+- `(status, next_attempt_at, lease_expires_at)` for claiming/recovery;
+- `(thread_id, run_id)`;
+- `(source_type, source, conversation_ref)`;
+- `updated_at`.
+
+### `workflow_events`
+
+Purpose: append-only lifecycle facts for audit, recovery, and timeline APIs.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Indexes:
+
+- unique `(workflow_id, seq)`;
+- `(workflow_id, created_at)`;
+- `(thread_id, run_id, run_event_seq)`;
+- `(event_type, created_at)`.
+
+## Store Contracts
+
+The runtime store should work with in-memory tests, SQLite local dev, and
+Postgres production.
+
+Required methods:
+
+- `create_or_get`: idempotent intake.
+- `append_event`: append a lifecycle event with monotonic per-workflow seq.
+- `get`: fetch workflow projection.
+- `list`: filter by status, source, thread, run, and updated time.
+- `update_status`: mutate projection and append lifecycle event.
+- `bind_runtime`: attach `thread_id`, `run_id`, checkpoint refs.
+- `claim_next`: atomically lease eligible workflow.
+- `renew_lease`: extend active ownership for long execution.
+- `release_for_retry`: clear lease and schedule next attempt.
+- `mark_orphaned`: terminal or recoverable orphan projection.
+- `timeline`: merge workflow events and run events.
+
+Postgres should use row-level locking and `SKIP LOCKED` for `claim_next`. SQLite
+can use a conservative transaction path suitable for local/single-process
+development.
+
+## PR Stack
+
+The stack is ordered so later PRs are optional expansions. If review stops at a
+given prefix, the runtime should still be useful at that maturity level. The
+first upstream-ready community demo should include PR 1 through PR 5: by then a
+normal DeerFlow run has a durable workflow identity, idempotent intake, and a
+visible run trace that explains what happened.
+
+- PR 1-2: schema/store foundation.
+- PR 1-3: durable envelope plus lifecycle events.
+- PR 1-4: observable Durable Run Trace for operators and users.
+- PR 1-5: existing run APIs create and update workflow envelopes.
+- PR 1-6: restart/orphan behavior is production-visible.
+- PR 1-8: universal API/dashboard/channel frontdoor.
+- PR 1-9: durable human-in-the-loop.
+- PR 1-10: horizontal worker readiness.
+
+### Community Value Milestone
+
+The first PR stack proposed upstream should not stop at invisible primitives.
+It should include enough surface area that a DeerFlow user or operator can see
+the benefit during normal chat/run usage:
+
+- every run created through existing run APIs has a `workflow_id`;
+- repeated client/channel retries with the same idempotency key do not create a
+  duplicate run;
+- the workflow can be found from `run_id` or `thread_id`;
+- the trace shows intake, run creation, running state, and terminal
+  success/failure/cancellation;
+- the trace links workflow lifecycle events with the existing run event stream
+  without copying LangGraph checkpoint payloads.
+
+This milestone is still runtime-only. It intentionally does not include Work
+Units, WorkBoard, PM adapters, visual workflow design, or an external durable
+engine dependency.
+
+### PR 1: Runtime Architecture and Shared Contracts
+
+Scope:
+
+- Add this plan.
+- Link it from the platform plan and docs index.
+- Align terminology with `DURABLE_WORKFLOW_FRONTDOOR.md`.
+
+Acceptance:
+
+- docs distinguish `workflow_id`, `workflow_definition_id`, and
+  `workflow_run_id`;
+- docs define initial runtime statuses and event contract;
+- no runtime behavior changes.
+
+### PR 2: Workflow Envelope Schema and Store
+
+Scope:
+
+- Add runtime enums for workflow kind/source/status.
+- Add `workflows` ORM model and migration.
+- Add in-memory and SQL store implementations.
+- Implement `create_or_get`, `get`, `list`, `update_status`,
+  `bind_runtime`, `claim_next`, and `release_for_retry`.
+- Wire store dependency without changing endpoint behavior.
+
+Acceptance:
+
+- idempotent create returns existing workflow for duplicate key;
+- lease claim is atomic under SQL store;
+- existing run APIs and channels behave unchanged;
+- tests cover memory and SQL store behavior.
+
+### PR 3: Workflow Events
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event`.
+- Emit events for create/dedupe/status/bind/claim/retry.
+- Add event list and timeline projection helpers.
+
+Acceptance:
+
+- every projection mutation can append a lifecycle fact;
+- event seq is monotonic per workflow;
+- timeline can include workflow events even before a run exists;
+- no run event duplication.
+
+### PR 4: Durable Run Trace APIs
+
+Scope:
+
+- Add read-only gateway endpoints for workflow envelopes and run traces.
+- Add filters by status, source, thread, run, and updated time.
+- Add a timeline endpoint that merges workflow lifecycle facts with existing
+  `RunEventStore` rows at query time.
+- Add run-to-workflow lookup so existing clients can discover the durable
+  workflow for a run.
+- Include idempotency/source refs, runtime refs, terminal status, and recovery
+  hints in responses.
+
+Acceptance:
+
+- operators can query active, waiting, failed, orphaned, and terminal
+  workflows;
+- users and developers can inspect a normal chat/run and see the durable trace;
+- one workflow timeline correlates workflow lifecycle events with run events;
+- endpoint additions do not alter existing run API compatibility.
+
+### PR 5: Run API Compatibility Wrapper and Status Projection
+
+Scope:
+
+- Wrap existing `/runs` and `/threads/{thread_id}/runs` paths with workflow
+  intake when enabled.
+- Create workflow envelope before `start_run`.
+- Bind `thread_id`, `run_id`, and checkpoint refs after run creation.
+- Project run lifecycle into workflow lifecycle (`running`, `succeeded`,
+  `failed`, `cancelled`) without making LangGraph checkpoint state secondary.
+- Preserve existing request/response behavior for clients.
+
+Acceptance:
+
+- old clients can ignore `workflow_id`;
+- new clients can find the workflow for a created run;
+- duplicate idempotency keys do not create duplicate runs when policy says
+  dedupe;
+- workflow terminal status matches the bound run terminal status;
+- tests cover direct run creation.
+
+### PR 6: Recovery and Reconciliation
+
+Scope:
+
+- Reconcile active workflow envelopes with existing run reconciliation.
+- Mark orphaned workflows explicitly when process-local execution was lost.
+- Requeue only workflows that are safe by idempotency/source policy.
+- Record `lease_expired`, `orphaned`, and `retry_scheduled` events.
+
+Acceptance:
+
+- restart behavior is explicit and queryable;
+- no workflow is silently left `running` without an owner;
+- automatic retry is conservative and policy-driven.
+
+### PR 7: Deterministic Binding Resolver
+
+Scope:
+
+- Add generic resolver for explicit `thread_id`, external conversation refs,
+  checkpoint refs, and active run binding.
+- Record ambiguous candidates in metadata.
+- Do not use semantic guessing in adapters.
+
+Acceptance:
+
+- explicit thread/checkpoint ids win;
+- unambiguous channel conversation mappings bind deterministically;
+- ambiguous cases are persisted and surfaced, not guessed.
+
+### PR 8: Channel and Dashboard Intake Adoption
+
+Scope:
+
+- Route channel adapters through workflow intake.
+- Route dashboard/API chat messages through workflow intake where applicable.
+- Normalize source refs and idempotency keys for channels.
+
+Acceptance:
+
+- Slack/Discord/Telegram-style messages produce workflow envelopes;
+- channel retries dedupe by stable external event/message ids;
+- channel behavior remains compatible for users.
+
+### PR 9: Waiting, Resume, and Human-In-The-Loop Refs
+
+Scope:
+
+- Add generic waiting metadata conventions for LangGraph interrupts and external
+  human input.
+- Route resume messages through workflow intake.
+- Bind resume workflows to `thread_id`, checkpoint refs, and parent workflow
+  metadata.
+
+Acceptance:
+
+- interrupted runs surface as `waiting`;
+- resume creates/uses a durable workflow envelope;
+- LangGraph remains owner of interrupt/resume state.
+
+### PR 10: Worker Pool Readiness
+
+Scope:
+
+- Add lease renewal.
+- Add configurable worker identity.
+- Add claim loop abstraction behind feature flag or internal API.
+- Keep gateway process execution as the default path.
+
+Acceptance:
+
+- Postgres deployments have a clear horizontal worker contract;
+- local SQLite/default deployments remain simple;
+- no mandatory external orchestrator dependency.
+
+## First Implementation Slice
+
+The safest first implementation slice is PR 1 plus PR 2 without runtime
+adoption:
+
+- docs and shared contracts;
+- `workflows` schema/store;
+- idempotent create;
+- lease primitives;
+- run/checkpoint binding fields;
+- focused repository tests.
+
+This creates the durable foundation without changing existing run/channel
+behavior. PR 3 should follow quickly because `workflow_events` is the audit and
+timeline foundation for enterprise operation.
+
+For the first community-visible stack, continue through PR 5 before opening the
+main upstream discussion. PR 4 makes the runtime inspectable as a Durable Run
+Trace. PR 5 makes existing DeerFlow run APIs update that trace through terminal
+status. PR 6 and later are important for production hardening, but PR 1-5 is
+the smallest stack that lets a normal user see value without installing a Work
+Module, WorkBoard, or external orchestrator.
+
+## Defer Explicitly
+
+Do not include in the runtime-first stack:
+
+- Agent Workflow DSL persistence;
+- visual designer UI;
+- Work Unit schemas;
+- WorkBoard;
+- PM adapters;
+- Restate/Temporal/Hatchet dependencies;
+- AICOS-X concepts;
+- checkpoint value copies;
+- generic deterministic code replay.
+
+These become easier and cleaner after the runtime identity, status, event, and
+binding contracts are stable.

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -17,6 +17,9 @@ This directory contains detailed documentation for the DeerFlow backend.
 | Document | Description |
 |----------|-------------|
 | [STREAMING.md](STREAMING.md) | Token-level streaming design: Gateway vs DeerFlowClient paths, `stream_mode` semantics, per-id dedup |
+| [DURABLE_WORKFLOW_RUNTIME_PLAN.md](DURABLE_WORKFLOW_RUNTIME_PLAN.md) | Runtime-first PR plan for workflow identity, status, events, idempotency, lease, and recovery |
+| [DURABLE_WORKFLOW_FRONTDOOR.md](DURABLE_WORKFLOW_FRONTDOOR.md) | Durable workflow intake/frontdoor architecture and PR stack |
+| [DURABLE_WORKFLOW_PR_STACK.md](DURABLE_WORKFLOW_PR_STACK.md) | Prefix-safe upstream PR sequence for durable runtime, recovery, intake, and worker readiness |
 | [FILE_UPLOAD.md](FILE_UPLOAD.md) | File upload functionality |
 | [PATH_EXAMPLES.md](PATH_EXAMPLES.md) | Path types and usage examples |
 | [SANDBOX_MEMORY_PROFILING.md](SANDBOX_MEMORY_PROFILING.md) | Sandbox memory baseline and runtime comparison guide |
@@ -52,6 +55,9 @@ docs/
 ├── summarization.md           # Summarization feature
 ├── plan_mode_usage.md         # Plan mode feature
 ├── STREAMING.md               # Token-level streaming design
+├── DURABLE_WORKFLOW_RUNTIME_PLAN.md # Runtime-first durable workflow PR plan
+├── DURABLE_WORKFLOW_FRONTDOOR.md # Durable workflow frontdoor design
+├── DURABLE_WORKFLOW_PR_STACK.md # Prefix-safe durable runtime PR sequence
 ├── AUTO_TITLE_GENERATION.md   # Title generation
 ├── TITLE_GENERATION_IMPLEMENTATION.md  # Title implementation details
 └── TODO.md                    # Roadmap and issues

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -20,6 +20,7 @@ This directory contains detailed documentation for the DeerFlow backend.
 | [DURABLE_WORKFLOW_RUNTIME_PLAN.md](DURABLE_WORKFLOW_RUNTIME_PLAN.md) | Runtime-first PR plan for workflow identity, status, events, idempotency, lease, and recovery |
 | [DURABLE_WORKFLOW_FRONTDOOR.md](DURABLE_WORKFLOW_FRONTDOOR.md) | Durable workflow intake/frontdoor architecture and PR stack |
 | [DURABLE_WORKFLOW_PR_STACK.md](DURABLE_WORKFLOW_PR_STACK.md) | Prefix-safe upstream PR sequence for durable runtime, recovery, intake, and worker readiness |
+| [DEERFLOW_WORK_MODULE.md](DEERFLOW_WORK_MODULE.md) | Generic work unit module for agent and PM-tool integration |
 | [FILE_UPLOAD.md](FILE_UPLOAD.md) | File upload functionality |
 | [PATH_EXAMPLES.md](PATH_EXAMPLES.md) | Path types and usage examples |
 | [SANDBOX_MEMORY_PROFILING.md](SANDBOX_MEMORY_PROFILING.md) | Sandbox memory baseline and runtime comparison guide |
@@ -58,6 +59,7 @@ docs/
 ├── DURABLE_WORKFLOW_RUNTIME_PLAN.md # Runtime-first durable workflow PR plan
 ├── DURABLE_WORKFLOW_FRONTDOOR.md # Durable workflow frontdoor design
 ├── DURABLE_WORKFLOW_PR_STACK.md # Prefix-safe durable runtime PR sequence
+├── DEERFLOW_WORK_MODULE.md    # Generic work unit module plan
 ├── AUTO_TITLE_GENERATION.md   # Title generation
 ├── TITLE_GENERATION_IMPLEMENTATION.md  # Title implementation details
 └── TODO.md                    # Roadmap and issues

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -45,6 +45,7 @@ from deerflow.config.app_config import AppConfig, get_app_config
 from deerflow.models import create_chat_model
 from deerflow.skills.tool_policy import filter_tools_by_skill_allowed_tools
 from deerflow.skills.types import Skill
+from deerflow.tools.builtins.work_unit_tool import build_work_unit_tool
 from deerflow.tracing import build_tracing_callbacks
 
 logger = logging.getLogger(__name__)
@@ -527,9 +528,21 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     # Custom agents can update their own SOUL.md / config via update_agent.
     # The default agent (no agent_name) does not see this tool.
     extra_tools = [update_agent] if agent_name else []
+    runtime_tools = []
+    bound_work_unit_id = str(cfg.get("work_unit_id") or "").strip()
+    if bound_work_unit_id and resolved_app_config.modules.work.enabled:
+        runtime_tools.append(
+            build_work_unit_tool(
+                work_unit_id=bound_work_unit_id,
+                actor_ref=f"agent:{agent_name or 'lead_agent'}",
+                user_id=str(cfg.get("user_id") or "") or None,
+                workflow_id=str(cfg.get("workflow_id") or "") or None,
+                run_id=str(cfg.get("run_id") or "") or None,
+            )
+        )
     # Default lead agent (unchanged behavior)
     raw_tools = get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled, app_config=resolved_app_config)
-    filtered = filter_tools_by_skill_allowed_tools(raw_tools + extra_tools, skills_for_tool_policy)
+    filtered = filter_tools_by_skill_allowed_tools(raw_tools + extra_tools, skills_for_tool_policy) + runtime_tools
     final_tools, setup = assemble_deferred_tools(filtered, enabled=resolved_app_config.tool_search.enabled)
     return create_agent(
         model=create_chat_model(name=model_name, thinking_enabled=thinking_enabled, reasoning_effort=reasoning_effort, app_config=resolved_app_config, attach_tracing=False),

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -21,6 +21,7 @@ from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_
 from deerflow.config.loop_detection_config import LoopDetectionConfig
 from deerflow.config.memory_config import MemoryConfig, load_memory_config_from_dict
 from deerflow.config.model_config import ModelConfig
+from deerflow.config.modules_config import ModulesConfig
 from deerflow.config.reload_boundary import format_field_description
 from deerflow.config.run_events_config import RunEventsConfig
 from deerflow.config.runtime_paths import existing_project_file
@@ -133,6 +134,13 @@ class AppConfig(BaseModel):
     loop_detection: LoopDetectionConfig = Field(default_factory=LoopDetectionConfig, description="Loop detection middleware configuration")
     safety_finish_reason: SafetyFinishReasonConfig = Field(default_factory=SafetyFinishReasonConfig, description="Provider safety-filter finish_reason interception middleware configuration")
     auth: AuthAppConfig = Field(default_factory=AuthAppConfig, description="Authentication configuration (local + OIDC SSO)")
+    modules: ModulesConfig = Field(
+        default_factory=ModulesConfig,
+        description=format_field_description(
+            "modules",
+            field_doc="Optional DeerFlow module gates for durable workflow runtime primitives.",
+        ),
+    )
     model_config = ConfigDict(extra="allow")
     database: DatabaseConfig = Field(
         default_factory=DatabaseConfig,

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -138,7 +138,7 @@ class AppConfig(BaseModel):
         default_factory=ModulesConfig,
         description=format_field_description(
             "modules",
-            field_doc="Optional DeerFlow module gates for durable workflow runtime primitives.",
+            field_doc="Optional DeerFlow module gates for durable workflows and generic work units.",
         ),
     )
     model_config = ConfigDict(extra="allow")

--- a/backend/packages/harness/deerflow/config/modules_config.py
+++ b/backend/packages/harness/deerflow/config/modules_config.py
@@ -13,11 +13,20 @@ class DurableWorkflowsConfig(BaseModel):
     auto_envelope_for_runs: bool = Field(default=True, description="Automatically bind API-created runs to workflow envelopes.")
 
 
+class WorkModuleConfig(BaseModel):
+    """Generic work unit module switches."""
+
+    enabled: bool = Field(default=True, description="Enable generic work unit storage and API support.")
+    api_enabled: bool = Field(default=True, description="Expose generic work unit APIs.")
+
+
 class ModulesConfig(BaseModel):
     """Feature gates for optional DeerFlow modules.
 
-    This module is intentionally small in the durable workflow runtime stack.
-    Higher-level modules can extend it with their own feature gates later.
+    The gates intentionally separate runtime primitives from generic work-unit
+    records. UI surfaces and PM-tool adapters can extend this config later
+    without being required by the durable runtime layer.
     """
 
     durable_workflows: DurableWorkflowsConfig = Field(default_factory=DurableWorkflowsConfig)
+    work: WorkModuleConfig = Field(default_factory=WorkModuleConfig)

--- a/backend/packages/harness/deerflow/config/modules_config.py
+++ b/backend/packages/harness/deerflow/config/modules_config.py
@@ -1,0 +1,23 @@
+"""Optional DeerFlow module configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DurableWorkflowsConfig(BaseModel):
+    """Durable workflow runtime envelope and observability switches."""
+
+    enabled: bool = Field(default=True, description="Create durable workflow envelopes around run execution.")
+    api_enabled: bool = Field(default=True, description="Expose durable workflow read APIs.")
+    auto_envelope_for_runs: bool = Field(default=True, description="Automatically bind API-created runs to workflow envelopes.")
+
+
+class ModulesConfig(BaseModel):
+    """Feature gates for optional DeerFlow modules.
+
+    This module is intentionally small in the durable workflow runtime stack.
+    Higher-level modules can extend it with their own feature gates later.
+    """
+
+    durable_workflows: DurableWorkflowsConfig = Field(default_factory=DurableWorkflowsConfig)

--- a/backend/packages/harness/deerflow/config/reload_boundary.py
+++ b/backend/packages/harness/deerflow/config/reload_boundary.py
@@ -59,6 +59,9 @@ STARTUP_ONLY_FIELDS: dict[str, str] = {
     "channel_connections": (
         "start_channel_service() wires the connection repository and channel workers once at startup, and the channel-connections router caches the merged provider config on app.state; channel_connections.* edits need a restart."
     ),
+    "modules": (
+        "create_app() and langgraph_runtime() mount optional routers and construct module stores once at startup; module gates need a restart."
+    ),
 }
 
 

--- a/backend/packages/harness/deerflow/persistence/engine.py
+++ b/backend/packages/harness/deerflow/persistence/engine.py
@@ -75,6 +75,10 @@ async def init_engine(
     global _engine, _session_factory
 
     if backend == "memory":
+        if _engine is not None:
+            await _engine.dispose()
+        _engine = None
+        _session_factory = None
         logger.info("Persistence backend=memory -- ORM engine not initialized")
         return
 

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0003_workflows.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0003_workflows.py
@@ -1,0 +1,88 @@
+"""Add workflow frontdoor envelope table.
+
+Revision ID: 0003_workflows
+Revises: 0002_runs_token_usage
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_workflows"
+down_revision: str | Sequence[str] | None = "0002_runs_token_usage"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if _table_exists("workflows"):
+        return
+    op.create_table(
+        "workflows",
+        sa.Column("workflow_id", sa.String(length=64), nullable=False),
+        sa.Column("workflow_kind", sa.String(length=32), nullable=False),
+        sa.Column("source_type", sa.String(length=32), nullable=False),
+        sa.Column("source", sa.String(length=128), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=256), nullable=True),
+        sa.Column("external_message_ref", sa.Text(), nullable=True),
+        sa.Column("conversation_ref", sa.Text(), nullable=True),
+        sa.Column("thread_ref", sa.Text(), nullable=True),
+        sa.Column("sender_ref", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.String(length=64), nullable=True),
+        sa.Column("thread_id", sa.String(length=64), nullable=True),
+        sa.Column("run_id", sa.String(length=64), nullable=True),
+        sa.Column("checkpoint_ns", sa.String(length=256), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=128), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("max_attempts", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lease_owner", sa.String(length=128), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("workflow_id"),
+    )
+    with op.batch_alter_table("workflows", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_workflows_run_id"), ["run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_source"), ["source"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_status"), ["status"], unique=False)
+        batch_op.create_index("ix_workflows_claimable", ["status", "next_attempt_at", "lease_expires_at"], unique=False)
+        batch_op.create_index("ix_workflows_status_updated", ["status", "updated_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_thread_id"), ["thread_id"], unique=False)
+        batch_op.create_index("ix_workflows_thread_run", ["thread_id", "run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_user_id"), ["user_id"], unique=False)
+        batch_op.create_index(
+            "uq_workflows_source_idempotency",
+            ["source_type", "source", "idempotency_key"],
+            unique=True,
+            sqlite_where=sa.text("idempotency_key IS NOT NULL"),
+            postgresql_where=sa.text("idempotency_key IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists("workflows"):
+        return
+    with op.batch_alter_table("workflows", schema=None) as batch_op:
+        batch_op.drop_index("uq_workflows_source_idempotency")
+        batch_op.drop_index(batch_op.f("ix_workflows_user_id"))
+        batch_op.drop_index("ix_workflows_thread_run")
+        batch_op.drop_index(batch_op.f("ix_workflows_thread_id"))
+        batch_op.drop_index("ix_workflows_status_updated")
+        batch_op.drop_index("ix_workflows_claimable")
+        batch_op.drop_index(batch_op.f("ix_workflows_status"))
+        batch_op.drop_index(batch_op.f("ix_workflows_source"))
+        batch_op.drop_index(batch_op.f("ix_workflows_run_id"))
+    op.drop_table("workflows")

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0004_workflow_events.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0004_workflow_events.py
@@ -1,0 +1,73 @@
+"""Add workflow event timeline table.
+
+Revision ID: 0004_workflow_events
+Revises: 0003_workflows
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_workflow_events"
+down_revision: str | Sequence[str] | None = "0003_workflows"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if _table_exists("workflow_events"):
+        return
+    op.create_table(
+        "workflow_events",
+        sa.Column("workflow_event_id", sa.String(length=64), nullable=False),
+        sa.Column("workflow_id", sa.String(length=64), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("category", sa.String(length=32), nullable=False),
+        sa.Column("thread_id", sa.String(length=64), nullable=True),
+        sa.Column("run_id", sa.String(length=64), nullable=True),
+        sa.Column("checkpoint_ns", sa.String(length=256), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=128), nullable=True),
+        sa.Column("run_event_seq", sa.Integer(), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=256), nullable=True),
+        sa.Column("source_event_ref", sa.Text(), nullable=True),
+        sa.Column("content_json", sa.JSON(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["workflow_id"], ["workflows.workflow_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("workflow_event_id"),
+        sa.UniqueConstraint("workflow_id", "seq", name="uq_workflow_events_workflow_seq"),
+    )
+    with op.batch_alter_table("workflow_events", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_workflow_events_category"), ["category"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_event_type"), ["event_type"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_run_id"), ["run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_thread_id"), ["thread_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_workflow_id"), ["workflow_id"], unique=False)
+        batch_op.create_index("ix_workflow_events_thread_run_seq", ["thread_id", "run_id", "run_event_seq"], unique=False)
+        batch_op.create_index("ix_workflow_events_workflow_created", ["workflow_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    if not _table_exists("workflow_events"):
+        return
+    with op.batch_alter_table("workflow_events", schema=None) as batch_op:
+        batch_op.drop_index("ix_workflow_events_workflow_created")
+        batch_op.drop_index("ix_workflow_events_thread_run_seq")
+        batch_op.drop_index(batch_op.f("ix_workflow_events_workflow_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_thread_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_run_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_event_type"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_created_at"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_category"))
+    op.drop_table("workflow_events")

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0005_work_units.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0005_work_units.py
@@ -1,0 +1,131 @@
+"""Add work unit module tables.
+
+Revision ID: 0005_work_units
+Revises: 0004_workflow_events
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_work_units"
+down_revision: str | Sequence[str] | None = "0004_workflow_events"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade() -> None:
+    if not _table_exists("work_units"):
+        op.create_table(
+            "work_units",
+            sa.Column("work_unit_id", sa.String(length=64), nullable=False),
+            sa.Column("title", sa.String(length=300), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("status", sa.String(length=32), nullable=False),
+            sa.Column("priority", sa.String(length=8), nullable=False),
+            sa.Column("assignee_ref", sa.String(length=256), nullable=True),
+            sa.Column("reporter_ref", sa.String(length=256), nullable=True),
+            sa.Column("due_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("user_id", sa.String(length=64), nullable=True),
+            sa.Column("workflow_id", sa.String(length=64), nullable=True),
+            sa.Column("thread_id", sa.String(length=64), nullable=True),
+            sa.Column("run_id", sa.String(length=64), nullable=True),
+            sa.Column("source_type", sa.String(length=32), nullable=False),
+            sa.Column("source", sa.String(length=128), nullable=True),
+            sa.Column("external_type", sa.String(length=64), nullable=True),
+            sa.Column("external_ref", sa.String(length=512), nullable=True),
+            sa.Column("external_url", sa.Text(), nullable=True),
+            sa.Column("labels_json", sa.JSON(), nullable=False),
+            sa.Column("metadata_json", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("work_unit_id"),
+        )
+        with op.batch_alter_table("work_units", schema=None) as batch_op:
+            batch_op.create_index(batch_op.f("ix_work_units_assignee_ref"), ["assignee_ref"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_due_at"), ["due_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_external_type"), ["external_type"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_priority"), ["priority"], unique=False)
+            batch_op.create_index("ix_work_units_priority_updated", ["priority", "updated_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_run_id"), ["run_id"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_source"), ["source"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_source_type"), ["source_type"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_status"), ["status"], unique=False)
+            batch_op.create_index("ix_work_units_status_updated", ["status", "updated_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_thread_id"), ["thread_id"], unique=False)
+            batch_op.create_index("ix_work_units_thread_run", ["thread_id", "run_id"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_user_id"), ["user_id"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_units_workflow_id"), ["workflow_id"], unique=False)
+            batch_op.create_index(
+                "uq_work_units_external_ref",
+                ["source_type", "source", "external_ref"],
+                unique=True,
+                sqlite_where=sa.text("external_ref IS NOT NULL"),
+                postgresql_where=sa.text("external_ref IS NOT NULL"),
+            )
+
+    if not _table_exists("work_events"):
+        op.create_table(
+            "work_events",
+            sa.Column("work_event_id", sa.String(length=64), nullable=False),
+            sa.Column("work_unit_id", sa.String(length=64), nullable=False),
+            sa.Column("seq", sa.Integer(), nullable=False),
+            sa.Column("event_type", sa.String(length=64), nullable=False),
+            sa.Column("actor_ref", sa.String(length=256), nullable=True),
+            sa.Column("workflow_id", sa.String(length=64), nullable=True),
+            sa.Column("run_id", sa.String(length=64), nullable=True),
+            sa.Column("content_json", sa.JSON(), nullable=True),
+            sa.Column("metadata_json", sa.JSON(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.ForeignKeyConstraint(["work_unit_id"], ["work_units.work_unit_id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("work_event_id"),
+            sa.UniqueConstraint("work_unit_id", "seq", name="uq_work_events_unit_seq"),
+        )
+        with op.batch_alter_table("work_events", schema=None) as batch_op:
+            batch_op.create_index(batch_op.f("ix_work_events_created_at"), ["created_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_events_event_type"), ["event_type"], unique=False)
+            batch_op.create_index("ix_work_events_unit_created", ["work_unit_id", "created_at"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_events_run_id"), ["run_id"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_events_work_unit_id"), ["work_unit_id"], unique=False)
+            batch_op.create_index(batch_op.f("ix_work_events_workflow_id"), ["workflow_id"], unique=False)
+
+
+def downgrade() -> None:
+    if _table_exists("work_events"):
+        with op.batch_alter_table("work_events", schema=None) as batch_op:
+            batch_op.drop_index(batch_op.f("ix_work_events_workflow_id"))
+            batch_op.drop_index(batch_op.f("ix_work_events_work_unit_id"))
+            batch_op.drop_index(batch_op.f("ix_work_events_run_id"))
+            batch_op.drop_index("ix_work_events_unit_created")
+            batch_op.drop_index(batch_op.f("ix_work_events_event_type"))
+            batch_op.drop_index(batch_op.f("ix_work_events_created_at"))
+        op.drop_table("work_events")
+
+    if _table_exists("work_units"):
+        with op.batch_alter_table("work_units", schema=None) as batch_op:
+            batch_op.drop_index("uq_work_units_external_ref")
+            batch_op.drop_index(batch_op.f("ix_work_units_workflow_id"))
+            batch_op.drop_index(batch_op.f("ix_work_units_user_id"))
+            batch_op.drop_index("ix_work_units_thread_run")
+            batch_op.drop_index(batch_op.f("ix_work_units_thread_id"))
+            batch_op.drop_index("ix_work_units_status_updated")
+            batch_op.drop_index(batch_op.f("ix_work_units_status"))
+            batch_op.drop_index(batch_op.f("ix_work_units_source_type"))
+            batch_op.drop_index(batch_op.f("ix_work_units_source"))
+            batch_op.drop_index(batch_op.f("ix_work_units_run_id"))
+            batch_op.drop_index("ix_work_units_priority_updated")
+            batch_op.drop_index(batch_op.f("ix_work_units_priority"))
+            batch_op.drop_index(batch_op.f("ix_work_units_external_type"))
+            batch_op.drop_index(batch_op.f("ix_work_units_due_at"))
+            batch_op.drop_index(batch_op.f("ix_work_units_assignee_ref"))
+        op.drop_table("work_units")

--- a/backend/packages/harness/deerflow/persistence/models/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/models/__init__.py
@@ -8,6 +8,7 @@ The actual ORM classes have moved to entity-specific subpackages:
 - ``deerflow.persistence.run``
 - ``deerflow.persistence.feedback``
 - ``deerflow.persistence.user``
+- ``deerflow.persistence.workflow``
 
 ``RunEventRow`` remains in ``deerflow.persistence.models.run_event`` because
 its storage implementation lives in ``deerflow.runtime.events.store.db`` and
@@ -25,6 +26,7 @@ from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.persistence.run.model import RunRow
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.persistence.user.model import UserRow
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
 
 __all__ = [
     "ChannelConnectionRow",
@@ -36,4 +38,6 @@ __all__ = [
     "RunRow",
     "ThreadMetaRow",
     "UserRow",
+    "WorkflowEventRow",
+    "WorkflowRow",
 ]

--- a/backend/packages/harness/deerflow/persistence/models/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/models/__init__.py
@@ -26,6 +26,7 @@ from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.persistence.run.model import RunRow
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.persistence.user.model import UserRow
+from deerflow.persistence.work_units.model import WorkEventRow, WorkUnitRow
 from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
 
 __all__ = [
@@ -38,6 +39,8 @@ __all__ = [
     "RunRow",
     "ThreadMetaRow",
     "UserRow",
+    "WorkEventRow",
+    "WorkUnitRow",
     "WorkflowEventRow",
     "WorkflowRow",
 ]

--- a/backend/packages/harness/deerflow/persistence/work_units/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/work_units/__init__.py
@@ -1,0 +1,6 @@
+"""Persistence support for DeerFlow work units."""
+
+from deerflow.persistence.work_units.model import WorkEventRow, WorkUnitRow
+from deerflow.persistence.work_units.sql import WorkUnitRepository
+
+__all__ = ["WorkEventRow", "WorkUnitRepository", "WorkUnitRow"]

--- a/backend/packages/harness/deerflow/persistence/work_units/model.py
+++ b/backend/packages/harness/deerflow/persistence/work_units/model.py
@@ -1,0 +1,81 @@
+"""ORM models for generic work units."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+class WorkUnitRow(Base):
+    __tablename__ = "work_units"
+
+    work_unit_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    title: Mapped[str] = mapped_column(String(300), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="backlog", index=True)
+    priority: Mapped[str] = mapped_column(String(8), nullable=False, default="P2", index=True)
+
+    assignee_ref: Mapped[str | None] = mapped_column(String(256), index=True)
+    reporter_ref: Mapped[str | None] = mapped_column(String(256))
+    due_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), index=True)
+    user_id: Mapped[str | None] = mapped_column(String(64), index=True)
+
+    workflow_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    thread_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+
+    source_type: Mapped[str] = mapped_column(String(32), nullable=False, default="local", index=True)
+    source: Mapped[str | None] = mapped_column(String(128), index=True)
+    external_type: Mapped[str | None] = mapped_column(String(64), index=True)
+    external_ref: Mapped[str | None] = mapped_column(String(512))
+    external_url: Mapped[str | None] = mapped_column(Text)
+
+    labels_json: Mapped[list] = mapped_column(JSON, default=list)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        Index(
+            "uq_work_units_external_ref",
+            "source_type",
+            "source",
+            "external_ref",
+            unique=True,
+            sqlite_where=text("external_ref IS NOT NULL"),
+            postgresql_where=text("external_ref IS NOT NULL"),
+        ),
+        Index("ix_work_units_status_updated", "status", "updated_at"),
+        Index("ix_work_units_priority_updated", "priority", "updated_at"),
+        Index("ix_work_units_thread_run", "thread_id", "run_id"),
+    )
+
+
+class WorkEventRow(Base):
+    __tablename__ = "work_events"
+
+    work_event_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    work_unit_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("work_units.work_unit_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    actor_ref: Mapped[str | None] = mapped_column(String(256))
+    workflow_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    content_json: Mapped[dict | list | str | int | float | bool | None] = mapped_column(JSON)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True)
+
+    __table_args__ = (
+        UniqueConstraint("work_unit_id", "seq", name="uq_work_events_unit_seq"),
+        Index("ix_work_events_unit_created", "work_unit_id", "created_at"),
+    )

--- a/backend/packages/harness/deerflow/persistence/work_units/sql.py
+++ b/backend/packages/harness/deerflow/persistence/work_units/sql.py
@@ -1,0 +1,227 @@
+"""SQLAlchemy-backed work unit repository."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.work_units.model import WorkEventRow, WorkUnitRow
+from deerflow.work.units.store.base import WorkUnitStore
+from deerflow.utils.time import coerce_iso
+
+
+class WorkUnitRepository(WorkUnitStore):
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sf = session_factory
+
+    @staticmethod
+    def _safe_json(obj: Any) -> Any:
+        if obj is None or isinstance(obj, (str, int, float, bool)):
+            return obj
+        if isinstance(obj, dict):
+            return {k: WorkUnitRepository._safe_json(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [WorkUnitRepository._safe_json(v) for v in obj]
+        if hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        try:
+            json.dumps(obj)
+            return obj
+        except (TypeError, ValueError):
+            return str(obj)
+
+    @staticmethod
+    def _coerce_datetime(value: str | datetime | None) -> datetime | None:
+        if value is None or isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(value)
+
+    @staticmethod
+    def _row_to_dict(row: WorkUnitRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["labels"] = d.pop("labels_json", []) or []
+        d["metadata"] = d.pop("metadata_json", {}) or {}
+        for key in ("created_at", "updated_at", "due_at"):
+            val = d.get(key)
+            if isinstance(val, datetime):
+                d[key] = coerce_iso(val)
+        return d
+
+    @staticmethod
+    def _event_row_to_dict(row: WorkEventRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["content"] = d.pop("content_json", None)
+        d["metadata"] = d.pop("metadata_json", {}) or {}
+        val = d.get("created_at")
+        if isinstance(val, datetime):
+            d["created_at"] = coerce_iso(val)
+        return d
+
+    async def create(
+        self,
+        *,
+        title: str,
+        description: str | None = None,
+        status: str = "backlog",
+        priority: str = "P2",
+        assignee_ref: str | None = None,
+        reporter_ref: str | None = None,
+        due_at: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str = "local",
+        source: str | None = None,
+        external_type: str | None = None,
+        external_ref: str | None = None,
+        external_url: str | None = None,
+        labels: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        user_id: str | None = None,
+        work_unit_id: str | None = None,
+    ) -> dict[str, Any]:
+        now = datetime.now(UTC)
+        row = WorkUnitRow(
+            work_unit_id=work_unit_id or str(uuid.uuid4()),
+            title=title,
+            description=description,
+            status=status,
+            priority=priority,
+            assignee_ref=assignee_ref,
+            reporter_ref=reporter_ref,
+            due_at=self._coerce_datetime(due_at),
+            workflow_id=workflow_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            source_type=source_type,
+            source=source,
+            external_type=external_type,
+            external_ref=external_ref,
+            external_url=external_url,
+            labels_json=list(labels or []),
+            metadata_json=self._safe_json(metadata) or {},
+            user_id=user_id,
+            created_at=now,
+            updated_at=now,
+        )
+        async with self._sf() as session:
+            session.add(row)
+            await session.commit()
+            return self._row_to_dict(row)
+
+    async def get(self, work_unit_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            row = await session.get(WorkUnitRow, work_unit_id)
+            if row is None:
+                return None
+            if user_id is not None and row.user_id != user_id:
+                return None
+            return self._row_to_dict(row)
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        stmt = select(WorkUnitRow)
+        filters = {
+            WorkUnitRow.status: status,
+            WorkUnitRow.workflow_id: workflow_id,
+            WorkUnitRow.thread_id: thread_id,
+            WorkUnitRow.run_id: run_id,
+            WorkUnitRow.source_type: source_type,
+            WorkUnitRow.source: source,
+            WorkUnitRow.user_id: user_id,
+        }
+        for column, expected in filters.items():
+            if expected is not None:
+                stmt = stmt.where(column == expected)
+        stmt = stmt.order_by(WorkUnitRow.updated_at.desc()).limit(limit)
+        async with self._sf() as session:
+            rows = (await session.execute(stmt)).scalars().all()
+            return [self._row_to_dict(row) for row in rows]
+
+    async def update(self, work_unit_id: str, *, user_id: str | None = None, **kwargs: Any) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            row = await session.get(WorkUnitRow, work_unit_id)
+            if row is None:
+                return None
+            if user_id is not None and row.user_id != user_id:
+                return None
+            values: dict[str, Any] = {"updated_at": datetime.now(UTC)}
+            for key, value in kwargs.items():
+                if value is None:
+                    continue
+                if key == "metadata":
+                    values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(value) or {})}
+                elif key == "labels":
+                    values["labels_json"] = list(value)
+                elif key == "due_at":
+                    values["due_at"] = self._coerce_datetime(value)
+                else:
+                    values[key] = value
+            stmt = update(WorkUnitRow).where(WorkUnitRow.work_unit_id == work_unit_id)
+            if user_id is not None:
+                stmt = stmt.where(WorkUnitRow.user_id == user_id)
+            await session.execute(stmt.values(**values))
+            await session.commit()
+            updated = await session.get(WorkUnitRow, work_unit_id)
+            return self._row_to_dict(updated) if updated is not None else None
+
+    async def append_event(
+        self,
+        work_unit_id: str,
+        *,
+        event_type: str,
+        actor_ref: str | None = None,
+        workflow_id: str | None = None,
+        run_id: str | None = None,
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        work_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            item = await session.get(WorkUnitRow, work_unit_id)
+            if item is None:
+                return None
+            max_seq = await session.scalar(select(func.max(WorkEventRow.seq)).where(WorkEventRow.work_unit_id == work_unit_id))
+            row = WorkEventRow(
+                work_event_id=work_event_id or str(uuid.uuid4()),
+                work_unit_id=work_unit_id,
+                seq=int(max_seq or 0) + 1,
+                event_type=event_type,
+                actor_ref=actor_ref,
+                workflow_id=workflow_id,
+                run_id=run_id,
+                content_json=self._safe_json(content),
+                metadata_json=self._safe_json(metadata) or {},
+                created_at=self._coerce_datetime(created_at) or datetime.now(UTC),
+            )
+            session.add(row)
+            await session.commit()
+            return self._event_row_to_dict(row)
+
+    async def list_events(self, work_unit_id: str, *, event_types: list[str] | None = None, limit: int = 500) -> list[dict[str, Any]]:
+        stmt = select(WorkEventRow).where(WorkEventRow.work_unit_id == work_unit_id)
+        if event_types:
+            stmt = stmt.where(WorkEventRow.event_type.in_(event_types))
+        stmt = stmt.order_by(WorkEventRow.seq.asc()).limit(limit)
+        async with self._sf() as session:
+            rows = (await session.execute(stmt)).scalars().all()
+            return [self._event_row_to_dict(row) for row in rows]

--- a/backend/packages/harness/deerflow/persistence/work_units/sql.py
+++ b/backend/packages/harness/deerflow/persistence/work_units/sql.py
@@ -14,6 +14,20 @@ from deerflow.persistence.work_units.model import WorkEventRow, WorkUnitRow
 from deerflow.work.units.store.base import WorkUnitStore
 from deerflow.utils.time import coerce_iso
 
+_NULLABLE_UPDATE_FIELDS = {
+    "description",
+    "assignee_ref",
+    "reporter_ref",
+    "due_at",
+    "workflow_id",
+    "thread_id",
+    "run_id",
+    "source",
+    "external_type",
+    "external_ref",
+    "external_url",
+}
+
 
 class WorkUnitRepository(WorkUnitStore):
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
@@ -165,14 +179,15 @@ class WorkUnitRepository(WorkUnitStore):
                 return None
             values: dict[str, Any] = {"updated_at": datetime.now(UTC)}
             for key, value in kwargs.items():
-                if value is None:
-                    continue
                 if key == "metadata":
                     values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(value) or {})}
                 elif key == "labels":
-                    values["labels_json"] = list(value)
+                    values["labels_json"] = list(value or [])
                 elif key == "due_at":
                     values["due_at"] = self._coerce_datetime(value)
+                elif value is None:
+                    if key in _NULLABLE_UPDATE_FIELDS:
+                        values[key] = None
                 else:
                     values[key] = value
             stmt = update(WorkUnitRow).where(WorkUnitRow.work_unit_id == work_unit_id)

--- a/backend/packages/harness/deerflow/persistence/workflow/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow persistence repository."""
+
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
+from deerflow.persistence.workflow.sql import WorkflowRepository
+
+__all__ = ["WorkflowEventRow", "WorkflowRepository", "WorkflowRow"]

--- a/backend/packages/harness/deerflow/persistence/workflow/model.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/model.py
@@ -1,0 +1,91 @@
+"""ORM model for workflow frontdoor envelopes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+class WorkflowRow(Base):
+    __tablename__ = "workflows"
+
+    workflow_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_kind: Mapped[str] = mapped_column(String(32), nullable=False, default="message")
+    source_type: Mapped[str] = mapped_column(String(32), nullable=False, default="api")
+    source: Mapped[str | None] = mapped_column(String(128), index=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(256))
+
+    external_message_ref: Mapped[str | None] = mapped_column(Text)
+    conversation_ref: Mapped[str | None] = mapped_column(Text)
+    thread_ref: Mapped[str | None] = mapped_column(Text)
+    sender_ref: Mapped[str | None] = mapped_column(Text)
+    user_id: Mapped[str | None] = mapped_column(String(64), index=True)
+
+    thread_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    checkpoint_ns: Mapped[str | None] = mapped_column(String(256))
+    checkpoint_id: Mapped[str | None] = mapped_column(String(128))
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="received", index=True)
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    lease_owner: Mapped[str | None] = mapped_column(String(128))
+    lease_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error: Mapped[str | None] = mapped_column(Text)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        Index(
+            "uq_workflows_source_idempotency",
+            "source_type",
+            "source",
+            "idempotency_key",
+            unique=True,
+            sqlite_where=text("idempotency_key IS NOT NULL"),
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+        ),
+        Index("ix_workflows_status_updated", "status", "updated_at"),
+        Index("ix_workflows_claimable", "status", "next_attempt_at", "lease_expires_at"),
+        Index("ix_workflows_thread_run", "thread_id", "run_id"),
+    )
+
+
+class WorkflowEventRow(Base):
+    __tablename__ = "workflow_events"
+
+    workflow_event_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("workflows.workflow_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(32), nullable=False, default="lifecycle", index=True)
+
+    thread_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    checkpoint_ns: Mapped[str | None] = mapped_column(String(256))
+    checkpoint_id: Mapped[str | None] = mapped_column(String(128))
+    run_event_seq: Mapped[int | None] = mapped_column(Integer)
+    idempotency_key: Mapped[str | None] = mapped_column(String(256))
+    source_event_ref: Mapped[str | None] = mapped_column(Text)
+
+    content_json: Mapped[dict | list | str | int | float | bool | None] = mapped_column(JSON)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True)
+
+    __table_args__ = (
+        UniqueConstraint("workflow_id", "seq", name="uq_workflow_events_workflow_seq"),
+        Index("ix_workflow_events_workflow_created", "workflow_id", "created_at"),
+        Index("ix_workflow_events_thread_run_seq", "thread_id", "run_id", "run_event_seq"),
+    )

--- a/backend/packages/harness/deerflow/persistence/workflow/sql.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/sql.py
@@ -1,0 +1,389 @@
+"""SQLAlchemy-backed workflow store implementation."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
+from deerflow.runtime.workflows.store.base import WorkflowStore
+from deerflow.utils.time import coerce_iso
+
+
+class WorkflowRepository(WorkflowStore):
+    """SQL-backed durable workflow envelope repository."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sf = session_factory
+
+    @staticmethod
+    def _safe_json(obj: Any) -> Any:
+        if obj is None:
+            return None
+        if isinstance(obj, (str, int, float, bool)):
+            return obj
+        if isinstance(obj, dict):
+            return {k: WorkflowRepository._safe_json(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [WorkflowRepository._safe_json(v) for v in obj]
+        if hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        try:
+            json.dumps(obj)
+            return obj
+        except (TypeError, ValueError):
+            return str(obj)
+
+    @staticmethod
+    def _row_to_dict(row: WorkflowRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["metadata"] = d.pop("metadata_json", {})
+        for key in ("created_at", "updated_at", "next_attempt_at", "lease_expires_at"):
+            val = d.get(key)
+            if isinstance(val, datetime):
+                d[key] = coerce_iso(val)
+        return d
+
+    @staticmethod
+    def _event_row_to_dict(row: WorkflowEventRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["content"] = d.pop("content_json", None)
+        d["metadata"] = d.pop("metadata_json", {})
+        val = d.get("created_at")
+        if isinstance(val, datetime):
+            d["created_at"] = coerce_iso(val)
+        return d
+
+    @staticmethod
+    def _coerce_datetime(value: str | datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(value)
+
+    @staticmethod
+    def _normalize_source(source: str | None) -> str | None:
+        if source is None:
+            return None
+        normalized = str(source).strip()
+        return normalized[:128] if normalized else None
+
+    @staticmethod
+    def _normalize_idempotency_key(idempotency_key: str | None) -> str | None:
+        if idempotency_key is None:
+            return None
+        normalized = str(idempotency_key).strip()
+        return normalized[:256] if normalized else None
+
+    async def _find_by_idempotency(
+        self,
+        *,
+        source_type: str,
+        source: str | None,
+        idempotency_key: str | None,
+    ) -> dict[str, Any] | None:
+        if not idempotency_key:
+            return None
+        stmt = select(WorkflowRow).where(
+            WorkflowRow.source_type == source_type,
+            WorkflowRow.source == source,
+            WorkflowRow.idempotency_key == idempotency_key,
+        )
+        async with self._sf() as session:
+            row = (await session.execute(stmt)).scalar_one_or_none()
+            return self._row_to_dict(row) if row is not None else None
+
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        source = self._normalize_source(source)
+        idempotency_key = self._normalize_idempotency_key(idempotency_key)
+        if idempotency_key and source is None:
+            source = ""
+        existing = await self._find_by_idempotency(
+            source_type=source_type,
+            source=source,
+            idempotency_key=idempotency_key,
+        )
+        if existing is not None:
+            return existing, False
+
+        now = datetime.now(UTC)
+        row = WorkflowRow(
+            workflow_id=workflow_id or str(uuid.uuid4()),
+            workflow_kind=workflow_kind,
+            source_type=source_type,
+            source=source,
+            idempotency_key=idempotency_key,
+            external_message_ref=external_message_ref,
+            conversation_ref=conversation_ref,
+            thread_ref=thread_ref,
+            sender_ref=sender_ref,
+            user_id=user_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=checkpoint_id,
+            status=status,
+            attempt_count=0,
+            max_attempts=max(1, int(max_attempts)),
+            metadata_json=self._safe_json(metadata) or {},
+            created_at=now,
+            updated_at=now,
+        )
+        async with self._sf() as session:
+            session.add(row)
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+                existing = await self._find_by_idempotency(
+                    source_type=source_type,
+                    source=source,
+                    idempotency_key=idempotency_key,
+                )
+                if existing is not None:
+                    return existing, False
+                raise
+            return self._row_to_dict(row), True
+
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        now = datetime.now(UTC)
+        lease_expires_at = now + timedelta(seconds=lease_seconds)
+        stmt = (
+            select(WorkflowRow)
+            .where(
+                WorkflowRow.status.in_(statuses),
+                WorkflowRow.attempt_count < WorkflowRow.max_attempts,
+                or_(WorkflowRow.next_attempt_at.is_(None), WorkflowRow.next_attempt_at <= now),
+                or_(WorkflowRow.lease_expires_at.is_(None), WorkflowRow.lease_expires_at <= now),
+            )
+            .order_by(WorkflowRow.created_at.asc())
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+        async with self._sf() as session:
+            async with session.begin():
+                row = (await session.execute(stmt)).scalar_one_or_none()
+                if row is None:
+                    return None
+                row.lease_owner = lease_owner
+                row.lease_expires_at = lease_expires_at
+                row.attempt_count = (row.attempt_count or 0) + 1
+                row.status = status_on_claim
+                row.updated_at = now
+            return self._row_to_dict(row)
+
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return None
+            if user_id is not None and row.user_id != user_id:
+                return None
+            return self._row_to_dict(row)
+
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {"status": status, "updated_at": datetime.now(UTC)}
+        if error is not None:
+            values["error"] = error
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {"updated_at": datetime.now(UTC)}
+        optional = {
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                values[key] = value
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "next_attempt_at": self._coerce_datetime(next_attempt_at),
+            "status": status,
+            "updated_at": datetime.now(UTC),
+        }
+        if error is not None:
+            values["error"] = error
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        stmt = select(WorkflowRow)
+        if status is not None:
+            stmt = stmt.where(WorkflowRow.status == status)
+        if source_type is not None:
+            stmt = stmt.where(WorkflowRow.source_type == source_type)
+        if source is not None:
+            stmt = stmt.where(WorkflowRow.source == self._normalize_source(source))
+        if thread_id is not None:
+            stmt = stmt.where(WorkflowRow.thread_id == thread_id)
+        if run_id is not None:
+            stmt = stmt.where(WorkflowRow.run_id == run_id)
+        if user_id is not None:
+            stmt = stmt.where(WorkflowRow.user_id == user_id)
+        stmt = stmt.order_by(WorkflowRow.created_at.desc()).limit(limit)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._row_to_dict(row) for row in result.scalars()]
+
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | datetime | None = None,
+    ) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            async with session.begin():
+                workflow = await session.get(WorkflowRow, workflow_id)
+                if workflow is None:
+                    return None
+                max_seq_stmt = select(func.max(WorkflowEventRow.seq)).where(WorkflowEventRow.workflow_id == workflow_id)
+                max_seq = (await session.execute(max_seq_stmt)).scalar_one()
+                row = WorkflowEventRow(
+                    workflow_event_id=workflow_event_id or str(uuid.uuid4()),
+                    workflow_id=workflow_id,
+                    seq=(max_seq or 0) + 1,
+                    event_type=event_type,
+                    category=category,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    checkpoint_ns=checkpoint_ns,
+                    checkpoint_id=checkpoint_id,
+                    run_event_seq=run_event_seq,
+                    idempotency_key=self._normalize_idempotency_key(idempotency_key),
+                    source_event_ref=source_event_ref,
+                    content_json=self._safe_json(content),
+                    metadata_json=self._safe_json(metadata) or {},
+                    created_at=self._coerce_datetime(created_at) or datetime.now(UTC),
+                )
+                session.add(row)
+            return self._event_row_to_dict(row)
+
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        stmt = select(WorkflowEventRow).where(WorkflowEventRow.workflow_id == workflow_id)
+        if event_types:
+            stmt = stmt.where(WorkflowEventRow.event_type.in_(event_types))
+        stmt = stmt.order_by(WorkflowEventRow.seq.asc()).limit(limit)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._event_row_to_dict(row) for row in result.scalars()]

--- a/backend/packages/harness/deerflow/runtime/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/__init__.py
@@ -10,6 +10,7 @@ from .runs import ConflictError, DisconnectMode, RunContext, RunManager, RunReco
 from .serialization import serialize, serialize_channel_values, serialize_channel_values_for_api, serialize_lc_object, serialize_messages_tuple, strip_data_url_image_blocks
 from .store import get_store, make_store, reset_store, store_context
 from .stream_bridge import END_SENTINEL, HEARTBEAT_SENTINEL, MemoryStreamBridge, StreamBridge, StreamEvent, make_stream_bridge
+from .workflows import MemoryWorkflowStore, WorkflowKind, WorkflowSourceType, WorkflowStatus, WorkflowStore
 
 __all__ = [
     # checkpointer
@@ -45,4 +46,10 @@ __all__ = [
     "StreamBridge",
     "StreamEvent",
     "make_stream_bridge",
+    # workflows
+    "MemoryWorkflowStore",
+    "WorkflowKind",
+    "WorkflowSourceType",
+    "WorkflowStatus",
+    "WorkflowStore",
 ]

--- a/backend/packages/harness/deerflow/runtime/workflows/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/__init__.py
@@ -1,0 +1,12 @@
+"""Durable workflow frontdoor primitives."""
+
+from deerflow.runtime.workflows.schemas import WorkflowKind, WorkflowSourceType, WorkflowStatus
+from deerflow.runtime.workflows.store import MemoryWorkflowStore, WorkflowStore
+
+__all__ = [
+    "MemoryWorkflowStore",
+    "WorkflowKind",
+    "WorkflowSourceType",
+    "WorkflowStatus",
+    "WorkflowStore",
+]

--- a/backend/packages/harness/deerflow/runtime/workflows/schemas.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/schemas.py
@@ -1,0 +1,39 @@
+"""Workflow frontdoor schema enums."""
+
+from enum import StrEnum
+
+
+class WorkflowKind(StrEnum):
+    """Generic workflow kinds accepted by the frontdoor."""
+
+    message = "message"
+    command = "command"
+    resume = "resume"
+    handoff = "handoff"
+    other = "other"
+
+
+class WorkflowSourceType(StrEnum):
+    """Source category for a workflow intake envelope."""
+
+    api = "api"
+    dashboard = "dashboard"
+    channel = "channel"
+    agent_session = "agent_session"
+    other = "other"
+
+
+class WorkflowStatus(StrEnum):
+    """Lifecycle status for a workflow envelope."""
+
+    received = "received"
+    bound = "bound"
+    claimed = "claimed"
+    run_created = "run_created"
+    running = "running"
+    waiting = "waiting"
+    succeeded = "succeeded"
+    failed = "failed"
+    cancelled = "cancelled"
+    orphaned = "orphaned"
+    ignored = "ignored"

--- a/backend/packages/harness/deerflow/runtime/workflows/store/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow store implementations."""
+
+from deerflow.runtime.workflows.store.base import WorkflowStore
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+__all__ = ["MemoryWorkflowStore", "WorkflowStore"]

--- a/backend/packages/harness/deerflow/runtime/workflows/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/base.py
@@ -1,0 +1,144 @@
+"""Abstract interface for workflow frontdoor storage."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+
+class WorkflowStore(abc.ABC):
+    """Durable workflow envelope storage interface."""
+
+    @abc.abstractmethod
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """Create a workflow or return the existing idempotency match.
+
+        Returns ``(row, created)``.
+        """
+
+    @abc.abstractmethod
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        """Lease the next eligible workflow for a worker.
+
+        Implementations should only claim rows whose existing lease is absent or
+        expired and whose ``next_attempt_at`` is due. Returns the claimed row or
+        ``None`` when no workflow is eligible.
+        """
+
+    @abc.abstractmethod
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        pass
+
+    @abc.abstractmethod
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Clear an active lease and make a workflow eligible for retry."""
+        pass
+
+    @abc.abstractmethod
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Append a durable workflow event.
+
+        Returns the event row, or ``None`` when the workflow does not exist.
+        """
+        pass
+
+    @abc.abstractmethod
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        pass
+
+    @abc.abstractmethod
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        pass

--- a/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
@@ -1,0 +1,282 @@
+"""In-memory workflow store."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from deerflow.runtime.workflows.store.base import WorkflowStore
+
+
+class MemoryWorkflowStore(WorkflowStore):
+    """In-memory WorkflowStore for development and tests."""
+
+    def __init__(self) -> None:
+        self._workflows: dict[str, dict[str, Any]] = {}
+        self._idempotency: dict[tuple[str, str, str], str] = {}
+        self._events: dict[str, list[dict[str, Any]]] = {}
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()
+
+    @staticmethod
+    def _idempotency_tuple(source_type: str, source: str | None, idempotency_key: str | None) -> tuple[str, str, str] | None:
+        if not idempotency_key:
+            return None
+        return (source_type, source or "", idempotency_key)
+
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        idem = self._idempotency_tuple(source_type, source, idempotency_key)
+        if idempotency_key and source is None:
+            source = ""
+        if idem is not None:
+            existing_id = self._idempotency.get(idem)
+            if existing_id is not None:
+                return dict(self._workflows[existing_id]), False
+
+        now = self._now()
+        workflow_id = workflow_id or str(uuid.uuid4())
+        row = {
+            "workflow_id": workflow_id,
+            "workflow_kind": workflow_kind,
+            "source_type": source_type,
+            "source": source,
+            "idempotency_key": idempotency_key,
+            "external_message_ref": external_message_ref,
+            "conversation_ref": conversation_ref,
+            "thread_ref": thread_ref,
+            "sender_ref": sender_ref,
+            "user_id": user_id,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+            "attempt_count": 0,
+            "max_attempts": max_attempts,
+            "next_attempt_at": None,
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "error": None,
+            "metadata": metadata or {},
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._workflows[workflow_id] = row
+        if idem is not None:
+            self._idempotency[idem] = workflow_id
+        self._events.setdefault(workflow_id, [])
+        return dict(row), True
+
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        now_dt = datetime.now(UTC)
+        now = now_dt.isoformat()
+        lease_expires_at = (now_dt + timedelta(seconds=lease_seconds)).isoformat()
+        candidates = sorted(self._workflows.values(), key=lambda row: row["created_at"])
+        for row in candidates:
+            if row.get("status") not in statuses:
+                continue
+            if int(row.get("attempt_count") or 0) >= int(row.get("max_attempts") or 1):
+                continue
+            next_attempt_at = row.get("next_attempt_at")
+            if next_attempt_at and next_attempt_at > now:
+                continue
+            lease_expires = row.get("lease_expires_at")
+            if row.get("lease_owner") and lease_expires and lease_expires > now:
+                continue
+            row["lease_owner"] = lease_owner
+            row["lease_expires_at"] = lease_expires_at
+            row["attempt_count"] = int(row.get("attempt_count") or 0) + 1
+            row["status"] = status_on_claim
+            row["updated_at"] = now
+            return dict(row)
+        return None
+
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return None
+        if user_id is not None and row.get("user_id") != user_id:
+            return None
+        return dict(row)
+
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        row["status"] = status
+        if error is not None:
+            row["error"] = error
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        updates = {
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+        }
+        for key, value in updates.items():
+            if value is not None:
+                row[key] = value
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        row["lease_owner"] = None
+        row["lease_expires_at"] = None
+        row["next_attempt_at"] = next_attempt_at
+        row["status"] = status
+        if error is not None:
+            row["error"] = error
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        if workflow_id not in self._workflows:
+            return None
+        events = self._events.setdefault(workflow_id, [])
+        row = {
+            "workflow_event_id": workflow_event_id or str(uuid.uuid4()),
+            "workflow_id": workflow_id,
+            "seq": len(events) + 1,
+            "event_type": event_type,
+            "category": category,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "run_event_seq": run_event_seq,
+            "idempotency_key": idempotency_key,
+            "source_event_ref": source_event_ref,
+            "content": content,
+            "metadata": metadata or {},
+            "created_at": created_at or self._now(),
+        }
+        events.append(row)
+        return dict(row)
+
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        events = list(self._events.get(workflow_id, []))
+        if event_types is not None:
+            wanted = set(event_types)
+            events = [event for event in events if event["event_type"] in wanted]
+        return [dict(event) for event in events[:limit]]
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        rows = list(self._workflows.values())
+        if status is not None:
+            rows = [row for row in rows if row.get("status") == status]
+        if source_type is not None:
+            rows = [row for row in rows if row.get("source_type") == source_type]
+        if source is not None:
+            rows = [row for row in rows if row.get("source") == source]
+        if thread_id is not None:
+            rows = [row for row in rows if row.get("thread_id") == thread_id]
+        if run_id is not None:
+            rows = [row for row in rows if row.get("run_id") == run_id]
+        if user_id is not None:
+            rows = [row for row in rows if row.get("user_id") == user_id]
+        rows.sort(key=lambda row: row["created_at"], reverse=True)
+        return [dict(row) for row in rows[:limit]]

--- a/backend/packages/harness/deerflow/tools/builtins/__init__.py
+++ b/backend/packages/harness/deerflow/tools/builtins/__init__.py
@@ -4,7 +4,7 @@ from .setup_agent_tool import setup_agent
 from .task_tool import task_tool
 from .update_agent_tool import update_agent
 from .view_image_tool import view_image_tool
-from .work_unit_tool import build_work_unit_tool
+from .work_unit_tool import build_work_unit_tool, work_units_tool
 
 __all__ = [
     "setup_agent",
@@ -14,4 +14,5 @@ __all__ = [
     "view_image_tool",
     "task_tool",
     "build_work_unit_tool",
+    "work_units_tool",
 ]

--- a/backend/packages/harness/deerflow/tools/builtins/__init__.py
+++ b/backend/packages/harness/deerflow/tools/builtins/__init__.py
@@ -4,6 +4,7 @@ from .setup_agent_tool import setup_agent
 from .task_tool import task_tool
 from .update_agent_tool import update_agent
 from .view_image_tool import view_image_tool
+from .work_unit_tool import build_work_unit_tool
 
 __all__ = [
     "setup_agent",
@@ -12,4 +13,5 @@ __all__ = [
     "ask_clarification_tool",
     "view_image_tool",
     "task_tool",
+    "build_work_unit_tool",
 ]

--- a/backend/packages/harness/deerflow/tools/builtins/work_unit_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/work_unit_tool.py
@@ -1,0 +1,160 @@
+"""Work Unit runtime action tool.
+
+The Work Module owns generic work-unit persistence. This tool is intentionally
+bound to a single work unit at construction time so agent runs can mutate only
+the unit that the runtime surface explicitly attached to the invocation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from langchain_core.tools import BaseTool, StructuredTool
+from pydantic import BaseModel, Field
+
+from deerflow.persistence.engine import get_session_factory
+from deerflow.persistence.work_units import WorkUnitRepository
+from deerflow.work.units.schemas import WorkUnitStatus
+
+logger = logging.getLogger(__name__)
+
+_StatusLiteral = Literal["backlog", "ready", "in_progress", "blocked", "review", "done", "closed", "cancelled"]
+
+
+class _WorkUnitActionInput(BaseModel):
+    action: Literal["get", "update_status"] = Field(
+        description="Action to perform on the current bound Work Unit.",
+    )
+    status: _StatusLiteral | None = Field(
+        default=None,
+        description="New status when action is update_status.",
+    )
+    note: str | None = Field(
+        default=None,
+        description="Short reason or execution note to record in the Work Unit event log.",
+    )
+
+
+def _public_work_unit(row: dict) -> dict:
+    return {
+        "work_unit_id": row.get("work_unit_id"),
+        "title": row.get("title"),
+        "description": row.get("description"),
+        "status": row.get("status"),
+        "priority": row.get("priority"),
+        "assignee_ref": row.get("assignee_ref"),
+        "workflow_id": row.get("workflow_id"),
+        "thread_id": row.get("thread_id"),
+        "run_id": row.get("run_id"),
+        "labels": row.get("labels") or [],
+        "updated_at": row.get("updated_at"),
+    }
+
+
+def build_work_unit_tool(
+    *,
+    work_unit_id: str,
+    actor_ref: str = "agent:lead_agent",
+    user_id: str | None = None,
+    workflow_id: str | None = None,
+    run_id: str | None = None,
+) -> BaseTool:
+    """Build a tool scoped to one runtime-bound Work Unit."""
+
+    bound_work_unit_id = work_unit_id
+
+    async def _work_unit(action: str, status: str | None = None, note: str | None = None) -> dict:
+        """Read or update the current Work Unit bound to this agent run."""
+
+        session_factory = get_session_factory()
+        if session_factory is None:
+            return {
+                "ok": False,
+                "error": "Work Unit actions require a database-backed Work Module. The current persistence backend is memory.",
+            }
+
+        repo = WorkUnitRepository(session_factory)
+        current = await repo.get(bound_work_unit_id, user_id=user_id)
+        if current is None:
+            return {"ok": False, "error": f"Work Unit {bound_work_unit_id} was not found."}
+
+        if action == "get":
+            return {"ok": True, "work_unit": _public_work_unit(current)}
+
+        if action != "update_status":
+            return {"ok": False, "error": f"Unsupported Work Unit action: {action}"}
+
+        if not status:
+            return {"ok": False, "error": "status is required when action is update_status."}
+
+        normalized_status = status.lower()
+        allowed_statuses = {item.value for item in WorkUnitStatus}
+        if normalized_status not in allowed_statuses:
+            return {
+                "ok": False,
+                "error": f"Invalid Work Unit status: {status}. Allowed statuses: {', '.join(sorted(allowed_statuses))}.",
+            }
+
+        previous_status = current.get("status")
+        if previous_status == normalized_status:
+            event = await repo.append_event(
+                bound_work_unit_id,
+                event_type="work_unit.observed",
+                actor_ref=actor_ref,
+                workflow_id=workflow_id or current.get("workflow_id"),
+                run_id=run_id or current.get("run_id"),
+                content={
+                    "status": normalized_status,
+                    "note": note,
+                },
+                metadata={"source": "agent_tool"},
+            )
+            return {
+                "ok": True,
+                "changed": False,
+                "work_unit": _public_work_unit(current),
+                "event": event,
+            }
+
+        updated = await repo.update(bound_work_unit_id, user_id=user_id, status=normalized_status)
+        if updated is None:
+            return {"ok": False, "error": f"Work Unit {bound_work_unit_id} disappeared before update."}
+
+        event = await repo.append_event(
+            bound_work_unit_id,
+            event_type="work_unit.status_changed",
+            actor_ref=actor_ref,
+            workflow_id=workflow_id or updated.get("workflow_id"),
+            run_id=run_id or updated.get("run_id"),
+            content={
+                "previous_status": previous_status,
+                "status": normalized_status,
+                "note": note,
+            },
+            metadata={"source": "agent_tool"},
+        )
+        logger.info(
+            "Work Unit %s status changed by %s: %s -> %s",
+            bound_work_unit_id,
+            actor_ref,
+            previous_status,
+            normalized_status,
+        )
+        return {
+            "ok": True,
+            "changed": True,
+            "work_unit": _public_work_unit(updated),
+            "event": event,
+        }
+
+    return StructuredTool.from_function(
+        name="work_unit",
+        description=(
+            "Read or update the current Work Unit bound to this run. "
+            "Use this tool before claiming that a Work Unit status has changed. "
+            "It can only act on the Work Unit attached by the runtime surface."
+        ),
+        coroutine=_work_unit,
+        args_schema=_WorkUnitActionInput,
+    )

--- a/backend/packages/harness/deerflow/tools/builtins/work_unit_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/work_unit_tool.py
@@ -8,18 +8,22 @@ the unit that the runtime surface explicitly attached to the invocation.
 from __future__ import annotations
 
 import logging
-from typing import Literal
+from typing import Any, Literal
 
+from langchain.tools import ToolRuntime, tool
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel, Field
 
 from deerflow.persistence.engine import get_session_factory
 from deerflow.persistence.work_units import WorkUnitRepository
-from deerflow.work.units.schemas import WorkUnitStatus
+from deerflow.runtime.user_context import resolve_runtime_user_id
+from deerflow.work.units.schemas import WorkUnitPriority, WorkUnitStatus
 
 logger = logging.getLogger(__name__)
 
 _StatusLiteral = Literal["backlog", "ready", "in_progress", "blocked", "review", "done", "closed", "cancelled"]
+_PriorityLiteral = Literal["P0", "P1", "P2", "P3", "P4"]
+WorkUnitToolRuntime = ToolRuntime[dict[str, Any], Any]
 
 
 class _WorkUnitActionInput(BaseModel):
@@ -50,6 +54,209 @@ def _public_work_unit(row: dict) -> dict:
         "labels": row.get("labels") or [],
         "updated_at": row.get("updated_at"),
     }
+
+
+def _allowed_statuses() -> set[str]:
+    return {item.value for item in WorkUnitStatus}
+
+
+def _allowed_priorities() -> set[str]:
+    return {item.value for item in WorkUnitPriority}
+
+
+def _normalize_status(status: str) -> str:
+    normalized = status.lower()
+    allowed_statuses = _allowed_statuses()
+    if normalized not in allowed_statuses:
+        raise ValueError(f"Invalid Work Unit status: {status}. Allowed statuses: {', '.join(sorted(allowed_statuses))}.")
+    return normalized
+
+
+def _validate_priority(priority: str) -> str:
+    allowed_priorities = _allowed_priorities()
+    if priority not in allowed_priorities:
+        raise ValueError(f"Invalid Work Unit priority: {priority}. Allowed priorities: {', '.join(sorted(allowed_priorities))}.")
+    return priority
+
+
+def _runtime_actor_ref(runtime: WorkUnitToolRuntime | None) -> str:
+    context = getattr(runtime, "context", None)
+    if isinstance(context, dict):
+        agent_name = str(context.get("agent_name") or "").strip()
+        if agent_name:
+            return f"agent:{agent_name}"
+    return "agent:lead_agent"
+
+
+async def _work_units_action(
+    *,
+    runtime: WorkUnitToolRuntime | None,
+    action: str,
+    work_unit_id: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    status: str | None = None,
+    priority: str = "P2",
+    assignee_ref: str | None = None,
+    workflow_id: str | None = None,
+    thread_id: str | None = None,
+    run_id: str | None = None,
+    labels: list[str] | None = None,
+    note: str | None = None,
+    limit: int = 20,
+) -> dict:
+    session_factory = get_session_factory()
+    if session_factory is None:
+        return {
+            "ok": False,
+            "error": "Work Unit actions require a database-backed Work Module. The current persistence backend is memory.",
+        }
+
+    repo = WorkUnitRepository(session_factory)
+    user_id = resolve_runtime_user_id(runtime)
+    actor_ref = _runtime_actor_ref(runtime)
+
+    if action == "create":
+        if not title or not title.strip():
+            return {"ok": False, "error": "title is required when action is create."}
+        try:
+            initial_status = _normalize_status(status or WorkUnitStatus.BACKLOG.value)
+            initial_priority = _validate_priority(priority)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+        row = await repo.create(
+            title=title.strip(),
+            description=description,
+            status=initial_status,
+            priority=initial_priority,
+            assignee_ref=assignee_ref,
+            reporter_ref=actor_ref,
+            workflow_id=workflow_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            labels=labels,
+            user_id=user_id,
+            source_type="api",
+            source="agent_tool",
+        )
+        event = await repo.append_event(
+            row["work_unit_id"],
+            event_type="work_unit.created",
+            actor_ref=actor_ref,
+            workflow_id=row.get("workflow_id"),
+            run_id=row.get("run_id"),
+            content={"title": row["title"], "status": row["status"], "priority": row["priority"], "note": note},
+            metadata={"source": "agent_tool"},
+        )
+        return {"ok": True, "work_unit": _public_work_unit(row), "event": event}
+
+    if action == "list":
+        try:
+            status_filter = _normalize_status(status) if status else None
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+        rows = await repo.list(
+            status=status_filter,
+            workflow_id=workflow_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            user_id=user_id,
+            limit=max(1, min(limit, 50)),
+        )
+        return {"ok": True, "work_units": [_public_work_unit(row) for row in rows]}
+
+    if not work_unit_id:
+        return {"ok": False, "error": "work_unit_id is required for this action."}
+
+    current = await repo.get(work_unit_id, user_id=user_id)
+    if current is None:
+        return {"ok": False, "error": f"Work Unit {work_unit_id} was not found."}
+
+    if action == "get":
+        return {"ok": True, "work_unit": _public_work_unit(current)}
+
+    if action != "update_status":
+        return {"ok": False, "error": f"Unsupported Work Unit action: {action}"}
+
+    if not status:
+        return {"ok": False, "error": "status is required when action is update_status."}
+
+    try:
+        normalized_status = _normalize_status(status)
+    except ValueError as exc:
+        return {"ok": False, "error": str(exc)}
+    previous_status = current.get("status")
+    updated = await repo.update(work_unit_id, user_id=user_id, status=normalized_status)
+    if updated is None:
+        return {"ok": False, "error": f"Work Unit {work_unit_id} disappeared before update."}
+    event = await repo.append_event(
+        work_unit_id,
+        event_type="work_unit.status_changed" if previous_status != normalized_status else "work_unit.observed",
+        actor_ref=actor_ref,
+        workflow_id=workflow_id or updated.get("workflow_id"),
+        run_id=run_id or updated.get("run_id"),
+        content={"previous_status": previous_status, "status": normalized_status, "note": note},
+        metadata={"source": "agent_tool"},
+    )
+    return {
+        "ok": True,
+        "changed": previous_status != normalized_status,
+        "work_unit": _public_work_unit(updated),
+        "event": event,
+    }
+
+
+@tool("work_units", parse_docstring=True)
+async def work_units_tool(
+    runtime: WorkUnitToolRuntime,
+    action: Literal["create", "list", "get", "update_status"],
+    work_unit_id: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    status: _StatusLiteral | None = None,
+    priority: _PriorityLiteral = "P2",
+    assignee_ref: str | None = None,
+    workflow_id: str | None = None,
+    thread_id: str | None = None,
+    run_id: str | None = None,
+    labels: list[str] | None = None,
+    note: str | None = None,
+    limit: int = 20,
+) -> dict:
+    """Create, read, list, or update generic Work Units.
+
+    Args:
+        action: Operation to perform. Use create for planning new work, list to inspect current work, get for one Work Unit, or update_status after actual progress.
+        work_unit_id: Existing Work Unit id for get or update_status.
+        title: Short title when creating a Work Unit.
+        description: Optional objective, next action, or acceptance context.
+        status: Optional status filter for list, initial status for create, or new status for update_status.
+        priority: Priority for newly-created Work Units.
+        assignee_ref: Optional user, team, agent, or external assignee reference.
+        workflow_id: Optional durable workflow id to link or filter.
+        thread_id: Optional DeerFlow thread id to link or filter.
+        run_id: Optional DeerFlow run id to link or filter.
+        labels: Optional labels for newly-created Work Units.
+        note: Optional audit note for created or updated Work Units.
+        limit: Maximum rows for list, capped at 50.
+    """
+
+    return await _work_units_action(
+        runtime=runtime,
+        action=action,
+        work_unit_id=work_unit_id,
+        title=title,
+        description=description,
+        status=status,
+        priority=priority,
+        assignee_ref=assignee_ref,
+        workflow_id=workflow_id,
+        thread_id=thread_id,
+        run_id=run_id,
+        labels=labels,
+        note=note,
+        limit=limit,
+    )
 
 
 def build_work_unit_tool(
@@ -89,7 +296,7 @@ def build_work_unit_tool(
             return {"ok": False, "error": "status is required when action is update_status."}
 
         normalized_status = status.lower()
-        allowed_statuses = {item.value for item in WorkUnitStatus}
+        allowed_statuses = _allowed_statuses()
         if normalized_status not in allowed_statuses:
             return {
                 "ok": False,

--- a/backend/packages/harness/deerflow/tools/tools.py
+++ b/backend/packages/harness/deerflow/tools/tools.py
@@ -6,7 +6,7 @@ from deerflow.config import get_app_config
 from deerflow.config.app_config import AppConfig
 from deerflow.reflection import resolve_variable
 from deerflow.sandbox.security import is_host_bash_allowed
-from deerflow.tools.builtins import ask_clarification_tool, present_file_tool, task_tool, view_image_tool
+from deerflow.tools.builtins import ask_clarification_tool, present_file_tool, task_tool, view_image_tool, work_units_tool
 from deerflow.tools.mcp_metadata import tag_mcp_tool
 from deerflow.tools.sync import make_sync_tool_wrapper
 
@@ -94,6 +94,9 @@ def get_available_tools(
         from deerflow.tools.skill_manage_tool import skill_manage_tool
 
         builtin_tools.append(skill_manage_tool)
+
+    if getattr(getattr(config, "modules", None), "work", None) is not None and config.modules.work.enabled:
+        builtin_tools.append(work_units_tool)
 
     # Add subagent tools only if enabled via runtime parameter
     if subagent_enabled:

--- a/backend/packages/harness/deerflow/work/__init__.py
+++ b/backend/packages/harness/deerflow/work/__init__.py
@@ -1,0 +1,1 @@
+"""Generic work module primitives."""

--- a/backend/packages/harness/deerflow/work/units/__init__.py
+++ b/backend/packages/harness/deerflow/work/units/__init__.py
@@ -1,0 +1,12 @@
+"""Generic work unit module primitives."""
+
+from deerflow.work.units.schemas import WorkUnitPriority, WorkUnitSourceType, WorkUnitStatus
+from deerflow.work.units.store import MemoryWorkUnitStore, WorkUnitStore
+
+__all__ = [
+    "MemoryWorkUnitStore",
+    "WorkUnitPriority",
+    "WorkUnitSourceType",
+    "WorkUnitStatus",
+    "WorkUnitStore",
+]

--- a/backend/packages/harness/deerflow/work/units/schemas.py
+++ b/backend/packages/harness/deerflow/work/units/schemas.py
@@ -1,0 +1,32 @@
+"""Work unit schema enums."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WorkUnitStatus(StrEnum):
+    BACKLOG = "backlog"
+    READY = "ready"
+    IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
+    REVIEW = "review"
+    DONE = "done"
+    CLOSED = "closed"
+    CANCELLED = "cancelled"
+
+
+class WorkUnitPriority(StrEnum):
+    P0 = "P0"
+    P1 = "P1"
+    P2 = "P2"
+    P3 = "P3"
+    P4 = "P4"
+
+
+class WorkUnitSourceType(StrEnum):
+    LOCAL = "local"
+    PM_TOOL = "pm_tool"
+    CHANNEL = "channel"
+    API = "api"
+    OTHER = "other"

--- a/backend/packages/harness/deerflow/work/units/store/__init__.py
+++ b/backend/packages/harness/deerflow/work/units/store/__init__.py
@@ -1,0 +1,6 @@
+"""Work unit store implementations."""
+
+from deerflow.work.units.store.base import WorkUnitStore
+from deerflow.work.units.store.memory import MemoryWorkUnitStore
+
+__all__ = ["MemoryWorkUnitStore", "WorkUnitStore"]

--- a/backend/packages/harness/deerflow/work/units/store/base.py
+++ b/backend/packages/harness/deerflow/work/units/store/base.py
@@ -1,0 +1,101 @@
+"""Abstract interface for generic work unit storage."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+
+class WorkUnitStore(abc.ABC):
+    """Storage contract for DeerFlow work units."""
+
+    @abc.abstractmethod
+    async def create(
+        self,
+        *,
+        title: str,
+        description: str | None = None,
+        status: str = "backlog",
+        priority: str = "P2",
+        assignee_ref: str | None = None,
+        reporter_ref: str | None = None,
+        due_at: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str = "local",
+        source: str | None = None,
+        external_type: str | None = None,
+        external_ref: str | None = None,
+        external_url: str | None = None,
+        labels: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        user_id: str | None = None,
+        work_unit_id: str | None = None,
+    ) -> dict[str, Any]:
+        pass
+
+    @abc.abstractmethod
+    async def get(self, work_unit_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        pass
+
+    @abc.abstractmethod
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        pass
+
+    @abc.abstractmethod
+    async def update(
+        self,
+        work_unit_id: str,
+        *,
+        user_id: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        status: str | None = None,
+        priority: str | None = None,
+        assignee_ref: str | None = None,
+        reporter_ref: str | None = None,
+        due_at: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        external_type: str | None = None,
+        external_ref: str | None = None,
+        external_url: str | None = None,
+        labels: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        pass
+
+    @abc.abstractmethod
+    async def append_event(
+        self,
+        work_unit_id: str,
+        *,
+        event_type: str,
+        actor_ref: str | None = None,
+        workflow_id: str | None = None,
+        run_id: str | None = None,
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        work_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        pass
+
+    @abc.abstractmethod
+    async def list_events(self, work_unit_id: str, *, event_types: list[str] | None = None, limit: int = 500) -> list[dict[str, Any]]:
+        pass

--- a/backend/packages/harness/deerflow/work/units/store/memory.py
+++ b/backend/packages/harness/deerflow/work/units/store/memory.py
@@ -10,6 +10,20 @@ from typing import Any
 from deerflow.work.units.store.base import WorkUnitStore
 from deerflow.utils.time import coerce_iso
 
+_NULLABLE_UPDATE_FIELDS = {
+    "description",
+    "assignee_ref",
+    "reporter_ref",
+    "due_at",
+    "workflow_id",
+    "thread_id",
+    "run_id",
+    "source",
+    "external_type",
+    "external_ref",
+    "external_url",
+}
+
 
 class MemoryWorkUnitStore(WorkUnitStore):
     def __init__(self) -> None:
@@ -118,12 +132,13 @@ class MemoryWorkUnitStore(WorkUnitStore):
         if user_id is not None and row.get("user_id") != user_id:
             return None
         for key, value in kwargs.items():
-            if value is None:
-                continue
             if key == "metadata":
-                row["metadata"] = {**(row.get("metadata") or {}), **value}
+                row["metadata"] = {**(row.get("metadata") or {}), **(value or {})}
             elif key == "labels":
-                row["labels"] = list(value)
+                row["labels"] = list(value or [])
+            elif value is None:
+                if key in _NULLABLE_UPDATE_FIELDS:
+                    row[key] = None
             else:
                 row[key] = value
         row["updated_at"] = self._now()

--- a/backend/packages/harness/deerflow/work/units/store/memory.py
+++ b/backend/packages/harness/deerflow/work/units/store/memory.py
@@ -1,0 +1,168 @@
+"""In-memory work unit store for local development and tests."""
+
+from __future__ import annotations
+
+import uuid
+from copy import deepcopy
+from datetime import UTC, datetime
+from typing import Any
+
+from deerflow.work.units.store.base import WorkUnitStore
+from deerflow.utils.time import coerce_iso
+
+
+class MemoryWorkUnitStore(WorkUnitStore):
+    def __init__(self) -> None:
+        self._items: dict[str, dict[str, Any]] = {}
+        self._events: dict[str, list[dict[str, Any]]] = {}
+
+    @staticmethod
+    def _now() -> str:
+        return coerce_iso(datetime.now(UTC))
+
+    @staticmethod
+    def _copy(row: dict[str, Any]) -> dict[str, Any]:
+        return deepcopy(row)
+
+    async def create(
+        self,
+        *,
+        title: str,
+        description: str | None = None,
+        status: str = "backlog",
+        priority: str = "P2",
+        assignee_ref: str | None = None,
+        reporter_ref: str | None = None,
+        due_at: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str = "local",
+        source: str | None = None,
+        external_type: str | None = None,
+        external_ref: str | None = None,
+        external_url: str | None = None,
+        labels: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        user_id: str | None = None,
+        work_unit_id: str | None = None,
+    ) -> dict[str, Any]:
+        now = self._now()
+        row = {
+            "work_unit_id": work_unit_id or str(uuid.uuid4()),
+            "title": title,
+            "description": description,
+            "status": status,
+            "priority": priority,
+            "assignee_ref": assignee_ref,
+            "reporter_ref": reporter_ref,
+            "due_at": due_at,
+            "workflow_id": workflow_id,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "source_type": source_type,
+            "source": source,
+            "external_type": external_type,
+            "external_ref": external_ref,
+            "external_url": external_url,
+            "labels": list(labels or []),
+            "metadata": dict(metadata or {}),
+            "user_id": user_id,
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._items[row["work_unit_id"]] = row
+        self._events[row["work_unit_id"]] = []
+        return self._copy(row)
+
+    async def get(self, work_unit_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        row = self._items.get(work_unit_id)
+        if row is None:
+            return None
+        if user_id is not None and row.get("user_id") != user_id:
+            return None
+        return self._copy(row)
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        workflow_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        rows = list(self._items.values())
+        filters = {
+            "status": status,
+            "workflow_id": workflow_id,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "source_type": source_type,
+            "source": source,
+            "user_id": user_id,
+        }
+        for key, expected in filters.items():
+            if expected is not None:
+                rows = [row for row in rows if row.get(key) == expected]
+        rows.sort(key=lambda row: str(row.get("updated_at") or ""), reverse=True)
+        return [self._copy(row) for row in rows[:limit]]
+
+    async def update(self, work_unit_id: str, *, user_id: str | None = None, **kwargs: Any) -> dict[str, Any] | None:
+        row = self._items.get(work_unit_id)
+        if row is None:
+            return None
+        if user_id is not None and row.get("user_id") != user_id:
+            return None
+        for key, value in kwargs.items():
+            if value is None:
+                continue
+            if key == "metadata":
+                row["metadata"] = {**(row.get("metadata") or {}), **value}
+            elif key == "labels":
+                row["labels"] = list(value)
+            else:
+                row[key] = value
+        row["updated_at"] = self._now()
+        return self._copy(row)
+
+    async def append_event(
+        self,
+        work_unit_id: str,
+        *,
+        event_type: str,
+        actor_ref: str | None = None,
+        workflow_id: str | None = None,
+        run_id: str | None = None,
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        work_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        if work_unit_id not in self._items:
+            return None
+        events = self._events.setdefault(work_unit_id, [])
+        row = {
+            "work_event_id": work_event_id or str(uuid.uuid4()),
+            "work_unit_id": work_unit_id,
+            "seq": len(events) + 1,
+            "event_type": event_type,
+            "actor_ref": actor_ref,
+            "workflow_id": workflow_id,
+            "run_id": run_id,
+            "content": content,
+            "metadata": dict(metadata or {}),
+            "created_at": created_at or self._now(),
+        }
+        events.append(row)
+        return self._copy(row)
+
+    async def list_events(self, work_unit_id: str, *, event_types: list[str] | None = None, limit: int = 500) -> list[dict[str, Any]]:
+        rows = list(self._events.get(work_unit_id, []))
+        if event_types:
+            allowed = set(event_types)
+            rows = [row for row in rows if row.get("event_type") in allowed]
+        return [self._copy(row) for row in rows[:limit]]

--- a/backend/tests/_router_auth_helpers.py
+++ b/backend/tests/_router_auth_helpers.py
@@ -48,6 +48,9 @@ _STUB_PERMISSIONS: list[str] = [
     Permissions.RUNS_CREATE,
     Permissions.RUNS_READ,
     Permissions.RUNS_CANCEL,
+    Permissions.WORK_READ,
+    Permissions.WORK_CREATE,
+    Permissions.WORK_UPDATE,
 ]
 
 

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -623,6 +623,7 @@ async def _capture_start_run_graph_input(body):
     from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
     from deerflow.runtime import RunManager
     from deerflow.runtime.runs.store.memory import MemoryRunStore
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
     run_manager = RunManager(store=MemoryRunStore())
     state = SimpleNamespace(
@@ -633,6 +634,7 @@ async def _capture_start_run_graph_input(body):
         run_event_store=SimpleNamespace(),
         run_events_config=None,
         thread_store=MemoryThreadMetaStore(InMemoryStore()),
+        workflow_store=MemoryWorkflowStore(),
     )
     request = SimpleNamespace(
         headers={},
@@ -709,6 +711,7 @@ def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
     from deerflow.runtime import RunManager
     from deerflow.runtime.runs.store.memory import MemoryRunStore
     from deerflow.runtime.user_context import get_effective_user_id
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
     async def _scenario():
         run_store = MemoryRunStore()
@@ -723,6 +726,7 @@ def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
             run_event_store=SimpleNamespace(),
             run_events_config=None,
             thread_store=thread_store,
+            workflow_store=MemoryWorkflowStore(),
         )
         request = SimpleNamespace(
             headers={INTERNAL_OWNER_USER_ID_HEADER_NAME: "owner-1"},

--- a/backend/tests/test_modules_router.py
+++ b/backend/tests/test_modules_router.py
@@ -1,0 +1,26 @@
+"""Tests for module feature flag router."""
+
+import pytest
+
+from deerflow.config.app_config import AppConfig, reset_app_config, set_app_config
+
+
+@pytest.mark.anyio
+async def test_modules_router_includes_work_module_flags():
+    from app.gateway.routers.modules import get_modules
+
+    set_app_config(
+        AppConfig.model_validate(
+            {
+                "sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"},
+                "modules": {"work": {"enabled": True, "api_enabled": False}},
+            }
+        )
+    )
+    try:
+        payload = await get_modules()
+    finally:
+        reset_app_config()
+
+    assert payload["durable_workflows"]["enabled"] is True
+    assert payload["work"] == {"enabled": True, "api_enabled": False}

--- a/backend/tests/test_persistence_bootstrap.py
+++ b/backend/tests/test_persistence_bootstrap.py
@@ -47,7 +47,7 @@ from deerflow.persistence.migrations._helpers import _normalize_default
 asyncio_test = pytest.mark.asyncio
 
 
-HEAD = "0002_runs_token_usage"
+HEAD = _get_head_revision()
 BASELINE = "0001_baseline"
 
 

--- a/backend/tests/test_persistence_bootstrap_concurrency.py
+++ b/backend/tests/test_persistence_bootstrap_concurrency.py
@@ -23,12 +23,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 import deerflow.persistence.models  # noqa: F401
 from deerflow.persistence import bootstrap as bootstrap_mod
-from deerflow.persistence.bootstrap import bootstrap_schema
+from deerflow.persistence.bootstrap import _get_head_revision, bootstrap_schema
 
 pytestmark = pytest.mark.asyncio
 
 
-HEAD = "0002_runs_token_usage"
+HEAD = _get_head_revision()
 
 
 def _url(tmp_path: Path) -> str:

--- a/backend/tests/test_persistence_bootstrap_regression.py
+++ b/backend/tests/test_persistence_bootstrap_regression.py
@@ -27,10 +27,12 @@ import sqlalchemy as sa
 
 import deerflow.persistence.models  # noqa: F401  -- registers ORM models
 from deerflow.persistence.base import Base
+from deerflow.persistence.bootstrap import _get_head_revision
 from deerflow.persistence.engine import close_engine, get_session_factory, init_engine
 from deerflow.persistence.run import RunRepository
 
 pytestmark = pytest.mark.asyncio
+HEAD = _get_head_revision()
 
 
 def _seed_pre_3658_database(db_path: Path) -> None:
@@ -76,7 +78,7 @@ async def test_legacy_database_recovers_token_usage_column(tmp_path: Path) -> No
             cols = {row[1] for row in raw.execute("PRAGMA table_info(runs)").fetchall()}
             assert "token_usage_by_model" in cols
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0002_runs_token_usage"
+            assert version_row[0] == HEAD
 
         # And the read path that originally 500'd must now succeed.
         sf = get_session_factory()
@@ -116,6 +118,6 @@ async def test_legacy_database_with_manual_alter_still_bootstraps(tmp_path: Path
             # No duplicate column -- list, not set, to catch dupes.
             assert cols.count("token_usage_by_model") == 1
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0002_runs_token_usage"
+            assert version_row[0] == HEAD
     finally:
         await close_engine()

--- a/backend/tests/test_stateless_runs_owner_isolation.py
+++ b/backend/tests/test_stateless_runs_owner_isolation.py
@@ -38,6 +38,7 @@ from app.gateway.routers import runs
 from deerflow.config.app_config import AppConfig, reset_app_config, set_app_config
 from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
 from deerflow.runtime import ConflictError
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
 USER_A = User(email="owner-a@example.com", password_hash="x", system_role="user", id=uuid4())
 USER_B = User(email="intruder-b@example.com", password_hash="x", system_role="user", id=uuid4())
@@ -84,6 +85,7 @@ def _client(user):
     app.state.store = MagicMock()
     app.state.run_events_config = None
     app.state.run_event_store = MagicMock()
+    app.state.workflow_store = MemoryWorkflowStore()
     run_manager = MagicMock()
     run_manager.create_or_reject = AsyncMock(side_effect=ConflictError("sentinel: owner check passed"))
     app.state.run_manager = run_manager

--- a/backend/tests/test_tool_deduplication.py
+++ b/backend/tests/test_tool_deduplication.py
@@ -8,6 +8,7 @@ priority, and logs a warning for every skipped duplicate.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from langchain_core.tools import BaseTool, StructuredTool, tool
@@ -58,6 +59,7 @@ def _make_minimal_config(tools):
     config.models = []
     config.tool_search.enabled = False
     config.skill_evolution.enabled = False
+    config.modules = SimpleNamespace(work=SimpleNamespace(enabled=False))
     config.sandbox = MagicMock()
     config.acp_agents = {}
     return config
@@ -198,3 +200,31 @@ def test_duplicate_triggers_warning(mock_bash, mock_cfg, caplog):
             get_available_tools(include_mcp=False)
 
     assert any("Duplicate tool name" in r.message for r in caplog.records), "Expected a duplicate-tool warning in log output"
+
+
+@patch("deerflow.tools.tools.get_app_config")
+@patch("deerflow.tools.tools.is_host_bash_allowed", return_value=True)
+def test_work_units_tool_respects_work_module_gate(mock_bash, mock_cfg):
+    """The generic Work Unit tool is only exposed when the Work Module is enabled."""
+    disabled_config = _make_minimal_config([])
+    enabled_config = _make_minimal_config([])
+    enabled_config.modules.work.enabled = True
+
+    with patch("deerflow.tools.tools.BUILTIN_TOOLS", []):
+        disabled_names = [
+            tool.name
+            for tool in get_available_tools(
+                include_mcp=False,
+                app_config=disabled_config,
+            )
+        ]
+        enabled_names = [
+            tool.name
+            for tool in get_available_tools(
+                include_mcp=False,
+                app_config=enabled_config,
+            )
+        ]
+
+    assert "work_units" not in disabled_names
+    assert "work_units" in enabled_names

--- a/backend/tests/test_work_unit_repository.py
+++ b/backend/tests/test_work_unit_repository.py
@@ -1,9 +1,11 @@
 """Tests for generic work unit stores."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from deerflow.persistence.work_units import WorkUnitRepository
-from deerflow.tools.builtins.work_unit_tool import build_work_unit_tool
+from deerflow.tools.builtins.work_unit_tool import _work_units_action, build_work_unit_tool
 from deerflow.work.units.store.memory import MemoryWorkUnitStore
 
 
@@ -198,5 +200,42 @@ class TestWorkUnitRepository:
             assert rejected["ok"] is False
             assert accepted["ok"] is True
             assert accepted["work_unit"]["status"] == "ready"
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_work_units_tool_creates_lists_and_updates_for_runtime_user(self, tmp_path):
+        await _make_repo(tmp_path)
+        runtime = SimpleNamespace(context={"user_id": "owner-1", "agent_name": "lead_agent"})
+        other_runtime = SimpleNamespace(context={"user_id": "owner-2", "agent_name": "lead_agent"})
+        try:
+            created = await _work_units_action(
+                runtime=runtime,
+                action="create",
+                title="Plan integration work",
+                description="Create a reusable PM mapping",
+                labels=["pm", "adapter"],
+            )
+            work_unit_id = created["work_unit"]["work_unit_id"]
+            listed = await _work_units_action(runtime=runtime, action="list")
+            rejected = await _work_units_action(
+                runtime=other_runtime,
+                action="update_status",
+                work_unit_id=work_unit_id,
+                status="ready",
+            )
+            updated = await _work_units_action(
+                runtime=runtime,
+                action="update_status",
+                work_unit_id=work_unit_id,
+                status="ready",
+                note="Ready for execution",
+            )
+
+            assert created["ok"] is True
+            assert listed["work_units"][0]["work_unit_id"] == work_unit_id
+            assert rejected["ok"] is False
+            assert updated["ok"] is True
+            assert updated["work_unit"]["status"] == "ready"
         finally:
             await _cleanup()

--- a/backend/tests/test_work_unit_repository.py
+++ b/backend/tests/test_work_unit_repository.py
@@ -63,6 +63,32 @@ async def test_memory_work_unit_store_update_is_user_scoped():
     assert accepted["status"] == "ready"
 
 
+@pytest.mark.anyio
+async def test_memory_work_unit_store_can_clear_nullable_fields():
+    store = MemoryWorkUnitStore()
+    await store.create(
+        work_unit_id="work-clear-memory",
+        title="Clear nullable refs",
+        assignee_ref="lead_agent",
+        thread_id="thread-1",
+        external_ref="EXT-1",
+        labels=["stale"],
+    )
+
+    updated = await store.update(
+        "work-clear-memory",
+        assignee_ref=None,
+        thread_id=None,
+        external_ref=None,
+        labels=None,
+    )
+
+    assert updated["assignee_ref"] is None
+    assert updated["thread_id"] is None
+    assert updated["external_ref"] is None
+    assert updated["labels"] == []
+
+
 class TestWorkUnitRepository:
     @pytest.mark.anyio
     async def test_create_list_update_and_events(self, tmp_path):
@@ -113,6 +139,34 @@ class TestWorkUnitRepository:
 
             assert rejected is None
             assert accepted["status"] == "ready"
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_update_can_clear_nullable_fields(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            await repo.create(
+                work_unit_id="work-sql-clear",
+                title="Clear nullable SQL fields",
+                assignee_ref="lead_agent",
+                thread_id="thread-sql",
+                external_ref="EXT-SQL",
+                labels=["old"],
+            )
+
+            updated = await repo.update(
+                "work-sql-clear",
+                assignee_ref=None,
+                thread_id=None,
+                external_ref=None,
+                labels=None,
+            )
+
+            assert updated["assignee_ref"] is None
+            assert updated["thread_id"] is None
+            assert updated["external_ref"] is None
+            assert updated["labels"] == []
         finally:
             await _cleanup()
 

--- a/backend/tests/test_work_unit_repository.py
+++ b/backend/tests/test_work_unit_repository.py
@@ -1,0 +1,148 @@
+"""Tests for generic work unit stores."""
+
+import pytest
+
+from deerflow.persistence.work_units import WorkUnitRepository
+from deerflow.tools.builtins.work_unit_tool import build_work_unit_tool
+from deerflow.work.units.store.memory import MemoryWorkUnitStore
+
+
+async def _make_repo(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    return WorkUnitRepository(get_session_factory())
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+@pytest.mark.anyio
+async def test_memory_work_unit_store_create_update_and_events():
+    store = MemoryWorkUnitStore()
+    item = await store.create(
+        work_unit_id="work-1",
+        title="Investigate durable run trace",
+        status="backlog",
+        priority="P1",
+        workflow_id="wf-1",
+        labels=["runtime"],
+    )
+    created = await store.append_event("work-1", event_type="work_unit.created", content={"title": item["title"]})
+    updated = await store.update("work-1", status="in_progress", metadata={"source": "test"})
+    status_changed = await store.append_event("work-1", event_type="work_unit.status_changed")
+    rows = await store.list(status="in_progress", workflow_id="wf-1")
+    events = await store.list_events("work-1")
+
+    assert item["work_unit_id"] == "work-1"
+    assert updated["status"] == "in_progress"
+    assert updated["metadata"] == {"source": "test"}
+    assert [row["work_unit_id"] for row in rows] == ["work-1"]
+    assert created["seq"] == 1
+    assert status_changed["seq"] == 2
+    assert [event["event_type"] for event in events] == ["work_unit.created", "work_unit.status_changed"]
+
+
+@pytest.mark.anyio
+async def test_memory_work_unit_store_update_is_user_scoped():
+    store = MemoryWorkUnitStore()
+    await store.create(
+        work_unit_id="work-user-scope",
+        title="Scoped update",
+        user_id="owner-1",
+    )
+
+    rejected = await store.update("work-user-scope", user_id="owner-2", status="ready")
+    accepted = await store.update("work-user-scope", user_id="owner-1", status="ready")
+
+    assert rejected is None
+    assert accepted["status"] == "ready"
+
+
+class TestWorkUnitRepository:
+    @pytest.mark.anyio
+    async def test_create_list_update_and_events(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            item = await repo.create(
+                work_unit_id="work-sql-1",
+                title="Connect board card to workflow",
+                status="ready",
+                priority="P2",
+                workflow_id="wf-sql-1",
+                thread_id="thread-1",
+                run_id="run-1",
+                labels=["board"],
+                metadata={"adapter": "local"},
+            )
+            event = await repo.append_event(
+                "work-sql-1",
+                event_type="work_unit.created",
+                workflow_id="wf-sql-1",
+                run_id="run-1",
+            )
+            updated = await repo.update("work-sql-1", status="done", metadata={"closed": True})
+            rows = await repo.list(status="done", workflow_id="wf-sql-1")
+            events = await repo.list_events("work-sql-1")
+
+            assert item["work_unit_id"] == "work-sql-1"
+            assert updated["status"] == "done"
+            assert updated["metadata"] == {"adapter": "local", "closed": True}
+            assert [row["work_unit_id"] for row in rows] == ["work-sql-1"]
+            assert event["seq"] == 1
+            assert events[0]["event_type"] == "work_unit.created"
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_update_is_user_scoped(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            await repo.create(
+                work_unit_id="work-sql-scoped",
+                title="Scoped SQL update",
+                user_id="owner-1",
+            )
+
+            rejected = await repo.update("work-sql-scoped", user_id="owner-2", status="ready")
+            accepted = await repo.update("work-sql-scoped", user_id="owner-1", status="ready")
+
+            assert rejected is None
+            assert accepted["status"] == "ready"
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_runtime_tool_is_bound_to_work_unit_owner(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            await repo.create(
+                work_unit_id="work-tool-scoped",
+                title="Tool scoped update",
+                status="backlog",
+                user_id="owner-1",
+            )
+
+            other_owner_tool = build_work_unit_tool(
+                work_unit_id="work-tool-scoped",
+                user_id="owner-2",
+                actor_ref="agent:lead_agent",
+            )
+            rejected = await other_owner_tool.ainvoke({"action": "update_status", "status": "ready"})
+
+            owner_tool = build_work_unit_tool(
+                work_unit_id="work-tool-scoped",
+                user_id="owner-1",
+                actor_ref="agent:lead_agent",
+            )
+            accepted = await owner_tool.ainvoke({"action": "update_status", "status": "ready", "note": "ready"})
+
+            assert rejected["ok"] is False
+            assert accepted["ok"] is True
+            assert accepted["work_unit"]["status"] == "ready"
+        finally:
+            await _cleanup()

--- a/backend/tests/test_work_units_router.py
+++ b/backend/tests/test_work_units_router.py
@@ -40,15 +40,23 @@ def test_work_unit_api_create_list_update_and_events():
         )
         listed = client.get("/api/work-units", params={"status": "backlog", "workflow_id": "wf-api-1"})
         updated = client.patch("/api/work-units/work-api-1", json={"status": "in_progress"})
+        cleared = client.patch(
+            "/api/work-units/work-api-1",
+            json={"workflow_id": None, "run_id": None, "labels": None},
+        )
         events = client.get("/api/work-units/work-api-1/events")
 
     assert created.status_code == 200
     assert created.json()["work_unit_id"] == "work-api-1"
     assert [row["work_unit_id"] for row in listed.json()["data"]] == ["work-api-1"]
     assert updated.json()["status"] == "in_progress"
+    assert cleared.json()["workflow_id"] is None
+    assert cleared.json()["run_id"] is None
+    assert cleared.json()["labels"] == []
     assert [event["event_type"] for event in events.json()["events"]] == [
         "work_unit.created",
         "work_unit.status_changed",
+        "work_unit.updated",
     ]
 
 
@@ -83,9 +91,12 @@ def test_work_unit_api_rejects_invalid_enum_values():
             },
         )
         updated = client.patch("/api/work-units/work-api-valid", json={"status": "shipped"})
+        null_status = client.patch("/api/work-units/work-api-valid", json={"status": None})
 
     assert created.status_code == 400
     assert "Invalid priority" in created.json()["detail"]
     assert valid.status_code == 200
     assert updated.status_code == 400
     assert "Invalid status" in updated.json()["detail"]
+    assert null_status.status_code == 400
+    assert "status cannot be null" in null_status.json()["detail"]

--- a/backend/tests/test_work_units_router.py
+++ b/backend/tests/test_work_units_router.py
@@ -1,0 +1,91 @@
+"""Tests for generic work unit endpoints."""
+
+from _router_auth_helpers import make_authed_test_app
+from fastapi.testclient import TestClient
+from uuid import UUID
+
+from app.gateway.auth.models import User
+from app.gateway.routers import work_units
+from deerflow.work.units.store.memory import MemoryWorkUnitStore
+
+
+def _make_client(store: MemoryWorkUnitStore) -> TestClient:
+    user = User(
+        email="work-router@example.com",
+        password_hash="x",
+        system_role="user",
+        id=UUID("11111111-1111-1111-1111-111111111111"),
+    )
+    app = make_authed_test_app(user_factory=lambda: user)
+    app.state.work_unit_store = store
+    app.include_router(work_units.router)
+    return TestClient(app)
+
+
+def test_work_unit_api_create_list_update_and_events():
+    store = MemoryWorkUnitStore()
+
+    with _make_client(store) as client:
+        created = client.post(
+            "/api/work-units",
+            json={
+                "work_unit_id": "work-api-1",
+                "title": "Review workflow trace",
+                "status": "backlog",
+                "priority": "P1",
+                "workflow_id": "wf-api-1",
+                "run_id": "run-api-1",
+                "labels": ["runtime"],
+            },
+        )
+        listed = client.get("/api/work-units", params={"status": "backlog", "workflow_id": "wf-api-1"})
+        updated = client.patch("/api/work-units/work-api-1", json={"status": "in_progress"})
+        events = client.get("/api/work-units/work-api-1/events")
+
+    assert created.status_code == 200
+    assert created.json()["work_unit_id"] == "work-api-1"
+    assert [row["work_unit_id"] for row in listed.json()["data"]] == ["work-api-1"]
+    assert updated.json()["status"] == "in_progress"
+    assert [event["event_type"] for event in events.json()["events"]] == [
+        "work_unit.created",
+        "work_unit.status_changed",
+    ]
+
+
+def test_work_unit_api_missing_and_empty_update():
+    store = MemoryWorkUnitStore()
+
+    with _make_client(store) as client:
+        missing = client.get("/api/work-units/missing")
+        empty_update = client.patch("/api/work-units/missing", json={})
+
+    assert missing.status_code == 404
+    assert empty_update.status_code == 400
+
+
+def test_work_unit_api_rejects_invalid_enum_values():
+    store = MemoryWorkUnitStore()
+
+    with _make_client(store) as client:
+        created = client.post(
+            "/api/work-units",
+            json={
+                "work_unit_id": "work-api-invalid",
+                "title": "Invalid priority",
+                "priority": "urgent",
+            },
+        )
+        valid = client.post(
+            "/api/work-units",
+            json={
+                "work_unit_id": "work-api-valid",
+                "title": "Valid work unit",
+            },
+        )
+        updated = client.patch("/api/work-units/work-api-valid", json={"status": "shipped"})
+
+    assert created.status_code == 400
+    assert "Invalid priority" in created.json()["detail"]
+    assert valid.status_code == 200
+    assert updated.status_code == 400
+    assert "Invalid status" in updated.json()["detail"]

--- a/backend/tests/test_workflow_repository.py
+++ b/backend/tests/test_workflow_repository.py
@@ -1,0 +1,382 @@
+"""Tests for workflow frontdoor stores."""
+
+import pytest
+
+from deerflow.persistence.workflow import WorkflowRepository
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+
+async def _make_repo(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    return WorkflowRepository(get_session_factory())
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_create_or_get_is_idempotent():
+    store = MemoryWorkflowStore()
+
+    first, created = await store.create_or_get(
+        source_type="channel",
+        source="slack:T1",
+        idempotency_key="m-1",
+        external_message_ref="m-1",
+        metadata={"attempt": 1},
+    )
+    second, created_again = await store.create_or_get(
+        source_type="channel",
+        source="slack:T1",
+        idempotency_key="m-1",
+        external_message_ref="m-1",
+        metadata={"attempt": 2},
+    )
+
+    assert created is True
+    assert created_again is False
+    assert second["workflow_id"] == first["workflow_id"]
+    assert second["metadata"] == {"attempt": 1}
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_bind_status_and_filter():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(source_type="api", source="dashboard", user_id="alice")
+
+    bound = await store.bind_runtime(
+        workflow["workflow_id"],
+        thread_id="thread-1",
+        run_id="run-1",
+        checkpoint_ns="",
+        checkpoint_id="ckpt-1",
+        status="run_created",
+        metadata={"binding": "direct"},
+    )
+    updated = await store.update_status(workflow["workflow_id"], "running", metadata={"phase": "streaming"})
+
+    row = await store.get(workflow["workflow_id"], user_id="alice")
+    rows = await store.list(thread_id="thread-1", run_id="run-1", user_id="alice")
+
+    assert bound is True
+    assert updated is True
+    assert row["status"] == "running"
+    assert row["thread_id"] == "thread-1"
+    assert row["run_id"] == "run-1"
+    assert row["checkpoint_id"] == "ckpt-1"
+    assert row["metadata"] == {"binding": "direct", "phase": "streaming"}
+    assert [item["workflow_id"] for item in rows] == [workflow["workflow_id"]]
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_claim_and_release_for_retry():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(source_type="api", source="dashboard", max_attempts=2)
+
+    claimed = await store.claim_next(lease_owner="worker-1", lease_seconds=30)
+    released = await store.release_for_retry(
+        workflow["workflow_id"],
+        status="received",
+        error="transient",
+        metadata={"retry": True},
+    )
+    claimed_again = await store.claim_next(lease_owner="worker-2", lease_seconds=30)
+    exhausted = await store.release_for_retry(workflow["workflow_id"], status="received")
+    should_skip = await store.claim_next(lease_owner="worker-3", lease_seconds=30)
+
+    assert claimed["workflow_id"] == workflow["workflow_id"]
+    assert claimed["lease_owner"] == "worker-1"
+    assert claimed["attempt_count"] == 1
+    assert released is True
+    assert claimed_again["lease_owner"] == "worker-2"
+    assert claimed_again["attempt_count"] == 2
+    assert exhausted is True
+    assert should_skip is None
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_appends_events_in_order():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(workflow_id="wf-memory-events", source_type="api")
+
+    first = await store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.received",
+        content={"source": "dashboard"},
+        metadata={"durable": True},
+    )
+    second = await store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.bound",
+        thread_id="thread-1",
+        run_id="run-1",
+        checkpoint_ns="",
+        checkpoint_id="ckpt-1",
+        run_event_seq=7,
+        idempotency_key="wf-memory-events:bound",
+    )
+    missing = await store.append_event("missing", event_type="workflow.received")
+    bound_events = await store.list_events(workflow["workflow_id"], event_types=["workflow.bound"])
+
+    assert first["seq"] == 1
+    assert first["content"] == {"source": "dashboard"}
+    assert first["metadata"] == {"durable": True}
+    assert second["seq"] == 2
+    assert second["thread_id"] == "thread-1"
+    assert second["run_id"] == "run-1"
+    assert second["checkpoint_ns"] == ""
+    assert second["run_event_seq"] == 7
+    assert second["idempotency_key"] == "wf-memory-events:bound"
+    assert missing is None
+    assert [event["event_type"] for event in bound_events] == ["workflow.bound"]
+
+
+class TestWorkflowRepository:
+    @pytest.mark.anyio
+    async def test_create_or_get_and_get(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, created = await repo.create_or_get(
+                workflow_id="wf-1",
+                workflow_kind="message",
+                source_type="api",
+                source="dashboard",
+                idempotency_key="idem-1",
+                external_message_ref="msg-1",
+                conversation_ref="conv-1",
+                sender_ref="user-1",
+                user_id="alice",
+                metadata={"source": "test"},
+            )
+
+            loaded = await repo.get("wf-1", user_id="alice")
+
+            assert created is True
+            assert loaded == row
+            assert loaded["workflow_id"] == "wf-1"
+            assert loaded["status"] == "received"
+            assert loaded["metadata"] == {"source": "test"}
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_create_or_get_is_idempotent_for_retried_writes(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            first, created = await repo.create_or_get(
+                workflow_kind="message",
+                source_type="channel",
+                source="slack:T1",
+                idempotency_key="event-1",
+                metadata={"attempt": 1},
+            )
+            second, created_again = await repo.create_or_get(
+                workflow_kind="message",
+                source_type="channel",
+                source="slack:T1",
+                idempotency_key="event-1",
+                metadata={"attempt": 2},
+            )
+
+            assert created is True
+            assert created_again is False
+            assert second["workflow_id"] == first["workflow_id"]
+            assert second["metadata"] == {"attempt": 1}
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_idempotency_without_source_uses_blank_scope(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            first, _ = await repo.create_or_get(source_type="api", idempotency_key="same")
+            second, created_again = await repo.create_or_get(source_type="api", idempotency_key="same")
+
+            assert created_again is False
+            assert second["workflow_id"] == first["workflow_id"]
+            assert second["source"] == ""
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_bind_runtime_and_update_status(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(workflow_id="wf-bind", source_type="api")
+
+            bound = await repo.bind_runtime(
+                row["workflow_id"],
+                thread_id="thread-1",
+                run_id="run-1",
+                checkpoint_ns="",
+                checkpoint_id="ckpt-1",
+                status="run_created",
+                metadata={"binding": "deterministic"},
+            )
+            updated = await repo.update_status(
+                row["workflow_id"],
+                "failed",
+                error="boom",
+                metadata={"recovery": "retryable"},
+            )
+            loaded = await repo.get(row["workflow_id"])
+
+            assert bound is True
+            assert updated is True
+            assert loaded["status"] == "failed"
+            assert loaded["error"] == "boom"
+            assert loaded["thread_id"] == "thread-1"
+            assert loaded["run_id"] == "run-1"
+            assert loaded["checkpoint_ns"] == ""
+            assert loaded["checkpoint_id"] == "ckpt-1"
+            assert loaded["metadata"] == {
+                "binding": "deterministic",
+                "recovery": "retryable",
+            }
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_claim_next_and_release_for_retry(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(
+                workflow_id="wf-claim",
+                source_type="api",
+                source="dashboard",
+                max_attempts=2,
+            )
+
+            claimed = await repo.claim_next(lease_owner="worker-1", lease_seconds=60)
+            none_while_leased = await repo.claim_next(lease_owner="worker-2", lease_seconds=60)
+            released = await repo.release_for_retry(
+                row["workflow_id"],
+                status="received",
+                error="transient",
+                metadata={"retry": True},
+            )
+            claimed_again = await repo.claim_next(lease_owner="worker-2", lease_seconds=60)
+            await repo.release_for_retry(row["workflow_id"], status="received")
+            should_skip = await repo.claim_next(lease_owner="worker-3", lease_seconds=60)
+
+            assert claimed["workflow_id"] == "wf-claim"
+            assert claimed["status"] == "claimed"
+            assert claimed["lease_owner"] == "worker-1"
+            assert claimed["lease_expires_at"] is not None
+            assert claimed["attempt_count"] == 1
+            assert none_while_leased is None
+            assert released is True
+            assert claimed_again["lease_owner"] == "worker-2"
+            assert claimed_again["attempt_count"] == 2
+            assert should_skip is None
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_list_filters(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            await repo.create_or_get(
+                workflow_id="wf-1",
+                source_type="channel",
+                source="slack",
+                user_id="alice",
+                thread_id="thread-1",
+                run_id="run-1",
+                status="running",
+            )
+            await repo.create_or_get(
+                workflow_id="wf-2",
+                source_type="channel",
+                source="discord",
+                user_id="alice",
+                thread_id="thread-2",
+                run_id="run-2",
+                status="received",
+            )
+            await repo.create_or_get(
+                workflow_id="wf-3",
+                source_type="api",
+                source="dashboard",
+                user_id="bob",
+                thread_id="thread-1",
+                run_id="run-3",
+                status="running",
+            )
+
+            rows = await repo.list(
+                status="running",
+                source_type="channel",
+                source="slack",
+                thread_id="thread-1",
+                user_id="alice",
+            )
+
+            assert [row["workflow_id"] for row in rows] == ["wf-1"]
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_missing_updates_return_false(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            assert await repo.bind_runtime("missing", thread_id="t1") is False
+            assert await repo.update_status("missing", "failed") is False
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_append_and_list_events(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(workflow_id="wf-events", source_type="api")
+
+            first = await repo.append_event(
+                row["workflow_id"],
+                event_type="workflow.received",
+                category="lifecycle",
+                content={"source": "dashboard"},
+                metadata={"attempt": 1},
+            )
+            second = await repo.append_event(
+                row["workflow_id"],
+                event_type="workflow.bound",
+                category="runtime",
+                thread_id="thread-1",
+                run_id="run-1",
+                checkpoint_ns="",
+                checkpoint_id="ckpt-1",
+                run_event_seq=9,
+                idempotency_key="wf-events:bound",
+                source_event_ref="run_events:thread-1:run-1:1",
+            )
+            missing = await repo.append_event("missing", event_type="workflow.received")
+            all_events = await repo.list_events(row["workflow_id"])
+            bound_events = await repo.list_events(row["workflow_id"], event_types=["workflow.bound"])
+
+            assert first["seq"] == 1
+            assert first["content"] == {"source": "dashboard"}
+            assert first["metadata"] == {"attempt": 1}
+            assert second["seq"] == 2
+            assert second["category"] == "runtime"
+            assert second["thread_id"] == "thread-1"
+            assert second["run_id"] == "run-1"
+            assert second["checkpoint_ns"] == ""
+            assert second["checkpoint_id"] == "ckpt-1"
+            assert second["run_event_seq"] == 9
+            assert second["idempotency_key"] == "wf-events:bound"
+            assert second["source_event_ref"] == "run_events:thread-1:run-1:1"
+            assert missing is None
+            assert [event["event_type"] for event in all_events] == [
+                "workflow.received",
+                "workflow.bound",
+            ]
+            assert [event["event_type"] for event in bound_events] == ["workflow.bound"]
+        finally:
+            await _cleanup()

--- a/backend/tests/test_workflows_router.py
+++ b/backend/tests/test_workflows_router.py
@@ -1,0 +1,148 @@
+"""Tests for durable workflow read endpoints."""
+
+import asyncio
+
+from _router_auth_helpers import make_authed_test_app
+from fastapi.testclient import TestClient
+
+from app.gateway.routers import workflows
+from deerflow.runtime.events.store.memory import MemoryRunEventStore
+from deerflow.runtime.runs.store.memory import MemoryRunStore
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+
+def _make_client(
+    store: MemoryWorkflowStore,
+    *,
+    run_event_store: MemoryRunEventStore | None = None,
+    run_store: MemoryRunStore | None = None,
+) -> TestClient:
+    app = make_authed_test_app()
+    app.state.workflow_store = store
+    app.state.run_event_store = run_event_store or MemoryRunEventStore()
+    app.state.run_store = run_store or MemoryRunStore()
+    app.include_router(workflows.router)
+    return TestClient(app)
+
+
+def test_list_and_get_workflows():
+    store = MemoryWorkflowStore()
+    asyncio.run(
+        store.create_or_get(
+            workflow_id="wf-api-1",
+            source_type="api",
+            source="dashboard",
+            status="running",
+            thread_id="thread-1",
+            run_id="run-1",
+            user_id="alice",
+        )
+    )
+    asyncio.run(
+        store.create_or_get(
+            workflow_id="wf-channel-1",
+            source_type="channel",
+            source="slack",
+            status="received",
+            user_id="bob",
+        )
+    )
+
+    with _make_client(store) as client:
+        listed = client.get("/api/workflows", params={"status": "running", "source_type": "api"}).json()
+        loaded = client.get("/api/workflows/wf-api-1").json()
+
+    assert [row["workflow_id"] for row in listed["data"]] == ["wf-api-1"]
+    assert loaded["workflow_id"] == "wf-api-1"
+    assert loaded["thread_id"] == "thread-1"
+    assert loaded["run_id"] == "run-1"
+
+
+def test_list_workflow_events_and_missing_workflow():
+    store = MemoryWorkflowStore()
+    asyncio.run(store.create_or_get(workflow_id="wf-events", source_type="api"))
+    asyncio.run(
+        store.append_event(
+            "wf-events",
+            event_type="workflow.received",
+            content={"source": "dashboard"},
+        )
+    )
+    asyncio.run(
+        store.append_event(
+            "wf-events",
+            event_type="workflow.bound",
+            thread_id="thread-1",
+            run_id="run-1",
+        )
+    )
+
+    with _make_client(store) as client:
+        events = client.get("/api/workflows/wf-events/events", params={"event_type": "workflow.bound"}).json()
+        missing = client.get("/api/workflows/missing/events")
+
+    assert events["workflow"]["workflow_id"] == "wf-events"
+    assert [event["event_type"] for event in events["events"]] == ["workflow.bound"]
+    assert events["events"][0]["seq"] == 2
+    assert missing.status_code == 404
+
+
+def test_workflow_by_run_and_timeline_merges_run_events():
+    workflow_store = MemoryWorkflowStore()
+    run_event_store = MemoryRunEventStore()
+    run_store = MemoryRunStore()
+    asyncio.run(
+        workflow_store.create_or_get(
+            workflow_id="wf-trace",
+            source_type="api",
+            source="/api/runs/wait",
+            status="succeeded",
+            thread_id="thread-1",
+            run_id="run-1",
+        )
+    )
+    asyncio.run(
+        workflow_store.append_event(
+            "wf-trace",
+            event_type="workflow.received",
+            created_at="2026-06-26T00:00:00+00:00",
+        )
+    )
+    asyncio.run(
+        workflow_store.append_event(
+            "wf-trace",
+            event_type="workflow.succeeded",
+            thread_id="thread-1",
+            run_id="run-1",
+            created_at="2026-06-26T00:00:02+00:00",
+        )
+    )
+    asyncio.run(
+        run_event_store.put(
+            thread_id="thread-1",
+            run_id="run-1",
+            event_type="messages",
+            category="message",
+            content={"role": "assistant", "content": "done"},
+            created_at="2026-06-26T00:00:01+00:00",
+        )
+    )
+    asyncio.run(run_store.put("run-1", thread_id="thread-1", status="success"))
+
+    with _make_client(workflow_store, run_event_store=run_event_store, run_store=run_store) as client:
+        by_run = client.get("/api/workflows/by-run/run-1").json()
+        timeline = client.get("/api/workflows/wf-trace/timeline").json()
+
+    assert by_run["workflow_id"] == "wf-trace"
+    assert timeline["workflow"]["workflow_id"] == "wf-trace"
+    assert timeline["run"]["run_id"] == "run-1"
+    assert [event["kind"] for event in timeline["timeline"]] == [
+        "workflow_event",
+        "run_event",
+        "workflow_event",
+    ]
+    assert [event["event_type"] for event in timeline["timeline"]] == [
+        "workflow.received",
+        "messages",
+        "workflow.succeeded",
+    ]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,12 +27,16 @@ log_level: info
 # Optional Modules
 # ============================================================================
 # These gates are startup-only: restart the gateway after changing them.
-# Durable workflows are the small runtime identity/trace layer.
+# Durable workflows are the small runtime identity/trace layer. Work is the
+# generic work unit module for agent and PM-tool integration.
 modules:
   durable_workflows:
     enabled: true
     api_enabled: true
     auto_envelope_for_runs: true
+  work:
+    enabled: true
+    api_enabled: true
 
 # ============================================================================
 # Token Usage

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,13 +15,24 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 15
+config_version: 16
 
 # ============================================================================
 # Logging
 # ============================================================================
 # Log level for deerflow modules (debug/info/warning/error)
 log_level: info
+
+# ============================================================================
+# Optional Modules
+# ============================================================================
+# These gates are startup-only: restart the gateway after changing them.
+# Durable workflows are the small runtime identity/trace layer.
+modules:
+  durable_workflows:
+    enabled: true
+    api_enabled: true
+    auto_envelope_for_runs: true
 
 # ============================================================================
 # Token Usage

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -22,12 +22,14 @@ import { ThreadTitle } from "@/components/workspace/thread-title";
 import { TodoList } from "@/components/workspace/todo-list";
 import { TokenUsageIndicator } from "@/components/workspace/token-usage-indicator";
 import { Welcome } from "@/components/workspace/welcome";
+import { WorkflowTraceTrigger } from "@/components/workspace/workflow-trace-trigger";
 import { useI18n } from "@/core/i18n/hooks";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
 import {
   useThreadMetadata,
+  useThreadRuns,
   useThreadStream,
   useThreadTokenUsage,
 } from "@/core/threads/hooks";
@@ -54,11 +56,15 @@ export default function ChatPage() {
     isNewThread || isMock ? undefined : threadId,
     { enabled: tokenUsageEnabled && !isMock },
   );
+  const threadRuns = useThreadRuns(isNewThread || isMock ? undefined : threadId, {
+    enabled: !isNewThread && !isMock,
+  });
   const threadMetadata = useThreadMetadata(threadId, {
     enabled: !isNewThread && !isMock,
     isMock,
   });
   const backendTokenUsage = threadTokenUsageToTokenUsage(threadTokenUsage.data);
+  const latestRunId = threadRuns.data?.[0]?.run_id;
   const mountedRef = useRef(false);
   useSpecificChatMode();
 
@@ -200,6 +206,10 @@ export default function ChatPage() {
                 }
               />
               <ExportTrigger threadId={threadId} />
+              <WorkflowTraceTrigger
+                enabled={!isMock}
+                runId={latestRunId}
+              />
               <ArtifactTrigger />
             </div>
           </header>

--- a/frontend/src/app/workspace/work/page.tsx
+++ b/frontend/src/app/workspace/work/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Activity,
   ChevronDown,
@@ -52,6 +52,7 @@ import { useThreadStream } from "@/core/threads/hooks";
 import { textOfMessage } from "@/core/threads/utils";
 import { uuid } from "@/core/utils/uuid";
 import {
+  workUnitsQueryKey,
   useCreateWorkUnit,
   useUpdateWorkUnit,
   useWorkUnits,
@@ -970,6 +971,7 @@ function WorkUnitChatPanel({
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
   const updateWorkUnit = useUpdateWorkUnit();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const nextAgent =
@@ -994,6 +996,14 @@ function WorkUnitChatPanel({
     threadId: persistedThreadId ?? undefined,
     displayThreadId: draftThreadId,
     context: chatContext,
+    onToolEnd: (event) => {
+      if (event.name === "work_unit" || event.name === "work_units") {
+        void queryClient.invalidateQueries({ queryKey: workUnitsQueryKey });
+      }
+    },
+    onFinish: () => {
+      void queryClient.invalidateQueries({ queryKey: workUnitsQueryKey });
+    },
     onStart: (createdThreadId) => {
       setPersistedThreadId(createdThreadId);
       if (item && item.thread_id !== createdThreadId) {

--- a/frontend/src/app/workspace/work/page.tsx
+++ b/frontend/src/app/workspace/work/page.tsx
@@ -1,0 +1,1261 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  FileText,
+  ListPlus,
+  MessageSquare,
+  PanelRightClose,
+  PanelRightOpen,
+  PlusIcon,
+  Search,
+  Send,
+} from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import type { FormEvent, ReactNode } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  WorkspaceBody,
+  WorkspaceContainer,
+  WorkspaceHeader,
+} from "@/components/workspace/workspace-container";
+import { useAgents } from "@/core/agents";
+import { isHiddenFromUIMessage } from "@/core/messages/utils";
+import { useModuleFlags } from "@/core/modules";
+import { useLocalSettings } from "@/core/settings";
+import { useThreadStream } from "@/core/threads/hooks";
+import { textOfMessage } from "@/core/threads/utils";
+import { uuid } from "@/core/utils/uuid";
+import {
+  useCreateWorkUnit,
+  useUpdateWorkUnit,
+  useWorkUnits,
+  type WorkUnit,
+} from "@/core/work-units";
+import { fetchWorkflowTimeline } from "@/core/workflows/api";
+import type { WorkflowTimelineEvent } from "@/core/workflows/api";
+
+const LEAD_AGENT_NAME = "lead_agent";
+
+const STATUS_COLUMNS = [
+  {
+    value: "backlog",
+    label: "Backlog",
+    description: "Captured or proposed work that is not dispatchable yet.",
+  },
+  {
+    value: "ready",
+    label: "Ready",
+    description: "Dispatchable work with minimum required context.",
+  },
+  {
+    value: "in_progress",
+    label: "Running",
+    description: "Active execution by human, agent, or runtime.",
+  },
+  {
+    value: "blocked",
+    label: "Waiting",
+    description: "Paused on dependency, external input, gate, or resume condition.",
+  },
+  {
+    value: "review",
+    label: "Review",
+    description: "Output or evidence exists and needs acceptance.",
+  },
+  {
+    value: "done",
+    label: "Done",
+    description: "Completed, accepted, or otherwise verified work.",
+  },
+  {
+    value: "closed",
+    label: "Closed",
+    description: "Archived or closed work that should not re-enter execution.",
+  },
+] as const;
+
+const PRIORITIES = [
+  { value: "P0", label: "Critical" },
+  { value: "P1", label: "High" },
+  { value: "P2", label: "Medium" },
+  { value: "P3", label: "Low" },
+  { value: "P4", label: "Later" },
+] as const;
+
+function compact(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function labelsFromText(value: string): string[] {
+  return value
+    .split(",")
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
+function groupByStatus(items: WorkUnit[]) {
+  return STATUS_COLUMNS.reduce<Record<string, WorkUnit[]>>((acc, column) => {
+    acc[column.value] = items.filter((item) => item.status === column.value);
+    return acc;
+  }, {});
+}
+
+function statusLabel(status: string) {
+  return STATUS_COLUMNS.find((column) => column.value === status)?.label ?? status;
+}
+
+function priorityLabel(priority: string) {
+  return PRIORITIES.find((item) => item.value === priority)?.label ?? priority;
+}
+
+function buildWorkUnitPrompt(item: WorkUnit | undefined, userMessage: string) {
+  if (!item) return userMessage;
+  const fields = [
+    ["work_unit_id", item.work_unit_id],
+    ["title", item.title],
+    ["status", statusLabel(item.status)],
+    ["priority", priorityLabel(item.priority)],
+    ["assignee_ref", item.assignee_ref ?? ""],
+    ["description", item.description ?? ""],
+    ["tags", item.labels.join(", ")],
+    ["workflow_id", item.workflow_id ?? ""],
+    ["thread_id", item.thread_id ?? ""],
+    ["run_id", item.run_id ?? ""],
+  ]
+    .filter(([, value]) => String(value).trim().length > 0)
+    .map(([key, value]) => `- ${key}: ${value}`)
+    .join("\n");
+
+  return [
+    "Work Unit Context",
+    fields,
+    "",
+    "User request",
+    userMessage,
+    "",
+    "Use the Work Unit Context above as the authoritative work record. If the user asks you to execute or continue the work unit, act on this context rather than asking them to paste it again.",
+    "If you need to change the Work Unit status, call the work_unit tool first and only claim the change after the tool returns ok=true.",
+  ].join("\n");
+}
+
+function agentOptionsFromDeerFlow(agents: Array<{ name: string }>) {
+  const seen = new Set<string>();
+  return [{ name: LEAD_AGENT_NAME }, ...agents].filter((agent) => {
+    if (seen.has(agent.name)) return false;
+    seen.add(agent.name);
+    return true;
+  });
+}
+
+function isLinked(item: WorkUnit) {
+  return Boolean(item.workflow_id ?? item.thread_id ?? item.run_id);
+}
+
+function itemNeedsAttention(item: WorkUnit) {
+  return item.status === "blocked" || item.status === "review" || item.priority === "P0" || item.priority === "P1";
+}
+
+function itemMatchesSearch(item: WorkUnit, search: string) {
+  const query = search.trim().toLowerCase();
+  if (!query) return true;
+  return [
+    item.work_unit_id,
+    item.title,
+    item.description,
+    item.priority,
+    priorityLabel(item.priority),
+    item.status,
+    item.workflow_id,
+    item.thread_id,
+    item.run_id,
+    item.labels.join(" "),
+  ]
+    .filter(Boolean)
+    .some((value) => String(value).toLowerCase().includes(query));
+}
+
+function parseBulkLines(value: string) {
+  return value
+    .split("\n")
+    .map((line) => line.trim().replace(/^[-*]\s+/, ""))
+    .filter(Boolean);
+}
+
+function priorityTone(priority: string) {
+  if (priority === "P0" || priority === "P1") return "bg-red-500/10 text-red-600 dark:text-red-300";
+  if (priority === "P2") return "bg-amber-500/10 text-amber-600 dark:text-amber-300";
+  return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-300";
+}
+
+function relativeDate(value?: string) {
+  if (!value) return "not updated";
+  const time = new Date(value).getTime();
+  if (Number.isNaN(time)) return value;
+  const days = Math.max(0, Math.floor((Date.now() - time) / 86_400_000));
+  if (days === 0) return "today";
+  if (days === 1) return "1d ago";
+  return `${days}d ago`;
+}
+
+export default function WorkPage() {
+  const { data: modules } = useModuleFlags();
+  const workApiEnabled = modules
+    ? modules.work.enabled && modules.work.api_enabled
+    : true;
+  const { data: items = [], error } = useWorkUnits({
+    enabled: workApiEnabled,
+  });
+  const { agents } = useAgents();
+  const createWorkUnit = useCreateWorkUnit();
+  const updateWorkUnit = useUpdateWorkUnit();
+  const agentOptions = useMemo(() => agentOptionsFromDeerFlow(agents), [agents]);
+
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [bulkText, setBulkText] = useState("");
+  const [priority, setPriority] = useState("P2");
+  const [assigneeRef, setAssigneeRef] = useState(LEAD_AGENT_NAME);
+  const [labels, setLabels] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("all");
+  const [assigneeFilter, setAssigneeFilter] = useState("all");
+  const [attentionFilter, setAttentionFilter] = useState("all");
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [collapsedColumns, setCollapsedColumns] = useState<Record<string, boolean>>({});
+  const [detailPanelOpen, setDetailPanelOpen] = useState(true);
+
+  const filteredItems = useMemo(() => {
+    return items.filter((item) => {
+      if (priorityFilter !== "all" && item.priority !== priorityFilter) return false;
+      if (assigneeFilter === "unassigned" && item.assignee_ref) return false;
+      if (
+        assigneeFilter !== "all" &&
+        assigneeFilter !== "unassigned" &&
+        item.assignee_ref !== assigneeFilter
+      ) {
+        return false;
+      }
+      if (attentionFilter === "attention" && !itemNeedsAttention(item)) return false;
+      if (attentionFilter === "runtime" && !isLinked(item)) return false;
+      return itemMatchesSearch(item, search);
+    });
+  }, [assigneeFilter, attentionFilter, items, priorityFilter, search]);
+
+  const columns = useMemo(() => groupByStatus(filteredItems), [filteredItems]);
+  const selectedItem =
+    filteredItems.find((item) => item.work_unit_id === selectedId) ?? filteredItems[0];
+  const blockedCount = items.filter((item) => item.status === "blocked").length;
+  const runtimeCount = items.filter(isLinked).length;
+  const health = blockedCount > 0 ? "red" : "green";
+
+  const errorMessage =
+    (error instanceof Error ? error.message : null) ??
+    createWorkUnit.error?.message;
+
+  useEffect(() => {
+    if (selectedId && filteredItems.some((item) => item.work_unit_id === selectedId)) return;
+    setSelectedId(filteredItems[0]?.work_unit_id ?? null);
+  }, [filteredItems, selectedId]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!compact(title)) return;
+    const created = await createWorkUnit.mutateAsync({
+      title: title.trim(),
+      description: compact(description),
+      status: "backlog",
+      priority,
+      assignee_ref: assigneeRef === "unassigned" ? undefined : assigneeRef,
+      labels: labelsFromText(labels),
+    });
+    setSelectedId(created.work_unit_id);
+    setTitle("");
+    setDescription("");
+    setAssigneeRef(LEAD_AGENT_NAME);
+    setLabels("");
+    setPriority("P2");
+    setCreateOpen(false);
+  }
+
+  async function handleBulkSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const titles = parseBulkLines(bulkText);
+    if (titles.length === 0) return;
+    let lastCreated: WorkUnit | null = null;
+    for (const workTitle of titles) {
+      lastCreated = await createWorkUnit.mutateAsync({
+        title: workTitle,
+        status: "backlog",
+        priority,
+        assignee_ref: assigneeRef === "unassigned" ? undefined : assigneeRef,
+        labels: labelsFromText(labels),
+      });
+    }
+    if (lastCreated) setSelectedId(lastCreated.work_unit_id);
+    setBulkText("");
+    setAssigneeRef(LEAD_AGENT_NAME);
+    setLabels("");
+    setPriority("P2");
+    setBulkOpen(false);
+  }
+
+  function openCreate() {
+    setCreateOpen(true);
+  }
+
+  function toggleColumn(status: string) {
+    setCollapsedColumns((current) => ({
+      ...current,
+      [status]: !current[status],
+    }));
+  }
+
+  if (!workApiEnabled) {
+    return (
+      <WorkspaceContainer>
+        <WorkspaceHeader />
+        <WorkspaceBody>
+          <div className="flex h-full w-full items-center justify-center p-6">
+            <div className="max-w-md space-y-2 text-center">
+              <h1 className="text-xl font-semibold">Work Module disabled</h1>
+              <p className="text-muted-foreground text-sm">
+                Enable the Work Module in DeerFlow module config to use this
+                workspace surface.
+              </p>
+            </div>
+          </div>
+        </WorkspaceBody>
+      </WorkspaceContainer>
+    );
+  }
+
+  return (
+    <WorkspaceContainer>
+      <WorkspaceHeader />
+      <WorkspaceBody className="items-stretch">
+        <div className="bg-background flex min-h-0 w-full flex-1 flex-col">
+          <div className="flex flex-wrap items-center gap-2 border-b px-4 py-3">
+            <FilterSelect label="Priority" value={priorityFilter} onValueChange={setPriorityFilter}>
+              <SelectItem value="all">All priorities</SelectItem>
+              {PRIORITIES.map((item) => (
+                <SelectItem key={item.value} value={item.value}>
+                  {item.label}
+                </SelectItem>
+              ))}
+            </FilterSelect>
+            <FilterSelect label="Attention" value={attentionFilter} onValueChange={setAttentionFilter}>
+              <SelectItem value="all">All attention</SelectItem>
+              <SelectItem value="attention">Needs attention</SelectItem>
+              <SelectItem value="runtime">Runtime linked</SelectItem>
+            </FilterSelect>
+            <FilterSelect label="Agent" value={assigneeFilter} onValueChange={setAssigneeFilter}>
+              <SelectItem value="all">All agents</SelectItem>
+              {agentOptions.map((agent) => (
+                <SelectItem key={agent.name} value={agent.name}>
+                  {agent.name}
+                </SelectItem>
+              ))}
+              <SelectItem value="unassigned">Unassigned</SelectItem>
+            </FilterSelect>
+            <div className="relative min-w-60 flex-1">
+              <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+              <Input
+                aria-label="Search work units"
+                className="h-9 pl-9"
+                placeholder="Search work unit, workflow, run"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+              />
+            </div>
+            <Button aria-label="New Work Unit" type="button" size="sm" onClick={() => openCreate()}>
+              <PlusIcon />
+              New
+            </Button>
+            <Button aria-label="Bulk capture Work Units" type="button" size="sm" variant="outline" onClick={() => setBulkOpen(true)}>
+              <ListPlus />
+              Bulk
+            </Button>
+            {errorMessage && <div className="text-destructive basis-full text-sm">{errorMessage}</div>}
+          </div>
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogContent className="max-h-[86vh] overflow-y-auto sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>New Work Unit</DialogTitle>
+                <DialogDescription>
+                  Capture a backlog unit for an agent or runtime to pick up.
+                </DialogDescription>
+              </DialogHeader>
+              <form className="grid gap-4" onSubmit={(event) => void handleSubmit(event)}>
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium" htmlFor="work-title">
+                    Title
+                  </label>
+                  <Input
+                    id="work-title"
+                    placeholder="Short work unit title"
+                    value={title}
+                    onChange={(event) => setTitle(event.target.value)}
+                  />
+                </div>
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium" htmlFor="work-description">
+                    Next action / description
+                  </label>
+                  <Textarea
+                    id="work-description"
+                    className="min-h-24 resize-none"
+                    placeholder="What should happen next?"
+                    value={description}
+                    onChange={(event) => setDescription(event.target.value)}
+                  />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium">Priority</label>
+                    <Select value={priority} onValueChange={setPriority}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {PRIORITIES.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium">Agent</label>
+                    <Select value={assigneeRef} onValueChange={setAssigneeRef}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {agentOptions.map((agent) => (
+                          <SelectItem key={agent.name} value={agent.name}>
+                            {agent.name}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value="unassigned">Unassigned</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium" htmlFor="work-tags">
+                    Tags
+                  </label>
+                  <Input
+                    id="work-tags"
+                    placeholder="customer, review, incident"
+                    value={labels}
+                    onChange={(event) => setLabels(event.target.value)}
+                  />
+                </div>
+                {errorMessage && <div className="text-destructive text-sm">{errorMessage}</div>}
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={createWorkUnit.isPending || !compact(title)}>
+                    <PlusIcon />
+                    Create Work Unit
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+          <Dialog open={bulkOpen} onOpenChange={setBulkOpen}>
+            <DialogContent className="max-h-[86vh] overflow-y-auto sm:max-w-2xl">
+              <DialogHeader>
+                <DialogTitle>Bulk Capture Work Units</DialogTitle>
+                <DialogDescription>
+                  Paste one work unit title per line. New units start in backlog.
+                </DialogDescription>
+              </DialogHeader>
+              <form className="grid gap-4" onSubmit={(event) => void handleBulkSubmit(event)}>
+                <div className="grid gap-2">
+                  <label className="text-sm font-medium" htmlFor="work-bulk">
+                    Work units
+                  </label>
+                  <Textarea
+                    id="work-bulk"
+                    className="min-h-52 resize-none font-mono text-sm"
+                    placeholder={"PR 1: Durable workflow docs\nPR 2: Workflow store\nPR 3: Workflow APIs"}
+                    value={bulkText}
+                    onChange={(event) => setBulkText(event.target.value)}
+                  />
+                </div>
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium">Priority</label>
+                    <Select value={priority} onValueChange={setPriority}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {PRIORITIES.map((item) => (
+                          <SelectItem key={item.value} value={item.value}>
+                            {item.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium">Agent</label>
+                    <Select value={assigneeRef} onValueChange={setAssigneeRef}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {agentOptions.map((agent) => (
+                          <SelectItem key={agent.name} value={agent.name}>
+                            {agent.name}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value="unassigned">Unassigned</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="grid gap-2">
+                    <label className="text-sm font-medium" htmlFor="work-bulk-tags">
+                      Tags
+                    </label>
+                    <Input
+                      id="work-bulk-tags"
+                      placeholder="upstream, pr-stack"
+                      value={labels}
+                      onChange={(event) => setLabels(event.target.value)}
+                    />
+                  </div>
+                </div>
+                {errorMessage && <div className="text-destructive text-sm">{errorMessage}</div>}
+                <DialogFooter>
+                  <Button type="button" variant="outline" onClick={() => setBulkOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button type="submit" disabled={createWorkUnit.isPending || parseBulkLines(bulkText).length === 0}>
+                    <ListPlus />
+                    Create {parseBulkLines(bulkText).length || ""} Work Units
+                  </Button>
+                </DialogFooter>
+              </form>
+            </DialogContent>
+          </Dialog>
+          <div
+            className={`grid min-h-0 flex-1 ${
+              detailPanelOpen
+                ? "grid-cols-[minmax(0,1fr)_minmax(320px,380px)]"
+                : "grid-cols-[minmax(0,1fr)_44px]"
+            }`}
+          >
+            <div className="min-h-0 overflow-x-auto overflow-y-hidden border-r">
+              <main className="flex min-w-max gap-3 p-4 pb-7">
+                {STATUS_COLUMNS.map((column) => {
+                  const collapsed = Boolean(collapsedColumns[column.value]);
+                  const columnItems = columns[column.value] ?? [];
+
+                  return (
+                    <section
+                      key={column.value}
+                      className={`bg-muted/15 flex min-h-[560px] min-w-0 flex-col rounded-md border transition-[width] duration-200 ${
+                        collapsed ? "w-14 shrink-0" : "w-[260px] shrink-0"
+                      }`}
+                    >
+                      <div className="border-b px-3 py-2">
+                        {collapsed ? (
+                          <div className="flex min-h-32 flex-col items-center gap-3">
+                            <Button
+                              aria-label={`Expand ${column.label}`}
+                              variant="ghost"
+                              size="icon"
+                              className="size-7"
+                              onClick={() => toggleColumn(column.value)}
+                            >
+                              <ChevronRight />
+                            </Button>
+                            <Badge variant="secondary">{columnItems.length}</Badge>
+                            <div className="text-muted-foreground rotate-180 [writing-mode:vertical-rl] text-xs font-semibold">
+                              {column.label}
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex h-7 items-center gap-2">
+                            <Button
+                              aria-label={`Collapse ${column.label}`}
+                              variant="ghost"
+                              size="icon"
+                              className="size-7 shrink-0"
+                              onClick={() => toggleColumn(column.value)}
+                            >
+                              <ChevronDown />
+                            </Button>
+                            <div
+                              className="min-w-0 flex-1 truncate text-sm font-semibold"
+                              title={column.description}
+                            >
+                              {column.label}
+                            </div>
+                            <Badge variant="secondary" className="shrink-0">
+                              {columnItems.length}
+                            </Badge>
+                            {column.value === "backlog" && (
+                              <Button
+                                aria-label="Create in Backlog"
+                                variant="ghost"
+                                size="icon"
+                                className="size-7 shrink-0"
+                                onClick={openCreate}
+                              >
+                                <PlusIcon />
+                              </Button>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                      {!collapsed && (
+                        <div className="flex flex-1 flex-col gap-2 overflow-y-auto p-2">
+                          {columnItems.length === 0 && (
+                            <div className="text-muted-foreground flex h-20 items-center justify-center rounded-md border border-dashed text-xs">
+                              No work units
+                            </div>
+                          )}
+                          {columnItems.map((item) => (
+                            <WorkUnitCard
+                              key={item.work_unit_id}
+                              item={item}
+                              selected={item.work_unit_id === selectedItem?.work_unit_id}
+                              onSelect={() => {
+                                setSelectedId(item.work_unit_id);
+                                setDetailPanelOpen(true);
+                              }}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </section>
+                  );
+                })}
+              </main>
+            </div>
+            <WorkUnitDetailPanel
+              item={selectedItem}
+              agents={agentOptions}
+              collapsed={!detailPanelOpen}
+              onToggle={() => setDetailPanelOpen((current) => !current)}
+              onAssign={(workUnitId, nextAssignee) =>
+                updateWorkUnit.mutate({
+                  workUnitId,
+                  request: {
+                    assignee_ref: nextAssignee === "unassigned" ? null : nextAssignee,
+                  },
+                })
+              }
+            />
+          </div>
+          <div className="text-muted-foreground flex h-8 shrink-0 items-center gap-4 border-t px-4 text-xs">
+            <span>
+              Attention <strong className="text-foreground">{blockedCount}</strong>
+            </span>
+            <span>
+              Health <strong className={health === "red" ? "text-red-500" : "text-emerald-500"}>{health}</strong>
+            </span>
+            <span>
+              Runtimes <strong className="text-emerald-500">{runtimeCount}</strong>
+            </span>
+            <span>Live gateway</span>
+          </div>
+        </div>
+      </WorkspaceBody>
+    </WorkspaceContainer>
+  );
+}
+
+function FilterSelect({
+  label,
+  value,
+  onValueChange,
+  children,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+  children: ReactNode;
+}) {
+  return (
+    <Select value={value} onValueChange={onValueChange}>
+      <SelectTrigger className="h-9 w-44 justify-between">
+        <span className="text-muted-foreground text-[11px] font-semibold uppercase">{label}</span>
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>{children}</SelectContent>
+    </Select>
+  );
+}
+
+function WorkUnitCard({
+  item,
+  selected,
+  onSelect,
+}: {
+  item: WorkUnit;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <article
+      className={`bg-background flex min-h-56 cursor-pointer flex-col gap-3 rounded-md border p-3 text-left shadow-xs transition-colors ${
+        selected ? "border-primary/70 ring-primary/20 ring-2" : "hover:border-primary/50"
+      }`}
+      onClick={onSelect}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-muted-foreground flex items-center gap-2 text-[11px] font-semibold uppercase">
+            <span className="truncate">{item.work_unit_id.slice(0, 12)}</span>
+            <span>Work Unit</span>
+          </div>
+          <div className="mt-1 line-clamp-3 text-sm font-semibold leading-snug">{item.title}</div>
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-1">
+        <Badge variant="secondary">{statusLabel(item.status)}</Badge>
+        <Badge variant="outline" className={priorityTone(item.priority)}>
+          {priorityLabel(item.priority)}
+        </Badge>
+        <Badge variant="outline">
+          {item.status === "done" || item.status === "closed"
+            ? "Verified"
+            : item.status === "backlog"
+              ? "Planned"
+              : "Agent managed"}
+        </Badge>
+      </div>
+      {item.description && (
+        <div className="bg-muted/25 rounded-md border p-2">
+          <div className="text-muted-foreground text-[11px] font-semibold uppercase">Next action</div>
+          <div className="mt-1 line-clamp-3 text-xs font-medium leading-snug">{item.description}</div>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-1 text-[11px]">
+        <MetricChip label="Tags" value={item.labels.length} />
+        <MetricChip label="Gates" value={item.status === "blocked" ? 1 : 0} />
+        <MetricChip label="Review" value={item.status === "review" ? "needed" : "not reviewed"} />
+        <MetricChip label="Updated" value={relativeDate(item.updated_at)} />
+      </div>
+      <div className="mt-auto flex flex-wrap gap-1">
+        {item.assignee_ref && <Badge variant="secondary">agent: {item.assignee_ref}</Badge>}
+        {isLinked(item) && <Badge variant="secondary">runtime linked</Badge>}
+        {item.labels.slice(0, 2).map((label) => (
+          <Badge key={label} variant="outline">
+            {label}
+          </Badge>
+        ))}
+        {itemNeedsAttention(item) && <Badge variant="outline">attention</Badge>}
+      </div>
+    </article>
+  );
+}
+
+function MetricChip({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="bg-muted/20 rounded border px-2 py-1">
+      <span className="text-muted-foreground">{label}</span>{" "}
+      <strong className="font-medium">{value}</strong>
+    </div>
+  );
+}
+
+function WorkUnitDetailPanel({
+  item,
+  agents,
+  collapsed,
+  onToggle,
+  onAssign,
+}: {
+  item?: WorkUnit;
+  agents: Array<{ name: string }>;
+  collapsed: boolean;
+  onToggle: () => void;
+  onAssign: (workUnitId: string, assigneeRef: string) => void;
+}) {
+  const [activeTab, setActiveTab] = useState<"overview" | "chat" | "trace">("overview");
+
+  if (collapsed) {
+    return (
+      <aside className="bg-background flex min-h-0 flex-col items-center border-l">
+        <Button
+          aria-label="Show detail panel"
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="mt-3 size-8"
+          onClick={onToggle}
+        >
+          <PanelRightOpen />
+        </Button>
+        <div className="text-muted-foreground mt-4 rotate-180 [writing-mode:vertical-rl] text-xs font-semibold">
+          Panel
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="bg-background flex min-h-0 flex-col">
+      <div className="flex h-12 items-center justify-between border-b px-4">
+        <div className="flex min-w-0 items-center gap-1">
+          <Button
+            type="button"
+            variant={activeTab === "overview" ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8"
+            onClick={() => setActiveTab("overview")}
+          >
+            <FileText />
+            Overview
+          </Button>
+          <Button
+            type="button"
+            variant={activeTab === "chat" ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8"
+            onClick={() => setActiveTab("chat")}
+          >
+            <MessageSquare />
+            Chat
+          </Button>
+          <Button
+            type="button"
+            variant={activeTab === "trace" ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8"
+            onClick={() => setActiveTab("trace")}
+          >
+            <Activity />
+            Trace
+          </Button>
+        </div>
+        <Button aria-label="Hide detail panel" type="button" variant="ghost" size="icon" onClick={onToggle}>
+          <PanelRightClose />
+        </Button>
+      </div>
+      {activeTab === "chat" ? (
+        <WorkUnitChatPanel agents={agents} item={item} />
+      ) : activeTab === "trace" ? (
+        <WorkUnitTracePanel item={item} />
+      ) : !item ? (
+          <div className="text-muted-foreground flex flex-1 items-center justify-center p-6 text-center text-sm">
+            Select a Work Unit
+          </div>
+        ) : (
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="space-y-4 p-4">
+              <div>
+                <div className="text-muted-foreground text-[11px] font-semibold uppercase">{item.work_unit_id}</div>
+                <h2 className="mt-1 text-base font-semibold leading-snug">{item.title}</h2>
+                {item.description && <p className="text-muted-foreground mt-2 text-sm leading-relaxed">{item.description}</p>}
+              </div>
+              <div className="grid grid-cols-2 gap-2">
+                <InfoCell label="Status" value={statusLabel(item.status)} />
+                <InfoCell label="Priority" value={priorityLabel(item.priority)} />
+                <InfoCell label="Source" value={item.source ?? item.source_type} />
+                <InfoCell label="Updated" value={relativeDate(item.updated_at)} />
+              </div>
+              <section className="space-y-2">
+                <div className="text-muted-foreground text-[11px] font-semibold uppercase">
+                  Assignment
+                </div>
+                <Select
+                  value={item.assignee_ref ?? "unassigned"}
+                  onValueChange={(value) => onAssign(item.work_unit_id, value)}
+                >
+                  <SelectTrigger aria-label="Assigned agent">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {agents.map((agent) => (
+                      <SelectItem key={agent.name} value={agent.name}>
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                    <SelectItem value="unassigned">Unassigned</SelectItem>
+                  </SelectContent>
+                </Select>
+              </section>
+              <section className="space-y-2">
+                <div className="text-muted-foreground text-[11px] font-semibold uppercase">Runtime refs</div>
+                <RefRow label="workflow_id" value={item.workflow_id} />
+                <RefRow label="thread_id" value={item.thread_id} />
+                <RefRow label="run_id" value={item.run_id} />
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {item.thread_id && (
+                    <Button asChild variant="outline" size="sm">
+                      <Link href={`/workspace/chats/${item.thread_id}`}>Open chat</Link>
+                    </Button>
+                  )}
+                  {item.workflow_id && (
+                    <Button type="button" variant="outline" size="sm" onClick={() => setActiveTab("trace")}>
+                      Trace
+                      <Activity />
+                    </Button>
+                  )}
+                </div>
+              </section>
+              <section className="space-y-2">
+                <div className="text-muted-foreground text-[11px] font-semibold uppercase">Tags</div>
+                <div className="flex flex-wrap gap-1">
+                  {item.labels.length > 0 ? (
+                    item.labels.map((label) => (
+                      <Badge key={label} variant="secondary">
+                        {label}
+                      </Badge>
+                    ))
+                  ) : (
+                    <span className="text-muted-foreground text-sm">No tags</span>
+                  )}
+                </div>
+              </section>
+            </div>
+          </ScrollArea>
+        )}
+    </aside>
+  );
+}
+
+function WorkUnitChatPanel({
+  agents,
+  item,
+}: {
+  agents: Array<{ name: string }>;
+  item?: WorkUnit;
+}) {
+  const [settings] = useLocalSettings();
+  const [selectedAgent, setSelectedAgent] = useState(LEAD_AGENT_NAME);
+  const [draftThreadId, setDraftThreadId] = useState(() => uuid());
+  const [persistedThreadId, setPersistedThreadId] = useState<string | null>(
+    item?.thread_id ?? null,
+  );
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const updateWorkUnit = useUpdateWorkUnit();
+
+  useEffect(() => {
+    const nextAgent =
+      item?.assignee_ref && agents.some((agent) => agent.name === item.assignee_ref)
+        ? item.assignee_ref
+        : LEAD_AGENT_NAME;
+    setSelectedAgent(nextAgent);
+    setDraftThreadId(uuid());
+    setPersistedThreadId(item?.thread_id ?? null);
+    setMessage("");
+  }, [agents, item?.assignee_ref, item?.thread_id, item?.work_unit_id]);
+
+  const chatContext = useMemo(
+    () => ({
+      ...settings.context,
+      agent_name: selectedAgent === LEAD_AGENT_NAME ? undefined : selectedAgent,
+    }),
+    [selectedAgent, settings.context],
+  );
+
+  const { thread, sendMessage } = useThreadStream({
+    threadId: persistedThreadId ?? undefined,
+    displayThreadId: draftThreadId,
+    context: chatContext,
+    onStart: (createdThreadId) => {
+      setPersistedThreadId(createdThreadId);
+      if (item && item.thread_id !== createdThreadId) {
+        void updateWorkUnit.mutateAsync({
+          workUnitId: item.work_unit_id,
+          request: { thread_id: createdThreadId },
+        });
+      }
+    },
+  });
+
+  const messages = (thread.messages ?? []).filter(
+    (chatMessage) => !isHiddenFromUIMessage(chatMessage),
+  );
+  const chatThreadId = persistedThreadId ?? draftThreadId;
+  const chatPath =
+    selectedAgent === LEAD_AGENT_NAME
+      ? `/workspace/chats/${chatThreadId}`
+      : `/workspace/agents/${encodeURIComponent(selectedAgent)}/chats/${chatThreadId}`;
+
+  async function handleSend(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const text = message.trim();
+    if (!text || sending || !item) return;
+    const promptText = buildWorkUnitPrompt(item, text);
+    setSending(true);
+    setMessage("");
+    try {
+      if (!persistedThreadId && !item.thread_id) {
+        setPersistedThreadId(chatThreadId);
+        await updateWorkUnit.mutateAsync({
+          workUnitId: item.work_unit_id,
+          request: { thread_id: chatThreadId },
+        });
+      }
+      await sendMessage(
+        chatThreadId,
+        { text: promptText, files: [] },
+        {
+          work_unit_id: item?.work_unit_id,
+          work_unit_title: item?.title,
+          work_unit_status: item?.status,
+          work_unit_priority: item?.priority,
+          work_unit_description: item?.description,
+          work_unit_assignee_ref: item?.assignee_ref,
+          source: "workboard",
+        },
+        {
+          additionalKwargs: {
+            work_unit_id: item?.work_unit_id,
+            work_unit_user_text: text,
+            source: "workboard",
+          },
+        },
+      );
+    } catch (error) {
+      setMessage(text);
+      throw error;
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex items-center gap-2 border-b p-3">
+        <Select value={selectedAgent} onValueChange={setSelectedAgent}>
+          <SelectTrigger aria-label="Agent" className="h-9 min-w-0 flex-1">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {agents.map((agent) => (
+              <SelectItem key={agent.name} value={agent.name}>
+                {agent.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {persistedThreadId ? (
+          <Button asChild variant="outline" size="icon" aria-label="Open full chat">
+            <Link href={chatPath}>
+              <ExternalLink />
+            </Link>
+          </Button>
+        ) : (
+          <Button variant="outline" size="icon" aria-label="Open full chat" disabled>
+            <ExternalLink />
+          </Button>
+        )}
+      </div>
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="space-y-2 p-3">
+          {messages.length === 0 ? (
+            <div className="text-muted-foreground rounded-md border border-dashed p-3 text-sm">
+              Start a chat about this work unit.
+            </div>
+          ) : (
+            messages.map((chatMessage, index) => {
+              const isHuman = chatMessage.type === "human";
+              const userText = Reflect.get(
+                chatMessage.additional_kwargs ?? {},
+                "work_unit_user_text",
+              );
+              const text = isHuman && typeof userText === "string" ? userText : textOfMessage(chatMessage);
+              if (!text) return null;
+              return (
+                <div
+                  key={chatMessage.id ?? index}
+                  className={`rounded-md border p-2 text-sm ${
+                    isHuman ? "bg-muted/30 ml-6" : "bg-background mr-6"
+                  }`}
+                >
+                  <div className="text-muted-foreground mb-1 text-[10px] font-semibold uppercase">
+                    {isHuman ? "You" : selectedAgent}
+                  </div>
+                  <div className="whitespace-pre-wrap leading-relaxed">{text}</div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </ScrollArea>
+      <form className="grid gap-2 border-t p-3" onSubmit={(event) => void handleSend(event)}>
+        <Textarea
+          className="min-h-20 resize-none"
+          placeholder="Message the agent about this work unit"
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          onKeyDown={(event) => {
+            if (
+              event.key !== "Enter" ||
+              event.shiftKey ||
+              event.nativeEvent.isComposing
+            ) {
+              return;
+            }
+            event.preventDefault();
+            event.currentTarget.form?.requestSubmit();
+          }}
+        />
+        <Button type="submit" disabled={sending || !message.trim()}>
+          <Send />
+          Send
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+function WorkUnitTracePanel({ item }: { item?: WorkUnit }) {
+  const workflowId = item?.workflow_id;
+  const traceQuery = useQuery({
+    queryKey: ["workflow-timeline", workflowId],
+    queryFn: () => fetchWorkflowTimeline(workflowId!),
+    enabled: Boolean(workflowId),
+    refetchOnWindowFocus: false,
+  });
+
+  if (!item) {
+    return (
+      <div className="text-muted-foreground flex flex-1 items-center justify-center p-6 text-center text-sm">
+        Select a Work Unit
+      </div>
+    );
+  }
+
+  if (!workflowId) {
+    return (
+      <div className="text-muted-foreground flex flex-1 items-center justify-center p-6 text-center text-sm">
+        No workflow trace is linked to this Work Unit yet.
+      </div>
+    );
+  }
+
+  const events = traceQuery.data?.timeline ?? [];
+
+  return (
+    <ScrollArea className="min-h-0 flex-1">
+      <div className="space-y-4 p-4">
+        <div className="space-y-2">
+          <div className="text-muted-foreground text-[11px] font-semibold uppercase">Workflow trace</div>
+          <RefRow label="workflow_id" value={workflowId} />
+          <RefRow label="run_id" value={item.run_id} />
+        </div>
+        {traceQuery.isLoading ? (
+          <div className="text-muted-foreground rounded-md border border-dashed p-3 text-sm">
+            Loading trace...
+          </div>
+        ) : traceQuery.error ? (
+          <div className="text-destructive rounded-md border p-3 text-sm">
+            {traceQuery.error instanceof Error ? traceQuery.error.message : "Failed to load trace"}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="text-muted-foreground rounded-md border border-dashed p-3 text-sm">
+            No trace events yet.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {events.map((event, index) => (
+              <TraceEventCard key={`${event.kind}-${event.seq ?? index}-${event.event_type}`} event={event} />
+            ))}
+          </div>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}
+
+function TraceEventCard({ event }: { event: WorkflowTimelineEvent }) {
+  const content = formatTraceContent(event.content ?? event.metadata);
+
+  return (
+    <article className="bg-muted/15 rounded-md border p-3 text-xs">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="text-sm font-semibold leading-snug">{event.event_type}</div>
+          <div className="text-muted-foreground mt-1 truncate">
+            {event.created_at ? relativeDate(event.created_at) : "undated"}
+            {typeof event.seq === "number" ? ` · seq ${event.seq}` : ""}
+          </div>
+        </div>
+        <Badge variant="outline" className="shrink-0">
+          {event.kind === "workflow_event" ? "Workflow" : "Run"}
+        </Badge>
+      </div>
+      {event.category && (
+        <div className="text-muted-foreground mt-2 font-medium uppercase">{event.category}</div>
+      )}
+      {content && (
+        <pre className="bg-background/70 text-muted-foreground mt-2 max-h-32 overflow-auto rounded border p-2 font-mono text-[11px] whitespace-pre-wrap">
+          {content}
+        </pre>
+      )}
+    </article>
+  );
+}
+
+function formatTraceContent(value: unknown) {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value.length > 700 ? `${value.slice(0, 700)}...` : value;
+  try {
+    const text = JSON.stringify(value, null, 2);
+    return text.length > 700 ? `${text.slice(0, 700)}...` : text;
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
+function InfoCell({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div className="bg-muted/20 min-w-0 rounded-md border p-2">
+      <div className="text-muted-foreground text-[11px] font-semibold uppercase">{label}</div>
+      <div className="mt-1 truncate text-sm font-medium">{value ?? "-"}</div>
+    </div>
+  );
+}
+
+function RefRow({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div className="bg-muted/20 grid grid-cols-[86px_minmax(0,1fr)] gap-2 rounded-md border p-2 text-xs">
+      <span className="text-muted-foreground font-semibold">{label}</span>
+      <span className="truncate font-mono">{value ?? "-"}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/workflow-trace-trigger.tsx
+++ b/frontend/src/components/workspace/workflow-trace-trigger.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  ActivityIcon,
+  CheckCircle2Icon,
+  CircleDashedIcon,
+  Loader2Icon,
+  XCircleIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useWorkflowTraceByRun } from "@/core/workflows/hooks";
+import { cn } from "@/lib/utils";
+
+function shortId(value?: string | null) {
+  if (!value) {
+    return "-";
+  }
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}
+
+function statusClass(status?: string) {
+  if (status === "succeeded") {
+    return "text-emerald-600 dark:text-emerald-400";
+  }
+  if (status === "failed" || status === "cancelled" || status === "orphaned") {
+    return "text-destructive";
+  }
+  if (status === "running" || status === "run_created") {
+    return "text-sky-600 dark:text-sky-400";
+  }
+  return "text-muted-foreground";
+}
+
+function StatusIcon({ status }: { status?: string }) {
+  if (status === "succeeded") {
+    return <CheckCircle2Icon className="size-3.5" />;
+  }
+  if (status === "failed" || status === "cancelled" || status === "orphaned") {
+    return <XCircleIcon className="size-3.5" />;
+  }
+  if (status === "running" || status === "run_created") {
+    return <Loader2Icon className="size-3.5 animate-spin" />;
+  }
+  return <CircleDashedIcon className="size-3.5" />;
+}
+
+export function WorkflowTraceTrigger({
+  runId,
+  enabled = true,
+}: {
+  runId?: string | null;
+  enabled?: boolean;
+}) {
+  const trace = useWorkflowTraceByRun(runId, { enabled: enabled && Boolean(runId) });
+  const workflow = trace.data?.workflow;
+  const status = workflow?.status;
+
+  if (!runId || trace.data === null) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Trace"
+          className={cn("gap-1.5", status && statusClass(status))}
+          disabled={!enabled}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {trace.isLoading ? (
+            <Loader2Icon className="size-4 animate-spin" />
+          ) : (
+            <ActivityIcon className="size-4" />
+          )}
+          <span className="hidden sm:inline">Trace</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-96 max-w-[calc(100vw-2rem)]">
+        <DropdownMenuLabel className="flex items-center justify-between gap-3">
+          <span>Durable Run Trace</span>
+          <span className={cn("inline-flex items-center gap-1 text-xs", statusClass(status))}>
+            <StatusIcon status={status} />
+            {status ?? "loading"}
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <div className="space-y-2 px-2 py-2 text-xs">
+          <div className="grid grid-cols-[88px_1fr] gap-2">
+            <span className="text-muted-foreground">workflow</span>
+            <span className="font-mono">{shortId(workflow?.workflow_id)}</span>
+            <span className="text-muted-foreground">run</span>
+            <span className="font-mono">{shortId(runId)}</span>
+            <span className="text-muted-foreground">source</span>
+            <span className="truncate">{workflow?.source ?? "-"}</span>
+          </div>
+          <DropdownMenuSeparator />
+          <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+            {(trace.data?.timeline ?? []).slice(0, 12).map((event, index) => (
+              <div
+                className="grid grid-cols-[16px_1fr] gap-2"
+                key={`${event.kind}/${event.seq ?? index}/${event.event_type}`}
+              >
+                <span
+                  className={cn(
+                    "mt-1 size-2 rounded-full",
+                    event.kind === "workflow_event" ? "bg-primary" : "bg-muted-foreground",
+                  )}
+                />
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{event.event_type}</div>
+                  <div className="text-muted-foreground flex min-w-0 gap-2">
+                    <span>{event.kind === "workflow_event" ? "workflow" : "run"}</span>
+                    {event.created_at && (
+                      <span className="truncate">{new Date(event.created_at).toLocaleTimeString()}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {trace.isLoading && (
+              <div className="text-muted-foreground flex items-center gap-2">
+                <Loader2Icon className="size-3 animate-spin" />
+                Loading trace
+              </div>
+            )}
+            {trace.isError && (
+              <div className="text-destructive">Trace unavailable</div>
+            )}
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/components/workspace/workspace-nav-chat-list.tsx
+++ b/frontend/src/components/workspace/workspace-nav-chat-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BotIcon, MessagesSquare } from "lucide-react";
+import { BotIcon, ClipboardListIcon, MessagesSquare } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
@@ -34,6 +34,17 @@ export function WorkspaceNavChatList() {
             <Link className="text-muted-foreground" href="/workspace/agents">
               <BotIcon />
               <span>{t.sidebar.agents}</span>
+            </Link>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={pathname.startsWith("/workspace/work")}
+            asChild
+          >
+            <Link className="text-muted-foreground" href="/workspace/work">
+              <ClipboardListIcon />
+              <span>Work Board</span>
             </Link>
           </SidebarMenuButton>
         </SidebarMenuItem>

--- a/frontend/src/core/modules/api.ts
+++ b/frontend/src/core/modules/api.ts
@@ -6,6 +6,10 @@ export type ModuleFlags = {
     api_enabled: boolean;
     auto_envelope_for_runs: boolean;
   };
+  work: {
+    enabled: boolean;
+    api_enabled: boolean;
+  };
 };
 
 export async function fetchModuleFlags(): Promise<ModuleFlags> {

--- a/frontend/src/core/modules/api.ts
+++ b/frontend/src/core/modules/api.ts
@@ -1,0 +1,19 @@
+import { getBackendBaseURL } from "@/core/config";
+
+export type ModuleFlags = {
+  durable_workflows: {
+    enabled: boolean;
+    api_enabled: boolean;
+    auto_envelope_for_runs: boolean;
+  };
+};
+
+export async function fetchModuleFlags(): Promise<ModuleFlags> {
+  const response = await globalThis.fetch(`${getBackendBaseURL()}/api/modules`, {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`Module flags unavailable (${response.status})`);
+  }
+  return (await response.json()) as ModuleFlags;
+}

--- a/frontend/src/core/modules/hooks.ts
+++ b/frontend/src/core/modules/hooks.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchModuleFlags } from "./api";
+
+export function useModuleFlags() {
+  return useQuery({
+    queryKey: ["module-flags"],
+    queryFn: fetchModuleFlags,
+    staleTime: 60_000,
+    retry: 1,
+  });
+}

--- a/frontend/src/core/modules/index.ts
+++ b/frontend/src/core/modules/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./hooks";

--- a/frontend/src/core/work-units/api.ts
+++ b/frontend/src/core/work-units/api.ts
@@ -1,0 +1,122 @@
+import { fetch } from "@/core/api/fetcher";
+import { getBackendBaseURL } from "@/core/config";
+
+export type WorkUnit = {
+  work_unit_id: string;
+  title: string;
+  description?: string | null;
+  status: string;
+  priority: string;
+  assignee_ref?: string | null;
+  reporter_ref?: string | null;
+  due_at?: string | null;
+  workflow_id?: string | null;
+  thread_id?: string | null;
+  run_id?: string | null;
+  source_type: string;
+  source?: string | null;
+  external_type?: string | null;
+  external_ref?: string | null;
+  external_url?: string | null;
+  labels: string[];
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type CreateWorkUnitRequest = {
+  title: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  assignee_ref?: string;
+  reporter_ref?: string;
+  due_at?: string;
+  workflow_id?: string;
+  thread_id?: string;
+  run_id?: string;
+  source_type?: string;
+  source?: string;
+  external_type?: string;
+  external_ref?: string;
+  external_url?: string;
+  labels?: string[];
+  metadata?: Record<string, unknown>;
+  work_unit_id?: string;
+};
+
+export type UpdateWorkUnitRequest = Partial<
+  Pick<
+    WorkUnit,
+    | "title"
+    | "description"
+    | "status"
+    | "priority"
+    | "assignee_ref"
+    | "reporter_ref"
+    | "due_at"
+    | "workflow_id"
+    | "thread_id"
+    | "run_id"
+    | "source_type"
+    | "source"
+    | "external_type"
+    | "external_ref"
+    | "external_url"
+    | "labels"
+    | "metadata"
+  >
+>;
+
+async function readJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const detail =
+      payload && typeof payload === "object" && "detail" in payload
+        ? String(payload.detail)
+        : `Request failed with ${response.status}`;
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+export async function listWorkUnits(params: {
+  status?: string;
+  limit?: number;
+} = {}): Promise<WorkUnit[]> {
+  const search = new URLSearchParams();
+  if (params.status) search.set("status", params.status);
+  if (params.limit) search.set("limit", String(params.limit));
+  const query = search.toString();
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/work-units${query ? `?${query}` : ""}`,
+  );
+  const payload = await readJson<{ data: WorkUnit[] }>(response);
+  return payload.data;
+}
+
+export async function createWorkUnit(
+  request: CreateWorkUnitRequest,
+): Promise<WorkUnit> {
+  const response = await fetch(`${getBackendBaseURL()}/api/work-units`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  return readJson<WorkUnit>(response);
+}
+
+export async function updateWorkUnit(
+  workUnitId: string,
+  request: UpdateWorkUnitRequest,
+): Promise<WorkUnit> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/work-units/${encodeURIComponent(workUnitId)}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    },
+  );
+  return readJson<WorkUnit>(response);
+}

--- a/frontend/src/core/work-units/hooks.ts
+++ b/frontend/src/core/work-units/hooks.ts
@@ -8,9 +8,11 @@ import {
   type UpdateWorkUnitRequest,
 } from "./api";
 
+export const workUnitsQueryKey = ["work-units"] as const;
+
 export function useWorkUnits(options: { enabled?: boolean } = {}) {
   return useQuery({
-    queryKey: ["work-units"],
+    queryKey: workUnitsQueryKey,
     queryFn: () => listWorkUnits({ limit: 500 }),
     enabled: options.enabled ?? true,
     refetchInterval: 10_000,
@@ -23,7 +25,7 @@ export function useCreateWorkUnit() {
   return useMutation({
     mutationFn: (request: CreateWorkUnitRequest) => createWorkUnit(request),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["work-units"] });
+      void queryClient.invalidateQueries({ queryKey: workUnitsQueryKey });
     },
   });
 }
@@ -39,7 +41,7 @@ export function useUpdateWorkUnit() {
       request: UpdateWorkUnitRequest;
     }) => updateWorkUnit(workUnitId, request),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["work-units"] });
+      void queryClient.invalidateQueries({ queryKey: workUnitsQueryKey });
     },
   });
 }

--- a/frontend/src/core/work-units/hooks.ts
+++ b/frontend/src/core/work-units/hooks.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  createWorkUnit,
+  listWorkUnits,
+  updateWorkUnit,
+  type CreateWorkUnitRequest,
+  type UpdateWorkUnitRequest,
+} from "./api";
+
+export function useWorkUnits(options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: ["work-units"],
+    queryFn: () => listWorkUnits({ limit: 500 }),
+    enabled: options.enabled ?? true,
+    refetchInterval: 10_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useCreateWorkUnit() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (request: CreateWorkUnitRequest) => createWorkUnit(request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["work-units"] });
+    },
+  });
+}
+
+export function useUpdateWorkUnit() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      workUnitId,
+      request,
+    }: {
+      workUnitId: string;
+      request: UpdateWorkUnitRequest;
+    }) => updateWorkUnit(workUnitId, request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["work-units"] });
+    },
+  });
+}

--- a/frontend/src/core/work-units/index.ts
+++ b/frontend/src/core/work-units/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./hooks";

--- a/frontend/src/core/workflows/api.ts
+++ b/frontend/src/core/workflows/api.ts
@@ -1,0 +1,85 @@
+import { fetch } from "@/core/api/fetcher";
+import { getBackendBaseURL } from "@/core/config";
+
+export type WorkflowEnvelope = {
+  workflow_id: string;
+  workflow_kind: string;
+  source_type: string;
+  source?: string | null;
+  idempotency_key?: string | null;
+  external_message_ref?: string | null;
+  thread_id?: string | null;
+  run_id?: string | null;
+  checkpoint_ns?: string | null;
+  checkpoint_id?: string | null;
+  status: string;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type WorkflowTimelineEvent = {
+  kind: "workflow_event" | "run_event";
+  seq?: number;
+  event_type: string;
+  category?: string;
+  created_at?: string;
+  thread_id?: string | null;
+  run_id?: string | null;
+  content?: unknown;
+  metadata?: Record<string, unknown>;
+};
+
+export type WorkflowTimelineResponse = {
+  workflow: WorkflowEnvelope;
+  run?: Record<string, unknown> | null;
+  timeline: WorkflowTimelineEvent[];
+  workflow_events: Record<string, unknown>[];
+  run_events: Record<string, unknown>[];
+};
+
+async function readJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const detail =
+      payload && typeof payload === "object" && "detail" in payload
+        ? String(payload.detail)
+        : `Request failed with ${response.status}`;
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchWorkflowByRun(
+  runId: string,
+): Promise<WorkflowEnvelope | null> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/workflows/by-run/${encodeURIComponent(runId)}`,
+  );
+  if (response.status === 404) {
+    return null;
+  }
+  return readJson<WorkflowEnvelope>(response);
+}
+
+export async function fetchWorkflowTimeline(
+  workflowId: string,
+): Promise<WorkflowTimelineResponse> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/workflows/${encodeURIComponent(
+      workflowId,
+    )}/timeline`,
+  );
+  return readJson<WorkflowTimelineResponse>(response);
+}
+
+export async function fetchWorkflowTraceByRun(
+  runId: string,
+): Promise<WorkflowTimelineResponse | null> {
+  const workflow = await fetchWorkflowByRun(runId);
+  if (!workflow) {
+    return null;
+  }
+  return fetchWorkflowTimeline(workflow.workflow_id);
+}

--- a/frontend/src/core/workflows/hooks.ts
+++ b/frontend/src/core/workflows/hooks.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWorkflowTraceByRun } from "./api";
+
+export function useWorkflowTraceByRun(
+  runId?: string | null,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: ["workflow-trace", "run", runId],
+    queryFn: () => {
+      if (!runId) {
+        return null;
+      }
+      return fetchWorkflowTraceByRun(runId);
+    },
+    enabled: enabled && Boolean(runId),
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
## Review Status

This PR is a follow-up added-value UI module, not the current core review
target. The updated RFC and Core Runtime Package are now submitted as #3813,
#3814, #3815, #3816, and #3848.

Please review the Native Durable Workflow Runtime Layer direction first. The
WorkBoard should stay draft until the runtime foundation and Work Module
direction have maintainer buy-in.

## Summary

Stacked after #3818. This PR adds a built-in WorkBoard workspace as a practical
UI over the generic Work Module.

It includes:

- `/workspace/work` board grouped by Work Unit status;
- WorkBoard nav entry;
- Work Unit frontend API and React Query hooks;
- backlog-only human creation dialog;
- bulk capture for long-running work stacks, one Work Unit per pasted line;
- agent assignment and assignee filtering;
- right detail panel with overview, chat, and trace tabs;
- Work Unit chat context that binds `work_unit_id` into the agent run context
  so the Work Unit tools can update real state;
- horizontal board scrolling and collapsible columns/detail panel.

## Boundary

The WorkBoard does not add schema or workflow semantics. It uses
`/api/work-units`, `/api/modules`, and durable workflow timeline APIs from
earlier PRs.

Human users can capture backlog work and assign it to an agent. Status remains
Work Unit state and should be updated by runtime/agent tools introduced in
#3818, not by board-specific workflow logic.

## Validation

Original focused validation for this branch:

```bash
cd frontend
CI=true pnpm run check
```

Result: passed with 3 pre-existing warnings.

- `git diff --check`
