### PR TITLE
Fix UnboundLocalError in memory injection when facts list is empty

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/prompt.py
+++ b/backend/packages/harness/deerflow/agents/memory/prompt.py
@@ -554,6 +554,13 @@ def format_memory_for_injection(
     #   performs a single-pass confidence-only ranking.
     facts_data = memory_data.get("facts", [])
     guaranteed_line_tokens = 0  # used later for the effective truncation limit
+    # Initialise the facts-block markers at function scope (alongside
+    # ``guaranteed_line_tokens`` above) so the structure-aware truncation at the
+    # bottom can reference them even when there are no facts and the block below
+    # never runs. Otherwise the overflow path raises ``UnboundLocalError`` when a
+    # user has sizeable context/history but an empty ``facts`` list.
+    facts_header = "Facts:\n"
+    all_fact_lines: list[str] = []
     if isinstance(facts_data, list) and facts_data:
         # Token cost of sections built above (user context, history).
         base_text = "\n\n".join(sections)
@@ -563,13 +570,6 @@ def format_memory_for_injection(
         # path can pass the same list straight into the fallback without
         # redoing validation work on the hot prompt-injection path.
         valid_facts = [f for f in facts_data if isinstance(f, dict) and isinstance(f.get("content"), str) and f.get("content", "").strip()]
-
-        # Initialise the facts-block markers *before* the try so the
-        # structure-aware truncation at the bottom of the function can
-        # reason about them regardless of whether the primary path or
-        # the except/fallback path produced the final Facts section.
-        facts_header = "Facts:\n"
-        all_fact_lines: list[str] = []
 
         try:
             # Partition valid facts into guaranteed vs regular groups.

--- a/backend/tests/test_memory_prompt_injection.py
+++ b/backend/tests/test_memory_prompt_injection.py
@@ -508,6 +508,36 @@ def test_structure_aware_truncation_preserves_guaranteed_on_overflow(monkeypatch
     assert result.rstrip().endswith("(avoid: pip is deprecated)")
 
 
+def test_structure_aware_truncation_no_facts_does_not_raise(monkeypatch) -> None:
+    """When preceding sections overflow but there are no facts at all, the
+    truncation path must still clip gracefully instead of raising
+    ``UnboundLocalError``.
+
+    Regression: ``facts_header`` / ``all_fact_lines`` were only bound inside the
+    ``if isinstance(facts_data, list) and facts_data:`` block, yet the
+    overflow-truncation path below references them unconditionally. With an empty
+    ``facts`` list and an oversized user-context section, the truncation branch
+    raised ``UnboundLocalError`` and aborted memory injection entirely.
+    """
+    monkeypatch.setattr(
+        "deerflow.agents.memory.prompt._count_tokens",
+        lambda text, encoding_name="cl100k_base", *, use_tiktoken=True: len(text),
+    )
+
+    memory_data = {
+        "user": {"workContext": {"summary": "X" * 4000}},
+        "facts": [],  # no facts -> the facts-block initializers are skipped
+    }
+
+    result = format_memory_for_injection(memory_data, max_tokens=200, use_tiktoken=False)
+
+    assert isinstance(result, str)
+    assert "User Context:" in result
+    # The oversized preceding section was clipped from the tail.
+    assert result.rstrip().endswith("...")
+    assert len(result) < 4000
+
+
 def test_single_inter_section_separator_between_user_and_facts() -> None:
     """[P2] Exactly one ``\\n\\n`` separator between ``User Context:`` and
     ``Facts:`` — never four newlines.


### PR DESCRIPTION
## Summary

`format_memory_for_injection` can raise `UnboundLocalError` and abort memory injection entirely when a user's memory has substantial context/history but no discrete facts.

## The bug

`facts_header` and `all_fact_lines` are initialized **inside** the facts block:

```python
facts_data = memory_data.get("facts", [])
guaranteed_line_tokens = 0  # used later for the effective truncation limit
if isinstance(facts_data, list) and facts_data:
    ...
    facts_header = "Facts:\n"
    all_fact_lines: list[str] = []
    ...
```

But the structure-aware overflow-truncation path at the end of the function references both **unconditionally**:

```python
if token_count > effective_limit:
    ...
    facts_block = (facts_header + "\n".join(all_fact_lines)) if all_fact_lines else ""   # <-- here
    ...
    preceding_sections = sections[:-1] if all_fact_lines else sections                    # <-- and here
```

Note that `guaranteed_line_tokens` right above already guards against exactly this by being initialized at function scope — `facts_header` / `all_fact_lines` just missed the same treatment.

When a user's memory has sizeable `user` context and/or `history` (so `sections` is non-empty and the assembled output exceeds `max_tokens`) but an **empty or missing `facts` list**, the `if ... and facts_data:` block is skipped, so neither name is ever bound. The overflow branch then raises:

```
UnboundLocalError: cannot access local variable 'all_fact_lines' where it is not associated with a value
```

and memory injection fails for that turn instead of gracefully truncating. This is a realistic state — a user whose memory is mostly rolled-up context/history summaries with no discrete facts yet (`facts: []` is also the default from `memory_data.get("facts", [])`).

## The fix

Hoist the two initializers to function scope, right next to the existing `guaranteed_line_tokens = 0`, so they are always bound:

```python
facts_data = memory_data.get("facts", [])
guaranteed_line_tokens = 0  # used later for the effective truncation limit
facts_header = "Facts:\n"
all_fact_lines: list[str] = []
if isinstance(facts_data, list) and facts_data:
    ...
```

Behaviour is unchanged when facts are present (the block simply reassigns `all_fact_lines`).

## Tests

Adds `test_structure_aware_truncation_no_facts_does_not_raise`: an oversized user-context section with an empty `facts` list, forced past `max_tokens`. It asserts the result is a truncated string (`...` tail) with the user-context header preserved.

Verified fail-before / pass-after: the test raises `UnboundLocalError` at the truncation branch without the fix and passes with it; the sibling `test_structure_aware_truncation_preserves_guaranteed_on_overflow` keeps passing either way. Full file: `27 passed`.

```
cd backend && PYTHONPATH=. pytest tests/test_memory_prompt_injection.py
```

`ruff format --check` and `ruff check` are clean.
