### PR TITLE
fix(frontend): keep orphan tool messages visible

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -79,7 +79,7 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
         const open = lastOpenGroup();
         if (open) {
           open.messages.push(message);
-        } else if (groups.length > 0) {
+        } else {
           // Fallback for orphan tool messages — LangGraph `messages-tuple` can
           // emit tool-result events out of order or replay them from subagent
           // state (e.g. bash subagent under LocalSandboxProvider with
@@ -88,15 +88,18 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
           // dropped the message with console.error, silently hiding the tool
           // result from the UI. Attach to the most recent group instead so the
           // user can still see what the agent did.
-          groups[groups.length - 1].messages.push(message);
-        } else {
-          // groups is empty (shouldn't happen — the outer for loop is guarded
-          // by `messages.length === 0 -> return []`), but keep the diagnostic
-          // just in case.
-          console.error(
-            "Unexpected tool message with no preceding group",
-            message,
-          );
+          const lastGroup = groups[groups.length - 1];
+          if (lastGroup) {
+            lastGroup.messages.push(message);
+          } else {
+            // groups is empty (shouldn't happen — the outer for loop is guarded
+            // by `messages.length === 0 -> return []`), but keep the diagnostic
+            // just in case.
+            console.error(
+              "Unexpected tool message with no preceding group",
+              message,
+            );
+          }
         }
       }
       continue;

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -79,9 +79,22 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
         const open = lastOpenGroup();
         if (open) {
           open.messages.push(message);
+        } else if (groups.length > 0) {
+          // Fallback for orphan tool messages — LangGraph `messages-tuple` can
+          // emit tool-result events out of order or replay them from subagent
+          // state (e.g. bash subagent under LocalSandboxProvider with
+          // allow_host_bash). When that happens, the tool message arrives after
+          // a terminal group and lastOpenGroup() returns null. Previously we
+          // dropped the message with console.error, silently hiding the tool
+          // result from the UI. Attach to the most recent group instead so the
+          // user can still see what the agent did.
+          groups[groups.length - 1].messages.push(message);
         } else {
+          // groups is empty (shouldn't happen — the outer for loop is guarded
+          // by `messages.length === 0 -> return []`), but keep the diagnostic
+          // just in case.
           console.error(
-            "Unexpected tool message outside a processing group",
+            "Unexpected tool message with no preceding group",
             message,
           );
         }

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -541,3 +541,94 @@ describe("multi-part content with bare-string continuations", () => {
     );
   });
 });
+
+describe("orphan tool messages", () => {
+  // LangGraph stream-mode "messages-tuple" can emit tool-result events out of order or
+  // replayed from subagent state (e.g. bash subagent under LocalSandboxProvider with
+  // allow_host_bash). When that happens, the tool message arrives after a terminal
+  // assistant/human group, so getMessageGroups' lastOpenGroup() returns null.
+  //
+  // The previous behaviour was console.error + drop, which silently hid the tool
+  // result from the UI. The fix falls back to attaching the orphan tool to the most
+  // recent group so the user can still see what the agent did.
+
+  test("attaches orphan tool message to the most recent group instead of dropping it", () => {
+    const messages = [
+      { id: "h-1", type: "human", content: "Run something" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "ok",
+        tool_calls: [{ id: "call-1", name: "bash", args: {} }],
+      },
+      {
+        id: "t-1",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-1",
+        content: "output-1",
+      },
+      { id: "ai-2", type: "ai", content: "Done." }, // terminal assistant group
+      // Orphan tool: arrives after a terminal group, no preceding processing group
+      {
+        id: "t-2",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-2",
+        content: "output-2",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    // Expect groups: human, assistant:processing (ai-1 + t-1), assistant (ai-2), and
+    // t-2 should be attached to the last group (assistant), not dropped.
+    const types = groups.map((g) => g.type);
+    expect(types).toEqual(["human", "assistant:processing", "assistant"]);
+
+    // t-2 must be retrievable from one of the groups — must NOT be silently dropped
+    const allMessages = groups.flatMap((g) => g.messages);
+    const t2 = allMessages.find((m) => m.id === "t-2");
+    expect(t2).toBeDefined();
+    expect(t2?.type).toBe("tool");
+  });
+
+  test("replayed tool with same tool_call_id is not lost (duplicate stream events)", () => {
+    // LangGraph subagent state restoration can replay tool-result events. The
+    // frontend log shows the same tool_call_id arriving twice. Both occurrences
+    // should be visible in the UI, not just the first.
+    const messages = [
+      { id: "h-1", type: "human", content: "q" },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "",
+        tool_calls: [{ id: "call-x", name: "bash", args: {} }],
+      },
+      {
+        id: "t-1a",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-x",
+        content: "first delivery",
+      },
+      // No terminal ai message — next event is a replay of the same tool message
+      {
+        id: "t-1b",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-x",
+        content: "first delivery",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+    const allMessages = groups.flatMap((g) => g.messages);
+    const toolOccurrences = allMessages.filter(
+      (m) => m.id === "t-1a" || m.id === "t-1b",
+    );
+    // Both should be present (replay semantics are determined by id dedup at a
+    // higher layer; this test only asserts that orphan-replayed tool is reachable).
+    expect(toolOccurrences.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -612,7 +612,13 @@ describe("orphan tool messages", () => {
         tool_call_id: "call-x",
         content: "first delivery",
       },
-      // No terminal ai message — next event is a replay of the same tool message
+      // Terminal assistant group ends the turn and closes the processing group.
+      // Without this interleave the replayed t-1b would still take the
+      // unchanged happy path; with it, t-1b arrives when lastOpenGroup()
+      // returns null and must take the new fallback branch to be visible.
+      { id: "ai-2", type: "ai", content: "Done." },
+      // Replayed tool-result for the original tool_call — must reach the new
+      // else-if (groups.length > 0) branch instead of being dropped.
       {
         id: "t-1b",
         type: "tool",
@@ -624,11 +630,12 @@ describe("orphan tool messages", () => {
 
     const groups = getMessageGroups(messages);
     const allMessages = groups.flatMap((g) => g.messages);
-    const toolOccurrences = allMessages.filter(
-      (m) => m.id === "t-1a" || m.id === "t-1b",
-    );
-    // Both should be present (replay semantics are determined by id dedup at a
-    // higher layer; this test only asserts that orphan-replayed tool is reachable).
-    expect(toolOccurrences.length).toBeGreaterThanOrEqual(1);
+
+    // Strict assertion: the replayed tool message must be reachable from a
+    // group (i.e. attached via the new fallback). Before the fix this was
+    // silently dropped by console.error.
+    const t1b = allMessages.find((m) => m.id === "t-1b");
+    expect(t1b).toBeDefined();
+    expect(t1b?.type).toBe("tool");
   });
 });


### PR DESCRIPTION
## Summary

Fix a frontend bug where tool-result messages are silently dropped from the chat UI when LangGraph's `messages-tuple` stream emits a tool message after a terminal group (e.g. out-of-order arrival or replay from subagent state under `LocalSandboxProvider` + `allow_host_bash: true`).

Fixes #3879.

## Problem

`frontend/src/core/messages/utils.ts` — in `getMessageGroups`, the non-clarification `tool` branch only attaches a tool message when `lastOpenGroup()` returns non-null. When the previous group is a terminal `human`/`assistant`/`assistant:clarification`, the fallback is a bare `console.error` and the message is dropped from `groupedMessages` — invisible to the user.

The backend is unaffected: the tool result reaches the LangGraph runtime, the agent run succeeds, and the Langfuse trace is intact. The bug is purely a UI rendering issue. See #3879 for the full reproduction (including a real `frontend.log` capture with the offending `tool_call_id`).

## Fix

In the orphan-tool `else` branch, fall back to attaching the message to the most recent group instead of dropping it:

```ts
} else {
  const open = lastOpenGroup();
  if (open) {
    open.messages.push(message);
  } else if (groups.length > 0) {
    // LangGraph `messages-tuple` can emit tool-result events out of order or
    // replay them from subagent state. Fall back to the most recent group
    // instead of dropping the message.
    groups[groups.length - 1].messages.push(message);
  } else {
    console.error("Unexpected tool message with no preceding group", message);
  }
}
```

The change is local (one branch, ~10 lines) and strictly additive: it only changes behavior in the previously-broken `console.error` path. The happy path is unchanged.

## Tests

Added a `describe("orphan tool messages")` block in `frontend/tests/unit/core/messages/utils.test.ts` covering:

1. **`attaches orphan tool message to the most recent group instead of dropping it`** — fixture: human → ai(tool_calls) → tool → ai(terminal) → orphan_tool. Asserts the orphan tool is attached to the last group (not dropped) and retrievable from the resulting flat message list. This is the failing case from #3879.
2. **`replayed tool with same tool_call_id is not lost (duplicate stream events)`** — fixture: same `tool_call_id` arrives twice (LangGraph subagent state replay). Asserts the replayed tool is reachable in the output.

Both tests fail on `main` and pass with the fix.

## Verification

- `pnpm test` — 38 test files, 375 tests pass (including the 2 new ones).
- `pre-commit run --all-files` — ruff (backend) and eslint + prettier (frontend) all pass.
- Manual end-to-end is impractical in CI (the orphan-tool path requires `allow_host_bash: true` + the lead agent choosing to dispatch a bash subagent + LangGraph subagent state replay). The unit tests cover the code path directly.

## Risk

Low. The change is in a single `else` branch that previously only logged an error and dropped the message. Any fallback (here: attach to last group) is strictly better than dropping. The happy path — `lastOpenGroup()` returns non-null — is unchanged.

## Related

- Companion issue: #3879
- Logs source: `logs/frontend.log` (Next.js dev server, captures `console.error` and full message object)
- Local Langfuse 3.95 + ClickHouse 24.3 confirmed the trace is complete despite the frontend drop.