### PR TITLE
fix(mcp): route tools by authoritative server, not name-prefix match

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -635,22 +635,24 @@ async def get_mcp_tools() -> list[BaseTool]:
         # Only pool stdio sessions. HTTP/SSE transports use anyio TaskGroups
         # internally which cannot be closed from a different async task, so
         # pooling them causes RuntimeError on cleanup (see #3203).
+        #
+        # Iterate (server_name, server_tools) pairs from `tools_by_server` to
+        # preserve the authoritative per-server grouping from `asyncio.gather`.
+        # Re-deriving the source server from the tool-name prefix is ambiguous
+        # when one server name is a prefix of another (e.g. `web` and
+        # `web_scraper`): `web_scraper_fetch` matches `web_` first, so the tool
+        # is pooled under the wrong server and invoked with the wrong stripped
+        # name (see #3811).
         wrapped_tools: list[BaseTool] = []
-        for tool in tools:
-            tool_server: str | None = None
-            for name in servers_config:
-                if tool.name.startswith(f"{name}_"):
-                    tool_server = name
-                    break
-
-            if tool_server is not None:
-                transport = servers_config[tool_server].get("transport", "stdio")
+        for server_name, server_tools in zip(servers_config, tools_by_server):
+            transport = servers_config[server_name].get("transport", "stdio")
+            for tool in server_tools:
                 if transport == "stdio":
-                    wrapped_tools.append(_make_session_pool_tool(tool, tool_server, servers_config[tool_server], tool_interceptors))
+                    wrapped_tools.append(
+                        _make_session_pool_tool(tool, server_name, servers_config[server_name], tool_interceptors)
+                    )
                 else:
                     wrapped_tools.append(tool)
-            else:
-                wrapped_tools.append(tool)
 
         # Patch tools to support sync invocation, as deerflow client streams synchronously
         for tool in wrapped_tools:

--- a/backend/tests/test_mcp_session_pool.py
+++ b/backend/tests/test_mcp_session_pool.py
@@ -917,6 +917,108 @@ async def test_http_transport_tools_not_pooled():
 
 
 # ---------------------------------------------------------------------------
+# Regression for #3811: tools must route to the server that produced them when
+# one server name is a prefix of another (e.g. `web` and `web_scraper`).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_mcp_tools_routes_tools_by_authoritative_server_when_names_overlap():
+    """A tool from `web_scraper` must be pooled under `web_scraper`, not under `web`.
+
+    With `tool_name_prefix=True`, a tool from `web_scraper` is named
+    `web_scraper_fetch`. The previous code re-derived the source server by
+    picking the first name in `servers_config` whose `name_` prefix matched the
+    tool name. `web_scraper_fetch`.startswith(`web_`) is True, so the tool was
+    pooled under `web` and invoked with the wrong stripped name (`scraper_fetch`
+    instead of `fetch`), producing "tool not found" at call time. The fix uses
+    the authoritative per-server grouping from `asyncio.gather` instead of
+    inferring the server from the tool-name prefix.
+    """
+    from langchain_core.tools import StructuredTool
+    from pydantic import BaseModel, Field
+
+    from deerflow.mcp.tools import get_mcp_tools
+
+    class Args(BaseModel):
+        url: str = Field(..., description="url")
+
+    # Both servers are stdio so both tools get wrapped. The shorter-named server
+    # is declared first to make a prefix-match regression visible: if
+    # `web_scraper_fetch` were matched against `web_` first, it would route
+    # under `web` with the wrong stripped name.
+    short_tool = StructuredTool(
+        name="web_search",
+        description="web search",
+        args_schema=Args,
+        coroutine=AsyncMock(),
+        response_format="content_and_artifact",
+    )
+    long_tool = StructuredTool(
+        name="web_scraper_fetch",
+        description="web scraper fetch",
+        args_schema=Args,
+        coroutine=AsyncMock(),
+        response_format="content_and_artifact",
+    )
+
+    mock_session = AsyncMock()
+    mock_session.call_tool = AsyncMock(return_value=MagicMock(content=[], isError=False, structuredContent=None))
+    mock_cm = MagicMock()
+    mock_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_cm.__aexit__ = AsyncMock(return_value=False)
+
+    extensions_config = MagicMock()
+    extensions_config.get_enabled_mcp_servers.return_value = {
+        "web": MagicMock(
+            type="stdio", command="web-srv", args=[], env=None, url=None, headers=None
+        ),
+        "web_scraper": MagicMock(
+            type="stdio", command="scraper-srv", args=[], env=None, url=None, headers=None
+        ),
+    }
+    extensions_config.model_extra = {}
+
+    servers_config = {
+        "web": {"transport": "stdio", "command": "web-srv", "args": []},
+        "web_scraper": {"transport": "stdio", "command": "scraper-srv", "args": []},
+    }
+
+    with (
+        patch("deerflow.mcp.tools.ExtensionsConfig.from_file", return_value=extensions_config),
+        patch("deerflow.mcp.tools.build_servers_config", return_value=servers_config),
+        patch("deerflow.mcp.tools.get_initial_oauth_headers", return_value={}),
+        patch("deerflow.mcp.tools.build_oauth_tool_interceptor", return_value=None),
+        patch("langchain_mcp_adapters.client.MultiServerMCPClient") as MockClient,
+        patch("langchain_mcp_adapters.sessions.create_session", return_value=mock_cm),
+    ):
+        mock_client_instance = MockClient.return_value
+
+        async def get_tools_for_server(*, server_name: str | None = None):
+            if server_name == "web":
+                return [short_tool]
+            if server_name == "web_scraper":
+                return [long_tool]
+            raise AssertionError(f"unexpected server_name: {server_name}")
+
+        mock_client_instance.get_tools = AsyncMock(side_effect=get_tools_for_server)
+
+        tools = await get_mcp_tools()
+
+        # Both tools are present and retain their original (prefixed) names.
+        names = sorted(t.name for t in tools)
+        assert names == ["web_scraper_fetch", "web_search"]
+
+        # Invoke the longer-named tool and verify the call lands on the right server
+        # with the correctly stripped name (`fetch`, not `scraper_fetch`). This must
+        # run inside the `create_session` patch so pool entry uses the mock session.
+        long_wrapped = next(t for t in tools if t.name == "web_scraper_fetch")
+        long_wrapped.func(url="https://example.com")
+
+    mock_session.call_tool.assert_called_once_with("fetch", {"url": "https://example.com"})
+
+
+# ---------------------------------------------------------------------------
 # Regression for #3379: cancel scope must be exited in the entering task
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What Problem This Solves

Closes #3811.

`get_mcp_tools()` (`backend/packages/harness/deerflow/mcp/tools.py`) flattened the per-server grouping from `asyncio.gather` and then re-derived each tool's source server by scanning `servers_config` for the first name whose `name_` prefix matched the tool name. With `tool_name_prefix=True`, when one server name is a prefix of another (e.g. `web` and `web_scraper`), a tool from the longer-named server is misrouted:

- `web_scraper_fetch`.startswith(`web_`) → True, so the tool matches `web` first
- It is pooled under `web` (wrong session)
- `_make_session_pool_tool` strips `web_` → `original_name = "scraper_fetch"` (wrong)
- The call hits the `web` session with a tool name that does not exist there → "tool not found"

For mixed transports, a stdio tool from the longer-named server can also lose session pooling when misrouted to an HTTP/SSE server.

The behavior was also order-dependent on config insertion order, so it could look intermittent.

## Why This Change Was Made

`tools_by_server` is the authoritative pairing: `asyncio.gather` preserves order, so index `i` corresponds to the `i`-th server in `servers_config`. Iterating `(server_name, server_tools)` pairs directly removes the ambiguous name-prefix inference and the order-dependence in one step.

The `_make_session_pool_tool` helper already strips the prefix `f"{server_name}_"` from the tool name (no-op if the tool is misnamed), so once each tool is paired with its producing server, both the session lookup and the original-name stripping are correct.

The "no matching server" fallthrough branch is no longer reachable (every tool is paired with its producing server) and is removed.

## User Impact

Operators with MCP servers whose names share a prefix (e.g. `github` and `github_enterprise`, `web` and `web_scraper`) will see tools routed to the correct server. Previously this was order-dependent and silently broken for the longer-named server's tools. No config change is required.

## Evidence

Local tests on top of `main`:

```
backend/.venv/bin/pytest tests/test_mcp_session_pool.py tests/test_mcp_custom_interceptors.py
# 47 passed
```

New regression test: `test_get_mcp_tools_routes_tools_by_authoritative_server_when_names_overlap`:

- Two stdio servers `web` and `web_scraper` (shorter first, to make a prefix-match regression visible).
- Asserts both tools are returned with their original prefixed names (`web_search`, `web_scraper_fetch`).
- Invokes the longer-named tool and asserts `mock_session.call_tool` is called once with `("fetch", {"url": ...})` — i.e. pooled under `web_scraper` with the correct stripped name, not under `web` as `scraper_fetch`.

On the unpatched code, the regression test fails because `call_tool` is invoked with `("scraper_fetch", ...)` against the wrong session.