### PR TITLE
fix(frontend): Fix uploaded file metadata in message copy

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -37,6 +37,7 @@ import { useI18n } from "@/core/i18n/hooks";
 import {
   extractContentFromMessage,
   extractReasoningContentFromMessage,
+  getMessageCopyData,
   parseUploadedFiles,
   stripUploadedFilesTag,
   type FileInMessage,
@@ -162,13 +163,7 @@ export function MessageListItem({
           )}
         >
           <div className="pointer-events-auto flex gap-1">
-            <CopyButton
-              clipboardData={
-                extractContentFromMessage(message) ??
-                extractReasoningContentFromMessage(message) ??
-                ""
-              }
-            />
+            <CopyButton clipboardData={getMessageCopyData(message)} />
             {feedback !== undefined && runId && threadId && (
               <FeedbackButtons
                 threadId={threadId}

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -277,6 +277,14 @@ export function getAssistantTurnCopyData(
   );
 }
 
+export function getMessageCopyData(message: Message) {
+  const content = extractContentFromMessage(message);
+  if (message.type === "human") {
+    return stripUploadedFilesTag(content);
+  }
+  return content ?? extractReasoningContentFromMessage(message) ?? "";
+}
+
 export function extractTextFromMessage(message: Message) {
   if (typeof message.content === "string") {
     return (

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -282,7 +282,10 @@ export function getMessageCopyData(message: Message) {
   if (message.type === "human") {
     return stripUploadedFilesTag(content);
   }
-  return content ?? extractReasoningContentFromMessage(message) ?? "";
+  if (content.length > 0) {
+    return content;
+  }
+  return extractReasoningContentFromMessage(message) ?? "";
 }
 
 export function extractTextFromMessage(message: Message) {

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractContentFromMessage,
   extractTextFromMessage,
   extractReasoningContentFromMessage,
+  getMessageCopyData,
   getAssistantTurnCopyData,
   getAssistantTurnUsageMessages,
   getMessageGroups,
@@ -246,6 +247,17 @@ describe("inline <think> tag splitting", () => {
 });
 
 describe("human message internal context stripping", () => {
+  test("strips uploaded file context from copy data", () => {
+    const message = {
+      id: "human-with-upload",
+      type: "human",
+      content:
+        "<uploaded_files>\nThe following files were uploaded in this message:\n\n- paper.pdf (1.0 MB)\n  Path: /mnt/user-data/uploads/paper.pdf\n</uploaded_files>\n\nSummarize this paper",
+    } as Message;
+
+    expect(getMessageCopyData(message)).toBe("Summarize this paper");
+  });
+
   test("strips slash skill activation context from display content", () => {
     const content =
       "<slash_skill_activation>\n<skill_content># Secret SKILL.md</skill_content>\n</slash_skill_activation>\nreal user task";


### PR DESCRIPTION
## Summary

- Strip internal uploaded-file context from copied human messages.
- Route the message hover copy button through a sanitized copy helper.
- Add a regression test for copying a user message that contains `<uploaded_files>` metadata.

## Root Cause

The rendered human-message path already strips internal upload context, but the hover copy button read `extractContentFromMessage(message)` directly. That copied the raw backend-injected attachment context instead of the user-visible message text.

## Validation

- `pnpm test tests/unit/core/messages/utils.test.ts`
- `pnpm check`
- pre-commit frontend check during `git commit`

Fixes #3943
