### PR TITLE
Fix KeyError in memory staleness review when a fact has no id

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -779,7 +779,12 @@ class MemoryUpdater:
             # non-aged fact id is silently rejected.  Runs unconditionally
             # so the apply-layer protection is independent of model behavior
             # AND of the staleness_review_enabled flag.
-            candidate_ids = {f["id"] for f in _select_stale_candidates(current_memory, config)}
+            # Guard against legacy / hand-edited facts that predate the id
+            # field: an aged, non-protected fact with no "id" is a valid
+            # staleness candidate but has no id to intersect against, so skip
+            # it here instead of raising KeyError (id-less facts can never be
+            # targeted by the id-based removal set anyway).
+            candidate_ids = {f["id"] for f in _select_stale_candidates(current_memory, config) if f.get("id") is not None}
             stale_ids_to_remove &= candidate_ids
 
             if not stale_ids_to_remove:

--- a/backend/tests/test_memory_staleness_review.py
+++ b/backend/tests/test_memory_staleness_review.py
@@ -244,6 +244,44 @@ class TestApplyUpdatesStaleness:
         assert len(result["facts"]) == 1
         assert result["facts"][0]["id"] == "fact_keep"
 
+    def test_stale_candidate_without_id_does_not_raise(self):
+        """A legacy / hand-edited fact that lacks an ``id`` must not crash the
+        staleness apply path.
+
+        Regression: ``candidate_ids`` was built with a direct ``f["id"]``
+        access over ``_select_stale_candidates`` output, but every other fact
+        access in the module uses ``f.get("id")``. An aged, non-protected fact
+        with no ``id`` key (common in legacy / migrated ``memory.json``) is a
+        valid staleness candidate, so it reached ``f["id"]`` and raised
+        ``KeyError: 'id'``, aborting the whole memory-update cycle.
+        """
+        updater = MemoryUpdater()
+        aged = (datetime.now(UTC) - timedelta(days=120)).isoformat().replace("+00:00", "Z")
+        # An aged, non-protected fact deliberately missing the "id" key.
+        idless_fact = {"content": "User uses Vue.js", "category": "knowledge", "confidence": 0.8, "createdAt": aged}
+        current_memory = _make_memory([_make_fact("fact_keep", days_ago=100), idless_fact])
+        update_data = {
+            "user": {},
+            "history": {},
+            "newFacts": [],
+            "factsToRemove": [],
+            "staleFactsToRemove": [
+                {"id": "fact_keep", "reason": "outdated"},
+            ],
+        }
+
+        with patch(
+            "deerflow.agents.memory.updater.get_memory_config",
+            return_value=_memory_config(max_facts=100, staleness_max_removals_per_cycle=10),
+        ):
+            # Must not raise KeyError: 'id'.
+            result = updater._apply_updates(current_memory, update_data)
+
+        # The id-less fact survives (it can never be targeted by the id-based
+        # removal set), and the id-based removal of fact_keep still applies.
+        contents = {f.get("content") for f in result["facts"]}
+        assert "User uses Vue.js" in contents
+
     def test_safety_cap_limits_removals(self):
         updater = MemoryUpdater()
         # 5 stale facts, but cap is 2 → only 2 lowest-confidence should be removed


### PR DESCRIPTION
## Summary

The apply-time staleness guardrail in `MemoryUpdater._apply_updates` raises `KeyError: 'id'` and aborts the whole background memory-update cycle when a fact lacks an `id` key.

## The bug

`candidate_ids` is built with a **direct** subscript over `_select_stale_candidates` output:

```python
candidate_ids = {f["id"] for f in _select_stale_candidates(current_memory, config)}
stale_ids_to_remove &= candidate_ids
```

Every other fact access in `updater.py` uses `f.get("id")` (e.g. lines 138, 167, 454, 770, 795, 799) — this was the lone direct-subscript outlier. `_select_stale_candidates` selects any fact that is older than `staleness_age_days` and not in `staleness_protected_categories`; it never requires an `id`:

```python
for fact in current_memory.get("facts", []):
    if not isinstance(fact, dict):
        continue
    category = fact.get("category", "")
    if isinstance(category, str) and category in protected:
        continue
    created_at = _parse_fact_datetime(fact.get("createdAt", ""))
    if created_at is not None and created_at < cutoff:
        candidates.append(fact)
```

Newly-created facts always get an `id`, but **legacy / hand-edited / migrated `memory.json`** facts can lack one. Such a fact — if aged and not protected — is returned as a candidate and then hits `f["id"]` → `KeyError: 'id'`.

The guardrail runs **unconditionally** (its comment notes it is independent of the `staleness_review_enabled` flag), so it fires whenever the LLM returns a non-empty `staleFactsToRemove`. The presence of *any* id-less aged fact is enough — the LLM does not need to target that specific fact. The exception propagates out of the background memory-update apply path, so that user's memory update cycle fails.

## The fix

Skip id-less candidates when building the intersection set:

```python
candidate_ids = {f["id"] for f in _select_stale_candidates(current_memory, config) if f.get("id") is not None}
```

An id-less fact can never be in `stale_ids_to_remove` (which is built from LLM `staleFactsToRemove` entries that carry an `id`), so excluding it from the intersection set does not change which facts are removed — it only avoids the crash. Behaviour is otherwise unchanged.

## Tests

Adds `TestApplyUpdatesStaleness::test_stale_candidate_without_id_does_not_raise`: an aged, non-protected fact deliberately missing the `id` key, alongside a normal fact, with a non-empty `staleFactsToRemove`. It asserts `_apply_updates` does not raise and the id-less fact survives.

Verified fail-before / pass-after: the test raises `KeyError: 'id'` without the fix and passes with it. Full memory suites: `94 passed` (`test_memory_staleness_review.py` + `test_memory_updater.py`).

```
cd backend && PYTHONPATH=. pytest tests/test_memory_staleness_review.py
```

`ruff format --check` and `ruff check` are clean.
