### PR TITLE
ci(containers): bake postgres extra into published backend image

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -51,6 +51,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Bake the `postgres` extra into the published image so multi-replica
+          # deployments (K8s/Helm) can use shared Postgres persistence instead of
+          # file-based SQLite. sqlite/redis-only single-replica setups still work;
+          # this only adds the Postgres driver. See backend/Dockerfile `UV_EXTRAS`.
+          build-args: |
+            UV_EXTRAS=postgres
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be #v2.4.0


### PR DESCRIPTION
## Why

The backend image published on `v*` tag push (`.github/workflows/container.yaml`) is built with no `UV_EXTRAS`, so it ships with only the `redis` extra (`backend/Dockerfile:66`) and no Postgres driver.

Multi-replica deployments - e.g. the Helm chart from #3987 on Kubernetes - need shared Postgres persistence instead of file-based SQLite (SQLite cannot be shared across gateway pods). Today they cannot use the published `*-backend` image as-is; operators have to rebuild it with `UV_EXTRAS=postgres` themselves.

## What changed

The `backend-container` job now passes `build-args: UV_EXTRAS=postgres`, so the published image installs `deerflow-harness[postgres]` (the `postgres` extra already declared at `backend/pyproject.toml:28`).

Additive only:
- Default single-replica sqlite/redis setups are unchanged - the Postgres driver is present but inert unless `database.backend: postgres` is configured.
- Mirrors how `redis` is already always baked in for the Docker Compose stream bridge.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [x] **Docs / tests / CI only** - no runtime code change; the published image additionally contains the (already-declared) `postgres` extra.

## Validation

- YAML parse check on the workflow (ruby `YAML.load_file`) - valid; `build-args` resolves to `UV_EXTRAS=postgres`.
- No backend/frontend code changed, so `make lint` / `make test` are unaffected.
- The same `UV_EXTRAS` build-arg path is already exercised locally by `docker/docker-compose.yaml` (`UV_EXTRAS: ${UV_EXTRAS:-}`) and `docker/dev-entrypoint.sh`; the release build itself runs on the next `v*` tag.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI investigated the release workflow, proposed the `build-args` change, and applied it under my direction; I reviewed the diff and the Dockerfile `UV_EXTRAS` handling.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
