### PR TITLE
fix(setup): fail-safe to init_admin on rate-limited setup-status

### DIFF
--- a/frontend/src/app/(auth)/setup/page.tsx
+++ b/frontend/src/app/(auth)/setup/page.tsx
@@ -11,6 +11,8 @@ import { getCsrfHeaders } from "@/core/api/fetcher";
 import { useAuth } from "@/core/auth/AuthProvider";
 import { parseAuthError } from "@/core/auth/types";
 
+import { decideSetupModeFromSetupStatus } from "./setup-status-helpers";
+
 type SetupMode = "loading" | "init_admin" | "change_password";
 
 export default function SetupPage() {
@@ -35,20 +37,33 @@ export default function SetupPage() {
     if (isAuthenticated && user?.needs_setup) {
       setMode("change_password");
     } else if (!isAuthenticated) {
-      // Check if the system has no users yet
+      // Check if the system has no users yet. Fail-safe to init_admin on
+      // any non-ok response (e.g. 429 rate-limited) so the operator can
+      // still reach first-boot setup — see #2999.
       void fetch("/api/v1/auth/setup-status")
-        .then((r) => r.json())
-        .then((data: { needs_setup?: boolean }) => {
+        .then(async (r) => {
+          let needsSetup: boolean | undefined;
+          if (r.ok) {
+            try {
+              const data = (await r.json()) as { needs_setup?: boolean };
+              needsSetup = data.needs_setup;
+            } catch {
+              needsSetup = undefined;
+            }
+          }
           if (cancelled) return;
-          if (data.needs_setup) {
-            setMode("init_admin");
-          } else {
-            // System already set up and user is not logged in — go to login
+          if (
+            decideSetupModeFromSetupStatus(r.ok, needsSetup) === "redirect_login"
+          ) {
             router.push("/login");
+          } else {
+            setMode("init_admin");
           }
         })
         .catch(() => {
-          if (!cancelled) router.push("/login");
+          // Network error: fail-safe to init_admin so the operator can
+          // still reach the setup form when the gateway is flaky — see #2999.
+          if (!cancelled) setMode("init_admin");
         });
     } else {
       // Authenticated but needs_setup is false — already set up

--- a/frontend/src/app/(auth)/setup/setup-status-helpers.ts
+++ b/frontend/src/app/(auth)/setup/setup-status-helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Decision helper for the /setup page's setup-status probe.
+ *
+ * Extracted to a pure module so the fail-safe behaviour can be unit-tested
+ * without rendering the page. See #2999: a rate-limited (429) or otherwise
+ * non-ok response used to be parsed as ``{ needs_setup: undefined }``, which
+ * is falsy and therefore sent the operator to /login instead of the
+ * init-admin form — breaking first-boot setup until the rate-limit window
+ * expired.
+ */
+
+export type SetupStatusDecision = "init_admin" | "redirect_login";
+
+/**
+ * Map a setup-status probe outcome to the page-level action.
+ *
+ * Fail-safe to ``init_admin`` whenever the response is non-ok or the body
+ * does not explicitly say setup is done. Showing the init-admin form
+ * unnecessarily is one extra page load; redirecting the operator away from
+ * first-boot setup silently breaks admin creation.
+ */
+export function decideSetupModeFromSetupStatus(
+  ok: boolean,
+  needsSetup: boolean | undefined,
+): SetupStatusDecision {
+  if (ok && needsSetup === false) {
+    return "redirect_login";
+  }
+  return "init_admin";
+}

--- a/frontend/tests/unit/app/setup/setup-status-helpers.test.ts
+++ b/frontend/tests/unit/app/setup/setup-status-helpers.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "@rstest/core";
+
+import { decideSetupModeFromSetupStatus } from "@/app/(auth)/setup/setup-status-helpers";
+
+describe("decideSetupModeFromSetupStatus", () => {
+  it("redirects to /login when the system is already set up", () => {
+    expect(decideSetupModeFromSetupStatus(true, false)).toBe("redirect_login");
+  });
+
+  it("stays on init_admin when needs_setup is true", () => {
+    expect(decideSetupModeFromSetupStatus(true, true)).toBe("init_admin");
+  });
+
+  it("fails safe to init_admin on a 429 rate-limited response", () => {
+    // Regression for #2999: 429 used to be parsed as needs_setup=undefined
+    // (falsy) and redirect the operator to /login, breaking first-boot.
+    expect(decideSetupModeFromSetupStatus(false, undefined)).toBe("init_admin");
+  });
+
+  it("fails safe to init_admin on any other non-ok response", () => {
+    expect(decideSetupModeFromSetupStatus(false, false)).toBe("init_admin");
+    expect(decideSetupModeFromSetupStatus(false, true)).toBe("init_admin");
+  });
+
+  it("fails safe to init_admin when the body lacks needs_setup", () => {
+    // 2xx with a malformed body — never silently send the operator to /login.
+    expect(decideSetupModeFromSetupStatus(true, undefined)).toBe("init_admin");
+  });
+});


### PR DESCRIPTION
## Problem

Closes #2999.

The `/setup` page probes `/api/v1/auth/setup-status` on first boot to decide whether to render the init-admin form. On any non-ok response — most importantly `429 Too Many Requests` — the page parses the body as `{ needs_setup: undefined }`, treats the falsy value as \"system already initialized\", and redirects the operator to `/login`.

Combined with the backend rate-limit, this makes first-boot admin creation unreachable until the cooldown window expires: SSR `/setup`, the setup page itself, and (in React Strict Mode) the doubled client effect can each consume a probe slot.

## Why This Change Was Made

- **First-boot setup must be reliably reachable.** The cost of an unnecessary init-admin form is one extra page load; the cost of an incorrect `/login` redirect is silent first-boot breakage that requires waiting out the rate-limit window. The fail-safe direction is unambiguous.
- **No backend change required.** The backend already caches the stable \"initialized\" result and dedupes inflight requests; the remaining gap is purely on the frontend's handling of non-ok responses.
- **Testable decision logic.** Extracted the mapping into a pure helper (`decideSetupModeFromSetupStatus`) so the fail-safe table can be unit-tested independently of the page effect — mirrors the existing `gateway-offline-banner-helpers` pattern.

## User Impact

- Operators on first boot reach the init-admin form reliably, even when the setup-status endpoint returns 429 or the network is flaky.
- No change for users on an already-initialized system: a successful `200 { needs_setup: false }` still redirects to `/login` as before.

## Change

- `frontend/src/app/(auth)/setup/setup-status-helpers.ts` — new pure helper `decideSetupModeFromSetupStatus(ok, needsSetup)` returning `\"init_admin\" | \"redirect_login\"`. Returns `\"redirect_login\"` only when `ok && needsSetup === false`; otherwise `\"init_admin\"`.
- `frontend/src/app/(auth)/setup/page.tsx` — probe effect now:
  - Guards `r.ok` before reading the body.
  - Maps the outcome through the helper.
  - `.catch` now fails safe to `init_admin` instead of redirecting to `/login` (network error → still reachable).

## Evidence

```
$ pnpm test -- run tests/unit/app/setup/setup-status-helpers.test.ts
tests: 374
failedTests: 0
passedTests: 374
```

New regression tests in `tests/unit/app/setup/setup-status-helpers.test.ts`:

- `redirects to /login when the system is already set up` — preserves existing behavior on `ok && needsSetup === false`.
- `stays on init_admin when needs_setup is true` — preserves existing behavior on `ok && needsSetup === true`.
- **`fails safe to init_admin on a 429 rate-limited response`** — the regression case from #2999: `ok=false, needsSetup=undefined` → `\"init_admin\"`, not `\"redirect_login\"`.
- `fails safe to init_admin on any other non-ok response` — covers 5xx, network, etc.
- `fails safe to init_admin when the body lacks needs_setup` — covers 2xx with malformed body.

### Type / lint

```
$ pnpm typecheck  # clean
$ pnpm lint       # 0 errors (3 pre-existing warnings in unrelated files)
```