### PR TITLE
fix(runtime): keep prompt guardrail wrapper out of UI events

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py
@@ -31,6 +31,8 @@ from langchain.agents.middleware.types import (
 from langchain_core.messages import HumanMessage
 from langgraph.errors import GraphBubbleUp
 
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY, message_content_to_text
+
 logger = logging.getLogger(__name__)
 
 _SUMMARY_MESSAGE_NAME = "summary"
@@ -233,11 +235,14 @@ class InputSanitizationMiddleware(AgentMiddleware[AgentState]):
             else:
                 new_content = processed
 
+            additional_kwargs = dict(msg.additional_kwargs or {})
+            additional_kwargs.setdefault(ORIGINAL_USER_CONTENT_KEY, message_content_to_text(content))
+
             messages[i] = HumanMessage(
                 content=new_content,
                 id=msg.id,
                 name=msg.name,
-                additional_kwargs=msg.additional_kwargs,
+                additional_kwargs=additional_kwargs,
             )
             logger.debug(
                 "InputSanitizationMiddleware: original=%r -> processed=%r",

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -29,7 +29,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
-from deerflow.utils.messages import message_to_text
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY, get_original_user_content_text, message_to_text
 
 if TYPE_CHECKING:
     from deerflow.runtime.events.store.base import RunEventStore
@@ -107,6 +107,16 @@ class RunJournal(BaseCallbackHandler):
     def _message_text(message: BaseMessage) -> str:
         """Extract displayable text from a message's mixed content shape."""
         return message_to_text(message, text_attribute_fallback=True)
+
+    @staticmethod
+    def _display_human_message(message: HumanMessage) -> HumanMessage:
+        """Return the user-facing form of a model-facing human message."""
+        additional_kwargs = dict(message.additional_kwargs or {})
+        if ORIGINAL_USER_CONTENT_KEY not in additional_kwargs:
+            return message
+        content = get_original_user_content_text(message.content, additional_kwargs)
+        additional_kwargs.pop(ORIGINAL_USER_CONTENT_KEY, None)
+        return message.model_copy(update={"content": content, "additional_kwargs": additional_kwargs})
 
     def _record_message_summary(self, message: BaseMessage, *, caller: str | None = None) -> None:
         """Update run-level convenience fields for persisted run rows."""
@@ -203,14 +213,15 @@ class RunJournal(BaseCallbackHandler):
                 for m in reversed(batch):
                     if isinstance(m, HumanMessage) and m.name != "summary" and m.additional_kwargs.get("hide_from_ui") is not True:
                         caller = self._identify_caller(tags)
-                        self.set_first_human_message(m.text)
+                        display_message = self._display_human_message(m)
+                        self.set_first_human_message(self._message_text(display_message))
                         self._put(
                             event_type="llm.human.input",
                             category="message",
-                            content=m.model_dump(),
+                            content=display_message.model_dump(),
                             metadata={"caller": caller},
                         )
-                        self._record_message_summary(m, caller=caller)
+                        self._record_message_summary(display_message, caller=caller)
                         break
                 if self._first_human_msg:
                     break

--- a/backend/tests/test_input_sanitization_middleware.py
+++ b/backend/tests/test_input_sanitization_middleware.py
@@ -19,6 +19,7 @@ from deerflow.agents.middlewares.input_sanitization_middleware import (
     _check_user_content,
     _is_genuine_user_message,
 )
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
 
 
 def _make_middleware() -> InputSanitizationMiddleware:
@@ -269,6 +270,34 @@ class TestWrapModelCallCleanInput:
         sanitized_content = captured[0].messages[-1].content
         assert _USER_INPUT_BEGIN in sanitized_content
         assert "Hello" in sanitized_content
+
+    def test_stamps_original_user_content_for_display_surfaces(self):
+        mw = _make_middleware()
+        request = _make_request([HumanMessage(content="Hello", id="msg-1")])
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        sanitized_message = captured[0].messages[-1]
+        assert sanitized_message.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "Hello"
+
+    def test_preserves_existing_original_user_content(self):
+        mw = _make_middleware()
+        request = _make_request(
+            [
+                HumanMessage(
+                    content="<uploaded_files>...</uploaded_files>\n\nHello",
+                    id="msg-1",
+                    additional_kwargs={ORIGINAL_USER_CONTENT_KEY: "Hello"},
+                )
+            ]
+        )
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        sanitized_message = captured[0].messages[-1]
+        assert sanitized_message.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "Hello"
 
     def test_does_not_mutate_original_request(self):
         mw = _make_middleware()

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -11,6 +11,7 @@ import pytest
 
 from deerflow.runtime.events.store.memory import MemoryRunEventStore
 from deerflow.runtime.journal import RunJournal
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
 
 
 @pytest.fixture
@@ -839,6 +840,35 @@ class TestChatModelStartHumanMessage:
         human_events = [e for e in events if e["event_type"] == "llm.human.input"]
         assert len(human_events) == 1
         assert human_events[0]["content"]["content"] == "What is AI?"
+
+    @pytest.mark.anyio
+    async def test_human_input_event_uses_original_user_content(self, journal_setup):
+        """Model-facing guardrail wrappers must not leak into UI message events."""
+        from langchain_core.messages import HumanMessage
+
+        j, store = journal_setup
+        wrapped_content = "--- BEGIN USER INPUT ---\nWhat is AI?\n--- END USER INPUT ---"
+        messages_batch = [
+            [
+                HumanMessage(
+                    content=wrapped_content,
+                    additional_kwargs={
+                        ORIGINAL_USER_CONTENT_KEY: "What is AI?",
+                        "files": [{"filename": "notes.txt"}],
+                    },
+                )
+            ],
+        ]
+        j.on_chat_model_start({}, messages_batch, run_id=uuid4(), tags=["lead_agent"])
+        await j.flush()
+
+        assert j._first_human_msg == "What is AI?"
+        events = await store.list_events("t1", "r1")
+        human_events = [e for e in events if e["event_type"] == "llm.human.input"]
+        assert len(human_events) == 1
+        content = human_events[0]["content"]
+        assert content["content"] == "What is AI?"
+        assert content["additional_kwargs"] == {"files": [{"filename": "notes.txt"}]}
 
     @pytest.mark.anyio
     async def test_skips_summary_named_human_messages(self, journal_setup):


### PR DESCRIPTION
## Summary
- stamp pre-sanitization user text on model-facing HumanMessages before adding prompt guardrail wrappers
- persist `llm.human.input` events and `first_human_message` from the user-facing original text
- keep file metadata while stripping the internal original-content marker from stored UI message events

Closes #3689

## Tests
- `cd backend && uv run pytest tests/test_input_sanitization_middleware.py tests/test_run_journal.py`
- `cd backend && uv run pytest tests/test_utils_messages.py tests/test_thread_run_messages_pagination.py tests/test_thread_messages_feedback.py`
- `cd backend && uv run ruff check packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py packages/harness/deerflow/runtime/journal.py tests/test_input_sanitization_middleware.py tests/test_run_journal.py`
- `cd backend && uv run ruff format --check packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py packages/harness/deerflow/runtime/journal.py tests/test_input_sanitization_middleware.py tests/test_run_journal.py`