### PR TITLE
feat(sandbox): add Vercel sandbox provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ DeerFlow supports multiple sandbox execution modes:
 - **Local Execution** (runs sandbox code directly on the host machine)
 - **Docker Execution** (runs sandbox code in isolated Docker containers)
 - **Docker Execution with Kubernetes** (runs sandbox code in Kubernetes pods via provisioner service)
+- **Vercel Sandbox Execution** (runs per-thread workspaces in Vercel Sandbox while DeerFlow services stay on your main host)
 
 For Docker development, service startup follows `config.yaml` sandbox mode. In Local/Docker modes, `provisioner` is not started.
 
@@ -651,7 +652,7 @@ DeerFlow doesn't just *talk* about doing things. It has its own computer.
 
 Each task gets its own execution environment with a full filesystem view — skills, workspace, uploads, outputs. The agent reads, writes, and edits files. It can view images and, when configured safely, execute shell commands.
 
-With `AioSandboxProvider`, shell execution runs inside isolated containers. With `LocalSandboxProvider`, file tools still map to per-thread directories on the host, but host `bash` is disabled by default because it is not a secure isolation boundary. Re-enable host bash only for fully trusted local workflows. Host bash commands have a wall-clock timeout, and long-lived processes should be started in the background with output redirected to a workspace log.
+With `AioSandboxProvider`, shell execution runs inside isolated containers. With `VercelSandboxProvider`, shell execution and file tools run in Vercel Sandbox, while DeerFlow mirrors `/mnt/user-data/*` writes back to the host thread directory so artifacts remain available to the app. With `LocalSandboxProvider`, file tools still map to per-thread directories on the host, but host `bash` is disabled by default because it is not a secure isolation boundary. Re-enable host bash only for fully trusted local workflows. Host bash commands have a wall-clock timeout, and long-lived processes should be started in the background with output redirected to a workspace log.
 
 This is the difference between a chatbot with tool access and an agent with an actual execution environment.
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -307,11 +307,12 @@ Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runti
 **Implementations**:
 - `LocalSandboxProvider` - Local filesystem execution. `acquire(thread_id)` returns a per-thread `LocalSandbox` (id `local:{thread_id}`) whose `path_mappings` resolve `/mnt/user-data/{workspace,uploads,outputs}` and `/mnt/acp-workspace` to that thread's host directories, so the public `Sandbox` API honours the `/mnt/user-data` contract uniformly with AIO. `acquire()` / `acquire(None)` keeps the legacy generic singleton (id `local`) for callers without a thread context. Per-thread sandboxes are held in an LRU cache (default 256 entries) guarded by a `threading.Lock`.
 - `AioSandboxProvider` (`packages/harness/deerflow/community/`) - Docker-based isolation. Active-cache and warm-pool entries are checked with the backend during acquire/reuse; definitively dead containers are dropped from all in-process maps so the thread can discover or create a fresh sandbox instead of reusing a stale client. Backend health-check failures are treated as unknown, not dead; local discovery likewise treats an unverifiable container as not adoptable and falls through to create rather than failing acquire. `get()` remains an in-memory lookup for event-loop-safe tool paths.
+- `VercelSandboxProvider` (`packages/harness/deerflow/community/vercel_sandbox/`) - Remote Vercel Sandbox execution. DeerFlow uses a deterministic per-thread sandbox id and stores the Vercel sandbox id separately in thread metadata. Acquire creates or resumes the Vercel sandbox, syncs host workspace/uploads into `/mnt/user-data`, and mirrors `/mnt/user-data/*` writes back to the host so `present_files` and artifacts still use the existing host-side delivery path. Release syncs workspace/outputs back, then stops the persistent Vercel sandbox by default so it snapshots while idle. `get()` remains an in-memory lookup; network resume happens in `acquire()`.
 
 **Virtual Path System**:
 - Agent sees: `/mnt/user-data/{workspace,uploads,outputs}`, `/mnt/skills`
 - Physical: `backend/.deer-flow/users/{user_id}/threads/{thread_id}/user-data/...`, `deer-flow/skills/`
-- Translation: `LocalSandboxProvider` builds per-thread `PathMapping`s for the user-data prefixes at acquire time; `tools.py` keeps `replace_virtual_path()` / `replace_virtual_paths_in_command()` as a defense-in-depth layer (and for path validation). AIO has the directories volume-mounted at the same virtual paths inside its container, so both implementations accept `/mnt/user-data/...` natively.
+- Translation: `LocalSandboxProvider` builds per-thread `PathMapping`s for the user-data prefixes at acquire time; `tools.py` keeps `replace_virtual_path()` / `replace_virtual_paths_in_command()` as a defense-in-depth layer (and for path validation). AIO has the directories volume-mounted at the same virtual paths inside its container, so it accepts `/mnt/user-data/...` natively. Vercel does not support these DeerFlow mounts, so the Vercel provider performs explicit sync/mirror around the same virtual paths.
 - Detection: `is_local_sandbox()` accepts both `sandbox_id == "local"` (legacy / no-thread) and `sandbox_id.startswith("local:")` (per-thread)
 
 **Sandbox Tools** (in `packages/harness/deerflow/sandbox/tools.py`):
@@ -351,6 +352,7 @@ Proxied through nginx: `/api/langgraph/*` → Gateway LangGraph-compatible runti
 - `firecrawl/` - Web scraping via Firecrawl API
 - `image_search/` - Image search
 - `aio_sandbox/` - Docker-based isolation (`AioSandboxProvider`)
+- `vercel_sandbox/` - Vercel Sandbox execution (`VercelSandboxProvider`)
 
 Additional providers also live here (`brave`, `browserless`, `ddg_search`, `exa`, `fastcrw`, `groundroute`, `infoquest`, `searxng`, `serper`); see each subpackage for specifics.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,12 +69,12 @@ Middlewares execute in strict order, each handling a specific concern:
 Per-thread isolated execution with virtual path translation:
 
 - **Abstract interface**: `execute_command`, `read_file`, `write_file`, `list_dir`
-- **Providers**: `LocalSandboxProvider` (filesystem) and `AioSandboxProvider` (Docker, in community/). Async runtime paths use async sandbox lifecycle hooks so startup, readiness polling, and release do not block the event loop. `AioSandboxProvider` validates active-cache and warm-pool containers during acquire/reuse, dropping definitively dead entries so a thread can provision a fresh sandbox after an unexpected container exit while keeping `get()` as an in-memory lookup. Backend health-check failures are treated as unknown, not dead, and a container that cannot be verified during discovery is simply not adopted (acquire falls through to create instead of failing).
+- **Providers**: `LocalSandboxProvider` (filesystem), `AioSandboxProvider` (Docker, in community/), and `VercelSandboxProvider` (Vercel Sandbox, in community/). Async runtime paths use async sandbox lifecycle hooks so startup, readiness polling, and release do not block the event loop. `AioSandboxProvider` validates active-cache and warm-pool containers during acquire/reuse, dropping definitively dead entries so a thread can provision a fresh sandbox after an unexpected container exit while keeping `get()` as an in-memory lookup. `VercelSandboxProvider` keeps DeerFlow's deterministic per-thread sandbox id separate from the Vercel sandbox id, syncs host thread data into Vercel on acquire, mirrors `/mnt/user-data/*` writes back to the host for artifact delivery, and stops persistent sandboxes on release by default so they can snapshot while idle.
 - **Virtual paths**: `/mnt/user-data/{workspace,uploads,outputs}` → thread-specific physical directories
 - **Skills path**: `/mnt/skills` → `deer-flow/skills/` directory
 - **Skills loading**: Recursively discovers nested `SKILL.md` files under `skills/{public,custom}` and preserves nested container paths
 - **File-write safety**: `str_replace` serializes read-modify-write per `(sandbox.id, path)` so isolated sandboxes keep concurrency even when virtual paths match
-- **Tools**: `bash`, `ls`, `read_file`, `write_file`, `str_replace` (`write_file` overwrites by default and exposes `append` for end-of-file writes; `bash` is disabled by default when using `LocalSandboxProvider`; use `AioSandboxProvider` for isolated shell access)
+- **Tools**: `bash`, `ls`, `read_file`, `write_file`, `str_replace` (`write_file` overwrites by default and exposes `append` for end-of-file writes; `bash` is disabled by default when using `LocalSandboxProvider`; use `AioSandboxProvider` or `VercelSandboxProvider` for isolated shell access)
 
 ### Subagent System
 

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -274,7 +274,48 @@ When using Docker development (`make docker-start`), DeerFlow starts the `provis
 
 See [Provisioner Setup Guide](../../docker/provisioner/README.md) for detailed configuration, prerequisites, and troubleshooting.
 
-Choose between local execution or Docker-based isolation:
+**Vercel Sandbox Execution** (runs sandbox workspaces in Vercel Sandbox):
+```yaml
+sandbox:
+   use: deerflow.community.vercel_sandbox:VercelSandboxProvider
+   vercel_token: $VERCEL_TOKEN
+   vercel_project_id: $VERCEL_PROJECT_ID
+   # vercel_team_id: $VERCEL_TEAM_ID
+```
+
+Vercel Sandbox runs only the execution workspace: bash commands, file reads/writes, lightweight
+code execution, and optional preview ports. Keep DeerFlow Gateway, LangGraph runtime, frontend,
+memory, thread store, IM channels, and orchestration in the main DeerFlow service. DeerFlow stores
+its own deterministic per-thread sandbox id and a separate Vercel sandbox id in thread metadata so
+threads can resume persistent Vercel sandboxes across turns without coupling business session ids
+to provider resource ids.
+
+Vercel does not mount DeerFlow's host thread directories. `VercelSandboxProvider` syncs existing
+workspace/uploads into the sandbox on acquire and mirrors writes under `/mnt/user-data/*` back to
+the host thread directory so artifacts and `present_files` continue to work. By default it stops
+the persistent Vercel sandbox after each agent run (`vercel_stop_on_release: true`), letting Vercel
+snapshot the session and reducing idle runtime cost.
+
+Common options:
+
+```yaml
+sandbox:
+  use: deerflow.community.vercel_sandbox:VercelSandboxProvider
+  vercel_token: $VERCEL_TOKEN
+  vercel_project_id: $VERCEL_PROJECT_ID
+  vercel_team_id: $VERCEL_TEAM_ID  # optional
+  vercel_runtime: python3.13
+  vercel_vcpus: 2
+  vercel_memory_mb: 4096           # must equal vercel_vcpus * 2048
+  vercel_timeout_ms: 3600000
+  vercel_ports: [3000]
+  vercel_stop_on_release: true
+  vercel_environment:
+    NODE_ENV: production
+    API_KEY: $MY_API_KEY
+```
+
+Choose between local execution, Docker-based isolation, Kubernetes provisioner, or Vercel Sandbox:
 
 **Option 1: Local Sandbox** (default, simpler setup):
 ```yaml

--- a/backend/packages/harness/deerflow/community/vercel_sandbox/__init__.py
+++ b/backend/packages/harness/deerflow/community/vercel_sandbox/__init__.py
@@ -1,0 +1,7 @@
+from .vercel_sandbox import VercelSandbox
+from .vercel_sandbox_provider import VercelSandboxProvider
+
+__all__ = [
+    "VercelSandbox",
+    "VercelSandboxProvider",
+]

--- a/backend/packages/harness/deerflow/community/vercel_sandbox/vercel_sandbox.py
+++ b/backend/packages/harness/deerflow/community/vercel_sandbox/vercel_sandbox.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import base64
+import errno
+import json
+import logging
+import os
+import posixpath
+import re
+import shlex
+import threading
+from pathlib import Path
+from typing import Any
+
+from deerflow.config.paths import VIRTUAL_PATH_PREFIX, Paths, get_paths
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.search import (
+    DEFAULT_LINE_SUMMARY_LENGTH,
+    DEFAULT_MAX_FILE_SIZE_BYTES,
+    IGNORE_PATTERNS,
+    GrepMatch,
+    should_ignore_name,
+    should_ignore_path,
+    truncate_line,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_DOWNLOAD_SIZE = 100 * 1024 * 1024
+_DEFAULT_CWD = f"{VIRTUAL_PATH_PREFIX}/workspace"
+
+
+def _is_under(path: str, prefix: str) -> bool:
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _normalize_sandbox_path(path: str) -> str:
+    normalised = path.replace("\\", "/")
+    if not normalised.startswith("/"):
+        raise PermissionError(f"Sandbox path must be absolute: {path}")
+    if any(segment == ".." for segment in normalised.split("/")):
+        raise PermissionError(f"Access denied: path traversal detected in '{path}'")
+    return posixpath.normpath(normalised)
+
+
+def _require_user_data_path(path: str) -> str:
+    normalised = _normalize_sandbox_path(path)
+    if not _is_under(normalised, VIRTUAL_PATH_PREFIX):
+        raise PermissionError(f"Access denied: path must be under '{VIRTUAL_PATH_PREFIX}': '{path}'")
+    return normalised
+
+
+class VercelSandbox(Sandbox):
+    """Sandbox implementation backed by Vercel Sandbox.
+
+    Vercel does not mount DeerFlow's host-side thread directories, so this class
+    mirrors `/mnt/user-data/*` writes back to the host thread data directory.
+    That keeps existing artifact delivery and `present_files` behavior working
+    with remote Vercel execution.
+    """
+
+    def __init__(
+        self,
+        id: str,
+        client: Any,
+        *,
+        thread_id: str | None = None,
+        user_id: str | None = None,
+        paths: Paths | None = None,
+        cwd: str = _DEFAULT_CWD,
+        max_download_bytes: int = _MAX_DOWNLOAD_SIZE,
+        max_sync_file_bytes: int = _MAX_DOWNLOAD_SIZE,
+    ):
+        super().__init__(id)
+        self._client = client
+        self._thread_id = thread_id
+        self._user_id = user_id
+        self._paths = paths or get_paths()
+        self._cwd = cwd
+        self._max_download_bytes = max_download_bytes
+        self._max_sync_file_bytes = max_sync_file_bytes
+        self._lock = threading.RLock()
+        self._closed = False
+
+    @property
+    def vercel_sandbox_id(self) -> str:
+        sandbox_id = getattr(self._client, "sandbox_id", None)
+        if sandbox_id:
+            return str(sandbox_id)
+
+        sandbox = getattr(self._client, "sandbox", None)
+        sandbox_id = getattr(sandbox, "id", None)
+        if sandbox_id:
+            return str(sandbox_id)
+
+        return ""
+
+    def close(self) -> None:
+        """Close the host-side SDK client, if the SDK exposes a close hook."""
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            client = self._client
+            self._client = None
+
+        sdk_client = getattr(client, "client", None)
+        close = getattr(sdk_client, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception as exc:
+                logger.warning("Failed to close Vercel sandbox client for %s: %s", self.id, exc)
+
+    def stop(self, *, blocking: bool = False) -> None:
+        """Stop the remote Vercel sandbox.
+
+        Persistent Vercel sandboxes snapshot on stop and can be resumed later by
+        retrieving the same Vercel sandbox id.
+        """
+        with self._lock:
+            self._sdk().stop(blocking=blocking)
+
+    def bootstrap(self) -> None:
+        """Create the standard DeerFlow directories inside the Vercel sandbox."""
+        quoted_prefix = shlex.quote(VIRTUAL_PATH_PREFIX)
+        output = self._run_bash(
+            f"mkdir -p {quoted_prefix}/workspace {quoted_prefix}/uploads {quoted_prefix}/outputs /mnt/acp-workspace",
+            cwd="/",
+        )
+        if output.startswith("Error:"):
+            raise RuntimeError(output)
+
+    def execute_command(self, command: str) -> str:
+        """Execute a bash command in the Vercel sandbox."""
+        return self._run_bash(command, cwd=self._cwd)
+
+    def _run_bash(self, command: str, *, cwd: str | None) -> str:
+        with self._lock:
+            try:
+                result = self._sdk().run_command("bash", ["-lc", command], cwd=cwd)
+                output = result.output("both") if hasattr(result, "output") else ""
+                if output:
+                    return output
+                exit_code = getattr(result, "exit_code", 0)
+                if exit_code:
+                    return f"Error: command exited with status {exit_code}"
+                return "(no output)"
+            except Exception as exc:
+                logger.error("Failed to execute command in Vercel sandbox %s: %s", self.id, exc)
+                return f"Error: {exc}"
+
+    def read_file(self, path: str) -> str:
+        """Read UTF-8 text content from `/mnt/user-data` inside the sandbox."""
+        path = _require_user_data_path(path)
+        with self._lock:
+            data = self._read_file_bytes_locked(path)
+        return data.decode("utf-8")
+
+    def download_file(self, path: str) -> bytes:
+        """Download file bytes from `/mnt/user-data` inside the sandbox."""
+        path = _require_user_data_path(path)
+        with self._lock:
+            chunks: list[bytes] = []
+            total = 0
+            try:
+                for chunk in self._sdk().iter_file(path, chunk_size=65536):
+                    total += len(chunk)
+                    if total > self._max_download_bytes:
+                        raise OSError(
+                            errno.EFBIG,
+                            f"File exceeds maximum download size of {self._max_download_bytes} bytes",
+                            path,
+                        )
+                    chunks.append(chunk)
+            except OSError:
+                raise
+            except Exception as exc:
+                logger.error("Failed to download file %s from Vercel sandbox %s: %s", path, self.id, exc)
+                raise OSError(f"Failed to download file '{path}' from Vercel sandbox: {exc}") from exc
+            return b"".join(chunks)
+
+    def list_dir(self, path: str, max_depth: int = 2) -> list[str]:
+        """List files and directories under a `/mnt/user-data` path."""
+        path = _require_user_data_path(path)
+        max_depth = max(0, int(max_depth))
+        command = (
+            f"find {shlex.quote(path)} -maxdepth {max_depth} "
+            r"\( -type f -o -type d \) -print 2>/dev/null | head -500"
+        )
+        output = self.execute_command(command)
+        if output.startswith("Error:"):
+            return []
+        return [line.strip() for line in output.splitlines() if line.strip()]
+
+    def write_file(self, path: str, content: str, append: bool = False) -> None:
+        """Write text content to a `/mnt/user-data` path."""
+        self._write_bytes(path, content.encode("utf-8"), append=append)
+
+    def update_file(self, path: str, content: bytes) -> None:
+        """Write binary content to a `/mnt/user-data` path."""
+        self._write_bytes(path, content, append=False)
+
+    def glob(
+        self,
+        path: str,
+        pattern: str,
+        *,
+        include_dirs: bool = False,
+        max_results: int = 200,
+    ) -> tuple[list[str], bool]:
+        path = _require_user_data_path(path)
+        payload = {
+            "root": path,
+            "pattern": pattern,
+            "include_dirs": include_dirs,
+            "max_results": max_results,
+            "ignore_patterns": IGNORE_PATTERNS,
+        }
+        data = self._run_python_json(_GLOB_SCRIPT, payload)
+        matches = data.get("matches", []) if isinstance(data, dict) else []
+        filtered = [match for match in matches if isinstance(match, str) and not should_ignore_path(match)]
+        truncated = bool(data.get("truncated")) if isinstance(data, dict) else False
+        if len(filtered) > max_results:
+            truncated = True
+        return filtered[:max_results], truncated
+
+    def grep(
+        self,
+        path: str,
+        pattern: str,
+        *,
+        glob: str | None = None,
+        literal: bool = False,
+        case_sensitive: bool = False,
+        max_results: int = 100,
+    ) -> tuple[list[GrepMatch], bool]:
+        path = _require_user_data_path(path)
+        regex_source = re.escape(pattern) if literal else pattern
+        re.compile(regex_source, 0 if case_sensitive else re.IGNORECASE)
+        payload = {
+            "root": path,
+            "regex": regex_source,
+            "glob": glob,
+            "case_sensitive": case_sensitive,
+            "max_results": max_results,
+            "max_file_size": DEFAULT_MAX_FILE_SIZE_BYTES,
+            "line_summary_length": DEFAULT_LINE_SUMMARY_LENGTH,
+            "ignore_patterns": IGNORE_PATTERNS,
+        }
+        data = self._run_python_json(_GREP_SCRIPT, payload)
+        raw_matches = data.get("matches", []) if isinstance(data, dict) else []
+        matches: list[GrepMatch] = []
+        for item in raw_matches:
+            if not isinstance(item, dict):
+                continue
+            file_path = item.get("path")
+            if not isinstance(file_path, str) or should_ignore_path(file_path):
+                continue
+            matches.append(
+                GrepMatch(
+                    path=file_path,
+                    line_number=item.get("line_number") if isinstance(item.get("line_number"), int) else 0,
+                    line=truncate_line(str(item.get("line", ""))),
+                )
+            )
+            if len(matches) >= max_results:
+                return matches, True
+        truncated = bool(data.get("truncated")) if isinstance(data, dict) else False
+        return matches, truncated
+
+    def sync_from_host(self, *, include_outputs: bool = False) -> None:
+        """Copy existing thread data from the host into the Vercel sandbox."""
+        if self._thread_id is None:
+            return
+
+        roots: list[tuple[Path, str]] = [
+            (
+                self._paths.sandbox_work_dir(self._thread_id, user_id=self._user_id),
+                f"{VIRTUAL_PATH_PREFIX}/workspace",
+            ),
+            (
+                self._paths.sandbox_uploads_dir(self._thread_id, user_id=self._user_id),
+                f"{VIRTUAL_PATH_PREFIX}/uploads",
+            ),
+        ]
+        if include_outputs:
+            roots.append(
+                (
+                    self._paths.sandbox_outputs_dir(self._thread_id, user_id=self._user_id),
+                    f"{VIRTUAL_PATH_PREFIX}/outputs",
+                )
+            )
+
+        for root, virtual_root in roots:
+            if not root.exists():
+                continue
+            for current_root, dirs, files in os.walk(root):
+                dirs[:] = [name for name in dirs if not should_ignore_name(name)]
+                for name in files:
+                    if should_ignore_name(name):
+                        continue
+                    host_path = Path(current_root) / name
+                    if host_path.is_symlink():
+                        continue
+                    try:
+                        if host_path.stat().st_size > self._max_sync_file_bytes:
+                            continue
+                        relative = host_path.relative_to(root).as_posix()
+                        self.update_file(f"{virtual_root}/{relative}", host_path.read_bytes())
+                    except OSError as exc:
+                        logger.warning("Failed to sync host file %s to Vercel sandbox %s: %s", host_path, self.id, exc)
+
+    def sync_to_host(self, *, subdirs: tuple[str, ...] = ("workspace", "outputs")) -> None:
+        """Copy selected `/mnt/user-data` files from Vercel back to the host."""
+        if self._thread_id is None:
+            return
+
+        roots = " ".join(shlex.quote(f"{VIRTUAL_PATH_PREFIX}/{subdir}") for subdir in subdirs)
+        output = self.execute_command(f"find {roots} -type f -print 2>/dev/null")
+        if output.startswith("Error:"):
+            logger.warning("Failed to list Vercel sandbox files for sync: %s", output)
+            return
+
+        for line in output.splitlines():
+            path = line.strip()
+            if not path or should_ignore_path(path):
+                continue
+            try:
+                data = self.download_file(path)
+                self._mirror_user_data_path(path, data)
+            except OSError as exc:
+                logger.warning("Failed to sync Vercel sandbox file %s to host: %s", path, exc)
+
+    def _sdk(self) -> Any:
+        if self._client is None or self._closed:
+            raise RuntimeError("Vercel sandbox client is closed")
+        return self._client
+
+    def _read_file_bytes_locked(self, path: str) -> bytes:
+        data = self._sdk().read_file(path)
+        if data is None:
+            raise FileNotFoundError(path)
+        return data
+
+    def _write_bytes(self, path: str, content: bytes, *, append: bool = False) -> None:
+        path = _require_user_data_path(path)
+        with self._lock:
+            data = content
+            if append:
+                try:
+                    data = self._read_file_bytes_locked(path) + content
+                except FileNotFoundError:
+                    data = content
+            parent = posixpath.dirname(path)
+            if parent:
+                self._sdk().mk_dir(parent)
+            self._sdk().write_files([{"path": path, "content": data, "mode": 0o644}])
+            self._mirror_user_data_path(path, data)
+
+    def _mirror_user_data_path(self, path: str, content: bytes) -> None:
+        if self._thread_id is None:
+            return
+        try:
+            host_path = self._paths.resolve_virtual_path(self._thread_id, path, user_id=self._user_id)
+        except ValueError:
+            logger.warning("Skipping host mirror for non-user-data path %s", path)
+            return
+
+        host_path.parent.mkdir(parents=True, exist_ok=True)
+        host_path.write_bytes(content)
+        try:
+            host_path.chmod(0o666)
+        except OSError:
+            logger.debug("Could not chmod mirrored Vercel sandbox file %s", host_path)
+
+    def _run_python_json(self, script: str, payload: dict[str, Any]) -> dict[str, Any]:
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+        command = f"python3 - <<'PY'\nimport base64, json\nparams = json.loads(base64.b64decode({encoded!r}))\n{script}\nPY"
+        output = self.execute_command(command)
+        try:
+            data = json.loads(output)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse Vercel sandbox JSON helper output: %s", output[:500])
+            return {}
+        return data if isinstance(data, dict) else {}
+
+
+_GLOB_SCRIPT = r"""
+import fnmatch
+import os
+from pathlib import PurePosixPath
+
+ignore_patterns = params["ignore_patterns"]
+exact_ignores = {pattern for pattern in ignore_patterns if not any(ch in pattern for ch in "*?[")}
+glob_ignores = [pattern for pattern in ignore_patterns if any(ch in pattern for ch in "*?[")]
+
+
+def should_ignore(name):
+    return name in exact_ignores or any(fnmatch.fnmatch(name, pattern) for pattern in glob_ignores)
+
+
+def path_matches(pattern, rel_path):
+    path = PurePosixPath(rel_path)
+    return path.match(pattern) or (pattern.startswith("**/") and path.match(pattern[3:]))
+
+
+root = params["root"]
+pattern = params["pattern"]
+include_dirs = bool(params["include_dirs"])
+max_results = int(params["max_results"])
+matches = []
+truncated = False
+
+if os.path.isdir(root):
+    for current_root, dirs, files in os.walk(root):
+        dirs[:] = [name for name in dirs if not should_ignore(name)]
+        rel_dir = os.path.relpath(current_root, root)
+        rel_dir = "" if rel_dir == "." else rel_dir.replace(os.sep, "/")
+
+        if include_dirs:
+            for name in dirs:
+                rel_path = f"{rel_dir}/{name}" if rel_dir else name
+                if path_matches(pattern, rel_path):
+                    matches.append(os.path.join(current_root, name).replace(os.sep, "/"))
+                    if len(matches) >= max_results:
+                        truncated = True
+                        break
+        if truncated:
+            break
+
+        for name in files:
+            if should_ignore(name):
+                continue
+            rel_path = f"{rel_dir}/{name}" if rel_dir else name
+            if path_matches(pattern, rel_path):
+                matches.append(os.path.join(current_root, name).replace(os.sep, "/"))
+                if len(matches) >= max_results:
+                    truncated = True
+                    break
+        if truncated:
+            break
+
+print(json.dumps({"matches": matches, "truncated": truncated}))
+"""
+
+
+_GREP_SCRIPT = r"""
+import fnmatch
+import os
+import re
+from pathlib import PurePosixPath
+
+ignore_patterns = params["ignore_patterns"]
+exact_ignores = {pattern for pattern in ignore_patterns if not any(ch in pattern for ch in "*?[")}
+glob_ignores = [pattern for pattern in ignore_patterns if any(ch in pattern for ch in "*?[")]
+
+
+def should_ignore(name):
+    return name in exact_ignores or any(fnmatch.fnmatch(name, pattern) for pattern in glob_ignores)
+
+
+def path_matches(pattern, rel_path):
+    path = PurePosixPath(rel_path)
+    return path.match(pattern) or (pattern.startswith("**/") and path.match(pattern[3:]))
+
+
+root = params["root"]
+glob_pattern = params["glob"]
+flags = 0 if params["case_sensitive"] else re.IGNORECASE
+regex = re.compile(params["regex"], flags)
+max_results = int(params["max_results"])
+max_file_size = int(params["max_file_size"])
+line_summary_length = int(params["line_summary_length"])
+max_line_chars = line_summary_length * 10
+matches = []
+truncated = False
+
+if os.path.isdir(root):
+    for current_root, dirs, files in os.walk(root):
+        dirs[:] = [name for name in dirs if not should_ignore(name)]
+        rel_dir = os.path.relpath(current_root, root)
+        rel_dir = "" if rel_dir == "." else rel_dir.replace(os.sep, "/")
+
+        for name in files:
+            if should_ignore(name):
+                continue
+            candidate = os.path.join(current_root, name)
+            rel_path = f"{rel_dir}/{name}" if rel_dir else name
+            if glob_pattern is not None and not path_matches(glob_pattern, rel_path):
+                continue
+            try:
+                if os.path.islink(candidate) or os.path.getsize(candidate) > max_file_size:
+                    continue
+                with open(candidate, "rb") as sample:
+                    if b"\0" in sample.read(8192):
+                        continue
+                with open(candidate, encoding="utf-8", errors="replace") as handle:
+                    for line_number, line in enumerate(handle, start=1):
+                        if len(line) > max_line_chars:
+                            continue
+                        if regex.search(line):
+                            clean_line = line.rstrip("\n\r")
+                            if len(clean_line) > line_summary_length:
+                                clean_line = clean_line[: line_summary_length - 3] + "..."
+                            matches.append(
+                                {
+                                    "path": candidate.replace(os.sep, "/"),
+                                    "line_number": line_number,
+                                    "line": clean_line,
+                                }
+                            )
+                            if len(matches) >= max_results:
+                                truncated = True
+                                break
+                if truncated:
+                    break
+            except OSError:
+                continue
+        if truncated:
+            break
+
+print(json.dumps({"matches": matches, "truncated": truncated}))
+"""

--- a/backend/packages/harness/deerflow/community/vercel_sandbox/vercel_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/vercel_sandbox/vercel_sandbox_provider.py
@@ -1,0 +1,498 @@
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import logging
+import os
+import signal
+import threading
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows fallback
+    fcntl = None  # type: ignore[assignment]
+    import msvcrt
+
+from deerflow.config import get_app_config
+from deerflow.config.paths import get_paths
+from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.sandbox_provider import SandboxProvider
+
+from .vercel_sandbox import VercelSandbox
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RUNTIME = "python3.13"
+DEFAULT_TIMEOUT_MS = 60 * 60 * 1000
+DEFAULT_VCPUS = 2
+DEFAULT_MEMORY_MB = DEFAULT_VCPUS * 2048
+DEFAULT_MAX_SYNC_FILE_BYTES = 100 * 1024 * 1024
+DEFAULT_STOP_ON_RELEASE = True
+
+
+def _lock_file_exclusive(lock_file) -> None:
+    if fcntl is not None:
+        fcntl.flock(lock_file, fcntl.LOCK_EX)
+        return
+
+    lock_file.seek(0)
+    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+
+
+def _unlock_file(lock_file) -> None:
+    if fcntl is not None:
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+        return
+
+    lock_file.seek(0)
+    msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+def _resolve_env_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str) and value.startswith("$"):
+        return os.environ.get(value[1:], "")
+    return str(value)
+
+
+def _resolve_env_vars(env_config: dict[str, str]) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for key, value in env_config.items():
+        resolved_value = _resolve_env_value(value)
+        resolved[key] = "" if resolved_value is None else resolved_value
+    return resolved
+
+
+def _load_vercel_sdk():
+    try:
+        from vercel.sandbox import Resources
+        from vercel.sandbox import Sandbox as VercelSDKSandbox
+    except ImportError as exc:
+        raise RuntimeError("VercelSandboxProvider requires the `vercel` Python package. Run `uv sync` after enabling this provider.") from exc
+    return VercelSDKSandbox, Resources
+
+
+@dataclass
+class VercelSandboxRecord:
+    """Persisted mapping from DeerFlow sandbox id to Vercel sandbox id."""
+
+    sandbox_id: str
+    vercel_sandbox_id: str
+    thread_id: str | None
+    user_id: str | None
+    status: str
+    created_at: float
+    last_active_at: float
+    stopped_at: float | None = None
+    runtime: str | None = None
+    vcpus: int | None = None
+    memory_mb: int | None = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> VercelSandboxRecord:
+        return cls(
+            sandbox_id=str(data["sandbox_id"]),
+            vercel_sandbox_id=str(data["vercel_sandbox_id"]),
+            thread_id=data.get("thread_id"),
+            user_id=data.get("user_id"),
+            status=str(data.get("status") or "unknown"),
+            created_at=float(data.get("created_at") or time.time()),
+            last_active_at=float(data.get("last_active_at") or time.time()),
+            stopped_at=data.get("stopped_at"),
+            runtime=data.get("runtime"),
+            vcpus=data.get("vcpus"),
+            memory_mb=data.get("memory_mb"),
+        )
+
+
+class VercelSandboxProvider(SandboxProvider):
+    """Sandbox provider that runs DeerFlow thread workspaces in Vercel Sandbox.
+
+    DeerFlow keeps a deterministic per-thread sandbox id and persists the
+    provider-owned Vercel sandbox id in thread metadata. This separates business
+    session identity from the external provider's resource identity and lets a
+    stopped persistent Vercel sandbox be resumed across turns.
+    """
+
+    uses_thread_data_mounts = False
+    needs_upload_permission_adjustment = False
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._sandboxes: dict[str, VercelSandbox] = {}
+        self._records: dict[str, VercelSandboxRecord] = {}
+        self._thread_sandboxes: dict[tuple[str, str], str] = {}
+        self._thread_locks: dict[tuple[str, str], threading.Lock] = {}
+        self._last_activity: dict[str, float] = {}
+        self._shutdown_called = False
+        self._config = self._load_config()
+
+        atexit.register(self.shutdown)
+        self._register_signal_handlers()
+
+    def acquire(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        effective_user_id = self._effective_acquire_user_id(user_id)
+        if thread_id:
+            thread_lock = self._get_thread_lock(thread_id, effective_user_id)
+            with thread_lock:
+                return self._acquire_internal(thread_id, user_id=effective_user_id)
+        return self._acquire_internal(thread_id, user_id=effective_user_id)
+
+    def get(self, sandbox_id: str) -> Sandbox | None:
+        with self._lock:
+            sandbox = self._sandboxes.get(sandbox_id)
+            if sandbox is not None:
+                self._last_activity[sandbox_id] = time.time()
+            return sandbox
+
+    def release(self, sandbox_id: str) -> None:
+        sandbox: VercelSandbox | None = None
+        record: VercelSandboxRecord | None = None
+        with self._lock:
+            sandbox = self._sandboxes.pop(sandbox_id, None)
+            record = self._records.get(sandbox_id)
+            self._last_activity.pop(sandbox_id, None)
+
+        if sandbox is None:
+            logger.info("Vercel sandbox %s is not active; nothing to release", sandbox_id)
+            return
+
+        try:
+            sandbox.sync_to_host()
+        except Exception as exc:
+            logger.warning("Failed to sync Vercel sandbox %s to host during release: %s", sandbox_id, exc)
+
+        try:
+            if self._config["stop_on_release"]:
+                sandbox.stop(blocking=False)
+                if record is not None:
+                    record.status = "stopped"
+                    record.stopped_at = time.time()
+            elif record is not None:
+                record.status = "running"
+        except Exception as exc:
+            logger.warning("Failed to stop Vercel sandbox %s during release: %s", sandbox_id, exc)
+        finally:
+            if record is not None:
+                record.last_active_at = time.time()
+                self._persist_record(record)
+            sandbox.close()
+
+        logger.info("Released Vercel sandbox %s", sandbox_id)
+
+    def destroy(self, sandbox_id: str) -> None:
+        """Stop and forget a Vercel-backed sandbox mapping."""
+        sandbox: VercelSandbox | None = None
+        record: VercelSandboxRecord | None = None
+        thread_keys_to_remove: list[tuple[str, str]] = []
+
+        with self._lock:
+            sandbox = self._sandboxes.pop(sandbox_id, None)
+            record = self._records.pop(sandbox_id, None)
+            thread_keys_to_remove = [key for key, sid in self._thread_sandboxes.items() if sid == sandbox_id]
+            for key in thread_keys_to_remove:
+                del self._thread_sandboxes[key]
+            self._last_activity.pop(sandbox_id, None)
+
+        if sandbox is not None:
+            try:
+                sandbox.sync_to_host()
+            except Exception as exc:
+                logger.warning("Failed to sync Vercel sandbox %s during destroy: %s", sandbox_id, exc)
+            try:
+                sandbox.stop(blocking=False)
+            except Exception as exc:
+                logger.warning("Failed to stop Vercel sandbox %s during destroy: %s", sandbox_id, exc)
+            finally:
+                sandbox.close()
+
+        if record and record.thread_id:
+            try:
+                self._record_path(record.thread_id, record.user_id, sandbox_id).unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("Failed to remove Vercel sandbox record for %s: %s", sandbox_id, exc)
+
+    def shutdown(self) -> None:
+        with self._lock:
+            if self._shutdown_called:
+                return
+            self._shutdown_called = True
+            sandbox_ids = list(self._sandboxes)
+
+        for sandbox_id in sandbox_ids:
+            try:
+                self.release(sandbox_id)
+            except Exception as exc:
+                logger.warning("Failed to release Vercel sandbox %s during shutdown: %s", sandbox_id, exc)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._sandboxes.clear()
+            self._records.clear()
+            self._thread_sandboxes.clear()
+            self._thread_locks.clear()
+            self._last_activity.clear()
+            self._shutdown_called = False
+
+    def _load_config(self) -> dict[str, Any]:
+        config = get_app_config()
+        sandbox_config = config.sandbox
+
+        vcpus = getattr(sandbox_config, "vercel_vcpus", None) or DEFAULT_VCPUS
+        memory_mb = getattr(sandbox_config, "vercel_memory_mb", None) or (vcpus * 2048)
+        if memory_mb != vcpus * 2048:
+            raise ValueError("Vercel Sandbox requires sandbox.vercel_memory_mb to equal sandbox.vercel_vcpus * 2048")
+
+        env = _resolve_env_vars(getattr(sandbox_config, "environment", None) or {})
+        env.update(_resolve_env_vars(getattr(sandbox_config, "vercel_environment", None) or {}))
+
+        return {
+            "token": _resolve_env_value(getattr(sandbox_config, "vercel_token", None)),
+            "project_id": _resolve_env_value(getattr(sandbox_config, "vercel_project_id", None)),
+            "team_id": _resolve_env_value(getattr(sandbox_config, "vercel_team_id", None)),
+            "runtime": getattr(sandbox_config, "vercel_runtime", None) or DEFAULT_RUNTIME,
+            "image": getattr(sandbox_config, "vercel_image", None),
+            "timeout": getattr(sandbox_config, "vercel_timeout_ms", None) or DEFAULT_TIMEOUT_MS,
+            "vcpus": vcpus,
+            "memory_mb": memory_mb,
+            "ports": getattr(sandbox_config, "vercel_ports", None) or None,
+            "interactive": bool(getattr(sandbox_config, "vercel_interactive", False)),
+            "environment": env,
+            "max_sync_file_bytes": (getattr(sandbox_config, "vercel_sync_max_file_bytes", None) or DEFAULT_MAX_SYNC_FILE_BYTES),
+            "stop_on_release": bool(getattr(sandbox_config, "vercel_stop_on_release", DEFAULT_STOP_ON_RELEASE)),
+        }
+
+    @staticmethod
+    def _effective_acquire_user_id(user_id: str | None) -> str:
+        return user_id or get_effective_user_id()
+
+    @staticmethod
+    def _thread_key(thread_id: str, user_id: str) -> tuple[str, str]:
+        return (user_id, thread_id)
+
+    @staticmethod
+    def _deterministic_sandbox_id(thread_id: str, user_id: str) -> str:
+        digest = hashlib.sha256(f"{user_id}:{thread_id}".encode()).hexdigest()[:12]
+        return f"vercel-{digest}"
+
+    def _sandbox_id_for_thread(self, thread_id: str | None, user_id: str) -> str:
+        if thread_id:
+            return self._deterministic_sandbox_id(thread_id, user_id)
+        return f"vercel-{str(uuid.uuid4())[:12]}"
+
+    def _get_thread_lock(self, thread_id: str, user_id: str) -> threading.Lock:
+        key = self._thread_key(thread_id, user_id)
+        with self._lock:
+            if key not in self._thread_locks:
+                self._thread_locks[key] = threading.Lock()
+            return self._thread_locks[key]
+
+    def _reuse_in_process_sandbox(self, thread_id: str | None, *, user_id: str) -> str | None:
+        if thread_id is None:
+            return None
+        key = self._thread_key(thread_id, user_id)
+        with self._lock:
+            existing_id = self._thread_sandboxes.get(key)
+            if existing_id is None or existing_id not in self._sandboxes:
+                return None
+            self._last_activity[existing_id] = time.time()
+            return existing_id
+
+    def _acquire_internal(self, thread_id: str | None, *, user_id: str) -> str:
+        cached_id = self._reuse_in_process_sandbox(thread_id, user_id=user_id)
+        if cached_id is not None:
+            return cached_id
+
+        sandbox_id = self._sandbox_id_for_thread(thread_id, user_id)
+        if thread_id is None:
+            return self._create_and_register(None, sandbox_id, user_id=user_id, record=None)
+
+        paths = get_paths()
+        paths.ensure_thread_dirs(thread_id, user_id=user_id)
+        lock_path = paths.thread_dir(thread_id, user_id=user_id) / f"{sandbox_id}.vercel.lock"
+        with open(lock_path, "a", encoding="utf-8") as lock_file:
+            locked = False
+            try:
+                _lock_file_exclusive(lock_file)
+                locked = True
+                cached_id = self._reuse_in_process_sandbox(thread_id, user_id=user_id)
+                if cached_id is not None:
+                    return cached_id
+
+                record = self._load_record(thread_id, user_id, sandbox_id)
+                if record is not None:
+                    try:
+                        client = self._get_vercel_sandbox(record.vercel_sandbox_id)
+                        return self._register_sandbox(thread_id, sandbox_id, user_id=user_id, client=client, record=record)
+                    except Exception as exc:
+                        logger.warning(
+                            "Failed to resume Vercel sandbox %s for DeerFlow sandbox %s; creating a new sandbox: %s",
+                            record.vercel_sandbox_id,
+                            sandbox_id,
+                            exc,
+                        )
+
+                return self._create_and_register(thread_id, sandbox_id, user_id=user_id, record=record)
+            finally:
+                if locked:
+                    _unlock_file(lock_file)
+
+    def _create_and_register(
+        self,
+        thread_id: str | None,
+        sandbox_id: str,
+        *,
+        user_id: str,
+        record: VercelSandboxRecord | None,
+    ) -> str:
+        client = self._create_vercel_sandbox()
+        remote_id = self._remote_sandbox_id(client)
+        now = time.time()
+        new_record = VercelSandboxRecord(
+            sandbox_id=sandbox_id,
+            vercel_sandbox_id=remote_id,
+            thread_id=thread_id,
+            user_id=user_id,
+            status="running",
+            created_at=record.created_at if record is not None else now,
+            last_active_at=now,
+            runtime=self._config["runtime"],
+            vcpus=self._config["vcpus"],
+            memory_mb=self._config["memory_mb"],
+        )
+        return self._register_sandbox(thread_id, sandbox_id, user_id=user_id, client=client, record=new_record)
+
+    def _register_sandbox(
+        self,
+        thread_id: str | None,
+        sandbox_id: str,
+        *,
+        user_id: str,
+        client: Any,
+        record: VercelSandboxRecord,
+    ) -> str:
+        sandbox = VercelSandbox(
+            id=sandbox_id,
+            client=client,
+            thread_id=thread_id,
+            user_id=user_id,
+            paths=get_paths(),
+            max_sync_file_bytes=self._config["max_sync_file_bytes"],
+        )
+        sandbox.bootstrap()
+        sandbox.sync_from_host()
+
+        record.vercel_sandbox_id = sandbox.vercel_sandbox_id or record.vercel_sandbox_id
+        record.status = "running"
+        record.last_active_at = time.time()
+        record.stopped_at = None
+
+        with self._lock:
+            self._sandboxes[sandbox_id] = sandbox
+            self._records[sandbox_id] = record
+            self._last_activity[sandbox_id] = time.time()
+            if thread_id:
+                self._thread_sandboxes[self._thread_key(thread_id, user_id)] = sandbox_id
+
+        self._persist_record(record)
+        logger.info(
+            "Acquired Vercel sandbox %s for DeerFlow sandbox %s thread %s",
+            record.vercel_sandbox_id,
+            sandbox_id,
+            thread_id,
+        )
+        return sandbox_id
+
+    def _create_vercel_sandbox(self):
+        VercelSDKSandbox, Resources = _load_vercel_sdk()
+        resources = Resources(vcpus=self._config["vcpus"], memory=self._config["memory_mb"])
+        return VercelSDKSandbox.create(
+            ports=self._config["ports"],
+            timeout=self._config["timeout"],
+            resources=resources,
+            runtime=self._config["runtime"],
+            image=self._config["image"],
+            token=self._config["token"],
+            project_id=self._config["project_id"],
+            team_id=self._config["team_id"],
+            interactive=self._config["interactive"],
+            env=self._config["environment"],
+        )
+
+    def _get_vercel_sandbox(self, vercel_sandbox_id: str):
+        VercelSDKSandbox, _ = _load_vercel_sdk()
+        return VercelSDKSandbox.get(
+            sandbox_id=vercel_sandbox_id,
+            token=self._config["token"],
+            project_id=self._config["project_id"],
+            team_id=self._config["team_id"],
+        )
+
+    @staticmethod
+    def _remote_sandbox_id(client: Any) -> str:
+        sandbox_id = getattr(client, "sandbox_id", None)
+        if sandbox_id:
+            return str(sandbox_id)
+
+        sandbox = getattr(client, "sandbox", None)
+        sandbox_id = getattr(sandbox, "id", None)
+        if sandbox_id:
+            return str(sandbox_id)
+
+        raise RuntimeError("Vercel SDK did not return a sandbox id")
+
+    def _record_path(self, thread_id: str, user_id: str | None, sandbox_id: str) -> Path:
+        return get_paths().thread_dir(thread_id, user_id=user_id) / f"{sandbox_id}.vercel-sandbox.json"
+
+    def _load_record(self, thread_id: str, user_id: str, sandbox_id: str) -> VercelSandboxRecord | None:
+        path = self._record_path(thread_id, user_id, sandbox_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return VercelSandboxRecord.from_dict(data)
+        except Exception as exc:
+            logger.warning("Failed to read Vercel sandbox record %s: %s", path, exc)
+            return None
+
+    def _persist_record(self, record: VercelSandboxRecord) -> None:
+        if record.thread_id is None:
+            return
+        path = self._record_path(record.thread_id, record.user_id, record.sandbox_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(record), indent=2, sort_keys=True), encoding="utf-8")
+
+    def _register_signal_handlers(self) -> None:
+        self._original_sigterm = signal.getsignal(signal.SIGTERM)
+        self._original_sigint = signal.getsignal(signal.SIGINT)
+        self._original_sighup = signal.getsignal(signal.SIGHUP) if hasattr(signal, "SIGHUP") else None
+
+        def signal_handler(signum, frame):
+            self.shutdown()
+            if signum == signal.SIGTERM:
+                original = self._original_sigterm
+            elif hasattr(signal, "SIGHUP") and signum == signal.SIGHUP:
+                original = self._original_sighup
+            else:
+                original = self._original_sigint
+            if callable(original):
+                original(signum, frame)
+            elif original == signal.SIG_DFL:
+                signal.signal(signum, signal.SIG_DFL)
+                signal.raise_signal(signum)
+
+        try:
+            signal.signal(signal.SIGTERM, signal_handler)
+            signal.signal(signal.SIGINT, signal_handler)
+            if hasattr(signal, "SIGHUP"):
+                signal.signal(signal.SIGHUP, signal_handler)
+        except ValueError:
+            logger.debug("Could not register Vercel sandbox signal handlers outside the main thread")

--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -38,6 +38,15 @@ class SandboxConfig(BaseModel):
         idle_timeout: Idle timeout in seconds before sandbox is released (default: 600 = 10 minutes). Set to 0 to disable.
         mounts: List of volume mounts to share directories with the container
         environment: Environment variables to inject into the container (values starting with $ are resolved from host env)
+
+    VercelSandboxProvider specific options:
+        vercel_token: Vercel API token, or `$ENV_VAR` reference
+        vercel_project_id: Vercel project id, or `$ENV_VAR` reference
+        vercel_team_id: Optional Vercel team id, or `$ENV_VAR` reference
+        vercel_runtime: Runtime name passed to Vercel Sandbox (default: python3.13)
+        vercel_vcpus: Vercel resource vCPU count (default: 2)
+        vercel_memory_mb: Vercel memory in MiB. Must equal vercel_vcpus * 2048.
+        vercel_stop_on_release: Stop persistent sandboxes after each agent run so Vercel can snapshot and idle.
     """
 
     use: str = Field(
@@ -75,6 +84,63 @@ class SandboxConfig(BaseModel):
     environment: dict[str, str] = Field(
         default_factory=dict,
         description="Environment variables to inject into the sandbox container. Values starting with $ will be resolved from host environment variables.",
+    )
+
+    vercel_token: str | None = Field(
+        default=None,
+        description="Vercel API token for VercelSandboxProvider. Values starting with $ are resolved from host environment variables.",
+    )
+    vercel_project_id: str | None = Field(
+        default=None,
+        description="Vercel project id for VercelSandboxProvider. Values starting with $ are resolved from host environment variables.",
+    )
+    vercel_team_id: str | None = Field(
+        default=None,
+        description="Optional Vercel team id for VercelSandboxProvider. Values starting with $ are resolved from host environment variables.",
+    )
+    vercel_runtime: str | None = Field(
+        default=None,
+        description="Runtime passed to Vercel Sandbox (default: python3.13).",
+    )
+    vercel_image: str | None = Field(
+        default=None,
+        description="Optional custom image passed to Vercel Sandbox.",
+    )
+    vercel_timeout_ms: int | None = Field(
+        default=None,
+        gt=0,
+        description="Vercel sandbox timeout in milliseconds (default: 3600000).",
+    )
+    vercel_vcpus: int | None = Field(
+        default=None,
+        gt=0,
+        description="Vercel sandbox vCPU count (default: 2). Vercel accepts 1 or even values.",
+    )
+    vercel_memory_mb: int | None = Field(
+        default=None,
+        gt=0,
+        description="Vercel sandbox memory in MiB. Must equal vercel_vcpus * 2048.",
+    )
+    vercel_ports: list[int] = Field(
+        default_factory=list,
+        description="Ports to expose from Vercel Sandbox for preview URLs.",
+    )
+    vercel_interactive: bool = Field(
+        default=False,
+        description="Whether to request an interactive Vercel sandbox session.",
+    )
+    vercel_environment: dict[str, str] = Field(
+        default_factory=dict,
+        description="Additional environment variables injected only into Vercel Sandbox. Values starting with $ are resolved from host environment variables.",
+    )
+    vercel_sync_max_file_bytes: int | None = Field(
+        default=None,
+        gt=0,
+        description="Maximum file size copied between host thread data and Vercel Sandbox (default: 100 MiB).",
+    )
+    vercel_stop_on_release: bool = Field(
+        default=True,
+        description="Stop the persistent Vercel sandbox after each agent run so it snapshots and stops accruing idle runtime.",
     )
 
     bash_output_max_chars: int = Field(

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "tiktoken>=0.8.0",
     "ddgs>=9.10.0",
     "duckdb>=1.4.4",
+    "vercel>=0.6.0",
     "langchain-google-genai>=4.2.1",
     "langgraph-checkpoint-sqlite>=3.0.3",
     "langgraph-sdk>=0.1.51",

--- a/backend/tests/test_vercel_sandbox_provider.py
+++ b/backend/tests/test_vercel_sandbox_provider.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import shlex
+from types import SimpleNamespace
+from typing import Any
+
+from deerflow.community.vercel_sandbox.vercel_sandbox import VercelSandbox
+from deerflow.config.paths import Paths
+
+
+class FakeCommandFinished:
+    def __init__(self, output: str = "", exit_code: int = 0):
+        self._output = output
+        self.exit_code = exit_code
+
+    def output(self, stream: str = "both") -> str:
+        return self._output
+
+
+class FakeVercelClient:
+    def __init__(self, sandbox_id: str):
+        self.sandbox_id = sandbox_id
+        self.files: dict[str, bytes] = {}
+        self.commands: list[tuple[str, list[str] | None, str | None]] = []
+        self.dirs: set[str] = set()
+        self.stopped = False
+        self.closed = False
+        self.client = SimpleNamespace(close=self._close)
+
+    def _close(self) -> None:
+        self.closed = True
+
+    def run_command(
+        self,
+        cmd: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        sudo: bool = False,
+    ) -> FakeCommandFinished:
+        self.commands.append((cmd, args, cwd))
+        command = args[1] if cmd == "bash" and args and len(args) >= 2 and args[0] == "-lc" else cmd
+        if command.startswith("mkdir -p "):
+            for path in shlex.split(command)[2:]:
+                self.dirs.add(path)
+            return FakeCommandFinished()
+        if command.startswith("find ") and " -type f -print" in command:
+            return FakeCommandFinished("\n".join(sorted(self.files)))
+        if command.startswith("find ") and " -maxdepth " in command:
+            return FakeCommandFinished("\n".join(sorted(self.files)))
+        return FakeCommandFinished()
+
+    def mk_dir(self, path: str, *, cwd: str | None = None) -> None:
+        self.dirs.add(path)
+
+    def write_files(self, files: list[dict[str, Any]]) -> None:
+        for file in files:
+            self.files[file["path"]] = file["content"]
+
+    def read_file(self, path: str, *, cwd: str | None = None) -> bytes | None:
+        return self.files.get(path)
+
+    def iter_file(self, path: str, *, cwd: str | None = None, chunk_size: int = 65536):
+        data = self.files[path]
+        for offset in range(0, len(data), chunk_size):
+            yield data[offset : offset + chunk_size]
+
+    def stop(self, *, blocking: bool = False) -> None:
+        self.stopped = True
+
+
+def test_vercel_sandbox_mirrors_user_data_writes_to_host(tmp_path):
+    paths = Paths(base_dir=tmp_path)
+    paths.ensure_thread_dirs("thread-1", user_id="user-1")
+    client = FakeVercelClient("sbx_1")
+    sandbox = VercelSandbox(
+        id="vercel-thread",
+        client=client,
+        thread_id="thread-1",
+        user_id="user-1",
+        paths=paths,
+    )
+
+    sandbox.write_file("/mnt/user-data/outputs/report.md", "hello")
+    sandbox.write_file("/mnt/user-data/outputs/report.md", " world", append=True)
+
+    host_file = paths.sandbox_outputs_dir("thread-1", user_id="user-1") / "report.md"
+    assert client.files["/mnt/user-data/outputs/report.md"] == b"hello world"
+    assert host_file.read_text(encoding="utf-8") == "hello world"
+
+
+def test_vercel_provider_persists_mapping_stops_and_resumes(tmp_path, monkeypatch):
+    import deerflow.community.vercel_sandbox.vercel_sandbox as sandbox_mod
+    import deerflow.community.vercel_sandbox.vercel_sandbox_provider as provider_mod
+
+    paths = Paths(base_dir=tmp_path)
+    paths.ensure_thread_dirs("thread-2", user_id="user-2")
+    (paths.sandbox_uploads_dir("thread-2", user_id="user-2") / "input.txt").write_text(
+        "uploaded",
+        encoding="utf-8",
+    )
+
+    sandbox_cfg = SimpleNamespace(
+        environment={"API_KEY": "$TEST_API_KEY"},
+        vercel_environment={"RUNTIME_ENV": "test"},
+        vercel_vcpus=2,
+        vercel_memory_mb=4096,
+        vercel_runtime="python3.13",
+        vercel_stop_on_release=True,
+    )
+    monkeypatch.setenv("TEST_API_KEY", "secret")
+    monkeypatch.setattr(provider_mod, "get_app_config", lambda: SimpleNamespace(sandbox=sandbox_cfg))
+    monkeypatch.setattr(provider_mod, "get_paths", lambda: paths)
+    monkeypatch.setattr(sandbox_mod, "get_paths", lambda: paths)
+    monkeypatch.setattr(provider_mod.VercelSandboxProvider, "_register_signal_handlers", lambda self: None)
+
+    remote_clients: dict[str, FakeVercelClient] = {}
+    created: list[str] = []
+    resumed: list[str] = []
+
+    def fake_create(self):
+        remote_id = f"sbx_{len(created) + 1}"
+        created.append(remote_id)
+        client = FakeVercelClient(remote_id)
+        remote_clients[remote_id] = client
+        return client
+
+    def fake_get(self, vercel_sandbox_id: str):
+        resumed.append(vercel_sandbox_id)
+        return remote_clients[vercel_sandbox_id]
+
+    monkeypatch.setattr(provider_mod.VercelSandboxProvider, "_create_vercel_sandbox", fake_create)
+    monkeypatch.setattr(provider_mod.VercelSandboxProvider, "_get_vercel_sandbox", fake_get)
+
+    provider = provider_mod.VercelSandboxProvider()
+
+    sandbox_id = provider.acquire("thread-2", user_id="user-2")
+    sandbox = provider.get(sandbox_id)
+    assert isinstance(sandbox, VercelSandbox)
+
+    client = remote_clients["sbx_1"]
+    assert client.files["/mnt/user-data/uploads/input.txt"] == b"uploaded"
+
+    record_path = paths.thread_dir("thread-2", user_id="user-2") / f"{sandbox_id}.vercel-sandbox.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["sandbox_id"] == sandbox_id
+    assert record["vercel_sandbox_id"] == "sbx_1"
+
+    client.files["/mnt/user-data/outputs/result.txt"] = b"done"
+    provider.release(sandbox_id)
+
+    assert client.stopped is True
+    assert client.closed is True
+    assert provider.get(sandbox_id) is None
+    assert (paths.sandbox_outputs_dir("thread-2", user_id="user-2") / "result.txt").read_text(encoding="utf-8") == "done"
+
+    reacquired_id = provider.acquire("thread-2", user_id="user-2")
+
+    assert reacquired_id == sandbox_id
+    assert created == ["sbx_1"]
+    assert resumed == ["sbx_1"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -486,6 +486,46 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/af/473c241e41c142ea06ebef8d1f660fa6ff928fb97210e7bec8ee5974f8cd/cbor2-6.1.2.tar.gz", hash = "sha256:6b43037a66947dee5af0abb1a4c3a13b3abac5a4a3f32f9771efbbcd030fd909", size = 86760, upload-time = "2026-06-02T19:01:29.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0c/a857b6ca032282b564cf25de18ad92fe0614e8b3fa3422eb10e32a873939/cbor2-6.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:92b158d3ff9d9dce70eeb09786a6e518e3cb0ecb927fd23e9a0f7fc4b175c01a", size = 409592, upload-time = "2026-06-02T19:00:44.556Z" },
+    { url = "https://files.pythonhosted.org/packages/29/db/e0518153b3228159d9373f3b5785d7ea2d68898e27ee1bce7d03f0b5f7aa/cbor2-6.1.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d29a11044b07048e19f39a87fe8fea7ea865eb0ace50dc4c29513d52d40e2ddf", size = 454598, upload-time = "2026-06-02T19:00:45.784Z" },
+    { url = "https://files.pythonhosted.org/packages/29/67/62127b22edc6011ba55b76a28ab7c2219a45d01871a8199532e0978b26d1/cbor2-6.1.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a106f174eda34d8937a621c7f3e6044586cb209170cdc8da0ffbea89d1d6e385", size = 467380, upload-time = "2026-06-02T19:00:47.196Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/95/7992d8ec904c116ad547abb4960cc3fde695d5853c66596b1465d14d2f7b/cbor2-6.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ea16a25cc457a92879ff7a36cc50b587bddba09d8176bf1a94803eec5aa27eb", size = 521672, upload-time = "2026-06-02T19:00:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/cf/80cc4be132a523f0c92fb4c71813577bb393abea9e27990ca74605e0e930/cbor2-6.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2652a94224980d47f2a3866dd35b1afe532ecdfaf91f8cfcec39a026c457a844", size = 534402, upload-time = "2026-06-02T19:00:50.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ea/99e466d8bef61a0775a1d8538ae6c9d95f4533fadc01f8f7814cb7ab80ad/cbor2-6.1.2-cp312-cp312-win32.whl", hash = "sha256:618666292900487db4a5abcade3150105c9c9fdd22576e6ff297c9a72eef0c6a", size = 283225, upload-time = "2026-06-02T19:00:51.406Z" },
+    { url = "https://files.pythonhosted.org/packages/14/13/e6a677bdc499e43049006cb54fe605b0f7aef621402d31354cc42ef293c9/cbor2-6.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:c61c0b2e2cee64497e6c62d1976bc212f62ac0cd2b5b903613610d79b8b06b60", size = 300844, upload-time = "2026-06-02T19:00:52.628Z" },
+    { url = "https://files.pythonhosted.org/packages/77/4a/08bd8461f8e2e1ce1de5ae2768f2b7ca39a090e3156c1ee0d9b5fd86e70d/cbor2-6.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c871e7266ddc545b258e6f8e5300396985dc485d7ccf8bb4777385782f302153", size = 289040, upload-time = "2026-06-02T19:00:53.971Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/dc/bc045c8f36317e4e5f7a60d94b36833139909fc32e3a65f44bc61a36def0/cbor2-6.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f1aa38c422d87ea61849b2a823b10b64053fb4da8763f19ac78ea9a69d682b2a", size = 408846, upload-time = "2026-06-02T19:00:55.476Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/36/d66f5f0dd98ecbdcfc7da1fbd423f7b3782a27719f0062a560476f00b334/cbor2-6.1.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:ff7d0bd8ff432832338a8d2430aee34f8a082342480ff537c0ba90e2b8ff7894", size = 454624, upload-time = "2026-06-02T19:00:56.744Z" },
+    { url = "https://files.pythonhosted.org/packages/38/6b/4884b9cf03db14dc5007825d5d1bf8678a75c49d4268d8e0c1c6e9580104/cbor2-6.1.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c1eedf3290d88a5f663bd8b4b8f0f0e2103d0594c293fa5f4e62e53100972309", size = 466585, upload-time = "2026-06-02T19:00:58.209Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/36a15beb3915f56a79d6e9213c6d40c0f5cb90cd3462923f555d78068847/cbor2-6.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3049b04bddf9a5a2d0e5bb25dccdaf4552fcaf607b404e249d4f78f010fcc7d0", size = 521678, upload-time = "2026-06-02T19:00:59.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3f/e899313371ebeb7a191d751de97ccd8242abc24bbc9d8e2c58e04475cfb0/cbor2-6.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:96eb687a62040401668f06a85de8f47361ef44574de1493899e0ec678109fc04", size = 534044, upload-time = "2026-06-02T19:01:00.875Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/1a872acdeb1ab9a884ec3460f73a43e02154dc20d8ccb627bbd60f4c0ea1/cbor2-6.1.2-cp313-cp313-win32.whl", hash = "sha256:03440b505882280023db1fedcee6844804e9968bb50f9eb4ff12aaf27777fcfe", size = 282328, upload-time = "2026-06-02T19:01:02.347Z" },
+    { url = "https://files.pythonhosted.org/packages/70/79/29721bc15d38889e7bec214ede2346ee15970bedcc5e6ce1fa30f21e9a4e/cbor2-6.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:d2c8da2c0f821827dcc9eb59a5c9351791a8aa3b389a2ea7ca64c4f97bcb94cf", size = 300313, upload-time = "2026-06-02T19:01:03.69Z" },
+    { url = "https://files.pythonhosted.org/packages/07/98/a13b424fb2f14fe332b57f71f479953b2f291a051f797d42ddab9fcd2027/cbor2-6.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:8e1478d3b980ddfcaf56e27cecbfe13057e0f67d5e8240fe8a398815acb9c4bf", size = 288725, upload-time = "2026-06-02T19:01:04.933Z" },
+    { url = "https://files.pythonhosted.org/packages/62/72/949bdc7422acd868a2355ae032561a104973fb5de284b36a237b85780dc9/cbor2-6.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b0b65314a0b18c47651e17792447171a858dd77e3f161c451ad850d63f8718a9", size = 407436, upload-time = "2026-06-02T19:01:06.259Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bd/5969f9263102d1c15aa370b39802e4a87b1d1703fdb51588daf38b5fbe7e/cbor2-6.1.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8904deb2849bae40cea970e114398a19da371e1048ae1409e64f167a1205daf6", size = 453507, upload-time = "2026-06-02T19:01:07.795Z" },
+    { url = "https://files.pythonhosted.org/packages/93/a5/227b785692a8374e3dbdf1fe76d1a9af48239855abd68a4111a1458fd81b/cbor2-6.1.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b29d58d8ce00535354d873df170a3e9f0f0a02af65d12102d2552e2129c65dc8", size = 464875, upload-time = "2026-06-02T19:01:09.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/48/a06527c3fbed4c32816abba4540e432fe9cd7e739a37fef0f205bd0f1e44/cbor2-6.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:27be1cc0abc42f154a48a315c92feb2bfb50397e51c70860460438ea172198a5", size = 519940, upload-time = "2026-06-02T19:01:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1b/0e3f0dac7140d4b94ffbcef765fa4cce0caa1d942060101149de998fa7be/cbor2-6.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b8d87fb8a33ff1971cb01511e74b044767cbba1ba536d3dc0b0c48f0d1b62237", size = 532612, upload-time = "2026-06-02T19:01:12.363Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2f/5af245e7667b65c6e4a714bb5d89c84de5573b857eba9137533d54bc2e4f/cbor2-6.1.2-cp314-cp314-win32.whl", hash = "sha256:72ba0ea913ca1a8d916867f1b7d414f140982d2873e5d92f8f51de437e08979e", size = 285886, upload-time = "2026-06-02T19:01:13.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0a/6303f3e19730450c5a82b97cd2c0ed54855f9108502041305b4c641116cd/cbor2-6.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:c02b7d94fe9914798a346a2f089f0f7f85be71d120d40080916d131fa0bd0442", size = 308808, upload-time = "2026-06-02T19:01:14.944Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/61/48f9c5545223dad9d2ea2061a76da739b4047a461297b621fc80ce0f65c0/cbor2-6.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:2af1309865000c401755fd4fdd5550f74ac34c3f79eb7db15f3956714769a5a9", size = 299522, upload-time = "2026-06-02T19:01:16.393Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2b/efcc6578b4e6142fb8ec9212c0dee5030345db2092f26aa960236067e717/cbor2-6.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9f26e08dd78ee77d103065543a65cfb838948fa8735180ad4d81d939950a1420", size = 402925, upload-time = "2026-06-02T19:01:17.979Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f6/58c86aa6246b3e7de473d8ff79ac8cc986e95cafe208899a70d6916012d7/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:596e238f24bf9ede11a1ad08d2115fe78105ed6dda42ce1dd35872e7e91974fd", size = 446201, upload-time = "2026-06-02T19:01:19.481Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/12/3b90820583e9860e35cb5e91f3b2cd2ab1bbdf1c57fc63aa572952f5f75f/cbor2-6.1.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:08a62f69fe0f0ee1428d901423853b56bb5c775430f798401f8fac4b9affdecc", size = 460193, upload-time = "2026-06-02T19:01:20.876Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/88/c1e841ffb39a8e7163d7d432f7ea0e59b812c5134a449c75b6b8eb8aad08/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6ca0080e4d8ab0d67c0518ac995d03151a1274b5c295c9e619fb6057c91ae49e", size = 511446, upload-time = "2026-06-02T19:01:22.18Z" },
+    { url = "https://files.pythonhosted.org/packages/db/0a/f1ede587a388f127b9fc3d8ecb2f5d948654fed9fc7698f8b05fd90986bf/cbor2-6.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b44eb2f3ea1c8d9cb3e39c345204ec4d9489f8149b78eb5e058b13b14a8c7b07", size = 527683, upload-time = "2026-06-02T19:01:23.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/e3210ea45855a8d6173821f712a71a90d23dea0c134c4017c6f666a04fdf/cbor2-6.1.2-cp314-cp314t-win32.whl", hash = "sha256:f93179b4b1ba958b5c37b56969b8f07b4fcf44a83319f47559c59f28a1c564a4", size = 280419, upload-time = "2026-06-02T19:01:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/96/84/b555de26cc01108a72ed1df8eb7ca1d63495a3727045f0f93318dc5f99a8/cbor2-6.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:3c6c3d6598c268abf7068ae75b23b19f708e7a4aa294341b356deb65cb2664f1", size = 302514, upload-time = "2026-06-02T19:01:26.782Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6e/5556939414c0d2bffed7c7a53cf2b32181b55a795944d19835d513a7bc88/cbor2-6.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:8c2202fd1906f978bff3f97b21351815753dd9a8fcf4612a5113b6b257089059", size = 290058, upload-time = "2026-06-02T19:01:28.077Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -866,6 +906,7 @@ dependencies = [
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "tavily-python" },
     { name = "tiktoken" },
+    { name = "vercel" },
 ]
 
 [package.optional-dependencies]
@@ -927,6 +968,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.17" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=0.80" },
     { name = "tiktoken", specifier = ">=0.8.0" },
+    { name = "vercel", specifier = ">=0.6.0" },
 ]
 provides-extras = ["tui", "groundroute", "ollama", "postgres", "pymupdf"]
 
@@ -4450,6 +4492,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "vercel"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cbor2" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel-headers" },
+    { name = "vercel-oidc" },
+    { name = "vercel-workers" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e8/03b28af09c4885d21449c27e721007529a842faa5b1c3228622c8761b852/vercel-0.6.0.tar.gz", hash = "sha256:c540bb463cb8c262bd352aa21ecde27811a1e33393c96c720bd112c952322e6b", size = 106602, upload-time = "2026-06-29T18:55:42.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/32/3547b12e0ebc8e2758a0893fece1c86478b61a0d96b57bf7c3b891a6f52b/vercel-0.6.0-py3-none-any.whl", hash = "sha256:fb2e3ecea1e153e3bace829ae8254760ed4916e36998e4a8ce1e1af7091861a0", size = 145183, upload-time = "2026-06-29T18:55:41.116Z" },
+]
+
+[[package]]
+name = "vercel-headers"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/2e/d18dbc7b32a309daf6494a5d51d5a1ddfce9cc702600a852eb671cc21802/vercel_headers-0.6.0.tar.gz", hash = "sha256:77794510ea746c7ee086c85490028bf084a7fc924ab46cc1d746eb89040fbba7", size = 3048, upload-time = "2026-06-29T18:09:22.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/fa/7fd5641c2cdbccee9538eb64eabb587ebcad2332307542a28f506f79a2c9/vercel_headers-0.6.0-py3-none-any.whl", hash = "sha256:d16c97626ef669b8c036898b08b43efa689b63aa66f187c14f52584793f87a51", size = 3365, upload-time = "2026-06-29T18:09:21.669Z" },
+]
+
+[[package]]
+name = "vercel-oidc"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "vercel-headers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/6d/51d875207ebbb0709ef01a1ceff6706bd3dd966c1edff732225824ed1f45/vercel_oidc-0.6.0.tar.gz", hash = "sha256:53d3af9fcf40dee0803db213c41f374d0df10fc81f33018230ce6525ba41ab5e", size = 5978, upload-time = "2026-06-29T18:12:57.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/6c/89129d15ae215cae7938b7cc5e54d7687c3ba624771e0aa85dfbaeb7b083/vercel_oidc-0.6.0-py3-none-any.whl", hash = "sha256:7db018b5a970f2d30a5c2b7fc62a21c5c79c06921bd9295c34b0960c9550d992", size = 7662, upload-time = "2026-06-29T18:12:56.9Z" },
+]
+
+[[package]]
+name = "vercel-workers"
+version = "0.0.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/5a/2ae6debc94fcfd7ce06b0e4ac5505be29ca04e76d6c99af35d4372dd7eda/vercel_workers-0.0.25-py3-none-any.whl", hash = "sha256:6901228a90e83e292e6a176161e66e6a7c43d9f4fd9e13d6bd87092ad09ffd8b", size = 61680, upload-time = "2026-06-20T19:26:25.971Z" },
 ]
 
 [[package]]

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -888,7 +888,8 @@ safety_finish_reason:
 # ============================================================================
 # Sandbox Configuration
 # ============================================================================
-# Choose between local sandbox (direct execution) or Docker-based AIO sandbox
+# Choose between local sandbox, Docker-based AIO sandbox, Kubernetes provisioner,
+# or Vercel Sandbox.
 
 # Option 1: Local Sandbox (Default)
 # Executes commands directly on the host machine
@@ -999,6 +1000,34 @@ sandbox:
 #   provisioner_url: http://provisioner:8002
 #   # Note: provisioner-created Pods use the provisioner's SANDBOX_IMAGE
 #   # environment variable, not sandbox.image from this config file.
+
+# Option 4: Vercel Sandbox
+# Runs bash/file/code execution in Vercel Sandbox while DeerFlow Gateway,
+# LangGraph runtime, frontend, memory, and thread storage stay in your main
+# DeerFlow service. DeerFlow persists a per-thread mapping from its own sandbox
+# id to the Vercel sandbox id under the thread data directory.
+# sandbox:
+#   use: deerflow.community.vercel_sandbox:VercelSandboxProvider
+#   vercel_token: $VERCEL_TOKEN
+#   vercel_project_id: $VERCEL_PROJECT_ID
+#   # Optional when your project is under a team:
+#   # vercel_team_id: $VERCEL_TEAM_ID
+#
+#   # Vercel resource options. Vercel requires memory to equal vcpus * 2048.
+#   # vercel_runtime: python3.13
+#   # vercel_vcpus: 2
+#   # vercel_memory_mb: 4096
+#   # vercel_timeout_ms: 3600000
+#   # vercel_ports: [3000]
+#
+#   # Stop persistent Vercel sandboxes after each agent run so they snapshot and
+#   # stop accruing idle runtime. The next turn resumes by Vercel sandbox id.
+#   # vercel_stop_on_release: true
+#
+#   # Environment variables injected only into Vercel Sandbox.
+#   # vercel_environment:
+#   #   NODE_ENV: production
+#   #   API_KEY: $MY_API_KEY
 
 # ============================================================================
 # Subagents Configuration


### PR DESCRIPTION
## Summary
- add `deerflow.community.vercel_sandbox:VercelSandboxProvider` with per-thread DeerFlow sandbox ids mapped to Vercel sandbox ids
- sync workspace/uploads into Vercel on acquire, mirror `/mnt/user-data/*` writes back to host, and sync workspace/outputs on release
- add Vercel sandbox config fields, dependency lock updates, config example, and docs

## Tests
- `uv run ruff check packages/harness/deerflow/community/vercel_sandbox tests/test_vercel_sandbox_provider.py packages/harness/deerflow/config/sandbox_config.py`
- `uv run pytest tests/test_vercel_sandbox_provider.py`
- `uv run pytest tests/test_harness_boundary.py`
- `uv run pytest tests/test_app_config_reload.py::test_app_config_defaults_missing_database_to_sqlite`
- `uv run python - <<'PY' ... _load_vercel_sdk() ... PY`