### PR TITLE
Fix circuit breaker wedging after a non-retriable half-open probe

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
@@ -354,6 +354,13 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 )
                 if retriable:
                     self._record_failure()
+                else:
+                    # A non-retriable error consumed the half-open probe without
+                    # recording a failure; release the probe so the circuit can
+                    # admit the next probe instead of fast-failing forever.
+                    with self._circuit_lock:
+                        if self._circuit_state == "half_open":
+                            self._circuit_probe_in_flight = False
                 return self._build_user_fallback_message(exc, reason)
 
     @override
@@ -406,6 +413,13 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 )
                 if retriable:
                     self._record_failure()
+                else:
+                    # A non-retriable error consumed the half-open probe without
+                    # recording a failure; release the probe so the circuit can
+                    # admit the next probe instead of fast-failing forever.
+                    with self._circuit_lock:
+                        if self._circuit_state == "half_open":
+                            self._circuit_probe_in_flight = False
                 return self._build_user_fallback_message(exc, reason)
 
 

--- a/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/llm_error_handling_middleware.py
@@ -182,6 +182,17 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                         self.circuit_recovery_timeout_sec,
                     )
 
+    def _release_half_open_probe(self) -> None:
+        """Release the in-flight half-open probe without recording a failure.
+
+        Used when something other than a classified success/failure consumes the probe (a
+        GraphBubbleUp control-flow signal, or a non-retriable error), so the circuit can admit
+        the next probe instead of fast-failing forever.
+        """
+        with self._circuit_lock:
+            if self._circuit_state == "half_open":
+                self._circuit_probe_in_flight = False
+
     def _classify_error(self, exc: BaseException) -> tuple[bool, str]:
         detail = _extract_error_detail(exc)
         lowered = detail.lower()
@@ -326,9 +337,7 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 return response
             except GraphBubbleUp:
                 # Preserve LangGraph control-flow signals (interrupt/pause/resume).
-                with self._circuit_lock:
-                    if self._circuit_state == "half_open":
-                        self._circuit_probe_in_flight = False
+                self._release_half_open_probe()
                 raise
             except Exception as exc:
                 retriable, reason = self._classify_error(exc)
@@ -355,12 +364,8 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 if retriable:
                     self._record_failure()
                 else:
-                    # A non-retriable error consumed the half-open probe without
-                    # recording a failure; release the probe so the circuit can
-                    # admit the next probe instead of fast-failing forever.
-                    with self._circuit_lock:
-                        if self._circuit_state == "half_open":
-                            self._circuit_probe_in_flight = False
+                    # Non-retriable: release the probe without recording a failure.
+                    self._release_half_open_probe()
                 return self._build_user_fallback_message(exc, reason)
 
     @override
@@ -385,9 +390,7 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 return response
             except GraphBubbleUp:
                 # Preserve LangGraph control-flow signals (interrupt/pause/resume).
-                with self._circuit_lock:
-                    if self._circuit_state == "half_open":
-                        self._circuit_probe_in_flight = False
+                self._release_half_open_probe()
                 raise
             except Exception as exc:
                 retriable, reason = self._classify_error(exc)
@@ -414,12 +417,8 @@ class LLMErrorHandlingMiddleware(AgentMiddleware[AgentState]):
                 if retriable:
                     self._record_failure()
                 else:
-                    # A non-retriable error consumed the half-open probe without
-                    # recording a failure; release the probe so the circuit can
-                    # admit the next probe instead of fast-failing forever.
-                    with self._circuit_lock:
-                        if self._circuit_state == "half_open":
-                            self._circuit_probe_in_flight = False
+                    # Non-retriable: release the probe without recording a failure.
+                    self._release_half_open_probe()
                 return self._build_user_fallback_message(exc, reason)
 
 

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -224,6 +224,73 @@ async def test_async_circuit_half_open_graph_bubble_up_resets_probe() -> None:
     assert middleware._circuit_state == "half_open"
 
 
+def test_circuit_half_open_non_retriable_error_resets_probe() -> None:
+    """A non-retriable error during a half-open probe must release the probe.
+
+    Regression: the non-retriable branch neither recorded a failure (correct —
+    business errors like quota/auth must not trip the breaker) nor reset
+    ``_circuit_probe_in_flight``. So one non-retriable probe left the circuit
+    stuck at half_open with probe_in_flight=True, and every subsequent call
+    fast-failed forever because no later call could ever run the handler to
+    reach ``_record_success`` / ``_record_failure``.
+    """
+    import unittest.mock
+
+    middleware = _build_middleware()
+
+    # Enter half_open and let one probe through (probe_in_flight -> True).
+    middleware._circuit_state = "half_open"
+    middleware._circuit_probe_in_flight = False
+    assert middleware._check_circuit() is False
+    assert middleware._circuit_probe_in_flight is True
+
+    def handler(_request) -> AIMessage:
+        raise FakeError("insufficient_quota", status_code=429, code="insufficient_quota")
+
+    # _check_circuit already admitted the probe above; keep it False here so the
+    # top-of-call gate does not fast-fail before the handler runs. Force the
+    # error to classify as non-retriable regardless of heuristics.
+    with unittest.mock.patch.object(middleware, "_check_circuit", return_value=False):
+        with unittest.mock.patch.object(middleware, "_classify_error", return_value=(False, "quota")):
+            result = middleware.wrap_model_call(SimpleNamespace(), handler)
+
+    # Non-retriable errors still surface a graceful fallback (not a raise) and
+    # must NOT trip the breaker.
+    assert isinstance(result, AIMessage)
+    assert middleware._circuit_state == "half_open"
+    # The probe was released, so the real gate re-admits the next probe instead
+    # of fast-failing forever.
+    assert middleware._circuit_probe_in_flight is False
+    assert middleware._check_circuit() is False
+    assert middleware._circuit_probe_in_flight is True
+
+
+@pytest.mark.anyio
+async def test_async_circuit_half_open_non_retriable_error_resets_probe() -> None:
+    """Async mirror: a non-retriable error during a half-open probe releases it."""
+    import unittest.mock
+
+    middleware = _build_middleware()
+
+    middleware._circuit_state = "half_open"
+    middleware._circuit_probe_in_flight = False
+    assert middleware._check_circuit() is False
+    assert middleware._circuit_probe_in_flight is True
+
+    async def handler(_request) -> AIMessage:
+        raise FakeError("insufficient_quota", status_code=429, code="insufficient_quota")
+
+    with unittest.mock.patch.object(middleware, "_check_circuit", return_value=False):
+        with unittest.mock.patch.object(middleware, "_classify_error", return_value=(False, "quota")):
+            result = await middleware.awrap_model_call(SimpleNamespace(), handler)
+
+    assert isinstance(result, AIMessage)
+    assert middleware._circuit_state == "half_open"
+    assert middleware._circuit_probe_in_flight is False
+    assert middleware._check_circuit() is False
+    assert middleware._circuit_probe_in_flight is True
+
+
 # ---------- Circuit Breaker Tests ----------
 
 


### PR DESCRIPTION
## Summary

`LLMErrorHandlingMiddleware`'s circuit breaker can wedge permanently in the `half_open` state after a single **non-retriable** probe failure, causing every subsequent LLM call to fast-fail forever.

## The bug

When the circuit is `half_open`, `_check_circuit()` admits exactly one probe call by setting `_circuit_probe_in_flight = True`. The probe call then runs through `wrap_model_call` / `awrap_model_call`. The failure path only ever resets that flag on two branches:

- `_record_success()` — on a successful probe (→ `closed`)
- `_record_failure()` — on a **retriable** probe failure (→ back to `open`)

```python
if retriable:
    self._record_failure()
return self._build_user_fallback_message(exc, reason)
```

If the probe raises a **non-retriable** error (quota / auth / generic), `retriable` is `False`, so:

- `_record_failure()` is correctly **not** called — business errors must not trip the breaker (this invariant is already covered by `test_circuit_breaker_does_not_trip_on_non_retriable_errors`), **but**
- nothing resets `_circuit_probe_in_flight`.

The circuit is now stuck at `half_open` with `_circuit_probe_in_flight = True`. From then on `_check_circuit()` returns `True` (fast fail) for **every** call, and because the handler never runs again, no call can ever reach `_record_success` / `_record_failure` to clear the flag. The breaker is wedged permanently — a transient quota blip during a recovery probe takes the model offline until the process restarts.

The existing `GraphBubbleUp` handler already recognises this exact hazard and releases the probe:

```python
except GraphBubbleUp:
    with self._circuit_lock:
        if self._circuit_state == "half_open":
            self._circuit_probe_in_flight = False
    raise
```

The non-retriable exception path was simply missing the equivalent reset.

## The fix

Release the half-open probe on the non-retriable path too, mirroring the `GraphBubbleUp` handler, on both the sync and async paths:

```python
if retriable:
    self._record_failure()
else:
    # A non-retriable error consumed the half-open probe without
    # recording a failure; release the probe so the circuit can
    # admit the next probe instead of fast-failing forever.
    with self._circuit_lock:
        if self._circuit_state == "half_open":
            self._circuit_probe_in_flight = False
return self._build_user_fallback_message(exc, reason)
```

The breaker still never trips on non-retriable errors (semantics unchanged); it just no longer leaks the probe slot, so the next call admits a fresh probe.

## Tests

Adds `test_circuit_half_open_non_retriable_error_resets_probe` and its async mirror `test_async_circuit_half_open_non_retriable_error_resets_probe`. Each drives the circuit to `half_open`, admits a probe, raises a non-retriable error during it, and asserts:

- the probe is released (`_circuit_probe_in_flight is False`),
- the circuit stays `half_open` (non-retriable errors don't trip it),
- a graceful fallback `AIMessage` is still returned, and
- the real `_check_circuit()` re-admits the next probe.

Verified fail-before / pass-after: both tests fail (`assert True is False` on the wedged flag) without the fix and pass with it. Full file: `31 passed`.

```
cd backend && PYTHONPATH=. pytest tests/test_llm_error_handling_middleware.py
```

`ruff format --check` and `ruff check` are clean.
