### PR TITLE
feat(runtime): track durable workflow waiting and resume refs

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -516,6 +516,53 @@ def _owner_headers(msg: InboundMessage) -> dict[str, str] | None:
     return create_internal_auth_headers(owner_user_id=owner_user_id)
 
 
+def _inbound_message_id(msg: InboundMessage) -> str | None:
+    metadata = msg.metadata or {}
+    for key in INBOUND_DEDUPE_METADATA_KEYS:
+        value = metadata.get(key)
+        if value:
+            return str(value)
+    raw_message = metadata.get("raw_message")
+    if isinstance(raw_message, Mapping):
+        for key in INBOUND_DEDUPE_METADATA_KEYS:
+            value = raw_message.get(key)
+            if value:
+                return str(value)
+    return None
+
+
+def _inbound_workspace_id(msg: InboundMessage) -> str | None:
+    metadata = msg.metadata or {}
+    workspace_id = msg.workspace_id or metadata.get("workspace_id") or metadata.get("team_id") or metadata.get("guild_id") or metadata.get("aibotid")
+    return str(workspace_id) if workspace_id else None
+
+
+def _workflow_intake_headers(msg: InboundMessage) -> dict[str, str]:
+    headers = {
+        "X-DeerFlow-Workflow-Source-Type": "channel",
+        "X-DeerFlow-Workflow-Source": msg.channel_name,
+        "X-DeerFlow-Workflow-Conversation-Ref": msg.chat_id,
+        "X-DeerFlow-Workflow-Thread-Ref": msg.topic_id or msg.thread_ts or msg.chat_id,
+        "X-DeerFlow-Workflow-Sender-Ref": msg.user_id,
+    }
+    message_id = _inbound_message_id(msg)
+    workspace_id = _inbound_workspace_id(msg)
+    if message_id:
+        external_ref = f"{msg.channel_name}:{workspace_id or ''}:{msg.chat_id}:{message_id}"
+        headers["X-External-Message-Ref"] = external_ref
+        if workspace_id:
+            headers["Idempotency-Key"] = f"channel:{external_ref}"
+    return headers
+
+
+def _run_headers(msg: InboundMessage) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if owner_headers := _owner_headers(msg):
+        headers.update(owner_headers)
+    headers.update(_workflow_intake_headers(msg))
+    return headers
+
+
 def _safe_user_id_for_run(raw_user_id: str) -> str:
     from deerflow.config.paths import get_paths
 
@@ -986,28 +1033,14 @@ class ChannelManager:
 
     @staticmethod
     def _inbound_dedupe_key(msg: InboundMessage) -> tuple[str, str, str, str] | None:
-        metadata = msg.metadata or {}
-        message_id = None
-        for key in INBOUND_DEDUPE_METADATA_KEYS:
-            value = metadata.get(key)
-            if value:
-                message_id = str(value)
-                break
-        if message_id is None:
-            raw_message = metadata.get("raw_message")
-            if isinstance(raw_message, Mapping):
-                for key in INBOUND_DEDUPE_METADATA_KEYS:
-                    value = raw_message.get(key)
-                    if value:
-                        message_id = str(value)
-                        break
+        message_id = _inbound_message_id(msg)
         if message_id is None:
             return None
 
         # Fail closed: without a workspace/team/guild identifier we cannot tell two
         # workspaces apart (e.g. Slack channel ids are not globally unique), so
         # skip dedupe rather than risk collapsing distinct workspaces' messages.
-        workspace_id = msg.workspace_id or metadata.get("workspace_id") or metadata.get("team_id") or metadata.get("guild_id") or metadata.get("aibotid")
+        workspace_id = _inbound_workspace_id(msg)
         if not workspace_id:
             return None
         return (msg.channel_name, str(workspace_id), msg.chat_id, message_id)
@@ -1333,8 +1366,7 @@ class ChannelManager:
             "context": run_context,
             "multitask_strategy": "reject",
         }
-        if owner_headers := _owner_headers(msg):
-            run_kwargs["headers"] = owner_headers
+        run_kwargs["headers"] = _run_headers(msg)
         try:
             result = await client.runs.wait(
                 thread_id,
@@ -1414,8 +1446,7 @@ class ChannelManager:
             "stream_mode": list(STREAM_MODES),
             "multitask_strategy": "reject",
         }
-        if owner_headers := _owner_headers(msg):
-            stream_kwargs["headers"] = owner_headers
+        stream_kwargs["headers"] = _run_headers(msg)
 
         try:
             async for chunk in client.runs.stream(

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -22,12 +22,14 @@ from app.gateway.routers import (
     mcp,
     memory,
     models,
+    modules,
     runs,
     skills,
     suggestions,
     thread_runs,
     threads,
     uploads,
+    workflows,
 )
 from deerflow.config import app_config as deerflow_app_config
 from deerflow.config.app_config import apply_logging_level
@@ -159,6 +161,75 @@ async def _migrate_orphaned_threads(store, admin_user_id: str) -> int:
     return migrated
 
 
+def _openapi_tags(config: AppConfig) -> list[dict[str, str]]:
+    tags = [
+        {
+            "name": "models",
+            "description": "Operations for querying available AI models and their configurations",
+        },
+        {
+            "name": "mcp",
+            "description": "Manage Model Context Protocol (MCP) server configurations",
+        },
+        {
+            "name": "memory",
+            "description": "Access and manage global memory data for personalized conversations",
+        },
+        {
+            "name": "skills",
+            "description": "Manage skills and their configurations",
+        },
+        {
+            "name": "artifacts",
+            "description": "Access and download thread artifacts and generated files",
+        },
+        {
+            "name": "uploads",
+            "description": "Upload and manage user files for threads",
+        },
+        {
+            "name": "threads",
+            "description": "Manage DeerFlow thread-local filesystem data",
+        },
+        {
+            "name": "agents",
+            "description": "Create and manage custom agents with per-agent config and prompts",
+        },
+        {
+            "name": "suggestions",
+            "description": "Generate follow-up question suggestions for conversations",
+        },
+        {
+            "name": "channels",
+            "description": "Manage IM channel integrations (Feishu, Slack, Telegram)",
+        },
+        {
+            "name": "modules",
+            "description": "Public optional module feature flags",
+        },
+        {
+            "name": "assistants-compat",
+            "description": "LangGraph Platform-compatible assistants API (stub)",
+        },
+        {
+            "name": "runs",
+            "description": "LangGraph Platform-compatible runs lifecycle (create, stream, cancel)",
+        },
+        {
+            "name": "health",
+            "description": "Health check and system status endpoints",
+        },
+    ]
+    if config.modules.durable_workflows.api_enabled:
+        tags.append(
+            {
+                "name": "workflows",
+                "description": "Durable workflow runtime envelopes and lifecycle events",
+            }
+        )
+    return tags
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Application lifespan handler."""
@@ -257,6 +328,7 @@ def create_app() -> FastAPI:
         Configured FastAPI application instance.
     """
     config = get_gateway_config()
+    startup_config = get_app_config()
     docs_url = "/docs" if config.enable_docs else None
     redoc_url = "/redoc" if config.enable_docs else None
     openapi_url = "/openapi.json" if config.enable_docs else None
@@ -287,60 +359,7 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
         docs_url=docs_url,
         redoc_url=redoc_url,
         openapi_url=openapi_url,
-        openapi_tags=[
-            {
-                "name": "models",
-                "description": "Operations for querying available AI models and their configurations",
-            },
-            {
-                "name": "mcp",
-                "description": "Manage Model Context Protocol (MCP) server configurations",
-            },
-            {
-                "name": "memory",
-                "description": "Access and manage global memory data for personalized conversations",
-            },
-            {
-                "name": "skills",
-                "description": "Manage skills and their configurations",
-            },
-            {
-                "name": "artifacts",
-                "description": "Access and download thread artifacts and generated files",
-            },
-            {
-                "name": "uploads",
-                "description": "Upload and manage user files for threads",
-            },
-            {
-                "name": "threads",
-                "description": "Manage DeerFlow thread-local filesystem data",
-            },
-            {
-                "name": "agents",
-                "description": "Create and manage custom agents with per-agent config and prompts",
-            },
-            {
-                "name": "suggestions",
-                "description": "Generate follow-up question suggestions for conversations",
-            },
-            {
-                "name": "channels",
-                "description": "Manage IM channel integrations (Feishu, Slack, Telegram)",
-            },
-            {
-                "name": "assistants-compat",
-                "description": "LangGraph Platform-compatible assistants API (stub)",
-            },
-            {
-                "name": "runs",
-                "description": "LangGraph Platform-compatible runs lifecycle (create, stream, cancel)",
-            },
-            {
-                "name": "health",
-                "description": "Health check and system status endpoints",
-            },
-        ],
+        openapi_tags=_openapi_tags(startup_config),
     )
 
     # Auth: reject unauthenticated requests to non-public paths (fail-closed safety net)
@@ -390,6 +409,9 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     # Suggestions API is mounted at /api/threads/{thread_id}/suggestions
     app.include_router(suggestions.router)
 
+    # Public module feature flags are mounted at /api/modules
+    app.include_router(modules.router)
+
     # User-facing IM channel connection API is mounted at /api/channels
     app.include_router(channel_connections.router)
 
@@ -410,6 +432,10 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
 
     # Stateless Runs API (stream/wait without a pre-existing thread)
     app.include_router(runs.router)
+
+    # Durable workflow runtime read API
+    if startup_config.modules.durable_workflows.api_enabled:
+        app.include_router(workflows.router)
 
     @app.get("/health", tags=["health"])
     async def health_check() -> dict[str, str]:

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -31,6 +31,7 @@ from deerflow.persistence.feedback import FeedbackRepository
 from deerflow.runtime import RunContext, RunManager, StreamBridge
 from deerflow.runtime.events.store.base import RunEventStore
 from deerflow.runtime.runs.store.base import RunStore
+from deerflow.runtime.workflows.store.base import WorkflowStore
 
 logger = logging.getLogger(__name__)
 
@@ -190,11 +191,19 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.persistence.run import RunRepository
 
             app.state.run_store = RunRepository(sf)
+            if config.modules.durable_workflows.enabled:
+                from deerflow.persistence.workflow import WorkflowRepository
+
+                app.state.workflow_store = WorkflowRepository(sf)
             app.state.feedback_repo = FeedbackRepository(sf)
         else:
             from deerflow.runtime.runs.store.memory import MemoryRunStore
 
             app.state.run_store = MemoryRunStore()
+            if config.modules.durable_workflows.enabled:
+                from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+                app.state.workflow_store = MemoryWorkflowStore()
             app.state.feedback_repo = None
 
         from deerflow.persistence.thread_meta import make_thread_store
@@ -260,6 +269,7 @@ get_checkpointer: Callable[[Request], Checkpointer] = _require("checkpointer", "
 get_run_event_store: Callable[[Request], RunEventStore] = _require("run_event_store", "Run event store")
 get_feedback_repo: Callable[[Request], FeedbackRepository] = _require("feedback_repo", "Feedback")
 get_run_store: Callable[[Request], RunStore] = _require("run_store", "Run store")
+get_workflow_store: Callable[[Request], WorkflowStore] = _require("workflow_store", "Workflow store")
 
 
 def get_store(request: Request):

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -81,6 +81,14 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 
+_WORKFLOW_ORPHAN_ACTIVE_STATUSES = frozenset({"claimed", "run_created", "running", "waiting"})
+
+
+def _durable_workflows_enabled(config: AppConfig) -> bool:
+    modules = getattr(config, "modules", None)
+    durable_workflows = getattr(modules, "durable_workflows", None)
+    return bool(getattr(durable_workflows, "enabled", False))
+
 
 async def _mark_latest_recovered_threads_error(
     run_manager: RunManager,
@@ -104,6 +112,55 @@ async def _mark_latest_recovered_threads_error(
             await thread_store.update_status(thread_id, "error", user_id=None)
         except Exception:
             logger.warning("Failed to mark thread %s as error during run reconciliation", thread_id, exc_info=True)
+
+
+async def _mark_recovered_workflows_orphaned(
+    workflow_store: WorkflowStore | None,
+    recovered_runs: list[RunRecord],
+    *,
+    error: str,
+) -> int:
+    """Mark workflow envelopes bound to recovered orphan runs as orphaned."""
+    if workflow_store is None or not recovered_runs:
+        return 0
+
+    marked = 0
+    for record in recovered_runs:
+        try:
+            workflows = await workflow_store.list(thread_id=record.thread_id, run_id=record.run_id, limit=100)
+        except Exception:
+            logger.warning("Failed to list workflows for recovered run %s", record.run_id, exc_info=True)
+            continue
+
+        for workflow in workflows:
+            workflow_id = workflow.get("workflow_id")
+            if not workflow_id or workflow.get("status") not in _WORKFLOW_ORPHAN_ACTIVE_STATUSES:
+                continue
+            metadata = {
+                "recovery": "gateway_restart_orphan",
+                "run_id": record.run_id,
+                "run_status": "error",
+            }
+            try:
+                updated = await workflow_store.mark_orphaned(str(workflow_id), error=error, metadata=metadata)
+                if not updated:
+                    continue
+                await workflow_store.append_event(
+                    str(workflow_id),
+                    event_type="workflow.orphaned",
+                    category="recovery",
+                    thread_id=record.thread_id,
+                    run_id=record.run_id,
+                    content={"reason": "gateway_restart_orphan"},
+                    metadata=metadata,
+                )
+                marked += 1
+            except Exception:
+                logger.warning("Failed to mark workflow %s orphaned during run reconciliation", workflow_id, exc_info=True)
+
+    if marked:
+        logger.warning("Recovered %d workflow(s) as orphaned after gateway restart", marked)
+    return marked
 
 
 def get_config() -> AppConfig:
@@ -191,7 +248,7 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.persistence.run import RunRepository
 
             app.state.run_store = RunRepository(sf)
-            if config.modules.durable_workflows.enabled:
+            if _durable_workflows_enabled(config):
                 from deerflow.persistence.workflow import WorkflowRepository
 
                 app.state.workflow_store = WorkflowRepository(sf)
@@ -200,7 +257,7 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
             from deerflow.runtime.runs.store.memory import MemoryRunStore
 
             app.state.run_store = MemoryRunStore()
-            if config.modules.durable_workflows.enabled:
+            if _durable_workflows_enabled(config):
                 from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
                 app.state.workflow_store = MemoryWorkflowStore()
@@ -223,13 +280,15 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
         if getattr(config.database, "backend", None) == "sqlite":
             from deerflow.utils.time import now_iso
 
+            orphan_error = "Gateway restarted before this run reached a durable final state."
             # Startup-only recovery: clean shutdowns return no active rows and
             # the thread-status update below becomes a no-op.
             recovered_runs = await app.state.run_manager.reconcile_orphaned_inflight_runs(
-                error="Gateway restarted before this run reached a durable final state.",
+                error=orphan_error,
                 before=now_iso(),
             )
             await _mark_latest_recovered_threads_error(app.state.run_manager, app.state.thread_store, recovered_runs)
+            await _mark_recovered_workflows_orphaned(getattr(app.state, "workflow_store", None), recovered_runs, error=orphan_error)
 
         try:
             yield

--- a/backend/app/gateway/routers/__init__.py
+++ b/backend/app/gateway/routers/__init__.py
@@ -1,3 +1,15 @@
-from . import artifacts, assistants_compat, mcp, models, skills, suggestions, thread_runs, threads, uploads
+from . import artifacts, assistants_compat, mcp, models, modules, skills, suggestions, thread_runs, threads, uploads, workflows
 
-__all__ = ["artifacts", "assistants_compat", "mcp", "models", "skills", "suggestions", "threads", "thread_runs", "uploads"]
+__all__ = [
+    "artifacts",
+    "assistants_compat",
+    "mcp",
+    "models",
+    "modules",
+    "skills",
+    "suggestions",
+    "threads",
+    "thread_runs",
+    "uploads",
+    "workflows",
+]

--- a/backend/app/gateway/routers/modules.py
+++ b/backend/app/gateway/routers/modules.py
@@ -1,0 +1,18 @@
+"""Read-only module feature flags."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from app.gateway.deps import get_config
+
+router = APIRouter(prefix="/api/modules", tags=["modules"])
+
+
+@router.get("")
+async def get_modules() -> dict:
+    """Return public feature gates for optional DeerFlow modules."""
+    modules = get_config().modules
+    return {
+        "durable_workflows": modules.durable_workflows.model_dump(),
+    }

--- a/backend/app/gateway/routers/workflows.py
+++ b/backend/app/gateway/routers/workflows.py
@@ -60,6 +60,15 @@ def _recovery_hints(workflow: dict, run: dict | None) -> list[dict]:
                 "message": "The gateway restarted while this workflow was active. DeerFlow marked it orphaned because the process-local run task is gone.",
             }
         )
+    if status == "waiting":
+        hints.append(
+            {
+                "code": "workflow_waiting",
+                "severity": "info",
+                "safe_auto_resume": False,
+                "message": "The bound run is interrupted and the workflow is waiting for a LangGraph resume or a new human input.",
+            }
+        )
     if run and run.get("status") == "error" and status in {"orphaned", "failed"}:
         hints.append(
             {

--- a/backend/app/gateway/routers/workflows.py
+++ b/backend/app/gateway/routers/workflows.py
@@ -48,6 +48,30 @@ def _timeline_sort_key(row: dict) -> tuple[str, int, int]:
     return created_at, kind_order, int(seq) if isinstance(seq, int) else 0
 
 
+def _recovery_hints(workflow: dict, run: dict | None) -> list[dict]:
+    hints: list[dict] = []
+    status = workflow.get("status")
+    if status == "orphaned":
+        hints.append(
+            {
+                "code": "workflow_orphaned",
+                "severity": "warning",
+                "safe_auto_resume": False,
+                "message": "The gateway restarted while this workflow was active. DeerFlow marked it orphaned because the process-local run task is gone.",
+            }
+        )
+    if run and run.get("status") == "error" and status in {"orphaned", "failed"}:
+        hints.append(
+            {
+                "code": "bound_run_error",
+                "severity": "info",
+                "run_id": run.get("run_id"),
+                "message": "The bound DeerFlow run is terminal error. Inspect run events before retrying or resubmitting the workflow.",
+            }
+        )
+    return hints
+
+
 @router.get("")
 @require_permission("runs", "read")
 async def list_workflows(
@@ -147,6 +171,7 @@ async def get_workflow_timeline(
     return {
         "workflow": workflow,
         "run": run,
+        "recovery_hints": _recovery_hints(workflow, run),
         "timeline": timeline[:limit],
         "workflow_events": workflow_events,
         "run_events": run_events,

--- a/backend/app/gateway/routers/workflows.py
+++ b/backend/app/gateway/routers/workflows.py
@@ -1,0 +1,153 @@
+"""Durable workflow runtime read endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from app.gateway.authz import require_permission
+from app.gateway.deps import get_run_event_store, get_run_store, get_workflow_store
+
+router = APIRouter(prefix="/api/workflows", tags=["workflows"])
+
+
+def _workflow_timeline_event(row: dict) -> dict:
+    return {
+        "kind": "workflow_event",
+        "seq": row.get("seq"),
+        "event_type": row.get("event_type"),
+        "category": row.get("category"),
+        "created_at": row.get("created_at"),
+        "thread_id": row.get("thread_id"),
+        "run_id": row.get("run_id"),
+        "checkpoint_ns": row.get("checkpoint_ns"),
+        "checkpoint_id": row.get("checkpoint_id"),
+        "run_event_seq": row.get("run_event_seq"),
+        "content": row.get("content"),
+        "metadata": row.get("metadata") or {},
+    }
+
+
+def _run_timeline_event(row: dict) -> dict:
+    return {
+        "kind": "run_event",
+        "seq": row.get("seq"),
+        "event_type": row.get("event_type"),
+        "category": row.get("category"),
+        "created_at": row.get("created_at"),
+        "thread_id": row.get("thread_id"),
+        "run_id": row.get("run_id"),
+        "content": row.get("content"),
+        "metadata": row.get("metadata") or {},
+    }
+
+
+def _timeline_sort_key(row: dict) -> tuple[str, int, int]:
+    created_at = str(row.get("created_at") or "")
+    kind_order = 0 if row.get("kind") == "workflow_event" else 1
+    seq = row.get("seq")
+    return created_at, kind_order, int(seq) if isinstance(seq, int) else 0
+
+
+@router.get("")
+@require_permission("runs", "read")
+async def list_workflows(
+    request: Request,
+    status: str | None = Query(default=None),
+    source_type: str | None = Query(default=None),
+    source: str | None = Query(default=None),
+    thread_id: str | None = Query(default=None),
+    run_id: str | None = Query(default=None),
+    user_id: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+) -> dict:
+    """List durable workflow envelopes."""
+    store = get_workflow_store(request)
+    rows = await store.list(
+        status=status,
+        source_type=source_type,
+        source=source,
+        thread_id=thread_id,
+        run_id=run_id,
+        user_id=user_id,
+        limit=limit,
+    )
+    return {"data": rows}
+
+
+@router.get("/by-run/{run_id}")
+@require_permission("runs", "read")
+async def get_workflow_by_run(run_id: str, request: Request, thread_id: str | None = Query(default=None)) -> dict:
+    """Fetch the durable workflow envelope bound to a DeerFlow run."""
+    store = get_workflow_store(request)
+    rows = await store.list(thread_id=thread_id, run_id=run_id, limit=2)
+    if not rows:
+        raise HTTPException(status_code=404, detail=f"Workflow for run {run_id} not found")
+    return rows[0]
+
+
+@router.get("/{workflow_id}")
+@require_permission("runs", "read")
+async def get_workflow(workflow_id: str, request: Request, user_id: str | None = Query(default=None)) -> dict:
+    """Fetch one durable workflow envelope."""
+    store = get_workflow_store(request)
+    row = await store.get(workflow_id, user_id=user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+    return row
+
+
+@router.get("/{workflow_id}/events")
+@require_permission("runs", "read")
+async def list_workflow_events(
+    workflow_id: str,
+    request: Request,
+    event_type: list[str] | None = Query(default=None),
+    limit: int = Query(default=500, ge=1, le=1000),
+) -> dict:
+    """List append-only lifecycle events for one workflow."""
+    store = get_workflow_store(request)
+    workflow = await store.get(workflow_id)
+    if workflow is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+    rows = await store.list_events(workflow_id, event_types=event_type, limit=limit)
+    return {"workflow": workflow, "events": rows}
+
+
+@router.get("/{workflow_id}/timeline")
+@require_permission("runs", "read")
+async def get_workflow_timeline(
+    workflow_id: str,
+    request: Request,
+    include_run_events: bool = Query(default=True),
+    limit: int = Query(default=500, ge=1, le=1000),
+) -> dict:
+    """Return a durable run trace merged from workflow and run events."""
+    store = get_workflow_store(request)
+    workflow = await store.get(workflow_id)
+    if workflow is None:
+        raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+
+    workflow_events = await store.list_events(workflow_id, limit=limit)
+    run_events: list[dict] = []
+    thread_id = workflow.get("thread_id")
+    run_id = workflow.get("run_id")
+    if include_run_events and thread_id and run_id:
+        run_event_store = get_run_event_store(request)
+        run_events = await run_event_store.list_events(thread_id, run_id, limit=limit)
+
+    run = None
+    if run_id:
+        run_store = get_run_store(request)
+        run = await run_store.get(run_id)
+
+    timeline = [_workflow_timeline_event(row) for row in workflow_events]
+    timeline.extend(_run_timeline_event(row) for row in run_events)
+    timeline.sort(key=_timeline_sort_key)
+
+    return {
+        "workflow": workflow,
+        "run": run,
+        "timeline": timeline[:limit],
+        "workflow_events": workflow_events,
+        "run_events": run_events,
+    }

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -20,7 +20,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.messages.utils import convert_to_messages
 from langgraph.types import Command
 
-from app.gateway.deps import get_checkpointer, get_run_context, get_run_manager, get_stream_bridge
+from app.gateway.deps import get_checkpointer, get_run_context, get_run_manager, get_stream_bridge, get_workflow_store
 from app.gateway.internal_auth import INTERNAL_SYSTEM_ROLE, get_trusted_internal_owner_user_id
 from app.gateway.utils import sanitize_log_param
 from deerflow.config.app_config import get_app_config
@@ -353,6 +353,189 @@ async def apply_checkpoint_to_run_config(
 # ---------------------------------------------------------------------------
 
 
+def _request_workflow_idempotency_key(request: Request) -> str | None:
+    return request.headers.get("Idempotency-Key") or request.headers.get("X-Idempotency-Key")
+
+
+def _request_user_id(request: Request, owner_user_id: str | None) -> str | None:
+    if owner_user_id:
+        return owner_user_id
+    user = getattr(request.state, "user", None)
+    user_id = getattr(user, "id", None)
+    return str(user_id) if user_id is not None else None
+
+
+def _workflow_kind_for_run(body: Any) -> str:
+    command = getattr(body, "command", None)
+    if isinstance(command, Mapping) and command.get("resume") is not None:
+        return "resume"
+    return "message"
+
+
+def _auto_workflow_envelopes_enabled() -> bool:
+    modules = get_app_config().modules
+    return modules.durable_workflows.enabled and modules.durable_workflows.auto_envelope_for_runs
+
+
+async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, owner_user_id: str | None) -> dict[str, Any]:
+    workflow_store = get_workflow_store(request)
+    idempotency_key = _request_workflow_idempotency_key(request)
+    external_message_ref = request.headers.get("X-External-Message-Ref")
+    route_path = str(getattr(getattr(request, "url", None), "path", None) or "/api/runs")
+    method = str(getattr(request, "method", None) or "POST")
+    workflow, created = await workflow_store.create_or_get(
+        workflow_kind=_workflow_kind_for_run(body),
+        source_type="api",
+        source=route_path,
+        idempotency_key=idempotency_key,
+        external_message_ref=external_message_ref,
+        conversation_ref=thread_id,
+        thread_ref=thread_id,
+        sender_ref=_request_user_id(request, owner_user_id),
+        user_id=_request_user_id(request, owner_user_id),
+        thread_id=thread_id,
+        status="received",
+        metadata={
+            "assistant_id": getattr(body, "assistant_id", None),
+            "route": route_path,
+            "method": method,
+        },
+    )
+    if not created and workflow.get("run_id"):
+        await workflow_store.append_event(
+            workflow["workflow_id"],
+            event_type="workflow.deduped",
+            idempotency_key=idempotency_key,
+            metadata={"existing_run_id": workflow.get("run_id")},
+        )
+        raise HTTPException(
+            status_code=409,
+            detail=f"Workflow {workflow['workflow_id']} is already bound to run {workflow['run_id']}",
+        )
+
+    await workflow_store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.received" if created else "workflow.deduped",
+        idempotency_key=idempotency_key,
+        content={"thread_id": thread_id, "source": route_path},
+    )
+    return workflow
+
+
+async def _mark_run_workflow_failed(request: Request, workflow_id: str, *, error: str) -> None:
+    workflow_store = get_workflow_store(request)
+    await workflow_store.update_status(workflow_id, "failed", error=error)
+    await workflow_store.append_event(workflow_id, event_type="workflow.failed", metadata={"error": error})
+
+
+async def _bind_run_workflow(
+    request: Request,
+    workflow_id: str,
+    *,
+    thread_id: str,
+    run_id: str,
+    checkpoint_ns: str | None,
+    checkpoint_id: str | None,
+) -> None:
+    workflow_store = get_workflow_store(request)
+    await workflow_store.bind_runtime(
+        workflow_id,
+        thread_id=thread_id,
+        run_id=run_id,
+        checkpoint_ns=checkpoint_ns,
+        checkpoint_id=checkpoint_id,
+        status="run_created",
+    )
+    await workflow_store.append_event(
+        workflow_id,
+        event_type="workflow.run_created",
+        category="runtime",
+        thread_id=thread_id,
+        run_id=run_id,
+        checkpoint_ns=checkpoint_ns,
+        checkpoint_id=checkpoint_id,
+    )
+
+
+def _workflow_status_for_run_status(status: RunStatus) -> tuple[str, str] | None:
+    if status == RunStatus.running:
+        return "running", "workflow.run_started"
+    if status == RunStatus.success:
+        return "succeeded", "workflow.succeeded"
+    if status in (RunStatus.error, RunStatus.timeout):
+        return "failed", "workflow.failed"
+    if status == RunStatus.interrupted:
+        return "cancelled", "workflow.cancelled"
+    return None
+
+
+async def _project_run_workflow_status(
+    request: Request,
+    workflow_id: str,
+    record: RunRecord,
+    *,
+    status: str,
+    event_type: str,
+    error: str | None = None,
+) -> None:
+    workflow_store = get_workflow_store(request)
+    metadata = {"run_status": record.status.value}
+    if error:
+        metadata["error"] = error
+    await workflow_store.update_status(workflow_id, status, error=error, metadata=metadata)
+    await workflow_store.append_event(
+        workflow_id,
+        event_type=event_type,
+        category="runtime",
+        thread_id=record.thread_id,
+        run_id=record.run_id,
+        metadata=metadata,
+    )
+
+
+async def _run_agent_with_workflow_projection(
+    request: Request,
+    workflow_id: str,
+    bridge: StreamBridge,
+    run_mgr: RunManager,
+    record: RunRecord,
+    **run_agent_kwargs: Any,
+) -> None:
+    await _project_run_workflow_status(
+        request,
+        workflow_id,
+        record,
+        status="running",
+        event_type="workflow.run_started",
+    )
+    escaped_error: BaseException | None = None
+    try:
+        await run_agent(bridge, run_mgr, record, **run_agent_kwargs)
+    except BaseException as exc:
+        escaped_error = exc
+        raise
+    finally:
+        projection = _workflow_status_for_run_status(record.status)
+        if escaped_error is not None and projection is None:
+            await _project_run_workflow_status(
+                request,
+                workflow_id,
+                record,
+                status="failed",
+                event_type="workflow.failed",
+                error=str(escaped_error),
+            )
+        elif projection is not None and projection[0] != "running":
+            await _project_run_workflow_status(
+                request,
+                workflow_id,
+                record,
+                status=projection[0],
+                event_type=projection[1],
+                error=record.error,
+            )
+
+
 async def start_run(
     body: Any,
     thread_id: str,
@@ -417,6 +600,11 @@ async def start_run(
         if not allowed:
             raise HTTPException(status_code=404, detail=f"Thread {thread_id} not found")
 
+    workflow_id: str | None = None
+    if _auto_workflow_envelopes_enabled():
+        workflow = await _create_run_workflow(body, thread_id, request, owner_user_id=owner_user_id)
+        workflow_id = workflow["workflow_id"]
+
     owner_context_token = set_current_user(SimpleNamespace(id=owner_user_id)) if owner_user_id else None
     try:
         try:
@@ -431,8 +619,12 @@ async def start_run(
                 user_id=owner_user_id,
             )
         except ConflictError as exc:
+            if workflow_id is not None:
+                await _mark_run_workflow_failed(request, workflow_id, error=str(exc))
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except UnsupportedStrategyError as exc:
+            if workflow_id is not None:
+                await _mark_run_workflow_failed(request, workflow_id, error=str(exc))
             raise HTTPException(status_code=501, detail=str(exc)) from exc
 
         # Upsert thread metadata so the thread appears in /threads/search,
@@ -465,6 +657,16 @@ async def start_run(
             graph_input = normalize_input(body.input)
         config = build_run_config(thread_id, body.config, body.metadata, assistant_id=body.assistant_id)
         await apply_checkpoint_to_run_config(config, body=body, thread_id=thread_id, request=request)
+        configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+        if workflow_id is not None:
+            await _bind_run_workflow(
+                request,
+                workflow_id,
+                thread_id=thread_id,
+                run_id=record.run_id,
+                checkpoint_ns=str(configurable.get("checkpoint_ns")) if configurable.get("checkpoint_ns") is not None else None,
+                checkpoint_id=str(configurable.get("checkpoint_id")) if configurable.get("checkpoint_id") is not None else None,
+            )
 
         # Merge DeerFlow-specific context overrides into both ``configurable`` and ``context``.
         # The ``context`` field is a custom extension for the langgraph-compat layer
@@ -475,21 +677,36 @@ async def start_run(
 
         stream_modes = normalize_stream_modes(body.stream_mode)
 
-        task = asyncio.create_task(
-            run_agent(
-                bridge,
-                run_mgr,
-                record,
-                ctx=run_ctx,
-                agent_factory=agent_factory,
-                graph_input=graph_input,
-                config=config,
-                stream_modes=stream_modes,
-                stream_subgraphs=body.stream_subgraphs,
-                interrupt_before=body.interrupt_before,
-                interrupt_after=body.interrupt_after,
-            )
+        run_agent_kwargs = dict(
+            ctx=run_ctx,
+            agent_factory=agent_factory,
+            graph_input=graph_input,
+            config=config,
+            stream_modes=stream_modes,
+            stream_subgraphs=body.stream_subgraphs,
+            interrupt_before=body.interrupt_before,
+            interrupt_after=body.interrupt_after,
         )
+        if workflow_id is not None:
+            task = asyncio.create_task(
+                _run_agent_with_workflow_projection(
+                    request,
+                    workflow_id,
+                    bridge,
+                    run_mgr,
+                    record,
+                    **run_agent_kwargs,
+                )
+            )
+        else:
+            task = asyncio.create_task(
+                run_agent(
+                    bridge,
+                    run_mgr,
+                    record,
+                    **run_agent_kwargs,
+                )
+            )
         record.task = task
 
         # Title sync is handled by worker.py's finally block which reads the

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -358,6 +358,14 @@ def _request_workflow_idempotency_key(request: Request) -> str | None:
     return request.headers.get("Idempotency-Key") or request.headers.get("X-Idempotency-Key")
 
 
+def _request_header_ref(request: Request, name: str) -> str | None:
+    value = request.headers.get(name)
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
 def _request_user_id(request: Request, owner_user_id: str | None) -> str | None:
     if owner_user_id:
         return owner_user_id
@@ -395,9 +403,14 @@ def _auto_workflow_envelopes_enabled() -> bool:
 async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, owner_user_id: str | None) -> dict[str, Any]:
     workflow_store = get_workflow_store(request)
     idempotency_key = _request_workflow_idempotency_key(request)
-    external_message_ref = request.headers.get("X-External-Message-Ref")
+    external_message_ref = _request_header_ref(request, "X-External-Message-Ref")
     route_path = str(getattr(getattr(request, "url", None), "path", None) or "/api/runs")
     method = str(getattr(request, "method", None) or "POST")
+    source_type = _request_header_ref(request, "X-DeerFlow-Workflow-Source-Type") or "api"
+    source = _request_header_ref(request, "X-DeerFlow-Workflow-Source") or route_path
+    conversation_ref = _request_header_ref(request, "X-DeerFlow-Workflow-Conversation-Ref") or thread_id
+    thread_ref = _request_header_ref(request, "X-DeerFlow-Workflow-Thread-Ref") or thread_id
+    sender_ref = _request_header_ref(request, "X-DeerFlow-Workflow-Sender-Ref") or _request_user_id(request, owner_user_id)
     checkpoint_ns, checkpoint_id = _requested_checkpoint_refs(body)
     binding_decision = resolve_workflow_binding(
         explicit_thread_id=thread_id,
@@ -406,13 +419,13 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
     )
     workflow, created = await workflow_store.create_or_get(
         workflow_kind=_workflow_kind_for_run(body),
-        source_type="api",
-        source=route_path,
+        source_type=source_type,
+        source=source,
         idempotency_key=idempotency_key,
         external_message_ref=external_message_ref,
-        conversation_ref=thread_id,
-        thread_ref=thread_id,
-        sender_ref=_request_user_id(request, owner_user_id),
+        conversation_ref=conversation_ref,
+        thread_ref=thread_ref,
+        sender_ref=sender_ref,
         user_id=_request_user_id(request, owner_user_id),
         thread_id=thread_id,
         checkpoint_ns=checkpoint_ns,
@@ -422,6 +435,8 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
             "assistant_id": getattr(body, "assistant_id", None),
             "route": route_path,
             "method": method,
+            "source_type": source_type,
+            "source": source,
             "binding": binding_decision.to_metadata(),
         },
     )
@@ -441,7 +456,7 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
         workflow["workflow_id"],
         event_type="workflow.received" if created else "workflow.deduped",
         idempotency_key=idempotency_key,
-        content={"thread_id": thread_id, "source": route_path},
+        content={"thread_id": thread_id, "source_type": source_type, "source": source},
     )
     if created and binding_decision.status == WorkflowBindingStatus.resolved:
         await workflow_store.append_event(

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -381,6 +381,18 @@ def _workflow_kind_for_run(body: Any) -> str:
     return "message"
 
 
+def _resume_ref_for_run(body: Any) -> dict[str, Any] | None:
+    command = getattr(body, "command", None)
+    if not isinstance(command, Mapping) or command.get("resume") is None:
+        return None
+    payload = command["resume"]
+    return {
+        "type": "langgraph_command_resume",
+        "has_payload": True,
+        "payload_type": type(payload).__name__,
+    }
+
+
 def _requested_checkpoint_refs(body: Any) -> tuple[str | None, str | None]:
     checkpoint_ns: str | None = None
     checkpoint_id = getattr(body, "checkpoint_id", None)
@@ -412,6 +424,7 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
     thread_ref = _request_header_ref(request, "X-DeerFlow-Workflow-Thread-Ref") or thread_id
     sender_ref = _request_header_ref(request, "X-DeerFlow-Workflow-Sender-Ref") or _request_user_id(request, owner_user_id)
     checkpoint_ns, checkpoint_id = _requested_checkpoint_refs(body)
+    resume_ref = _resume_ref_for_run(body)
     binding_decision = resolve_workflow_binding(
         explicit_thread_id=thread_id,
         explicit_checkpoint_ns=checkpoint_ns,
@@ -438,6 +451,7 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
             "source_type": source_type,
             "source": source,
             "binding": binding_decision.to_metadata(),
+            **({"resume": resume_ref} if resume_ref is not None else {}),
         },
     )
     if not created and workflow.get("run_id"):
@@ -468,6 +482,16 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
             checkpoint_ns=binding_decision.checkpoint_ns,
             checkpoint_id=binding_decision.checkpoint_id,
             metadata=binding_decision.to_metadata(),
+        )
+    if created and resume_ref is not None:
+        await workflow_store.append_event(
+            workflow["workflow_id"],
+            event_type="workflow.resume_requested",
+            category="runtime",
+            thread_id=thread_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=checkpoint_id,
+            metadata=resume_ref,
         )
     return workflow
 
@@ -515,7 +539,7 @@ def _workflow_status_for_run_status(status: RunStatus) -> tuple[str, str] | None
     if status in (RunStatus.error, RunStatus.timeout):
         return "failed", "workflow.failed"
     if status == RunStatus.interrupted:
-        return "cancelled", "workflow.cancelled"
+        return "waiting", "workflow.waiting"
     return None
 
 
@@ -530,6 +554,13 @@ async def _project_run_workflow_status(
 ) -> None:
     workflow_store = get_workflow_store(request)
     metadata = {"run_status": record.status.value}
+    if status == "waiting":
+        metadata.update(
+            {
+                "wait_reason": "run_interrupted",
+                "resume_supported": True,
+            }
+        )
     if error:
         metadata["error"] = error
     await workflow_store.update_status(workflow_id, status, error=error, metadata=metadata)

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -37,6 +37,7 @@ from deerflow.runtime import (
     run_agent,
 )
 from deerflow.runtime.runs.naming import resolve_root_run_name
+from deerflow.runtime.workflows import WorkflowBindingStatus, resolve_workflow_binding
 from deerflow.runtime.user_context import reset_current_user, set_current_user
 
 logger = logging.getLogger(__name__)
@@ -372,6 +373,20 @@ def _workflow_kind_for_run(body: Any) -> str:
     return "message"
 
 
+def _requested_checkpoint_refs(body: Any) -> tuple[str | None, str | None]:
+    checkpoint_ns: str | None = None
+    checkpoint_id = getattr(body, "checkpoint_id", None)
+    checkpoint = getattr(body, "checkpoint", None)
+    if isinstance(checkpoint, Mapping):
+        raw_checkpoint_ns = checkpoint.get("checkpoint_ns")
+        raw_checkpoint_id = checkpoint.get("checkpoint_id")
+        if raw_checkpoint_ns is not None:
+            checkpoint_ns = str(raw_checkpoint_ns)
+        if raw_checkpoint_id is not None:
+            checkpoint_id = str(raw_checkpoint_id)
+    return checkpoint_ns, str(checkpoint_id) if checkpoint_id is not None else None
+
+
 def _auto_workflow_envelopes_enabled() -> bool:
     modules = get_app_config().modules
     return modules.durable_workflows.enabled and modules.durable_workflows.auto_envelope_for_runs
@@ -383,6 +398,12 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
     external_message_ref = request.headers.get("X-External-Message-Ref")
     route_path = str(getattr(getattr(request, "url", None), "path", None) or "/api/runs")
     method = str(getattr(request, "method", None) or "POST")
+    checkpoint_ns, checkpoint_id = _requested_checkpoint_refs(body)
+    binding_decision = resolve_workflow_binding(
+        explicit_thread_id=thread_id,
+        explicit_checkpoint_ns=checkpoint_ns,
+        explicit_checkpoint_id=checkpoint_id,
+    )
     workflow, created = await workflow_store.create_or_get(
         workflow_kind=_workflow_kind_for_run(body),
         source_type="api",
@@ -394,11 +415,14 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
         sender_ref=_request_user_id(request, owner_user_id),
         user_id=_request_user_id(request, owner_user_id),
         thread_id=thread_id,
-        status="received",
+        checkpoint_ns=checkpoint_ns,
+        checkpoint_id=checkpoint_id,
+        status="bound" if binding_decision.status == WorkflowBindingStatus.resolved else "received",
         metadata={
             "assistant_id": getattr(body, "assistant_id", None),
             "route": route_path,
             "method": method,
+            "binding": binding_decision.to_metadata(),
         },
     )
     if not created and workflow.get("run_id"):
@@ -419,6 +443,17 @@ async def _create_run_workflow(body: Any, thread_id: str, request: Request, *, o
         idempotency_key=idempotency_key,
         content={"thread_id": thread_id, "source": route_path},
     )
+    if created and binding_decision.status == WorkflowBindingStatus.resolved:
+        await workflow_store.append_event(
+            workflow["workflow_id"],
+            event_type="workflow.bound",
+            category="binding",
+            thread_id=binding_decision.thread_id,
+            run_id=binding_decision.run_id,
+            checkpoint_ns=binding_decision.checkpoint_ns,
+            checkpoint_id=binding_decision.checkpoint_id,
+            metadata=binding_decision.to_metadata(),
+        )
     return workflow
 
 

--- a/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
+++ b/backend/docs/DURABLE_WORKFLOW_FRONTDOOR.md
@@ -1,0 +1,485 @@
+# Durable Workflow Frontdoor
+
+Status: architecture decision draft
+Date: 2026-06-26
+Scope: DeerFlow backend gateway, runtime, persistence, and channel adapters
+
+## Decision
+
+DeerFlow should add a native, minimal durable workflow frontdoor for every
+inbound message that may invoke an agent. The first layer should be a DeerFlow
+owned workflow envelope and ledger, not a hard dependency on AICOS, Restate,
+Temporal, or any product-specific task model.
+
+The frontdoor provides stable intake identity, idempotency, routing/binding
+metadata, run/checkpoint references, and queryable workflow status. LangGraph
+continues to own graph execution state, checkpoint values, graph-local memory,
+interrupt semantics, and replay from checkpoints. DeerFlow owns generic intake,
+run orchestration, channel routing, and event correlation.
+
+External workflow engines such as Restate or Temporal should be optional
+adapters above this interface, not a required DeerFlow core dependency.
+
+Scalable DeerFlow deployments should add a small native workflow leasing layer
+to this envelope. Leasing gives DeerFlow a horizontal worker contract without
+claiming full durable code replay: a worker can atomically claim an eligible
+workflow, bind it to a LangGraph thread/run, renew or finish the lease, and let
+another worker recover it when the lease expires.
+
+For deployments that need durable work management, this frontdoor can later be
+paired with an optional DeerFlow Work Module. The frontdoor remains the generic
+intake and runtime-dispatch layer; the Work module would add reusable work unit,
+acceptance criterion, gate, artifact reference, review, and external PM-tool
+binding schemas.
+
+## Current Architecture Summary
+
+DeerFlow already has the foundation for durable agent runtime behavior:
+
+- LangGraph checkpointer persists thread-scoped graph state by `thread_id`,
+  `checkpoint_ns`, and `checkpoint_id`.
+- LangGraph store persists runtime/application memory outside graph state.
+- `RunManager` creates process-local `RunRecord` objects and persists run
+  metadata through `RunStore`.
+- `RunRepository` stores `run_id`, `thread_id`, status, model, token usage,
+  first/last messages, and run kwargs/metadata.
+- `RunEventStore` stores an ordered event stream keyed by
+  `(thread_id, run_id, seq)`.
+- `run_agent()` executes `agent.astream(...)` in an `asyncio.Task`, writes run
+  status transitions, publishes stream bridge events, and flushes `RunJournal`
+  events.
+- Gateway endpoints (`/runs`, `/threads/{thread_id}/runs`) call `start_run()`
+  directly.
+- Channel adapters normalize platform events into `InboundMessage`; the
+  channel manager resolves/creates a DeerFlow thread, then calls
+  `client.runs.wait()` or `client.runs.stream()`.
+
+The important current limitation is that the executing run task is process
+local. A persisted `pending` or `running` row does not imply an executor still
+exists after gateway restart. Startup reconciliation explicitly marks orphaned
+active runs as `error` for SQLite-backed deployments instead of pretending they
+are resumable.
+
+## Research Notes
+
+LangGraph persistence separates thread-scoped checkpointers from cross-thread
+stores. Checkpointers are the right owner for graph state snapshots,
+conversation continuity, human-in-the-loop, time travel, and fault tolerance.
+They require a stable `thread_id` and can reference concrete checkpoints by
+`checkpoint_id`.
+
+LangGraph interrupts pause graph execution, persist graph state through the
+checkpointer, and resume by invoking the same thread with `Command(resume=...)`.
+Interrupt side effects before the interrupt must be idempotent because the
+node can restart when resumed.
+
+Temporal and Restate solve a different boundary: durable orchestration replay.
+Temporal workflows must be deterministic and push non-deterministic operations
+such as API/LLM calls into activities. Restate journals steps, side effects,
+timers, and service calls so handlers can replay without duplicating completed
+effects. These are valuable optional execution adapters, but making either
+mandatory would raise DeerFlow's deployment bar and entangle the core runtime
+with a specific orchestrator.
+
+Hatchet is useful as a scale and worker model reference. Its durable execution
+docs separate ordinary task execution from durable tasks that checkpoint when
+they wait or spawn children. Its DAG model persists each completed task result
+so retries can avoid re-running succeeded parts, and its platform emphasizes
+worker slots, concurrency, priority, retries, and observability. DeerFlow should
+borrow those operational primitives at the workflow-envelope layer, while still
+leaving graph execution and checkpoint state inside LangGraph.
+
+OpenAI Agents SDK tracing and handoffs are useful compatibility concepts:
+trace/group IDs and spans map naturally to workflow/run/event correlation,
+while handoffs show how multi-agent delegation can remain tool-like and
+runtime-owned. They do not replace DeerFlow's need for an intake ledger.
+
+Dust-style platforms are useful as product pattern evidence: many surfaces
+(web, Slack, Teams, API, browser extension) can call the same agent layer with
+selected knowledge sources and tools. DeerFlow should generalize that as
+surface-agnostic intake and routing, not as a Dust-specific feature.
+
+References:
+
+- https://docs.langchain.com/oss/python/langgraph/persistence
+- https://docs.langchain.com/oss/python/langgraph/checkpointers
+- https://docs.langchain.com/oss/python/langgraph/interrupts
+- https://docs.temporal.io/workflow-definition
+- https://docs.restate.dev/foundations/key-concepts
+- https://docs.hatchet.run/v1/durable-execution
+- https://docs.hatchet.run/v1/durable-tasks
+- https://docs.hatchet.run/v1/directed-acyclic-graphs
+- https://openai.github.io/openai-agents-python/tracing/
+- https://openai.github.io/openai-agents-python/handoffs/
+- https://docs.dust.tt/docs/intro
+
+## Schema Lessons From Durable Workflow Systems
+
+The schema should borrow the smallest durable ideas from LangGraph, Restate,
+Temporal, and Hatchet without turning DeerFlow into another workflow engine.
+
+From LangGraph:
+
+- use `thread_id`, `checkpoint_ns`, and `checkpoint_id` as refs into graph
+  state;
+- never copy checkpoint `values` into DeerFlow workflow rows;
+- remember that a checkpoint snapshot already has `metadata`, `created_at`,
+  `parent_config`, `tasks`, and `next` for graph-local replay and inspection;
+- rely on LangGraph checkpoint writes/pending writes for graph node recovery
+  inside a super-step;
+- use interrupts/resume as the primary graph-local human-in-the-loop primitive.
+
+From Restate:
+
+- keep a durable identity before handler execution starts;
+- dedupe repeated submissions by identity/idempotency key;
+- distinguish retryable errors from terminal errors;
+- model external waits as durable workflow state, not as an in-memory future;
+- optionally support Restate as an execution adapter later, where Restate owns
+  its execution log and DeerFlow owns workflow/run/checkpoint refs.
+
+From Temporal:
+
+- separate stable `workflow_id` from per-attempt/per-run execution identity;
+- use append-only event history concepts for observability and recovery
+  decisions;
+- keep workers stateless enough that another worker can pick up eligible work;
+- treat calls to LLMs, databases, channels, and PM tools as external effects
+  that require idempotency or a durable result record;
+- avoid putting critical execution data only in searchable/memo metadata.
+
+From Hatchet:
+
+- expose worker-facing lease/claim/concurrency primitives without requiring
+  full deterministic replay in core;
+- make waits and child work visible as durable state;
+- persist completed step/task refs so retries do not need to guess what already
+  happened;
+- keep DAG/workflow-builder concerns separate from the minimal intake ledger.
+
+The practical result is a small DeerFlow schema made of a mutable workflow
+projection plus append-only lifecycle facts. LangGraph remains the durable graph
+runtime. Optional engines can wrap DeerFlow, but DeerFlow still has a native
+frontdoor that every deployment can run.
+
+## Boundary Rules
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint values and checkpoint writes;
+- graph-local memory and interrupt/resume mechanics;
+- replay from a checkpoint.
+
+DeerFlow core owns:
+
+- generic workflow intake identity;
+- source/channel metadata;
+- deterministic conversation/thread binding records;
+- run creation and cancellation orchestration;
+- workflow-to-run/checkpoint references;
+- workflow event projection over `RunEventStore`;
+- restart reconciliation and orphan status visibility.
+
+Integrations own:
+
+- domain-specific work semantics;
+- task/goal/work-unit lifecycle;
+- approval policies and business gates;
+- evidence/artifact acceptance rules;
+- semantic completion beyond "the DeerFlow run ended".
+
+DeerFlow runtime core must not know integration-specific names such as Gate,
+Evidence, Review, Runtime Invocation, AICOS, OpenClaw, Restate, or Temporal.
+It also must not require the Work Module to run durable workflows.
+
+The optional Work Module intentionally sits between DeerFlow runtime core and
+external integrations. It provides generic community primitives such as Work
+Units and Work Gates, while adapter packages map those primitives to Jira
+issues, Trello cards, ClickUp tasks, Plane issues, Lark tasks/docs, or AICOS-X
+records.
+
+## Core Primitive: Workflow Envelope
+
+The workflow envelope is a generic record for one inbound message or command
+that may cause an agent invocation.
+
+Minimum fields:
+
+- `workflow_id`: DeerFlow-generated durable identity.
+- `workflow_kind`: `message`, `command`, `resume`, `handoff`, or `other`.
+- `source_type`: `api`, `dashboard`, `channel`, `agent_session`, or `other`.
+- `source`: provider/surface name such as `slack`, `telegram`, `dashboard`, or
+  `api`.
+- `external_message_ref`: stable external message/event id when one exists.
+- `conversation_ref`: external conversation/session/channel id.
+- `thread_ref`: external topic/thread/reply id.
+- `sender_ref`: external user/account/bot id.
+- `thread_id`: DeerFlow LangGraph thread id, once resolved.
+- `run_id`: DeerFlow run id, once created.
+- `checkpoint_ns`: checkpoint namespace, usually `""` for the root graph.
+- `checkpoint_id`: checkpoint ref when the workflow targets or observes one.
+- `idempotency_key`: caller or adapter supplied stable key.
+- `status`: `received`, `bound`, `claimed`, `run_created`, `running`, `waiting`,
+  `succeeded`, `failed`, `cancelled`, `orphaned`, or `ignored`.
+- `attempt_count`: how many times DeerFlow has claimed or attempted the
+  workflow.
+- `max_attempts`: retry ceiling for safe retry policies.
+- `next_attempt_at`: earliest time the workflow can be claimed again.
+- `lease_owner`: worker/process id that currently owns execution.
+- `lease_expires_at`: time after which another worker may recover/claim it.
+- `error`: short error summary.
+- `metadata`: JSON for adapter/runtime extension data.
+- `created_at`, `updated_at`.
+
+The envelope stores refs and summaries. It must not copy LangGraph checkpoint
+state values or large raw transcripts.
+
+## Core Primitive: Workflow Event
+
+The workflow row is the latest projection. A separate append-only event table
+should record workflow lifecycle facts that are useful for audit, recovery, and
+UI timelines.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Suggested event types:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+This table is not a copy of `RunEventStore`. It records DeerFlow workflow facts
+and points at run event sequence numbers where graph execution details already
+exist. UI timelines can merge workflow events and run events at query time.
+
+## Minimal Durable Schema
+
+The first scalable schema should be intentionally small:
+
+```text
+workflows
+  durable intake identity
+  source refs and idempotency key
+  current status projection
+  worker lease and retry metadata
+  LangGraph thread/checkpoint refs
+  DeerFlow run refs
+  compact error/metadata
+
+workflow_events
+  append-only workflow lifecycle facts
+  refs to run_events, checkpoints, and external ids
+  compact payload summaries
+
+run_events
+  existing DeerFlow execution stream
+
+LangGraph checkpoints/checkpoint_writes/store
+  existing graph state and graph-local memory
+```
+
+Do not add a `workflow_steps` table in the first native layer. Step-level
+durability is already owned by LangGraph for graph nodes and can later be owned
+by an optional Restate/Temporal/Hatchet adapter for deployments that need
+deterministic code replay beyond LangGraph checkpoints.
+
+Do not add a separate `workflow_runtime_bindings` table until DeerFlow needs
+one workflow to fan out into multiple runs or runtimes. The first model can bind
+the current `thread_id`, `run_id`, and checkpoint refs directly on `workflows`,
+with richer execution attempts represented later by the optional Work module's
+`runtime_invocations`.
+
+Human waits can begin as `status = waiting` plus checkpoint/interrupt metadata.
+If this becomes too overloaded, add a focused `workflow_waits` or
+`workflow_signals` table later with `wait_id`, `workflow_id`, `wait_type`,
+`status`, `resume_id`, `expires_at`, and `metadata`.
+
+## Deterministic Binding Resolver
+
+Routing should be deterministic before the agent is invoked:
+
+1. Respect explicit request fields (`thread_id`, `checkpoint_id`, selected
+   assistant/agent, explicit external refs).
+2. Resolve channel conversation mappings using existing channel connection and
+   conversation stores.
+3. Detect explicit references in message text only when their syntax is
+   unambiguous and generic, such as a DeerFlow thread/run/workflow id.
+4. Bind to an active thread/run only when the source conversation and binding
+   rules make that deterministic.
+5. If multiple valid candidates exist, persist the candidates in workflow
+   metadata and pass the ambiguity to the agent or human flow. Do not guess in
+   the adapter.
+
+This resolver is intentionally not a semantic classifier. Semantic intent
+belongs in the agent or integration layer.
+
+## Scalable Execution Model
+
+The native DeerFlow layer should be a durable intake and dispatch ledger, not a
+second graph engine. The scalable path is:
+
+```text
+surface/API/channel
+  -> workflow intake row (idempotent)
+  -> deterministic binding resolver
+  -> workflow lease claim
+  -> LangGraph run creation
+  -> LangGraph checkpointer/store/run_events
+  -> workflow status projection
+```
+
+Core primitives needed for scale:
+
+- `create_or_get`: idempotent intake.
+- `claim_next`: atomically lease an eligible workflow for one worker.
+- `bind_runtime`: attach `thread_id`, `run_id`, and checkpoint refs after run
+  creation.
+- `update_status`: complete, fail, wait, cancel, or orphan the workflow.
+- `release_for_retry`: clear a lease, increment/reuse retry metadata, and set
+  `next_attempt_at`.
+- `recover_expired_leases`: mark or requeue workflows whose lease owner died.
+
+The first implementation can keep run execution in the gateway process. A later
+worker pool can use the same store API to claim workflows from Postgres without
+changing public intake semantics.
+
+This design intentionally does not provide Temporal/Restate-style deterministic
+code replay in core. DeerFlow should replay at three safer boundaries instead:
+
+1. API/channel retries dedupe at `workflow.idempotency_key`.
+2. Workflow dispatch retries re-enter before LangGraph run creation, or after a
+   known terminal/orphaned run state.
+3. LangGraph graph resume uses `thread_id` and checkpoint/interrupt refs.
+
+Any side effect outside those boundaries must be idempotent or pushed into a
+tool/runtime layer that records its own durable result.
+
+## Runtime Binding
+
+Workflow rows bind to DeerFlow runtime refs:
+
+```text
+workflow_id
+  -> thread_id
+  -> run_id
+  -> checkpoint_ns/checkpoint_id refs
+  -> run_events(thread_id, run_id, seq)
+```
+
+Run events remain the source event stream for graph execution observations.
+Workflow timeline APIs should project from workflow status changes plus
+`RunEventStore` rows. The projection should include links/correlation, not
+duplicate every run event into a second canonical stream.
+
+## Recovery Semantics
+
+The initial native layer does not make process-local `asyncio.Task` execution
+durable across gateway restarts.
+
+On startup:
+
+- orphaned `pending`/`running` runs remain explicitly marked as `error` under
+  current run reconciliation;
+- workflows bound to those runs should be marked `orphaned` or `failed` with a
+  recovery hint;
+- workflows with expired leases and no run can be requeued when their
+  idempotency key and source policy make retry safe;
+- workflows with expired leases and an active/local run should keep the run as
+  source of truth until the run reaches a terminal state;
+- workflows that were only `received` or `bound` before a run was created can
+  be retried only when the idempotency key, input refs, and adapter policy make
+  retry safe;
+- retry/resume policies must be explicit per workflow kind/source.
+
+Future Restate/Temporal adapters can provide stronger execution replay by
+driving DeerFlow through the same workflow envelope and marking their own
+orchestrator refs in metadata.
+
+## Human-In-The-Loop
+
+LangGraph interrupts should remain the primary graph-local HITL primitive.
+DeerFlow workflow records should add:
+
+- a durable `waiting` status for workflows whose run reached an interrupt or
+  requires user input;
+- references to the relevant `thread_id`, `run_id`, and checkpoint config;
+- a generic pending-input record or metadata block that stores prompt summary,
+  interrupt id(s), source, and resume route;
+- `Command(resume=...)` intake through the same workflow frontdoor.
+
+The human decision semantics remain outside DeerFlow unless they are generic
+approval/resume mechanics.
+
+## Observability
+
+DeerFlow should expose workflow observability without requiring an integration:
+
+- list workflows by status, source, thread, run, and updated time;
+- get one workflow envelope;
+- get workflow timeline projected from workflow lifecycle plus run events;
+- show idempotency and external refs;
+- surface orphan/retry/recovery hints;
+- correlate workflow rows to run rows and checkpoint refs.
+
+## PR Stack
+
+Detailed implementation order lives in
+[Durable Workflow Runtime Plan](DURABLE_WORKFLOW_RUNTIME_PLAN.md). The stack is
+ordered so that cutting later PRs still leaves a useful durable runtime prefix.
+
+1. Runtime architecture and shared contracts.
+2. Workflow envelope schema/store/idempotency/lease tests.
+3. Workflow events append-only lifecycle log.
+4. Runtime read APIs and observability.
+5. Existing run endpoint compatibility wrapper.
+6. Recovery/reconciliation for orphaned workflows/runs.
+7. Deterministic binding resolver.
+8. Channel/dashboard intake adoption.
+9. Waiting, resume, and human-in-the-loop refs.
+10. Worker pool readiness.
+
+## First Implementation Slice
+
+The first safe slice is PR 1 plus the persistence skeleton for PR 2:
+
+- add this design doc;
+- add generic workflow status/kind/source enums;
+- add a `workflows` ORM model and Alembic migration;
+- add a small repository/store API with idempotent create-or-get by
+  idempotency key;
+- add lease/attempt fields so later PRs can scale workers horizontally without
+  another schema break;
+- add unit tests for idempotent create, binding updates, status updates, and
+  list filters;
+- do not change any gateway or channel runtime behavior yet.
+
+This gives downstream PRs a stable table and API surface without changing the
+current run endpoints or channel dispatch path.

--- a/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
+++ b/backend/docs/DURABLE_WORKFLOW_PR_STACK.md
@@ -1,0 +1,286 @@
+# Durable Workflow PR Stack
+
+Status: working stack
+Date: 2026-06-26
+
+This stack is ordered for upstream review. PR 1-5 is the first community-visible
+milestone: existing DeerFlow run APIs keep their current behavior, but each run
+also has durable workflow identity, idempotency, lifecycle events, and an
+inspectable trace.
+
+## Review Principles
+
+- Keep the Durable Workflow Runtime layer generic. Do not introduce AICOS, PM
+  tool, visual designer, board, or external-orchestrator concepts into that
+  runtime layer.
+- Keep module boundaries explicit. Durable Workflow Runtime, Work Module, and
+  WorkBoard are separately gated by `modules.*` config and should not require
+  each other except for WorkBoard depending on the Work Module API.
+- LangGraph remains owner of graph execution, checkpoint state, graph-local
+  memory, interrupts, and resume semantics.
+- DeerFlow owns intake identity, workflow status projection, idempotency,
+  run/checkpoint references, channel/API routing, and runtime observability.
+- The optional DeerFlow Work Module may map workflow ids to generic Work Units,
+  and external adapters may map those Work Units to domain task/card/issue
+  systems. Those mappings live outside this runtime stack.
+
+## PR 1: Runtime Architecture And Shared Contracts
+
+Purpose: align vocabulary before schema and API changes.
+
+Scope:
+
+- Add `DURABLE_WORKFLOW_RUNTIME_PLAN.md`.
+- Add `DURABLE_WORKFLOW_FRONTDOOR.md`.
+- Link both docs from the backend docs index.
+- Define shared identity names: `workflow_id`, `workflow_event_id`,
+  `thread_id`, `run_id`, `checkpoint_ns`, `checkpoint_id`,
+  `workflow_definition_id`, and `workflow_run_id`.
+- Define status and event contracts.
+
+Acceptance:
+
+- No runtime behavior changes.
+- Docs clearly separate runtime workflow identity from future visual workflow
+  definitions and future work unit modules.
+
+Suggested checks:
+
+```bash
+git diff --check
+```
+
+## PR 2: Workflow Envelope Schema And Store
+
+Purpose: persist the minimal durable frontdoor envelope.
+
+Scope:
+
+- Add runtime workflow enums and `WorkflowStore`.
+- Add in-memory workflow store.
+- Add SQLAlchemy workflow repository.
+- Add `workflows` ORM model and migration.
+- Wire gateway dependency so production uses SQL store when a DB session
+  factory exists, otherwise memory store.
+
+Acceptance:
+
+- `create_or_get` dedupes by `(source_type, source, idempotency_key)`.
+- Store supports `get`, `list`, `bind_runtime`, `update_status`,
+  `claim_next`, and `release_for_retry`.
+- Existing run APIs still behave the same before wrapper adoption.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py \
+  tests/test_persistence_scaffold.py -q
+```
+
+## PR 3: Workflow Events
+
+Purpose: add append-only lifecycle facts for audit and recovery decisions.
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event` and `list_events` to workflow stores.
+- Keep workflow events separate from `RunEventStore`.
+- Ensure migrations are idempotent when legacy `create_all` already created
+  tables.
+
+Acceptance:
+
+- Event `seq` is monotonic per workflow.
+- Events can exist before a run exists.
+- No checkpoint values are copied into workflow event rows.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflow_repository.py \
+  tests/test_workflows_router.py \
+  tests/test_persistence_bootstrap.py \
+  tests/test_persistence_bootstrap_concurrency.py \
+  tests/test_persistence_bootstrap_regression.py -q
+```
+
+## PR 4: Durable Run Trace API And UI
+
+Purpose: make the runtime value visible without requiring WorkBoard, PM
+adapters, or an external workflow engine.
+
+Scope:
+
+- Add read-only workflow endpoints:
+  - `GET /api/workflows`
+  - `GET /api/workflows/{workflow_id}`
+  - `GET /api/workflows/{workflow_id}/events`
+  - `GET /api/workflows/by-run/{run_id}`
+  - `GET /api/workflows/{workflow_id}/timeline`
+- Timeline merges workflow lifecycle events and run events at query time.
+- Add a compact workspace Trace trigger for the latest run in a chat.
+
+Acceptance:
+
+- A user can open a chat and inspect the latest run trace.
+- A developer can find `workflow_id` from `run_id`.
+- Timeline includes both workflow events and existing run events.
+- Endpoint additions do not change existing run API responses.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest \
+  tests/test_workflows_router.py \
+  tests/test_gateway_services.py -q
+
+cd ../frontend
+CI=true pnpm run check
+```
+
+## PR 5: Run API Wrapper And Status Projection
+
+Purpose: route existing run creation through workflow intake while preserving
+client compatibility.
+
+Scope:
+
+- Wrap `/api/runs/*` and `/api/threads/{thread_id}/runs*` creation paths.
+- Create a workflow envelope before run creation.
+- Bind `thread_id`, `run_id`, `checkpoint_ns`, and `checkpoint_id`.
+- Project run lifecycle to workflow status:
+  - `running`
+  - `succeeded`
+  - `failed`
+  - `cancelled`
+- Append lifecycle events:
+  - `workflow.received`
+  - `workflow.deduped`
+  - `workflow.run_created`
+  - `workflow.run_started`
+  - `workflow.succeeded`
+  - `workflow.failed`
+  - `workflow.cancelled`
+
+Acceptance:
+
+- Old clients can ignore workflows entirely.
+- Duplicate idempotency keys do not create duplicate bound runs.
+- Workflow terminal status matches the bound run terminal status.
+- Trace UI shows terminal status on new runs.
+
+Suggested checks:
+
+```bash
+cd backend
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -q
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff check .
+PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run ruff format --check .
+
+cd ../frontend
+CI=true pnpm run check
+NEXT_PUBLIC_BACKEND_BASE_URL=http://127.0.0.1:18081 \
+NEXT_PUBLIC_LANGGRAPH_BASE_URL=http://127.0.0.1:18081/api \
+DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://127.0.0.1:18081 \
+DEER_FLOW_TRUSTED_ORIGINS=http://127.0.0.1:13001,http://localhost:13001 \
+DEER_FLOW_AUTH_DISABLED=1 \
+pnpm exec next build
+```
+
+## Post-Milestone PRs
+
+These should come after PR 1-5, so the foundation is already visible and
+testable.
+
+### PR 6: Recovery And Orphan Reconciliation
+
+- Reconcile active workflows with existing run reconciliation at gateway
+  startup.
+- Mark `running` / `run_created` workflows as `orphaned` when process-local
+  execution was lost.
+- Add recovery hints in timeline responses.
+
+### PR 7: Deterministic Binding Resolver
+
+- Normalize explicit thread/run/checkpoint/source bindings.
+- Persist ambiguous candidates instead of guessing.
+- Give channel adapters a generic binding contract.
+
+### PR 8: Channel And Dashboard Intake Adoption
+
+- Route Slack/Discord/Telegram-style adapters through workflow intake.
+- Use stable external message ids as idempotency keys.
+- Keep channel UX compatible.
+
+### PR 9: Durable Waiting And Resume Refs
+
+- Represent LangGraph interrupt waits as durable workflow state.
+- Route resume commands through workflow intake.
+- Keep actual interrupt payloads in LangGraph checkpoint state.
+
+### PR 10: Worker Pool Readiness
+
+- Add worker identity and lease renewal.
+- Add a claim loop abstraction behind a feature flag.
+- Keep gateway process execution as the default mode.
+
+## Next Module Tracks
+
+The following tracks should remain separate from the runtime PRs:
+
+- Work Module: generic Work Unit records and external PM mappings.
+- WorkBoard: built-in board UI for deployments without a PM tool.
+- Workflow Designer: visual workflow definition authoring and versioning.
+- Optional orchestrator adapters: Restate, Temporal, Hatchet integration
+  examples, not hard dependencies.
+
+## Module PRs After Runtime
+
+These PRs depend on the runtime identity/event foundation but should not be
+required for a minimal durable runtime deployment.
+
+### PR 11: Work Module Schema And API
+
+- Add `DEERFLOW_WORK_MODULE.md`.
+- Add `work_units` and `work_events` schema/migration.
+- Add memory and SQL stores.
+- Add `/api/work-units` CRUD and event list endpoints.
+- Allow optional links to `workflow_id`, `thread_id`, and `run_id`.
+
+### PR 12: WorkBoard MVP
+
+- Add `/workspace/work`.
+- Show Trello-style columns over `work_units.status`.
+- Create local work units.
+- Show runtime-driven status projection; local human-created work starts in
+  `backlog`.
+- Link cards to chat threads and workflow traces when refs exist.
+
+### PR 13: External PM Binding Contract
+
+- Define adapter mapping for Jira/Trello/ClickUp/Plane/Lark-style work
+  objects.
+- Add external ref/url/source conventions.
+- Keep credentials, webhooks, sync cursors, and conflict policy in adapters.
+
+### PR 14: Work Gates And Criteria
+
+- Add acceptance criteria and lightweight human gates.
+- Link gates to runtime `waiting` workflows where appropriate.
+- Keep LangGraph interrupt payloads in LangGraph checkpoint state.
+
+### PR 15: Agent Workflow Definition Plane
+
+- Add Agent Workflow DSL schema/validation.
+- Add definition/version persistence.
+- Add visual designer under a feature flag.
+- Compile from DeerFlow DSL to LangGraph/runtime plans, not from editor JSON.

--- a/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
+++ b/backend/docs/DURABLE_WORKFLOW_RUNTIME_PLAN.md
@@ -1,0 +1,450 @@
+# Durable Workflow Runtime Plan
+
+Status: implementation plan
+Date: 2026-06-26
+Scope: first-priority PR stack for DeerFlow durable workflow runtime, shared identity, workflow events, and runtime adoption
+
+## Relationship To Platform Plan
+
+This plan is the focused execution track for the Durable Workflow Runtime plane
+in [Durable Agent Platform Plan](DURABLE_AGENT_PLATFORM_PLAN.md). It should land
+before the Agent Workflow Definition, Compiler/Run Binding, Work Module,
+WorkBoard, and PM adapter tracks depend on it.
+
+The runtime layer is the shared foundation because it gives all later modules a
+stable way to answer:
+
+- what external request/message arrived;
+- whether it was already accepted;
+- which DeerFlow thread/run/checkpoint it bound to;
+- who claimed execution;
+- whether it is running, waiting, terminal, retryable, or orphaned;
+- which lifecycle and run events explain what happened.
+
+## Core Standardization Goals
+
+### Shared Identity Model
+
+Standardize these names before expanding module surface area:
+
+- `workflow_id`: durable frontdoor envelope id for one inbound command/message.
+- `workflow_event_id`: append-only lifecycle fact id.
+- `workflow_definition_id`: design-time workflow definition id; not owned by
+  this runtime plan, but reserved now to avoid name collisions.
+- `workflow_definition_version`: immutable design snapshot version/id.
+- `workflow_run_id`: execution of a designed workflow; later compiler/run
+  binding plane.
+- `thread_id`: LangGraph/DeerFlow thread id.
+- `run_id`: DeerFlow run id.
+- `checkpoint_ns`: LangGraph checkpoint namespace.
+- `checkpoint_id`: LangGraph checkpoint ref.
+- `step_id`: designed workflow node/step id; reserved for later projection.
+- `work_unit_id`: generic task/card/issue id; Work module, not runtime core.
+- `external_binding_id`: PM/external object mapping id; Work module/adapters.
+
+Runtime core owns `workflow_id` and `workflow_event_id`. It may store refs to
+the other ids, but it must not require the modules that own them.
+
+### Status Contracts
+
+Initial workflow statuses:
+
+- `received`: intake persisted, not yet resolved/claimed.
+- `bound`: deterministic thread/checkpoint binding resolved.
+- `claimed`: worker/process lease acquired.
+- `run_created`: DeerFlow run row created.
+- `running`: bound run is executing.
+- `waiting`: run/workflow is paused for interrupt, human input, external event,
+  or safe retry time.
+- `succeeded`: terminal success.
+- `failed`: terminal failure.
+- `cancelled`: terminal cancellation.
+- `orphaned`: previous executor is gone and automatic safe resume is not known.
+- `ignored`: accepted and intentionally not executed.
+
+These statuses are a public runtime contract. Later modules can project their
+own statuses from them, but should not redefine runtime meaning.
+
+### Event Contract
+
+`workflows` is the mutable latest projection. `workflow_events` is the
+append-only lifecycle log.
+
+`workflow_events` should record DeerFlow runtime facts such as:
+
+- `received`
+- `deduped`
+- `bound`
+- `claimed`
+- `run_created`
+- `run_started`
+- `waiting`
+- `resumed`
+- `retry_scheduled`
+- `lease_expired`
+- `orphaned`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `ignored`
+
+It should reference `run_events` by `(thread_id, run_id, run_event_seq)` rather
+than copying low-level execution events. Timeline APIs merge workflow lifecycle
+facts with `RunEventStore` rows at query time.
+
+### LangGraph Boundary
+
+LangGraph owns:
+
+- graph execution;
+- checkpoint state values;
+- checkpoint writes and pending writes;
+- graph-local memory;
+- interrupt/resume mechanics;
+- replay from checkpoints.
+
+DeerFlow runtime owns:
+
+- intake identity;
+- idempotency;
+- source/channel refs;
+- deterministic thread/run/checkpoint binding records;
+- worker lease and retry metadata;
+- startup reconciliation;
+- lifecycle events and runtime correlation.
+
+The runtime layer stores refs to LangGraph state, never checkpoint payloads.
+
+## Minimal Data Model
+
+### `workflows`
+
+Purpose: durable intake envelope and latest runtime projection.
+
+Minimum fields:
+
+- `workflow_id`
+- `workflow_kind`
+- `source_type`
+- `source`
+- `external_message_ref`
+- `conversation_ref`
+- `thread_ref`
+- `sender_ref`
+- `idempotency_key`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `status`
+- `attempt_count`
+- `max_attempts`
+- `next_attempt_at`
+- `lease_owner`
+- `lease_expires_at`
+- `error`
+- `metadata`
+- `created_at`
+- `updated_at`
+
+Indexes:
+
+- unique idempotency scope, initially `(source_type, source, idempotency_key)`
+  when `idempotency_key` is present;
+- `(status, next_attempt_at, lease_expires_at)` for claiming/recovery;
+- `(thread_id, run_id)`;
+- `(source_type, source, conversation_ref)`;
+- `updated_at`.
+
+### `workflow_events`
+
+Purpose: append-only lifecycle facts for audit, recovery, and timeline APIs.
+
+Minimum fields:
+
+- `workflow_event_id`
+- `workflow_id`
+- `seq`
+- `event_type`
+- `source`
+- `thread_id`
+- `run_id`
+- `checkpoint_ns`
+- `checkpoint_id`
+- `run_event_seq`
+- `idempotency_key`
+- `payload_summary`
+- `metadata`
+- `created_at`
+
+Indexes:
+
+- unique `(workflow_id, seq)`;
+- `(workflow_id, created_at)`;
+- `(thread_id, run_id, run_event_seq)`;
+- `(event_type, created_at)`.
+
+## Store Contracts
+
+The runtime store should work with in-memory tests, SQLite local dev, and
+Postgres production.
+
+Required methods:
+
+- `create_or_get`: idempotent intake.
+- `append_event`: append a lifecycle event with monotonic per-workflow seq.
+- `get`: fetch workflow projection.
+- `list`: filter by status, source, thread, run, and updated time.
+- `update_status`: mutate projection and append lifecycle event.
+- `bind_runtime`: attach `thread_id`, `run_id`, checkpoint refs.
+- `claim_next`: atomically lease eligible workflow.
+- `renew_lease`: extend active ownership for long execution.
+- `release_for_retry`: clear lease and schedule next attempt.
+- `mark_orphaned`: terminal or recoverable orphan projection.
+- `timeline`: merge workflow events and run events.
+
+Postgres should use row-level locking and `SKIP LOCKED` for `claim_next`. SQLite
+can use a conservative transaction path suitable for local/single-process
+development.
+
+## PR Stack
+
+The stack is ordered so later PRs are optional expansions. If review stops at a
+given prefix, the runtime should still be useful at that maturity level. The
+first upstream-ready community demo should include PR 1 through PR 5: by then a
+normal DeerFlow run has a durable workflow identity, idempotent intake, and a
+visible run trace that explains what happened.
+
+- PR 1-2: schema/store foundation.
+- PR 1-3: durable envelope plus lifecycle events.
+- PR 1-4: observable Durable Run Trace for operators and users.
+- PR 1-5: existing run APIs create and update workflow envelopes.
+- PR 1-6: restart/orphan behavior is production-visible.
+- PR 1-8: universal API/dashboard/channel frontdoor.
+- PR 1-9: durable human-in-the-loop.
+- PR 1-10: horizontal worker readiness.
+
+### Community Value Milestone
+
+The first PR stack proposed upstream should not stop at invisible primitives.
+It should include enough surface area that a DeerFlow user or operator can see
+the benefit during normal chat/run usage:
+
+- every run created through existing run APIs has a `workflow_id`;
+- repeated client/channel retries with the same idempotency key do not create a
+  duplicate run;
+- the workflow can be found from `run_id` or `thread_id`;
+- the trace shows intake, run creation, running state, and terminal
+  success/failure/cancellation;
+- the trace links workflow lifecycle events with the existing run event stream
+  without copying LangGraph checkpoint payloads.
+
+This milestone is still runtime-only. It intentionally does not include Work
+Units, WorkBoard, PM adapters, visual workflow design, or an external durable
+engine dependency.
+
+### PR 1: Runtime Architecture and Shared Contracts
+
+Scope:
+
+- Add this plan.
+- Link it from the platform plan and docs index.
+- Align terminology with `DURABLE_WORKFLOW_FRONTDOOR.md`.
+
+Acceptance:
+
+- docs distinguish `workflow_id`, `workflow_definition_id`, and
+  `workflow_run_id`;
+- docs define initial runtime statuses and event contract;
+- no runtime behavior changes.
+
+### PR 2: Workflow Envelope Schema and Store
+
+Scope:
+
+- Add runtime enums for workflow kind/source/status.
+- Add `workflows` ORM model and migration.
+- Add in-memory and SQL store implementations.
+- Implement `create_or_get`, `get`, `list`, `update_status`,
+  `bind_runtime`, `claim_next`, and `release_for_retry`.
+- Wire store dependency without changing endpoint behavior.
+
+Acceptance:
+
+- idempotent create returns existing workflow for duplicate key;
+- lease claim is atomic under SQL store;
+- existing run APIs and channels behave unchanged;
+- tests cover memory and SQL store behavior.
+
+### PR 3: Workflow Events
+
+Scope:
+
+- Add `workflow_events` ORM model and migration.
+- Add `append_event`.
+- Emit events for create/dedupe/status/bind/claim/retry.
+- Add event list and timeline projection helpers.
+
+Acceptance:
+
+- every projection mutation can append a lifecycle fact;
+- event seq is monotonic per workflow;
+- timeline can include workflow events even before a run exists;
+- no run event duplication.
+
+### PR 4: Durable Run Trace APIs
+
+Scope:
+
+- Add read-only gateway endpoints for workflow envelopes and run traces.
+- Add filters by status, source, thread, run, and updated time.
+- Add a timeline endpoint that merges workflow lifecycle facts with existing
+  `RunEventStore` rows at query time.
+- Add run-to-workflow lookup so existing clients can discover the durable
+  workflow for a run.
+- Include idempotency/source refs, runtime refs, terminal status, and recovery
+  hints in responses.
+
+Acceptance:
+
+- operators can query active, waiting, failed, orphaned, and terminal
+  workflows;
+- users and developers can inspect a normal chat/run and see the durable trace;
+- one workflow timeline correlates workflow lifecycle events with run events;
+- endpoint additions do not alter existing run API compatibility.
+
+### PR 5: Run API Compatibility Wrapper and Status Projection
+
+Scope:
+
+- Wrap existing `/runs` and `/threads/{thread_id}/runs` paths with workflow
+  intake when enabled.
+- Create workflow envelope before `start_run`.
+- Bind `thread_id`, `run_id`, and checkpoint refs after run creation.
+- Project run lifecycle into workflow lifecycle (`running`, `succeeded`,
+  `failed`, `cancelled`) without making LangGraph checkpoint state secondary.
+- Preserve existing request/response behavior for clients.
+
+Acceptance:
+
+- old clients can ignore `workflow_id`;
+- new clients can find the workflow for a created run;
+- duplicate idempotency keys do not create duplicate runs when policy says
+  dedupe;
+- workflow terminal status matches the bound run terminal status;
+- tests cover direct run creation.
+
+### PR 6: Recovery and Reconciliation
+
+Scope:
+
+- Reconcile active workflow envelopes with existing run reconciliation.
+- Mark orphaned workflows explicitly when process-local execution was lost.
+- Requeue only workflows that are safe by idempotency/source policy.
+- Record `lease_expired`, `orphaned`, and `retry_scheduled` events.
+
+Acceptance:
+
+- restart behavior is explicit and queryable;
+- no workflow is silently left `running` without an owner;
+- automatic retry is conservative and policy-driven.
+
+### PR 7: Deterministic Binding Resolver
+
+Scope:
+
+- Add generic resolver for explicit `thread_id`, external conversation refs,
+  checkpoint refs, and active run binding.
+- Record ambiguous candidates in metadata.
+- Do not use semantic guessing in adapters.
+
+Acceptance:
+
+- explicit thread/checkpoint ids win;
+- unambiguous channel conversation mappings bind deterministically;
+- ambiguous cases are persisted and surfaced, not guessed.
+
+### PR 8: Channel and Dashboard Intake Adoption
+
+Scope:
+
+- Route channel adapters through workflow intake.
+- Route dashboard/API chat messages through workflow intake where applicable.
+- Normalize source refs and idempotency keys for channels.
+
+Acceptance:
+
+- Slack/Discord/Telegram-style messages produce workflow envelopes;
+- channel retries dedupe by stable external event/message ids;
+- channel behavior remains compatible for users.
+
+### PR 9: Waiting, Resume, and Human-In-The-Loop Refs
+
+Scope:
+
+- Add generic waiting metadata conventions for LangGraph interrupts and external
+  human input.
+- Route resume messages through workflow intake.
+- Bind resume workflows to `thread_id`, checkpoint refs, and parent workflow
+  metadata.
+
+Acceptance:
+
+- interrupted runs surface as `waiting`;
+- resume creates/uses a durable workflow envelope;
+- LangGraph remains owner of interrupt/resume state.
+
+### PR 10: Worker Pool Readiness
+
+Scope:
+
+- Add lease renewal.
+- Add configurable worker identity.
+- Add claim loop abstraction behind feature flag or internal API.
+- Keep gateway process execution as the default path.
+
+Acceptance:
+
+- Postgres deployments have a clear horizontal worker contract;
+- local SQLite/default deployments remain simple;
+- no mandatory external orchestrator dependency.
+
+## First Implementation Slice
+
+The safest first implementation slice is PR 1 plus PR 2 without runtime
+adoption:
+
+- docs and shared contracts;
+- `workflows` schema/store;
+- idempotent create;
+- lease primitives;
+- run/checkpoint binding fields;
+- focused repository tests.
+
+This creates the durable foundation without changing existing run/channel
+behavior. PR 3 should follow quickly because `workflow_events` is the audit and
+timeline foundation for enterprise operation.
+
+For the first community-visible stack, continue through PR 5 before opening the
+main upstream discussion. PR 4 makes the runtime inspectable as a Durable Run
+Trace. PR 5 makes existing DeerFlow run APIs update that trace through terminal
+status. PR 6 and later are important for production hardening, but PR 1-5 is
+the smallest stack that lets a normal user see value without installing a Work
+Module, WorkBoard, or external orchestrator.
+
+## Defer Explicitly
+
+Do not include in the runtime-first stack:
+
+- Agent Workflow DSL persistence;
+- visual designer UI;
+- Work Unit schemas;
+- WorkBoard;
+- PM adapters;
+- Restate/Temporal/Hatchet dependencies;
+- AICOS-X concepts;
+- checkpoint value copies;
+- generic deterministic code replay.
+
+These become easier and cleaner after the runtime identity, status, event, and
+binding contracts are stable.

--- a/backend/docs/README.md
+++ b/backend/docs/README.md
@@ -17,6 +17,9 @@ This directory contains detailed documentation for the DeerFlow backend.
 | Document | Description |
 |----------|-------------|
 | [STREAMING.md](STREAMING.md) | Token-level streaming design: Gateway vs DeerFlowClient paths, `stream_mode` semantics, per-id dedup |
+| [DURABLE_WORKFLOW_RUNTIME_PLAN.md](DURABLE_WORKFLOW_RUNTIME_PLAN.md) | Runtime-first PR plan for workflow identity, status, events, idempotency, lease, and recovery |
+| [DURABLE_WORKFLOW_FRONTDOOR.md](DURABLE_WORKFLOW_FRONTDOOR.md) | Durable workflow intake/frontdoor architecture and PR stack |
+| [DURABLE_WORKFLOW_PR_STACK.md](DURABLE_WORKFLOW_PR_STACK.md) | Prefix-safe upstream PR sequence for durable runtime, recovery, intake, and worker readiness |
 | [FILE_UPLOAD.md](FILE_UPLOAD.md) | File upload functionality |
 | [PATH_EXAMPLES.md](PATH_EXAMPLES.md) | Path types and usage examples |
 | [SANDBOX_MEMORY_PROFILING.md](SANDBOX_MEMORY_PROFILING.md) | Sandbox memory baseline and runtime comparison guide |
@@ -52,6 +55,9 @@ docs/
 ├── summarization.md           # Summarization feature
 ├── plan_mode_usage.md         # Plan mode feature
 ├── STREAMING.md               # Token-level streaming design
+├── DURABLE_WORKFLOW_RUNTIME_PLAN.md # Runtime-first durable workflow PR plan
+├── DURABLE_WORKFLOW_FRONTDOOR.md # Durable workflow frontdoor design
+├── DURABLE_WORKFLOW_PR_STACK.md # Prefix-safe durable runtime PR sequence
 ├── AUTO_TITLE_GENERATION.md   # Title generation
 ├── TITLE_GENERATION_IMPLEMENTATION.md  # Title implementation details
 └── TODO.md                    # Roadmap and issues

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -21,6 +21,7 @@ from deerflow.config.guardrails_config import GuardrailsConfig, load_guardrails_
 from deerflow.config.loop_detection_config import LoopDetectionConfig
 from deerflow.config.memory_config import MemoryConfig, load_memory_config_from_dict
 from deerflow.config.model_config import ModelConfig
+from deerflow.config.modules_config import ModulesConfig
 from deerflow.config.reload_boundary import format_field_description
 from deerflow.config.run_events_config import RunEventsConfig
 from deerflow.config.runtime_paths import existing_project_file
@@ -133,6 +134,13 @@ class AppConfig(BaseModel):
     loop_detection: LoopDetectionConfig = Field(default_factory=LoopDetectionConfig, description="Loop detection middleware configuration")
     safety_finish_reason: SafetyFinishReasonConfig = Field(default_factory=SafetyFinishReasonConfig, description="Provider safety-filter finish_reason interception middleware configuration")
     auth: AuthAppConfig = Field(default_factory=AuthAppConfig, description="Authentication configuration (local + OIDC SSO)")
+    modules: ModulesConfig = Field(
+        default_factory=ModulesConfig,
+        description=format_field_description(
+            "modules",
+            field_doc="Optional DeerFlow module gates for durable workflow runtime primitives.",
+        ),
+    )
     model_config = ConfigDict(extra="allow")
     database: DatabaseConfig = Field(
         default_factory=DatabaseConfig,

--- a/backend/packages/harness/deerflow/config/modules_config.py
+++ b/backend/packages/harness/deerflow/config/modules_config.py
@@ -1,0 +1,23 @@
+"""Optional DeerFlow module configuration."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DurableWorkflowsConfig(BaseModel):
+    """Durable workflow runtime envelope and observability switches."""
+
+    enabled: bool = Field(default=True, description="Create durable workflow envelopes around run execution.")
+    api_enabled: bool = Field(default=True, description="Expose durable workflow read APIs.")
+    auto_envelope_for_runs: bool = Field(default=True, description="Automatically bind API-created runs to workflow envelopes.")
+
+
+class ModulesConfig(BaseModel):
+    """Feature gates for optional DeerFlow modules.
+
+    This module is intentionally small in the durable workflow runtime stack.
+    Higher-level modules can extend it with their own feature gates later.
+    """
+
+    durable_workflows: DurableWorkflowsConfig = Field(default_factory=DurableWorkflowsConfig)

--- a/backend/packages/harness/deerflow/config/reload_boundary.py
+++ b/backend/packages/harness/deerflow/config/reload_boundary.py
@@ -59,6 +59,9 @@ STARTUP_ONLY_FIELDS: dict[str, str] = {
     "channel_connections": (
         "start_channel_service() wires the connection repository and channel workers once at startup, and the channel-connections router caches the merged provider config on app.state; channel_connections.* edits need a restart."
     ),
+    "modules": (
+        "create_app() and langgraph_runtime() mount optional routers and construct module stores once at startup; module gates need a restart."
+    ),
 }
 
 

--- a/backend/packages/harness/deerflow/persistence/engine.py
+++ b/backend/packages/harness/deerflow/persistence/engine.py
@@ -75,6 +75,10 @@ async def init_engine(
     global _engine, _session_factory
 
     if backend == "memory":
+        if _engine is not None:
+            await _engine.dispose()
+        _engine = None
+        _session_factory = None
         logger.info("Persistence backend=memory -- ORM engine not initialized")
         return
 

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0003_workflows.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0003_workflows.py
@@ -1,0 +1,88 @@
+"""Add workflow frontdoor envelope table.
+
+Revision ID: 0003_workflows
+Revises: 0002_runs_token_usage
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0003_workflows"
+down_revision: str | Sequence[str] | None = "0002_runs_token_usage"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if _table_exists("workflows"):
+        return
+    op.create_table(
+        "workflows",
+        sa.Column("workflow_id", sa.String(length=64), nullable=False),
+        sa.Column("workflow_kind", sa.String(length=32), nullable=False),
+        sa.Column("source_type", sa.String(length=32), nullable=False),
+        sa.Column("source", sa.String(length=128), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=256), nullable=True),
+        sa.Column("external_message_ref", sa.Text(), nullable=True),
+        sa.Column("conversation_ref", sa.Text(), nullable=True),
+        sa.Column("thread_ref", sa.Text(), nullable=True),
+        sa.Column("sender_ref", sa.Text(), nullable=True),
+        sa.Column("user_id", sa.String(length=64), nullable=True),
+        sa.Column("thread_id", sa.String(length=64), nullable=True),
+        sa.Column("run_id", sa.String(length=64), nullable=True),
+        sa.Column("checkpoint_ns", sa.String(length=256), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=128), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("attempt_count", sa.Integer(), nullable=False),
+        sa.Column("max_attempts", sa.Integer(), nullable=False),
+        sa.Column("next_attempt_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lease_owner", sa.String(length=128), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("workflow_id"),
+    )
+    with op.batch_alter_table("workflows", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_workflows_run_id"), ["run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_source"), ["source"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_status"), ["status"], unique=False)
+        batch_op.create_index("ix_workflows_claimable", ["status", "next_attempt_at", "lease_expires_at"], unique=False)
+        batch_op.create_index("ix_workflows_status_updated", ["status", "updated_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_thread_id"), ["thread_id"], unique=False)
+        batch_op.create_index("ix_workflows_thread_run", ["thread_id", "run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflows_user_id"), ["user_id"], unique=False)
+        batch_op.create_index(
+            "uq_workflows_source_idempotency",
+            ["source_type", "source", "idempotency_key"],
+            unique=True,
+            sqlite_where=sa.text("idempotency_key IS NOT NULL"),
+            postgresql_where=sa.text("idempotency_key IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists("workflows"):
+        return
+    with op.batch_alter_table("workflows", schema=None) as batch_op:
+        batch_op.drop_index("uq_workflows_source_idempotency")
+        batch_op.drop_index(batch_op.f("ix_workflows_user_id"))
+        batch_op.drop_index("ix_workflows_thread_run")
+        batch_op.drop_index(batch_op.f("ix_workflows_thread_id"))
+        batch_op.drop_index("ix_workflows_status_updated")
+        batch_op.drop_index("ix_workflows_claimable")
+        batch_op.drop_index(batch_op.f("ix_workflows_status"))
+        batch_op.drop_index(batch_op.f("ix_workflows_source"))
+        batch_op.drop_index(batch_op.f("ix_workflows_run_id"))
+    op.drop_table("workflows")

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0004_workflow_events.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0004_workflow_events.py
@@ -1,0 +1,73 @@
+"""Add workflow event timeline table.
+
+Revision ID: 0004_workflow_events
+Revises: 0003_workflows
+Create Date: 2026-06-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0004_workflow_events"
+down_revision: str | Sequence[str] | None = "0003_workflows"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if _table_exists("workflow_events"):
+        return
+    op.create_table(
+        "workflow_events",
+        sa.Column("workflow_event_id", sa.String(length=64), nullable=False),
+        sa.Column("workflow_id", sa.String(length=64), nullable=False),
+        sa.Column("seq", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("category", sa.String(length=32), nullable=False),
+        sa.Column("thread_id", sa.String(length=64), nullable=True),
+        sa.Column("run_id", sa.String(length=64), nullable=True),
+        sa.Column("checkpoint_ns", sa.String(length=256), nullable=True),
+        sa.Column("checkpoint_id", sa.String(length=128), nullable=True),
+        sa.Column("run_event_seq", sa.Integer(), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=256), nullable=True),
+        sa.Column("source_event_ref", sa.Text(), nullable=True),
+        sa.Column("content_json", sa.JSON(), nullable=True),
+        sa.Column("metadata_json", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["workflow_id"], ["workflows.workflow_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("workflow_event_id"),
+        sa.UniqueConstraint("workflow_id", "seq", name="uq_workflow_events_workflow_seq"),
+    )
+    with op.batch_alter_table("workflow_events", schema=None) as batch_op:
+        batch_op.create_index(batch_op.f("ix_workflow_events_category"), ["category"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_created_at"), ["created_at"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_event_type"), ["event_type"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_run_id"), ["run_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_thread_id"), ["thread_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_workflow_events_workflow_id"), ["workflow_id"], unique=False)
+        batch_op.create_index("ix_workflow_events_thread_run_seq", ["thread_id", "run_id", "run_event_seq"], unique=False)
+        batch_op.create_index("ix_workflow_events_workflow_created", ["workflow_id", "created_at"], unique=False)
+
+
+def downgrade() -> None:
+    if not _table_exists("workflow_events"):
+        return
+    with op.batch_alter_table("workflow_events", schema=None) as batch_op:
+        batch_op.drop_index("ix_workflow_events_workflow_created")
+        batch_op.drop_index("ix_workflow_events_thread_run_seq")
+        batch_op.drop_index(batch_op.f("ix_workflow_events_workflow_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_thread_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_run_id"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_event_type"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_created_at"))
+        batch_op.drop_index(batch_op.f("ix_workflow_events_category"))
+    op.drop_table("workflow_events")

--- a/backend/packages/harness/deerflow/persistence/models/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/models/__init__.py
@@ -8,6 +8,7 @@ The actual ORM classes have moved to entity-specific subpackages:
 - ``deerflow.persistence.run``
 - ``deerflow.persistence.feedback``
 - ``deerflow.persistence.user``
+- ``deerflow.persistence.workflow``
 
 ``RunEventRow`` remains in ``deerflow.persistence.models.run_event`` because
 its storage implementation lives in ``deerflow.runtime.events.store.db`` and
@@ -25,6 +26,7 @@ from deerflow.persistence.models.run_event import RunEventRow
 from deerflow.persistence.run.model import RunRow
 from deerflow.persistence.thread_meta.model import ThreadMetaRow
 from deerflow.persistence.user.model import UserRow
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
 
 __all__ = [
     "ChannelConnectionRow",
@@ -36,4 +38,6 @@ __all__ = [
     "RunRow",
     "ThreadMetaRow",
     "UserRow",
+    "WorkflowEventRow",
+    "WorkflowRow",
 ]

--- a/backend/packages/harness/deerflow/persistence/workflow/__init__.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow persistence repository."""
+
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
+from deerflow.persistence.workflow.sql import WorkflowRepository
+
+__all__ = ["WorkflowEventRow", "WorkflowRepository", "WorkflowRow"]

--- a/backend/packages/harness/deerflow/persistence/workflow/model.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/model.py
@@ -1,0 +1,91 @@
+"""ORM model for workflow frontdoor envelopes."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, Text, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from deerflow.persistence.base import Base
+
+
+class WorkflowRow(Base):
+    __tablename__ = "workflows"
+
+    workflow_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_kind: Mapped[str] = mapped_column(String(32), nullable=False, default="message")
+    source_type: Mapped[str] = mapped_column(String(32), nullable=False, default="api")
+    source: Mapped[str | None] = mapped_column(String(128), index=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(256))
+
+    external_message_ref: Mapped[str | None] = mapped_column(Text)
+    conversation_ref: Mapped[str | None] = mapped_column(Text)
+    thread_ref: Mapped[str | None] = mapped_column(Text)
+    sender_ref: Mapped[str | None] = mapped_column(Text)
+    user_id: Mapped[str | None] = mapped_column(String(64), index=True)
+
+    thread_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    checkpoint_ns: Mapped[str | None] = mapped_column(String(256))
+    checkpoint_id: Mapped[str | None] = mapped_column(String(128))
+
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="received", index=True)
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    next_attempt_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    lease_owner: Mapped[str | None] = mapped_column(String(128))
+    lease_expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    error: Mapped[str | None] = mapped_column(Text)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+
+    __table_args__ = (
+        Index(
+            "uq_workflows_source_idempotency",
+            "source_type",
+            "source",
+            "idempotency_key",
+            unique=True,
+            sqlite_where=text("idempotency_key IS NOT NULL"),
+            postgresql_where=text("idempotency_key IS NOT NULL"),
+        ),
+        Index("ix_workflows_status_updated", "status", "updated_at"),
+        Index("ix_workflows_claimable", "status", "next_attempt_at", "lease_expires_at"),
+        Index("ix_workflows_thread_run", "thread_id", "run_id"),
+    )
+
+
+class WorkflowEventRow(Base):
+    __tablename__ = "workflow_events"
+
+    workflow_event_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    workflow_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("workflows.workflow_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    seq: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    category: Mapped[str] = mapped_column(String(32), nullable=False, default="lifecycle", index=True)
+
+    thread_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    run_id: Mapped[str | None] = mapped_column(String(64), index=True)
+    checkpoint_ns: Mapped[str | None] = mapped_column(String(256))
+    checkpoint_id: Mapped[str | None] = mapped_column(String(128))
+    run_event_seq: Mapped[int | None] = mapped_column(Integer)
+    idempotency_key: Mapped[str | None] = mapped_column(String(256))
+    source_event_ref: Mapped[str | None] = mapped_column(Text)
+
+    content_json: Mapped[dict | list | str | int | float | bool | None] = mapped_column(JSON)
+    metadata_json: Mapped[dict] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), index=True)
+
+    __table_args__ = (
+        UniqueConstraint("workflow_id", "seq", name="uq_workflow_events_workflow_seq"),
+        Index("ix_workflow_events_workflow_created", "workflow_id", "created_at"),
+        Index("ix_workflow_events_thread_run_seq", "thread_id", "run_id", "run_event_seq"),
+    )

--- a/backend/packages/harness/deerflow/persistence/workflow/sql.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/sql.py
@@ -1,0 +1,389 @@
+"""SQLAlchemy-backed workflow store implementation."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from deerflow.persistence.workflow.model import WorkflowEventRow, WorkflowRow
+from deerflow.runtime.workflows.store.base import WorkflowStore
+from deerflow.utils.time import coerce_iso
+
+
+class WorkflowRepository(WorkflowStore):
+    """SQL-backed durable workflow envelope repository."""
+
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._sf = session_factory
+
+    @staticmethod
+    def _safe_json(obj: Any) -> Any:
+        if obj is None:
+            return None
+        if isinstance(obj, (str, int, float, bool)):
+            return obj
+        if isinstance(obj, dict):
+            return {k: WorkflowRepository._safe_json(v) for k, v in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [WorkflowRepository._safe_json(v) for v in obj]
+        if hasattr(obj, "model_dump"):
+            try:
+                return obj.model_dump()
+            except Exception:
+                pass
+        try:
+            json.dumps(obj)
+            return obj
+        except (TypeError, ValueError):
+            return str(obj)
+
+    @staticmethod
+    def _row_to_dict(row: WorkflowRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["metadata"] = d.pop("metadata_json", {})
+        for key in ("created_at", "updated_at", "next_attempt_at", "lease_expires_at"):
+            val = d.get(key)
+            if isinstance(val, datetime):
+                d[key] = coerce_iso(val)
+        return d
+
+    @staticmethod
+    def _event_row_to_dict(row: WorkflowEventRow) -> dict[str, Any]:
+        d = row.to_dict()
+        d["content"] = d.pop("content_json", None)
+        d["metadata"] = d.pop("metadata_json", {})
+        val = d.get("created_at")
+        if isinstance(val, datetime):
+            d["created_at"] = coerce_iso(val)
+        return d
+
+    @staticmethod
+    def _coerce_datetime(value: str | datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value
+        return datetime.fromisoformat(value)
+
+    @staticmethod
+    def _normalize_source(source: str | None) -> str | None:
+        if source is None:
+            return None
+        normalized = str(source).strip()
+        return normalized[:128] if normalized else None
+
+    @staticmethod
+    def _normalize_idempotency_key(idempotency_key: str | None) -> str | None:
+        if idempotency_key is None:
+            return None
+        normalized = str(idempotency_key).strip()
+        return normalized[:256] if normalized else None
+
+    async def _find_by_idempotency(
+        self,
+        *,
+        source_type: str,
+        source: str | None,
+        idempotency_key: str | None,
+    ) -> dict[str, Any] | None:
+        if not idempotency_key:
+            return None
+        stmt = select(WorkflowRow).where(
+            WorkflowRow.source_type == source_type,
+            WorkflowRow.source == source,
+            WorkflowRow.idempotency_key == idempotency_key,
+        )
+        async with self._sf() as session:
+            row = (await session.execute(stmt)).scalar_one_or_none()
+            return self._row_to_dict(row) if row is not None else None
+
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        source = self._normalize_source(source)
+        idempotency_key = self._normalize_idempotency_key(idempotency_key)
+        if idempotency_key and source is None:
+            source = ""
+        existing = await self._find_by_idempotency(
+            source_type=source_type,
+            source=source,
+            idempotency_key=idempotency_key,
+        )
+        if existing is not None:
+            return existing, False
+
+        now = datetime.now(UTC)
+        row = WorkflowRow(
+            workflow_id=workflow_id or str(uuid.uuid4()),
+            workflow_kind=workflow_kind,
+            source_type=source_type,
+            source=source,
+            idempotency_key=idempotency_key,
+            external_message_ref=external_message_ref,
+            conversation_ref=conversation_ref,
+            thread_ref=thread_ref,
+            sender_ref=sender_ref,
+            user_id=user_id,
+            thread_id=thread_id,
+            run_id=run_id,
+            checkpoint_ns=checkpoint_ns,
+            checkpoint_id=checkpoint_id,
+            status=status,
+            attempt_count=0,
+            max_attempts=max(1, int(max_attempts)),
+            metadata_json=self._safe_json(metadata) or {},
+            created_at=now,
+            updated_at=now,
+        )
+        async with self._sf() as session:
+            session.add(row)
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+                existing = await self._find_by_idempotency(
+                    source_type=source_type,
+                    source=source,
+                    idempotency_key=idempotency_key,
+                )
+                if existing is not None:
+                    return existing, False
+                raise
+            return self._row_to_dict(row), True
+
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        now = datetime.now(UTC)
+        lease_expires_at = now + timedelta(seconds=lease_seconds)
+        stmt = (
+            select(WorkflowRow)
+            .where(
+                WorkflowRow.status.in_(statuses),
+                WorkflowRow.attempt_count < WorkflowRow.max_attempts,
+                or_(WorkflowRow.next_attempt_at.is_(None), WorkflowRow.next_attempt_at <= now),
+                or_(WorkflowRow.lease_expires_at.is_(None), WorkflowRow.lease_expires_at <= now),
+            )
+            .order_by(WorkflowRow.created_at.asc())
+            .limit(1)
+            .with_for_update(skip_locked=True)
+        )
+        async with self._sf() as session:
+            async with session.begin():
+                row = (await session.execute(stmt)).scalar_one_or_none()
+                if row is None:
+                    return None
+                row.lease_owner = lease_owner
+                row.lease_expires_at = lease_expires_at
+                row.attempt_count = (row.attempt_count or 0) + 1
+                row.status = status_on_claim
+                row.updated_at = now
+            return self._row_to_dict(row)
+
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return None
+            if user_id is not None and row.user_id != user_id:
+                return None
+            return self._row_to_dict(row)
+
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {"status": status, "updated_at": datetime.now(UTC)}
+        if error is not None:
+            values["error"] = error
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {"updated_at": datetime.now(UTC)}
+        optional = {
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+        }
+        for key, value in optional.items():
+            if value is not None:
+                values[key] = value
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "next_attempt_at": self._coerce_datetime(next_attempt_at),
+            "status": status,
+            "updated_at": datetime.now(UTC),
+        }
+        if error is not None:
+            values["error"] = error
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        stmt = select(WorkflowRow)
+        if status is not None:
+            stmt = stmt.where(WorkflowRow.status == status)
+        if source_type is not None:
+            stmt = stmt.where(WorkflowRow.source_type == source_type)
+        if source is not None:
+            stmt = stmt.where(WorkflowRow.source == self._normalize_source(source))
+        if thread_id is not None:
+            stmt = stmt.where(WorkflowRow.thread_id == thread_id)
+        if run_id is not None:
+            stmt = stmt.where(WorkflowRow.run_id == run_id)
+        if user_id is not None:
+            stmt = stmt.where(WorkflowRow.user_id == user_id)
+        stmt = stmt.order_by(WorkflowRow.created_at.desc()).limit(limit)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._row_to_dict(row) for row in result.scalars()]
+
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | datetime | None = None,
+    ) -> dict[str, Any] | None:
+        async with self._sf() as session:
+            async with session.begin():
+                workflow = await session.get(WorkflowRow, workflow_id)
+                if workflow is None:
+                    return None
+                max_seq_stmt = select(func.max(WorkflowEventRow.seq)).where(WorkflowEventRow.workflow_id == workflow_id)
+                max_seq = (await session.execute(max_seq_stmt)).scalar_one()
+                row = WorkflowEventRow(
+                    workflow_event_id=workflow_event_id or str(uuid.uuid4()),
+                    workflow_id=workflow_id,
+                    seq=(max_seq or 0) + 1,
+                    event_type=event_type,
+                    category=category,
+                    thread_id=thread_id,
+                    run_id=run_id,
+                    checkpoint_ns=checkpoint_ns,
+                    checkpoint_id=checkpoint_id,
+                    run_event_seq=run_event_seq,
+                    idempotency_key=self._normalize_idempotency_key(idempotency_key),
+                    source_event_ref=source_event_ref,
+                    content_json=self._safe_json(content),
+                    metadata_json=self._safe_json(metadata) or {},
+                    created_at=self._coerce_datetime(created_at) or datetime.now(UTC),
+                )
+                session.add(row)
+            return self._event_row_to_dict(row)
+
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        stmt = select(WorkflowEventRow).where(WorkflowEventRow.workflow_id == workflow_id)
+        if event_types:
+            stmt = stmt.where(WorkflowEventRow.event_type.in_(event_types))
+        stmt = stmt.order_by(WorkflowEventRow.seq.asc()).limit(limit)
+        async with self._sf() as session:
+            result = await session.execute(stmt)
+            return [self._event_row_to_dict(row) for row in result.scalars()]

--- a/backend/packages/harness/deerflow/persistence/workflow/sql.py
+++ b/backend/packages/harness/deerflow/persistence/workflow/sql.py
@@ -299,6 +299,30 @@ class WorkflowRepository(WorkflowStore):
             await session.commit()
             return True
 
+    async def mark_orphaned(
+        self,
+        workflow_id: str,
+        *,
+        error: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        values: dict[str, Any] = {
+            "status": "orphaned",
+            "error": error,
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "updated_at": datetime.now(UTC),
+        }
+        async with self._sf() as session:
+            row = await session.get(WorkflowRow, workflow_id)
+            if row is None:
+                return False
+            if metadata:
+                values["metadata_json"] = {**(row.metadata_json or {}), **(self._safe_json(metadata) or {})}
+            await session.execute(update(WorkflowRow).where(WorkflowRow.workflow_id == workflow_id).values(**values))
+            await session.commit()
+            return True
+
     async def list(
         self,
         *,

--- a/backend/packages/harness/deerflow/runtime/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/__init__.py
@@ -10,6 +10,7 @@ from .runs import ConflictError, DisconnectMode, RunContext, RunManager, RunReco
 from .serialization import serialize, serialize_channel_values, serialize_channel_values_for_api, serialize_lc_object, serialize_messages_tuple, strip_data_url_image_blocks
 from .store import get_store, make_store, reset_store, store_context
 from .stream_bridge import END_SENTINEL, HEARTBEAT_SENTINEL, MemoryStreamBridge, StreamBridge, StreamEvent, make_stream_bridge
+from .workflows import MemoryWorkflowStore, WorkflowKind, WorkflowSourceType, WorkflowStatus, WorkflowStore
 
 __all__ = [
     # checkpointer
@@ -45,4 +46,10 @@ __all__ = [
     "StreamBridge",
     "StreamEvent",
     "make_stream_bridge",
+    # workflows
+    "MemoryWorkflowStore",
+    "WorkflowKind",
+    "WorkflowSourceType",
+    "WorkflowStatus",
+    "WorkflowStore",
 ]

--- a/backend/packages/harness/deerflow/runtime/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/__init__.py
@@ -10,7 +10,17 @@ from .runs import ConflictError, DisconnectMode, RunContext, RunManager, RunReco
 from .serialization import serialize, serialize_channel_values, serialize_channel_values_for_api, serialize_lc_object, serialize_messages_tuple, strip_data_url_image_blocks
 from .store import get_store, make_store, reset_store, store_context
 from .stream_bridge import END_SENTINEL, HEARTBEAT_SENTINEL, MemoryStreamBridge, StreamBridge, StreamEvent, make_stream_bridge
-from .workflows import MemoryWorkflowStore, WorkflowKind, WorkflowSourceType, WorkflowStatus, WorkflowStore
+from .workflows import (
+    MemoryWorkflowStore,
+    WorkflowBindingCandidate,
+    WorkflowBindingDecision,
+    WorkflowBindingStatus,
+    WorkflowKind,
+    WorkflowSourceType,
+    WorkflowStatus,
+    WorkflowStore,
+    resolve_workflow_binding,
+)
 
 __all__ = [
     # checkpointer
@@ -48,8 +58,12 @@ __all__ = [
     "make_stream_bridge",
     # workflows
     "MemoryWorkflowStore",
+    "WorkflowBindingCandidate",
+    "WorkflowBindingDecision",
+    "WorkflowBindingStatus",
     "WorkflowKind",
     "WorkflowSourceType",
     "WorkflowStatus",
     "WorkflowStore",
+    "resolve_workflow_binding",
 ]

--- a/backend/packages/harness/deerflow/runtime/workflows/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/__init__.py
@@ -1,0 +1,12 @@
+"""Durable workflow frontdoor primitives."""
+
+from deerflow.runtime.workflows.schemas import WorkflowKind, WorkflowSourceType, WorkflowStatus
+from deerflow.runtime.workflows.store import MemoryWorkflowStore, WorkflowStore
+
+__all__ = [
+    "MemoryWorkflowStore",
+    "WorkflowKind",
+    "WorkflowSourceType",
+    "WorkflowStatus",
+    "WorkflowStore",
+]

--- a/backend/packages/harness/deerflow/runtime/workflows/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/__init__.py
@@ -1,12 +1,22 @@
 """Durable workflow frontdoor primitives."""
 
+from deerflow.runtime.workflows.binding import (
+    WorkflowBindingCandidate,
+    WorkflowBindingDecision,
+    WorkflowBindingStatus,
+    resolve_workflow_binding,
+)
 from deerflow.runtime.workflows.schemas import WorkflowKind, WorkflowSourceType, WorkflowStatus
 from deerflow.runtime.workflows.store import MemoryWorkflowStore, WorkflowStore
 
 __all__ = [
     "MemoryWorkflowStore",
+    "WorkflowBindingCandidate",
+    "WorkflowBindingDecision",
+    "WorkflowBindingStatus",
     "WorkflowKind",
     "WorkflowSourceType",
     "WorkflowStatus",
     "WorkflowStore",
+    "resolve_workflow_binding",
 ]

--- a/backend/packages/harness/deerflow/runtime/workflows/binding.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/binding.py
@@ -1,0 +1,172 @@
+"""Deterministic workflow-to-runtime binding helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class WorkflowBindingStatus(StrEnum):
+    """Binding decision status for workflow intake."""
+
+    resolved = "resolved"
+    ambiguous = "ambiguous"
+    unresolved = "unresolved"
+
+
+@dataclass(frozen=True)
+class WorkflowBindingCandidate:
+    """One possible runtime binding target."""
+
+    thread_id: str | None = None
+    run_id: str | None = None
+    checkpoint_ns: str | None = None
+    checkpoint_id: str | None = None
+    reason: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> "WorkflowBindingCandidate":
+        return cls(
+            thread_id=_clean_ref(value.get("thread_id")),
+            run_id=_clean_ref(value.get("run_id")),
+            checkpoint_ns=_clean_ref(value.get("checkpoint_ns"), allow_empty=True),
+            checkpoint_id=_clean_ref(value.get("checkpoint_id")),
+            reason=_clean_ref(value.get("reason")),
+            metadata=dict(value.get("metadata") or {}),
+        )
+
+    def identity(self) -> tuple[str | None, str | None, str | None, str | None]:
+        return (self.thread_id, self.run_id, self.checkpoint_ns, self.checkpoint_id)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "thread_id": self.thread_id,
+            "run_id": self.run_id,
+            "checkpoint_ns": self.checkpoint_ns,
+            "checkpoint_id": self.checkpoint_id,
+            "reason": self.reason,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass(frozen=True)
+class WorkflowBindingDecision:
+    """Deterministic binding result persisted with workflow metadata."""
+
+    status: WorkflowBindingStatus
+    reason: str
+    thread_id: str | None = None
+    run_id: str | None = None
+    checkpoint_ns: str | None = None
+    checkpoint_id: str | None = None
+    candidates: tuple[WorkflowBindingCandidate, ...] = ()
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "reason": self.reason,
+            "thread_id": self.thread_id,
+            "run_id": self.run_id,
+            "checkpoint_ns": self.checkpoint_ns,
+            "checkpoint_id": self.checkpoint_id,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+        }
+
+
+def _clean_ref(value: Any, *, allow_empty: bool = False) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if allow_empty and text == "":
+        return ""
+    return text or None
+
+
+def _candidate_from_explicit_refs(
+    *,
+    explicit_thread_id: str | None = None,
+    explicit_run_id: str | None = None,
+    explicit_checkpoint_ns: str | None = None,
+    explicit_checkpoint_id: str | None = None,
+) -> WorkflowBindingCandidate | None:
+    candidate = WorkflowBindingCandidate(
+        thread_id=_clean_ref(explicit_thread_id),
+        run_id=_clean_ref(explicit_run_id),
+        checkpoint_ns=_clean_ref(explicit_checkpoint_ns, allow_empty=True),
+        checkpoint_id=_clean_ref(explicit_checkpoint_id),
+        reason="explicit_reference",
+    )
+    return candidate if any(candidate.identity()) else None
+
+
+def _dedupe_candidates(candidates: list[WorkflowBindingCandidate]) -> tuple[WorkflowBindingCandidate, ...]:
+    seen: set[tuple[str | None, str | None, str | None, str | None]] = set()
+    deduped: list[WorkflowBindingCandidate] = []
+    for candidate in candidates:
+        identity = candidate.identity()
+        if not any(identity) or identity in seen:
+            continue
+        seen.add(identity)
+        deduped.append(candidate)
+    return tuple(deduped)
+
+
+def resolve_workflow_binding(
+    *,
+    explicit_thread_id: str | None = None,
+    explicit_run_id: str | None = None,
+    explicit_checkpoint_ns: str | None = None,
+    explicit_checkpoint_id: str | None = None,
+    candidate_bindings: list[dict[str, Any] | WorkflowBindingCandidate] | None = None,
+) -> WorkflowBindingDecision:
+    """Resolve a workflow runtime binding without guessing.
+
+    Explicit references win because they came from the API route, user action,
+    or adapter command. Without explicit refs, exactly one candidate is
+    deterministic. Multiple distinct candidates are persisted as ambiguity for
+    a human or agent to resolve later.
+    """
+    explicit = _candidate_from_explicit_refs(
+        explicit_thread_id=explicit_thread_id,
+        explicit_run_id=explicit_run_id,
+        explicit_checkpoint_ns=explicit_checkpoint_ns,
+        explicit_checkpoint_id=explicit_checkpoint_id,
+    )
+    if explicit is not None:
+        return WorkflowBindingDecision(
+            status=WorkflowBindingStatus.resolved,
+            reason="explicit_reference",
+            thread_id=explicit.thread_id,
+            run_id=explicit.run_id,
+            checkpoint_ns=explicit.checkpoint_ns,
+            checkpoint_id=explicit.checkpoint_id,
+            candidates=(explicit,),
+        )
+
+    normalized_candidates: list[WorkflowBindingCandidate] = []
+    for item in candidate_bindings or []:
+        if isinstance(item, WorkflowBindingCandidate):
+            normalized_candidates.append(item)
+        else:
+            normalized_candidates.append(WorkflowBindingCandidate.from_mapping(item))
+    candidates = _dedupe_candidates(normalized_candidates)
+    if not candidates:
+        return WorkflowBindingDecision(status=WorkflowBindingStatus.unresolved, reason="no_candidate")
+    if len(candidates) == 1:
+        candidate = candidates[0]
+        return WorkflowBindingDecision(
+            status=WorkflowBindingStatus.resolved,
+            reason=candidate.reason or "single_candidate",
+            thread_id=candidate.thread_id,
+            run_id=candidate.run_id,
+            checkpoint_ns=candidate.checkpoint_ns,
+            checkpoint_id=candidate.checkpoint_id,
+            candidates=candidates,
+        )
+    return WorkflowBindingDecision(
+        status=WorkflowBindingStatus.ambiguous,
+        reason="multiple_candidates",
+        candidates=candidates,
+    )

--- a/backend/packages/harness/deerflow/runtime/workflows/schemas.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/schemas.py
@@ -1,0 +1,39 @@
+"""Workflow frontdoor schema enums."""
+
+from enum import StrEnum
+
+
+class WorkflowKind(StrEnum):
+    """Generic workflow kinds accepted by the frontdoor."""
+
+    message = "message"
+    command = "command"
+    resume = "resume"
+    handoff = "handoff"
+    other = "other"
+
+
+class WorkflowSourceType(StrEnum):
+    """Source category for a workflow intake envelope."""
+
+    api = "api"
+    dashboard = "dashboard"
+    channel = "channel"
+    agent_session = "agent_session"
+    other = "other"
+
+
+class WorkflowStatus(StrEnum):
+    """Lifecycle status for a workflow envelope."""
+
+    received = "received"
+    bound = "bound"
+    claimed = "claimed"
+    run_created = "run_created"
+    running = "running"
+    waiting = "waiting"
+    succeeded = "succeeded"
+    failed = "failed"
+    cancelled = "cancelled"
+    orphaned = "orphaned"
+    ignored = "ignored"

--- a/backend/packages/harness/deerflow/runtime/workflows/store/__init__.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/__init__.py
@@ -1,0 +1,6 @@
+"""Workflow store implementations."""
+
+from deerflow.runtime.workflows.store.base import WorkflowStore
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+__all__ = ["MemoryWorkflowStore", "WorkflowStore"]

--- a/backend/packages/harness/deerflow/runtime/workflows/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/base.py
@@ -1,0 +1,144 @@
+"""Abstract interface for workflow frontdoor storage."""
+
+from __future__ import annotations
+
+import abc
+from typing import Any
+
+
+class WorkflowStore(abc.ABC):
+    """Durable workflow envelope storage interface."""
+
+    @abc.abstractmethod
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        """Create a workflow or return the existing idempotency match.
+
+        Returns ``(row, created)``.
+        """
+
+    @abc.abstractmethod
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        """Lease the next eligible workflow for a worker.
+
+        Implementations should only claim rows whose existing lease is absent or
+        expired and whose ``next_attempt_at`` is due. Returns the claimed row or
+        ``None`` when no workflow is eligible.
+        """
+
+    @abc.abstractmethod
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        pass
+
+    @abc.abstractmethod
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        pass
+
+    @abc.abstractmethod
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Clear an active lease and make a workflow eligible for retry."""
+        pass
+
+    @abc.abstractmethod
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Append a durable workflow event.
+
+        Returns the event row, or ``None`` when the workflow does not exist.
+        """
+        pass
+
+    @abc.abstractmethod
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        pass
+
+    @abc.abstractmethod
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        pass

--- a/backend/packages/harness/deerflow/runtime/workflows/store/base.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/base.py
@@ -95,6 +95,17 @@ class WorkflowStore(abc.ABC):
         pass
 
     @abc.abstractmethod
+    async def mark_orphaned(
+        self,
+        workflow_id: str,
+        *,
+        error: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        """Mark a workflow as orphaned and clear active worker ownership."""
+        pass
+
+    @abc.abstractmethod
     async def append_event(
         self,
         workflow_id: str,

--- a/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
@@ -200,6 +200,25 @@ class MemoryWorkflowStore(WorkflowStore):
         row["updated_at"] = self._now()
         return True
 
+    async def mark_orphaned(
+        self,
+        workflow_id: str,
+        *,
+        error: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        row["status"] = "orphaned"
+        row["error"] = error
+        row["lease_owner"] = None
+        row["lease_expires_at"] = None
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
     async def append_event(
         self,
         workflow_id: str,

--- a/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
+++ b/backend/packages/harness/deerflow/runtime/workflows/store/memory.py
@@ -1,0 +1,282 @@
+"""In-memory workflow store."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from deerflow.runtime.workflows.store.base import WorkflowStore
+
+
+class MemoryWorkflowStore(WorkflowStore):
+    """In-memory WorkflowStore for development and tests."""
+
+    def __init__(self) -> None:
+        self._workflows: dict[str, dict[str, Any]] = {}
+        self._idempotency: dict[tuple[str, str, str], str] = {}
+        self._events: dict[str, list[dict[str, Any]]] = {}
+
+    @staticmethod
+    def _now() -> str:
+        return datetime.now(UTC).isoformat()
+
+    @staticmethod
+    def _idempotency_tuple(source_type: str, source: str | None, idempotency_key: str | None) -> tuple[str, str, str] | None:
+        if not idempotency_key:
+            return None
+        return (source_type, source or "", idempotency_key)
+
+    async def create_or_get(
+        self,
+        *,
+        workflow_kind: str = "message",
+        source_type: str = "api",
+        source: str | None = None,
+        idempotency_key: str | None = None,
+        external_message_ref: str | None = None,
+        conversation_ref: str | None = None,
+        thread_ref: str | None = None,
+        sender_ref: str | None = None,
+        user_id: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str = "received",
+        max_attempts: int = 1,
+        metadata: dict[str, Any] | None = None,
+        workflow_id: str | None = None,
+    ) -> tuple[dict[str, Any], bool]:
+        idem = self._idempotency_tuple(source_type, source, idempotency_key)
+        if idempotency_key and source is None:
+            source = ""
+        if idem is not None:
+            existing_id = self._idempotency.get(idem)
+            if existing_id is not None:
+                return dict(self._workflows[existing_id]), False
+
+        now = self._now()
+        workflow_id = workflow_id or str(uuid.uuid4())
+        row = {
+            "workflow_id": workflow_id,
+            "workflow_kind": workflow_kind,
+            "source_type": source_type,
+            "source": source,
+            "idempotency_key": idempotency_key,
+            "external_message_ref": external_message_ref,
+            "conversation_ref": conversation_ref,
+            "thread_ref": thread_ref,
+            "sender_ref": sender_ref,
+            "user_id": user_id,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+            "attempt_count": 0,
+            "max_attempts": max_attempts,
+            "next_attempt_at": None,
+            "lease_owner": None,
+            "lease_expires_at": None,
+            "error": None,
+            "metadata": metadata or {},
+            "created_at": now,
+            "updated_at": now,
+        }
+        self._workflows[workflow_id] = row
+        if idem is not None:
+            self._idempotency[idem] = workflow_id
+        self._events.setdefault(workflow_id, [])
+        return dict(row), True
+
+    async def claim_next(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        statuses: tuple[str, ...] = ("received", "bound"),
+        status_on_claim: str = "claimed",
+    ) -> dict[str, Any] | None:
+        now_dt = datetime.now(UTC)
+        now = now_dt.isoformat()
+        lease_expires_at = (now_dt + timedelta(seconds=lease_seconds)).isoformat()
+        candidates = sorted(self._workflows.values(), key=lambda row: row["created_at"])
+        for row in candidates:
+            if row.get("status") not in statuses:
+                continue
+            if int(row.get("attempt_count") or 0) >= int(row.get("max_attempts") or 1):
+                continue
+            next_attempt_at = row.get("next_attempt_at")
+            if next_attempt_at and next_attempt_at > now:
+                continue
+            lease_expires = row.get("lease_expires_at")
+            if row.get("lease_owner") and lease_expires and lease_expires > now:
+                continue
+            row["lease_owner"] = lease_owner
+            row["lease_expires_at"] = lease_expires_at
+            row["attempt_count"] = int(row.get("attempt_count") or 0) + 1
+            row["status"] = status_on_claim
+            row["updated_at"] = now
+            return dict(row)
+        return None
+
+    async def get(self, workflow_id: str, *, user_id: str | None = None) -> dict[str, Any] | None:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return None
+        if user_id is not None and row.get("user_id") != user_id:
+            return None
+        return dict(row)
+
+    async def update_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        row["status"] = status
+        if error is not None:
+            row["error"] = error
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def bind_runtime(
+        self,
+        workflow_id: str,
+        *,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        status: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        updates = {
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "status": status,
+        }
+        for key, value in updates.items():
+            if value is not None:
+                row[key] = value
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def release_for_retry(
+        self,
+        workflow_id: str,
+        *,
+        next_attempt_at: str | None = None,
+        status: str = "received",
+        error: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> bool:
+        row = self._workflows.get(workflow_id)
+        if row is None:
+            return False
+        row["lease_owner"] = None
+        row["lease_expires_at"] = None
+        row["next_attempt_at"] = next_attempt_at
+        row["status"] = status
+        if error is not None:
+            row["error"] = error
+        if metadata:
+            row["metadata"] = {**(row.get("metadata") or {}), **metadata}
+        row["updated_at"] = self._now()
+        return True
+
+    async def append_event(
+        self,
+        workflow_id: str,
+        *,
+        event_type: str,
+        category: str = "lifecycle",
+        content: Any | None = None,
+        metadata: dict[str, Any] | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        checkpoint_ns: str | None = None,
+        checkpoint_id: str | None = None,
+        run_event_seq: int | None = None,
+        idempotency_key: str | None = None,
+        source_event_ref: str | None = None,
+        workflow_event_id: str | None = None,
+        created_at: str | None = None,
+    ) -> dict[str, Any] | None:
+        if workflow_id not in self._workflows:
+            return None
+        events = self._events.setdefault(workflow_id, [])
+        row = {
+            "workflow_event_id": workflow_event_id or str(uuid.uuid4()),
+            "workflow_id": workflow_id,
+            "seq": len(events) + 1,
+            "event_type": event_type,
+            "category": category,
+            "thread_id": thread_id,
+            "run_id": run_id,
+            "checkpoint_ns": checkpoint_ns,
+            "checkpoint_id": checkpoint_id,
+            "run_event_seq": run_event_seq,
+            "idempotency_key": idempotency_key,
+            "source_event_ref": source_event_ref,
+            "content": content,
+            "metadata": metadata or {},
+            "created_at": created_at or self._now(),
+        }
+        events.append(row)
+        return dict(row)
+
+    async def list_events(
+        self,
+        workflow_id: str,
+        *,
+        event_types: list[str] | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        events = list(self._events.get(workflow_id, []))
+        if event_types is not None:
+            wanted = set(event_types)
+            events = [event for event in events if event["event_type"] in wanted]
+        return [dict(event) for event in events[:limit]]
+
+    async def list(
+        self,
+        *,
+        status: str | None = None,
+        source_type: str | None = None,
+        source: str | None = None,
+        thread_id: str | None = None,
+        run_id: str | None = None,
+        user_id: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        rows = list(self._workflows.values())
+        if status is not None:
+            rows = [row for row in rows if row.get("status") == status]
+        if source_type is not None:
+            rows = [row for row in rows if row.get("source_type") == source_type]
+        if source is not None:
+            rows = [row for row in rows if row.get("source") == source]
+        if thread_id is not None:
+            rows = [row for row in rows if row.get("thread_id") == thread_id]
+        if run_id is not None:
+            rows = [row for row in rows if row.get("run_id") == run_id]
+        if user_id is not None:
+            rows = [row for row in rows if row.get("user_id") == user_id]
+        rows.sort(key=lambda row: row["created_at"], reverse=True)
+        return [dict(row) for row in rows[:limit]]

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -1288,6 +1288,48 @@ class TestChannelManager:
 
         _run(go())
 
+    def test_handle_chat_forwards_workflow_intake_headers(self):
+        from app.channels.manager import ChannelManager
+
+        async def go():
+            bus = MessageBus()
+            store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+            manager = ChannelManager(bus=bus, store=store)
+            outbound_received = []
+
+            async def capture_outbound(msg):
+                outbound_received.append(msg)
+
+            bus.subscribe_outbound(capture_outbound)
+
+            mock_client = _make_mock_langgraph_client()
+            manager._client = mock_client
+
+            await manager.start()
+
+            inbound = InboundMessage(
+                channel_name="slack",
+                chat_id="C123",
+                user_id="U123",
+                text="hi",
+                topic_id="1710000000.000100",
+                metadata={"team_id": "T123", "message_id": "m-1"},
+            )
+            await bus.publish_inbound(inbound)
+            await _wait_for(lambda: len(outbound_received) >= 1)
+            await manager.stop()
+
+            headers = mock_client.runs.wait.call_args.kwargs["headers"]
+            assert headers["X-DeerFlow-Workflow-Source-Type"] == "channel"
+            assert headers["X-DeerFlow-Workflow-Source"] == "slack"
+            assert headers["X-DeerFlow-Workflow-Conversation-Ref"] == "C123"
+            assert headers["X-DeerFlow-Workflow-Thread-Ref"] == "1710000000.000100"
+            assert headers["X-DeerFlow-Workflow-Sender-Ref"] == "U123"
+            assert headers["X-External-Message-Ref"] == "slack:T123:C123:m-1"
+            assert headers["Idempotency-Key"] == "channel:slack:T123:C123:m-1"
+
+        _run(go())
+
     def test_clarification_follow_up_preserves_history(self, monkeypatch):
         """Conversation should continue after ask_clarification instead of resetting history."""
         from app.channels.manager import ChannelManager

--- a/backend/tests/test_gateway_run_recovery.py
+++ b/backend/tests/test_gateway_run_recovery.py
@@ -57,6 +57,38 @@ class _FakeThreadStore:
         self.status_updates.append((thread_id, status, user_id))
 
 
+class _FakeWorkflowStore:
+    def __init__(self, rows: list[dict]) -> None:
+        self.rows = rows
+        self.mark_calls: list[dict] = []
+        self.events: list[dict] = []
+
+    async def list(self, *, thread_id=None, run_id=None, limit=100, **_kwargs):
+        return [
+            row
+            for row in self.rows[:limit]
+            if (thread_id is None or row.get("thread_id") == thread_id)
+            and (run_id is None or row.get("run_id") == run_id)
+        ]
+
+    async def mark_orphaned(self, workflow_id: str, *, error: str, metadata=None):
+        self.mark_calls.append({"workflow_id": workflow_id, "error": error, "metadata": metadata})
+        for row in self.rows:
+            if row.get("workflow_id") == workflow_id:
+                row["status"] = "orphaned"
+                row["error"] = error
+                row["lease_owner"] = None
+                row["lease_expires_at"] = None
+                row["metadata"] = {**(row.get("metadata") or {}), **(metadata or {})}
+                return True
+        return False
+
+    async def append_event(self, workflow_id: str, **kwargs):
+        event = {"workflow_id": workflow_id, **kwargs}
+        self.events.append(event)
+        return event
+
+
 @pytest.mark.anyio
 async def test_sqlite_runtime_reconciles_orphaned_runs_on_startup(monkeypatch):
     """SQLite startup should recover stale active runs before serving requests."""
@@ -131,3 +163,49 @@ async def test_sqlite_runtime_does_not_mark_thread_error_when_newer_run_is_succe
     assert len(_FakeRunManager.instances) == 1
     assert _FakeRunManager.instances[0].list_by_thread_calls == [{"thread_id": "thread-1", "user_id": None, "limit": 1}]
     assert thread_store.status_updates == []
+
+
+@pytest.mark.anyio
+async def test_recovered_run_marks_active_workflows_orphaned():
+    workflow_store = _FakeWorkflowStore(
+        [
+            {
+                "workflow_id": "wf-running",
+                "thread_id": "thread-1",
+                "run_id": "run-1",
+                "status": "running",
+                "lease_owner": "worker-old",
+                "lease_expires_at": "2099-01-01T00:00:00+00:00",
+            },
+            {
+                "workflow_id": "wf-terminal",
+                "thread_id": "thread-1",
+                "run_id": "run-1",
+                "status": "succeeded",
+            },
+        ]
+    )
+    recovered_runs = [SimpleNamespace(run_id="run-1", thread_id="thread-1")]
+
+    marked = await gateway_deps._mark_recovered_workflows_orphaned(
+        workflow_store,
+        recovered_runs,
+        error="gateway restarted",
+    )
+
+    assert marked == 1
+    assert workflow_store.mark_calls == [
+        {
+            "workflow_id": "wf-running",
+            "error": "gateway restarted",
+            "metadata": {
+                "recovery": "gateway_restart_orphan",
+                "run_id": "run-1",
+                "run_status": "error",
+            },
+        }
+    ]
+    assert workflow_store.rows[0]["status"] == "orphaned"
+    assert workflow_store.rows[0]["lease_owner"] is None
+    assert [event["event_type"] for event in workflow_store.events] == ["workflow.orphaned"]
+    assert workflow_store.events[0]["category"] == "recovery"

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -623,6 +623,7 @@ async def _capture_start_run_graph_input(body):
     from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
     from deerflow.runtime import RunManager
     from deerflow.runtime.runs.store.memory import MemoryRunStore
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
     run_manager = RunManager(store=MemoryRunStore())
     state = SimpleNamespace(
@@ -633,6 +634,7 @@ async def _capture_start_run_graph_input(body):
         run_event_store=SimpleNamespace(),
         run_events_config=None,
         thread_store=MemoryThreadMetaStore(InMemoryStore()),
+        workflow_store=MemoryWorkflowStore(),
     )
     request = SimpleNamespace(
         headers={},
@@ -709,6 +711,7 @@ def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
     from deerflow.runtime import RunManager
     from deerflow.runtime.runs.store.memory import MemoryRunStore
     from deerflow.runtime.user_context import get_effective_user_id
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
     async def _scenario():
         run_store = MemoryRunStore()
@@ -723,6 +726,7 @@ def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
             run_event_store=SimpleNamespace(),
             run_events_config=None,
             thread_store=thread_store,
+            workflow_store=MemoryWorkflowStore(),
         )
         request = SimpleNamespace(
             headers={INTERNAL_OWNER_USER_ID_HEADER_NAME: "owner-1"},

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -859,6 +859,89 @@ def test_start_run_uses_workflow_intake_headers(_stub_app_config):
     assert "workflow.bound" in [event["event_type"] for event in events]
 
 
+def test_interrupted_run_projects_waiting_workflow_status():
+    from app.gateway.services import _workflow_status_for_run_status
+    from deerflow.runtime import RunStatus
+
+    assert _workflow_status_for_run_status(RunStatus.interrupted) == ("waiting", "workflow.waiting")
+
+
+def test_start_run_records_resume_ref_without_payload(_stub_app_config):
+    import asyncio
+    import json
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.store.memory import InMemoryStore
+
+    from app.gateway.services import start_run
+    from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
+    from deerflow.runtime import RunManager
+    from deerflow.runtime.runs.store.memory import MemoryRunStore
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+    async def _scenario():
+        workflow_store = MemoryWorkflowStore()
+        run_manager = RunManager(store=MemoryRunStore())
+        state = SimpleNamespace(
+            stream_bridge=SimpleNamespace(),
+            run_manager=run_manager,
+            checkpointer=InMemorySaver(),
+            store=InMemoryStore(),
+            run_event_store=SimpleNamespace(),
+            run_events_config=None,
+            thread_store=MemoryThreadMetaStore(InMemoryStore()),
+            workflow_store=workflow_store,
+        )
+        request = SimpleNamespace(
+            headers={},
+            state=SimpleNamespace(),
+            app=SimpleNamespace(state=state),
+            url=SimpleNamespace(path="/api/threads/thread-resume/runs/wait"),
+            method="POST",
+        )
+        body = SimpleNamespace(
+            assistant_id="lead_agent",
+            input=None,
+            command={"resume": {"answer": "approved"}},
+            metadata={},
+            config=None,
+            context=None,
+            on_disconnect="cancel",
+            multitask_strategy="reject",
+            stream_mode=None,
+            stream_subgraphs=False,
+            interrupt_before=None,
+            interrupt_after=None,
+        )
+
+        async def fake_run_agent(*args, **kwargs):
+            return None
+
+        with (
+            patch("app.gateway.services.resolve_agent_factory", return_value=object()),
+            patch("app.gateway.services.run_agent", side_effect=fake_run_agent),
+        ):
+            record = await start_run(body, "thread-resume", request)
+            await record.task
+
+        rows = await workflow_store.list(run_id=record.run_id)
+        events = await workflow_store.list_events(rows[0]["workflow_id"])
+        return rows[0], events
+
+    workflow, events = asyncio.run(_scenario())
+
+    assert workflow["workflow_kind"] == "resume"
+    assert workflow["metadata"]["resume"] == {
+        "type": "langgraph_command_resume",
+        "has_payload": True,
+        "payload_type": "dict",
+    }
+    assert "workflow.resume_requested" in [event["event_type"] for event in events]
+    assert "approved" not in json.dumps({"workflow": workflow, "events": events}, default=str)
+
+
 # ---------------------------------------------------------------------------
 # build_run_config — context / configurable precedence (LangGraph >= 0.6.0)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -776,6 +776,89 @@ def test_start_run_uses_internal_owner_header_for_persistence(_stub_app_config):
     assert task_context["user_id"] == "owner-1"
 
 
+def test_start_run_uses_workflow_intake_headers(_stub_app_config):
+    import asyncio
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.store.memory import InMemoryStore
+
+    from app.gateway.services import start_run
+    from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
+    from deerflow.runtime import RunManager
+    from deerflow.runtime.runs.store.memory import MemoryRunStore
+    from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+    async def _scenario():
+        workflow_store = MemoryWorkflowStore()
+        run_manager = RunManager(store=MemoryRunStore())
+        state = SimpleNamespace(
+            stream_bridge=SimpleNamespace(),
+            run_manager=run_manager,
+            checkpointer=InMemorySaver(),
+            store=InMemoryStore(),
+            run_event_store=SimpleNamespace(),
+            run_events_config=None,
+            thread_store=MemoryThreadMetaStore(InMemoryStore()),
+            workflow_store=workflow_store,
+        )
+        request = SimpleNamespace(
+            headers={
+                "Idempotency-Key": "channel:slack:T123:C123:m-1",
+                "X-External-Message-Ref": "slack:T123:C123:m-1",
+                "X-DeerFlow-Workflow-Source-Type": "channel",
+                "X-DeerFlow-Workflow-Source": "slack",
+                "X-DeerFlow-Workflow-Conversation-Ref": "C123",
+                "X-DeerFlow-Workflow-Thread-Ref": "1710000000.000100",
+                "X-DeerFlow-Workflow-Sender-Ref": "U123",
+            },
+            state=SimpleNamespace(),
+            app=SimpleNamespace(state=state),
+            url=SimpleNamespace(path="/api/threads/thread-channel/runs/wait"),
+            method="POST",
+        )
+        body = SimpleNamespace(
+            assistant_id="lead_agent",
+            input={"messages": [{"role": "human", "content": "hi"}]},
+            metadata={},
+            config=None,
+            context=None,
+            on_disconnect="cancel",
+            multitask_strategy="reject",
+            stream_mode=None,
+            stream_subgraphs=False,
+            interrupt_before=None,
+            interrupt_after=None,
+        )
+
+        async def fake_run_agent(*args, **kwargs):
+            return None
+
+        with (
+            patch("app.gateway.services.resolve_agent_factory", return_value=object()),
+            patch("app.gateway.services.run_agent", side_effect=fake_run_agent),
+        ):
+            record = await start_run(body, "thread-channel", request)
+            await record.task
+
+        rows = await workflow_store.list(run_id=record.run_id)
+        events = await workflow_store.list_events(rows[0]["workflow_id"])
+        return rows[0], events
+
+    workflow, events = asyncio.run(_scenario())
+
+    assert workflow["source_type"] == "channel"
+    assert workflow["source"] == "slack"
+    assert workflow["idempotency_key"] == "channel:slack:T123:C123:m-1"
+    assert workflow["external_message_ref"] == "slack:T123:C123:m-1"
+    assert workflow["conversation_ref"] == "C123"
+    assert workflow["thread_ref"] == "1710000000.000100"
+    assert workflow["sender_ref"] == "U123"
+    assert workflow["metadata"]["binding"]["status"] == "resolved"
+    assert "workflow.bound" in [event["event_type"] for event in events]
+
+
 # ---------------------------------------------------------------------------
 # build_run_config — context / configurable precedence (LangGraph >= 0.6.0)
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_persistence_bootstrap.py
+++ b/backend/tests/test_persistence_bootstrap.py
@@ -47,7 +47,7 @@ from deerflow.persistence.migrations._helpers import _normalize_default
 asyncio_test = pytest.mark.asyncio
 
 
-HEAD = "0002_runs_token_usage"
+HEAD = _get_head_revision()
 BASELINE = "0001_baseline"
 
 

--- a/backend/tests/test_persistence_bootstrap_concurrency.py
+++ b/backend/tests/test_persistence_bootstrap_concurrency.py
@@ -23,12 +23,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 import deerflow.persistence.models  # noqa: F401
 from deerflow.persistence import bootstrap as bootstrap_mod
-from deerflow.persistence.bootstrap import bootstrap_schema
+from deerflow.persistence.bootstrap import _get_head_revision, bootstrap_schema
 
 pytestmark = pytest.mark.asyncio
 
 
-HEAD = "0002_runs_token_usage"
+HEAD = _get_head_revision()
 
 
 def _url(tmp_path: Path) -> str:

--- a/backend/tests/test_persistence_bootstrap_regression.py
+++ b/backend/tests/test_persistence_bootstrap_regression.py
@@ -27,10 +27,12 @@ import sqlalchemy as sa
 
 import deerflow.persistence.models  # noqa: F401  -- registers ORM models
 from deerflow.persistence.base import Base
+from deerflow.persistence.bootstrap import _get_head_revision
 from deerflow.persistence.engine import close_engine, get_session_factory, init_engine
 from deerflow.persistence.run import RunRepository
 
 pytestmark = pytest.mark.asyncio
+HEAD = _get_head_revision()
 
 
 def _seed_pre_3658_database(db_path: Path) -> None:
@@ -76,7 +78,7 @@ async def test_legacy_database_recovers_token_usage_column(tmp_path: Path) -> No
             cols = {row[1] for row in raw.execute("PRAGMA table_info(runs)").fetchall()}
             assert "token_usage_by_model" in cols
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0002_runs_token_usage"
+            assert version_row[0] == HEAD
 
         # And the read path that originally 500'd must now succeed.
         sf = get_session_factory()
@@ -116,6 +118,6 @@ async def test_legacy_database_with_manual_alter_still_bootstraps(tmp_path: Path
             # No duplicate column -- list, not set, to catch dupes.
             assert cols.count("token_usage_by_model") == 1
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0002_runs_token_usage"
+            assert version_row[0] == HEAD
     finally:
         await close_engine()

--- a/backend/tests/test_stateless_runs_owner_isolation.py
+++ b/backend/tests/test_stateless_runs_owner_isolation.py
@@ -38,6 +38,7 @@ from app.gateway.routers import runs
 from deerflow.config.app_config import AppConfig, reset_app_config, set_app_config
 from deerflow.persistence.thread_meta.memory import MemoryThreadMetaStore
 from deerflow.runtime import ConflictError
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
 
 USER_A = User(email="owner-a@example.com", password_hash="x", system_role="user", id=uuid4())
 USER_B = User(email="intruder-b@example.com", password_hash="x", system_role="user", id=uuid4())
@@ -84,6 +85,7 @@ def _client(user):
     app.state.store = MagicMock()
     app.state.run_events_config = None
     app.state.run_event_store = MagicMock()
+    app.state.workflow_store = MemoryWorkflowStore()
     run_manager = MagicMock()
     run_manager.create_or_reject = AsyncMock(side_effect=ConflictError("sentinel: owner check passed"))
     app.state.run_manager = run_manager

--- a/backend/tests/test_workflow_binding.py
+++ b/backend/tests/test_workflow_binding.py
@@ -1,0 +1,64 @@
+"""Tests for deterministic workflow binding resolution."""
+
+from deerflow.runtime.workflows import WorkflowBindingCandidate, WorkflowBindingStatus, resolve_workflow_binding
+
+
+def test_explicit_refs_resolve_without_candidates():
+    decision = resolve_workflow_binding(
+        explicit_thread_id="thread-1",
+        explicit_checkpoint_ns="",
+        explicit_checkpoint_id="ckpt-1",
+    )
+
+    assert decision.status == WorkflowBindingStatus.resolved
+    assert decision.reason == "explicit_reference"
+    assert decision.thread_id == "thread-1"
+    assert decision.checkpoint_ns == ""
+    assert decision.checkpoint_id == "ckpt-1"
+    assert decision.to_metadata()["status"] == "resolved"
+
+
+def test_single_candidate_resolves():
+    decision = resolve_workflow_binding(
+        candidate_bindings=[
+            {
+                "thread_id": "thread-1",
+                "run_id": "run-1",
+                "reason": "channel_thread_mapping",
+            }
+        ]
+    )
+
+    assert decision.status == WorkflowBindingStatus.resolved
+    assert decision.reason == "channel_thread_mapping"
+    assert decision.thread_id == "thread-1"
+    assert decision.run_id == "run-1"
+
+
+def test_duplicate_candidates_dedupe_to_resolved():
+    candidate = WorkflowBindingCandidate(thread_id="thread-1", reason="active_thread")
+    decision = resolve_workflow_binding(candidate_bindings=[candidate, candidate])
+
+    assert decision.status == WorkflowBindingStatus.resolved
+    assert len(decision.candidates) == 1
+
+
+def test_multiple_candidates_are_ambiguous():
+    decision = resolve_workflow_binding(
+        candidate_bindings=[
+            {"thread_id": "thread-1", "reason": "reply_thread"},
+            {"thread_id": "thread-2", "reason": "active_run"},
+        ]
+    )
+
+    assert decision.status == WorkflowBindingStatus.ambiguous
+    assert decision.reason == "multiple_candidates"
+    assert decision.thread_id is None
+    assert len(decision.candidates) == 2
+
+
+def test_no_candidates_unresolved():
+    decision = resolve_workflow_binding()
+
+    assert decision.status == WorkflowBindingStatus.unresolved
+    assert decision.reason == "no_candidate"

--- a/backend/tests/test_workflow_repository.py
+++ b/backend/tests/test_workflow_repository.py
@@ -101,6 +101,28 @@ async def test_memory_workflow_store_claim_and_release_for_retry():
 
 
 @pytest.mark.anyio
+async def test_memory_workflow_store_mark_orphaned_clears_lease():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(source_type="api", source="dashboard", max_attempts=2)
+
+    claimed = await store.claim_next(lease_owner="worker-1", lease_seconds=30)
+    marked = await store.mark_orphaned(
+        workflow["workflow_id"],
+        error="gateway restarted",
+        metadata={"recovery": "gateway_restart_orphan"},
+    )
+    row = await store.get(workflow["workflow_id"])
+
+    assert claimed["lease_owner"] == "worker-1"
+    assert marked is True
+    assert row["status"] == "orphaned"
+    assert row["error"] == "gateway restarted"
+    assert row["lease_owner"] is None
+    assert row["lease_expires_at"] is None
+    assert row["metadata"] == {"recovery": "gateway_restart_orphan"}
+
+
+@pytest.mark.anyio
 async def test_memory_workflow_store_appends_events_in_order():
     store = MemoryWorkflowStore()
     workflow, _ = await store.create_or_get(workflow_id="wf-memory-events", source_type="api")
@@ -275,6 +297,35 @@ class TestWorkflowRepository:
             assert claimed_again["lease_owner"] == "worker-2"
             assert claimed_again["attempt_count"] == 2
             assert should_skip is None
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_mark_orphaned_clears_lease(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(
+                workflow_id="wf-orphan",
+                source_type="api",
+                source="dashboard",
+                max_attempts=2,
+            )
+
+            claimed = await repo.claim_next(lease_owner="worker-1", lease_seconds=60)
+            marked = await repo.mark_orphaned(
+                row["workflow_id"],
+                error="gateway restarted",
+                metadata={"recovery": "gateway_restart_orphan"},
+            )
+            loaded = await repo.get(row["workflow_id"])
+
+            assert claimed["lease_owner"] == "worker-1"
+            assert marked is True
+            assert loaded["status"] == "orphaned"
+            assert loaded["error"] == "gateway restarted"
+            assert loaded["lease_owner"] is None
+            assert loaded["lease_expires_at"] is None
+            assert loaded["metadata"] == {"recovery": "gateway_restart_orphan"}
         finally:
             await _cleanup()
 

--- a/backend/tests/test_workflow_repository.py
+++ b/backend/tests/test_workflow_repository.py
@@ -1,0 +1,382 @@
+"""Tests for workflow frontdoor stores."""
+
+import pytest
+
+from deerflow.persistence.workflow import WorkflowRepository
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+
+async def _make_repo(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    return WorkflowRepository(get_session_factory())
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_create_or_get_is_idempotent():
+    store = MemoryWorkflowStore()
+
+    first, created = await store.create_or_get(
+        source_type="channel",
+        source="slack:T1",
+        idempotency_key="m-1",
+        external_message_ref="m-1",
+        metadata={"attempt": 1},
+    )
+    second, created_again = await store.create_or_get(
+        source_type="channel",
+        source="slack:T1",
+        idempotency_key="m-1",
+        external_message_ref="m-1",
+        metadata={"attempt": 2},
+    )
+
+    assert created is True
+    assert created_again is False
+    assert second["workflow_id"] == first["workflow_id"]
+    assert second["metadata"] == {"attempt": 1}
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_bind_status_and_filter():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(source_type="api", source="dashboard", user_id="alice")
+
+    bound = await store.bind_runtime(
+        workflow["workflow_id"],
+        thread_id="thread-1",
+        run_id="run-1",
+        checkpoint_ns="",
+        checkpoint_id="ckpt-1",
+        status="run_created",
+        metadata={"binding": "direct"},
+    )
+    updated = await store.update_status(workflow["workflow_id"], "running", metadata={"phase": "streaming"})
+
+    row = await store.get(workflow["workflow_id"], user_id="alice")
+    rows = await store.list(thread_id="thread-1", run_id="run-1", user_id="alice")
+
+    assert bound is True
+    assert updated is True
+    assert row["status"] == "running"
+    assert row["thread_id"] == "thread-1"
+    assert row["run_id"] == "run-1"
+    assert row["checkpoint_id"] == "ckpt-1"
+    assert row["metadata"] == {"binding": "direct", "phase": "streaming"}
+    assert [item["workflow_id"] for item in rows] == [workflow["workflow_id"]]
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_claim_and_release_for_retry():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(source_type="api", source="dashboard", max_attempts=2)
+
+    claimed = await store.claim_next(lease_owner="worker-1", lease_seconds=30)
+    released = await store.release_for_retry(
+        workflow["workflow_id"],
+        status="received",
+        error="transient",
+        metadata={"retry": True},
+    )
+    claimed_again = await store.claim_next(lease_owner="worker-2", lease_seconds=30)
+    exhausted = await store.release_for_retry(workflow["workflow_id"], status="received")
+    should_skip = await store.claim_next(lease_owner="worker-3", lease_seconds=30)
+
+    assert claimed["workflow_id"] == workflow["workflow_id"]
+    assert claimed["lease_owner"] == "worker-1"
+    assert claimed["attempt_count"] == 1
+    assert released is True
+    assert claimed_again["lease_owner"] == "worker-2"
+    assert claimed_again["attempt_count"] == 2
+    assert exhausted is True
+    assert should_skip is None
+
+
+@pytest.mark.anyio
+async def test_memory_workflow_store_appends_events_in_order():
+    store = MemoryWorkflowStore()
+    workflow, _ = await store.create_or_get(workflow_id="wf-memory-events", source_type="api")
+
+    first = await store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.received",
+        content={"source": "dashboard"},
+        metadata={"durable": True},
+    )
+    second = await store.append_event(
+        workflow["workflow_id"],
+        event_type="workflow.bound",
+        thread_id="thread-1",
+        run_id="run-1",
+        checkpoint_ns="",
+        checkpoint_id="ckpt-1",
+        run_event_seq=7,
+        idempotency_key="wf-memory-events:bound",
+    )
+    missing = await store.append_event("missing", event_type="workflow.received")
+    bound_events = await store.list_events(workflow["workflow_id"], event_types=["workflow.bound"])
+
+    assert first["seq"] == 1
+    assert first["content"] == {"source": "dashboard"}
+    assert first["metadata"] == {"durable": True}
+    assert second["seq"] == 2
+    assert second["thread_id"] == "thread-1"
+    assert second["run_id"] == "run-1"
+    assert second["checkpoint_ns"] == ""
+    assert second["run_event_seq"] == 7
+    assert second["idempotency_key"] == "wf-memory-events:bound"
+    assert missing is None
+    assert [event["event_type"] for event in bound_events] == ["workflow.bound"]
+
+
+class TestWorkflowRepository:
+    @pytest.mark.anyio
+    async def test_create_or_get_and_get(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, created = await repo.create_or_get(
+                workflow_id="wf-1",
+                workflow_kind="message",
+                source_type="api",
+                source="dashboard",
+                idempotency_key="idem-1",
+                external_message_ref="msg-1",
+                conversation_ref="conv-1",
+                sender_ref="user-1",
+                user_id="alice",
+                metadata={"source": "test"},
+            )
+
+            loaded = await repo.get("wf-1", user_id="alice")
+
+            assert created is True
+            assert loaded == row
+            assert loaded["workflow_id"] == "wf-1"
+            assert loaded["status"] == "received"
+            assert loaded["metadata"] == {"source": "test"}
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_create_or_get_is_idempotent_for_retried_writes(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            first, created = await repo.create_or_get(
+                workflow_kind="message",
+                source_type="channel",
+                source="slack:T1",
+                idempotency_key="event-1",
+                metadata={"attempt": 1},
+            )
+            second, created_again = await repo.create_or_get(
+                workflow_kind="message",
+                source_type="channel",
+                source="slack:T1",
+                idempotency_key="event-1",
+                metadata={"attempt": 2},
+            )
+
+            assert created is True
+            assert created_again is False
+            assert second["workflow_id"] == first["workflow_id"]
+            assert second["metadata"] == {"attempt": 1}
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_idempotency_without_source_uses_blank_scope(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            first, _ = await repo.create_or_get(source_type="api", idempotency_key="same")
+            second, created_again = await repo.create_or_get(source_type="api", idempotency_key="same")
+
+            assert created_again is False
+            assert second["workflow_id"] == first["workflow_id"]
+            assert second["source"] == ""
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_bind_runtime_and_update_status(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(workflow_id="wf-bind", source_type="api")
+
+            bound = await repo.bind_runtime(
+                row["workflow_id"],
+                thread_id="thread-1",
+                run_id="run-1",
+                checkpoint_ns="",
+                checkpoint_id="ckpt-1",
+                status="run_created",
+                metadata={"binding": "deterministic"},
+            )
+            updated = await repo.update_status(
+                row["workflow_id"],
+                "failed",
+                error="boom",
+                metadata={"recovery": "retryable"},
+            )
+            loaded = await repo.get(row["workflow_id"])
+
+            assert bound is True
+            assert updated is True
+            assert loaded["status"] == "failed"
+            assert loaded["error"] == "boom"
+            assert loaded["thread_id"] == "thread-1"
+            assert loaded["run_id"] == "run-1"
+            assert loaded["checkpoint_ns"] == ""
+            assert loaded["checkpoint_id"] == "ckpt-1"
+            assert loaded["metadata"] == {
+                "binding": "deterministic",
+                "recovery": "retryable",
+            }
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_claim_next_and_release_for_retry(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(
+                workflow_id="wf-claim",
+                source_type="api",
+                source="dashboard",
+                max_attempts=2,
+            )
+
+            claimed = await repo.claim_next(lease_owner="worker-1", lease_seconds=60)
+            none_while_leased = await repo.claim_next(lease_owner="worker-2", lease_seconds=60)
+            released = await repo.release_for_retry(
+                row["workflow_id"],
+                status="received",
+                error="transient",
+                metadata={"retry": True},
+            )
+            claimed_again = await repo.claim_next(lease_owner="worker-2", lease_seconds=60)
+            await repo.release_for_retry(row["workflow_id"], status="received")
+            should_skip = await repo.claim_next(lease_owner="worker-3", lease_seconds=60)
+
+            assert claimed["workflow_id"] == "wf-claim"
+            assert claimed["status"] == "claimed"
+            assert claimed["lease_owner"] == "worker-1"
+            assert claimed["lease_expires_at"] is not None
+            assert claimed["attempt_count"] == 1
+            assert none_while_leased is None
+            assert released is True
+            assert claimed_again["lease_owner"] == "worker-2"
+            assert claimed_again["attempt_count"] == 2
+            assert should_skip is None
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_list_filters(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            await repo.create_or_get(
+                workflow_id="wf-1",
+                source_type="channel",
+                source="slack",
+                user_id="alice",
+                thread_id="thread-1",
+                run_id="run-1",
+                status="running",
+            )
+            await repo.create_or_get(
+                workflow_id="wf-2",
+                source_type="channel",
+                source="discord",
+                user_id="alice",
+                thread_id="thread-2",
+                run_id="run-2",
+                status="received",
+            )
+            await repo.create_or_get(
+                workflow_id="wf-3",
+                source_type="api",
+                source="dashboard",
+                user_id="bob",
+                thread_id="thread-1",
+                run_id="run-3",
+                status="running",
+            )
+
+            rows = await repo.list(
+                status="running",
+                source_type="channel",
+                source="slack",
+                thread_id="thread-1",
+                user_id="alice",
+            )
+
+            assert [row["workflow_id"] for row in rows] == ["wf-1"]
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_missing_updates_return_false(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            assert await repo.bind_runtime("missing", thread_id="t1") is False
+            assert await repo.update_status("missing", "failed") is False
+        finally:
+            await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_append_and_list_events(self, tmp_path):
+        repo = await _make_repo(tmp_path)
+        try:
+            row, _ = await repo.create_or_get(workflow_id="wf-events", source_type="api")
+
+            first = await repo.append_event(
+                row["workflow_id"],
+                event_type="workflow.received",
+                category="lifecycle",
+                content={"source": "dashboard"},
+                metadata={"attempt": 1},
+            )
+            second = await repo.append_event(
+                row["workflow_id"],
+                event_type="workflow.bound",
+                category="runtime",
+                thread_id="thread-1",
+                run_id="run-1",
+                checkpoint_ns="",
+                checkpoint_id="ckpt-1",
+                run_event_seq=9,
+                idempotency_key="wf-events:bound",
+                source_event_ref="run_events:thread-1:run-1:1",
+            )
+            missing = await repo.append_event("missing", event_type="workflow.received")
+            all_events = await repo.list_events(row["workflow_id"])
+            bound_events = await repo.list_events(row["workflow_id"], event_types=["workflow.bound"])
+
+            assert first["seq"] == 1
+            assert first["content"] == {"source": "dashboard"}
+            assert first["metadata"] == {"attempt": 1}
+            assert second["seq"] == 2
+            assert second["category"] == "runtime"
+            assert second["thread_id"] == "thread-1"
+            assert second["run_id"] == "run-1"
+            assert second["checkpoint_ns"] == ""
+            assert second["checkpoint_id"] == "ckpt-1"
+            assert second["run_event_seq"] == 9
+            assert second["idempotency_key"] == "wf-events:bound"
+            assert second["source_event_ref"] == "run_events:thread-1:run-1:1"
+            assert missing is None
+            assert [event["event_type"] for event in all_events] == [
+                "workflow.received",
+                "workflow.bound",
+            ]
+            assert [event["event_type"] for event in bound_events] == ["workflow.bound"]
+        finally:
+            await _cleanup()

--- a/backend/tests/test_workflows_router.py
+++ b/backend/tests/test_workflows_router.py
@@ -146,3 +146,33 @@ def test_workflow_by_run_and_timeline_merges_run_events():
         "messages",
         "workflow.succeeded",
     ]
+
+
+def test_workflow_timeline_includes_waiting_recovery_hint():
+    workflow_store = MemoryWorkflowStore()
+    run_store = MemoryRunStore()
+    asyncio.run(
+        workflow_store.create_or_get(
+            workflow_id="wf-waiting",
+            source_type="api",
+            source="/api/runs/wait",
+            status="waiting",
+            thread_id="thread-1",
+            run_id="run-wait",
+        )
+    )
+    asyncio.run(run_store.put("run-wait", thread_id="thread-1", status="interrupted"))
+
+    with _make_client(workflow_store, run_store=run_store) as client:
+        timeline = client.get("/api/workflows/wf-waiting/timeline").json()
+
+    assert timeline["workflow"]["status"] == "waiting"
+    assert timeline["run"]["status"] == "interrupted"
+    assert timeline["recovery_hints"] == [
+        {
+            "code": "workflow_waiting",
+            "severity": "info",
+            "safe_auto_resume": False,
+            "message": "The bound run is interrupted and the workflow is waiting for a LangGraph resume or a new human input.",
+        }
+    ]

--- a/backend/tests/test_workflows_router.py
+++ b/backend/tests/test_workflows_router.py
@@ -1,0 +1,148 @@
+"""Tests for durable workflow read endpoints."""
+
+import asyncio
+
+from _router_auth_helpers import make_authed_test_app
+from fastapi.testclient import TestClient
+
+from app.gateway.routers import workflows
+from deerflow.runtime.events.store.memory import MemoryRunEventStore
+from deerflow.runtime.runs.store.memory import MemoryRunStore
+from deerflow.runtime.workflows.store.memory import MemoryWorkflowStore
+
+
+def _make_client(
+    store: MemoryWorkflowStore,
+    *,
+    run_event_store: MemoryRunEventStore | None = None,
+    run_store: MemoryRunStore | None = None,
+) -> TestClient:
+    app = make_authed_test_app()
+    app.state.workflow_store = store
+    app.state.run_event_store = run_event_store or MemoryRunEventStore()
+    app.state.run_store = run_store or MemoryRunStore()
+    app.include_router(workflows.router)
+    return TestClient(app)
+
+
+def test_list_and_get_workflows():
+    store = MemoryWorkflowStore()
+    asyncio.run(
+        store.create_or_get(
+            workflow_id="wf-api-1",
+            source_type="api",
+            source="dashboard",
+            status="running",
+            thread_id="thread-1",
+            run_id="run-1",
+            user_id="alice",
+        )
+    )
+    asyncio.run(
+        store.create_or_get(
+            workflow_id="wf-channel-1",
+            source_type="channel",
+            source="slack",
+            status="received",
+            user_id="bob",
+        )
+    )
+
+    with _make_client(store) as client:
+        listed = client.get("/api/workflows", params={"status": "running", "source_type": "api"}).json()
+        loaded = client.get("/api/workflows/wf-api-1").json()
+
+    assert [row["workflow_id"] for row in listed["data"]] == ["wf-api-1"]
+    assert loaded["workflow_id"] == "wf-api-1"
+    assert loaded["thread_id"] == "thread-1"
+    assert loaded["run_id"] == "run-1"
+
+
+def test_list_workflow_events_and_missing_workflow():
+    store = MemoryWorkflowStore()
+    asyncio.run(store.create_or_get(workflow_id="wf-events", source_type="api"))
+    asyncio.run(
+        store.append_event(
+            "wf-events",
+            event_type="workflow.received",
+            content={"source": "dashboard"},
+        )
+    )
+    asyncio.run(
+        store.append_event(
+            "wf-events",
+            event_type="workflow.bound",
+            thread_id="thread-1",
+            run_id="run-1",
+        )
+    )
+
+    with _make_client(store) as client:
+        events = client.get("/api/workflows/wf-events/events", params={"event_type": "workflow.bound"}).json()
+        missing = client.get("/api/workflows/missing/events")
+
+    assert events["workflow"]["workflow_id"] == "wf-events"
+    assert [event["event_type"] for event in events["events"]] == ["workflow.bound"]
+    assert events["events"][0]["seq"] == 2
+    assert missing.status_code == 404
+
+
+def test_workflow_by_run_and_timeline_merges_run_events():
+    workflow_store = MemoryWorkflowStore()
+    run_event_store = MemoryRunEventStore()
+    run_store = MemoryRunStore()
+    asyncio.run(
+        workflow_store.create_or_get(
+            workflow_id="wf-trace",
+            source_type="api",
+            source="/api/runs/wait",
+            status="succeeded",
+            thread_id="thread-1",
+            run_id="run-1",
+        )
+    )
+    asyncio.run(
+        workflow_store.append_event(
+            "wf-trace",
+            event_type="workflow.received",
+            created_at="2026-06-26T00:00:00+00:00",
+        )
+    )
+    asyncio.run(
+        workflow_store.append_event(
+            "wf-trace",
+            event_type="workflow.succeeded",
+            thread_id="thread-1",
+            run_id="run-1",
+            created_at="2026-06-26T00:00:02+00:00",
+        )
+    )
+    asyncio.run(
+        run_event_store.put(
+            thread_id="thread-1",
+            run_id="run-1",
+            event_type="messages",
+            category="message",
+            content={"role": "assistant", "content": "done"},
+            created_at="2026-06-26T00:00:01+00:00",
+        )
+    )
+    asyncio.run(run_store.put("run-1", thread_id="thread-1", status="success"))
+
+    with _make_client(workflow_store, run_event_store=run_event_store, run_store=run_store) as client:
+        by_run = client.get("/api/workflows/by-run/run-1").json()
+        timeline = client.get("/api/workflows/wf-trace/timeline").json()
+
+    assert by_run["workflow_id"] == "wf-trace"
+    assert timeline["workflow"]["workflow_id"] == "wf-trace"
+    assert timeline["run"]["run_id"] == "run-1"
+    assert [event["kind"] for event in timeline["timeline"]] == [
+        "workflow_event",
+        "run_event",
+        "workflow_event",
+    ]
+    assert [event["event_type"] for event in timeline["timeline"]] == [
+        "workflow.received",
+        "messages",
+        "workflow.succeeded",
+    ]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -15,13 +15,24 @@
 # ============================================================================
 # Bump this number when the config schema changes.
 # Run `make config-upgrade` to merge new fields into your local config.yaml.
-config_version: 15
+config_version: 16
 
 # ============================================================================
 # Logging
 # ============================================================================
 # Log level for deerflow modules (debug/info/warning/error)
 log_level: info
+
+# ============================================================================
+# Optional Modules
+# ============================================================================
+# These gates are startup-only: restart the gateway after changing them.
+# Durable workflows are the small runtime identity/trace layer.
+modules:
+  durable_workflows:
+    enabled: true
+    api_enabled: true
+    auto_envelope_for_runs: true
 
 # ============================================================================
 # Token Usage

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -22,12 +22,14 @@ import { ThreadTitle } from "@/components/workspace/thread-title";
 import { TodoList } from "@/components/workspace/todo-list";
 import { TokenUsageIndicator } from "@/components/workspace/token-usage-indicator";
 import { Welcome } from "@/components/workspace/welcome";
+import { WorkflowTraceTrigger } from "@/components/workspace/workflow-trace-trigger";
 import { useI18n } from "@/core/i18n/hooks";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
 import {
   useThreadMetadata,
+  useThreadRuns,
   useThreadStream,
   useThreadTokenUsage,
 } from "@/core/threads/hooks";
@@ -54,11 +56,15 @@ export default function ChatPage() {
     isNewThread || isMock ? undefined : threadId,
     { enabled: tokenUsageEnabled && !isMock },
   );
+  const threadRuns = useThreadRuns(isNewThread || isMock ? undefined : threadId, {
+    enabled: !isNewThread && !isMock,
+  });
   const threadMetadata = useThreadMetadata(threadId, {
     enabled: !isNewThread && !isMock,
     isMock,
   });
   const backendTokenUsage = threadTokenUsageToTokenUsage(threadTokenUsage.data);
+  const latestRunId = threadRuns.data?.[0]?.run_id;
   const mountedRef = useRef(false);
   useSpecificChatMode();
 
@@ -200,6 +206,10 @@ export default function ChatPage() {
                 }
               />
               <ExportTrigger threadId={threadId} />
+              <WorkflowTraceTrigger
+                enabled={!isMock}
+                runId={latestRunId}
+              />
               <ArtifactTrigger />
             </div>
           </header>

--- a/frontend/src/components/workspace/workflow-trace-trigger.tsx
+++ b/frontend/src/components/workspace/workflow-trace-trigger.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  ActivityIcon,
+  CheckCircle2Icon,
+  CircleDashedIcon,
+  Loader2Icon,
+  XCircleIcon,
+} from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useWorkflowTraceByRun } from "@/core/workflows/hooks";
+import { cn } from "@/lib/utils";
+
+function shortId(value?: string | null) {
+  if (!value) {
+    return "-";
+  }
+  return value.length > 12 ? `${value.slice(0, 8)}...${value.slice(-4)}` : value;
+}
+
+function statusClass(status?: string) {
+  if (status === "succeeded") {
+    return "text-emerald-600 dark:text-emerald-400";
+  }
+  if (status === "failed" || status === "cancelled" || status === "orphaned") {
+    return "text-destructive";
+  }
+  if (status === "running" || status === "run_created") {
+    return "text-sky-600 dark:text-sky-400";
+  }
+  return "text-muted-foreground";
+}
+
+function StatusIcon({ status }: { status?: string }) {
+  if (status === "succeeded") {
+    return <CheckCircle2Icon className="size-3.5" />;
+  }
+  if (status === "failed" || status === "cancelled" || status === "orphaned") {
+    return <XCircleIcon className="size-3.5" />;
+  }
+  if (status === "running" || status === "run_created") {
+    return <Loader2Icon className="size-3.5 animate-spin" />;
+  }
+  return <CircleDashedIcon className="size-3.5" />;
+}
+
+export function WorkflowTraceTrigger({
+  runId,
+  enabled = true,
+}: {
+  runId?: string | null;
+  enabled?: boolean;
+}) {
+  const trace = useWorkflowTraceByRun(runId, { enabled: enabled && Boolean(runId) });
+  const workflow = trace.data?.workflow;
+  const status = workflow?.status;
+
+  if (!runId || trace.data === null) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          aria-label="Trace"
+          className={cn("gap-1.5", status && statusClass(status))}
+          disabled={!enabled}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {trace.isLoading ? (
+            <Loader2Icon className="size-4 animate-spin" />
+          ) : (
+            <ActivityIcon className="size-4" />
+          )}
+          <span className="hidden sm:inline">Trace</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-96 max-w-[calc(100vw-2rem)]">
+        <DropdownMenuLabel className="flex items-center justify-between gap-3">
+          <span>Durable Run Trace</span>
+          <span className={cn("inline-flex items-center gap-1 text-xs", statusClass(status))}>
+            <StatusIcon status={status} />
+            {status ?? "loading"}
+          </span>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <div className="space-y-2 px-2 py-2 text-xs">
+          <div className="grid grid-cols-[88px_1fr] gap-2">
+            <span className="text-muted-foreground">workflow</span>
+            <span className="font-mono">{shortId(workflow?.workflow_id)}</span>
+            <span className="text-muted-foreground">run</span>
+            <span className="font-mono">{shortId(runId)}</span>
+            <span className="text-muted-foreground">source</span>
+            <span className="truncate">{workflow?.source ?? "-"}</span>
+          </div>
+          <DropdownMenuSeparator />
+          <div className="max-h-64 space-y-2 overflow-y-auto pr-1">
+            {(trace.data?.timeline ?? []).slice(0, 12).map((event, index) => (
+              <div
+                className="grid grid-cols-[16px_1fr] gap-2"
+                key={`${event.kind}/${event.seq ?? index}/${event.event_type}`}
+              >
+                <span
+                  className={cn(
+                    "mt-1 size-2 rounded-full",
+                    event.kind === "workflow_event" ? "bg-primary" : "bg-muted-foreground",
+                  )}
+                />
+                <div className="min-w-0">
+                  <div className="truncate font-medium">{event.event_type}</div>
+                  <div className="text-muted-foreground flex min-w-0 gap-2">
+                    <span>{event.kind === "workflow_event" ? "workflow" : "run"}</span>
+                    {event.created_at && (
+                      <span className="truncate">{new Date(event.created_at).toLocaleTimeString()}</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            ))}
+            {trace.isLoading && (
+              <div className="text-muted-foreground flex items-center gap-2">
+                <Loader2Icon className="size-3 animate-spin" />
+                Loading trace
+              </div>
+            )}
+            {trace.isError && (
+              <div className="text-destructive">Trace unavailable</div>
+            )}
+          </div>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/core/modules/api.ts
+++ b/frontend/src/core/modules/api.ts
@@ -1,0 +1,19 @@
+import { getBackendBaseURL } from "@/core/config";
+
+export type ModuleFlags = {
+  durable_workflows: {
+    enabled: boolean;
+    api_enabled: boolean;
+    auto_envelope_for_runs: boolean;
+  };
+};
+
+export async function fetchModuleFlags(): Promise<ModuleFlags> {
+  const response = await globalThis.fetch(`${getBackendBaseURL()}/api/modules`, {
+    credentials: "include",
+  });
+  if (!response.ok) {
+    throw new Error(`Module flags unavailable (${response.status})`);
+  }
+  return (await response.json()) as ModuleFlags;
+}

--- a/frontend/src/core/modules/hooks.ts
+++ b/frontend/src/core/modules/hooks.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchModuleFlags } from "./api";
+
+export function useModuleFlags() {
+  return useQuery({
+    queryKey: ["module-flags"],
+    queryFn: fetchModuleFlags,
+    staleTime: 60_000,
+    retry: 1,
+  });
+}

--- a/frontend/src/core/modules/index.ts
+++ b/frontend/src/core/modules/index.ts
@@ -1,0 +1,2 @@
+export * from "./api";
+export * from "./hooks";

--- a/frontend/src/core/workflows/api.ts
+++ b/frontend/src/core/workflows/api.ts
@@ -1,0 +1,85 @@
+import { fetch } from "@/core/api/fetcher";
+import { getBackendBaseURL } from "@/core/config";
+
+export type WorkflowEnvelope = {
+  workflow_id: string;
+  workflow_kind: string;
+  source_type: string;
+  source?: string | null;
+  idempotency_key?: string | null;
+  external_message_ref?: string | null;
+  thread_id?: string | null;
+  run_id?: string | null;
+  checkpoint_ns?: string | null;
+  checkpoint_id?: string | null;
+  status: string;
+  error?: string | null;
+  metadata?: Record<string, unknown>;
+  created_at?: string;
+  updated_at?: string;
+};
+
+export type WorkflowTimelineEvent = {
+  kind: "workflow_event" | "run_event";
+  seq?: number;
+  event_type: string;
+  category?: string;
+  created_at?: string;
+  thread_id?: string | null;
+  run_id?: string | null;
+  content?: unknown;
+  metadata?: Record<string, unknown>;
+};
+
+export type WorkflowTimelineResponse = {
+  workflow: WorkflowEnvelope;
+  run?: Record<string, unknown> | null;
+  timeline: WorkflowTimelineEvent[];
+  workflow_events: Record<string, unknown>[];
+  run_events: Record<string, unknown>[];
+};
+
+async function readJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const payload = await response.json().catch(() => null);
+    const detail =
+      payload && typeof payload === "object" && "detail" in payload
+        ? String(payload.detail)
+        : `Request failed with ${response.status}`;
+    throw new Error(detail);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchWorkflowByRun(
+  runId: string,
+): Promise<WorkflowEnvelope | null> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/workflows/by-run/${encodeURIComponent(runId)}`,
+  );
+  if (response.status === 404) {
+    return null;
+  }
+  return readJson<WorkflowEnvelope>(response);
+}
+
+export async function fetchWorkflowTimeline(
+  workflowId: string,
+): Promise<WorkflowTimelineResponse> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/workflows/${encodeURIComponent(
+      workflowId,
+    )}/timeline`,
+  );
+  return readJson<WorkflowTimelineResponse>(response);
+}
+
+export async function fetchWorkflowTraceByRun(
+  runId: string,
+): Promise<WorkflowTimelineResponse | null> {
+  const workflow = await fetchWorkflowByRun(runId);
+  if (!workflow) {
+    return null;
+  }
+  return fetchWorkflowTimeline(workflow.workflow_id);
+}

--- a/frontend/src/core/workflows/hooks.ts
+++ b/frontend/src/core/workflows/hooks.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchWorkflowTraceByRun } from "./api";
+
+export function useWorkflowTraceByRun(
+  runId?: string | null,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
+  return useQuery({
+    queryKey: ["workflow-trace", "run", runId],
+    queryFn: () => {
+      if (!runId) {
+        return null;
+      }
+      return fetchWorkflowTraceByRun(runId);
+    },
+    enabled: enabled && Boolean(runId),
+    refetchOnWindowFocus: false,
+  });
+}


### PR DESCRIPTION
## Review Status

This PR is part of the Hardening/Scale Package after the RFC and Core Runtime
Package (#3813, #3814, #3815, #3816, #3848). It should be reviewed after the
native Durable Workflow Runtime Layer direction is accepted.

## Summary

Adds durable workflow-level waiting/resume references for workflows whose
execution needs human input or an interrupt-style resume. LangGraph remains the
owner of actual interrupt payloads and checkpoint state; DeerFlow only records
the runtime correlation needed for observability and recovery.

## Scope

- Project waiting/resume references into durable workflow metadata.
- Expose waiting/resume state through workflow APIs and timeline output.
- Keep actual resume payloads in LangGraph checkpoint state.
- Add tests for service projection and workflow router responses.

## Modular Value

If this PR is not merged, ordinary durable workflow execution, recovery,
binding, and channel intake still work. Human-in-the-loop observability remains
less explicit until this layer lands.

## Validation

Original focused validation for this branch:

```bash
DEER_FLOW_CONFIG_PATH=config.example.yaml \
PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 \
uv run pytest tests/test_gateway_services.py tests/test_workflows_router.py -q
```

Result locally: `57 passed`.
