### PR TITLE
feat(gateway): refuse multi-worker startup on non-Postgres backends

### DIFF
--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncGenerator, Callable
 from contextlib import AsyncExitStack, asynccontextmanager
 from typing import TYPE_CHECKING, TypeVar, cast
@@ -43,6 +44,27 @@ logger = logging.getLogger(__name__)
 # them together if their sum must stay within the server's graceful-shutdown
 # timeout.
 _RUN_DRAIN_TIMEOUT_SECONDS = 5.0
+
+
+def _enforce_postgres_for_multi_worker(config: AppConfig) -> None:
+    """Refuse to start when GATEWAY_WORKERS > 1 and the DB backend is not Postgres.
+
+    SQLite write-locks cannot support concurrent multi-process access.
+    This gate runs once at startup before any persistence engine is
+    initialised so the error message is clear and the process exits
+    immediately.
+    """
+    try:
+        workers = int(os.environ.get("GATEWAY_WORKERS", "1"))
+    except (TypeError, ValueError):
+        workers = 1
+
+    if workers <= 1:
+        return
+
+    backend = getattr(config.database, "backend", None)
+    if backend != "postgres":
+        raise SystemExit(f"GATEWAY_WORKERS={workers} requires database.backend='postgres', but database.backend is '{backend}'. SQLite cannot support concurrent multi-process access. Set GATEWAY_WORKERS=1 or switch to Postgres.")
 
 
 async def _drain_inflight_runs(run_manager: RunManager) -> None:
@@ -208,6 +230,12 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
     from deerflow.runtime import make_store, make_stream_bridge
     from deerflow.runtime.checkpointer.async_provider import make_checkpointer
     from deerflow.runtime.events.store import make_run_event_store
+
+    # ------------------------------------------------------------------
+    # Multi-worker safety gate: reject SQLite when GATEWAY_WORKERS > 1.
+    # SQLite write-locks cannot support concurrent multi-process access.
+    # ------------------------------------------------------------------
+    _enforce_postgres_for_multi_worker(startup_config)
 
     async with AsyncExitStack() as stack:
         config = startup_config

--- a/backend/tests/test_multi_worker_postgres_gate.py
+++ b/backend/tests/test_multi_worker_postgres_gate.py
@@ -1,0 +1,142 @@
+"""Tests for the multi-worker Postgres startup gate.
+
+Pins the contract documented in ``docs/multi_worker.md`` work item 1
+(issue #3948): when ``GATEWAY_WORKERS > 1`` and the configured
+database backend is not Postgres, the Gateway must refuse to start.
+The gate runs inside :func:`langgraph_runtime` *before* any
+persistence engine is initialised so operators see a clear error
+instead of intermittent SQLite ``database is locked`` failures in
+production.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from app.gateway.deps import _enforce_postgres_for_multi_worker, langgraph_runtime
+from deerflow.config.database_config import DatabaseConfig
+
+
+def _config_with_backend(backend: str) -> SimpleNamespace:
+    return SimpleNamespace(database=DatabaseConfig(backend=backend))
+
+
+# ---------------------------------------------------------------------------
+# Unit tests of the gate function itself
+# ---------------------------------------------------------------------------
+
+
+def test_gate_noop_when_gateway_workers_unset(monkeypatch):
+    """With GATEWAY_WORKERS unset, every backend must be accepted."""
+    monkeypatch.delenv("GATEWAY_WORKERS", raising=False)
+    for backend in ("sqlite", "memory", "postgres"):
+        _enforce_postgres_for_multi_worker(_config_with_backend(backend))
+
+
+def test_gate_noop_for_single_worker(monkeypatch):
+    """GATEWAY_WORKERS=1 preserves the historical single-worker behavior."""
+    monkeypatch.setenv("GATEWAY_WORKERS", "1")
+    for backend in ("sqlite", "memory", "postgres"):
+        _enforce_postgres_for_multi_worker(_config_with_backend(backend))
+
+
+def test_gate_allows_multi_worker_with_postgres(monkeypatch):
+    monkeypatch.setenv("GATEWAY_WORKERS", "2")
+    _enforce_postgres_for_multi_worker(_config_with_backend("postgres"))
+
+
+def test_gate_rejects_multi_worker_with_sqlite(monkeypatch):
+    monkeypatch.setenv("GATEWAY_WORKERS", "2")
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_postgres_for_multi_worker(_config_with_backend("sqlite"))
+    msg = str(exc_info.value)
+    assert "GATEWAY_WORKERS=2" in msg
+    assert "postgres" in msg.lower()
+    assert "sqlite" in msg.lower()
+
+
+def test_gate_rejects_multi_worker_with_memory(monkeypatch):
+    """The gate is not sqlite-specific: memory is also unsafe across processes."""
+    monkeypatch.setenv("GATEWAY_WORKERS", "2")
+    with pytest.raises(SystemExit):
+        _enforce_postgres_for_multi_worker(_config_with_backend("memory"))
+
+
+def test_gate_rejects_high_worker_counts(monkeypatch):
+    """The threshold is >1, not ==2; prod-scale counts must also be gated."""
+    monkeypatch.setenv("GATEWAY_WORKERS", "4")
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_postgres_for_multi_worker(_config_with_backend("sqlite"))
+    assert "GATEWAY_WORKERS=4" in str(exc_info.value)
+
+
+def test_gate_treats_invalid_env_as_single_worker(monkeypatch):
+    """Non-integer GATEWAY_WORKERS values must not crash startup.
+
+    Uvicorn itself rejects these later; the gate should not preempt
+    that with its own crash. Falling back to 1 keeps the gate inert.
+    """
+    for invalid in ("", "auto", "1.5", "abc", "0x4"):
+        monkeypatch.setenv("GATEWAY_WORKERS", invalid)
+        _enforce_postgres_for_multi_worker(_config_with_backend("sqlite"))
+
+
+def test_gate_treats_zero_and_negatives_as_single_worker(monkeypatch):
+    """GATEWAY_WORKERS <= 1 (including 0 and negatives) skips the gate."""
+    for value in ("0", "-1", "-999"):
+        monkeypatch.setenv("GATEWAY_WORKERS", value)
+        _enforce_postgres_for_multi_worker(_config_with_backend("sqlite"))
+
+
+def test_gate_error_message_lists_both_remediations(monkeypatch):
+    """Operators must see both fix options without reading docs."""
+    monkeypatch.setenv("GATEWAY_WORKERS", "2")
+    with pytest.raises(SystemExit) as exc_info:
+        _enforce_postgres_for_multi_worker(_config_with_backend("sqlite"))
+    msg = str(exc_info.value)
+    assert "GATEWAY_WORKERS=1" in msg, "must mention the rollback knob"
+    assert "Postgres" in msg, "must mention the alternative backend"
+
+
+# ---------------------------------------------------------------------------
+# Integration: the gate is wired into langgraph_runtime before init_engine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_langgraph_runtime_invokes_gate_before_persistence_setup(monkeypatch):
+    """When the gate trips, no persistence / stream-bridge setup may run.
+
+    Guards against regressions that reorder the gate behind
+    ``init_engine_from_config`` (or any other expensive startup step).
+    """
+    monkeypatch.setenv("GATEWAY_WORKERS", "2")
+
+    init_engine_from_config = AsyncMock(name="init_engine_from_config")
+
+    @asynccontextmanager
+    async def _noop_stream_bridge(_config):
+        yield MagicMock()
+
+    with (
+        patch(
+            "deerflow.persistence.engine.init_engine_from_config",
+            init_engine_from_config,
+        ),
+        patch("deerflow.runtime.make_stream_bridge", side_effect=_noop_stream_bridge) as make_stream_bridge,
+        patch("deerflow.runtime.make_store", side_effect=_noop_stream_bridge) as make_store,
+    ):
+        app = FastAPI()
+        startup_config = _config_with_backend("sqlite")
+        with pytest.raises(SystemExit):
+            async with langgraph_runtime(app, startup_config):
+                pass
+
+    init_engine_from_config.assert_not_called()
+    make_stream_bridge.assert_not_called()
+    make_store.assert_not_called()


### PR DESCRIPTION
Fixes #3948

## Why

Issue #3948 lays out four correctness breakers that ship today when an
operator bumps `GATEWAY_WORKERS` past 1. This PR is work item 1 of that
plan — the foundation gate that unblocks the rest.

The acute pain: with `database.backend=sqlite` and
`GATEWAY_WORKERS > 1`, multiple Uvicorn workers share a single SQLite
file with no startup guard. Production hits intermittent
`database is locked`, the runs table drifts between workers, and
there is **no signal at boot** that the configuration is unsupported.
Operators discover it from random failures in the middle of a deploy.

The fix is intentionally narrow: refuse to start. Operators get a
clear, actionable error before any traffic flows; everyone else gets
to ship the deeper fixes (cross-process run ownership, lease
heartbeats, cancel routing) on top of a stable foundation.

## What changed

- **No behavior change for `GATEWAY_WORKERS=1`** (the documented default
  in `docker/docker-compose.yaml` and `tests/test_compose_default_workers.py`).
  Single-worker Gateway runs are byte-identical to before.
- **`GATEWAY_WORKERS > 1` + non-Postgres backend** now fails fast at
  lifespan startup. The process exits with a message naming both
  remediation paths:
  > `GATEWAY_WORKERS=2 requires database.backend='postgres', but database.backend is 'sqlite'. SQLite cannot support concurrent multi-process access. Set GATEWAY_WORKERS=1 or switch to Postgres.`
- The gate runs inside `langgraph_runtime()` **before**
  `init_engine_from_config()`, `make_stream_bridge()`, and every other
  expensive startup step, so a misconfigured deploy never opens a
  listener or writes to disk.
- Malicious / typo'd `GATEWAY_WORKERS` values (empty string, `"auto"`,
  floats) fall back to `1` instead of crashing startup — uvicorn still
  gets to do its own validation, the gate just stays inert.

Redis is **not** enforced. `stream_bridge.type=redis` remains the
operator's call: it affects SSE delivery across workers (already
shipped in #3191), not run-data correctness.

## Surface area

- [x] **Backend API** — startup-time gate inside
  `app/gateway/deps.py::langgraph_runtime`; no endpoint / SSE / request
  shape changes.

## Validation

```
cd backend && make lint
cd backend && PYTHONPATH=. uv run pytest tests/test_multi_worker_postgres_gate.py -v
cd backend && make test
```

New regression suite (`tests/test_multi_worker_postgres_gate.py`, 10
tests) covers:

- `GATEWAY_WORKERS` unset / `1` / `0` / negative → gate stays inert
  for every backend (sqlite, memory, postgres).
- `GATEWAY_WORKERS = 2 | 4` + sqlite → `SystemExit` with both
  remediation knobs in the message.
- `GATEWAY_WORKERS = 2` + memory → `SystemExit` (gate is not
  sqlite-only; memory is also unsafe across processes).
- `GATEWAY_WORKERS = 2` + postgres → no-op.
- Non-integer env values (`""`, `"auto"`, `"1.5"`, `"abc"`, `"0x4"`)
  fall back to single-worker semantics without crashing.
- Integration: when the gate trips inside `langgraph_runtime`,
  `init_engine_from_config`, `make_stream_bridge`, and `make_store`
  are never called — pins the fail-fast ordering.

Manual smoke (recommended before merge):

```
GATEWAY_WORKERS=2 PYTHONPATH=. uv run uvicorn app.gateway.app:app --workers 2
# with config.yaml -> database.backend: sqlite
# expect: process exits non-zero with the message above
```

## Out of scope (deliberate)

Work items 2–4 from #3948 — cross-process run ownership (`create_or_reject`
atomicity), lease heartbeats, and Postgres-side reconciliation of orphaned
runs — are intentionally deferred so this PR can be reviewed and rolled out
independently. Until those land, the safe multi-worker envelope is still
`GATEWAY_WORKERS=1`. This PR exists so that breaking the envelope stops
being a silent foot-gun.

## Rollout / rollback

| Stage | Config | Expected |
|---|---|---|
| Stage 0 (this PR) | `GATEWAY_WORKERS=1` | No change. |
| Stage 0 (this PR) | `GATEWAY_WORKERS=2` + sqlite | Refuses to start. |
| Stage 0 (this PR) | `GATEWAY_WORKERS=2` + postgres | Starts (still not safe for full multi-worker correctness until #3948 items 2–4 land; operator accepts the IM-channel / subagent caveats already documented in `docker/docker-compose.yaml`). |

Rollback: set `GATEWAY_WORKERS=1`. No code revert needed.

## AI assistance

**Tool(s) used:** Claude Code.

**How you used it:** the gate implementation was authored by hand; AI
assisted with the regression test suite ( enumerating edge cases and
the integration test that pins call order) and with drafting this PR
description. Code and tests were reviewed and validated locally before
push.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
