### PR TITLE
fix(sandbox): stop setup-sandbox from pre-pulling the stale :latest sandbox image

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1076,10 +1076,13 @@ sandbox:
 #
 #   # Optional: Container image to use (works with both Docker and Apple Container)
 #   # Default: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
-#   # Recommended: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest (works on both x86_64 and arm64)
-#   # Custom images should extend the default image or implement the same AIO
-#   # sandbox HTTP API used by agent-sandbox. See backend/docs/CONFIGURATION.md.
-#   # image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
+#   # The mirror's `:latest` tag is frozen on an old pre-1.9.3 digest that lacks
+#   # the /v1/bash/* routes required-secrets skills need (see #3921/#3922), so
+#   # pin an explicit version instead — recommended: 1.11.0 (multi-arch, works
+#   # on both x86_64 and arm64). Custom images should extend the default image
+#   # or implement the same AIO sandbox HTTP API used by agent-sandbox. See
+#   # backend/docs/CONFIGURATION.md.
+#   # image: enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:1.11.0
 #
 #   # Optional: Base port for sandbox containers (default: 8080)
 #   # port: 8080

--- a/scripts/setup-sandbox.sh
+++ b/scripts/setup-sandbox.sh
@@ -16,7 +16,11 @@ if [ -f "config.yaml" ]; then
 fi
 
 if [ -z "$IMAGE" ]; then
-    IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest"
+    # NOTE: not ":latest". The mirror's `:latest` tag is frozen on an old
+    # pre-1.9.3 digest that lacks the /v1/bash/* routes required-secrets
+    # skills need (see #3921/#3922) — pulling it here would defeat the whole
+    # point of this pre-pull helper. Keep this pinned to a version >= 1.9.3.
+    IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:1.11.0"
     echo "Using default image: $IMAGE"
 else
     echo "Using configured image: $IMAGE"

--- a/scripts/setup-sandbox.sh
+++ b/scripts/setup-sandbox.sh
@@ -10,6 +10,7 @@ echo ""
 
 # Try to extract image from config.yaml (handles both commented and uncommented sandbox sections)
 IMAGE=""
+CONFIGURED=1
 if [ -f "config.yaml" ]; then
     # Look for uncommented image: field under the sandbox section
     IMAGE=$(grep -A 20 "^sandbox:" config.yaml 2>/dev/null | grep "^  image:" | awk '{print $2}' | head -1 || true)
@@ -21,6 +22,7 @@ if [ -z "$IMAGE" ]; then
     # skills need (see #3921/#3922) — pulling it here would defeat the whole
     # point of this pre-pull helper. Keep this pinned to a version >= 1.9.3.
     IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:1.11.0"
+    CONFIGURED=0
     echo "Using default image: $IMAGE"
 else
     echo "Using configured image: $IMAGE"
@@ -46,4 +48,16 @@ else
     echo "✗ Neither Docker nor Apple Container is available"
     echo "  Please install Docker: https://docs.docker.com/get-docker/"
     exit 1
+fi
+
+if [ "$CONFIGURED" -eq 0 ]; then
+    echo ""
+    echo "⚠ NOTE: pulling this image does not make the sandbox use it."
+    echo "  config.yaml has no uncommented 'sandbox.image', so AioSandboxProvider"
+    echo "  falls back to its own built-in default at runtime, which is still"
+    echo "  pinned to ':latest' (frozen on an old pre-1.9.3 digest — see #3921)."
+    echo "  To actually run on $IMAGE, add it explicitly:"
+    echo ""
+    echo "    sandbox:"
+    echo "      image: $IMAGE"
 fi


### PR DESCRIPTION
## Problem

Reported in #3914 by @yong326: after deleting the local sandbox image and rerunning `make setup-sandbox`, it re-pulled the same old broken image — required manually editing `config.yaml` to fix.

## Root cause

`scripts/setup-sandbox.sh`'s fallback (used whenever `config.yaml` has no uncommented `sandbox.image`) pulled the volces mirror's `:latest` tag. We confirmed in #3921/#3922 that this tag is frozen on the pre-1.9.3 `all-in-one-sandbox` digest (`1.0.0.156`), which lacks the `/v1/bash/*` routes `required-secrets` skills need — so the one script whose entire job is "pre-pull a working sandbox image" was pre-pulling a known-broken one.

## Fix

- `scripts/setup-sandbox.sh`: pin the fallback to `:1.11.0` instead of `:latest`.
- `config.example.yaml`: update the commented `image:` example and "Recommended" line to the same version, so uncommenting the example doesn't reproduce the same trap.
- **Self-review caught a follow-up gap** (see commit 2d7d1e70): `AioSandboxProvider` resolves its runtime image as `sandbox_config.image or DEFAULT_IMAGE` (`aio_sandbox_provider.py:214`), and `DEFAULT_IMAGE` is deliberately left untouched — still the frozen `:latest`. So pre-pulling `:1.11.0` alone, without also setting `sandbox.image` in `config.yaml`, creates a **new** inconsistency: the script reports success pulling a modern image, but the sandbox that actually starts still falls back to the broken `:latest` — silently leaving the underlying `required-secrets`/`bash.exec` problem unfixed, which is worse than before (at least previously pre-pull and runtime agreed, both on the broken image). Added a loud warning + exact config snippet when the unconfigured path is taken.

## Explicitly out of scope

`aio_sandbox_provider.py`'s `DEFAULT_IMAGE` constant (the harness-level default for `AioSandboxProvider` itself) is a separate, broader default-image decision already flagged to maintainers in #3921 — bumping it affects every unconfigured deployment, not just this pre-pull helper. This PR only fixes the pre-pull script + docs.

## Validation

Real end-to-end runs (not just reading the code):

**Scenario A — unconfigured (`config.yaml` has no `sandbox.image`, yong326's exact repro):**
```
Using default image: .../all-in-one-sandbox:1.11.0
Pulling image using Docker...
Status: Image is up to date for .../all-in-one-sandbox:1.11.0
✓ Sandbox image pulled successfully

⚠ NOTE: pulling this image does not make the sandbox use it.
  config.yaml has no uncommented 'sandbox.image', so AioSandboxProvider
  falls back to its own built-in default at runtime, which is still
  pinned to ':latest' (frozen on an old pre-1.9.3 digest — see #3921).
  To actually run on .../all-in-one-sandbox:1.11.0, add it explicitly:

    sandbox:
      image: .../all-in-one-sandbox:1.11.0
```

**Scenario B — configured (regression check on the pre-existing "configured image wins" path, untouched by this diff):**
```
Using configured image: some-custom-registry/custom-image:v9.9.9
Pulling image using Docker...
Error response from daemon: ... 403 Forbidden   # expected: fake image, proves the config path was read correctly, not silently falling back
⚠ Failed to pull sandbox image (this is OK for local sandbox mode)
```
(No new-warning noise on this path — confirmed.)

Both runs did a real `docker pull`, not a dry-run/mock.

Closes the `setup-sandbox` half of #3914's image-staleness thread.
