### PR TITLE
fix(frontend): keep subtask running steps visible

### DIFF
--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -42,6 +42,13 @@ export function SubtaskCard({
   const [collapsed, setCollapsed] = useState(true);
   const rehypePlugins = useRehypeSplitWordsIntoSpans(isLoading);
   const task = useSubtask(taskId)!;
+  const runningSteps =
+    task.steps
+      ?.map((step) => step.message)
+      .filter((message) => hasToolCalls(message)) ??
+    (task.latestMessage && hasToolCalls(task.latestMessage)
+      ? [task.latestMessage]
+      : []);
   const icon = useMemo(() => {
     if (task.status === "completed") {
       return <CheckCircleIcon className="size-3" />;
@@ -136,15 +143,15 @@ export function SubtaskCard({
             ></ChainOfThoughtStep>
           )}
           {task.status === "in_progress" &&
-            task.latestMessage &&
-            hasToolCalls(task.latestMessage) && (
+            runningSteps.map((message, index) => (
               <ChainOfThoughtStep
+                key={message.id ?? `${task.id}-${index}`}
                 label={t.subtasks.in_progress}
                 icon={<Loader2Icon className="size-4 animate-spin" />}
               >
-                {explainLastToolCall(task.latestMessage, t)}
+                {explainLastToolCall(message, t)}
               </ChainOfThoughtStep>
-            )}
+            ))}
           {task.status === "completed" && (
             <>
               <ChainOfThoughtStep

--- a/frontend/src/core/tasks/context.tsx
+++ b/frontend/src/core/tasks/context.tsx
@@ -7,6 +7,7 @@ import {
   useState,
 } from "react";
 
+import { mergeSubtaskStep } from "./steps";
 import type { Subtask } from "./types";
 
 function isTerminalSubtaskStatus(status: Subtask["status"] | undefined) {
@@ -62,15 +63,29 @@ export function useUpdateSubtask() {
   });
 
   const updateSubtask = useCallback(
-    (task: Partial<Subtask> & { id: string }) => {
+    (
+      update: Partial<Subtask> & {
+        id: string;
+        runningMessageIndex?: number;
+      },
+    ) => {
+      const { runningMessageIndex, ...task } = update;
       const previous = tasks[task.id];
       const previousStatus = previous?.status;
+      const steps = task.latestMessage
+        ? mergeSubtaskStep(
+            previous?.steps,
+            task.latestMessage,
+            runningMessageIndex,
+          )
+        : task.steps;
       // MessageList writes the pending task tool-call state before parsing the
       // matching ToolMessage in the same render. Keep terminal results stable
       // across the next render so the refresh notification does not loop.
       const next = {
         ...previous,
         ...task,
+        ...(steps ? { steps } : {}),
         ...(task.status === "in_progress" &&
         isTerminalSubtaskStatus(previousStatus)
           ? { status: previousStatus }

--- a/frontend/src/core/tasks/index.ts
+++ b/frontend/src/core/tasks/index.ts
@@ -1,1 +1,2 @@
 export * from "./types";
+export * from "./steps";

--- a/frontend/src/core/tasks/steps.ts
+++ b/frontend/src/core/tasks/steps.ts
@@ -1,0 +1,53 @@
+import type { AIMessage } from "@langchain/langgraph-sdk";
+
+import type { SubtaskStep } from "./types";
+
+function normalizeMessageIndex(messageIndex: unknown) {
+  return typeof messageIndex === "number" &&
+    Number.isInteger(messageIndex) &&
+    messageIndex > 0
+    ? messageIndex
+    : undefined;
+}
+
+export function mergeSubtaskStep(
+  steps: SubtaskStep[] | undefined,
+  message: AIMessage,
+  messageIndex?: number,
+): SubtaskStep[] {
+  const next = [...(steps ?? [])];
+  const normalizedMessageIndex = normalizeMessageIndex(messageIndex);
+  const indexMatch =
+    normalizedMessageIndex !== undefined
+      ? next.findIndex((step) => step.messageIndex === normalizedMessageIndex)
+      : -1;
+  const idMatch = message.id
+    ? next.findIndex((step) => step.message.id === message.id)
+    : -1;
+  const existingIndex = indexMatch >= 0 ? indexMatch : idMatch;
+  const nextStep: SubtaskStep = {
+    message,
+    ...(normalizedMessageIndex !== undefined
+      ? { messageIndex: normalizedMessageIndex }
+      : {}),
+  };
+
+  if (existingIndex >= 0) {
+    next[existingIndex] = nextStep;
+  } else {
+    next.push(nextStep);
+  }
+
+  return next.sort((a, b) => {
+    if (a.messageIndex !== undefined && b.messageIndex !== undefined) {
+      return a.messageIndex - b.messageIndex;
+    }
+    if (a.messageIndex !== undefined) {
+      return -1;
+    }
+    if (b.messageIndex !== undefined) {
+      return 1;
+    }
+    return 0;
+  });
+}

--- a/frontend/src/core/tasks/types.ts
+++ b/frontend/src/core/tasks/types.ts
@@ -1,11 +1,17 @@
 import type { AIMessage } from "@langchain/langgraph-sdk";
 
+export interface SubtaskStep {
+  message: AIMessage;
+  messageIndex?: number;
+}
+
 export interface Subtask {
   id: string;
   status: "in_progress" | "completed" | "failed";
   subagent_type: string;
   description: string;
   latestMessage?: AIMessage;
+  steps?: SubtaskStep[];
   prompt: string;
   result?: string;
   error?: string;

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -816,8 +816,14 @@ export function useThreadStream({
           type: "task_running";
           task_id: string;
           message: AIMessage;
+          message_index?: unknown;
         };
-        updateSubtask({ id: e.task_id, latestMessage: e.message });
+        updateSubtask({
+          id: e.task_id,
+          latestMessage: e.message,
+          runningMessageIndex:
+            typeof e.message_index === "number" ? e.message_index : undefined,
+        });
         return;
       }
 

--- a/frontend/tests/unit/core/tasks/steps.test.ts
+++ b/frontend/tests/unit/core/tasks/steps.test.ts
@@ -1,0 +1,86 @@
+import type { AIMessage } from "@langchain/langgraph-sdk";
+import { describe, expect, it } from "@rstest/core";
+
+import { mergeSubtaskStep } from "@/core/tasks/steps";
+
+function aiMessage(id: string): AIMessage {
+  return {
+    id,
+    type: "ai",
+    content: "",
+    tool_calls: [
+      {
+        id: `tool-${id}`,
+        name: "web_search",
+        args: { query: id },
+        type: "tool_call",
+      },
+    ],
+  } as AIMessage;
+}
+
+describe("mergeSubtaskStep", () => {
+  it("orders running messages by backend message_index", () => {
+    const third = aiMessage("third");
+    const first = aiMessage("first");
+
+    const steps = mergeSubtaskStep(
+      mergeSubtaskStep(undefined, third, 3),
+      first,
+      1,
+    );
+
+    expect(steps.map((step) => step.message.id)).toEqual(["first", "third"]);
+  });
+
+  it("replaces an existing indexed step instead of duplicating it", () => {
+    const initial = aiMessage("initial");
+    const replacement = aiMessage("replacement");
+
+    const steps = mergeSubtaskStep(
+      mergeSubtaskStep(undefined, initial, 2),
+      replacement,
+      2,
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.message.id).toBe("replacement");
+  });
+
+  it("deduplicates unindexed messages by message id", () => {
+    const initial = aiMessage("same");
+    const replacement = aiMessage("same");
+
+    const steps = mergeSubtaskStep(
+      mergeSubtaskStep(undefined, initial),
+      replacement,
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.message).toBe(replacement);
+  });
+
+  it("replaces an unindexed duplicate when a later indexed copy arrives", () => {
+    const initial = aiMessage("same");
+    const replacement = aiMessage("same");
+
+    const steps = mergeSubtaskStep(
+      mergeSubtaskStep(undefined, initial),
+      replacement,
+      1,
+    );
+
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.message).toBe(replacement);
+    expect(steps[0]?.messageIndex).toBe(1);
+  });
+
+  it("appends unindexed messages without ids", () => {
+    const first = { ...aiMessage("first"), id: undefined } as AIMessage;
+    const second = { ...aiMessage("second"), id: undefined } as AIMessage;
+
+    const steps = mergeSubtaskStep(mergeSubtaskStep(undefined, first), second);
+
+    expect(steps).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Accumulate `task_running` messages for each subtask instead of replacing the previous running message.
- Render every accumulated running tool-call step in the expanded subtask card while keeping the collapsed summary on the latest message.
- Use the backend `message_index` for stable ordering and dedupe, with message-id fallback for unindexed events.

## Why
Addresses the live-display portion of #3779. The backend already emits each subagent AI message as a separate `task_running` event, but the frontend only kept `latestMessage`, so earlier steps flashed and disappeared.

This does not claim to solve refresh/replay persistence; the issue thread calls that out as a larger backend/storage design.

## Testing
- `frontend/node_modules/.bin/rstest run tests/unit/core/tasks/steps.test.ts tests/unit/core/tasks/subtask-result.test.ts`
- `frontend/node_modules/.bin/rstest run`
- `frontend/node_modules/.bin/tsc --noEmit`
- `frontend/node_modules/.bin/eslint . --ext .ts,.tsx` (passes with 3 existing warnings outside this change)
- `git diff --check`
- `BETTER_AUTH_SECRET=codex-frontend-build-secret-at-least-32-chars SKIP_ENV_VALIDATION=1 frontend/node_modules/.bin/next build` (passes; existing Turbopack NFT tracing warning)
- `PLAYWRIGHT_TEST_BASE_URL=http://localhost:3000 frontend/node_modules/.bin/playwright test --config=playwright.config.ts tests/e2e/subtask-card.spec.ts --project=chromium` against a manual `next start` server
