### PR TITLE
fix(frontend): retain presented artifacts in header dropdown

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -565,12 +565,11 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 - Output Files: Final deliverables must be in `/mnt/user-data/outputs`
 - File Editing Workflow: When revising an existing file, prefer
   `str_replace` over `write_file` — it sends only the diff and avoids
-  re-emitting the whole file (mirrors Claude Code's Edit and Codex's
-  apply_patch). When writing long new content from scratch, split it
-  into sections: the first `write_file` call creates the file, then use
-  `write_file` with append=True to extend it section by section. This
-  keeps each tool call small and avoids mid-stream chunk-gap timeouts
-  on oversized single-shot writes. (See issue #3189.)  
+  re-emitting the whole file. When writing long new content from scratch,
+  split it into sections: the first `write_file` call creates the file,
+  then use `write_file` with append=True to extend it section by section.
+  This keeps each tool call small and avoids mid-stream chunk-gap timeouts
+  on oversized single-shot writes.
 - Clarity: Be direct and helpful, avoid unnecessary meta-commentary
 - Including Images and Mermaid: Images and Mermaid diagrams are always welcomed in the Markdown format, and you're encouraged to use `![Image Description](image_path)\n\n` or "```mermaid" to display images in response or Markdown files
 - Multi-task: Better utilize parallel tool calling to call multiple tools at one time for better performance

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -565,11 +565,12 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 - Output Files: Final deliverables must be in `/mnt/user-data/outputs`
 - File Editing Workflow: When revising an existing file, prefer
   `str_replace` over `write_file` — it sends only the diff and avoids
-  re-emitting the whole file. When writing long new content from scratch,
-  split it into sections: the first `write_file` call creates the file,
-  then use `write_file` with append=True to extend it section by section.
-  This keeps each tool call small and avoids mid-stream chunk-gap timeouts
-  on oversized single-shot writes.
+  re-emitting the whole file (mirrors Claude Code's Edit and Codex's
+  apply_patch). When writing long new content from scratch, split it
+  into sections: the first `write_file` call creates the file, then use
+  `write_file` with append=True to extend it section by section. This
+  keeps each tool call small and avoids mid-stream chunk-gap timeouts
+  on oversized single-shot writes. (See issue #3189.)  
 - Clarity: Be direct and helpful, avoid unnecessary meta-commentary
 - Including Images and Mermaid: Images and Mermaid diagrams are always welcomed in the Markdown format, and you're encouraged to use `![Image Description](image_path)\n\n` or "```mermaid" to display images in response or Markdown files
 - Multi-task: Better utilize parallel tool calling to call multiple tools at one time for better performance

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -84,13 +84,41 @@ export function ArtifactFileDetail({
     }
     return filepathFromProps;
   }, [filepathFromProps, isWriteFile]);
-  const artifactOptions = useMemo(() => {
-    const list = artifacts ?? [];
-    if (list.includes(filepath)) {
-      return list;
+  // Keep these local because ChatBox replaces context artifacts with thread state.
+  const [openedPresentedFilepaths, setOpenedPresentedFilepaths] = useState<
+    string[]
+  >(() => {
+    if (isWriteFile || artifacts.includes(filepath)) {
+      return [];
     }
-    return [filepath, ...list];
-  }, [artifacts, filepath]);
+    return [filepath];
+  });
+  useEffect(() => {
+    if (isWriteFile || artifacts.includes(filepath)) {
+      return;
+    }
+    setOpenedPresentedFilepaths((current) => {
+      if (current.includes(filepath)) {
+        return current;
+      }
+      return [...current, filepath];
+    });
+  }, [artifacts, filepath, isWriteFile]);
+  const artifactOptions = useMemo(() => {
+    if (isWriteFile) {
+      return artifacts;
+    }
+    const currentIsPresented = !artifacts.includes(filepath);
+    const presentedFilepaths =
+      currentIsPresented && !openedPresentedFilepaths.includes(filepath)
+        ? [...openedPresentedFilepaths, filepath]
+        : openedPresentedFilepaths;
+    const presentedSet = new Set(presentedFilepaths);
+    return [
+      ...presentedFilepaths,
+      ...artifacts.filter((artifact) => !presentedSet.has(artifact)),
+    ];
+  }, [artifacts, filepath, isWriteFile, openedPresentedFilepaths]);
   const isSkillFile = useMemo(() => {
     return filepath.endsWith(".skill");
   }, [filepath]);

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -262,16 +262,16 @@ test.describe("Artifact preview stability", () => {
     ).toBeVisible();
   });
 
-  test("shows the title for a presented artifact missing from thread artifacts", async ({
+  test("keeps an opened presented artifact in the header dropdown", async ({
     page,
   }) => {
     mockLangGraphAPI(page, {
       threads: [
         {
           thread_id: PRESENTED_THREAD_ID,
-          title: "Presented artifact title fallback",
+          title: "Presented artifact dropdown history",
           messages: presentFilesMessages(),
-          artifacts: [],
+          artifacts: [MARKDOWN_ARTIFACT_PATH],
         },
       ],
     });
@@ -282,6 +282,15 @@ test.describe("Artifact preview stability", () => {
           status: 200,
           contentType: "text/markdown",
           body: "# Presented Report\n\nGenerated content",
+        }),
+    );
+    await page.route(
+      `**/api/threads/${PRESENTED_THREAD_ID}/artifacts/artifact-fixtures/report.md`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "text/markdown",
+          body: "# Thread Report\n\nTracked artifact content",
         }),
     );
 
@@ -295,11 +304,20 @@ test.describe("Artifact preview stability", () => {
 
     const artifactsPanel = page.locator("#artifacts");
 
-    // 1. Header title should fall back to the current filepath even though
-    //    thread.values.artifacts is empty.
     await expect(artifactsPanel.getByText("presented-report.md")).toBeVisible();
+    await expect(artifactsPanel.getByText("Presented Report")).toBeVisible();
 
-    // 2. Preview content should still render correctly.
+    const artifactSelect = artifactsPanel.getByRole("combobox");
+    await artifactSelect.click();
+    await page.getByRole("option", { name: "report.md", exact: true }).click();
+    await expect(artifactsPanel.getByText("Thread Report")).toBeVisible();
+
+    await artifactSelect.click();
+    const presentedOption = page.getByRole("option", {
+      name: "presented-report.md",
+    });
+    await expect(presentedOption).toBeVisible();
+    await presentedOption.click();
     await expect(artifactsPanel.getByText("Presented Report")).toBeVisible();
   });
 });


### PR DESCRIPTION
Closes #3853

## Why

PR #3198 made the currently selected presented filepath visible in the artifact header dropdown when it was missing from `thread.values.artifacts`.

However, the fallback was derived only from the current filepath. After opening a presented file and then switching to a regular thread artifact, the presented file disappeared from the dropdown. Users had to return to the original message card to reopen it.

The root cause was that `artifactOptions` had no session memory. Adding presented paths directly to the artifacts context would not be reliable because `ChatBox` replaces that context with `thread.values.artifacts` during thread updates.

## What changed

- Presented filepaths opened in the current artifact-detail session now remain available in the header dropdown.
- Previously opened presented paths are merged with thread artifacts and deduplicated.
- The accumulator stays local to `ArtifactFileDetail`, outside the context list overwritten by thread synchronization.
- Temporary `write-file:` preview paths are not accumulated.
- Artifact auto-discovery and backend thread state remain unchanged.
- The existing Playwright regression test now covers the complete navigation path:
  1. Open presented file A.
  2. Switch to regular artifact B.
  3. Confirm A remains in the dropdown.
  4. Switch back to A successfully.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before: after switching from a presented file to a regular artifact, the presented file disappears from the header dropdown.

After: previously opened presented files remain available and can be selected again.

<img width="2882" height="1420" alt="image" src="https://github.com/user-attachments/assets/26791d6c-06f4-4068-9827-b1ae008592bb" />

## Bug fix verification

- Test path that reproduces the bug: `frontend/tests/e2e/artifact-preview.spec.ts`
- Did it go red on `main` and green on this branch? **yes**
- On the original implementation, the test failed because the `presented-report.md` option could not be found after switching to `report.md`.
- With this change, the same A → B → A navigation test passes.

## Validation

Executed from `frontend/`:

- `pnpm format` — passed
- `pnpm lint` — passed with 3 pre-existing warnings in unrelated message-list files
- `pnpm typecheck` — passed
- `pnpm test` — passed, 373 tests
- `SKIP_ENV_VALIDATION=1 DEER_FLOW_AUTH_DISABLED=1 pnpm build` — passed
- `pnpm exec playwright test tests/e2e/artifact-preview.spec.ts --reporter=line` — passed, 6 tests

The production build emitted the existing Turbopack NFT tracing warning for `next.config.js`; the build completed successfully.
