### PR TITLE
Fix AttributeError in ThreadDataMiddleware when runtime.context is None

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/thread_data_middleware.py
@@ -107,7 +107,7 @@ class ThreadDataMiddleware(AgentMiddleware[ThreadDataMiddlewareState]):
                 content=last_message.content,
                 id=last_message.id,
                 name=last_message.name or "user-input",
-                additional_kwargs={**last_message.additional_kwargs, "run_id": runtime.context.get("run_id"), "timestamp": datetime.now(UTC).isoformat()},
+                additional_kwargs={**last_message.additional_kwargs, "run_id": context.get("run_id"), "timestamp": datetime.now(UTC).isoformat()},
             )
 
         return {

--- a/backend/tests/test_thread_data_middleware.py
+++ b/backend/tests/test_thread_data_middleware.py
@@ -47,6 +47,23 @@ class TestThreadDataMiddleware:
         assert _as_posix(result["thread_data"]["uploads_path"]).endswith("threads/thread-from-config/user-data/uploads")
         assert runtime.context == {}
 
+    def test_before_agent_handles_none_context_with_trailing_human_message(self, tmp_path, monkeypatch):
+        # Regression: run_id was read via the unguarded `runtime.context`, so a None context plus a
+        # trailing HumanMessage raised AttributeError (thread_id still resolves from config.configurable).
+        from langchain_core.messages import HumanMessage
+
+        middleware = ThreadDataMiddleware(base_dir=str(tmp_path), lazy_init=True)
+        runtime = Runtime(context=None)
+        monkeypatch.setattr(
+            "deerflow.agents.middlewares.thread_data_middleware.get_config",
+            lambda: {"configurable": {"thread_id": "thread-from-config"}},
+        )
+
+        result = middleware.before_agent(state={"messages": [HumanMessage(content="hello", id="m1")]}, runtime=runtime)
+
+        assert result is not None
+        assert runtime.context is None
+
     def test_before_agent_raises_clear_error_when_thread_id_missing_everywhere(self, tmp_path, monkeypatch):
         middleware = ThreadDataMiddleware(base_dir=str(tmp_path), lazy_init=True)
         monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

`ThreadDataMiddleware.before_agent` guards `context = runtime.context or {}` at the top (since `thread_id` can be resolved from `config.configurable` when the context is `None`). But when stamping `run_id` onto a trailing `HumanMessage`, it still reads the raw `runtime.context`:

```python
"run_id": runtime.context.get("run_id")
```

So if `runtime.context is None` **and** the last message is a `HumanMessage`, this raises `AttributeError: 'NoneType' object has no attribute 'get'`.

Fix: use the already-guarded local `context`. Adds a regression test (`Runtime(context=None)` + trailing `HumanMessage`), which fails on `main` and passes with this change.
