### PR TITLE
fix(mcp): route tools by authoritative grouping, not name-prefix matching

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -635,22 +635,20 @@ async def get_mcp_tools() -> list[BaseTool]:
         # Only pool stdio sessions. HTTP/SSE transports use anyio TaskGroups
         # internally which cannot be closed from a different async task, so
         # pooling them causes RuntimeError on cleanup (see #3203).
+        # Route each tool to the server that produced it via the authoritative
+        # tools_by_server grouping (gather preserves servers_config order).
+        # Re-deriving the server by `tool.name.startswith(f"{name}_")` is
+        # ambiguous when one server name is a prefix of another (e.g. `web` and
+        # `web_scraper`): the first prefix match wins and the tool is routed to
+        # the wrong server (see #3811).
         wrapped_tools: list[BaseTool] = []
-        for tool in tools:
-            tool_server: str | None = None
-            for name in servers_config:
-                if tool.name.startswith(f"{name}_"):
-                    tool_server = name
-                    break
-
-            if tool_server is not None:
+        for tool_server, server_tools in zip(servers_config, tools_by_server):
+            for tool in server_tools:
                 transport = servers_config[tool_server].get("transport", "stdio")
                 if transport == "stdio":
                     wrapped_tools.append(_make_session_pool_tool(tool, tool_server, servers_config[tool_server], tool_interceptors))
                 else:
                     wrapped_tools.append(tool)
-            else:
-                wrapped_tools.append(tool)
 
         # Patch tools to support sync invocation, as deerflow client streams synchronously
         for tool in wrapped_tools:

--- a/backend/tests/test_mcp_session_pool.py
+++ b/backend/tests/test_mcp_session_pool.py
@@ -917,6 +917,89 @@ async def test_http_transport_tools_not_pooled():
 
 
 # ---------------------------------------------------------------------------
+# Regression for #3811: tools must route to the server that produced them
+# even when one server name is a prefix of another (e.g. `web` / `web_scraper`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overlapping_server_name_prefixes_route_to_correct_server():
+    """A tool from `web_scraper` must be wrapped against `web_scraper`, not `web`.
+
+    Before the fix, get_mcp_tools() re-derived each tool's source server by
+    scanning servers_config for the first name that is a prefix of the tool
+    name. With overlapping prefixes, `web_scraper_search` matched `web` first
+    (length-4 strip → `scraper_search`) instead of `web_scraper` (length-12
+    strip → `search`), so the call was routed to the wrong server with the
+    wrong stripped name and failed at the MCP layer.
+    """
+    from langchain_core.tools import StructuredTool
+    from pydantic import BaseModel, Field
+
+    from deerflow.mcp.tools import _make_session_pool_tool, get_mcp_tools
+
+    class Args(BaseModel):
+        query: str = Field(..., description="query")
+
+    web_tool = StructuredTool(
+        name="web_search",
+        description="web search",
+        args_schema=Args,
+        coroutine=AsyncMock(),
+        response_format="content_and_artifact",
+    )
+    web_scraper_tool = StructuredTool(
+        name="web_scraper_search",
+        description="web_scraper search",
+        args_schema=Args,
+        coroutine=AsyncMock(),
+        response_format="content_and_artifact",
+    )
+
+    extensions_config = MagicMock()
+    extensions_config.get_enabled_mcp_servers.return_value = {
+        "web": MagicMock(type="stdio", command="web-bin", args=[], env=None, url=None, headers=None),
+        "web_scraper": MagicMock(type="stdio", command="ws-bin", args=[], env=None, url=None, headers=None),
+    }
+    extensions_config.model_extra = {}
+
+    servers_config = {
+        "web": {"transport": "stdio", "command": "web-bin", "args": []},
+        "web_scraper": {"transport": "stdio", "command": "ws-bin", "args": []},
+    }
+
+    with (
+        patch("deerflow.mcp.tools.ExtensionsConfig.from_file", return_value=extensions_config),
+        patch("deerflow.mcp.tools.build_servers_config", return_value=servers_config),
+        patch("deerflow.mcp.tools.get_initial_oauth_headers", return_value={}),
+        patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=None),
+        patch("langchain_mcp_adapters.client.MultiServerMCPClient") as MockClient,
+        patch("deerflow.mcp.tools._make_session_pool_tool", side_effect=_make_session_pool_tool) as wrap_spy,
+    ):
+        mock_client_instance = MockClient.return_value
+
+        async def get_tools_for_server(*, server_name: str | None = None):
+            if server_name == "web":
+                return [web_tool]
+            if server_name == "web_scraper":
+                return [web_scraper_tool]
+            raise AssertionError(f"unexpected server_name: {server_name}")
+
+        mock_client_instance.get_tools = AsyncMock(side_effect=get_tools_for_server)
+
+        await get_mcp_tools()
+
+    # Each (tool_name, server_name) pair that the wrapper was called with.
+    # The bug routes `web_scraper_search` to server `web` (first prefix match),
+    # so this would show ("web_scraper_search", "web") instead of
+    # ("web_scraper_search", "web_scraper").
+    wrap_calls = [(call.args[0].name, call.args[1]) for call in wrap_spy.call_args_list]
+    assert ("web_search", "web") in wrap_calls
+    assert ("web_scraper_search", "web_scraper") in wrap_calls
+    assert ("web_scraper_search", "web") not in wrap_calls
+
+
+# ---------------------------------------------------------------------------
 # Regression for #3379: cancel scope must be exited in the entering task
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_mcp_sync_wrapper.py
+++ b/backend/tests/test_mcp_sync_wrapper.py
@@ -36,7 +36,7 @@ def test_mcp_tool_sync_wrapper_generation():
     with (
         patch("langchain_mcp_adapters.client.MultiServerMCPClient", return_value=mock_client_instance),
         patch("deerflow.config.extensions_config.ExtensionsConfig.from_file"),
-        patch("deerflow.mcp.tools.build_servers_config", return_value={"test-server": {}}),
+        patch("deerflow.mcp.tools.build_servers_config", return_value={"test-server": {"transport": "http"}}),
         patch("deerflow.mcp.tools.get_initial_oauth_headers", new_callable=AsyncMock, return_value={}),
     ):
         # Run the async function manually with asyncio.run


### PR DESCRIPTION
## Summary

When two MCP server names overlap by prefix (e.g. `web` and `web_scraper`), `get_mcp_tools()` re-derived each tool's source server by scanning `servers_config` for the first name that is a prefix of the tool name and taking the first match. A tool from `web_scraper` named `web_scraper_search` matched `web` first (length-4 strip → `scraper_search`), so the call was routed to the wrong server with the wrong stripped name and failed at the MCP layer. The failure was also order-dependent on `servers_config` insertion order, so it could look intermittent.

Fix: drop the prefix-matching loop and use the authoritative `tools_by_server` grouping (`asyncio.gather` preserves `servers_config` order), which is built directly from `client.get_tools(server_name=X)` calls. Same wrap behavior, correct attribution.

Closes #3811.

## Root cause

`get_mcp_tools()` already loads each server's tools via `client.get_tools(server_name=X)` into `tools_by_server` (index `i` corresponds to the i-th server in `servers_config`). That grouping is authoritative. But the existing wrap loop then **discarded** it — flattening `tools_by_server` and re-deriving the source server via ambiguous `tool.name.startswith(f"{name}_")` matching:

```python
for tool in tools:
    tool_server: str | None = None
    for name in servers_config:
        if tool.name.startswith(f"{name}_"):
            tool_server = name
            break
```

With `web` and `web_scraper` both configured, `web_scraper_search` matches `web` first. The downstream `_make_session_pool_tool(tool, "web", ...)` then strips only `web_` (length 4) from the name when invoking the MCP, leaving `scraper_search`, which the `web` server does not expose → `tool not found`. For mixed transports a stdio tool from the longer-named server can also lose session pooling.

## Change

- `backend/packages/harness/deerflow/mcp/tools.py`: replace the prefix-matching loop with `for tool_server, server_tools in zip(servers_config, tools_by_server):` — same wrap decision per tool, but routed via the authoritative grouping.
- `backend/tests/test_mcp_session_pool.py`: regression test `test_overlapping_server_name_prefixes_route_to_correct_server` spies on `_make_session_pool_tool` and asserts each tool is paired with the server that produced it. Verified **red** on the old code (`web_scraper_search` routed to `web`) and **green** on the fix.
- `backend/tests/test_mcp_sync_wrapper.py`: one-line tightening — `test_mcp_tool_sync_wrapper_generation` now uses `transport: http` for its mock server so it no longer relies on the buggy prefix-mismatch skip path to avoid the session-pool wrap.

## Tests

```
cd backend && PYTHONPATH=. uv run pytest tests/test_mcp_session_pool.py tests/test_mcp_sync_wrapper.py
# 44 passed
```

`ruff format` and `ruff check` clean. No harness→app boundary violations.

## AI assistance disclosure

This change was authored with AI assistance (Claude Code). The bug analysis, fix design, red-green regression test, and PR description were produced collaboratively. All code was reviewed and tested by the author before pushing.