### PR TITLE
fix(config): Make the sync checkpointer honor the unified database config

### DIFF
--- a/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
+++ b/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
@@ -26,8 +26,8 @@ from collections.abc import Iterator
 
 from langgraph.types import Checkpointer
 
-from deerflow.config.app_config import get_app_config
-from deerflow.config.checkpointer_config import CheckpointerConfig, ensure_config_loaded
+from deerflow.config.app_config import AppConfig, get_app_config
+from deerflow.config.checkpointer_config import CheckpointerConfig, ensure_config_loaded, get_checkpointer_config
 from deerflow.runtime.store._sqlite_utils import ensure_sqlite_parent_dir, resolve_sqlite_conn_str
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,51 @@ POSTGRES_INSTALL = (
     "langgraph-checkpoint-postgres is required for the PostgreSQL checkpointer. Install the package extra with: pip install 'deerflow-harness[postgres]' (or use: uv sync --all-packages --extra postgres when developing locally)"
 )
 POSTGRES_CONN_REQUIRED = "checkpointer.connection_string is required for the postgres backend"
+
+
+# ---------------------------------------------------------------------------
+# Config resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_checkpointer_config(app_config: AppConfig) -> CheckpointerConfig:
+    """Resolve the checkpointer backend from legacy or unified application config.
+
+    The legacy ``checkpointer`` section remains authoritative when present so
+    Checkpointer and Store keep using the same backend. Otherwise the unified
+    ``database`` section drives the checkpointer, matching the async
+    :func:`~deerflow.runtime.checkpointer.async_provider.make_checkpointer`
+    factory and the sync Store provider's ``_resolve_store_config``.
+    """
+    if app_config.checkpointer is not None:
+        return app_config.checkpointer
+
+    database = app_config.database
+    if database.backend == "memory":
+        return CheckpointerConfig(type="memory")
+    if database.backend == "sqlite":
+        return CheckpointerConfig(type="sqlite", connection_string=database.checkpointer_sqlite_path)
+    if database.backend == "postgres":
+        if not database.postgres_url:
+            raise ValueError("database.postgres_url is required for the postgres backend")
+        return CheckpointerConfig(type="postgres", connection_string=database.postgres_url)
+    raise ValueError(f"Unknown database backend: {database.backend!r}")
+
+
+def _get_checkpointer_config() -> CheckpointerConfig:
+    """Load checkpointer config without holding the provider singleton lock."""
+    ensure_config_loaded()
+
+    # Preserve callers that initialise the legacy config singleton directly.
+    legacy_config = get_checkpointer_config()
+    if legacy_config is not None:
+        return legacy_config
+    try:
+        app_config = get_app_config()
+    except FileNotFoundError:
+        return CheckpointerConfig(type="memory")
+    return _resolve_checkpointer_config(app_config)
+
 
 # ---------------------------------------------------------------------------
 # Sync factory
@@ -107,7 +152,9 @@ _checkpointer_lock = threading.Lock()
 def get_checkpointer() -> Checkpointer:
     """Return the global sync checkpointer singleton, creating it on first call.
 
-    Returns an ``InMemorySaver`` when no checkpointer is configured in *config.yaml*.
+    The legacy ``checkpointer`` section takes precedence when configured;
+    otherwise the unified ``database`` section selects the backend. Returns an
+    ``InMemorySaver`` when neither selects a persistent backend.
 
     Raises:
         ImportError: If the required package for the configured backend is not installed.
@@ -118,23 +165,12 @@ def get_checkpointer() -> Checkpointer:
     if _checkpointer is not None:
         return _checkpointer
 
-    # Config loading can reset both persistence singletons. Keep it outside
-    # this provider lock to avoid cross-provider lock-order inversion.
-    ensure_config_loaded()
+    # Config loading can reset both persistence singletons. Resolve the full
+    # config outside this provider lock to avoid cross-provider lock-order inversion.
+    config = _get_checkpointer_config()
 
     with _checkpointer_lock:
         if _checkpointer is not None:
-            return _checkpointer
-
-        from deerflow.config.checkpointer_config import get_checkpointer_config
-
-        config = get_checkpointer_config()
-
-        if config is None:
-            from langgraph.checkpoint.memory import InMemorySaver
-
-            logger.info("Checkpointer: using InMemorySaver (in-process, not persistent)")
-            _checkpointer = InMemorySaver()
             return _checkpointer
 
         checkpointer_ctx = _sync_checkpointer_cm(config)
@@ -178,15 +214,11 @@ def checkpointer_context() -> Iterator[Checkpointer]:
         with checkpointer_context() as cp:
             graph.invoke(input, config={"configurable": {"thread_id": "1"}})
 
-    Yields an ``InMemorySaver`` when no checkpointer is configured in *config.yaml*.
+    The legacy ``checkpointer`` section takes precedence when configured;
+    otherwise the unified ``database`` section selects the backend. Yields an
+    ``InMemorySaver`` when neither selects a persistent backend.
     """
 
-    config = get_app_config()
-    if config.checkpointer is None:
-        from langgraph.checkpoint.memory import InMemorySaver
-
-        yield InMemorySaver()
-        return
-
-    with _sync_checkpointer_cm(config.checkpointer) as saver:
+    config = _resolve_checkpointer_config(get_app_config())
+    with _sync_checkpointer_cm(config) as saver:
         yield saver

--- a/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
+++ b/backend/packages/harness/deerflow/runtime/checkpointer/provider.py
@@ -61,7 +61,7 @@ def _resolve_checkpointer_config(app_config: AppConfig) -> CheckpointerConfig:
         return app_config.checkpointer
 
     database = app_config.database
-    if database.backend == "memory":
+    if database is None or database.backend == "memory":
         return CheckpointerConfig(type="memory")
     if database.backend == "sqlite":
         return CheckpointerConfig(type="sqlite", connection_string=database.checkpointer_sqlite_path)

--- a/backend/packages/harness/deerflow/runtime/store/provider.py
+++ b/backend/packages/harness/deerflow/runtime/store/provider.py
@@ -56,7 +56,7 @@ def _resolve_store_config(app_config: AppConfig) -> CheckpointerConfig:
         return app_config.checkpointer
 
     database = app_config.database
-    if database.backend == "memory":
+    if database is None or database.backend == "memory":
         return CheckpointerConfig(type="memory")
     if database.backend == "sqlite":
         return CheckpointerConfig(type="sqlite", connection_string=database.checkpointer_sqlite_path)

--- a/backend/tests/test_checkpointer.py
+++ b/backend/tests/test_checkpointer.py
@@ -739,6 +739,26 @@ class TestCheckpointerDatabaseConfig:
         assert resolved.type == "postgres"
         assert resolved.connection_string == "postgresql://localhost/db"
 
+    def test_sync_checkpointer_context_uses_sqlite_database_config(self, tmp_path):
+        """The one-shot sync checkpointer factory must resolve the sqlite branch too, not just postgres."""
+        from deerflow.runtime.checkpointer.provider import checkpointer_context
+
+        db_config = DatabaseConfig(backend="sqlite", sqlite_dir=str(tmp_path))
+        app_config = SimpleNamespace(checkpointer=None, database=db_config)
+        expected = object()
+        factory = MagicMock(return_value=nullcontext(expected))
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch("deerflow.runtime.checkpointer.provider._sync_checkpointer_cm", factory),
+            checkpointer_context() as cp,
+        ):
+            assert cp is expected
+
+        resolved = factory.call_args.args[0]
+        assert resolved.type == "sqlite"
+        assert resolved.connection_string == db_config.checkpointer_sqlite_path
+
     def test_sync_checkpointer_singleton_uses_database_config(self):
         """The cached sync checkpointer factory must resolve database config before locking."""
         app_config = SimpleNamespace(

--- a/backend/tests/test_checkpointer.py
+++ b/backend/tests/test_checkpointer.py
@@ -705,6 +705,108 @@ class TestAsyncCheckpointer:
         mock_saver.setup.assert_awaited_once()
 
 
+class TestCheckpointerDatabaseConfig:
+    """The sync checkpointer must follow the unified ``database`` section when no
+    legacy ``checkpointer`` section is configured — matching the async
+    ``make_checkpointer`` factory and the sync Store provider.
+
+    Regression: ``get_checkpointer`` / ``checkpointer_context`` previously read
+    only the legacy ``checkpointer`` section and fell back to ``InMemorySaver``,
+    silently ignoring ``database``. Embedded callers (``DeerFlowClient``) and the
+    TUI then persisted Store rows to sqlite/postgres while checkpoints went to an
+    in-memory saver and were lost on exit.
+    """
+
+    def test_sync_checkpointer_context_uses_database_config(self):
+        """The one-shot sync checkpointer factory must follow unified database config."""
+        from deerflow.runtime.checkpointer.provider import checkpointer_context
+
+        app_config = SimpleNamespace(
+            checkpointer=None,
+            database=DatabaseConfig(backend="postgres", postgres_url="postgresql://localhost/db"),
+        )
+        expected = object()
+        factory = MagicMock(return_value=nullcontext(expected))
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch("deerflow.runtime.checkpointer.provider._sync_checkpointer_cm", factory),
+            checkpointer_context() as cp,
+        ):
+            assert cp is expected
+
+        resolved = factory.call_args.args[0]
+        assert resolved.type == "postgres"
+        assert resolved.connection_string == "postgresql://localhost/db"
+
+    def test_sync_checkpointer_singleton_uses_database_config(self):
+        """The cached sync checkpointer factory must resolve database config before locking."""
+        app_config = SimpleNamespace(
+            checkpointer=None,
+            database=DatabaseConfig(backend="postgres", postgres_url="postgresql://localhost/db"),
+        )
+        expected = object()
+        factory = MagicMock(return_value=nullcontext(expected))
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.ensure_config_loaded"),
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch("deerflow.runtime.checkpointer.provider._sync_checkpointer_cm", factory),
+        ):
+            assert get_checkpointer() is expected
+
+        resolved = factory.call_args.args[0]
+        assert resolved.type == "postgres"
+        assert resolved.connection_string == "postgresql://localhost/db"
+
+    def test_sync_checkpointer_falls_back_to_memory_when_config_file_is_missing(self):
+        """The sync checkpointer keeps its no-config fallback for embedded callers."""
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.ensure_config_loaded"),
+            patch("deerflow.runtime.checkpointer.provider.get_checkpointer_config", return_value=None),
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", side_effect=FileNotFoundError),
+        ):
+            assert isinstance(get_checkpointer(), InMemorySaver)
+
+    def test_legacy_checkpointer_config_takes_precedence(self):
+        """Backward-compatible checkpointer config must override database."""
+        from deerflow.runtime.checkpointer.provider import checkpointer_context
+
+        app_config = SimpleNamespace(
+            checkpointer=CheckpointerConfig(type="memory"),
+            database=DatabaseConfig(backend="postgres", postgres_url="postgresql://localhost/db"),
+        )
+        expected = object()
+        factory = MagicMock(return_value=nullcontext(expected))
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            patch("deerflow.runtime.checkpointer.provider._sync_checkpointer_cm", factory),
+            checkpointer_context() as cp,
+        ):
+            assert cp is expected
+
+        resolved = factory.call_args.args[0]
+        assert resolved.type == "memory"
+        assert resolved.connection_string is None
+
+    def test_explicit_memory_database_uses_in_memory_saver(self):
+        """Explicit memory mode remains an intentional non-persistent checkpointer."""
+        from langgraph.checkpoint.memory import InMemorySaver
+
+        from deerflow.runtime.checkpointer.provider import checkpointer_context
+
+        app_config = SimpleNamespace(checkpointer=None, database=DatabaseConfig(backend="memory"))
+
+        with (
+            patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=app_config),
+            checkpointer_context() as cp,
+        ):
+            assert isinstance(cp, InMemorySaver)
+
+
 class TestStoreDatabaseConfig:
     def test_sync_store_falls_back_to_memory_when_config_file_is_missing(self):
         """The sync Store keeps its no-config fallback for embedded callers."""

--- a/backend/tests/test_checkpointer_none_fix.py
+++ b/backend/tests/test_checkpointer_none_fix.py
@@ -38,9 +38,10 @@ class TestCheckpointerNoneFix:
         """checkpointer_context should return InMemorySaver when config.checkpointer is None."""
         from deerflow.runtime.checkpointer.provider import checkpointer_context
 
-        # Mock get_app_config to return a config with checkpointer=None
+        # Mock get_app_config to return a config with checkpointer=None and database=None
         mock_config = MagicMock()
         mock_config.checkpointer = None
+        mock_config.database = None
 
         with patch("deerflow.runtime.checkpointer.provider.get_app_config", return_value=mock_config):
             with checkpointer_context() as checkpointer:


### PR DESCRIPTION
## Summary

The **sync** checkpointer factory ignores the unified `database:` config section, so embedded (`DeerFlowClient`) and TUI runs silently drop their checkpoints to an in-memory saver even when `database:` selects sqlite/postgres.

## The bug

`runtime/checkpointer/provider.py` — both `get_checkpointer()` (singleton) and `checkpointer_context()` (one-shot) read **only** the legacy `checkpointer:` section and fall back to `InMemorySaver` when it is absent:

```python
# get_checkpointer()
config = get_checkpointer_config()      # legacy checkpointer: section only
if config is None:
    ... return InMemorySaver()

# checkpointer_context()
config = get_app_config()
if config.checkpointer is None:
    yield InMemorySaver(); return
```

Every sibling resolver already honors `database:`:

- async checkpointer `async_provider.py::make_checkpointer` — legacy `checkpointer:` first, else `database:`, else memory
- sync Store `store/provider.py::_resolve_store_config` (+ `store_context` / `get_store`)
- async Store `store/async_provider.py::make_store`

So the sync checkpointer is the lone outlier. With `database: {backend: sqlite|postgres}` and **no** legacy `checkpointer:` section:

- the Store (same process, same config) persists to sqlite/postgres, but
- the sync checkpointer silently returns `InMemorySaver`.

This contradicts `backend/AGENTS.md`:

> the unified `database` section selects the Gateway's LangGraph checkpointer, LangGraph Store, and DeerFlow SQL repositories

The Gateway is unaffected (it uses the async `make_checkpointer` path). The reachable failures are the embedded/sync callers:

- `DeerFlowClient` (`client.py`) when no explicit checkpointer is passed
- the TUI (`tui/session.py`): `persistence.py` writes a `threads_meta` row to sqlite so the thread shows up in the Web UI sidebar, but the conversation checkpoints go to `InMemorySaver` and are lost when the process exits.

## The fix

Mirror the sync Store provider. Add `_resolve_checkpointer_config` (legacy `checkpointer:` precedence, else translate `database:` into a `CheckpointerConfig`) and `_get_checkpointer_config` (the lock-free loader with the `FileNotFoundError` → memory fallback that embedded callers rely on), then route both the singleton and the context manager through them:

```python
def _resolve_checkpointer_config(app_config: AppConfig) -> CheckpointerConfig:
    if app_config.checkpointer is not None:
        return app_config.checkpointer
    database = app_config.database
    if database.backend == "memory":
        return CheckpointerConfig(type="memory")
    if database.backend == "sqlite":
        return CheckpointerConfig(type="sqlite", connection_string=database.checkpointer_sqlite_path)
    if database.backend == "postgres":
        if not database.postgres_url:
            raise ValueError("database.postgres_url is required for the postgres backend")
        return CheckpointerConfig(type="postgres", connection_string=database.postgres_url)
    raise ValueError(f"Unknown database backend: {database.backend!r}")
```

This makes the sync checkpointer resolution identical to the sync Store's, and consistent with the async checkpointer's documented priority. `memory` backend still yields `InMemorySaver`; the legacy `checkpointer:` section still takes precedence.

## Tests

Adds `TestCheckpointerDatabaseConfig`, mirroring the existing `TestStoreDatabaseConfig` suite:

- `test_sync_checkpointer_context_uses_database_config` — one-shot honors `database: postgres`
- `test_sync_checkpointer_singleton_uses_database_config` — singleton honors `database: postgres`
- `test_sync_checkpointer_falls_back_to_memory_when_config_file_is_missing` — embedded no-config fallback preserved
- `test_legacy_checkpointer_config_takes_precedence` — legacy `checkpointer:` overrides `database:`
- `test_explicit_memory_database_uses_in_memory_saver` — explicit memory mode stays non-persistent

Verified fail-before / pass-after: the two `uses_database_config` tests return `InMemorySaver` (assertion fails) before the fix and pass after. Full file: `49 passed`; TUI-persistence + persistence-bootstrap suites also green.

```
cd backend && PYTHONPATH=. pytest tests/test_checkpointer.py
```

`ruff format --check` and `ruff check` are clean.
