### PR TITLE
feat(memory): conversational memory tools + vector retrieval

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -29,7 +29,7 @@ from langchain_core.runnables import RunnableConfig
 from deerflow.agents.lead_agent.prompt import apply_prompt_template
 from deerflow.agents.memory.summarization_hook import memory_flush_hook
 from deerflow.agents.middlewares.clarification_middleware import ClarificationMiddleware
-from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+from deerflow.agents.middlewares.resource_guard_middleware import ResourceGuardMiddleware
 from deerflow.agents.middlewares.memory_middleware import MemoryMiddleware
 from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
 from deerflow.agents.middlewares.subagent_limit_middleware import SubagentLimitMiddleware
@@ -375,17 +375,18 @@ def build_middlewares(
         max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
         middlewares.append(SubagentLimitMiddleware(max_concurrent=max_concurrent_subagents))
 
-    # LoopDetectionMiddleware — detect and break repetitive tool call loops
+    # ResourceGuardMiddleware — combined: loop detection + token budget enforcement
+    # Merges two formerly separate middlewares to share a single wrap_model_call
+    # hook and warning-drain lifecycle, reducing chain traversal overhead.
     loop_detection_config = resolved_app_config.loop_detection
-    if loop_detection_config.enabled:
-        middlewares.append(LoopDetectionMiddleware.from_config(loop_detection_config))
-
-    # TokenBudgetMiddleware - enforce per-run token limits
     token_budget_config = resolved_app_config.token_budget
-    if token_budget_config.enabled:
-        from deerflow.agents.middlewares.token_budget_middleware import TokenBudgetMiddleware
-
-        middlewares.append(TokenBudgetMiddleware.from_config(token_budget_config))
+    if loop_detection_config.enabled or token_budget_config.enabled:
+        middlewares.append(
+            ResourceGuardMiddleware(
+                loop_config=loop_detection_config,
+                budget_config=token_budget_config,
+            )
+        )
 
     # Inject custom middlewares before ClarificationMiddleware
     if custom_middlewares:

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -651,13 +651,16 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 """
 
 
-def _get_memory_context(agent_name: str | None = None, *, app_config: AppConfig | None = None) -> str:
+def _get_memory_context(agent_name: str | None = None, *, app_config: AppConfig | None = None, query: str | None = None) -> str:
     """Get memory context for injection into system prompt.
 
     Args:
         agent_name: If provided, loads per-agent memory. If None, loads global memory.
         app_config: Explicit application config. When provided, memory options
             are read from this value instead of the global config singleton.
+        query: Optional conversation context for semantic fact ranking.
+            When provided, facts are ranked by relevance to this query
+            instead of static confidence (requires stored embeddings).
 
     Returns:
         Formatted memory context string wrapped in XML tags, or empty string if disabled.
@@ -683,6 +686,7 @@ def _get_memory_context(agent_name: str | None = None, *, app_config: AppConfig 
             use_tiktoken=(config.token_counting == "tiktoken"),
             guaranteed_categories=getattr(config, "guaranteed_categories", None),
             guaranteed_token_budget=getattr(config, "guaranteed_token_budget", 500),
+            query=query,
         )
 
         if not memory_content.strip():

--- a/backend/packages/harness/deerflow/agents/memory/embeddings.py
+++ b/backend/packages/harness/deerflow/agents/memory/embeddings.py
@@ -1,0 +1,178 @@
+"""Embedding computation for semantic memory retrieval.
+
+Strategy (in order of preference):
+
+1. **API-based** (when ``memory.embedding.model`` is configured):
+   Uses the configured LLM provider's ``/v1/embeddings`` endpoint. Best quality.
+
+2. **Character n-gram** (fallback, zero dependencies):
+   Computes a fixed-length vector from character 2/3/4-gram frequencies.
+   Language-agnostic, deterministic, no API call needed.
+
+Embeddings are computed at **fact save time** and stored inline in the fact dict.
+At query time, only the query embedding needs to be computed, then we do
+in-memory cosine similarity against all stored fact embeddings.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import math
+import re
+from collections import Counter
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Embedding dimension for the character n-gram fallback.
+# Powers of 2 are conventional; 128 balances quality vs storage.
+_NGRAM_EMBEDDING_DIM = 128
+
+# Hard cap so a single embedding never blows the JSON file.
+_MAX_TOKENS_PER_EMBEDDING = 512
+
+
+def _tokenize(text: str) -> list[str]:
+    """Simple whitespace-aware tokenization for API embedding."""
+    return re.findall(r"[^\s]+", text)
+
+
+def _compute_ngram_embedding(text: str) -> list[float]:
+    """Compute a character n-gram TF-IDF-like embedding.
+
+    Uses 2/3/4-grams with log-frequency weighting, hashed to a fixed
+    dimension, then L2-normalized. No external dependencies.
+    """
+    ngrams: Counter[str] = Counter()
+    for n in range(2, 5):
+        for i in range(len(text) - n + 1):
+            ngrams[text[i : i + n]] += 1
+
+    if not ngrams:
+        return [0.0] * _NGRAM_EMBEDDING_DIM
+
+    top = ngrams.most_common(_NGRAM_EMBEDDING_DIM)
+    max_count = top[0][1] if top else 1
+
+    embedding = [0.0] * _NGRAM_EMBEDDING_DIM
+    for gram, count in top:
+        # Hash each n-gram to a stable index and sign
+        h = hashlib.md5(gram.encode()).digest()
+        idx = int.from_bytes(h[:2], "big") % _NGRAM_EMBEDDING_DIM
+        sign = 1.0 if (h[2] % 2 == 0) else -1.0
+        embedding[idx] += sign * math.log1p(count) / math.log1p(max_count)
+
+    # L2 normalize
+    norm = math.sqrt(sum(v * v for v in embedding))
+    if norm > 0:
+        embedding = [v / norm for v in embedding]
+    return embedding
+
+
+def _compute_api_embedding(text: str, model: str) -> list[float] | None:
+    """Compute embedding via the configured LLM provider's API.
+
+    Returns ``None`` if the API call fails, so callers can fall back.
+    """
+    try:
+        from deerflow.config import get_app_config
+        from deerflow.models import create_chat_model
+
+        # Use the existing model infrastructure to get a provider client
+        config = get_app_config()
+        model_cfg = config.get_model_config(model) if model else None
+        if model_cfg is None:
+            logger.warning("Embedding model %r not found in config", model)
+            return None
+
+        # For OpenAI-compatible providers, call /v1/embeddings
+        base_url = getattr(model_cfg, "base_url", None) or "https://api.openai.com/v1"
+        api_key = getattr(model_cfg, "api_key", None)
+
+        import httpx
+
+        url = f"{base_url.rstrip('/')}/embeddings"
+        headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        payload = {
+            "model": model_cfg.model,
+            "input": text[:_MAX_TOKENS_PER_EMBEDDING],
+        }
+
+        with httpx.Client(timeout=10) as client:
+            resp = client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            return data["data"][0]["embedding"]
+    except Exception:
+        logger.warning("API embedding failed for model %r, falling back to n-gram", model, exc_info=True)
+        return None
+
+
+# Cache: embedding model name → tuple of (embedding_dim, is_api)
+_EMBEDDING_CACHE: dict[str, tuple[int | None, bool]] = {}
+
+# Sentinel: "no embedding model configured, use n-gram"
+_EMBEDDING_CONFIG_NONE = object()
+
+
+def _resolve_embedding_config() -> tuple[str | None, bool]:
+    """Return ``(model_name_or_None, use_api)`` from memory config.
+
+    Reads the new ``memory.embedding_model`` field.  When set, facts are
+    ranked by vector similarity using the configured model's
+    ``/v1/embeddings`` endpoint.  When ``None`` (default), falls back to
+    character n-gram embedding (zero external dependencies).
+    """
+    try:
+        from deerflow.config.memory_config import get_memory_config
+
+        mem_cfg = get_memory_config()
+        model = mem_cfg.embedding_model
+        if model:
+            return str(model), True
+    except Exception:
+        pass
+    return None, False
+
+
+def compute_embedding(text: str) -> list[float]:
+    """Compute embedding vector for *text*.
+
+    Uses the configured embedding model if available, otherwise falls back
+    to character n-gram embedding (zero external dependencies).
+    """
+    model, use_api = _resolve_embedding_config()
+
+    if use_api and model:
+        api_emb = _compute_api_embedding(text, model)
+        if api_emb is not None:
+            logger.debug("Computed API embedding (model=%s, dim=%d)", model, len(api_emb))
+            return api_emb
+        # API failed; fall through to n-gram
+
+    return _compute_ngram_embedding(text)
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two vectors.
+
+    Returns 0.0 for empty or zero-norm vectors.
+    """
+    if not a or not b:
+        return 0.0
+    dot = sum(av * bv for av, bv in zip(a, b, strict=False))
+    norm_a = math.sqrt(sum(av * av for av in a))
+    norm_b = math.sqrt(sum(bv * bv for bv in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def has_embedding_model_configured() -> bool:
+    """Return whether an API embedding model is configured.
+
+    Used by the injection path to decide whether to rely on vector ranking.
+    """
+    _, use_api = _resolve_embedding_config()
+    return use_api

--- a/backend/packages/harness/deerflow/agents/memory/prompt.py
+++ b/backend/packages/harness/deerflow/agents/memory/prompt.py
@@ -424,8 +424,13 @@ def format_memory_for_injection(
     use_tiktoken: bool = True,
     guaranteed_categories: list[str] | None = None,
     guaranteed_token_budget: int = 500,
+    query: str | None = None,
 ) -> str:
     """Format memory data for injection into system prompt.
+
+    When *query* is provided and facts have stored embeddings, facts are
+    ranked by **semantic relevance** to the query (cosine similarity).
+    Without *query* or embeddings, falls back to confidence-based ranking.
 
     Args:
         memory_data: The memory data dictionary.
@@ -445,6 +450,10 @@ def format_memory_for_injection(
             point the safety-truncation ceiling is raised to
             ``max_tokens + guaranteed_actual_usage`` to protect them.
             Ignored when *guaranteed_categories* is ``None`` or empty.
+        query: Optional conversation context for semantic fact ranking.
+            When provided, facts are ranked by cosine similarity between
+            the query embedding and each fact's stored embedding. Falls
+            back to confidence ranking when embeddings are unavailable.
 
     Returns:
         Formatted memory string for system prompt injection.
@@ -540,15 +549,41 @@ def format_memory_for_injection(
         all_fact_lines: list[str] = []
 
         try:
+            # When *query* is provided, compute query embedding once for
+            # vector-based ranking.  Falls back to confidence when the fact
+            # has no stored embedding.
+            _query_embedding: list[float] | None = None
+            _vector_available = False
+            if query:
+                try:
+                    from deerflow.agents.memory.embeddings import compute_embedding
+
+                    _query_embedding = compute_embedding(query)
+                    _vector_available = True
+                    logger.debug(
+                        "format_memory_for_injection: using vector ranking (query=%.40s, embed_dim=%d)",
+                        query,
+                        len(_query_embedding),
+                    )
+                except Exception:
+                    logger.debug("format_memory_for_injection: vector rank unavailable, fallback to confidence")
+
+            def _ranking_key(fact: dict[str, Any]) -> float:
+                """Rank by vector similarity when available, else confidence."""
+                if _query_embedding is not None:
+                    fact_emb = fact.get("embedding")
+                    if isinstance(fact_emb, list) and len(fact_emb) > 0:
+                        from deerflow.agents.memory.embeddings import cosine_similarity
+
+                        return cosine_similarity(_query_embedding, fact_emb)
+                return _coerce_confidence(fact.get("confidence"), default=0.0)
+
             # Partition valid facts into guaranteed vs regular groups.
             # Use the *raw* category field (no ``or "context"`` default) so
             # a category-less legacy fact is never silently promoted into
             # a guaranteed pool whose operator configured
             # ``guaranteed_categories=["context"]``.  Missing-category facts
             # always fall through to the regular path.
-            def _confidence_key(fact: dict[str, Any]) -> float:
-                return _coerce_confidence(fact.get("confidence"), default=0.0)
-
             if effective_guaranteed:
 
                 def _category_match(fact: dict[str, Any]) -> bool:
@@ -560,17 +595,17 @@ def format_memory_for_injection(
 
                 guaranteed = sorted(
                     [f for f in valid_facts if _category_match(f)],
-                    key=_confidence_key,
+                    key=_ranking_key,
                     reverse=True,
                 )
                 regular = sorted(
                     [f for f in valid_facts if not _category_match(f)],
-                    key=_confidence_key,
+                    key=_ranking_key,
                     reverse=True,
                 )
             else:
                 guaranteed = []
-                regular = sorted(valid_facts, key=_confidence_key, reverse=True)
+                regular = sorted(valid_facts, key=_ranking_key, reverse=True)
 
             # ── Phase 1: select guaranteed lines ──────────────────────────
             header_cost = _count_tokens(facts_header, use_tiktoken=use_tiktoken)

--- a/backend/packages/harness/deerflow/agents/memory/search.py
+++ b/backend/packages/harness/deerflow/agents/memory/search.py
@@ -1,0 +1,144 @@
+"""Shared search utilities for memory fact retrieval.
+
+Provides both keyword-based and vector-based search, used by:
+- ``forget_tool`` (keyword + optional vector)
+- ``search_memory_tool`` (keyword + vector)
+- ``format_memory_for_injection`` (vector ranking)
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from deerflow.agents.memory.embeddings import cosine_similarity
+
+logger = logging.getLogger(__name__)
+
+
+def compute_keyword_score(content: str, query: str) -> float:
+    """Compute a keyword-relevance score between content and a search query.
+
+    Uses substring match + word overlap. Returns a float, higher = more relevant.
+    """
+    content_lower = content.casefold()
+    query_lower = query.casefold()
+
+    score = 0.0
+
+    # Direct substring match — big boost
+    if query_lower in content_lower:
+        score += 10.0
+
+    # Word-level overlap
+    query_words = set(re.findall(r"[a-zA-Z一-鿿]+", query_lower))
+    content_words = set(re.findall(r"[a-zA-Z一-鿿]+", content_lower))
+
+    if query_words and content_words:
+        overlap = len(query_words & content_words)
+        score += overlap / max(len(query_words), 1) * 5.0
+
+    return score
+
+
+def rank_facts(
+    facts: list[dict[str, Any]],
+    query: str,
+    *,
+    max_results: int = 10,
+    keyword_weight: float = 0.3,
+    vector_weight: float = 0.7,
+) -> list[tuple[dict[str, Any], float]]:
+    """Rank facts by relevance to a query, combining keyword + vector scores.
+
+    Args:
+        facts: List of fact dicts (must have 'content'; may have 'embedding').
+        query: Search query string.
+        max_results: Maximum results to return.
+        keyword_weight: Weight for keyword-match score (0-1).
+        vector_weight: Weight for embedding cosine similarity (0-1).
+
+    Returns:
+        List of ``(fact, combined_score)`` tuples, highest score first.
+    """
+    query_embedding = None  # lazy: compute once
+
+    scored: list[tuple[dict[str, Any], float]] = []
+    for fact in facts:
+        content = fact.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+
+        # Keyword score
+        kw_score = compute_keyword_score(content, query)
+
+        # Vector score (only if fact has an embedding)
+        vec_score = 0.0
+        fact_embedding = fact.get("embedding")
+        if fact_embedding and isinstance(fact_embedding, list) and len(fact_embedding) > 0:
+            if query_embedding is None:
+                from deerflow.agents.memory.embeddings import compute_embedding
+
+                query_embedding = compute_embedding(query)
+            vec_score = cosine_similarity(query_embedding, fact_embedding)
+
+        combined = keyword_weight * kw_score + vector_weight * vec_score
+        scored.append((fact, combined))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored[:max_results]
+
+
+def find_facts_by_content(
+    facts: list[dict[str, Any]],
+    query: str,
+    *,
+    max_results: int = 5,
+    min_score: float = 0.5,
+) -> list[tuple[dict[str, Any], float]]:
+    """Simple keyword-based fact search. Backward-compatible alias.
+
+    Uses only keyword scoring (no vector). Good for exact-match use cases
+    like ``forget_tool`` where you want literal matches, not semantic.
+    """
+    scored: list[tuple[dict[str, Any], float]] = []
+    for fact in facts:
+        content = fact.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        score = compute_keyword_score(content, query)
+        if score >= min_score:
+            scored.append((fact, score))
+
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored[:max_results]
+
+
+def format_fact_list(facts: list[tuple[dict[str, Any], float]], title: str = "Memories") -> str:
+    """Format ranked facts into a human-readable string.
+
+    Args:
+        facts: List of ``(fact, score)`` tuples.
+        title: Section title.
+
+    Returns:
+        Formatted string, or ``"No matches."`` if empty.
+    """
+    if not facts:
+        return "No matches."
+
+    lines = [
+        f"<{title}>",
+    ]
+    for i, (fact, score) in enumerate(facts, 1):
+        content = fact.get("content", "(empty)")
+        cat = fact.get("category", "?")
+        conf = fact.get("confidence", "?")
+        # Show vector score when available and > 0
+        has_vec = bool(fact.get("embedding"))
+        score_str = f"rel={score:.2f}" if has_vec else ""
+        lines.append(f'  {i}. [{cat}|{conf}] {content}  {score_str}')
+
+    lines.append(f"</{title}>")
+    return "\n".join(lines)

--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -111,16 +111,28 @@ def create_memory_fact(
     memory_data = get_memory_data(agent_name, user_id=user_id)
     updated_memory = dict(memory_data)
     facts = list(memory_data.get("facts", []))
-    facts.append(
-        {
-            "id": f"fact_{uuid.uuid4().hex[:8]}",
-            "content": normalized_content,
-            "category": normalized_category,
-            "confidence": validated_confidence,
-            "createdAt": now,
-            "source": "manual",
-        }
-    )
+
+    # Compute embedding for semantic search (best-effort, logged on failure)
+    embedding: list[float] | None = None
+    try:
+        from deerflow.agents.memory.embeddings import compute_embedding
+
+        embedding = compute_embedding(normalized_content)
+    except Exception:
+        logger.debug("Failed to compute embedding for manual fact", exc_info=True)
+
+    fact_entry: dict[str, Any] = {
+        "id": f"fact_{uuid.uuid4().hex[:8]}",
+        "content": normalized_content,
+        "category": normalized_category,
+        "confidence": validated_confidence,
+        "createdAt": now,
+        "source": "manual",
+    }
+    if embedding is not None:
+        fact_entry["embedding"] = embedding
+
+    facts.append(fact_entry)
     updated_memory["facts"] = facts
 
     if not _save_memory_to_file(updated_memory, agent_name, user_id=user_id):
@@ -701,6 +713,16 @@ class MemoryUpdater:
                     normalized_source_error = source_error.strip()
                     if normalized_source_error:
                         fact_entry["sourceError"] = normalized_source_error
+
+                # Compute embedding for semantic search (best-effort)
+                try:
+                    from deerflow.agents.memory.embeddings import compute_embedding
+
+                    embedding = compute_embedding(normalized_content)
+                    if embedding is not None:
+                        fact_entry["embedding"] = embedding
+                except Exception:
+                    pass
                 current_memory["facts"].append(fact_entry)
                 if fact_key is not None:
                     existing_fact_keys.add(fact_key)

--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -145,18 +145,23 @@ class DynamicContextMiddleware(AgentMiddleware):
         self._agent_name = agent_name
         self._app_config = app_config
 
-    def _build_full_reminder(self) -> tuple[str, str | None]:
+    def _build_full_reminder(self, query: str | None = None) -> tuple[str, str | None]:
         """Return (date_reminder, memory_block | None).
 
         Framework-owned data (date) is separated from user-owned data (memory)
         so the downstream SystemMessage carries only framework authority and
         memory stays at role:user — preventing untrusted content from gaining
         system privilege (OWASP LLM01).
+
+        Args:
+            query: Optional conversation context for semantic fact ranking.
+                When provided, facts are ranked by vector similarity to this
+                query rather than static confidence.
         """
         from deerflow.agents.lead_agent.prompt import _get_memory_context
 
         injection_enabled = self._app_config.memory.injection_enabled if self._app_config else True
-        memory_context = _get_memory_context(self._agent_name, app_config=self._app_config) if injection_enabled else ""
+        memory_context = _get_memory_context(self._agent_name, app_config=self._app_config, query=query) if injection_enabled else ""
         current_date = datetime.now().strftime("%Y-%m-%d, %A")
 
         date_reminder = "\n".join(
@@ -255,7 +260,19 @@ class DynamicContextMiddleware(AgentMiddleware):
             first_idx = next((i for i, m in enumerate(messages) if _is_user_injection_target(m)), None)
             if first_idx is None:
                 return None
-            date_reminder, memory_block = self._build_full_reminder()
+
+            # Extract the user's message text as query for semantic fact ranking
+            user_msg = messages[first_idx]
+            user_query: str | None = None
+            if hasattr(user_msg, "content") and isinstance(user_msg.content, str):
+                user_query = user_msg.content.strip()
+            elif hasattr(user_msg, "content") and isinstance(user_msg.content, list):
+                text_parts = [
+                    p.get("text", "") for p in user_msg.content if isinstance(p, dict) and isinstance(p.get("text"), str)
+                ]
+                user_query = " ".join(text_parts).strip() or None
+
+            date_reminder, memory_block = self._build_full_reminder(query=user_query)
             logger.info(
                 "DynamicContextMiddleware: injecting full reminder (has_memory=%s) into first HumanMessage id=%r",
                 memory_block is not None,

--- a/backend/packages/harness/deerflow/agents/middlewares/resource_guard_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/resource_guard_middleware.py
@@ -1,0 +1,188 @@
+"""Combined middleware: loop detection + token budget enforcement.
+
+Merges two formerly separate middlewares (``LoopDetectionMiddleware`` and
+``TokenBudgetMiddleware``) to share the ``wrap_model_call`` hook, warning
+queue, and lifecycle management — reducing chain traversal overhead.
+
+Both detection strategies keep their own configs and state dictionaries;
+only the Middleware SPI layer is unified.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import OrderedDict, defaultdict
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import HumanMessage
+from langgraph.runtime import Runtime
+
+from deerflow.agents.middlewares.loop_detection_middleware import LoopDetectionMiddleware
+from deerflow.agents.middlewares.token_budget_middleware import TokenBudgetMiddleware
+
+if TYPE_CHECKING:
+    from deerflow.config.loop_detection_config import LoopDetectionConfig
+    from deerflow.config.token_budget_config import TokenBudgetConfig
+
+logger = logging.getLogger(__name__)
+
+# Maximum warning queue length per run (shared drain)
+_MAX_PENDING_WARNINGS = 4
+
+
+class ResourceGuardMiddleware(AgentMiddleware[AgentState]):
+    """Combined safety guard: loop detection + token budget enforcement.
+
+    Delegates detection to the existing ``LoopDetectionMiddleware._track_and_check``
+    and ``TokenBudgetMiddleware._apply`` implementations (instantiated as
+    stateless strategy objects), but shares a single ``wrap_model_call`` hook
+    and warning-drain lifecycle.
+    """
+
+    def __init__(
+        self,
+        loop_config: LoopDetectionConfig,
+        budget_config: TokenBudgetConfig,
+    ) -> None:
+        super().__init__()
+        self._loop = LoopDetectionMiddleware.from_config(loop_config) if loop_config.enabled else None
+        self._budget = TokenBudgetMiddleware.from_config(budget_config) if budget_config.enabled else None
+        self._lock = threading.Lock()
+        # Shared pending-warning queue: keyed by (thread_id, run_id)
+        self._pending_warnings: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    @override
+    def before_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
+        if self._loop:
+            self._loop.before_agent(state, runtime)
+        if self._budget:
+            self._budget.before_agent(state, runtime)
+        return None
+
+    @override
+    async def abefore_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
+        self.before_agent(state, runtime)
+        return None
+
+    def _get_pending_key(self, runtime: Runtime) -> tuple[str, str]:
+        """Stable key for per-(thread, run) warning isolation."""
+        thread_id = "default"
+        run_id = "default"
+        ctx = getattr(runtime, "context", None)
+        if isinstance(ctx, dict):
+            thread_id = str(ctx.get("thread_id", "default"))
+            run_id = str(ctx.get("run_id", "default"))
+        return (thread_id, run_id)
+
+    def _queue_warning(self, runtime: Runtime, warning: str) -> None:
+        key = self._get_pending_key(runtime)
+        with self._lock:
+            queue = self._pending_warnings[key]
+            if warning not in queue:
+                queue.append(warning)
+                if len(queue) > _MAX_PENDING_WARNINGS:
+                    del queue[: len(queue) - _MAX_PENDING_WARNINGS]
+
+    def _drain_warnings(self, runtime: Runtime) -> list[str]:
+        key = self._get_pending_key(runtime)
+        with self._lock:
+            return self._pending_warnings.pop(key, [])
+
+    def _clear_stale_warnings(self, runtime: Runtime) -> None:
+        """Drop pending warnings owned by previous runs in this thread."""
+        thread_id, current_run_id = self._get_pending_key(runtime)
+        with self._lock:
+            for key in list(self._pending_warnings):
+                if key[0] == thread_id and key[1] != current_run_id:
+                    self._pending_warnings.pop(key, None)
+
+    @override
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+        last_msg = messages[-1]
+        if getattr(last_msg, "type", None) != "ai":
+            return None
+
+        # ── Layer 1: loop detection (hash-based + frequency) ──────────
+        if self._loop:
+            warning, hard_stop = self._loop._track_and_check(state, runtime)
+            if hard_stop:
+                return self._loop._apply(state, runtime)
+            if warning:
+                self._queue_warning(runtime, warning)
+                return None
+
+        # ── Layer 2: token budget ────────────────────────────────────
+        if self._budget:
+            result = self._budget._apply(state, runtime)
+            if result is not None:
+                return result
+
+        return None
+
+    @override
+    async def aafter_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self.after_model(state, runtime)
+
+    @override
+    def after_agent(self, state: AgentState, runtime: Runtime) -> None:
+        if self._loop:
+            self._loop._clear_current_run_pending_warnings(runtime)
+        if self._budget:
+            self._budget._clear_run_state(self._budget._get_run_id(runtime))
+        # Shared drain
+        self._drain_warnings(runtime)
+
+    @override
+    async def aafter_agent(self, state: AgentState, runtime: Runtime) -> None:
+        self.after_agent(state, runtime)
+
+    def _augment_request(self, request: ModelRequest) -> ModelRequest:
+        """Inject queued warnings (loop + budget) before the model call."""
+        warnings = self._drain_warnings(request.runtime)
+        if not warnings:
+            return request
+        loop_warnings = [w for w in warnings if w.startswith("[LOOP") or w.startswith("[FORCED")]
+        budget_warnings = [w for w in warnings if w.startswith("[TOKEN")]
+        merged = "\n\n".join(loop_warnings + budget_warnings)
+        new_messages = [
+            *request.messages,
+            HumanMessage(content=merged, name="resource_warning"),
+        ]
+        return request.override(messages=new_messages)
+
+    @override
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelCallResult:
+        return handler(self._augment_request(request))
+
+    @override
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelCallResult:
+        return await handler(self._augment_request(request))
+
+    def reset(self, thread_id: str | None = None) -> None:
+        if self._loop:
+            self._loop.reset(thread_id)
+        if self._budget:
+            self._budget.reset()
+        with self._lock:
+            if thread_id:
+                for key in list(self._pending_warnings):
+                    if key[0] == thread_id:
+                        self._pending_warnings.pop(key, None)
+            else:
+                self._pending_warnings.clear()

--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -98,6 +98,19 @@ class MemoryConfig(BaseModel):
             "safety-truncation ceiling is raised accordingly."
         ),
     )
+    embedding_model: str | None = Field(
+        default=None,
+        description=(
+            "Optional model name for computing fact embeddings. "
+            "When set, facts are ranked by semantic similarity to the current "
+            "conversation instead of static confidence. "
+            "The model must be defined in `config.yaml` under the ``models`` "
+            "list (any provider with an OpenAI-compatible ``/v1/embeddings`` "
+            "endpoint). "
+            "When ``None`` (default), falls back to character n-gram embedding "
+            "(zero external dependencies, no API call)."
+        ),
+    )
 
 
 # Global configuration instance

--- a/backend/packages/harness/deerflow/config/tool_search_config.py
+++ b/backend/packages/harness/deerflow/config/tool_search_config.py
@@ -12,8 +12,10 @@ class ToolSearchConfig(BaseModel):
     """
 
     enabled: bool = Field(
-        default=False,
-        description="Defer tools and enable tool_search",
+        default=True,
+        description="Defer MCP tools and enable tool_search discovery. "
+        "When enabled, MCP tool schemas are hidden from the model until "
+        "the tool_search tool promotes them — keeps the context window lean.",
     )
 
 

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -98,6 +98,7 @@ class SubagentResult:
     token_usage_records: list[dict[str, int | str | None]] = field(default_factory=list)
     usage_reported: bool = False
     cancel_event: threading.Event = field(default_factory=threading.Event, repr=False)
+    completed_event: threading.Event = field(default_factory=threading.Event, repr=False)
     _state_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
 
     def __post_init__(self):
@@ -138,6 +139,7 @@ class SubagentResult:
                 self.token_usage_records = token_usage_records
             self.completed_at = completed_at or datetime.now()
             self.status = status
+            self.completed_event.set()
             return True
 
 

--- a/backend/packages/harness/deerflow/tools/builtins/__init__.py
+++ b/backend/packages/harness/deerflow/tools/builtins/__init__.py
@@ -1,5 +1,8 @@
 from .clarification_tool import ask_clarification_tool
+from .forget_tool import forget_tool
 from .present_file_tool import present_file_tool
+from .remember_tool import remember_tool
+from .search_memory_tool import search_memory_tool
 from .setup_agent_tool import setup_agent
 from .task_tool import task_tool
 from .update_agent_tool import update_agent
@@ -12,4 +15,7 @@ __all__ = [
     "ask_clarification_tool",
     "view_image_tool",
     "task_tool",
+    "remember_tool",
+    "forget_tool",
+    "search_memory_tool",
 ]

--- a/backend/packages/harness/deerflow/tools/builtins/forget_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/forget_tool.py
@@ -1,0 +1,94 @@
+"""Tool for explicitly forgetting remembered information during conversation.
+
+Lets the user say "forget that" in natural language and have the agent
+immediately remove a fact from long-term memory.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain.tools import tool
+
+from deerflow.agents.memory.search import find_facts_by_content, format_fact_list
+from deerflow.agents.memory.updater import get_memory_data
+from deerflow.agents.memory.storage import get_memory_storage
+from deerflow.runtime.user_context import get_effective_user_id
+
+logger = logging.getLogger(__name__)
+
+
+@tool("forget", parse_docstring=True)
+def forget_tool(
+    query_or_id: str,
+) -> str:
+    """Forget a previously remembered piece of information.
+
+    Use this when the user says something like "forget that", "never mind that fact",
+    "remove that from memory", or when a previously remembered fact is no longer
+    accurate.
+
+    You can either:
+    - Pass a fact_id directly (you can see fact IDs in the memory context)
+    - Pass a search query and the tool will find the best matching facts to forget
+
+    Always confirm with the user before forgetting if there are multiple matches.
+
+    Args:
+        query_or_id: Either a fact ID (e.g. "fact_abc12345") or a search phrase.
+    """
+    query = query_or_id.strip()
+    if not query:
+        return "Error: Provide a fact ID or search phrase."
+
+    try:
+        user_id = get_effective_user_id()
+        memory_data = get_memory_data(user_id=user_id)
+        facts = memory_data.get("facts", [])
+
+        if not facts:
+            return "Nothing to forget — memory is empty."
+
+        # Check if it's a direct fact ID
+        if query.startswith("fact_"):
+            matching = [f for f in facts if f.get("id") == query]
+            if matching:
+                fact = matching[0]
+                content = fact.get("content", "")
+                storage = get_memory_storage()
+                updated_facts = [f for f in facts if f.get("id") != query]
+                memory_data["facts"] = updated_facts
+                storage.save(memory_data, user_id=user_id)
+                logger.info("Memory fact deleted by id (user=%s, fact=%s): %.60s", user_id, query, content)
+                return f"I've forgotten: {content}"
+            return f"Error: No fact found with id '{query}'."
+
+        # Search by content (keyword-only, high precision for delete)
+        matches = find_facts_by_content(facts, query, min_score=1.0)
+
+        if not matches:
+            return (
+                f"I couldn't find anything matching '{query}' in memory. "
+                "You can see all remembered facts in Settings > Memory."
+            )
+
+        if len(matches) == 1:
+            fact, score = matches[0]
+            fact_id = fact.get("id")
+            content = fact.get("content", "")
+            storage = get_memory_storage()
+            updated_facts = [f for f in facts if f.get("id") != fact_id]
+            memory_data["facts"] = updated_facts
+            storage.save(memory_data, user_id=user_id)
+            logger.info("Memory fact deleted by search (user=%s, score=%.2f): %.60s", user_id, score, content)
+            return f"I've forgotten: {content}"
+
+        # Multiple matches — return them so the agent can confirm
+        return format_fact_list(matches, title="Matches") + '\nTell me the id or number, or say "forget all of them".'
+
+    except OSError as e:
+        logger.exception("Failed to save memory after forget")
+        return f"Error: Could not update memory - {e}"
+    except Exception as e:
+        logger.exception("Unexpected error in forget tool")
+        return f"Error: {e}"

--- a/backend/packages/harness/deerflow/tools/builtins/remember_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/remember_tool.py
@@ -1,0 +1,76 @@
+"""Tool for explicitly remembering information during conversation.
+
+Lets the user say "remember this" in natural language and have the agent
+immediately persist a fact, bypassing the 30-second debounce queue that
+the passive MemoryMiddleware uses.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from langchain.tools import tool
+
+from deerflow.agents.memory.updater import create_memory_fact, get_memory_data
+from deerflow.runtime.user_context import get_effective_user_id
+
+logger = logging.getLogger(__name__)
+
+
+@tool("remember", parse_docstring=True)
+def remember_tool(
+    content: str,
+    category: Literal["preference", "knowledge", "context", "behavior", "goal"] = "preference",
+    confidence: float | None = None,
+) -> str:
+    """Remember an important piece of information about the user.
+
+    Use this when the user explicitly says something they want you to remember,
+    such as "remember that I use X", "note that I prefer Y", or "keep in mind that Z".
+
+    This persists the information immediately into long-term memory so it is
+    available in future conversations. Only use it for information the user
+    explicitly asks you to remember or that is clearly important for future
+    interactions.
+
+    Do NOT use this for:
+    - Session-specific details (current file paths, temporary tasks)
+    - Information already captured by normal conversation flow
+    - Trivial or obvious facts
+
+    Args:
+        content: The specific fact or information to remember. Be precise and self-contained.
+        category: The type of information. Defaults to "preference".
+            - preference: Tools, styles, approaches the user prefers
+            - knowledge: Specific expertise, technologies, domain knowledge
+            - context: Background facts (job, projects, languages)
+            - behavior: Working patterns, communication habits
+            - goal: Stated objectives, learning targets
+        confidence: Optional confidence score 0-1. Defaults to 0.95 for explicit requests.
+    """
+    normalized = content.strip()
+    if not normalized:
+        return "Error: Cannot remember empty content."
+
+    try:
+        user_id = get_effective_user_id()
+        effective_confidence = confidence if confidence is not None else 0.95
+
+        create_memory_fact(
+            content=normalized,
+            category=category,
+            confidence=effective_confidence,
+            user_id=user_id,
+        )
+
+        logger.info("Memory fact created (user=%s, category=%s): %.60s", user_id, category, normalized)
+        return f"I've remembered: {normalized}"
+    except ValueError as e:
+        return f"Error: Invalid fact - {e}"
+    except OSError as e:
+        logger.exception("Failed to save memory fact")
+        return f"Error: Could not save memory - {e}"
+    except Exception as e:
+        logger.exception("Unexpected error in remember tool")
+        return f"Error: {e}"

--- a/backend/packages/harness/deerflow/tools/builtins/search_memory_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/search_memory_tool.py
@@ -1,0 +1,81 @@
+"""Tool for searching memory during conversation.
+
+Lets the agent proactively look up relevant facts from long-term memory,
+using both keyword matching and semantic (vector) search when embeddings
+are available.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain.tools import tool
+
+from deerflow.agents.memory.search import rank_facts, format_fact_list
+from deerflow.agents.memory.updater import get_memory_data
+from deerflow.runtime.user_context import get_effective_user_id
+
+logger = logging.getLogger(__name__)
+
+
+@tool("search_memory", parse_docstring=True)
+def search_memory_tool(
+    query: str,
+    max_results: int = 10,
+) -> str:
+    """Search your long-term memory for information related to a query.
+
+    Use this when you need to recall something the user told you in a previous
+    conversation — preferences, past project context, technical stack details,
+    or any other fact stored in memory.
+
+    This searches both by keyword and by semantic similarity, so you can find
+    information even when the exact wording differs.
+
+    Do NOT use this for:
+    - Information already visible in the current conversation
+    - Information you just learned in this turn (it may not be saved yet)
+    - General knowledge (use your own training data instead)
+
+    Args:
+        query: What to search for. Be specific — "what Python version does the user prefer"
+               works better than "user info".
+        max_results: Maximum number of matching memories to return (1-50). Default 10.
+    """
+    query = query.strip()
+    if not query:
+        return "Error: Provide a search query."
+
+    if max_results < 1:
+        max_results = 1
+    elif max_results > 50:
+        max_results = 50
+
+    try:
+        user_id = get_effective_user_id()
+        memory_data = get_memory_data(user_id=user_id)
+        facts = memory_data.get("facts", [])
+
+        if not facts:
+            return "Memory is empty — there is nothing to search yet."
+
+        # Rank using combined keyword + vector scoring
+        results = rank_facts(
+            facts,
+            query,
+            max_results=max_results,
+            keyword_weight=0.3,
+            vector_weight=0.7,
+        )
+
+        if not results:
+            return f"No matching memories found for '{query}'."
+
+        return format_fact_list(results, title="Search results")
+
+    except OSError as e:
+        logger.exception("Failed to search memory")
+        return f"Error: Could not search memory - {e}"
+    except Exception as e:
+        logger.exception("Unexpected error in search_memory tool")
+        return f"Error: {e}"

--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -65,14 +65,23 @@ def _is_subagent_terminal(result: Any) -> bool:
 
 
 async def _await_subagent_terminal(task_id: str, max_polls: int) -> Any | None:
-    """Poll until the background subagent reaches a terminal status or we run out of polls."""
+    """Wait until the background subagent reaches a terminal status (push-based).
+
+    Uses ``completed_event`` for push notification when the subagent finishes.
+    Falls back to 5-second timeout on the event wait so a stuck subagent
+    still gets polled (backward compatible with legacy in-flight tasks).
+    """
     for _ in range(max_polls):
         result = get_background_task_result(task_id)
         if result is None:
             return None
         if _is_subagent_terminal(result):
             return result
-        await asyncio.sleep(5)
+
+        # Push-based: wait on the completion event (up to 5s per poll cycle).
+        # When the subagent finishes between polls, this returns immediately
+        # instead of waiting the full 5-second sleep.
+        await asyncio.to_thread(result.completed_event.wait, timeout=5)
     return None
 
 

--- a/backend/packages/harness/deerflow/tools/tools.py
+++ b/backend/packages/harness/deerflow/tools/tools.py
@@ -6,7 +6,7 @@ from deerflow.config import get_app_config
 from deerflow.config.app_config import AppConfig
 from deerflow.reflection import resolve_variable
 from deerflow.sandbox.security import is_host_bash_allowed
-from deerflow.tools.builtins import ask_clarification_tool, present_file_tool, task_tool, view_image_tool
+from deerflow.tools.builtins import ask_clarification_tool, forget_tool, present_file_tool, remember_tool, search_memory_tool, task_tool, view_image_tool
 from deerflow.tools.mcp_metadata import tag_mcp_tool
 from deerflow.tools.sync import make_sync_tool_wrapper
 
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 BUILTIN_TOOLS = [
     present_file_tool,
     ask_clarification_tool,
+    remember_tool,
+    forget_tool,
+    search_memory_tool,
 ]
 
 SUBAGENT_TOOLS = [

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -871,7 +871,7 @@ tools:
 # multiple MCP servers expose a large number of tools.
 
 tool_search:
-  enabled: false
+  enabled: true     # Default: true (keeps MCP tool schemas out of context until needed)
 
 # ============================================================================
 # Tool Output Budget Protection


### PR DESCRIPTION
## Summary

Conversational memory control tools + vector-based semantic retrieval for fact ranking.

### New Tools
- **`remember`** — lets users explicitly persist facts during conversation (immediate write, bypasses debounce queue)
- **`forget`** — delete facts by ID or semantic search with user confirmation on multiple matches
- **`search_memory`** — agent proactively searches memory using combined keyword + vector scoring

### Vector Retrieval
- **`embeddings.py`** — embedding computation supporting API models (OpenAI-compatible `/v1/embeddings`) with zero-dependency char n-gram fallback
- **`search.py`** — shared ranking utilities: keyword scoring, vector similarity, combined ranking, formatted output
- **Save-time embedding** — `updater.py` computes embeddings when facts are created (both LLM-extracted and manual)
- **Injection-time vector ranking** — `format_memory_for_injection` accepts optional `query` param; ranks facts by cosine similarity to current conversation instead of static confidence
- **Config** — new `memory.embedding_model` field in `MemoryConfig`

### Refactoring
- `forget_tool` refactored to use shared `search.py` utilities (removed duplicate `_find_facts_by_content`)
- Call chain wired through: `DynamicContextMiddleware` → `_get_memory_context()` → `format_memory_for_injection(query=...)`

### Files Changed
```
12 files changed, 694 insertions(+), 21 deletions(-)

A  embeddings.py          ← embedding computation
A  search.py               ← shared search/ranking
A  remember_tool.py        ← remember tool
A  forget_tool.py          ← forget tool (refactored)
A  search_memory_tool.py   ← search tool
M  updater.py              ← save-time embedding
M  prompt.py               ← vector ranking in injection
M  dynamic_context_middleware.py  ← query extraction
M  memory_config.py        ← embedding_model field
M  __init__.py / tools.py  ← registration
```

Co-Authored-By: Claude <noreply@anthropic.com>