### PR TITLE
Correct memory-config documentation to match the code

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -581,9 +581,9 @@ Focused regression coverage for the updater lives in `backend/tests/test_memory_
 - `max_injection_tokens` - Token limit for prompt injection (2000)
 - `token_counting` - Token counting strategy for the injection budget: `tiktoken` (default, accurate but may download BPE data from a public endpoint on first use — can block for a long time in network-restricted environments, see issues #3402/#3429) or `char` (network-free CJK-aware char estimate, never touches tiktoken)
 - `staleness_review_enabled` - Enable proactive staleness pruning of aged facts (default: `true`; only triggers when aged candidates exist)
-- `staleness_age_days` - Age in days before a fact becomes a staleness candidate (default: 180; range: 1–3650)
+- `staleness_age_days` - Age in days before a fact becomes a staleness candidate (default: 90; range: 30–365)
 - `staleness_min_candidates` - Minimum aged candidates required to trigger a review cycle (default: 3; range: 1–50)
-- `staleness_max_removals_per_cycle` - Maximum facts removed in a single cycle; lowest-confidence entries are kept when the LLM requests more (default: 5; range: 1–20)
+- `staleness_max_removals_per_cycle` - Maximum facts removed in a single cycle; lowest-confidence entries are kept when the LLM requests more (default: 10; range: 1–50)
 - `staleness_protected_categories` - Fact categories that are never pruned by staleness review (default: `["correction"]`)
 
 ### Reflection System (`packages/harness/deerflow/reflection/`)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1350,7 +1350,7 @@ summarization:
 # Stores user context and conversation history for personalized responses
 memory:
   enabled: true
-  storage_path: memory.json # Path relative to backend directory
+  storage_path: memory.json # Absolute path opts out of per-user isolation; a relative path resolves under the data base_dir, not the backend directory
   debounce_seconds: 30 # Wait time before processing queued updates
   model_name: null # Use default model
   max_facts: 100 # Maximum number of facts to store


### PR DESCRIPTION
## Summary

Two memory-configuration docs disagree with the actual defaults / behavior in the code. Doc-only change, no behavior change.

## 1. `backend/AGENTS.md` — staleness defaults & ranges

The `memory` config reference lists values that don't match `packages/harness/deerflow/config/memory_config.py`:

| Field | AGENTS.md said | Actual (`memory_config.py`) |
|-------|----------------|------------------------------|
| `staleness_age_days` | default: 180; range: 1–3650 | `default=90, ge=30, le=365` |
| `staleness_max_removals_per_cycle` | default: 5; range: 1–20 | `default=10, ge=1, le=50` |

(`staleness_min_candidates` "default: 3; range: 1–50" and `staleness_protected_categories` `["correction"]` already match and are left unchanged.)

## 2. `config.example.yaml` — `storage_path` comment

```yaml
storage_path: memory.json # Path relative to backend directory
```

The "relative to backend directory" comment is wrong. Per `memory_config.py`'s field description and `agents/memory/storage.py::_get_memory_file_path`:

- a **relative** `storage_path` resolves against the data `base_dir` (`get_paths().base_dir / p`), **not** the backend working directory;
- an **absolute** `storage_path` is what opts out of per-user isolation.

Updated the comment to:

```yaml
storage_path: memory.json # Absolute path opts out of per-user isolation; a relative path resolves under the data base_dir, not the backend directory
```

## Notes

Doc-only; there is no runtime behavior to test. Values were cross-checked against `memory_config.py` (field defaults/bounds) and `storage.py` (path resolution).
