### PR TITLE
fix(docker): keep config mounts stable across host saves

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -283,6 +283,11 @@ Config values starting with `$` are resolved as environment variables (e.g., `$O
 
 MCP servers and skills are configured together in `extensions_config.json` in project root:
 
+Docker development mounts the project directory at `/app/project` and points
+`DEER_FLOW_CONFIG_PATH` / `DEER_FLOW_EXTENSIONS_CONFIG_PATH` into that directory.
+Keep mutable config files behind a directory bind mount: single-file bind mounts
+can become stale or inaccessible when a host editor replaces a file on save.
+
 Configuration priority:
 1. Explicit `config_path` argument
 2. `DEER_FLOW_EXTENSIONS_CONFIG_PATH` environment variable

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -43,6 +43,16 @@ def test_service_launchers_always_use_gateway_runtime():
         assert "LANGGRAPH_REWRITE" not in content, path
 
 
+def test_docker_dev_mounts_mutable_configs_through_project_directory():
+    compose = _read("docker/docker-compose-dev.yaml")
+
+    assert "- ../:/app/project" in compose
+    assert "- ../config.yaml:/app/config.yaml" not in compose
+    assert "- ../extensions_config.json:/app/extensions_config.json" not in compose
+    assert "- DEER_FLOW_CONFIG_PATH=/app/project/config.yaml" in compose
+    assert "- DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/project/extensions_config.json" in compose
+
+
 def test_local_dev_gateway_reload_excludes_runtime_state_with_absolute_dirs():
     serve_sh = _read("scripts/serve.sh")
 

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -46,11 +46,11 @@ def test_service_launchers_always_use_gateway_runtime():
 def test_docker_dev_mounts_mutable_configs_through_project_directory():
     compose = _read("docker/docker-compose-dev.yaml")
 
-    assert "- ../:/app/project" in compose
-    assert "- ../config.yaml:/app/config.yaml" not in compose
-    assert "- ../extensions_config.json:/app/extensions_config.json" not in compose
-    assert "- DEER_FLOW_CONFIG_PATH=/app/project/config.yaml" in compose
-    assert "- DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/project/extensions_config.json" in compose
+    assert re.search(r"^\s*-\s*\.\./:/app/project(?:\:\S+)?\s*$", compose, re.M)
+    assert not re.search(r"^\s*-\s*[^\n#]*config\.yaml\s*:\s*[^\n#]*$", compose, re.M)
+    assert not re.search(r"^\s*-\s*[^\n#]*extensions_config\.json\s*:\s*[^\n#]*$", compose, re.M)
+    assert "DEER_FLOW_CONFIG_PATH=/app/project/config.yaml" in compose
+    assert "DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/project/extensions_config.json" in compose
 
 
 def test_local_dev_gateway_reload_excludes_runtime_state_with_absolute_dirs():

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -155,8 +155,10 @@ services:
       # Preserve the .venv built during Docker image build — mounting the full backend/
       # directory above would otherwise shadow it with the (empty) host directory.
       - gateway-venv:/app/backend/.venv
-      - ../config.yaml:/app/config.yaml
-      - ../extensions_config.json:/app/extensions_config.json
+      # Mount the project directory instead of its mutable config files individually.
+      # Host editors commonly replace files on save; a directory bind keeps those
+      # replacements visible inside Docker Desktop/WSL containers.
+      - ../:/app/project
       - ../skills:/app/skills
       - ../logs:/app/logs
       # Use a Docker-managed uv cache volume instead of a host bind mount.
@@ -178,6 +180,8 @@ services:
       - CI=true
       - DEER_FLOW_PROJECT_ROOT=/app
       - DEER_FLOW_HOME=/app/backend/.deer-flow
+      - DEER_FLOW_CONFIG_PATH=/app/project/config.yaml
+      - DEER_FLOW_EXTENSIONS_CONFIG_PATH=/app/project/extensions_config.json
       - DEER_FLOW_STREAM_BRIDGE_REDIS_URL=${DEER_FLOW_STREAM_BRIDGE_REDIS_URL:-redis://redis:6379/0}
       - DEER_FLOW_CHANNELS_LANGGRAPH_URL=${DEER_FLOW_CHANNELS_LANGGRAPH_URL:-http://gateway:8001/api}
       - DEER_FLOW_CHANNELS_GATEWAY_URL=${DEER_FLOW_CHANNELS_GATEWAY_URL:-http://gateway:8001}


### PR DESCRIPTION
Fixes #3953

## Why

Docker development bind-mounted `config.yaml` and
`extensions_config.json` as individual files. On WSL/Docker Desktop, editors
that save by replacing the original file can leave those single-file mounts
stale or inaccessible, causing `FileNotFoundError` inside the Gateway.

## What changed

- Mount the project directory at `/app/project` instead of bind-mounting the
  two mutable configuration files individually.
- Point `DEER_FLOW_CONFIG_PATH` and `DEER_FLOW_EXTENSIONS_CONFIG_PATH` to the
  files inside that directory mount.
- Add regression coverage that prevents single-file config mounts from being
  reintroduced.
- Document the Docker development mount invariant in `backend/AGENTS.md`.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Not applicable; this change affects Docker development configuration mounting.

## Bug fix verification

- Test path: `backend/tests/test_gateway_runtime_cleanup.py::test_docker_dev_mounts_mutable_configs_through_project_directory`
- Red on `main`: yes
- Green on this branch: yes
- Manual verification:
  - Rebuilt the stack with `make docker-start`.
  - Replaced both host config files using temp-file + rename saves.
  - Confirmed both files remained readable and writable in the Gateway container.
  - Confirmed host/container SHA-256 values matched.
  - Confirmed both configuration loaders completed successfully.
  - Confirmed no `FileNotFoundError` appeared in Gateway logs.

## Validation

- `pytest tests/test_gateway_runtime_cleanup.py -q` — 13 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 761 files already formatted
- `docker compose -p deer-flow-dev -f docker/docker-compose-dev.yaml config --quiet` — passed
- `make docker-start` — passed
- Full backend suite — 6361 passed, 26 skipped, 12 environment-related failures caused by unavailable DNS/LLM connectivity; none touched this change

