### PR TITLE
fix(sidecar): correct text-selection toolbar actions inside the side chat

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -85,6 +85,7 @@ The frontend is a stateful chat application. Users create **threads** (conversat
 - `src/app/workspace/chats/[thread_id]/page.tsx` owns branch-from-turn submission and navigation; sidecar `MessageList` instances do not receive the branch action.
 - `src/app/workspace/chats/[thread_id]/page.tsx` and `src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx` own active-goal display state for their composer overlays.
 - `src/core/threads/hooks.ts` owns pre-submit upload state and thread submission.
+- The text-selection toolbar in `src/components/workspace/messages/message-list.tsx` adapts to its surface via the `sidecarSurface` prop. On the main list it offers "Add to conversation" (→ `sidecar.addContextToConversation`, main composer quotes) and "Ask in side chat" (→ `sidecar.openContext`). Inside the sidecar's own `MessageList` (`sidecarSurface`), the "Ask in side chat" action is hidden and "Add to conversation" routes to `sidecar.openContext` so the snippet attaches to the side chat's own composer rather than the main composer.
 
 ## Code Style
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -85,7 +85,6 @@ The frontend is a stateful chat application. Users create **threads** (conversat
 - `src/app/workspace/chats/[thread_id]/page.tsx` owns branch-from-turn submission and navigation; sidecar `MessageList` instances do not receive the branch action.
 - `src/app/workspace/chats/[thread_id]/page.tsx` and `src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx` own active-goal display state for their composer overlays.
 - `src/core/threads/hooks.ts` owns pre-submit upload state and thread submission.
-- The text-selection toolbar in `src/components/workspace/messages/message-list.tsx` adapts to its surface via the `sidecarSurface` prop. On the main list it offers "Add to conversation" (→ `sidecar.addContextToConversation`, main composer quotes) and "Ask in side chat" (→ `sidecar.openContext`). Inside the sidecar's own `MessageList` (`sidecarSurface`), the "Ask in side chat" action is hidden and "Add to conversation" routes to `sidecar.openContext` so the snippet attaches to the side chat's own composer rather than the main composer.
 
 ## Code Style
 

--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -212,6 +212,7 @@ export function MessageList({
   canRegenerate = false,
   canBranch = false,
   enableSidecarActions = true,
+  sidecarSurface = false,
   initialScroll = "smooth",
   resizeScroll = "smooth",
 }: {
@@ -235,6 +236,7 @@ export function MessageList({
   canRegenerate?: boolean;
   canBranch?: boolean;
   enableSidecarActions?: boolean;
+  sidecarSurface?: boolean;
   initialScroll?: ConversationProps["initial"];
   resizeScroll?: ConversationProps["resize"];
 }) {
@@ -417,10 +419,18 @@ export function MessageList({
     if (!selectionToolbar) {
       return;
     }
-    sidecar?.addContextToConversation(selectionToolbar.context);
+    // On the sidecar surface, "add to conversation" targets the side chat's
+    // own composer (activeReferences) rather than the main composer's quotes,
+    // so the selected snippet is attached to the conversation the user is
+    // actually reading.
+    if (sidecarSurface) {
+      sidecar?.openContext(selectionToolbar.context);
+    } else {
+      sidecar?.addContextToConversation(selectionToolbar.context);
+    }
     window.getSelection()?.removeAllRanges();
     setSelectionToolbar(null);
-  }, [selectionToolbar, sidecar]);
+  }, [selectionToolbar, sidecar, sidecarSurface]);
 
   const handleAskSelectionInSidecar = useCallback(() => {
     if (!selectionToolbar) {
@@ -873,17 +883,19 @@ export function MessageList({
             <MessageCircleIcon className="size-3.5" />
             {t.sidecar.addToConversation}
           </Button>
-          <Button
-            className="h-8 rounded-full px-2.5 text-xs"
-            size="sm"
-            type="button"
-            variant="ghost"
-            onClick={handleAskSelectionInSidecar}
-            onMouseDown={(event) => event.preventDefault()}
-          >
-            <MessageSquarePlusIcon className="size-3.5" />
-            {t.sidecar.askInSideChat}
-          </Button>
+          {!sidecarSurface && (
+            <Button
+              className="h-8 rounded-full px-2.5 text-xs"
+              size="sm"
+              type="button"
+              variant="ghost"
+              onClick={handleAskSelectionInSidecar}
+              onMouseDown={(event) => event.preventDefault()}
+            >
+              <MessageSquarePlusIcon className="size-3.5" />
+              {t.sidecar.askInSideChat}
+            </Button>
+          )}
           <Button
             aria-label={t.common.close}
             className="size-8 rounded-full"

--- a/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
+++ b/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
@@ -478,6 +478,7 @@ export function SidecarPanel({ className }: { className?: string }) {
             loadMoreHistory={loadMoreHistory}
             isHistoryLoading={isHistoryLoading}
             tokenUsageInlineMode={tokenUsageInlineMode}
+            sidecarSurface
             initialScroll="instant"
             resizeScroll="instant"
           />

--- a/frontend/tests/e2e/sidecar-chat.spec.ts
+++ b/frontend/tests/e2e/sidecar-chat.spec.ts
@@ -105,6 +105,32 @@ async function selectTextAndClickToolbarButton(
   throw lastError;
 }
 
+async function expectSidecarSelectionToolbarActions(page: Page, text: string) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      await selectTextOnPage(page, text, "sidecar-message-list");
+      const labels = await page.evaluate(() =>
+        Array.from(
+          document.querySelectorAll<HTMLButtonElement>(
+            "[data-sidecar-selection-toolbar] button",
+          ),
+        ).map((button) => button.textContent?.trim() ?? ""),
+      );
+      expect(labels.some((label) => /add to conversation/i.test(label))).toBe(
+        true,
+      );
+      expect(labels.some((label) => /ask in side chat/i.test(label))).toBe(
+        false,
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
 async function expectComposerHeightsEqual(page: Page) {
   const metrics = await page.evaluate(() => {
     const findFormByPlaceholder = (pattern: RegExp) => {
@@ -943,28 +969,14 @@ test.describe("Side chat", () => {
         .first(),
     ).toBeVisible();
 
+    // Selecting text inside the side chat itself only offers "Add to
+    // conversation" (no "Ask in side chat"), and the snippet attaches to the
+    // side chat's own composer rather than the main composer's quotes.
+    await expectSidecarSelectionToolbarActions(page, "Hello from DeerFlow!");
     await selectTextAndClickToolbarButton(
       page,
       "Hello from DeerFlow!",
       "Add to conversation",
-      "sidecar-message-list",
-    );
-    await expect(
-      mainInputForm.getByTestId("conversation-quote-attachment"),
-    ).toContainText("1 selected text fragment");
-    await expect(sidecarReference).toBeHidden();
-    await mainInputForm
-      .getByTestId("conversation-quote-attachment")
-      .getByRole("button", { name: /clear selected references/i })
-      .click();
-    await expect(
-      mainInputForm.getByTestId("conversation-quote-attachment"),
-    ).toBeHidden();
-
-    await selectTextAndClickToolbarButton(
-      page,
-      "Hello from DeerFlow!",
-      "Ask in side chat",
       "sidecar-message-list",
     );
     await expect(sidecarReference).toContainText("1 selected text fragment");


### PR DESCRIPTION
## Summary

Fixes two confusing interactions with the text-selection toolbar that appears when you select text **inside the side chat** (sidecar) panel.

The sidecar panel reuses the shared `MessageList` component, but it did not tell the component that it was rendering the side chat surface. As a result, selecting text inside the side chat behaved exactly like selecting text in the main conversation:

1. **"Ask in side chat" was still offered inside the side chat.** You're already in the side chat, so this action is a no-op / meaningless choice.
2. **"Add to conversation" attached the snippet to the wrong composer.** It routed the reference to the *main* composer's quotes (`conversationQuotes`, rendered in `input-box.tsx`) instead of the side chat's own composer. So a quote taken from the side chat would show up attached to the main input box on the left — an odd, unexpected jump.

## Fix

- Add a `sidecarSurface` prop to `MessageList` (`src/components/workspace/messages/message-list.tsx`), passed by the sidecar's own list in `sidecar-panel.tsx`.
- When `sidecarSurface` is set:
  - Hide the **"Ask in side chat"** action.
  - Route **"Add to conversation"** to `sidecar.openContext(...)`, so the selected snippet attaches to the side chat's own composer (`activeReferences`) — the conversation the user is actually reading.
- Main-list behavior is unchanged: it still offers both actions, with "Add to conversation" targeting the main composer quotes and "Ask in side chat" opening the sidecar.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm format` (Prettier) passes
- [x] Updated `tests/e2e/sidecar-chat.spec.ts`: selecting text inside the side chat now asserts that only "Add to conversation" is shown (no "Ask in side chat"), and that the snippet attaches to the side chat's own composer rather than the main composer. The relevant E2E test passes.

<img width="3456" height="1750" alt="image" src="https://github.com/user-attachments/assets/b95c85c4-1e38-4cd3-8d44-fb9a1f34ae75" />
