### PR TITLE
fix(subagents): inherit LoopDetectionMiddleware to break tool loops (#3875)

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -252,6 +252,26 @@ def build_subagent_runtime_middlewares(
 
         middlewares.append(DeferredToolFilterMiddleware(deferred_setup.deferred_names, deferred_setup.catalog_hash))
 
+    # LoopDetectionMiddleware — subagents inherit none of the lead's runaway
+    # guards today (see #3875): with no loop detection a degenerate subagent tool
+    # loop runs unchecked until ``max_turns``, re-sending a growing context each
+    # turn (the reported 4.4M-token burn). Mirror the lead chain so the loop is
+    # detected and broken. Subagents disallow ``task``, so only the tool-loop
+    # heuristic can fire here — no recursive-delegation path to false-positive on.
+    # Registered before SafetyFinishReasonMiddleware (earlier in the list).
+    # LangChain dispatches after_model hooks in REVERSE registration order, so
+    # SafetyFinishReasonMiddleware (appended below) executes first and strips
+    # safety-terminated tool_calls; LoopDetectionMiddleware then accounts on the
+    # cleaned message. This is the placement SafetyFinishReasonMiddleware's
+    # docstring requires ("register after LoopDetection") and mirrors the lead
+    # chain (``lead_agent/agent.py``). Phase 1 of #3875; a deterministic
+    # turn/token budget with lead-visible stop reason is Phase 2.
+    loop_detection_config = app_config.loop_detection
+    if loop_detection_config.enabled:
+        from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+
+        middlewares.append(LoopDetectionMiddleware.from_config(loop_detection_config))
+
     # Same provider safety-termination guard the lead agent uses — subagents
     # are equally exposed to truncated tool_calls returned with
     # finish_reason=content_filter (and friends), and the bad call would then

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -142,12 +142,12 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
     assert captured["app_config"] is app_config
     # 8 baseline (InputSanitization, ToolOutputBudget, ThreadData, Sandbox,
     # DanglingToolCall, LLMErrorHandling, SandboxAudit, ToolErrorHandling)
-    # + 1 ReadBeforeWriteMiddleware + 1 SafetyFinishReasonMiddleware (both
-    # enabled by default).
+    # + 1 ReadBeforeWriteMiddleware + 1 LoopDetectionMiddleware
+    # + 1 SafetyFinishReasonMiddleware (all enabled by default).
     from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
     from deerflow.agents.middlewares.tool_output_budget_middleware import ToolOutputBudgetMiddleware
 
-    assert len(middlewares) == 10
+    assert len(middlewares) == 11
     assert isinstance(middlewares[0], FakeMiddleware)  # InputSanitizationMiddleware stub
     assert isinstance(middlewares[1], ToolOutputBudgetMiddleware)
     assert any(isinstance(m, ToolErrorHandlingMiddleware) for m in middlewares)
@@ -372,6 +372,56 @@ def test_subagent_runtime_middlewares_skip_deferred_filter_without_names(monkeyp
     for setup in (None, DeferredToolSetup(None, frozenset(), None)):
         middlewares = build_subagent_runtime_middlewares(app_config=app_config, deferred_setup=setup)
         assert not any(isinstance(m, DeferredToolFilterMiddleware) for m in middlewares)
+
+
+def test_subagent_runtime_middlewares_attach_loop_detection_when_enabled(monkeypatch):
+    """Subagents must inherit the lead's LoopDetectionMiddleware so a degenerate
+    tool loop is broken instead of burning tokens until ``max_turns`` (#3875).
+    ``loop_detection.enabled`` defaults to True, so the default subagent chain
+    carries the guard. Phase 1 of #3875."""
+    from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+
+    app_config = _make_app_config()
+    _stub_runtime_middleware_imports(monkeypatch)
+
+    middlewares = build_subagent_runtime_middlewares(app_config=app_config, model_name="test-model")
+
+    loop = [m for m in middlewares if isinstance(m, LoopDetectionMiddleware)]
+    assert len(loop) == 1
+
+
+def test_subagent_runtime_middlewares_omit_loop_detection_when_disabled(monkeypatch):
+    """``loop_detection.enabled=False`` must drop the guard from the subagent
+    chain, mirroring the lead's gate (``lead_agent/agent.py``)."""
+    from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+    from deerflow.config.loop_detection_config import LoopDetectionConfig
+
+    app_config = _make_app_config().model_copy(update={"loop_detection": LoopDetectionConfig(enabled=False)})
+    _stub_runtime_middleware_imports(monkeypatch)
+
+    middlewares = build_subagent_runtime_middlewares(app_config=app_config, model_name="test-model")
+
+    assert not any(isinstance(m, LoopDetectionMiddleware) for m in middlewares)
+
+
+def test_subagent_runtime_middlewares_place_loop_detection_before_safety_finish(monkeypatch):
+    """LoopDetectionMiddleware must be registered before SafetyFinishReasonMiddleware
+    (earlier in the middleware list). LangChain dispatches after_model hooks in
+    reverse registration order, so SafetyFinishReasonMiddleware (registered
+    later) executes first — the placement its docstring requires and the lead
+    chain (``lead_agent/agent.py``) uses. The assertion pins registration order,
+    not execution order."""
+    from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+    from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
+
+    app_config = _make_app_config()
+    _stub_runtime_middleware_imports(monkeypatch)
+
+    middlewares = build_subagent_runtime_middlewares(app_config=app_config, model_name="test-model")
+
+    loop_idx = next(i for i, m in enumerate(middlewares) if isinstance(m, LoopDetectionMiddleware))
+    safety_idx = next(i for i, m in enumerate(middlewares) if isinstance(m, SafetyFinishReasonMiddleware))
+    assert loop_idx < safety_idx
 
 
 def test_lead_runtime_chain_finds_historical_uploads_under_lazy_init_false(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Phase 1 of #3875: subagents now inherit `LoopDetectionMiddleware`, so a degenerate subagent tool loop is detected and broken instead of running unchecked until `max_turns` (the reported ~4.4M-token burn over ~110 turns/subagent).

## Root cause

`build_subagent_runtime_middlewares()` attached **none** of the lead's runaway guards — no `LoopDetectionMiddleware`, `SummarizationMiddleware`, or `TokenBudgetMiddleware` (all three are lead-only). So a subagent stuck in a tool loop re-sent a growing context every turn until `max_turns=150` (`general-purpose`).

## Fix (Phase 1 — smallest blast radius)

Append `LoopDetectionMiddleware.from_config(app_config.loop_detection)` to the subagent chain, gated by the existing `loop_detection.enabled` config (default on) — **no new config field**.

- Registered **before** `SafetyFinishReasonMiddleware`, matching the lead's after-model ordering (the safety middleware's docstring requires placement after `LoopDetection`).
- Subagents disallow `task`, so only the tool-loop heuristic can fire — no recursive-delegation false positives (per @fancyboi999's triage note).

## Why Phase 1 only

Per the phased plan I floated on #3875, Phase 1 is the structural gap with zero new config decisions. Phases 2–3 need sign-off:

- **Phase 2 — deterministic turn/token budget with a lead-visible stop reason.** Open questions:
  1. Budget config: a new `subagents.*` field, or reuse `loop_detection`?
  2. Should "capped" map to a new `subagent_status` enum value so the lead can distinguish "finished" from "capped"?
- **Phase 3 — summarization** (deferred; "summarization alone can hide the loop").

## Test plan

- `test_subagent_runtime_middlewares_attach_loop_detection_when_enabled` — default chain carries the guard.
- `test_subagent_runtime_middlewares_omit_loop_detection_when_disabled` — `enabled=False` drops it (mirrors the lead gate).
- `test_subagent_runtime_middlewares_place_loop_detection_before_safety_finish` — ordering matches the lead chain.
- Updated the existing `len(middlewares)` baseline (`+1` for the new default-on middleware).

`LoopDetectionMiddleware` behavior itself is covered by `test_loop_detection_middleware.py`; this PR is the wiring, not new detection logic.

`ruff format` + `ruff check` clean; `detect-blocking-io` unaffected (no IO in the change).

cc @fancyboi999 — Phase 1 ready for review; the Phase 2 config/status questions above are what I'd like your call on before starting Phase 2.