### PR TITLE
fix(wizard): update DeepSeek provider models to deepseek-v4-pro/deepseek-v4-flash

### DIFF
--- a/backend/tests/test_patched_deepseek.py
+++ b/backend/tests/test_patched_deepseek.py
@@ -18,7 +18,7 @@ def _make_model(**kwargs):
     from deerflow.models.patched_deepseek import PatchedChatDeepSeek
 
     return PatchedChatDeepSeek(
-        model="deepseek-reasoner",
+        model="deepseek-v4-pro",
         api_key="test-key",
         **kwargs,
     )
@@ -53,7 +53,7 @@ def test_to_json_produces_constructor_type():
 def test_to_json_kwargs_contains_model():
     model = _make_model()
     result = model.to_json()
-    assert result["kwargs"]["model_name"] == "deepseek-reasoner"
+    assert result["kwargs"]["model_name"] == "deepseek-v4-pro"
     assert result["kwargs"]["api_base"] == "https://api.deepseek.com/v1"
 
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -243,17 +243,17 @@ models:
   #       thinking:
   #         type: disabled
 
-  # Example: DeepSeek model (with thinking support)
-  # - name: deepseek-v3
-  #   display_name: DeepSeek V3 (Thinking)
+  # Example: DeepSeek V4 model (with thinking support)
+  # - name: deepseek-v4
+  #   display_name: DeepSeek V4 (Thinking)
   #   use: deerflow.models.patched_deepseek:PatchedChatDeepSeek
-  #   model: deepseek-reasoner
+  #   model: deepseek-v4-pro
   #   api_key: $DEEPSEEK_API_KEY
   #   timeout: 600.0
   #   max_retries: 2
   #   max_tokens: 8192
   #   supports_thinking: true
-  #   supports_vision: false  # DeepSeek V3 does not support vision
+  #   supports_vision: false  # DeepSeek V4 does not support vision
   #   when_thinking_enabled:
   #     extra_body:
   #       thinking:

--- a/frontend/src/app/mock/api/models/route.ts
+++ b/frontend/src/app/mock/api/models/route.ts
@@ -9,10 +9,10 @@ export function GET() {
         supports_thinking: true,
       },
       {
-        id: "deepseek-v3.2",
-        name: "deepseek-v3.2",
-        model: "deepseek-chat",
-        display_name: "DeepSeek v3.2",
+        id: "deepseek-v4",
+        name: "deepseek-v4",
+        model: "deepseek-v4-pro",
+        display_name: "DeepSeek V4",
         supports_thinking: true,
       },
       {

--- a/frontend/src/content/en/application/configuration.mdx
+++ b/frontend/src/content/en/application/configuration.mdx
@@ -68,9 +68,9 @@ models:
   <Tabs.Tab>
 ```yaml
 models:
-  - name: deepseek-v3
+  - name: deepseek-v4
     use: deerflow.models.patched_deepseek:PatchedChatDeepSeek
-    model: deepseek-reasoner
+    model: deepseek-v4-pro
     api_key: $DEEPSEEK_API_KEY
     timeout: 600.0
     max_retries: 2

--- a/frontend/src/content/en/harness/lead-agent.mdx
+++ b/frontend/src/content/en/harness/lead-agent.mdx
@@ -107,9 +107,9 @@ Thinking mode is controlled per-request through the `thinking_enabled` flag. If 
 
 ```yaml
 models:
-  - name: deepseek-v3
+  - name: deepseek-v4
     use: deerflow.models.patched_deepseek:PatchedChatDeepSeek
-    model: deepseek-reasoner
+    model: deepseek-v4-pro
     api_key: $DEEPSEEK_API_KEY
     supports_thinking: true
     when_thinking_enabled:

--- a/frontend/src/content/zh/application/configuration.mdx
+++ b/frontend/src/content/zh/application/configuration.mdx
@@ -75,9 +75,9 @@ models:
   <Tabs.Tab>
 ```yaml
 models:
-  - name: deepseek
+  - name: deepseek-v4
     use: langchain_openai:ChatOpenAI
-    model: deepseek-reasoner
+    model: deepseek-v4-pro
     api_key: $DEEPSEEK_API_KEY
     base_url: https://api.deepseek.com
     request_timeout: 600.0

--- a/scripts/wizard/providers.py
+++ b/scripts/wizard/providers.py
@@ -167,10 +167,10 @@ LLM_PROVIDERS: list[LLMProvider] = [
     LLMProvider(
         name="deepseek",
         display_name="DeepSeek",
-        description="DeepSeek Reasoner with thinking support",
+        description="DeepSeek V4 with thinking support",
         use="deerflow.models.patched_deepseek:PatchedChatDeepSeek",
-        models=["deepseek-reasoner", "deepseek-chat"],
-        default_model="deepseek-reasoner",
+        models=["deepseek-v4-pro", "deepseek-v4-flash"],
+        default_model="deepseek-v4-pro",
         env_var="DEEPSEEK_API_KEY",
         package="langchain-deepseek",
         extra_config={

--- a/scripts/wizard/writer.py
+++ b/scripts/wizard/writer.py
@@ -153,7 +153,7 @@ def _make_model_config_name(model_name: str) -> str:
 
     Replaces path separators and dots with hyphens so the result is a clean
     YAML-friendly identifier (e.g. "google/gemini-2.5-pro" → "gemini-2-5-pro",
-    "gpt-5.4" → "gpt-5-4", "deepseek-chat" → "deepseek-chat").
+    "gpt-5.4" → "gpt-5-4", "deepseek-v4-pro" → "deepseek-v4-pro").
     """
     # Take only the last path component for namespaced models (e.g. "org/model-name")
     base = model_name.split("/")[-1]


### PR DESCRIPTION
Replace deprecated model names across providers, config example, docs, mocks, and tests:
- deepseek-reasoner → deepseek-v4-pro (default)
- deepseek-chat → deepseek-v4-flash
- Standardize zh docs to use PatchedChatDeepSeek (was ChatOpenAI)

<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->


## Why

<!-- Why are you opening this PR? Cover two things:
       - The trigger — what made you write this? A bug you hit, a feature you need,
         tech debt, or a prod issue?
       - The pain being addressed — user-facing problem, or what it unblocks.
     For non-trivial features, please open an issue/discussion first to align on
     scope before writing code. -->
DeepSeek is deprecating `deepseek-reasoner` and `deepseek-chat` on **2026/07/24** in favor of the V4 
 lineup (`deepseek-v4-pro`, `deepseek-v4-flash`). The Setup Wizard and docs still referenced the        
 soon-to-be-removed model names, so new users configuring a DeepSeek model would get non-working        
 defaults after the cutoff.  

## What changed

<!-- Describe the change from a user's / caller's perspective, not as a code diff. e.g.:
       - "Settings now has a 'Custom endpoint' field, off by default"
       - "Backend /api/chat gains a `stream` flag, defaults to false"
       - "Default model changed from X to Y — existing users notice on first run" -->
 - **Setup Wizard**: DeepSeek provider now defaults to `deepseek-v4-pro` and offers                   
 `deepseek-v4-flash` as the alternative.                                                                
   - **config.example.yaml**: DeepSeek example block updated to V4.                                     
   - **Docs (en/zh)**: All YAML examples now reference V4 model names. Chinese docs also switched from  
 raw `ChatOpenAI` to `PatchedChatDeepSeek` for consistency with the English docs.                       
   - **Frontend mock**: Model list mock updated.                                                        
   - **Tests**: Fixture and assertion in `test_patched_deepseek.py` use the new name.    


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

<!-- If you checked "Frontend UI", attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip (delete) this section if this PR is not a bug fix.

     Bugs should be encoded as a failing test that goes red before the fix.
     Confirm:
       - Test path that reproduces the bug:
       - Did it go red on `main` and green on this branch? (yes / no)
       - If a red test wasn't cheap to write, explain why and what you did instead. -->


## Validation

<!-- What you actually ran. Run at least the checks for the area you changed:
       Backend:   cd backend  && make lint && make test
       Frontend:  cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test
       Frontend E2E (if you touched frontend/): cd frontend && make test-e2e -->


## AI assistance

<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
     welcome. Disclosing it just helps reviewers calibrate how closely to read the
     diff. Please fill all three; don't delete the section. -->

**Tool(s) used:** oh-my-pi

**How you used it:** Identified all references to the deprecated model names across the repo (8      
 files) and performed mechanical replacement. I reviewed every line. 

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

