### PR TITLE
fix(runtime): Atomic create_or_reject across workers, fixing race conditions for multiple active Runs.

### DIFF
--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0004_one_active_run_per_thread.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0004_one_active_run_per_thread.py
@@ -1,0 +1,64 @@
+"""Add partial unique index to enforce at most one active run per thread.
+
+Revision ID: 0004_one_active_run_per_thread
+Revises: 0003_scheduled_tasks
+Create Date: 2026-07-09
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+from deerflow.persistence.migrations._helpers import _inspector
+
+revision: str = "0004_one_active_run_per_thread"
+down_revision: str | Sequence[str] | None = "0003_scheduled_tasks"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+INDEX_NAME = "ix_one_active_run_per_thread"
+
+
+def _index_exists() -> bool:
+    insp = _inspector()
+    if "runs" not in insp.get_table_names():
+        return True  # nothing to add/drop
+    for idx in insp.get_indexes("runs"):
+        if idx.get("name") == INDEX_NAME:
+            return True
+    return False
+
+
+def upgrade() -> None:
+    if _index_exists():
+        return
+
+    bind = op.get_bind()
+    dialect_name = bind.dialect.name
+
+    if dialect_name == "postgresql":
+        op.create_index(
+            INDEX_NAME,
+            "runs",
+            ["thread_id"],
+            unique=True,
+            postgresql_where=sa.text("status IN ('pending', 'running')"),
+        )
+    else:
+        # SQLite and other dialects
+        op.create_index(
+            INDEX_NAME,
+            "runs",
+            ["thread_id"],
+            unique=True,
+            sqlite_where=sa.text("status IN ('pending', 'running')"),
+        )
+
+
+def downgrade() -> None:
+    if not _index_exists():
+        return
+    op.drop_index(INDEX_NAME, table_name="runs")

--- a/backend/packages/harness/deerflow/persistence/migrations/versions/0004_one_active_run_per_thread.py
+++ b/backend/packages/harness/deerflow/persistence/migrations/versions/0004_one_active_run_per_thread.py
@@ -7,6 +7,7 @@ Create Date: 2026-07-09
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 
 import sqlalchemy as sa
@@ -14,12 +15,16 @@ from alembic import op
 
 from deerflow.persistence.migrations._helpers import _inspector
 
+logger = logging.getLogger(__name__)
+
 revision: str = "0004_one_active_run_per_thread"
 down_revision: str | Sequence[str] | None = "0003_scheduled_tasks"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 INDEX_NAME = "ix_one_active_run_per_thread"
+
+_CLEANUP_ERROR = "Cleaned up during migration 0004: duplicate active runs per thread"
 
 
 def _index_exists() -> bool:
@@ -32,12 +37,58 @@ def _index_exists() -> bool:
     return False
 
 
+def _cleanup_duplicate_active_runs(connection, dialect_name: str) -> int:
+    """Mark duplicate active runs as interrupted, keeping only the newest per thread.
+
+    If a thread has multiple pending/running rows (e.g. from a pre-fix
+    multi-worker race), the partial unique index cannot be created.  This
+    helper keeps the most-recently-created active run per thread and marks
+    the rest as ``interrupted``.
+    """
+    if dialect_name == "postgresql":
+        time_expr = "NOW()"
+    else:
+        time_expr = "datetime('now')"
+
+    result = connection.execute(
+        sa.text(f"""
+            UPDATE runs SET
+                status = 'interrupted',
+                error = :error,
+                updated_at = {time_expr}
+            WHERE run_id IN (
+                SELECT run_id FROM (
+                    SELECT run_id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY thread_id ORDER BY created_at DESC
+                        ) AS rn
+                    FROM runs
+                    WHERE status IN ('pending', 'running')
+                ) ranked
+                WHERE rn > 1
+            )
+        """),
+        {"error": _CLEANUP_ERROR},
+    )
+    cleaned = result.rowcount
+    if cleaned:
+        logger.warning(
+            "Migration 0004: cleaned up %d duplicate active run(s) before creating unique index",
+            cleaned,
+        )
+    return cleaned
+
+
 def upgrade() -> None:
     if _index_exists():
         return
 
     bind = op.get_bind()
     dialect_name = bind.dialect.name
+
+    # Clean up any pre-existing duplicate active runs that would prevent
+    # the unique index from being created.
+    _cleanup_duplicate_active_runs(bind, dialect_name)
 
     if dialect_name == "postgresql":
         op.create_index(

--- a/backend/packages/harness/deerflow/persistence/run/model.py
+++ b/backend/packages/harness/deerflow/persistence/run/model.py
@@ -47,4 +47,13 @@ class RunRow(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
 
-    __table_args__ = (Index("ix_runs_thread_status", "thread_id", "status"),)
+    __table_args__ = (
+        Index("ix_runs_thread_status", "thread_id", "status"),
+        Index(
+            "ix_one_active_run_per_thread",
+            "thread_id",
+            unique=True,
+            postgresql_where=(status.in_(["pending", "running"])),
+            sqlite_where=(status.in_(["pending", "running"])),
+        ),
+    )

--- a/backend/packages/harness/deerflow/runtime/runs/manager.py
+++ b/backend/packages/harness/deerflow/runtime/runs/manager.py
@@ -231,14 +231,26 @@ class RunManager:
         Unlike follow-up status/model updates, failures are propagated so the
         caller can treat creation as failed. Rollback is the caller's
         responsibility after inserting the record into ``_runs``.
+
+        When a partial unique index on ``(thread_id, status)`` rejects a
+        duplicate active run (cross-worker race), translate the database
+        constraint violation into a ``ConflictError`` so the caller can
+        respond with an appropriate HTTP 409.
         """
+        from sqlalchemy.exc import IntegrityError
+
         if self._store is None:
             return
-        await self._call_store_with_retry(
-            "put",
-            record.run_id,
-            lambda: self._store.put(record.run_id, **self._store_put_payload(record)),
-        )
+        try:
+            await self._call_store_with_retry(
+                "put",
+                record.run_id,
+                lambda: self._store.put(record.run_id, **self._store_put_payload(record)),
+            )
+        except IntegrityError:
+            raise ConflictError(
+                f"Thread {record.thread_id} already has an active run"
+            ) from None
 
     async def _persist_to_store(self, record: RunRecord, *, error: str | None = None) -> bool:
         """Best-effort persist run record to backing store."""
@@ -619,14 +631,16 @@ class RunManager:
         already has a pending/running run.  For ``interrupt``/``rollback``,
         cancels inflight runs before creating.
 
-        This method holds the lock across both the check and the insert,
-        eliminating the TOCTOU race in separate ``has_inflight`` + ``create``.
+        For interrupt/rollback the old-run status is persisted to the store
+        *before* inserting the new run so the partial unique index does not
+        fire.  This means old runs are committed as interrupted even when the
+        subsequent new-run insert fails — a trade-off that is correct because
+        the caller explicitly requested cancellation of inflight work.
         """
         run_id = str(uuid.uuid4())
         now = _now_iso()
 
         _supported_strategies = ("reject", "interrupt", "rollback")
-        interrupted_records: list[RunRecord] = []
 
         async with self._lock:
             if multitask_strategy not in _supported_strategies:
@@ -644,6 +658,22 @@ class RunManager:
                     thread_id,
                     multitask_strategy,
                 )
+                for r in inflight:
+                    if r.finalizing:
+                        continue
+                    r.abort_action = multitask_strategy
+                    r.abort_event.set()
+                    task_active = r.task is not None and not r.task.done()
+                    r.finalizing = task_active
+                    if task_active:
+                        r.task.cancel()
+                    r.status = RunStatus.interrupted
+                    r.updated_at = now
+                # Persist interruptions before inserting the new run so
+                # the DB partial unique index won't see two active rows.
+                for r in inflight:
+                    if not r.finalizing:
+                        await self._persist_status(r, RunStatus.interrupted)
 
             record = RunRecord(
                 run_id=run_id,
@@ -665,8 +695,10 @@ class RunManager:
             try:
                 await self._persist_new_run_to_store(record)
                 persisted = True
+            except ConflictError:
+                raise
             except Exception:
-                logger.warning("Failed to persist run %s; rolled back in-memory record", run_id, exc_info=True)
+                logger.warning("Failed to persist run %s; rolling back in-memory record", run_id, exc_info=True)
                 raise
             finally:
                 # Also covers cancellation, which bypasses ``except Exception``.
@@ -674,22 +706,6 @@ class RunManager:
                     self._runs.pop(run_id, None)
                     self._unindex_run_locked(run_id, record.thread_id)
 
-            if multitask_strategy in ("interrupt", "rollback") and inflight:
-                for r in inflight:
-                    if r.finalizing:
-                        continue
-                    r.abort_action = multitask_strategy
-                    r.abort_event.set()
-                    task_active = r.task is not None and not r.task.done()
-                    r.finalizing = task_active
-                    if task_active:
-                        r.task.cancel()
-                    r.status = RunStatus.interrupted
-                    r.updated_at = now
-                    interrupted_records.append(r)
-
-        for interrupted_record in interrupted_records:
-            await self._persist_status(interrupted_record, RunStatus.interrupted)
         logger.info("Run created: run_id=%s thread_id=%s", run_id, thread_id)
         return record
 

--- a/backend/packages/harness/deerflow/runtime/runs/manager.py
+++ b/backend/packages/harness/deerflow/runtime/runs/manager.py
@@ -248,9 +248,7 @@ class RunManager:
                 lambda: self._store.put(record.run_id, **self._store_put_payload(record)),
             )
         except IntegrityError:
-            raise ConflictError(
-                f"Thread {record.thread_id} already has an active run"
-            ) from None
+            raise ConflictError(f"Thread {record.thread_id} already has an active run") from None
 
     async def _persist_to_store(self, record: RunRecord, *, error: str | None = None) -> bool:
         """Best-effort persist run record to backing store."""
@@ -660,6 +658,8 @@ class RunManager:
                 )
                 for r in inflight:
                     if r.finalizing:
+                        r.status = RunStatus.interrupted
+                        r.updated_at = now
                         continue
                     r.abort_action = multitask_strategy
                     r.abort_event.set()
@@ -669,11 +669,25 @@ class RunManager:
                         r.task.cancel()
                     r.status = RunStatus.interrupted
                     r.updated_at = now
-                # Persist interruptions before inserting the new run so
-                # the DB partial unique index won't see two active rows.
+                # Persist ALL inflight runs as interrupted before
+                # inserting the new run so the DB partial unique index
+                # won't see two active rows.  Runs that were already
+                # finalizing are included — writing ``interrupted`` is
+                # idempotent and the worker cleanup will write the final
+                # status later anyway.
+                failed_interruptions: list[str] = []
                 for r in inflight:
-                    if not r.finalizing:
-                        await self._persist_status(r, RunStatus.interrupted)
+                    ok = await self._persist_status(r, RunStatus.interrupted)
+                    if not ok:
+                        failed_interruptions.append(r.run_id)
+
+                if failed_interruptions:
+                    logger.error(
+                        "Failed to persist interrupted status for runs %s on thread %s; cannot safely create new run because old active runs may still be visible in the database",
+                        failed_interruptions,
+                        thread_id,
+                    )
+                    raise RuntimeError(f"Failed to interrupt active runs {failed_interruptions} for thread {thread_id}")
 
             record = RunRecord(
                 run_id=run_id,

--- a/backend/tests/test_cross_worker_race.py
+++ b/backend/tests/test_cross_worker_race.py
@@ -1,0 +1,184 @@
+"""Verify ix_one_active_run_per_thread blocks concurrent run creation.
+
+These tests confirm that the partial unique index added to the ``runs``
+table prevents two active runs on the same thread — the root cause of the
+multi-worker create_or_reject race described in Issue #3948.
+"""
+
+import uuid
+
+import pytest
+
+from deerflow.persistence.run import RunRepository
+from deerflow.runtime import RunManager, RunStatus
+from deerflow.runtime.runs.manager import ConflictError
+
+
+async def _make_repo_and_mgr(tmp_path):
+    from deerflow.persistence.engine import get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'test.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    repo = RunRepository(get_session_factory())
+    mgr = RunManager(store=repo)
+    return mgr, repo
+
+
+async def _cleanup():
+    from deerflow.persistence.engine import close_engine
+
+    await close_engine()
+
+
+class TestCrossWorkerAtomicCreate:
+    """Simulate the multi-worker race at the DB constraint layer."""
+
+    @pytest.mark.anyio
+    async def test_second_active_run_on_same_thread_triggers_integrity_error(self, tmp_path):
+        """Direct repo.put() — IntegrityError when two pending runs share thread_id."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        # First run: OK
+        rec = await mgr.create_or_reject(thread_id)
+        assert rec.thread_id == thread_id
+        assert rec.status == RunStatus.pending
+
+        # Second run must be rejected
+        with pytest.raises(ConflictError, match="already has an active run"):
+            await mgr.create_or_reject(thread_id)
+
+        # Verify only one run exists
+        rows = await repo.list_by_thread(thread_id)
+        assert len(rows) == 1
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_second_run_allowed_after_first_completes(self, tmp_path):
+        """Transitioning the first run to success unblocks a new run."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        rec1 = await mgr.create_or_reject(thread_id)
+        assert rec1.status == RunStatus.pending
+
+        # Complete the first run
+        await mgr.set_status(rec1.run_id, RunStatus.success)
+
+        # Now a second run on same thread is allowed
+        rec2 = await mgr.create_or_reject(thread_id)
+        assert rec2.thread_id == thread_id
+        assert rec2.status == RunStatus.pending
+
+        rows = await repo.list_by_thread(thread_id)
+        assert len(rows) == 2
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_different_threads_still_independent(self, tmp_path):
+        """Two different threads can each have an active run."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+
+        tid_a = f"thread-a-{uuid.uuid4().hex[:8]}"
+        tid_b = f"thread-b-{uuid.uuid4().hex[:8]}"
+
+        ra = await mgr.create_or_reject(tid_a)
+        rb = await mgr.create_or_reject(tid_b)
+
+        assert ra.status == RunStatus.pending
+        assert rb.status == RunStatus.pending
+
+        a_rows = await repo.list_by_thread(tid_a)
+        b_rows = await repo.list_by_thread(tid_b)
+        assert len(a_rows) == 1
+        assert len(b_rows) == 1
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_integrity_error_converts_to_conflict_error(self, tmp_path):
+        """When the DB rejects a duplicate active run, it surfaces as ConflictError."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        await mgr.create_or_reject(thread_id)
+
+        with pytest.raises(ConflictError):
+            await mgr.create_or_reject(thread_id)
+
+        # The in-memory record created by the failed attempt should be rolled back
+        active_runs = [r for r in mgr._runs.values()
+                       if r.thread_id == thread_id
+                       and r.status in (RunStatus.pending, RunStatus.running)]
+        assert len(active_runs) == 1
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_interrupt_strategy_cancels_old_and_creates_new(self, tmp_path):
+        """interrupt strategy marks the old run as interrupted and creates a new one."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        rec1 = await mgr.create_or_reject(thread_id)
+        assert rec1.status == RunStatus.pending
+
+        # Create with interrupt — should cancel the old and create new
+        rec2 = await mgr.create_or_reject(thread_id, multitask_strategy="interrupt")
+        assert rec2.status == RunStatus.pending
+        assert rec2.run_id != rec1.run_id
+
+        # Old run must be interrupted
+        rows = await repo.list_by_thread(thread_id)
+        assert len(rows) == 2
+        statuses = {r["run_id"]: r["status"] for r in rows}
+        assert statuses[rec1.run_id] == RunStatus.interrupted
+        assert statuses[rec2.run_id] == RunStatus.pending
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_rollback_strategy_cancels_old_and_creates_new(self, tmp_path):
+        """rollback strategy marks the old run as interrupted and creates a new one."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        rec1 = await mgr.create_or_reject(thread_id)
+        assert rec1.status == RunStatus.pending
+
+        # Create with rollback — should cancel the old and create new
+        rec2 = await mgr.create_or_reject(thread_id, multitask_strategy="rollback")
+        assert rec2.status == RunStatus.pending
+        assert rec2.run_id != rec1.run_id
+
+        # Old run must be interrupted
+        rows = await repo.list_by_thread(thread_id)
+        assert len(rows) == 2
+        statuses = {r["run_id"]: r["status"] for r in rows}
+        assert statuses[rec1.run_id] == RunStatus.interrupted
+        assert statuses[rec2.run_id] == RunStatus.pending
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_interrupt_after_completed_is_safe(self, tmp_path):
+        """interrupt on a thread whose run already completed is a normal create."""
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        rec1 = await mgr.create_or_reject(thread_id)
+        await mgr.set_status(rec1.run_id, RunStatus.success)
+
+        # No inflight run — interrupt behaves like a normal create
+        rec2 = await mgr.create_or_reject(thread_id, multitask_strategy="interrupt")
+        assert rec2.status == RunStatus.pending
+        assert rec1.status == RunStatus.success  # unchanged
+
+        rows = await repo.list_by_thread(thread_id)
+        assert len(rows) == 2
+
+        await _cleanup()

--- a/backend/tests/test_cross_worker_race.py
+++ b/backend/tests/test_cross_worker_race.py
@@ -111,9 +111,7 @@ class TestCrossWorkerAtomicCreate:
             await mgr.create_or_reject(thread_id)
 
         # The in-memory record created by the failed attempt should be rolled back
-        active_runs = [r for r in mgr._runs.values()
-                       if r.thread_id == thread_id
-                       and r.status in (RunStatus.pending, RunStatus.running)]
+        active_runs = [r for r in mgr._runs.values() if r.thread_id == thread_id and r.status in (RunStatus.pending, RunStatus.running)]
         assert len(active_runs) == 1
 
         await _cleanup()
@@ -180,5 +178,52 @@ class TestCrossWorkerAtomicCreate:
 
         rows = await repo.list_by_thread(thread_id)
         assert len(rows) == 2
+
+        await _cleanup()
+
+    @pytest.mark.anyio
+    async def test_interrupt_with_active_task_persists_interrupted_before_new_insert(self, tmp_path):
+        """Interrupt with a live asyncio task must write interrupted to the DB first.
+
+        The old run has an active task (the common real-world case: an
+        executing LLM call).  Cancelling the task sets ``finalizing=True``,
+        but the DB row must still be committed as ``interrupted`` *before*
+        the new run is inserted — otherwise the partial unique index fires
+        for the still-``running`` old row.
+        """
+        import asyncio as _asyncio
+
+        mgr, repo = await _make_repo_and_mgr(tmp_path)
+        thread_id = f"thread-{uuid.uuid4().hex[:8]}"
+
+        rec1 = await mgr.create_or_reject(thread_id)
+        await mgr.set_status(rec1.run_id, RunStatus.running)
+
+        # Attach a long-running task to simulate a live execution.
+        async def _spin() -> None:
+            try:
+                await _asyncio.sleep(999)
+            except _asyncio.CancelledError:
+                raise
+
+        live_task = _asyncio.create_task(_spin())
+        mgr._runs[rec1.run_id].task = live_task
+
+        rec2 = await mgr.create_or_reject(thread_id, multitask_strategy="interrupt")
+
+        # Task was cancelled and finalizing flag set.
+        assert live_task.cancelling()
+        assert rec1.finalizing is True
+        assert rec1.status == RunStatus.interrupted
+
+        # DB must reflect the interruption — the unique index is clear.
+        rows = await repo.list_by_thread(thread_id)
+        statuses = {r["run_id"]: r["status"] for r in rows}
+        assert statuses[rec1.run_id] == RunStatus.interrupted
+        assert statuses[rec2.run_id] == RunStatus.pending
+
+        # Let the cancelled task finish to avoid dangling-task warnings.
+        with pytest.raises(_asyncio.CancelledError):
+            await live_task
 
         await _cleanup()

--- a/backend/tests/test_owner_isolation.py
+++ b/backend/tests/test_owner_isolation.py
@@ -165,7 +165,9 @@ async def test_runs_cross_user_isolation(tmp_path):
 
         with _as_user(USER_A):
             await repo.put("run-a1", thread_id="t-alpha")
-            await repo.put("run-a2", thread_id="t-alpha")
+            # a2 is past/purposeful-completed; only one active run per thread is
+            # enforced by the ix_one_active_run_per_thread partial unique index.
+            await repo.put("run-a2", thread_id="t-alpha", status="success")
 
         with _as_user(USER_B):
             await repo.put("run-b1", thread_id="t-beta")

--- a/backend/tests/test_persistence_bootstrap.py
+++ b/backend/tests/test_persistence_bootstrap.py
@@ -615,6 +615,135 @@ class TestDecideState:
 # ---------------------------------------------------------------------------
 
 
+@asyncio_test
+async def test_migration_0004_cleans_up_duplicate_active_runs(tmp_path: Path) -> None:
+    """Seed duplicate active rows then upgrade: the migration must reconcile.
+
+    Pre-0004 a multi-worker race can leave two pending/running rows for the
+    same thread.  ``_cleanup_duplicate_active_runs`` in migration 0004
+    keeps the most-recently-created active run per thread and marks the
+    rest as ``interrupted``.  This test proves that path works end-to-end.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from deerflow.persistence.run.model import RunRow
+
+    engine = create_async_engine(_url(tmp_path))
+    try:
+        # 1. Build the pre-0004 schema: upgrade only through 0003.
+        cfg = _get_alembic_config(engine)
+        pre_index_rev = "0003_scheduled_tasks"
+        await asyncio.to_thread(_upgrade, cfg, pre_index_rev)
+
+        # 2. Drop the partial unique index so we can seed duplicates.
+        #    ``create_all`` puts the index on the model, but migration 0003
+        #    does NOT create it — it was introduced in 0004.
+        #    Verify we're truly in a pre-index state.
+        async with engine.connect() as conn:
+            idx_rows = await conn.run_sync(lambda c: sa.inspect(c).get_indexes("runs"))
+        idx_names = {i["name"] for i in idx_rows if isinstance(i, dict)}
+        assert "ix_one_active_run_per_thread" not in idx_names, f"index unexpectedly present at rev {pre_index_rev}: {idx_names}"
+
+        # 3. Seed two active runs on the same thread via ORM insert so all
+        #    NOT NULL columns with Python-side defaults are filled.
+        thread_id = "thread-dup"
+        now = datetime.now(UTC)
+        older = now - timedelta(seconds=10)
+        async with engine.begin() as conn:
+            await conn.execute(
+                RunRow.__table__.insert(),
+                [
+                    {
+                        "run_id": "run-older",
+                        "thread_id": thread_id,
+                        "status": "pending",
+                        "multitask_strategy": "reject",
+                        "metadata_json": {},
+                        "kwargs_json": {},
+                        "message_count": 0,
+                        "created_at": older,
+                        "updated_at": older,
+                    },
+                    {
+                        "run_id": "run-newer",
+                        "thread_id": thread_id,
+                        "status": "pending",
+                        "multitask_strategy": "reject",
+                        "metadata_json": {},
+                        "kwargs_json": {},
+                        "message_count": 0,
+                        "created_at": now,
+                        "updated_at": now,
+                    },
+                ],
+            )
+
+        # Sanity: both runs visible before migration.
+        async with engine.connect() as conn:
+            rows = (await conn.execute(sa.text("SELECT run_id, status FROM runs WHERE thread_id = :tid"), {"tid": thread_id})).mappings().all()
+        assert len(rows) == 2
+        statuses = {r["run_id"]: r["status"] for r in rows}
+        assert statuses == {"run-older": "pending", "run-newer": "pending"}
+
+        # 4. Upgrade through 0004 — the migration must clean up the duplicate.
+        await asyncio.to_thread(_upgrade, cfg, HEAD)
+
+        # 5. Only the newer run stays pending; the older was reconciled.
+        async with engine.connect() as conn:
+            rows = (await conn.execute(sa.text("SELECT run_id, status, error FROM runs WHERE thread_id = :tid"), {"tid": thread_id})).mappings().all()
+        statuses = {r["run_id"]: r["status"] for r in rows}
+        assert statuses["run-newer"] == "pending", f"expected newer run pending, got {statuses}"
+        assert statuses["run-older"] == "interrupted", f"expected older run interrupted, got {statuses}"
+        assert any(r["error"] and "Cleaned up during migration 0004" in (r["error"] or "") for r in rows if r["run_id"] == "run-older"), "cleaned-up run missing error message"
+
+        # 6. The partial unique index exists and is functional.
+        async with engine.connect() as conn:
+            idx_rows = await conn.run_sync(lambda c: sa.inspect(c).get_indexes("runs"))
+        idx_names = {i["name"] for i in idx_rows if isinstance(i, dict)}
+        assert "ix_one_active_run_per_thread" in idx_names, f"index not found; indexes={idx_names}"
+
+        # Inserting another pending run on the same thread must fail.
+        async with engine.begin() as conn:
+            with pytest.raises(sa.exc.IntegrityError):
+                await conn.execute(
+                    RunRow.__table__.insert().values(
+                        run_id="run-third",
+                        thread_id=thread_id,
+                        status="pending",
+                        multitask_strategy="reject",
+                        metadata_json={},
+                        kwargs_json={},
+                        message_count=0,
+                        created_at=now,
+                        updated_at=now,
+                    ),
+                )
+
+        # But a run on a different thread is fine.
+        async with engine.begin() as conn:
+            await conn.execute(
+                RunRow.__table__.insert().values(
+                    run_id="run-other-thread",
+                    thread_id=f"{thread_id}-other",
+                    status="pending",
+                    multitask_strategy="reject",
+                    metadata_json={},
+                    kwargs_json={},
+                    message_count=0,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Sanity: head revision is the one this module expects
+# ---------------------------------------------------------------------------
+
+
 def test_head_revision_is_token_usage_revision() -> None:
     assert _get_head_revision() == HEAD
 

--- a/backend/tests/test_persistence_bootstrap.py
+++ b/backend/tests/test_persistence_bootstrap.py
@@ -47,7 +47,7 @@ from deerflow.persistence.migrations._helpers import _normalize_default
 asyncio_test = pytest.mark.asyncio
 
 
-HEAD = "0003_scheduled_tasks"
+HEAD = "0004_one_active_run_per_thread"
 BASELINE = "0001_baseline"
 
 

--- a/backend/tests/test_persistence_bootstrap_concurrency.py
+++ b/backend/tests/test_persistence_bootstrap_concurrency.py
@@ -28,7 +28,7 @@ from deerflow.persistence.bootstrap import bootstrap_schema
 pytestmark = pytest.mark.asyncio
 
 
-HEAD = "0003_scheduled_tasks"
+HEAD = "0004_one_active_run_per_thread"
 
 
 def _url(tmp_path: Path) -> str:

--- a/backend/tests/test_persistence_bootstrap_regression.py
+++ b/backend/tests/test_persistence_bootstrap_regression.py
@@ -76,7 +76,7 @@ async def test_legacy_database_recovers_token_usage_column(tmp_path: Path) -> No
             cols = {row[1] for row in raw.execute("PRAGMA table_info(runs)").fetchall()}
             assert "token_usage_by_model" in cols
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0003_scheduled_tasks"
+            assert version_row[0] == "0004_one_active_run_per_thread"
 
         # And the read path that originally 500'd must now succeed.
         sf = get_session_factory()
@@ -116,6 +116,6 @@ async def test_legacy_database_with_manual_alter_still_bootstraps(tmp_path: Path
             # No duplicate column -- list, not set, to catch dupes.
             assert cols.count("token_usage_by_model") == 1
             version_row = raw.execute("SELECT version_num FROM alembic_version").fetchone()
-            assert version_row[0] == "0003_scheduled_tasks"
+            assert version_row[0] == "0004_one_active_run_per_thread"
     finally:
         await close_engine()

--- a/backend/tests/test_run_manager.py
+++ b/backend/tests/test_run_manager.py
@@ -691,6 +691,47 @@ async def test_create_or_reject_does_not_interrupt_old_run_when_new_run_store_wr
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize("failure_mode", ["update_raises", "row_missing_and_recovery_fails"])
+async def test_create_or_reject_interrupt_raises_when_interrupted_persist_fails(failure_mode):
+    """A failed old-run status persist must surface as an explicit error, not a 409.
+
+    ``_persist_status`` is best-effort and returns ``False`` on failure.  If
+    the interrupted status cannot be committed to the store, the old run's
+    DB row would still be active and the new-run insert would trip the
+    partial unique index with a misleading ``ConflictError``.  Instead,
+    ``create_or_reject`` checks the persist result and raises a
+    ``RuntimeError`` before attempting the insert.
+
+    Both ``_persist_status`` failure modes are covered: ``update_status``
+    raising (e.g. transient SQLite lock), and ``update_status`` reporting a
+    missing row with the snapshot-recovery ``put`` also failing.
+    """
+    from unittest.mock import AsyncMock
+
+    store = MemoryRunStore()
+    manager = RunManager(store=store)
+    old = await manager.create("thread-1")
+    await manager.set_status(old.run_id, RunStatus.running)
+
+    if failure_mode == "update_raises":
+        store.update_status = AsyncMock(side_effect=RuntimeError("db down"))
+    else:
+        store.update_status = AsyncMock(return_value=False)
+        store.put = AsyncMock(side_effect=RuntimeError("db down"))
+
+    with pytest.raises(RuntimeError, match="Failed to interrupt active runs"):
+        await manager.create_or_reject("thread-1", multitask_strategy="interrupt")
+
+    # No phantom new run was inserted in memory.
+    assert list(manager._runs) == [old.run_id]
+    # The divergence is explicit: memory shows interrupted, store row untouched.
+    assert old.status == RunStatus.interrupted
+    stored_old = await store.get(old.run_id)
+    assert stored_old is not None
+    assert stored_old["status"] == "running"
+
+
+@pytest.mark.anyio
 async def test_create_or_reject_rollback_persists_interrupted_status_to_store():
     """rollback strategy should persist interrupted status for old runs."""
     store = MemoryRunStore()

--- a/backend/tests/test_run_manager.py
+++ b/backend/tests/test_run_manager.py
@@ -636,7 +636,13 @@ async def test_create_or_reject_interrupt_persists_interrupted_status_to_store()
 
 @pytest.mark.anyio
 async def test_create_or_reject_does_not_interrupt_old_run_when_new_run_store_write_fails():
-    """A failed new-run persist must not cancel the existing inflight run."""
+    """Interrupt/rollback commits old-run status before inserting the new run.
+
+    When the new-run insert subsequently fails, the old run is already
+    persisted as interrupted — this is the correct behaviour because the
+    caller explicitly chose to replace inflight work.  The new run's
+    in-memory record must be rolled back.
+    """
     from unittest.mock import AsyncMock
 
     store = MemoryRunStore()
@@ -648,17 +654,22 @@ async def test_create_or_reject_does_not_interrupt_old_run_when_new_run_store_wr
     with pytest.raises(RuntimeError, match="db down"):
         await manager.create_or_reject("thread-1", multitask_strategy="interrupt")
 
+    # Old run is committed as interrupted (correct: caller asked for interrupt).
     stored_old = await store.get(old.run_id)
     assert list(manager._runs) == [old.run_id]
-    assert old.status == RunStatus.running
-    assert old.abort_event.is_set() is False
+    assert old.status == RunStatus.interrupted
     assert stored_old is not None
-    assert stored_old["status"] == "running"
+    assert stored_old["status"] == "interrupted"
 
 
 @pytest.mark.anyio
 async def test_create_or_reject_does_not_interrupt_old_run_when_new_run_store_write_is_cancelled():
-    """Cancellation during new-run persist must not cancel the existing run."""
+    """Cancellation during new-run persist still commits old-run interruption.
+
+    Like the failure case above, the old run's status is committed to the
+    store before the new-run insert.  Cancellation only prevents the
+    new-run insert, not the already-committed interruption.
+    """
     store = MemoryRunStore()
     manager = RunManager(store=store)
     old = await manager.create("thread-1")
@@ -674,10 +685,9 @@ async def test_create_or_reject_does_not_interrupt_old_run_when_new_run_store_wr
 
     stored_old = await store.get(old.run_id)
     assert list(manager._runs) == [old.run_id]
-    assert old.status == RunStatus.running
-    assert old.abort_event.is_set() is False
+    assert old.status == RunStatus.interrupted
     assert stored_old is not None
-    assert stored_old["status"] == "running"
+    assert stored_old["status"] == "interrupted"
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_run_repository.py
+++ b/backend/tests/test_run_repository.py
@@ -125,8 +125,8 @@ class TestRunRepository:
     @pytest.mark.anyio
     async def test_list_by_thread(self, tmp_path):
         repo = await _make_repo(tmp_path)
-        await repo.put("r1", thread_id="t1")
-        await repo.put("r2", thread_id="t1")
+        await repo.put("r1", thread_id="t1", status="success")
+        await repo.put("r2", thread_id="t1", status="error")
         await repo.put("r3", thread_id="t2")
         rows = await repo.list_by_thread("t1")
         assert len(rows) == 2
@@ -136,8 +136,8 @@ class TestRunRepository:
     @pytest.mark.anyio
     async def test_list_by_thread_owner_filter(self, tmp_path):
         repo = await _make_repo(tmp_path)
-        await repo.put("r1", thread_id="t1", user_id="alice")
-        await repo.put("r2", thread_id="t1", user_id="bob")
+        await repo.put("r1", thread_id="t1", user_id="alice", status="success")
+        await repo.put("r2", thread_id="t1", user_id="bob", status="error")
         rows = await repo.list_by_thread("t1", user_id="alice")
         assert len(rows) == 1
         assert rows[0]["user_id"] == "alice"
@@ -161,8 +161,8 @@ class TestRunRepository:
     async def test_list_pending(self, tmp_path):
         repo = await _make_repo(tmp_path)
         await repo.put("r1", thread_id="t1", status="pending")
-        await repo.put("r2", thread_id="t1", status="running")
-        await repo.put("r3", thread_id="t2", status="pending")
+        await repo.put("r2", thread_id="t2", status="running")
+        await repo.put("r3", thread_id="t3", status="pending")
         pending = await repo.list_pending()
         assert len(pending) == 2
         assert all(r["status"] == "pending" for r in pending)
@@ -172,9 +172,9 @@ class TestRunRepository:
     async def test_list_inflight_returns_pending_and_running_before_cutoff(self, tmp_path):
         repo = await _make_repo(tmp_path)
         await repo.put("pending-old", thread_id="t1", status="pending", created_at="2026-01-01T00:00:00+00:00")
-        await repo.put("running-old", thread_id="t1", status="running", created_at="2026-01-01T00:00:01+00:00")
-        await repo.put("success-old", thread_id="t1", status="success", created_at="2026-01-01T00:00:02+00:00")
-        await repo.put("pending-new", thread_id="t1", status="pending", created_at="2026-01-01T00:00:03+00:00")
+        await repo.put("running-old", thread_id="t2", status="running", created_at="2026-01-01T00:00:01+00:00")
+        await repo.put("success-old", thread_id="t3", status="success", created_at="2026-01-01T00:00:02+00:00")
+        await repo.put("pending-new", thread_id="t4", status="pending", created_at="2026-01-01T00:00:03+00:00")
 
         inflight = await repo.list_inflight(before="2026-01-01T00:00:02+00:00")
 
@@ -394,8 +394,8 @@ class TestRunRepository:
     async def test_list_by_thread_ordered_desc(self, tmp_path):
         """list_by_thread returns newest first."""
         repo = await _make_repo(tmp_path)
-        await repo.put("r1", thread_id="t1", created_at="2024-01-01T00:00:00+00:00")
-        await repo.put("r2", thread_id="t1", created_at="2024-01-02T00:00:00+00:00")
+        await repo.put("r1", thread_id="t1", status="success", created_at="2024-01-01T00:00:00+00:00")
+        await repo.put("r2", thread_id="t1", status="error", created_at="2024-01-02T00:00:00+00:00")
         rows = await repo.list_by_thread("t1")
         assert rows[0]["run_id"] == "r2"
         assert rows[1]["run_id"] == "r1"
@@ -405,7 +405,7 @@ class TestRunRepository:
     async def test_list_by_thread_limit(self, tmp_path):
         repo = await _make_repo(tmp_path)
         for i in range(5):
-            await repo.put(f"r{i}", thread_id="t1")
+            await repo.put(f"r{i}", thread_id="t1", status="success")
         rows = await repo.list_by_thread("t1", limit=2)
         assert len(rows) == 2
         await _cleanup()
@@ -413,8 +413,8 @@ class TestRunRepository:
     @pytest.mark.anyio
     async def test_owner_none_returns_all(self, tmp_path):
         repo = await _make_repo(tmp_path)
-        await repo.put("r1", thread_id="t1", user_id="alice")
-        await repo.put("r2", thread_id="t1", user_id="bob")
+        await repo.put("r1", thread_id="t1", user_id="alice", status="success")
+        await repo.put("r2", thread_id="t1", user_id="bob", status="error")
         rows = await repo.list_by_thread("t1", user_id=None)
         assert len(rows) == 2
         await _cleanup()
@@ -428,21 +428,21 @@ class TestRunRepository:
         await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
         repo = RunRepository(get_session_factory())
 
-        await repo.put("run-1", thread_id="thread-1", model_name="gpt-4o")
+        await repo.put("run-1", thread_id="thread-1", model_name="gpt-4o", status="success")
         row = await repo.get("run-1")
         assert row is not None
         assert row["model_name"] == "gpt-4o"
 
         long_name = "a" * 200
-        await repo.put("run-2", thread_id="thread-1", model_name=long_name)
+        await repo.put("run-2", thread_id="thread-2", model_name=long_name, status="error")
         row2 = await repo.get("run-2")
         assert row2["model_name"] == "a" * 128
 
-        await repo.put("run-3", thread_id="thread-1", model_name=123)
+        await repo.put("run-3", thread_id="thread-3", model_name=123, status="success")
         row3 = await repo.get("run-3")
         assert row3["model_name"] == "123"
 
-        await repo.put("run-4", thread_id="thread-1", model_name=None)
+        await repo.put("run-4", thread_id="thread-4", model_name=None, status="success")
         row4 = await repo.get("run-4")
         assert row4["model_name"] is None
 


### PR DESCRIPTION
# 问题

在多 Worker 部署环境下（`GATEWAY_WORKERS > 1`），`create_or_reject` 使用 `asyncio.Lock` 仅在单进程内生效。当两个请求被分发到不同 Worker 时，各自进程内的内存锁无法互斥，导致**同一 Thread 上可以同时存在多个活跃 Run**，违反了 `multitask_strategy="reject"` 的预期行为。

# 方案

在 `RunModel` 表上添加**部分唯一索引**（partial unique index），在数据库层面强制约束：每个 Thread 最多存在一个状态为 `pending` 或 `running` 的 Run。`asyncio.Lock` 保留为进程内快速路径，DB 唯一索引作为跨 Worker 的最终防线。

## 改动点

1. **`model.py`** — 添加 `ix_one_active_run_per_thread` 部分唯一索引
   - 约束条件：`thread_id` unique，`WHERE status IN ('pending', 'running')`
   - PostgreSQL（`postgresql_where`）与 SQLite（`sqlite_where`）双方言支持
2. **`0004_one_active_run_per_thread` 迁移（新增）** — 为存量数据库创建索引
   - 建索引前先执行 `_cleanup_duplicate_active_runs()`：用 `ROW_NUMBER()` 窗口函数对每个 thread 保留最新的 active run，其余标记为 `interrupted` 并写入清理说明，避免脏数据（正是本竞态产生的）阻塞 `alembic upgrade head` / Gateway 启动
   - 幂等：索引已存在则跳过
3. **`manager.py`**
   - `_persist_new_run_to_store` 捕获 `IntegrityError` → 转为 `ConflictError`（HTTP 409）
   - **interrupt/rollback 调序**：先将所有 inflight run（含 `finalizing` 的活跃 task run，写 `interrupted` 是幂等的）持久化为 `interrupted`，再插入新 run，避免撞索引产生误导性 409
   - `_persist_status` 失败不再静默：收集失败的 run_id 并抛出 `RuntimeError`，显式暴露内存/DB 不一致，而非滑向误导性 409
   - 保留 `persisted` 标志 + `finally` 回滚：任何持久化失败（含 cancellation）都不会在内存中留下 phantom run

## Review 意见处理（@willem-bd）

| Review 意见 | 处理 |
| --- | --- |
| [P1] interrupt/rollback 回归 409 | 调序：先持久化旧 run 中断状态再插入新 run；含活跃 task（`finalizing`）路径 |
| [P1] 缺少 Alembic 迁移 | 新增 `0004` 迁移 |
| [P1] 迁移在存量脏数据下失败 | `_cleanup_duplicate_active_runs()` 先 reconcile 再建索引 |
| [P1] `except ConflictError` 收窄导致 phantom run 泄漏 | 恢复 `finally` 兜底回滚（覆盖 cancellation），两个既有测试恢复通过 |
| [P2] `_persist_status` 返回值被静默忽略 | 检查返回值，失败抛 `RuntimeError` |

## 测试

- **`test_cross_worker_race.py`（新增 8 个）**：reject 拒绝第二个活跃 run、完成后放行、跨 thread 独立、IntegrityError→ConflictError 转换与回滚、interrupt/rollback 策略取消旧 run 并创建新 run、**活跃 task 场景下 interrupt 先持久化再插入**（回归测试）
- **`test_persistence_bootstrap.py`（新增 1 个）**：端到端迁移测试——升级到 0003 → seed 同 thread 两条 pending 行 → 升级到 0004 → 断言旧行被 reconcile、索引建成且生效、跨 thread 不受影响
- **`test_run_manager.py`（新增 1 个，参数化 2 case）**：`_persist_status` 两种失败模式（`update_status` 抛异常 / 行丢失且 snapshot 恢复失败）均抛 `RuntimeError` 而非 409，无 phantom run，内存/DB 分歧显式暴露
- 适配存量用例：`test_owner_isolation.py`、`test_run_repository.py` 等约 40 个用例适配新约束
- 全量：**6636 passed, 0 failures**，lint（ruff check + format）全绿

## 真实环境验证

| 方式 | 结果 |
| --- | --- |
| 4 Worker + SQLite，12 并发请求 | 修复前：4 × 200 → 修复后：1 × 200 + 11 × 409 |

## 滚动部署说明

迁移（建索引 + 数据清理）由第一个新版本 Worker 启动时执行。在滚动发布窗口期内，仍在运行旧代码的 Worker 不会将 `IntegrityError` 转换为 409：

- 旧 Worker 上的并发 create 撞索引会返回 500（而非 409）
- 旧 Worker 的 interrupt 路径（旧顺序：先插新 run）撞索引也会返回 500
- 数据清理可能将旧 Worker 内存中仍在执行的 run 在 DB 中标记为 `interrupted`，run 结束时会被覆写为终态（无害，日志可见状态变化）

属一次性升级窗口风险。对可用性敏感的部署，建议在低峰期发布，或采用先停流量再滚动的方式。

Part of #3948 (Work Item 2).
