### PR TITLE
fix(frontend): stop rendering reasoning twice for reasoning+answer messages (#3868)

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -90,6 +90,16 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
     }
 
     if (message.type === "ai") {
+      // A message with answer content and no tool calls becomes its own
+      // assistant bubble below, which already renders the message's
+      // reasoning_content inside the bubble's <Reasoning> collapsible. Such a
+      // message must NOT also feed the processing group, or the ChainOfThought
+      // panel above the bubble paints the identical reasoning a second time
+      // (#3868). Intermediate reasoning (no content) and tool-calling steps
+      // still belong in the processing group.
+      const becomesAssistantBubble =
+        hasContent(message) && !hasToolCalls(message);
+
       if (hasPresentFiles(message)) {
         groups.push({
           id: message.id,
@@ -102,7 +112,10 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
           type: "assistant:subagent",
           messages: [message],
         });
-      } else if (hasReasoning(message) || hasToolCalls(message)) {
+      } else if (
+        !becomesAssistantBubble &&
+        (hasReasoning(message) || hasToolCalls(message))
+      ) {
         const lastGroup = groups[groups.length - 1];
         // Accumulate consecutive intermediate AI messages into one processing group.
         if (lastGroup?.type !== "assistant:processing") {
@@ -116,9 +129,7 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
         }
       }
 
-      // Not an else-if: a message with reasoning + content (but no tool calls) goes
-      // into the processing group above AND gets its own assistant bubble here.
-      if (hasContent(message) && !hasToolCalls(message)) {
+      if (becomesAssistantBubble) {
         groups.push({ id: message.id, type: "assistant", messages: [message] });
       }
     }

--- a/frontend/tests/unit/core/messages/usage.test.ts
+++ b/frontend/tests/unit/core/messages/usage.test.ts
@@ -42,7 +42,13 @@ test("counts later usage-bearing snapshots for the same AI message id", () => {
   });
 });
 
-test("keeps header and per-turn aggregation consistent for duplicated UI groups", () => {
+test("keeps header and per-turn aggregation consistent for a reasoning+answer message", () => {
+  // A single AI message carrying both reasoning (here via inline <think>) and
+  // answer text now lands in exactly one assistant group (#3868), so its usage
+  // is counted once both in the per-turn aggregation and against the header
+  // total. The by-id dedupe (see "accumulates each AI message usage only once")
+  // remains the defence-in-depth guard if any future grouping reintroduces a
+  // duplicate.
   const messages = [
     {
       id: "human-1",
@@ -61,15 +67,8 @@ test("keeps header and per-turn aggregation consistent for duplicated UI groups"
   const usageMessagesByGroupIndex = getAssistantTurnUsageMessages(groups);
   const turnUsageMessages = usageMessagesByGroupIndex.at(-1);
 
-  expect(groups.map((group) => group.type)).toEqual([
-    "human",
-    "assistant:processing",
-    "assistant",
-  ]);
-  expect(turnUsageMessages?.map((message) => message.id)).toEqual([
-    "ai-1",
-    "ai-1",
-  ]);
+  expect(groups.map((group) => group.type)).toEqual(["human", "assistant"]);
+  expect(turnUsageMessages?.map((message) => message.id)).toEqual(["ai-1"]);
   expect(accumulateUsage(messages)).toEqual(
     accumulateUsage(turnUsageMessages!),
   );

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -81,6 +81,76 @@ test("aggregates token usage messages once per assistant turn", () => {
   ).toEqual([null, null, ["ai-1", "ai-2"], null, ["ai-3"]]);
 });
 
+test("reasoning + content (no tool calls) yields a single assistant bubble, not a duplicate processing group", () => {
+  // Regression for #3868: in thinking/pro/ultra modes the final assistant
+  // message carries both reasoning_content and answer text. It must surface its
+  // reasoning exactly once — inside the assistant bubble's <Reasoning>
+  // collapsible. Routing the same message into a processing group as well makes
+  // the ChainOfThought panel above the bubble paint the identical reasoning a
+  // second time.
+  const messages = [
+    { id: "human-1", type: "human", content: "Why is the sky blue?" },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "Rayleigh scattering makes the sky blue.",
+      additional_kwargs: { reasoning_content: "Recall Rayleigh scattering." },
+    },
+  ] as Message[];
+
+  const groups = getMessageGroups(messages);
+
+  expect(groups.map((group) => group.type)).toEqual(["human", "assistant"]);
+
+  // The reasoning-bearing message lands in exactly one group, so turn-usage
+  // aggregation never double-counts it (see #2770).
+  const turnUsage = getAssistantTurnUsageMessages(groups);
+  expect(turnUsage.at(-1)?.map((message) => message.id)).toEqual(["ai-1"]);
+});
+
+test("keeps tool-call reasoning in the processing group while the final answer's reasoning rides its own bubble", () => {
+  // Companion to #3868: only the message that also becomes an assistant bubble
+  // (content, no tool calls) is pulled out of the processing group. Reasoning
+  // attached to an intermediate tool-calling step still belongs above, with its
+  // tool steps.
+  const messages = [
+    { id: "human-1", type: "human", content: "Search and summarize" },
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "",
+      additional_kwargs: { reasoning_content: "I should search first." },
+      tool_calls: [{ id: "tool-1", name: "web_search", args: { query: "x" } }],
+    },
+    {
+      id: "tool-1-result",
+      type: "tool",
+      name: "web_search",
+      tool_call_id: "tool-1",
+      content: "[]",
+    },
+    {
+      id: "ai-2",
+      type: "ai",
+      content: "Here is the summary.",
+      additional_kwargs: { reasoning_content: "Synthesize the findings." },
+    },
+  ] as Message[];
+
+  const groups = getMessageGroups(messages);
+
+  expect(groups.map((group) => group.type)).toEqual([
+    "human",
+    "assistant:processing",
+    "assistant",
+  ]);
+  expect(groups[1]?.messages.map((message) => message.id)).toEqual([
+    "ai-1",
+    "tool-1-result",
+  ]);
+  expect(groups[2]?.messages.map((message) => message.id)).toEqual(["ai-2"]);
+});
+
 describe("inline <think> tag splitting", () => {
   test("strips a fully closed <think> block from AI content", () => {
     const message = aiMessage("<think>internal reasoning</think>final answer");


### PR DESCRIPTION
## Problem

In non-flash modes (Thinking / Pro / Ultra), an AI reply's reasoning content was
rendered **twice** on the page (#3868):

1. **Above the bubble** — the `MessageGroup` ChainOfThought panel ("💡 思考"),
   which paints the reasoning text directly.
2. **Inside the bubble** — the `Reasoning` collapsible ("Thought for X seconds").

Both render the same message's `reasoning_content`.

## Root cause

`getMessageGroups()` in `frontend/src/core/messages/utils.ts`. When an AI message
carries **reasoning + answer content but no tool calls**, the old logic put the
*same* message into **two** groups:

- `hasReasoning(message) || hasToolCalls(message)` was true (it has reasoning), so
  it was pushed into an `assistant:processing` group → rendered by `MessageGroup`
  as the "💡 思考" panel above the bubble;
- a deliberately non-`else-if` branch then matched `hasContent && !hasToolCalls`
  and pushed the *same* message into an `assistant` group → rendered by
  `MessageListItem`, whose `<Reasoning>` collapsible shows the reasoning again.

So one message landed in two groups that each render reasoning → duplicate.

This double-grouping was introduced in #1018 (the "Not an else-if" comment). It
also forced the per-message-id dedupe guard in #2770 (token usage was being
double-counted for exactly these duplicated groups).

## Fix

A message that becomes its own `assistant` bubble (has content, no tool calls)
already renders its reasoning inside the bubble's `<Reasoning>` collapsible, so it
must **not** also feed the `assistant:processing` group:

```ts
const becomesAssistantBubble = hasContent(message) && !hasToolCalls(message);
// ...
} else if (!becomesAssistantBubble && (hasReasoning(message) || hasToolCalls(message))) {
  // processing group
}
if (becomesAssistantBubble) {
  // assistant bubble
}
```

Behavior is unchanged for every other message shape — only the
reasoning+content+no-tools message stops being double-grouped:

| message shape | before | after |
| --- | --- | --- |
| content only, no reasoning/tool | `assistant` | `assistant` (same) |
| **reasoning + content, no tool** (#3868) | `assistant:processing` + `assistant` | **`assistant` only** |
| tool calls (± content/reasoning) | `assistant:processing` | `assistant:processing` (same) |
| reasoning only (streaming, no content yet) | `assistant:processing` | `assistant:processing` (same) |
| present_files / subagent(task) | own group | own group (same) |

Intermediate reasoning (streaming, or attached to a tool-calling step) still
flows into the processing group and shows in the ChainOfThought panel; only the
final answer's reasoning rides its own bubble.

## Verification

### Unit tests (red → green)
Added two regression tests in `tests/unit/core/messages/utils.test.ts` that fail
on `main` and pass with the fix:
- reasoning + content (no tool calls) yields a single `assistant` group;
- tool-call reasoning stays in the processing group while the final answer's
  reasoning rides its own bubble.

Updated `tests/unit/core/messages/usage.test.ts`: the test previously named
"…for duplicated UI groups" asserted the buggy double-grouping as a fixture; it
now asserts the correct single-group result. The #2770 per-id dedupe guard is
still covered by "accumulates each AI message usage only once".

- `pnpm test`: **375 passed / 0 failed / 0 skipped** (38 files)
- `pnpm check`: **0 errors** (the only 3 warnings are pre-existing, in
  `message-list-item.tsx` / `message-list.tsx`, both untouched here); `tsc
  --noEmit` exits 0.

### Real browser (end-to-end, before/after on the *same* real message)
Ran the full stack against a real reasoning model (DeepSeek `deepseek-reasoner`,
which streams `reasoning_content`), Thinking mode, then toggled only the frontend
code and reloaded the same thread:

- **before (buggy):** reasoning shows in both the "💡 思考" panel and the bubble's
  "Thought for X seconds".
- **after (fixed):** reasoning shows only once (the bubble); the duplicate panel
  is gone. `reasoning_content` is still present in thread state — no data lost.

_Same DeepSeek message, frontend code toggled and the thread reloaded:_

**Before (on `main`) — reasoning shown twice** (the "💡 思考" panel above *and* the
bubble's "Thought for X seconds"):

![before](https://github.com/fancyboi999/deer-flow/releases/download/_gh-attach-assets/before-buggy-duplicate.png)

**After (this PR) — reasoning shown once** (only the bubble; the duplicate panel
is gone):

![after](https://github.com/fancyboi999/deer-flow/releases/download/_gh-attach-assets/after-fixed-single.png)

### Streaming note (expected, not a regression)
While streaming, a message starts reasoning-only (rendered in the ChainOfThought
panel) and, once answer content arrives, moves to the `assistant` bubble — a
single, one-way container switch (content only grows, so no flicker loop). `main`
already mounts that bubble at the same point; it just *also* kept the panel,
which is the duplicate. This change replaces "panel + duplicated bubble" with
"panel handed off to the bubble". No reasoning text is lost.

### Not verified
The end-to-end browser check above was done manually; there is no automated E2E
for reasoning rendering in `tests/e2e/` (none exists today), so the streaming
hand-off was confirmed by reading the render path rather than by an automated
visual test.

Closes #3868
