### PR TITLE
fix(composer): stop bottom mask strip from clipping the focus ring

### DIFF
--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -1157,7 +1157,7 @@ export function InputBox({
       )}
       <PromptInput
         className={cn(
-          "bg-background/85 rounded-2xl backdrop-blur-sm transition-all duration-300 ease-out *:data-[slot='input-group']:rounded-2xl",
+          "bg-background/85 relative z-10 rounded-2xl backdrop-blur-sm transition-all duration-300 ease-out *:data-[slot='input-group']:rounded-2xl",
           className,
         )}
         disabled={disabled}
@@ -1559,10 +1559,10 @@ export function InputBox({
             />
           </PromptInputTools>
         </PromptInputFooter>
-        {!isWelcomeMode && (
-          <div className="bg-background absolute right-0 -bottom-[17px] left-0 z-0 h-4"></div>
-        )}
       </PromptInput>
+      {!isWelcomeMode && (
+        <div className="bg-background absolute right-0 -bottom-[17px] left-0 z-0 h-4"></div>
+      )}
 
       {isWelcomeMode &&
         searchParams.get("mode") !== "skill" &&


### PR DESCRIPTION
## Summary

On conversation pages, the composer's blue focus ring was missing its **bottom edge** whenever the composer sat flush at the bottom of the viewport.

### Root cause

Conversation pages render an opaque `bg-background` strip just below the composer (`-bottom-[17px] h-4`) to mask the sliver of scrolled content that would otherwise peek past the composer's rounded bottom corners. That strip was a **child of `PromptInput`** — the element that draws the focus ring.

The focus ring is a `box-shadow` that extends ~3px beyond the border box. In CSS, a parent element's box-shadow always paints **beneath its own descendants**, so the opaque strip covered the bottom segment of the ring. No `z-index` on the strip can fix this while it remains a child (verified: even `z-index: -1` on the child has no effect).

This is why the bug only appeared on conversation pages (welcome mode never renders the strip via `!isWelcomeMode`) and only along the bottom edge.

### Fix

- Move the mask strip out of `PromptInput` so it is a **sibling** in the outer container, keeping its `z-0`.
- Give the composer `relative z-10` so it establishes a higher stacking context and its ring composites above the strip.

The strip still masks the exact same region — only the paint order changes.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec prettier --check` on the changed file
- [x] Verified in-browser on a conversation page: with the composer flush at the viewport bottom, the focus ring now renders completely on all four sides (previously the bottom edge was clipped), and the mask strip still hides scrolled content behind the composer.

## Notes

Purely a CSS stacking/paint-order change to one file; no behavior or logic changes.


before:
<img width="1024" height="568" alt="image" src="https://github.com/user-attachments/assets/d8a6df36-195a-4030-884b-a97259372fba" />

now:
<img width="1024" height="568" alt="image" src="https://github.com/user-attachments/assets/994a83f7-b763-4077-883e-f9c86a718866" />
