### PR TITLE
fix(skills): preserve read_file in skill allowed-tools filter (#3862)

### DIFF
--- a/backend/packages/harness/deerflow/skills/tool_policy.py
+++ b/backend/packages/harness/deerflow/skills/tool_policy.py
@@ -10,6 +10,19 @@ class NamedTool(Protocol):
     name: str
 
 
+# Framework tools required for the agent runtime itself, not subject to
+# per-skill ``allowed-tools`` restrictions. ``read_file`` is needed for
+# progressive skill loading: the lead-agent prompt instructs the model to
+# ``read_file`` the matched skill's ``SKILL.md`` (see
+# agents/lead_agent/prompt.py), and filtering it out when a skill declares a
+# restrictive ``allowed-tools`` list breaks that contract with
+# "read_file is not a valid tool". See #3862.
+#
+# ``tool_search`` is exempted separately in ``assemble_deferred_tools``
+# (appended after the policy filter); it is not duplicated here.
+SKILL_LOADING_FRAMEWORK_TOOLS: frozenset[str] = frozenset({"read_file"})
+
+
 def allowed_tool_names_for_skills(skills: list[Skill]) -> set[str] | None:
     """Return the union of explicit skill allowed-tools declarations.
 
@@ -40,5 +53,10 @@ def filter_tools_by_skill_allowed_tools[ToolT: NamedTool](tools: list[ToolT], sk
     allowed = allowed_tool_names_for_skills(skills)
     if allowed is None:
         return tools
+
+    # Exempt framework tools that the runtime itself needs (e.g. read_file
+    # for progressive skill loading) so a restrictive skill allowed-tools
+    # list cannot break the agent's skill-loading contract. See #3862.
+    allowed = allowed | SKILL_LOADING_FRAMEWORK_TOOLS
 
     return [tool for tool in tools if tool.name in allowed]

--- a/backend/tests/test_deferred_tool_crosscontext.py
+++ b/backend/tests/test_deferred_tool_crosscontext.py
@@ -38,6 +38,12 @@ def mcp_secret(x: str) -> str:
     return x
 
 
+@as_tool
+def read_file(path: str) -> str:
+    "framework tool needed for progressive skill loading"
+    return ""
+
+
 _BOUND: list[list[str]] = []
 
 
@@ -171,3 +177,22 @@ def test_tool_search_appended_after_policy_but_never_exposes_denied_tool():
     assert "tool_search" in names  # appended despite not being in the allowlist
     assert setup.deferred_names == frozenset({"mcp_secret"})
     assert set(setup.deferred_names) <= set(allowed)  # catalog never exceeds the allowlist
+
+
+def test_skill_allowed_tools_preserves_read_file_for_progressive_loading():
+    """Regression for #3862.
+
+    A skill that declares a restrictive ``allowed-tools`` list (omitting
+    ``read_file``) must not strip ``read_file`` from the bound tool list,
+    because the lead-agent prompt instructs the model to ``read_file`` the
+    matched skill's ``SKILL.md`` for progressive skill loading. Without this
+    exemption the model calls ``read_file`` and the run fails with
+    "read_file is not a valid tool".
+    """
+    filtered = filter_tools_by_skill_allowed_tools(
+        [active_tool, read_file],
+        [_make_skill(["active_tool"])],  # allowed-tools omits read_file
+    )
+    names = {t.name for t in filtered}
+    assert "active_tool" in names
+    assert "read_file" in names  # framework tool preserved despite the allowlist


### PR DESCRIPTION
## What Problem This Solves

Closes #3862.

When a custom skill declares a restrictive `allowed-tools` list, the runtime filters the bound tool list down to the union of declared tools. If `read_file` is not in that union it gets filtered out — but the lead-agent prompt instructs the model to `read_file` the matched skill's `SKILL.md` for progressive skill loading. So when the model follows that instruction, the run fails with:

```
read_file is not a valid tool
```

## Why This Change Was Made

`filter_tools_by_skill_allowed_tools` (`backend/packages/harness/deerflow/skills/tool_policy.py`) treats every tool uniformly: if it isn't in the per-skill allowlist union, it's dropped. That breaks the runtime's own skill-loading contract — `read_file` is a framework tool the agent itself needs, not a business tool the skill is scoping.

`tool_search` was already exempted from this filter (it's appended after the policy filter via `assemble_deferred_tools`); `read_file` was missed when that pattern was introduced.

The fix adds a small `SKILL_LOADING_FRAMEWORK_TOOLS` allowlist (initially just `read_file`) and unions it with the per-skill allowlist inside the filter, so framework tools the runtime needs can never be stripped by a skill's `allowed-tools` declaration. Business/action tool scoping is preserved.

## User Impact

- Custom skills that declare `allowed-tools` (omitting `read_file`) no longer break progressive skill loading. The model can `read_file` the matched `SKILL.md` and continue normally.
- Skills that explicitly include `read_file` in their `allowed-tools` see no change (it was already allowed).
- Skills that don't declare `allowed-tools` see no change (the filter short-circuits to allow-all).

## Evidence

- New regression test `test_skill_allowed_tools_preserves_read_file_for_progressive_loading` in `backend/tests/test_deferred_tool_crosscontext.py`: a skill declaring `allowed-tools: [active_tool]` (omitting `read_file`) yields a filtered list that still contains both `active_tool` and `read_file`.
- All 7 tests in the file pass: `PYTHONPATH=.:packages/harness python3 -m pytest tests/test_deferred_tool_crosscontext.py -v`.
- Adjacent `test_tool_search_appended_after_policy_but_never_exposes_denied_tool` (the existing `tool_search` exemption test) still passes — confirms the existing exemption pattern is preserved.
- Touched files: `backend/packages/harness/deerflow/skills/tool_policy.py` (1 const + 1 set union), `backend/tests/test_deferred_tool_crosscontext.py` (1 new fixture + 1 new test).
