### PR TITLE
feat(auth): accept signed Orpheus embed tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Notes:
 - `assistant_id: lead_agent` calls the default LangGraph assistant directly.
 - If `assistant_id` is set to a custom agent name, DeerFlow still routes through `lead_agent` and injects that value as `agent_name`, so the custom agent's SOUL/config takes effect for IM channels.
 - IM channel workers call Gateway's LangGraph-compatible API internally and automatically attach process-local internal auth plus the CSRF cookie/header pair required for thread and run creation.
+- Orpheus iframe embeds can use `DEERFLOW_EMBED_TOKEN_SECRET` to sign short-lived `/embed/chats/{thread_id}` access tokens; Gateway accepts `X-DeerFlow-Embed-Token` only for the token-bound thread.
 
 Set the corresponding API keys in your `.env` file:
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -274,6 +274,8 @@ FastAPI application on port 8001 with health check at `GET /health`. Set `GATEWA
 
 CORS is same-origin by default when requests enter through nginx on port 2026. Split-origin or port-forwarded browser clients must opt in with `GATEWAY_CORS_ORIGINS` (comma-separated exact origins); Gateway `CORSMiddleware` and `CSRFMiddleware` both read that variable so browser CORS and auth-origin checks stay aligned.
 
+Orpheus embeds use `DEERFLOW_EMBED_TOKEN_SECRET` and the `X-DeerFlow-Embed-Token` header. `app/gateway/embed_auth.py` verifies the short-lived HMAC token, binds it to a single thread id, and lets `AuthMiddleware` stamp an `auth_source="embed"` user context. `CSRFMiddleware` skips double-submit CSRF only after that same token verifies for the request path.
+
 **Routers**:
 
 | Router | Endpoints |

--- a/backend/README.md
+++ b/backend/README.md
@@ -33,6 +33,7 @@ DeerFlow is a LangGraph-based AI super agent with sandbox execution, persistent 
 - `/api/langgraph/*` → Gateway LangGraph-compatible API - agent interactions, threads, streaming
 - `/api/*` (other) → Gateway API - models, MCP, skills, memory, artifacts, uploads, thread-local cleanup
 - `/` (non-API) → Frontend - Next.js web interface
+- `/embed/chats/{thread_id}` → Frontend iframe route for Orpheus; API calls authenticate with `X-DeerFlow-Embed-Token`
 
 ---
 

--- a/backend/app/gateway/auth_disabled.py
+++ b/backend/app/gateway/auth_disabled.py
@@ -15,6 +15,7 @@ AUTH_DISABLED_USER_EMAIL = "default@test.local"
 AUTH_SOURCE_SESSION = "session"
 AUTH_SOURCE_INTERNAL = "internal"
 AUTH_SOURCE_AUTH_DISABLED = "auth_disabled"
+AUTH_SOURCE_EMBED = "embed"
 
 _PRODUCTION_ENV_VARS: tuple[str, ...] = ("DEER_FLOW_ENV", "ENVIRONMENT")
 _PRODUCTION_ENV_VALUES: frozenset[str] = frozenset({"prod", "production"})

--- a/backend/app/gateway/auth_middleware.py
+++ b/backend/app/gateway/auth_middleware.py
@@ -19,12 +19,14 @@ from starlette.types import ASGIApp
 from app.gateway.auth.errors import AuthErrorCode, AuthErrorResponse
 from app.gateway.auth_disabled import (
     AUTH_SOURCE_AUTH_DISABLED,
+    AUTH_SOURCE_EMBED,
     AUTH_SOURCE_INTERNAL,
     AUTH_SOURCE_SESSION,
     get_auth_disabled_user,
     is_auth_disabled,
 )
 from app.gateway.authz import _ALL_PERMISSIONS, AuthContext
+from app.gateway.embed_auth import EMBED_AUTH_HEADER_NAME, EmbedTokenError, get_embed_user_from_request
 from app.gateway.internal_auth import INTERNAL_AUTH_HEADER_NAME, get_internal_user, is_valid_internal_auth_token
 from deerflow.runtime.user_context import reset_current_user, set_current_user
 
@@ -92,11 +94,18 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         auth_source = AUTH_SOURCE_SESSION
         access_token = request.cookies.get("access_token")
+        embed_token = request.headers.get(EMBED_AUTH_HEADER_NAME)
 
         # Non-public path: require session cookie
         if internal_user is not None:
             user = internal_user
             auth_source = AUTH_SOURCE_INTERNAL
+        elif embed_token:
+            try:
+                user = get_embed_user_from_request(request)
+            except EmbedTokenError as exc:
+                return JSONResponse(status_code=401, content={"detail": str(exc)})
+            auth_source = AUTH_SOURCE_EMBED
         elif access_token:
             # Strict JWT validation: reject junk/expired tokens with 401
             # right here instead of silently passing through. This closes

--- a/backend/app/gateway/csrf_middleware.py
+++ b/backend/app/gateway/csrf_middleware.py
@@ -15,6 +15,7 @@ from starlette.responses import JSONResponse
 from starlette.types import ASGIApp
 
 from app.gateway.auth_disabled import is_auth_disabled
+from app.gateway.embed_auth import EMBED_AUTH_HEADER_NAME, EmbedTokenError, verify_embed_request
 
 CSRF_COOKIE_NAME = "csrf_token"
 CSRF_HEADER_NAME = "X-CSRF-Token"
@@ -192,6 +193,16 @@ class CSRFMiddleware(BaseHTTPMiddleware):
             )
 
         if should_check_csrf(request) and not _is_auth:
+            if request.headers.get(EMBED_AUTH_HEADER_NAME):
+                try:
+                    verify_embed_request(request)
+                    return await call_next(request)
+                except EmbedTokenError:
+                    return JSONResponse(
+                        status_code=403,
+                        content={"detail": "Embed token invalid."},
+                    )
+
             cookie_token = request.cookies.get(CSRF_COOKIE_NAME)
             header_token = request.headers.get(CSRF_HEADER_NAME)
 

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -333,12 +333,13 @@ async def get_current_user_from_request(request: Request):
     """
     state = getattr(request, "state", None)
     state_user = getattr(state, "user", None)
-    from app.gateway.auth_disabled import AUTH_SOURCE_AUTH_DISABLED, AUTH_SOURCE_INTERNAL, AUTH_SOURCE_SESSION
+    from app.gateway.auth_disabled import AUTH_SOURCE_AUTH_DISABLED, AUTH_SOURCE_EMBED, AUTH_SOURCE_INTERNAL, AUTH_SOURCE_SESSION
 
     if state_user is not None and getattr(state, "auth_source", None) in {
         AUTH_SOURCE_SESSION,
         AUTH_SOURCE_AUTH_DISABLED,
         AUTH_SOURCE_INTERNAL,
+        AUTH_SOURCE_EMBED,
     }:
         return state_user
 

--- a/backend/app/gateway/embed_auth.py
+++ b/backend/app/gateway/embed_auth.py
@@ -1,0 +1,162 @@
+"""Signed embed-token authentication for Orpheus-hosted DeerFlow workspaces."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import re
+import time
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from fastapi import Request
+
+EMBED_AUTH_HEADER_NAME = "X-DeerFlow-Embed-Token"
+EMBED_AUTH_SECRET_ENV = "DEERFLOW_EMBED_TOKEN_SECRET"
+
+_MAX_TOKEN_BYTES = 4096
+_ALLOWED_CLOCK_SKEW_SECONDS = 30
+_THREAD_PATH_RE = re.compile(r"^/api/(?:langgraph/)?threads/([^/?#]+)(?:/|$)")
+_NON_THREAD_SEGMENTS = {"search"}
+
+
+class EmbedTokenError(ValueError):
+    """Raised when a signed embed token is missing, malformed, or invalid."""
+
+
+@dataclass(frozen=True)
+class EmbedTokenPayload:
+    sub: str
+    thread_id: str
+    session_id: str | None
+    workspace_id: str | None
+    exp: int
+    iat: int
+
+
+def _base64_url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.urlsafe_b64decode((value + padding).encode("ascii"))
+    except Exception as exc:
+        raise EmbedTokenError("Malformed embed token encoding") from exc
+
+
+def _base64_url_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _secret() -> str:
+    return os.environ.get(EMBED_AUTH_SECRET_ENV, "").strip()
+
+
+def _signature(secret: str, encoded_payload: str) -> str:
+    digest = hmac.new(secret.encode("utf-8"), encoded_payload.encode("ascii"), hashlib.sha256).digest()
+    return _base64_url_encode(digest)
+
+
+def create_embed_token(payload: dict[str, Any], *, secret: str | None = None) -> str:
+    """Create a signed embed token.
+
+    Production tokens are minted by Orpheus. This helper exists for regression
+    tests and local tooling so the verifier and signer stay byte-compatible.
+    """
+    actual_secret = (secret or _secret()).strip()
+    if not actual_secret:
+        raise EmbedTokenError(f"{EMBED_AUTH_SECRET_ENV} is not configured")
+    encoded_payload = _base64_url_encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    return f"{encoded_payload}.{_signature(actual_secret, encoded_payload)}"
+
+
+def verify_embed_token(raw_token: str | None, *, secret: str | None = None, now: int | None = None) -> EmbedTokenPayload:
+    actual_secret = (secret or _secret()).strip()
+    if not actual_secret:
+        raise EmbedTokenError(f"{EMBED_AUTH_SECRET_ENV} is not configured")
+    if not raw_token:
+        raise EmbedTokenError("Embed token is missing")
+    if len(raw_token.encode("utf-8")) > _MAX_TOKEN_BYTES:
+        raise EmbedTokenError("Embed token is too large")
+
+    encoded_payload, sep, encoded_signature = raw_token.partition(".")
+    if not sep or not encoded_payload or not encoded_signature:
+        raise EmbedTokenError("Malformed embed token")
+
+    expected_signature = _signature(actual_secret, encoded_payload)
+    if not hmac.compare_digest(expected_signature, encoded_signature):
+        raise EmbedTokenError("Invalid embed token signature")
+
+    try:
+        data = json.loads(_base64_url_decode(encoded_payload).decode("utf-8"))
+    except Exception as exc:
+        raise EmbedTokenError("Malformed embed token payload") from exc
+    if not isinstance(data, dict):
+        raise EmbedTokenError("Embed token payload must be an object")
+
+    if data.get("iss") != "orpheus" or data.get("aud") != "deerflow":
+        raise EmbedTokenError("Embed token issuer or audience is invalid")
+
+    current = int(time.time() if now is None else now)
+    try:
+        exp = int(data.get("exp") or 0)
+        iat = int(data.get("iat") or 0)
+    except (TypeError, ValueError) as exc:
+        raise EmbedTokenError("Embed token timestamps are invalid") from exc
+    if exp <= 0 or iat <= 0:
+        raise EmbedTokenError("Embed token missing timestamps")
+    if exp < current - _ALLOWED_CLOCK_SKEW_SECONDS:
+        raise EmbedTokenError("Embed token has expired")
+    if iat > current + _ALLOWED_CLOCK_SKEW_SECONDS:
+        raise EmbedTokenError("Embed token was issued in the future")
+
+    sub = str(data.get("sub") or "").strip()
+    thread_id = str(data.get("thread_id") or "").strip()
+    if not sub or not thread_id:
+        raise EmbedTokenError("Embed token missing subject or thread_id")
+
+    return EmbedTokenPayload(
+        sub=sub,
+        thread_id=thread_id,
+        session_id=str(data.get("session_id") or "") or None,
+        workspace_id=str(data.get("workspace_id") or "") or None,
+        exp=exp,
+        iat=iat,
+    )
+
+
+def _thread_id_from_path(path: str) -> str | None:
+    match = _THREAD_PATH_RE.match(path)
+    if not match:
+        return None
+    thread_id = match.group(1)
+    if thread_id in _NON_THREAD_SEGMENTS:
+        return None
+    return thread_id
+
+
+def verify_embed_request(request: Request) -> EmbedTokenPayload:
+    payload = verify_embed_token(request.headers.get(EMBED_AUTH_HEADER_NAME))
+    path_thread_id = _thread_id_from_path(request.url.path)
+    if path_thread_id is not None and path_thread_id != payload.thread_id:
+        raise EmbedTokenError("Embed token is not valid for this thread")
+    return payload
+
+
+def get_embed_user_from_request(request: Request):
+    payload = verify_embed_request(request)
+    safe_sub = re.sub(r"[^a-zA-Z0-9_.+-]+", "-", payload.sub).strip("-") or "user"
+    return SimpleNamespace(
+        id=payload.sub,
+        email=f"orpheus+{safe_sub}@embed.local",
+        password_hash=None,
+        system_role="user",
+        needs_setup=False,
+        token_version=0,
+        oauth_provider="orpheus_embed",
+        embed_thread_id=payload.thread_id,
+        embed_session_id=payload.session_id,
+        embed_workspace_id=payload.workspace_id,
+    )

--- a/backend/docs/CONFIGURATION.md
+++ b/backend/docs/CONFIGURATION.md
@@ -15,6 +15,22 @@ Run `make config-upgrade` to merge new fields into your config.
 - Run `make config-upgrade` to auto-merge missing fields (your existing values are preserved, a `.bak` backup is created).
 - When changing the config schema, bump `config_version` in `config.example.yaml`.
 
+## Orpheus Embed Auth
+
+When DeerFlow Workspace is embedded inside Orpheus, configure the same HMAC
+secret in both services:
+
+```bash
+DEERFLOW_EMBED_TOKEN_SECRET=use-the-same-secret-in-orpheus
+```
+
+Orpheus opens `/embed/chats/{thread_id}?embed=1&embed_token=...`. The frontend
+stores the short-lived token in `sessionStorage`, strips it from the address bar,
+and sends it as `X-DeerFlow-Embed-Token` on Gateway/LangGraph requests. Gateway
+accepts the token as `auth_source=embed` only when the signature, expiry,
+issuer/audience, and requested thread id all match. CSRF double-submit checks are
+skipped only for requests carrying a valid embed token.
+
 ## Configuration Sections
 
 ### Models

--- a/backend/tests/test_auth_middleware.py
+++ b/backend/tests/test_auth_middleware.py
@@ -5,6 +5,7 @@ from starlette.testclient import TestClient
 
 from app.gateway.auth_middleware import AuthMiddleware, _is_public
 from app.gateway.csrf_middleware import CSRFMiddleware
+from app.gateway.embed_auth import EMBED_AUTH_HEADER_NAME, create_embed_token
 
 # ── _is_public unit tests ─────────────────────────────────────────────────
 
@@ -186,6 +187,23 @@ def _make_auth_csrf_app():
         return {"ok": True}
 
     return app
+
+
+def _embed_token(thread_id: str, *, user_id: str = "orpheus-user", secret: str = "embed-test-secret") -> str:
+    return create_embed_token(
+        {
+            "v": 1,
+            "iss": "orpheus",
+            "aud": "deerflow",
+            "sub": user_id,
+            "thread_id": thread_id,
+            "session_id": "agws_test",
+            "workspace_id": "workspace_test",
+            "iat": 1_700_000_000,
+            "exp": 4_000_000_000,
+        },
+        secret=secret,
+    )
 
 
 @pytest.fixture
@@ -382,6 +400,57 @@ def test_protected_post_with_internal_auth_header_passes():
     )
 
     assert res.status_code == 200
+
+
+def test_protected_path_with_embed_token_stamps_user(monkeypatch):
+    monkeypatch.setenv("DEERFLOW_EMBED_TOKEN_SECRET", "embed-test-secret")
+    client = TestClient(_make_app())
+
+    res = client.get(
+        "/api/current-user-from-dep",
+        headers={EMBED_AUTH_HEADER_NAME: _embed_token("abc", user_id="orpheus-user-123")},
+    )
+
+    assert res.status_code == 200
+    assert res.json() == {
+        "id": "orpheus-user-123",
+        "state_id": "orpheus-user-123",
+        "auth_source": "embed",
+        "context_user_id": "orpheus-user-123",
+    }
+
+
+def test_protected_path_rejects_embed_token_for_wrong_thread(monkeypatch):
+    monkeypatch.setenv("DEERFLOW_EMBED_TOKEN_SECRET", "embed-test-secret")
+    client = TestClient(_make_app())
+
+    res = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={EMBED_AUTH_HEADER_NAME: _embed_token("other-thread")},
+    )
+
+    assert res.status_code == 401
+
+
+def test_protected_path_rejects_embed_token_with_invalid_timestamps(monkeypatch):
+    monkeypatch.setenv("DEERFLOW_EMBED_TOKEN_SECRET", "embed-test-secret")
+    client = TestClient(_make_app())
+    token = create_embed_token(
+        {
+            "v": 1,
+            "iss": "orpheus",
+            "aud": "deerflow",
+            "sub": "orpheus-user",
+            "thread_id": "abc",
+            "iat": "not-a-timestamp",
+            "exp": 4_000_000_000,
+        },
+        secret="embed-test-secret",
+    )
+
+    res = client.get("/api/threads/abc", headers={EMBED_AUTH_HEADER_NAME: token})
+
+    assert res.status_code == 401
 
 
 # ── Method matrix: PUT/DELETE/PATCH also protected ────────────────────────

--- a/backend/tests/test_csrf_middleware.py
+++ b/backend/tests/test_csrf_middleware.py
@@ -4,6 +4,24 @@ from fastapi import FastAPI
 from starlette.testclient import TestClient
 
 from app.gateway.csrf_middleware import CSRFMiddleware
+from app.gateway.embed_auth import EMBED_AUTH_HEADER_NAME, create_embed_token
+
+
+def _embed_token(thread_id: str, *, secret: str = "embed-test-secret") -> str:
+    return create_embed_token(
+        {
+            "v": 1,
+            "iss": "orpheus",
+            "aud": "deerflow",
+            "sub": "orpheus-user",
+            "thread_id": thread_id,
+            "session_id": "agws_test",
+            "workspace_id": "workspace_test",
+            "iat": 1_700_000_000,
+            "exp": 4_000_000_000,
+        },
+        secret=secret,
+    )
 
 
 def _make_app() -> FastAPI:
@@ -217,6 +235,37 @@ def test_non_auth_mutation_allows_valid_double_submit_token():
     )
 
     assert response.status_code == 200
+
+
+def test_non_auth_mutation_allows_valid_embed_token_without_csrf(monkeypatch):
+    monkeypatch.setenv("DEERFLOW_EMBED_TOKEN_SECRET", "embed-test-secret")
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={
+            "Origin": "https://deerflow.example",
+            EMBED_AUTH_HEADER_NAME: _embed_token("abc"),
+        },
+    )
+
+    assert response.status_code == 200
+
+
+def test_non_auth_mutation_rejects_invalid_embed_token(monkeypatch):
+    monkeypatch.setenv("DEERFLOW_EMBED_TOKEN_SECRET", "embed-test-secret")
+    client = TestClient(_make_app(), base_url="https://deerflow.example")
+
+    response = client.post(
+        "/api/threads/abc/runs/stream",
+        headers={
+            "Origin": "https://deerflow.example",
+            EMBED_AUTH_HEADER_NAME: _embed_token("other-thread"),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Embed token invalid."
 
 
 def test_non_auth_mutation_rejects_mismatched_double_submit_token():

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -46,14 +46,14 @@ The frontend is a stateful chat application. Users create **threads** (conversat
 
 ### Source Layout (`src/`)
 
-- **`app/`** — Next.js App Router. Routes include `/` (landing), `/workspace/chats/[thread_id]` (chat), `/workspace/agents/[agent_name]` and `/workspace/agents/new` (custom agents), `/blog/…`, the `(auth)/{login,setup,auth/callback}` flow, `/[lang]/docs/…`, and `/api/…` route handlers (e.g. `/api/memory`).
+- **`app/`** — Next.js App Router. Routes include `/` (landing), `/workspace/chats/[thread_id]` (chat), `/embed/chats/[thread_id]` (Orpheus iframe embed without the workspace auth layout), `/workspace/agents/[agent_name]` and `/workspace/agents/new` (custom agents), `/blog/…`, the `(auth)/{login,setup,auth/callback}` flow, `/[lang]/docs/…`, and `/api/…` route handlers (e.g. `/api/memory`).
 - **`components/`** — React components:
   - `ui/` — Shadcn UI primitives (auto-generated, ESLint-ignored)
   - `ai-elements/` — Vercel AI SDK elements (auto-generated, ESLint-ignored)
   - `workspace/` — Chat page components (messages, artifacts, settings)
   - `landing/` — Landing page sections
   - `docs/` — Docs / MDX rendering components
-- **`core/`** — Business logic, the heart of the app. Domains include `threads/` (creation, streaming, state), `api/` (LangGraph client singleton), `agents/` (custom agents), `auth/` (authentication), `artifacts/`, `channels/` (IM connections), `i18n/` (en-US, zh-CN), `settings/`, `memory/`, `skills/`, `messages/`, `mcp/`, `models/`, `suggestions/`, `tasks/`, `todos/`, `tools/`, `config/`, `notification/`, `blog/`, plus rendering helpers (`rehype/`, `streamdown/`) and `utils/`.
+- **`core/`** — Business logic, the heart of the app. Domains include `threads/` (creation, streaming, state), `api/` (LangGraph client singleton), `embed-auth` (stores Orpheus embed tokens and injects `X-DeerFlow-Embed-Token`), `agents/` (custom agents), `auth/` (authentication), `artifacts/`, `channels/` (IM connections), `i18n/` (en-US, zh-CN), `settings/`, `memory/`, `skills/`, `messages/`, `mcp/`, `models/`, `suggestions/`, `tasks/`, `todos/`, `tools/`, `config/`, `notification/`, `blog/`, plus rendering helpers (`rehype/`, `streamdown/`) and `utils/`.
 - **`hooks/`** — Shared React hooks
 - **`lib/`** — Utilities (`cn()` from clsx + tailwind-merge)
 - **`content/`** — MDX content (blog posts, docs) rendered by the app

--- a/frontend/src/app/embed/chats/[thread_id]/embed-token-bootstrap.tsx
+++ b/frontend/src/app/embed/chats/[thread_id]/embed-token-bootstrap.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { consumeEmbedTokenFromUrl } from "@/core/embed-auth";
+
+export function EmbedTokenBootstrap() {
+  useEffect(() => {
+    consumeEmbedTokenFromUrl();
+  }, []);
+
+  return null;
+}

--- a/frontend/src/app/embed/chats/[thread_id]/layout.tsx
+++ b/frontend/src/app/embed/chats/[thread_id]/layout.tsx
@@ -1,0 +1,30 @@
+import { Toaster } from "sonner";
+
+import { ChatProviders } from "@/app/workspace/chats/[thread_id]/providers";
+import { QueryClientProvider } from "@/components/query-client-provider";
+import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { AuthProvider } from "@/core/auth/AuthProvider";
+
+import { EmbedTokenBootstrap } from "./embed-token-bootstrap";
+
+export const dynamic = "force-dynamic";
+
+export default function EmbedChatLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <AuthProvider initialUser={null}>
+      <QueryClientProvider>
+        <SidebarProvider className="h-screen" defaultOpen={false}>
+          <SidebarInset className="min-w-0">
+            <ChatProviders>
+              <EmbedTokenBootstrap />
+              {children}
+            </ChatProviders>
+          </SidebarInset>
+        </SidebarProvider>
+        <Toaster position="top-center" />
+      </QueryClientProvider>
+    </AuthProvider>
+  );
+}

--- a/frontend/src/app/embed/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/embed/chats/[thread_id]/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/workspace/chats/[thread_id]/page";

--- a/frontend/src/core/api/api-client.ts
+++ b/frontend/src/core/api/api-client.ts
@@ -3,6 +3,7 @@
 import { Client as LangGraphClient } from "@langchain/langgraph-sdk/client";
 
 import { getLangGraphBaseURL } from "../config";
+import { withEmbedAuthHeader } from "../embed-auth";
 import { isStaticWebsiteOnly } from "../static-mode";
 import {
   loadStaticDemoThread,
@@ -26,12 +27,13 @@ import { sanitizeRunStreamOptions } from "./stream-mode";
  * the contract stays in lockstep.
  */
 function injectCsrfHeader(_url: URL, init: RequestInit): RequestInit {
+  let headers: HeadersInit | undefined = withEmbedAuthHeader(init.headers);
   if (!isStateChangingMethod(init.method ?? "GET")) {
-    return init;
+    return { ...init, headers };
   }
   const token = readCsrfCookie();
-  if (!token) return init;
-  const headers = new Headers(init.headers);
+  if (!token) return { ...init, headers };
+  headers = new Headers(headers);
   if (!headers.has("X-CSRF-Token")) {
     headers.set("X-CSRF-Token", token);
   }

--- a/frontend/src/core/api/fetcher.ts
+++ b/frontend/src/core/api/fetcher.ts
@@ -1,4 +1,5 @@
 import { buildLoginUrl } from "@/core/auth/types";
+import { hasEmbedToken, withEmbedAuthHeader } from "@/core/embed-auth";
 
 /** HTTP methods that the gateway's CSRFMiddleware checks. */
 export type StateChangingMethod = "POST" | "PUT" | "DELETE" | "PATCH";
@@ -61,7 +62,7 @@ export async function fetch(
 
   // Inject CSRF for state-changing methods. GET/HEAD/OPTIONS/TRACE skip
   // it to mirror the gateway's ``should_check_csrf`` logic exactly.
-  let headers = init?.headers;
+  let headers: HeadersInit | undefined = withEmbedAuthHeader(init?.headers);
   if (isStateChangingMethod(init?.method ?? "GET")) {
     const token = readCsrfCookie();
     if (token) {
@@ -81,6 +82,9 @@ export async function fetch(
   });
 
   if (res.status === 401) {
+    if (hasEmbedToken()) {
+      throw new Error("Unauthorized embed request");
+    }
     window.location.href = buildLoginUrl(window.location.pathname);
     throw new Error("Unauthorized");
   }

--- a/frontend/src/core/auth/AuthProvider.tsx
+++ b/frontend/src/core/auth/AuthProvider.tsx
@@ -10,6 +10,7 @@ import React, {
   type ReactNode,
 } from "react";
 
+import { hasEmbedToken, withEmbedAuthHeader } from "../embed-auth";
 import { isStaticWebsiteOnly } from "../static-mode";
 
 import { type User, buildLoginUrl } from "./types";
@@ -73,6 +74,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       setIsLoading(true);
       const res = await fetch("/api/v1/auth/me", {
         credentials: "include",
+        headers: withEmbedAuthHeader(undefined),
       });
 
       if (res.ok) {
@@ -81,6 +83,7 @@ export function AuthProvider({ children, initialUser }: AuthProviderProps) {
       } else if (res.status === 401) {
         // Session expired or invalid
         setUser(null);
+        if (hasEmbedToken()) return;
         // Redirect to login if on a protected route
         if (pathname?.startsWith("/workspace")) {
           router.push(buildLoginUrl(pathname));

--- a/frontend/src/core/embed-auth.ts
+++ b/frontend/src/core/embed-auth.ts
@@ -1,0 +1,63 @@
+export const EMBED_TOKEN_QUERY_PARAM = "embed_token";
+export const EMBED_AUTH_HEADER_NAME = "X-DeerFlow-Embed-Token";
+
+const STORAGE_KEY = "deerflow:embed-token";
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function readTokenFromLocation(): string | null {
+  if (!isBrowser()) return null;
+  const token = new URLSearchParams(window.location.search).get(
+    EMBED_TOKEN_QUERY_PARAM,
+  );
+  const trimmed = token?.trim();
+  if (!trimmed) return null;
+  return trimmed;
+}
+
+export function getEmbedToken(): string | null {
+  if (!isBrowser()) return null;
+  const urlToken = readTokenFromLocation();
+  if (urlToken) {
+    try {
+      window.sessionStorage.setItem(STORAGE_KEY, urlToken);
+    } catch {
+      // Ignore storage failures; the URL token is still usable this request.
+    }
+    return urlToken;
+  }
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function withEmbedAuthHeader(headers: HeadersInit | undefined): Headers {
+  const merged = new Headers(headers);
+  const token = getEmbedToken();
+  if (token && !merged.has(EMBED_AUTH_HEADER_NAME)) {
+    merged.set(EMBED_AUTH_HEADER_NAME, token);
+  }
+  return merged;
+}
+
+export function consumeEmbedTokenFromUrl(): void {
+  if (!isBrowser()) return;
+  const url = new URL(window.location.href);
+  const token = url.searchParams.get(EMBED_TOKEN_QUERY_PARAM)?.trim();
+  if (!token) return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, token);
+  } catch {
+    // Non-fatal: API wrappers can still read the token before it is stripped.
+  }
+  url.searchParams.delete(EMBED_TOKEN_QUERY_PARAM);
+  window.history.replaceState(window.history.state, "", url.toString());
+}
+
+export function hasEmbedToken(): boolean {
+  return Boolean(getEmbedToken());
+}

--- a/frontend/tests/unit/core/embed-auth.test.ts
+++ b/frontend/tests/unit/core/embed-auth.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, expect, test } from "@rstest/core";
+
+import {
+  EMBED_AUTH_HEADER_NAME,
+  consumeEmbedTokenFromUrl,
+  getEmbedToken,
+  withEmbedAuthHeader,
+} from "@/core/embed-auth";
+
+type FakeWindow = {
+  location: URL;
+  history: {
+    state: unknown;
+    replaceState: (
+      state: unknown,
+      title: string,
+      url?: string | URL | null,
+    ) => void;
+  };
+  sessionStorage: {
+    clear: () => void;
+    getItem: (key: string) => string | null;
+    setItem: (key: string, value: string) => void;
+  };
+};
+
+function installFakeWindow() {
+  const storage = new Map<string, string>();
+  const fakeWindow = {
+    location: new URL("https://deerflow.example/"),
+    history: {
+      state: null,
+      replaceState(state: unknown, _title: string, url?: string | URL | null) {
+        this.state = state;
+        if (url) {
+          fakeWindow.location = new URL(url, fakeWindow.location.origin);
+        }
+      },
+    },
+    sessionStorage: {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    },
+  } satisfies FakeWindow;
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: fakeWindow,
+  });
+}
+
+beforeEach(() => {
+  installFakeWindow();
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+test("getEmbedToken reads URL token and stores it for later requests", () => {
+  window.history.replaceState(
+    null,
+    "",
+    "/embed/chats/thread-1?embed=1&embed_token=signed-token",
+  );
+
+  expect(getEmbedToken()).toBe("signed-token");
+
+  window.history.replaceState(null, "", "/embed/chats/thread-1?embed=1");
+
+  expect(getEmbedToken()).toBe("signed-token");
+});
+
+test("withEmbedAuthHeader injects the embed auth header", () => {
+  window.history.replaceState(
+    null,
+    "",
+    "/embed/chats/thread-1?embed_token=signed-token",
+  );
+
+  const headers = withEmbedAuthHeader({ Accept: "application/json" });
+
+  expect(headers.get("Accept")).toBe("application/json");
+  expect(headers.get(EMBED_AUTH_HEADER_NAME)).toBe("signed-token");
+});
+
+test("consumeEmbedTokenFromUrl stores token and removes it from the address bar", () => {
+  window.history.replaceState(
+    null,
+    "",
+    "/embed/chats/thread-1?embed=1&embed_token=signed-token&x=1",
+  );
+
+  consumeEmbedTokenFromUrl();
+
+  expect(window.location.search).toBe("?embed=1&x=1");
+  expect(getEmbedToken()).toBe("signed-token");
+});


### PR DESCRIPTION
## Summary
- add signed Orpheus embed-token verification in the DeerFlow gateway
- add iframe-safe /embed/chats/[thread_id] route that reuses the native workspace chat page
- inject X-DeerFlow-Embed-Token from the embed URL into frontend API and LangGraph SDK calls
- document DEERFLOW_EMBED_TOKEN_SECRET and add backend/frontend regression tests

## Validation
- backend: uv run pytest tests/test_auth_middleware.py tests/test_csrf_middleware.py -q
- backend: uv run ruff check app/gateway/embed_auth.py app/gateway/auth_middleware.py app/gateway/csrf_middleware.py app/gateway/deps.py tests/test_auth_middleware.py tests/test_csrf_middleware.py
- backend: uv run ruff format --check app/gateway/embed_auth.py app/gateway/auth_middleware.py app/gateway/csrf_middleware.py app/gateway/deps.py tests/test_auth_middleware.py tests/test_csrf_middleware.py
- frontend: pnpm test -- tests/unit/core/embed-auth.test.ts
- frontend: pnpm lint
- frontend: pnpm typecheck
- frontend: pnpm format
