### PR TITLE
fix(guardrail): keep prompt-injection wrapper out of chat UI and titles (#3689)

### DIFF
--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -25,7 +25,12 @@ from app.gateway.deps import get_checkpointer, get_current_user, get_feedback_re
 from app.gateway.pagination import trim_run_message_page
 from app.gateway.services import sse_consumer, start_run, wait_for_run_completion
 from deerflow.runtime import RunRecord, RunStatus, serialize_channel_values_for_api
-from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY, get_original_user_content_text, message_to_text
+from deerflow.utils.messages import (
+    ORIGINAL_USER_CONTENT_KEY,
+    get_original_user_content_text,
+    message_to_text,
+    restore_original_user_content_blocks,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/threads", tags=["runs"])
@@ -247,13 +252,17 @@ def _checkpoint_response(checkpoint_tuple: Any) -> dict[str, Any]:
 
 def _clean_human_message_for_regenerate(message: Any) -> dict[str, Any]:
     additional_kwargs = _message_additional_kwargs(message)
-    content = get_original_user_content_text(_message_content(message), additional_kwargs)
+    raw_content = _message_content(message)
+    original_text = get_original_user_content_text(raw_content, additional_kwargs)
     additional_kwargs.pop(ORIGINAL_USER_CONTENT_KEY, None)
     additional_kwargs.pop("hide_from_ui", None)
 
     clean_message: dict[str, Any] = {
         "type": "human",
-        "content": [{"type": "text", "text": content}],
+        # Preserve non-text blocks (images/files) for multimodal messages by
+        # restoring through the merge helper instead of collapsing to a lone
+        # text block. See restore_original_user_content_blocks.
+        "content": restore_original_user_content_blocks(raw_content, original_text),
         "additional_kwargs": additional_kwargs,
     }
     message_id = _message_id(message)
@@ -639,7 +648,14 @@ async def list_thread_messages(
         original_content = additional_kwargs.get(ORIGINAL_USER_CONTENT_KEY)
         if not isinstance(original_content, str) or not original_content.strip():
             continue
-        inner["content"] = [{"type": "text", "text": original_content}]
+        # Preserve non-text blocks (images, files) for multimodal messages by
+        # restoring through the merge helper instead of collapsing to a lone
+        # text block. Without this an uploaded image disappears from history
+        # on reload — see InputSanitizationMiddleware._rebuild_content for the
+        # mirror-shape on the write path. (#3689 review feedback.)
+        inner["content"] = restore_original_user_content_blocks(
+            inner.get("content"), original_content
+        )
 
     # Resolve the caller once; it is needed both to scope the feedback query
     # below and to list the thread's runs for turn-duration injection.

--- a/backend/app/gateway/routers/thread_runs.py
+++ b/backend/app/gateway/routers/thread_runs.py
@@ -624,6 +624,23 @@ async def list_thread_messages(
     event_store = get_run_event_store(request)
     messages = await event_store.list_messages(thread_id, limit=limit, before_seq=before_seq, after_seq=after_seq)
 
+    # Unwrap prompt-injection boundary wrappers stamped by InputSanitizationMiddleware
+    # so the UI sees the original user text, not the model-facing wrapper. Only
+    # human-input events are affected; AI messages and tool flows pass through.
+    for row in messages:
+        if row.get("event_type") != "llm.human.input":
+            continue
+        inner = row.get("content")
+        if not isinstance(inner, dict) or inner.get("type") != "human":
+            continue
+        additional_kwargs = inner.get("additional_kwargs")
+        if not isinstance(additional_kwargs, dict):
+            continue
+        original_content = additional_kwargs.get(ORIGINAL_USER_CONTENT_KEY)
+        if not isinstance(original_content, str) or not original_content.strip():
+            continue
+        inner["content"] = [{"type": "text", "text": original_content}]
+
     # Resolve the caller once; it is needed both to scope the feedback query
     # below and to list the thread's runs for turn-duration injection.
     user_id = await get_current_user(request)

--- a/backend/packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py
@@ -31,6 +31,8 @@ from langchain.agents.middleware.types import (
 from langchain_core.messages import HumanMessage
 from langgraph.errors import GraphBubbleUp
 
+from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY, message_content_to_text
+
 logger = logging.getLogger(__name__)
 
 _SUMMARY_MESSAGE_NAME = "summary"
@@ -233,11 +235,22 @@ class InputSanitizationMiddleware(AgentMiddleware[AgentState]):
             else:
                 new_content = processed
 
+            # Stamp the pre-wrap text so downstream surfaces (journal's
+            # first_human_message, GET /threads/{id}/messages) can unwrap
+            # the boundary markers via get_original_user_content_text.
+            # setdefault preserves an existing stamp from an earlier middleware
+            # (e.g. UploadsMiddleware) so the earliest pre-transform text wins.
+            new_additional_kwargs = dict(msg.additional_kwargs or {})
+            new_additional_kwargs.setdefault(
+                ORIGINAL_USER_CONTENT_KEY,
+                message_content_to_text(content),
+            )
+
             messages[i] = HumanMessage(
                 content=new_content,
                 id=msg.id,
                 name=msg.name,
-                additional_kwargs=msg.additional_kwargs,
+                additional_kwargs=new_additional_kwargs,
             )
             logger.debug(
                 "InputSanitizationMiddleware: original=%r -> processed=%r",

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -29,7 +29,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
-from deerflow.utils.messages import message_to_text
+from deerflow.utils.messages import get_original_user_content_text, message_to_text
 
 if TYPE_CHECKING:
     from deerflow.runtime.events.store.base import RunEventStore
@@ -203,7 +203,12 @@ class RunJournal(BaseCallbackHandler):
             for batch in reversed(messages):
                 for m in reversed(batch):
                     if isinstance(m, HumanMessage) and m.name != "summary" and m.additional_kwargs.get("hide_from_ui") is not True:
-                        self.set_first_human_message(m.text)
+                        # Unwrap boundary-marker wrappers stamped by
+                        # InputSanitizationMiddleware (and UploadsMiddleware)
+                        # so first_human_message reflects the user's text,
+                        # not the model-facing guardrail wrapper.
+                        original_text = get_original_user_content_text(m.content, m.additional_kwargs)
+                        self.set_first_human_message(original_text)
                         self._put(
                             event_type="llm.human.input",
                             category="message",

--- a/backend/packages/harness/deerflow/utils/messages.py
+++ b/backend/packages/harness/deerflow/utils/messages.py
@@ -72,3 +72,38 @@ def get_original_user_content_text(content: Any, additional_kwargs: Mapping[str,
     if isinstance(original_content, str):
         return original_content
     return message_content_to_text(content)
+
+
+def restore_original_user_content_blocks(content: Any, original_text: str) -> list[dict]:
+    """Restore display content for a user message stamped with ``ORIGINAL_USER_CONTENT_KEY``.
+
+    Mirrors the merge shape produced by ``InputSanitizationMiddleware._rebuild_content``:
+    the first text block is replaced with the pre-wrap text, any subsequent text
+    blocks (already merged into the first by the middleware) are dropped, and
+    non-text blocks (images, files) stay in place. For string content (or any
+    non-list shape) a single text-block list is returned.
+
+    Without this, display surfaces that wholesale-replace ``content`` with a
+    single text block lose the image/file blocks of multimodal user messages.
+    """
+    if not isinstance(content, list):
+        return [{"type": "text", "text": original_text}]
+
+    result: list[dict] = []
+    text_replaced = False
+    for block in content:
+        if isinstance(block, Mapping) and block.get("type") == "text":
+            if not text_replaced:
+                result.append({"type": "text", "text": original_text})
+                text_replaced = True
+            # Subsequent text blocks were merged into the first by the
+            # middleware; drop them so the displayed text is not duplicated.
+            continue
+        result.append(block)
+
+    if not text_replaced:
+        # No text block in the persisted list — prepend the original text
+        # so the user's typed input still renders.
+        result.insert(0, {"type": "text", "text": original_text})
+
+    return result

--- a/backend/tests/test_input_sanitization_middleware.py
+++ b/backend/tests/test_input_sanitization_middleware.py
@@ -571,3 +571,115 @@ async def test_awrap_model_call_escapes_injection():
     result_content = captured[0].messages[-1].content
     assert "&lt;system&gt;" in result_content
     assert "<system>" not in result_content
+
+
+# ---------------------------------------------------------------------------
+# Regression: ORIGINAL_USER_CONTENT_KEY stamping (issue #3689)
+# ---------------------------------------------------------------------------
+#
+# When the middleware wraps a user message in prompt-injection boundary
+# markers, it must also stamp the pre-wrap text in additional_kwargs so
+# downstream surfaces (RunJournal's first_human_message, the messages API)
+# can recover the user's original text via get_original_user_content_text.
+
+
+class TestOriginalUserContentStamp:
+    """Wrapping must preserve the pre-wrap user text via ORIGINAL_USER_CONTENT_KEY."""
+
+    def test_stamps_original_text_when_wrapping(self):
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        mw = _make_middleware()
+        request = _make_request([HumanMessage(content="test", id="msg-1")])
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        result_msg = captured[0].messages[-1]
+        assert result_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "test"
+        # Content remains wrapped for the model
+        assert _USER_INPUT_BEGIN in result_msg.content
+        assert _USER_INPUT_END in result_msg.content
+
+    def test_stamps_pre_wrap_text_when_tags_escaped(self):
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        mw = _make_middleware()
+        request = _make_request([HumanMessage(content="<think>hack</think>", id="msg-1")])
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        result_msg = captured[0].messages[-1]
+        # Original (pre-escape, pre-wrap) text preserved verbatim
+        assert result_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY] == "<think>hack</think>"
+        # Model-facing content has the escaped form
+        assert "&lt;think&gt;" in result_msg.content
+
+    def test_stamps_joined_text_for_list_content(self):
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        mw = _make_middleware()
+        list_content = [
+            {"type": "text", "text": "Hello"},
+            {"type": "image_url", "image_url": {"url": "data:x"}},
+            {"type": "text", "text": "world"},
+        ]
+        request = _make_request([HumanMessage(content=list_content, id="msg-1")])
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        result_msg = captured[0].messages[-1]
+        # Text blocks are joined with newlines (matching message_content_to_text)
+        assert (
+            result_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY]
+            == "Hello\nworld"
+        )
+
+    def test_does_not_overwrite_existing_original_stamp(self):
+        """Earlier middleware (e.g. UploadsMiddleware) stamp wins via setdefault."""
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        mw = _make_middleware()
+        prior_kwargs = {
+            ORIGINAL_USER_CONTENT_KEY: "/data-analysis run report",
+            "files": [{"filename": "report.csv"}],
+        }
+        request = _make_request(
+            [
+                HumanMessage(
+                    content="/data-analysis run report",
+                    id="msg-1",
+                    additional_kwargs=prior_kwargs,
+                ),
+            ],
+        )
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        result_msg = captured[0].messages[-1]
+        # Existing stamp preserved
+        assert (
+            result_msg.additional_kwargs[ORIGINAL_USER_CONTENT_KEY]
+            == "/data-analysis run report"
+        )
+        # Non-stamp kwargs preserved
+        assert result_msg.additional_kwargs["files"] == [{"filename": "report.csv"}]
+        # Content still wrapped for the model
+        assert _USER_INPUT_BEGIN in result_msg.content
+
+    def test_skips_stamp_when_message_not_wrapped(self):
+        """Empty / image-only messages that bypass wrapping also bypass stamping."""
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        mw = _make_middleware()
+        image_only = [{"type": "image_url", "image_url": {"url": "data:x"}}]
+        request = _make_request([HumanMessage(content=image_only, id="msg-1")])
+        captured = []
+
+        mw.wrap_model_call(request, lambda req: captured.append(req) or "ok")
+
+        result_msg = captured[0].messages[-1]
+        assert ORIGINAL_USER_CONTENT_KEY not in result_msg.additional_kwargs

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -997,3 +997,41 @@ class TestChatModelStartHumanMessage:
         j.on_chat_model_start({}, [], run_id=uuid4(), tags=["lead_agent"])
         await j.flush()
         assert j._first_human_msg is None
+
+    @pytest.mark.anyio
+    async def test_first_human_message_unwraps_prompt_injection_boundary(
+        self, journal_setup
+    ):
+        """first_human_message reflects the user's text, not the model-facing wrapper.
+
+        Regression for issue #3689: InputSanitizationMiddleware stamps the
+        pre-wrap text in ORIGINAL_USER_CONTENT_KEY. The journal must prefer
+        that stamp over the wrapped model-facing ``.text`` so thread titles /
+        previews stay clean.
+        """
+        from langchain_core.messages import HumanMessage
+
+        from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+        j, store = journal_setup
+        wrapped_content = "--- BEGIN USER INPUT ---\ntest\n--- END USER INPUT ---"
+        message = HumanMessage(
+            content=wrapped_content,
+            additional_kwargs={ORIGINAL_USER_CONTENT_KEY: "test"},
+        )
+        j.on_chat_model_start({}, [[message]], run_id=uuid4(), tags=["lead_agent"])
+        await j.flush()
+
+        # first_human_message is the unwrapped user text
+        assert j._first_human_msg == "test"
+        # The persisted llm.human.input event still has the wrapped content
+        # for parity with the model-facing stream — list_thread_messages
+        # handles the read-side unwrap separately.
+        events = await store.list_events("t1", "r1")
+        human_events = [e for e in events if e["event_type"] == "llm.human.input"]
+        assert len(human_events) == 1
+        assert human_events[0]["content"]["content"] == wrapped_content
+        assert (
+            human_events[0]["content"]["additional_kwargs"][ORIGINAL_USER_CONTENT_KEY]
+            == "test"
+        )

--- a/backend/tests/test_thread_regenerate_prepare.py
+++ b/backend/tests/test_thread_regenerate_prepare.py
@@ -259,3 +259,56 @@ def test_prepare_regenerate_payload_reports_recent_checkpoint_scan_limit():
     assert exc.value.status_code == 409
     assert exc.value.detail == "Could not locate target user message in recent checkpoint history (limit=200)"
     assert checkpointer.alist_limits == [200]
+
+
+def test_prepare_regenerate_payload_preserves_image_block_for_multimodal_message():
+    """Regression for #3689 review feedback: regenerating from a multimodal
+    human message must preserve the image/file blocks. The original code
+    collapsed ``content`` to ``[{text}]`` for every regenerated message,
+    which dropped image_url blocks when the source message had text + image.
+    """
+    from app.gateway.routers.thread_runs import _prepare_regenerate_payload
+
+    image_block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,ABC"}}
+    # Persisted shape after middleware's _rebuild_content: single merged text
+    # block carrying the boundary wrapper, followed by the image block.
+    human = HumanMessage(
+        id="human-1",
+        content=[
+            {
+                "type": "text",
+                "text": "--- BEGIN USER INPUT ---\nlook at this\n--- END USER INPUT ---",
+            },
+            image_block,
+        ],
+        additional_kwargs={
+            ORIGINAL_USER_CONTENT_KEY: "look at this",
+        },
+    )
+    ai = AIMessage(id="ai-1", content="answer v1")
+    base = _checkpoint("ckpt-base", [])
+    after_human = _checkpoint("ckpt-human", [human])
+    latest = _checkpoint("ckpt-ai", [human, ai])
+    checkpointer = FakeCheckpointer([latest, after_human, base])
+    event_store = FakeEventStore(
+        [
+            {
+                "run_id": "run-old",
+                "event_type": "llm.ai.response",
+                "category": "message",
+                "content": {"id": "ai-1", "type": "ai", "content": "answer v1"},
+                "metadata": {"caller": "lead_agent"},
+            }
+        ]
+    )
+
+    response = asyncio.run(_prepare_regenerate_payload("thread-1", "ai-1", _request(checkpointer, event_store)))
+
+    regenerated_human = response.input["messages"][0]
+    assert regenerated_human["id"] == "human-1"
+    # Text block carries the original (unwrapped) text; image block preserved.
+    assert regenerated_human["content"] == [
+        {"type": "text", "text": "look at this"},
+        image_block,
+    ]
+    assert "BEGIN USER INPUT" not in str(regenerated_human["content"])

--- a/backend/tests/test_thread_run_messages_pagination.py
+++ b/backend/tests/test_thread_run_messages_pagination.py
@@ -411,3 +411,66 @@ def test_list_thread_messages_leaves_unstamped_human_messages_untouched():
     assert response.status_code == 200
     data = response.json()
     assert data[0]["content"]["content"] == "no middleware touched this"
+
+
+def test_list_thread_messages_unwraps_multimodal_message_preserving_non_text_blocks():
+    """Regression for #3689 review feedback: multimodal user messages must
+    keep their image/file blocks after the boundary wrapper is unwrapped.
+
+    The middleware's ``_rebuild_content`` persists the wrapped text as a single
+    merged text block alongside non-text blocks (image_url, files). The read
+    path must restore the original text in place without dropping the image —
+    otherwise an uploaded image disappears from history on reload.
+    """
+    from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+    image_block = {"type": "image_url", "image_url": {"url": "data:image/png;base64,XYZ"}}
+    rows = [
+        {
+            "seq": 1,
+            "run_id": "run-1",
+            "event_type": "llm.human.input",
+            "category": "message",
+            "content": {
+                "type": "human",
+                # Persisted shape after InputSanitizationMiddleware._rebuild_content:
+                # [{text: wrapped}, {image_url: ...}] — text block first, non-text
+                # blocks preserved in place.
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "--- BEGIN USER INPUT ---\nlook\n--- END USER INPUT ---",
+                    },
+                    image_block,
+                ],
+                "additional_kwargs": {ORIGINAL_USER_CONTENT_KEY: "look"},
+            },
+        },
+    ]
+
+    event_store = MagicMock()
+    event_store.list_messages = AsyncMock(return_value=rows)
+
+    run_manager = AsyncMock()
+    run_manager.list_by_thread = AsyncMock(return_value=[])
+
+    feedback_repo = MagicMock()
+    feedback_repo.list_by_thread_grouped = AsyncMock(return_value={})
+
+    app = _make_app(event_store=event_store, run_manager=run_manager)
+    app.state.feedback_repo = feedback_repo
+
+    with TestClient(app) as client:
+        response = client.get("/api/threads/thread-1/messages")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    human = data[0]["content"]
+    assert human["type"] == "human"
+    # Original text restored in the text block, image block preserved.
+    assert human["content"] == [
+        {"type": "text", "text": "look"},
+        image_block,
+    ]
+    assert "BEGIN USER INPUT" not in str(human["content"])

--- a/backend/tests/test_thread_run_messages_pagination.py
+++ b/backend/tests/test_thread_run_messages_pagination.py
@@ -315,3 +315,99 @@ def test_list_thread_messages_injects_turn_duration():
 
     assert "turn_duration" not in data[0].get("content", {}).get("additional_kwargs", {})
     assert data[1]["content"]["additional_kwargs"]["turn_duration"] == 5
+
+
+def test_list_thread_messages_unwraps_prompt_injection_boundary_markers():
+    """Human messages must show original text, not the model-facing wrapper (#3689)."""
+    from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
+
+    rows = [
+        {
+            "seq": 1,
+            "run_id": "run-1",
+            "event_type": "llm.human.input",
+            "category": "message",
+            "content": {
+                "type": "human",
+                "content": "--- BEGIN USER INPUT ---\ntest\n--- END USER INPUT ---",
+                "additional_kwargs": {ORIGINAL_USER_CONTENT_KEY: "test"},
+            },
+        },
+        {
+            "seq": 2,
+            "run_id": "run-1",
+            "event_type": "llm.ai.response",
+            "category": "message",
+            "content": {
+                "type": "ai",
+                "content": "Here is the answer.",
+                "additional_kwargs": {},
+            },
+        },
+    ]
+
+    event_store = MagicMock()
+    event_store.list_messages = AsyncMock(return_value=rows)
+
+    run_manager = AsyncMock()
+    run_manager.list_by_thread = AsyncMock(return_value=[])
+
+    feedback_repo = MagicMock()
+    feedback_repo.list_by_thread_grouped = AsyncMock(return_value={})
+
+    app = _make_app(event_store=event_store, run_manager=run_manager)
+    app.state.feedback_repo = feedback_repo
+
+    with TestClient(app) as client:
+        response = client.get("/api/threads/thread-1/messages")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Human message unwrapped to original user text
+    human = data[0]["content"]
+    assert human["type"] == "human"
+    assert human["content"] == [{"type": "text", "text": "test"}]
+    # Boundary markers gone from the UI-facing content
+    assert "BEGIN USER INPUT" not in str(human["content"])
+
+    # AI message untouched
+    ai = data[1]["content"]
+    assert ai["type"] == "ai"
+    assert ai["content"] == "Here is the answer."
+
+
+def test_list_thread_messages_leaves_unstamped_human_messages_untouched():
+    """Human messages without ORIGINAL_USER_CONTENT_KEY pass through verbatim."""
+    rows = [
+        {
+            "seq": 1,
+            "run_id": "run-1",
+            "event_type": "llm.human.input",
+            "category": "message",
+            "content": {
+                "type": "human",
+                "content": "no middleware touched this",
+                "additional_kwargs": {},
+            },
+        },
+    ]
+
+    event_store = MagicMock()
+    event_store.list_messages = AsyncMock(return_value=rows)
+
+    run_manager = AsyncMock()
+    run_manager.list_by_thread = AsyncMock(return_value=[])
+
+    feedback_repo = MagicMock()
+    feedback_repo.list_by_thread_grouped = AsyncMock(return_value={})
+
+    app = _make_app(event_store=event_store, run_manager=run_manager)
+    app.state.feedback_repo = feedback_repo
+
+    with TestClient(app) as client:
+        response = client.get("/api/threads/thread-1/messages")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data[0]["content"]["content"] == "no middleware touched this"

--- a/backend/tests/test_utils_messages.py
+++ b/backend/tests/test_utils_messages.py
@@ -70,3 +70,113 @@ def test_non_string_text_attribute_ignored():
 
 def test_message_content_to_text_still_joins_with_newline():
     assert message_content_to_text(["a", {"text": "b"}]) == "a\nb"
+
+
+# ---------- restore_original_user_content_blocks (#3689 review feedback) ----------
+
+
+def _image(url: str = "data:image/png;base64,ABC") -> dict:
+    return {"type": "image_url", "image_url": {"url": url}}
+
+
+def test_restore_string_content_returns_single_text_block():
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    assert restore_original_user_content_blocks("anything", "look") == [
+        {"type": "text", "text": "look"},
+    ]
+
+
+def test_restore_non_list_non_string_returns_single_text_block():
+    """Non-list content (e.g. legacy Mapping shape) collapses to a text block."""
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    assert restore_original_user_content_blocks(None, "look") == [
+        {"type": "text", "text": "look"},
+    ]
+    assert restore_original_user_content_blocks({"text": "wrapped"}, "look") == [
+        {"type": "text", "text": "look"},
+    ]
+
+
+def test_restore_list_replaces_first_text_block_with_original_text():
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    content = [
+        {"type": "text", "text": "--- BEGIN USER INPUT ---\nlook\n--- END USER INPUT ---"},
+        _image(),
+    ]
+    assert restore_original_user_content_blocks(content, "look") == [
+        {"type": "text", "text": "look"},
+        _image(),
+    ]
+
+
+def test_restore_list_drops_subsequent_text_blocks_already_merged_into_first():
+    """The middleware merges all text blocks into one; the read path must not
+    re-emit the merged-away text blocks (would duplicate displayed text)."""
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    content = [
+        {"type": "text", "text": "wrapped-1"},
+        _image(),
+        {"type": "text", "text": "wrapped-2"},
+    ]
+    out = restore_original_user_content_blocks(content, "merged text")
+    assert out == [
+        {"type": "text", "text": "merged text"},
+        _image(),
+    ]
+
+
+def test_restore_list_preserves_non_text_blocks_between_text_blocks():
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    file_block = {"type": "file", "file_id": "f1"}
+    content = [
+        {"type": "text", "text": "wrapped"},
+        file_block,
+        _image("data:image/png;base64,XYZ"),
+    ]
+    out = restore_original_user_content_blocks(content, "look")
+    assert out == [
+        {"type": "text", "text": "look"},
+        file_block,
+        _image("data:image/png;base64,XYZ"),
+    ]
+
+
+def test_restore_list_with_no_text_block_prepends_original_text():
+    """Edge case: persisted content has only non-text blocks (rare, but
+    defensive). Original text should still surface."""
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    content = [_image()]
+    out = restore_original_user_content_blocks(content, "look")
+    assert out == [
+        {"type": "text", "text": "look"},
+        _image(),
+    ]
+
+
+def test_restore_empty_list_prepends_original_text():
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    assert restore_original_user_content_blocks([], "look") == [
+        {"type": "text", "text": "look"},
+    ]
+
+
+def test_restore_list_does_not_mutate_input_blocks():
+    """Helper must not mutate the caller's block dicts — display path should
+    be a fresh list with a new first text block."""
+    from deerflow.utils.messages import restore_original_user_content_blocks
+
+    original_text_block = {"type": "text", "text": "wrapped"}
+    content = [original_text_block, _image()]
+    out = restore_original_user_content_blocks(content, "look")
+    # Caller's text block unchanged
+    assert original_text_block == {"type": "text", "text": "wrapped"}
+    # Output is a fresh shape
+    assert out[0] == {"type": "text", "text": "look"}
+    assert out[0] is not original_text_block


### PR DESCRIPTION
## What Problem This Solves

Closes #3689.

`InputSanitizationMiddleware` (issue #3630) wraps clean user input in boundary markers (`--- BEGIN USER INPUT ---` / `--- END USER INPUT ---`) as a structured-prompt defense. The wrap is supposed to be model-facing only, but the wrapper leaked into:

- The chat UI — a plain `test` is rendered as `--- BEGIN USER INPUT ---\ntest\n--- END USER INPUT ---`
- `runs.first_human_message` — so thread titles / previews are polluted
- The `llm.human.input` event row persisted by `RunJournal.on_chat_model_start`

The root cause is that the middleware replaces the user message's content at the LLM-call boundary, but the journal observes the wrapped message when capturing `first_human_message` and `GET /api/threads/{id}/messages` returns event-store content verbatim. Unlike `UploadsMiddleware` (which stamps the pre-transform text in `additional_kwargs[ORIGINAL_USER_CONTENT_KEY]`) and IM channels, a plain web text message was never stamped.

## Why This Change Was Made

The fix follows the same pattern already established by `UploadsMiddleware` and the IM channel path: stamp the pre-wrap user text in `ORIGINAL_USER_CONTENT_KEY`, then read it back at the surfaces that display human text.

Three coordinated changes:

1. **`InputSanitizationMiddleware._process_request`** — stamp `ORIGINAL_USER_CONTENT_KEY` with `message_content_to_text(content)` *before* constructing the wrapped message, using `setdefault` so an earlier stamp from `UploadsMiddleware` (or any other upstream middleware) wins. This is the same shape as `uploads_middleware.py:270`.

2. **`RunJournal.on_chat_model_start`** — extract `first_human_message` via `get_original_user_content_text(m.content, m.additional_kwargs)` instead of `m.text`, so thread titles/previews stay clean.

3. **`list_thread_messages`** — for `llm.human.input` event rows whose inner message carries `ORIGINAL_USER_CONTENT_KEY`, replace the inner content with the original text before returning so the chat UI renders user text, not boundary markers.

The persisted `llm.human.input` event still carries the wrapped content for parity with the model-facing stream; only the read path (and the title extraction) unwraps. This keeps the boundary defense intact for the model while ensuring UI surfaces show the user's actual text.

## User Impact

- Sending a plain text message in a fresh web thread no longer renders the boundary markers in the chat UI. The original text (`test`) is displayed instead of `--- BEGIN USER INPUT ---\ntest\n--- END USER INPUT ---`.
- Thread titles / previews (`first_human_message`) reflect the original text.
- The model still receives the protective wrapper; no change to guardrail behavior.
- Messages without `ORIGINAL_USER_CONTENT_KEY` (e.g. before this fix lands, or messages that bypass the middleware) pass through unchanged — fully backward compatible.

## Evidence

```
$ .venv/bin/python -m pytest \
    tests/test_input_sanitization_middleware.py \
    tests/test_run_journal.py \
    tests/test_thread_messages_feedback.py \
    tests/test_thread_run_messages_pagination.py \
    tests/test_thread_regenerate_prepare.py \
    tests/test_uploads_middleware_core_logic.py \
    tests/test_slash_skills.py \
    tests/test_dynamic_context_middleware.py
======================= 257 passed, 2 warnings in 2.96s ========================
```

Regression coverage added:

- `test_input_sanitization_middleware.py::TestOriginalUserContentStamp` (5 tests):
  - `test_stamps_original_text_when_wrapping` — basic wrap stamps `ORIGINAL_USER_CONTENT_KEY`
  - `test_stamps_pre_wrap_text_when_tags_escaped` — pre-escape, pre-wrap text preserved verbatim
  - `test_stamps_joined_text_for_list_content` — multimodal text blocks joined with newlines
  - `test_does_not_overwrite_existing_original_stamp` — earlier middleware stamp wins via `setdefault`
  - `test_skips_stamp_when_message_not_wrapped` — image-only / empty messages bypass stamping
- `test_run_journal.py::test_first_human_message_unwraps_prompt_injection_boundary` — `first_human_message` is `"test"`, not the wrapped text; persisted event retains wrapped content for parity
- `test_thread_run_messages_pagination.py`:
  - `test_list_thread_messages_unwraps_prompt_injection_boundary_markers` — UI sees original text, AI messages untouched
  - `test_list_thread_messages_leaves_unstamped_human_messages_untouched` — no regression for unstamped messages

### Tested surface

- `backend/packages/harness/deerflow/agents/middlewares/input_sanitization_middleware.py` — wrap path stamps `ORIGINAL_USER_CONTENT_KEY` before constructing the wrapped HumanMessage
- `backend/packages/harness/deerflow/runtime/journal.py` — `first_human_message` extraction reads via `get_original_user_content_text`
- `backend/app/gateway/routers/thread_runs.py` — `list_thread_messages` unwraps human input events before returning