### PR TITLE
feat(guardrails): persist security interventions as run events

### DIFF
--- a/backend/packages/harness/deerflow/guardrails/middleware.py
+++ b/backend/packages/harness/deerflow/guardrails/middleware.py
@@ -16,6 +16,8 @@ from deerflow.guardrails.provider import GuardrailDecision, GuardrailProvider, G
 
 logger = logging.getLogger(__name__)
 
+_REASON_MESSAGE_LIMIT = 500
+
 
 class GuardrailMiddleware(AgentMiddleware[AgentState]):
     """Evaluate tool calls against a GuardrailProvider before execution.
@@ -63,6 +65,57 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             status="error",
         )
 
+    def _record_guardrail_event(
+        self,
+        request: ToolCallRequest,
+        guardrail_request: GuardrailRequest,
+        decision: GuardrailDecision,
+        *,
+        action: str,
+        provider_error: bool,
+    ) -> None:
+        """Persist a security-relevant guardrail decision to RunJournal.
+
+        This mirrors SafetyFinishReasonMiddleware: audit persistence is
+        best-effort and must never change tool execution behavior.
+        """
+        runtime = getattr(request, "runtime", None)
+        context = getattr(runtime, "context", None) if runtime is not None else None
+        if not isinstance(context, dict):
+            return
+
+        journal = context.get("__run_journal")
+        if journal is None:
+            return
+
+        reason_codes = [reason.code for reason in decision.reasons if reason.code]
+        reason_messages = [reason.message[:_REASON_MESSAGE_LIMIT] for reason in decision.reasons if reason.message]
+
+        changes = {
+            "tool_name": guardrail_request.tool_name,
+            "tool_call_id": guardrail_request.tool_call_id,
+            "agent_id": guardrail_request.agent_id,
+            "is_subagent": guardrail_request.is_subagent,
+            "user_role": guardrail_request.user_role,
+            "allow": decision.allow,
+            "policy_id": decision.policy_id,
+            "reason_codes": reason_codes,
+            "reason_messages": reason_messages,
+            "fail_closed": self.fail_closed,
+            "provider_error": provider_error,
+        }
+
+        try:
+            journal.record_middleware(
+                tag="guardrail",
+                name=type(self).__name__,
+                hook="wrap_tool_call",
+                action=action,
+                changes=changes,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to record middleware:guardrail event", exc_info=True)
+
     @override
     def wrap_tool_call(
         self,
@@ -79,10 +132,33 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             logger.exception("Guardrail provider error (sync)")
             if self.fail_closed:
                 decision = GuardrailDecision(allow=False, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-closed)")])
+                self._record_guardrail_event(
+                    request,
+                    gr,
+                    decision,
+                    action="deny_tool_call",
+                    provider_error=True,
+                )
+                return self._build_denied_message(request, decision)
             else:
+                decision = GuardrailDecision(allow=True, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-open)")])
+                self._record_guardrail_event(
+                    request,
+                    gr,
+                    decision,
+                    action="allow_tool_call_after_provider_error",
+                    provider_error=True,
+                )
                 return handler(request)
         if not decision.allow:
             logger.warning("Guardrail denied: tool=%s policy=%s code=%s", gr.tool_name, decision.policy_id, decision.reasons[0].code if decision.reasons else "unknown")
+            self._record_guardrail_event(
+                request,
+                gr,
+                decision,
+                action="deny_tool_call",
+                provider_error=False,
+            )
             return self._build_denied_message(request, decision)
         return handler(request)
 
@@ -102,9 +178,32 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             logger.exception("Guardrail provider error (async)")
             if self.fail_closed:
                 decision = GuardrailDecision(allow=False, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-closed)")])
+                self._record_guardrail_event(
+                    request,
+                    gr,
+                    decision,
+                    action="deny_tool_call",
+                    provider_error=True,
+                )
+                return self._build_denied_message(request, decision)
             else:
+                decision = GuardrailDecision(allow=True, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-open)")])
+                self._record_guardrail_event(
+                    request,
+                    gr,
+                    decision,
+                    action="allow_tool_call_after_provider_error",
+                    provider_error=True,
+                )
                 return await handler(request)
         if not decision.allow:
             logger.warning("Guardrail denied: tool=%s policy=%s code=%s", gr.tool_name, decision.policy_id, decision.reasons[0].code if decision.reasons else "unknown")
+            self._record_guardrail_event(
+                request,
+                gr,
+                decision,
+                action="deny_tool_call",
+                provider_error=False,
+            )
             return self._build_denied_message(request, decision)
         return await handler(request)

--- a/backend/packages/harness/deerflow/guardrails/middleware.py
+++ b/backend/packages/harness/deerflow/guardrails/middleware.py
@@ -33,11 +33,13 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         self.fail_closed = fail_closed
         self.passport = passport
 
-    def _build_request(self, request: ToolCallRequest) -> GuardrailRequest:
+    @staticmethod
+    def _resolve_context(request: ToolCallRequest) -> dict:
         runtime = getattr(request, "runtime", None)
         context = getattr(runtime, "context", None) if runtime is not None else None
-        context = context if isinstance(context, dict) else {}
+        return context if isinstance(context, dict) else {}
 
+    def _build_request(self, request: ToolCallRequest, context: dict) -> GuardrailRequest:
         return GuardrailRequest(
             tool_name=str(request.tool_call.get("name", "")),
             tool_input=request.tool_call.get("args", {}),
@@ -67,7 +69,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
 
     def _record_guardrail_event(
         self,
-        request: ToolCallRequest,
+        context: dict,
         guardrail_request: GuardrailRequest,
         decision: GuardrailDecision,
         *,
@@ -81,11 +83,6 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         behavior. Runtimes without ``__run_journal`` (including embedded and
         subagent execution) skip persistence.
         """
-        runtime = getattr(request, "runtime", None)
-        context = getattr(runtime, "context", None) if runtime is not None else None
-        if not isinstance(context, dict):
-            return
-
         journal = context.get("__run_journal")
         if journal is None:
             return
@@ -97,6 +94,8 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             "tool_name": guardrail_request.tool_name,
             "tool_call_id": guardrail_request.tool_call_id,
             "agent_id": guardrail_request.agent_id,
+            # Native subagents do not currently inherit __run_journal; custom
+            # runtimes may still provide one with subagent attribution.
             "is_subagent": guardrail_request.is_subagent,
             "user_role": guardrail_request.user_role,
             "allow": decision.allow,
@@ -124,7 +123,8 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], ToolMessage | Command],
     ) -> ToolMessage | Command:
-        gr = self._build_request(request)
+        context = self._resolve_context(request)
+        gr = self._build_request(request, context)
         try:
             decision = self.provider.evaluate(gr)
         except GraphBubbleUp:
@@ -135,7 +135,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             if self.fail_closed:
                 decision = GuardrailDecision(allow=False, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-closed)")])
                 self._record_guardrail_event(
-                    request,
+                    context,
                     gr,
                     decision,
                     action="deny_tool_call",
@@ -145,7 +145,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             else:
                 decision = GuardrailDecision(allow=True, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-open)")])
                 self._record_guardrail_event(
-                    request,
+                    context,
                     gr,
                     decision,
                     action="allow_tool_call_after_provider_error",
@@ -155,7 +155,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         if not decision.allow:
             logger.warning("Guardrail denied: tool=%s policy=%s code=%s", gr.tool_name, decision.policy_id, decision.reasons[0].code if decision.reasons else "unknown")
             self._record_guardrail_event(
-                request,
+                context,
                 gr,
                 decision,
                 action="deny_tool_call",
@@ -170,7 +170,8 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         request: ToolCallRequest,
         handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
     ) -> ToolMessage | Command:
-        gr = self._build_request(request)
+        context = self._resolve_context(request)
+        gr = self._build_request(request, context)
         try:
             decision = await self.provider.aevaluate(gr)
         except GraphBubbleUp:
@@ -181,7 +182,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             if self.fail_closed:
                 decision = GuardrailDecision(allow=False, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-closed)")])
                 self._record_guardrail_event(
-                    request,
+                    context,
                     gr,
                     decision,
                     action="deny_tool_call",
@@ -191,7 +192,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             else:
                 decision = GuardrailDecision(allow=True, reasons=[GuardrailReason(code="oap.evaluator_error", message="guardrail provider error (fail-open)")])
                 self._record_guardrail_event(
-                    request,
+                    context,
                     gr,
                     decision,
                     action="allow_tool_call_after_provider_error",
@@ -201,7 +202,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         if not decision.allow:
             logger.warning("Guardrail denied: tool=%s policy=%s code=%s", gr.tool_name, decision.policy_id, decision.reasons[0].code if decision.reasons else "unknown")
             self._record_guardrail_event(
-                request,
+                context,
                 gr,
                 decision,
                 action="deny_tool_call",

--- a/backend/packages/harness/deerflow/guardrails/middleware.py
+++ b/backend/packages/harness/deerflow/guardrails/middleware.py
@@ -97,6 +97,7 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             "tool_name": guardrail_request.tool_name,
             "tool_call_id": guardrail_request.tool_call_id,
             "agent_id": guardrail_request.agent_id,
+            "is_subagent": guardrail_request.is_subagent,
             "user_role": guardrail_request.user_role,
             "allow": decision.allow,
             "policy_id": decision.policy_id,

--- a/backend/packages/harness/deerflow/guardrails/middleware.py
+++ b/backend/packages/harness/deerflow/guardrails/middleware.py
@@ -76,10 +76,10 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
     ) -> None:
         """Persist a security-relevant guardrail decision to RunJournal.
 
-        This mirrors SafetyFinishReasonMiddleware: audit persistence is
-        best-effort and must never change tool execution behavior. Runtimes
-        without ``__run_journal`` (including embedded and subagent execution)
-        skip persistence.
+        This follows the optional-Journal pattern used by existing middleware:
+        audit persistence is best-effort and must never change tool execution
+        behavior. Runtimes without ``__run_journal`` (including embedded and
+        subagent execution) skip persistence.
         """
         runtime = getattr(request, "runtime", None)
         context = getattr(runtime, "context", None) if runtime is not None else None

--- a/backend/packages/harness/deerflow/guardrails/middleware.py
+++ b/backend/packages/harness/deerflow/guardrails/middleware.py
@@ -77,7 +77,9 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
         """Persist a security-relevant guardrail decision to RunJournal.
 
         This mirrors SafetyFinishReasonMiddleware: audit persistence is
-        best-effort and must never change tool execution behavior.
+        best-effort and must never change tool execution behavior. Runtimes
+        without ``__run_journal`` (including embedded and subagent execution)
+        skip persistence.
         """
         runtime = getattr(request, "runtime", None)
         context = getattr(runtime, "context", None) if runtime is not None else None
@@ -95,7 +97,6 @@ class GuardrailMiddleware(AgentMiddleware[AgentState]):
             "tool_name": guardrail_request.tool_name,
             "tool_call_id": guardrail_request.tool_call_id,
             "agent_id": guardrail_request.agent_id,
-            "is_subagent": guardrail_request.is_subagent,
             "user_role": guardrail_request.user_role,
             "allow": decision.allow,
             "policy_id": decision.policy_id,

--- a/backend/tests/test_guardrail_middleware.py
+++ b/backend/tests/test_guardrail_middleware.py
@@ -322,6 +322,7 @@ class TestGuardrailMiddleware:
         with pytest.raises(GraphBubbleUp):
             asyncio.run(run())
 
+    # Journal: a denied tool call records the complete guardrail audit event.
     def test_denied_tool_records_guardrail_event(self):
         journal = _FakeJournal()
         mw = GuardrailMiddleware(_DenyAllProvider(), passport="lead-agent")
@@ -331,7 +332,6 @@ class TestGuardrailMiddleware:
             call_id="tool_call_1",
             context={
                 "__run_journal": journal,
-                "is_subagent": True,
                 "user_role": "member",
             },
         )
@@ -348,7 +348,6 @@ class TestGuardrailMiddleware:
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "tool_call_1"
         assert changes["agent_id"] == "lead-agent"
-        assert changes["is_subagent"] is True
         assert changes["user_role"] == "member"
         assert changes["allow"] is False
         assert changes["policy_id"] == "test.deny.v1"
@@ -362,7 +361,9 @@ class TestGuardrailMiddleware:
         assert "user_id" not in changes
         assert "oauth_provider" not in changes
         assert "oauth_id" not in changes
+        assert "is_subagent" not in changes
 
+    # Journal: a fail-closed provider error is recorded as a denied tool call.
     def test_fail_closed_provider_error_records_guardrail_event(self):
         journal = _FakeJournal()
         mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=True)
@@ -382,6 +383,7 @@ class TestGuardrailMiddleware:
         assert changes["provider_error"] is True
         assert changes["fail_closed"] is True
 
+    # Journal: a fail-open provider error is recorded without blocking the tool.
     def test_fail_open_provider_error_records_guardrail_event_and_allows_handler(self):
         journal = _FakeJournal()
         mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=False)
@@ -402,6 +404,7 @@ class TestGuardrailMiddleware:
         assert changes["provider_error"] is True
         assert changes["fail_closed"] is False
 
+    # Journal: ordinary allowed decisions do not create guardrail audit events.
     def test_allowed_tool_does_not_record_guardrail_event(self):
         journal = _FakeJournal()
         mw = GuardrailMiddleware(_AllowAllProvider())
@@ -414,6 +417,7 @@ class TestGuardrailMiddleware:
         assert result is expected
         assert journal.calls == []
 
+    # Journal: a recording failure must not alter the guardrail denial outcome.
     def test_guardrail_event_recording_failure_does_not_change_denial(self):
         journal = _FakeJournal(fail=True)
         mw = GuardrailMiddleware(_DenyAllProvider())
@@ -426,13 +430,14 @@ class TestGuardrailMiddleware:
         assert result.status == "error"
         assert "oap.denied" in result.content
 
+    # Journal: the async denial path records the same guardrail audit event.
     def test_async_denied_tool_records_guardrail_event(self):
         journal = _FakeJournal()
-        mw = GuardrailMiddleware(_DenyAllProvider(), passport="subagent:research")
+        mw = GuardrailMiddleware(_DenyAllProvider(), passport="lead-agent")
         req = _make_tool_call_request(
             "bash",
             call_id="async_call_1",
-            context={"__run_journal": journal, "is_subagent": True},
+            context={"__run_journal": journal},
         )
 
         async def handler(r):
@@ -452,11 +457,12 @@ class TestGuardrailMiddleware:
         changes = event["changes"]
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "async_call_1"
-        assert changes["agent_id"] == "subagent:research"
-        assert changes["is_subagent"] is True
+        assert changes["agent_id"] == "lead-agent"
+        assert "is_subagent" not in changes
         assert changes["allow"] is False
         assert changes["provider_error"] is False
 
+    # Journal: the async fail-open path records the error and still runs the tool.
     def test_async_fail_open_provider_error_records_guardrail_event_and_allows_handler(self):
         journal = _FakeJournal()
         mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=False)

--- a/backend/tests/test_guardrail_middleware.py
+++ b/backend/tests/test_guardrail_middleware.py
@@ -325,15 +325,14 @@ class TestGuardrailMiddleware:
     # Journal: a denied tool call records the complete guardrail audit event.
     def test_denied_tool_records_guardrail_event(self):
         journal = _FakeJournal()
-        mw = GuardrailMiddleware(_DenyAllProvider(), passport="lead-agent")
+        mw = GuardrailMiddleware(_DenyAllProvider(), passport="agent_id")
         req = _make_tool_call_request(
             "bash",
             args={"command": "cat secret.txt"},
             call_id="tool_call_1",
             context={
                 "__run_journal": journal,
-                "is_subagent": True,
-                "user_role": "member",
+                "user_role": "user",
             },
         )
         result = mw.wrap_tool_call(req, MagicMock())
@@ -348,9 +347,9 @@ class TestGuardrailMiddleware:
         changes = event["changes"]
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "tool_call_1"
-        assert changes["agent_id"] == "lead-agent"
-        assert changes["is_subagent"] is True
-        assert changes["user_role"] == "member"
+        assert changes["agent_id"] == "agent_id"
+        assert changes["is_subagent"] is False
+        assert changes["user_role"] == "user"
         assert changes["allow"] is False
         assert changes["policy_id"] == "test.deny.v1"
         assert changes["reason_codes"] == ["oap.denied"]
@@ -434,7 +433,7 @@ class TestGuardrailMiddleware:
     # Journal: the async denial path records the same guardrail audit event.
     def test_async_denied_tool_records_guardrail_event(self):
         journal = _FakeJournal()
-        mw = GuardrailMiddleware(_DenyAllProvider(), passport="lead-agent")
+        mw = GuardrailMiddleware(_DenyAllProvider(), passport="agent_id")
         req = _make_tool_call_request(
             "bash",
             call_id="async_call_1",
@@ -458,7 +457,7 @@ class TestGuardrailMiddleware:
         changes = event["changes"]
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "async_call_1"
-        assert changes["agent_id"] == "lead-agent"
+        assert changes["agent_id"] == "agent_id"
         assert changes["is_subagent"] is False
         assert changes["allow"] is False
         assert changes["provider_error"] is False

--- a/backend/tests/test_guardrail_middleware.py
+++ b/backend/tests/test_guardrail_middleware.py
@@ -332,6 +332,7 @@ class TestGuardrailMiddleware:
             call_id="tool_call_1",
             context={
                 "__run_journal": journal,
+                "is_subagent": True,
                 "user_role": "member",
             },
         )
@@ -348,6 +349,7 @@ class TestGuardrailMiddleware:
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "tool_call_1"
         assert changes["agent_id"] == "lead-agent"
+        assert changes["is_subagent"] is True
         assert changes["user_role"] == "member"
         assert changes["allow"] is False
         assert changes["policy_id"] == "test.deny.v1"
@@ -361,7 +363,6 @@ class TestGuardrailMiddleware:
         assert "user_id" not in changes
         assert "oauth_provider" not in changes
         assert "oauth_id" not in changes
-        assert "is_subagent" not in changes
 
     # Journal: a fail-closed provider error is recorded as a denied tool call.
     def test_fail_closed_provider_error_records_guardrail_event(self):
@@ -458,7 +459,7 @@ class TestGuardrailMiddleware:
         assert changes["tool_name"] == "bash"
         assert changes["tool_call_id"] == "async_call_1"
         assert changes["agent_id"] == "lead-agent"
-        assert "is_subagent" not in changes
+        assert changes["is_subagent"] is False
         assert changes["allow"] is False
         assert changes["provider_error"] is False
 

--- a/backend/tests/test_guardrail_middleware.py
+++ b/backend/tests/test_guardrail_middleware.py
@@ -15,10 +15,33 @@ from deerflow.guardrails.provider import GuardrailDecision, GuardrailReason, Gua
 # --- Helpers ---
 
 
-def _make_tool_call_request(name: str = "bash", args: dict | None = None, call_id: str = "call_1"):
+class _FakeRuntime:
+    def __init__(self, context: dict | None = None):
+        self.context = context or {}
+
+
+class _FakeJournal:
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.calls: list[dict] = []
+
+    def record_middleware(self, **kwargs):
+        if self.fail:
+            raise RuntimeError("journal unavailable")
+        self.calls.append(kwargs)
+
+
+def _make_tool_call_request(
+    name: str = "bash",
+    args: dict | None = None,
+    call_id: str = "call_1",
+    *,
+    context: dict | None = None,
+):
     """Create a mock ToolCallRequest."""
     req = MagicMock()
     req.tool_call = {"name": name, "args": args or {}, "id": call_id}
+    req.runtime = _FakeRuntime(context)
     return req
 
 
@@ -298,6 +321,164 @@ class TestGuardrailMiddleware:
 
         with pytest.raises(GraphBubbleUp):
             asyncio.run(run())
+
+    def test_denied_tool_records_guardrail_event(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_DenyAllProvider(), passport="lead-agent")
+        req = _make_tool_call_request(
+            "bash",
+            args={"command": "cat secret.txt"},
+            call_id="tool_call_1",
+            context={
+                "__run_journal": journal,
+                "is_subagent": True,
+                "user_role": "member",
+            },
+        )
+        result = mw.wrap_tool_call(req, MagicMock())
+
+        assert result.status == "error"
+        assert len(journal.calls) == 1
+        event = journal.calls[0]
+        assert event["tag"] == "guardrail"
+        assert event["name"] == "GuardrailMiddleware"
+        assert event["hook"] == "wrap_tool_call"
+        assert event["action"] == "deny_tool_call"
+        changes = event["changes"]
+        assert changes["tool_name"] == "bash"
+        assert changes["tool_call_id"] == "tool_call_1"
+        assert changes["agent_id"] == "lead-agent"
+        assert changes["is_subagent"] is True
+        assert changes["user_role"] == "member"
+        assert changes["allow"] is False
+        assert changes["policy_id"] == "test.deny.v1"
+        assert changes["reason_codes"] == ["oap.denied"]
+        assert changes["reason_messages"] == ["all tools blocked"]
+        assert changes["fail_closed"] is True
+        assert changes["provider_error"] is False
+        assert "tool_input" not in changes
+        assert "args" not in changes
+        assert "command" not in changes
+        assert "user_id" not in changes
+        assert "oauth_provider" not in changes
+        assert "oauth_id" not in changes
+
+    def test_fail_closed_provider_error_records_guardrail_event(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=True)
+        req = _make_tool_call_request("bash", context={"__run_journal": journal})
+        handler = MagicMock()
+
+        result = mw.wrap_tool_call(req, handler)
+
+        handler.assert_not_called()
+        assert result.status == "error"
+        assert len(journal.calls) == 1
+        event = journal.calls[0]
+        assert event["action"] == "deny_tool_call"
+        changes = event["changes"]
+        assert changes["allow"] is False
+        assert changes["reason_codes"] == ["oap.evaluator_error"]
+        assert changes["provider_error"] is True
+        assert changes["fail_closed"] is True
+
+    def test_fail_open_provider_error_records_guardrail_event_and_allows_handler(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=False)
+        req = _make_tool_call_request("bash", context={"__run_journal": journal})
+        expected = MagicMock()
+        handler = MagicMock(return_value=expected)
+
+        result = mw.wrap_tool_call(req, handler)
+
+        handler.assert_called_once_with(req)
+        assert result is expected
+        assert len(journal.calls) == 1
+        event = journal.calls[0]
+        assert event["action"] == "allow_tool_call_after_provider_error"
+        changes = event["changes"]
+        assert changes["allow"] is True
+        assert changes["reason_codes"] == ["oap.evaluator_error"]
+        assert changes["provider_error"] is True
+        assert changes["fail_closed"] is False
+
+    def test_allowed_tool_does_not_record_guardrail_event(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_AllowAllProvider())
+        req = _make_tool_call_request("web_search", context={"__run_journal": journal})
+        expected = MagicMock()
+        handler = MagicMock(return_value=expected)
+
+        result = mw.wrap_tool_call(req, handler)
+
+        assert result is expected
+        assert journal.calls == []
+
+    def test_guardrail_event_recording_failure_does_not_change_denial(self):
+        journal = _FakeJournal(fail=True)
+        mw = GuardrailMiddleware(_DenyAllProvider())
+        req = _make_tool_call_request("bash", context={"__run_journal": journal})
+        handler = MagicMock()
+
+        result = mw.wrap_tool_call(req, handler)
+
+        handler.assert_not_called()
+        assert result.status == "error"
+        assert "oap.denied" in result.content
+
+    def test_async_denied_tool_records_guardrail_event(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_DenyAllProvider(), passport="subagent:research")
+        req = _make_tool_call_request(
+            "bash",
+            call_id="async_call_1",
+            context={"__run_journal": journal, "is_subagent": True},
+        )
+
+        async def handler(r):
+            return MagicMock()
+
+        async def run():
+            return await mw.awrap_tool_call(req, handler)
+
+        result = asyncio.run(run())
+
+        assert result.status == "error"
+        assert len(journal.calls) == 1
+        event = journal.calls[0]
+        assert event["tag"] == "guardrail"
+        assert event["hook"] == "wrap_tool_call"
+        assert event["action"] == "deny_tool_call"
+        changes = event["changes"]
+        assert changes["tool_name"] == "bash"
+        assert changes["tool_call_id"] == "async_call_1"
+        assert changes["agent_id"] == "subagent:research"
+        assert changes["is_subagent"] is True
+        assert changes["allow"] is False
+        assert changes["provider_error"] is False
+
+    def test_async_fail_open_provider_error_records_guardrail_event_and_allows_handler(self):
+        journal = _FakeJournal()
+        mw = GuardrailMiddleware(_ExplodingProvider(), fail_closed=False)
+        req = _make_tool_call_request("bash", context={"__run_journal": journal})
+        expected = MagicMock()
+
+        async def handler(r):
+            return expected
+
+        async def run():
+            return await mw.awrap_tool_call(req, handler)
+
+        result = asyncio.run(run())
+
+        assert result is expected
+        assert len(journal.calls) == 1
+        event = journal.calls[0]
+        assert event["action"] == "allow_tool_call_after_provider_error"
+        changes = event["changes"]
+        assert changes["allow"] is True
+        assert changes["provider_error"] is True
+        assert changes["fail_closed"] is False
 
 
 class TestGuardrailRequestAttribution:


### PR DESCRIPTION

Closes #3836 

## Summary

This PR persists security-relevant `GuardrailMiddleware` outcomes as run events. When guardrail intervenes, it writes a `middleware:guardrail` event through the existing `RunJournal.record_middleware()` path.

The recorded scope is intentionally narrow:

- provider deny;
- provider error + fail-closed;
- provider error + fail-open;
- normal allow decisions are not recorded.

The implementation follows the optional-Journal pattern already used by
`SkillActivationMiddleware` and `SafetyFinishReasonMiddleware`: read the
run-scoped journal from `runtime.context["__run_journal"]`, skip when it is
absent, and treat recording failures as non-fatal debug-only errors.

## Motivation

`GuardrailMiddleware` changes the actual execution path of tool calls, but these decisions were previously only written to the logger. After a run completes, structured run events could not explain whether a tool call was denied by guardrail or failed during execution, nor whether a provider error resulted in fail-open or fail-closed behavior.

By persisting these interventions as run events, operators and developers can use `RunEventStore` to review:

- which tool call was denied by guardrail;
- which policy / reason code was involved;
- whether the provider failed;
- whether provider failure allowed or blocked the tool call.

Explicit policy denial and fail-closed handling after a provider error both use `action="deny_tool_call"` to represent the same final execution action. `provider_error`, `fail_closed`, `reason_codes`, and `policy_id` distinguish the causes.

## Surface Area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [x] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Changes

### `GuardrailMiddleware`

Adds a private helper:

```python
_record_guardrail_event(...)
```

The helper:

- reads `__run_journal` from `ToolCallRequest.runtime.context`;
- builds a bounded `changes` payload;
- calls `journal.record_middleware(tag="guardrail", ...)`;
- catches recording failures and logs them at debug level without changing execution behavior.

The `changes` payload includes:

- `tool_name`
- `tool_call_id`
- `agent_id`
- `is_subagent`
- `user_role`
- `allow`
- `policy_id`
- `reason_codes`
- `reason_messages`
- `fail_closed`
- `provider_error`

It does not record:

- `tool_input`
- raw tool arguments
- `user_id`
- `oauth_provider`
- `oauth_id`

Each reason message is truncated to 500 characters.

### Applicability Boundary

Recording follows the existing `SkillActivationMiddleware` and
`SafetyFinishReasonMiddleware` boundary: an event is written only when
`runtime.context["__run_journal"]` already exists.

- Frontend/API and Message Channel runs execute through Gateway `run_agent()` and are covered.
- Embedded `DeerFlowClient`, TUI, and direct `agent.invoke()` execution do not create a `RunJournal` and are not recorded.
- Subagents do not inherit the parent run's `__run_journal`; this PR does not add a cross-thread Journal bridge or claim persistence for decisions made inside subagents.

`is_subagent` remains an attribution field so the event accurately preserves `GuardrailRequest` context and remains compatible with custom runtimes or a future Journal bridge. Its presence does not imply native subagent Journal propagation.

This is not a Guardrail-specific limitation. Lead-agent and subagent executions
currently have independent runtime contexts, so any middleware that relies on
the lead run's Journal has the same boundary. Defining Journal ownership,
lifecycle, cross-thread propagation, and event ordering for subagents is a
shared runtime concern that should be designed by the project maintainers
rather than solved locally inside `GuardrailMiddleware`. It is explicitly out
of scope for this PR.

### Tests

Extends `test_guardrail_middleware.py` to cover:

- deny records `middleware:guardrail`;
- provider error + fail-closed records and denies;
- provider error + fail-open records and allows the handler;
- normal allow does not record;
- payload excludes tool args and user identity fields;
- `record_middleware()` failure does not affect denial behavior;
- sync and async paths remain aligned.

## Verification

Ran:

```bash
uv run pytest tests/test_guardrail_middleware.py tests/test_sandbox_audit_middleware.py -q
```

Result:

**189 passed.**

## Manual Runtime Validation

The implementation is also intended to be exercised against a locally running
DeerFlow instance with persistent run-event storage enabled.

Validation procedure:

1. Start the DeerFlow Gateway and frontend using the project-supported setup,
   with a persistent run-event backend configured.
2. Configure a guardrail provider to deny a known tool call such as `bash`.
3. Trigger that tool call from the DeerFlow UI.
4. Confirm that the tool is not executed and that the run contains a
   `middleware:guardrail` event.
5. Inspect the persisted event and verify `action`, `tool_name`, `is_subagent`,
   `provider_error`, and `fail_closed`.

config.yaml:
```
run_events:
  backend: db
  max_trace_content: 10240
  track_token_usage: true
guardrails:
  enabled: true
  fail_closed: true
  provider:
    use: deerflow.guardrails.builtin:AllowlistProvider
    config:
      denied_tools:
      - bash
```

Example query when using the DB-backed event store:

```sql
sqlite3 -json backend/.deer-flow/data/deerflow.db "
SELECT run_id, seq, event_type, content
FROM run_events
WHERE event_type = 'middleware:guardrail'
ORDER BY id DESC
LIMIT 10;"
```

### Runtime Behavior

<img width="1022" height="713" alt="image" src="https://github.com/user-attachments/assets/a289ee6e-57b7-49af-bcc5-faade3fc9faf" />

### Persisted Run Event
<img width="1183" height="473" alt="image" src="https://github.com/user-attachments/assets/47c08791-0798-4650-8749-bb20dfa1d3ed" />



The observed values and screenshots will be added after the local runtime
validation and before this PR is submitted.

## Security and Privacy Notes

This PR does not persist tool input or raw args, avoiding storage of sensitive
content that the guardrail may have blocked. It also does not duplicate
`user_id` in middleware content; the event continues to use existing
`thread_id` / `run_id` correlation and DeerFlow's ownership/access-control
paths. This PR does not change identity semantics across run-event backends.

Recording is best-effort and does not change guardrail allow/deny behavior.

## Non-Goals

- Do not record every allow decision;
- do not add a new `RunJournal` API;
- do not change the `RunEventStore` schema;
- do not create a new audit subsystem;
- do not change guardrail provider decision semantics.
- do not add Journal lifecycle or propagation for Embedded/TUI or subagent execution.

## AI Assistance

**Tool(s) used:** Claude Code and Codex

**How they were used:** The implementation was produced from a reviewed design
with Claude Code, then reviewed and refined with Codex. Tests and repository
behavior were inspected as part of that review.

- [x] I've read and understand every line of this change and take
  responsibility for it; it is not unreviewed AI output.
