### PR TITLE
Return the full-resolution image URL from image_search

### DIFF
--- a/backend/packages/harness/deerflow/community/image_search/tools.py
+++ b/backend/packages/harness/deerflow/community/image_search/tools.py
@@ -119,7 +119,7 @@ def image_search_tool(
     normalized_results = [
         {
             "title": r.get("title", ""),
-            "image_url": r.get("thumbnail", ""),
+            "image_url": r.get("image", ""),
             "thumbnail_url": r.get("thumbnail", ""),
         }
         for r in results

--- a/backend/tests/test_image_search.py
+++ b/backend/tests/test_image_search.py
@@ -1,0 +1,28 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from deerflow.community.image_search.tools import image_search_tool
+
+
+def test_image_search_uses_full_image_url_not_thumbnail():
+    # Regression: `image_url` must expose the full-resolution `image` from the DDGS result,
+    # not the low-res `thumbnail` (both fields were previously set to `thumbnail`).
+    fake_results = [
+        {
+            "title": "a cat",
+            "image": "https://example.com/full.jpg",
+            "thumbnail": "https://example.com/thumb.jpg",
+        }
+    ]
+    cfg = MagicMock()
+    cfg.get_tool_config.return_value = None
+
+    with (
+        patch("deerflow.community.image_search.tools._search_images", return_value=fake_results),
+        patch("deerflow.community.image_search.tools.get_app_config", return_value=cfg),
+    ):
+        output = json.loads(image_search_tool.invoke({"query": "a cat"}))
+
+    result = output["results"][0]
+    assert result["image_url"] == "https://example.com/full.jpg"
+    assert result["thumbnail_url"] == "https://example.com/thumb.jpg"


### PR DESCRIPTION
## What does this PR do?

The `image_search` tool set **both** `image_url` and `thumbnail_url` to the same field:

```python
"image_url": r.get("thumbnail", ""),
"thumbnail_url": r.get("thumbnail", ""),
```

So it never returned the full-resolution image, even though the tool's docstring and `usage_hint` promise reference-quality images ("Use the 'image_url' values as reference images in image generation"). A result that has an `image` but no `thumbnail` also comes back with an empty `image_url`.

DDGS `.images()` results expose the full-resolution source under the separate `image` key (vs `thumbnail` for the preview). This reads `image` for `image_url`, matching the sibling providers `serper` (`imageUrl` vs `thumbnailUrl`) and `brave` (`properties.url` vs `thumbnail.src`) which already keep the two distinct. `image_search` is the default image-search provider in `config.example.yaml`.

Adds a regression test.
