### PR TITLE
fix(mcp): route tools by server index, not name prefix

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -627,6 +627,8 @@ async def get_mcp_tools() -> list[BaseTool]:
 
         # Get tools from each server independently so one broken MCP server does
         # not prevent healthy servers from contributing their tools.
+        # ``tools_by_server[i]`` aligns with the i-th server in
+        # ``servers_config`` because ``asyncio.gather`` preserves input order.
         tools_by_server = await asyncio.gather(*(load_server_tools(name) for name in servers_config))
         tools = [tool for server_tools in tools_by_server for tool in server_tools]
         logger.info(f"Successfully loaded {len(tools)} tool(s) from MCP servers")
@@ -635,22 +637,24 @@ async def get_mcp_tools() -> list[BaseTool]:
         # Only pool stdio sessions. HTTP/SSE transports use anyio TaskGroups
         # internally which cannot be closed from a different async task, so
         # pooling them causes RuntimeError on cleanup (see #3203).
+        #
+        # Walk servers and their tools in lockstep rather than re-deriving the
+        # server from each tool's ``{server}_`` name prefix. A prefix match
+        # ambiguity arises when one server name is a prefix of another (e.g.
+        # ``web`` and ``web_scraper``): a ``web_scraper_search`` tool would
+        # match ``web`` first and be pooled under the wrong server, then
+        # invoked with a wrongly-stripped name — see #3811.
         wrapped_tools: list[BaseTool] = []
-        for tool in tools:
-            tool_server: str | None = None
-            for name in servers_config:
-                if tool.name.startswith(f"{name}_"):
-                    tool_server = name
-                    break
-
-            if tool_server is not None:
-                transport = servers_config[tool_server].get("transport", "stdio")
+        for server_name, server_tools in zip(servers_config, tools_by_server):
+            if not server_tools:
+                continue
+            connection = servers_config[server_name]
+            transport = connection.get("transport", "stdio")
+            for tool in server_tools:
                 if transport == "stdio":
-                    wrapped_tools.append(_make_session_pool_tool(tool, tool_server, servers_config[tool_server], tool_interceptors))
+                    wrapped_tools.append(_make_session_pool_tool(tool, server_name, connection, tool_interceptors))
                 else:
                     wrapped_tools.append(tool)
-            else:
-                wrapped_tools.append(tool)
 
         # Patch tools to support sync invocation, as deerflow client streams synchronously
         for tool in wrapped_tools:

--- a/backend/tests/test_mcp_tools_routing.py
+++ b/backend/tests/test_mcp_tools_routing.py
@@ -1,0 +1,81 @@
+"""Regression tests for ``get_mcp_tools`` server routing.
+
+Covers the prefix-collision bug (#3811): when one server name is a prefix of
+another (e.g. ``web`` and ``web_scraper``), tools from the longer-named server
+must still be pooled under their own server, not the shorter-named one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.tools import StructuredTool
+
+from deerflow.mcp import tools as mcp_tools
+
+
+def _make_fake_tool(name: str) -> StructuredTool:
+    """Build a minimal LangChain tool with the given (already-prefixed) name."""
+    return StructuredTool(
+        name=name,
+        description=f"fake tool {name}",
+        args_schema=None,
+        coroutine=AsyncMock(return_value="ok"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_prefix_collision_routes_each_tool_to_its_own_server():
+    """``web_scraper_*`` tools must pool under ``web_scraper``, not ``web``.
+
+    With the old re-derivation logic (``tool.name.startswith(f"{name}_")`` with
+    the first match winning), a ``web_scraper_search`` tool matched ``web_``
+    first because ``web`` precedes ``web_scraper`` in insertion order. The tool
+    was then wrapped with the wrong server name, so the persistent-session
+    wrapper stripped the wrong prefix and the call failed with "tool not found".
+    """
+    web_tool = _make_fake_tool("web_search")
+    scraper_tool = _make_fake_tool("web_scraper_search")
+
+    fake_extensions = MagicMock()
+    fake_extensions.model_extra = None
+
+    fake_servers_config = {
+        "web": {"transport": "stdio", "command": "echo", "args": ["web"]},
+        "web_scraper": {"transport": "stdio", "command": "echo", "args": ["scraper"]},
+    }
+
+    captured_calls: list[tuple[str, str]] = []
+
+    def fake_wrap(tool, server_name, connection, interceptors):  # noqa: ANN001
+        # Record (tool_name, server_name_passed_to_wrapper) for assertion.
+        captured_calls.append((tool.name, server_name))
+        # Return the tool unchanged; we only care about routing here.
+        return tool
+
+    async def fake_load(server_name):  # noqa: ANN202
+        return {"web": [web_tool], "web_scraper": [scraper_tool]}[server_name]
+
+    fake_client = MagicMock()
+    fake_client.get_tools = MagicMock(side_effect=fake_load)
+
+    with (
+        patch.object(mcp_tools.ExtensionsConfig, "from_file", return_value=fake_extensions),
+        patch.object(mcp_tools, "build_servers_config", return_value=fake_servers_config),
+        patch.object(mcp_tools, "get_initial_oauth_headers", return_value={}),
+        patch.object(mcp_tools, "build_oauth_tool_interceptor", return_value=None),
+        patch("langchain_mcp_adapters.client.MultiServerMCPClient", return_value=fake_client),
+        patch.object(mcp_tools, "_make_session_pool_tool", side_effect=fake_wrap),
+        patch.object(mcp_tools, "make_sync_tool_wrapper", lambda coro, name: coro),
+    ):
+        result = await mcp_tools.get_mcp_tools()
+
+    # Both tools are returned.
+    assert {t.name for t in result} == {"web_search", "web_scraper_search"}
+
+    # Each tool was routed to its authoritative server, not the prefix-matched one.
+    assert ("web_search", "web") in captured_calls
+    assert ("web_scraper_search", "web_scraper") in captured_calls
+    # And the bug-shaped routing is gone.
+    assert ("web_scraper_search", "web") not in captured_calls


### PR DESCRIPTION
## What Problem This Solves

Closes #3811.

When two MCP servers are configured and one server's name is a prefix of another (e.g. `web` and `web_scraper`, or `github` and `github_enterprise`), tools from the longer-named server are routed to the wrong server. With `tool_name_prefix=True`, a tool from `web_scraper` is named `web_scraper_search`; the wrapping loop re-derives the source server by scanning `servers_config` for the first name that is a prefix of the tool name, so `"web_scraper_search".startswith("web_")` matches `web` first. The tool is then pooled under `web` and invoked with the wrongly-stripped original name (`scraper_search`), causing every call to fail with `"tool not found"`. For mixed transports, a stdio tool from the longer-named server can also lose session pooling.

It is order-dependent on config insertion order, so it can look intermittent.

## Why This Change Was Made

`get_mcp_tools()` already had the authoritative per-server grouping in hand — `tools_by_server[i]` aligns with the i-th server in `servers_config` because `asyncio.gather` preserves input order — but discarded it by flattening and re-deriving the server via ambiguous name-prefix matching.

The fix walks servers and their tools in lockstep (`zip(servers_config, tools_by_server)`) and wraps each tool with the server that actually produced it. This removes the prefix-match heuristic entirely.

## User Impact

- MCP servers whose names share a prefix (e.g. `web` + `web_scraper`, `github` + `github_enterprise`) now route tools correctly. No more silent "tool not found" failures for the longer-named server.
- Users running a single MCP server, or servers with no name overlap, see no behavior change.
- Config insertion order no longer affects routing.

## Evidence

New regression test `tests/test_mcp_tools_routing.py::test_prefix_collision_routes_each_tool_to_its_own_server`:

- Mocks `MultiServerMCPClient.get_tools(server_name=...)` to return `web_search` for `web` and `web_scraper_search` for `web_scraper`.
- Captures every `_make_session_pool_tool(tool, server_name, ...)` call.
- Asserts `web_scraper_search` is routed to `web_scraper`, not `web`.

Verified the test catches the bug — it FAILS against the pre-fix code:

```
E       AssertionError: assert ('web_scraper_search', 'web_scraper') in [('web_search', 'web'), ('web_scraper_search', 'web')]
tests/test_mcp_tools_routing.py:79: AssertionError
```

And PASSES with the fix.

Full local MCP test suite (no regressions):

```
uv run pytest tests/test_mcp_session_pool.py tests/test_mcp_custom_interceptors.py tests/test_mcp_tools_routing.py tests/test_mcp_client_config.py
======================== 60 passed, 1 warning in 1.48s =========================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
