### PR TITLE
fix(harness): don't flag outline as truncated at exactly MAX_OUTLINE_ENTRIES headings

### DIFF
--- a/backend/packages/harness/deerflow/utils/file_conversion.py
+++ b/backend/packages/harness/deerflow/utils/file_conversion.py
@@ -279,7 +279,11 @@ def extract_outline(md_path: Path) -> list[dict]:
                     if title:
                         outline.append({"title": title, "line": lineno})
 
-                if len(outline) >= MAX_OUTLINE_ENTRIES:
+                if len(outline) > MAX_OUTLINE_ENTRIES:
+                    # We collected one heading beyond the limit, which proves the
+                    # document genuinely has more than MAX_OUTLINE_ENTRIES headings.
+                    # Drop that extra entry and append the truncation sentinel.
+                    outline.pop()
                     outline.append({"truncated": True})
                     break
     except Exception:

--- a/backend/tests/test_file_conversion.py
+++ b/backend/tests/test_file_conversion.py
@@ -422,6 +422,15 @@ class TestExtractOutline:
         assert len(outline) == 5
         assert not any(e.get("truncated") for e in outline)
 
+    def test_no_truncation_sentinel_at_exact_limit(self, tmp_path):
+        """A document with exactly MAX_OUTLINE_ENTRIES headings is not truncated."""
+        lines = [f"# Heading {i}" for i in range(MAX_OUTLINE_ENTRIES)]
+        md = tmp_path / "exact.md"
+        md.write_text("\n".join(lines), encoding="utf-8")
+        outline = extract_outline(md)
+        assert len(outline) == MAX_OUTLINE_ENTRIES
+        assert not any(e.get("truncated") for e in outline)
+
     def test_blank_lines_and_whitespace_ignored(self, tmp_path):
         """Blank lines between headings do not produce empty entries."""
         md = tmp_path / "spaced.md"


### PR DESCRIPTION
## Problem

`extract_outline` (in `backend/packages/harness/deerflow/utils/file_conversion.py`) appended the `{"truncated": True}` sentinel as soon as `len(outline) >= MAX_OUTLINE_ENTRIES` — i.e. right after collecting the 50th heading, **before** knowing whether a 51st actually exists.

So a document with **exactly** 50 headings is reported as truncated. `uploads_middleware.py` then injects a misleading `"... (showing first 50 headings; use read_file to explore further)"` hint into the agent's context, telling the model there are more headings when there aren't.

## Reproduction (real function)

```
headings=49 -> truncated_sentinel=False
headings=50 -> truncated_sentinel=True    # before: false positive
headings=51 -> truncated_sentinel=True
```

After the fix, 50 → `False`, 51 → `True`.

## Fix

Use a `limit + 1` lookahead: only mark the outline truncated once a heading **beyond** the limit is actually seen, then drop that extra entry. Matches the docstring ("truncated at MAX_OUTLINE_ENTRIES").

## Test

Adds `test_no_truncation_sentinel_at_exact_limit` to `backend/tests/test_file_conversion.py` (the suite already covers over-limit and under-limit, but not the exact boundary).