### PR TITLE
fix(memory): coerce stored confidence in the three remaining raw reads

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/updater.py
@@ -239,7 +239,7 @@ def search_memory_facts(
             continue
         matched.append(fact)
 
-    matched.sort(key=lambda f: f.get("confidence", 0), reverse=True)
+    matched.sort(key=_coerce_source_confidence, reverse=True)
     return matched[:limit]
 
 
@@ -592,7 +592,7 @@ def _build_staleness_section(
     for fact in stale_candidates:
         fid = fact.get("id", "?")
         cat = html.escape(str(fact.get("category", "context")).strip() or "context")
-        conf = fact.get("confidence", 0.0)
+        conf = _coerce_source_confidence(fact)
         created_raw = fact.get("createdAt", "")
         created_short = created_raw[:10] if isinstance(created_raw, str) and len(created_raw) >= 10 else created_raw
         content = html.escape(str(fact.get("content", "")))
@@ -1038,7 +1038,7 @@ class MemoryUpdater:
                 max_stale = config.staleness_max_removals_per_cycle
                 if len(stale_ids_to_remove) > max_stale:
                     stale_facts = [f for f in current_memory.get("facts", []) if f.get("id") in stale_ids_to_remove]
-                    stale_facts.sort(key=lambda f: f.get("confidence", 0))
+                    stale_facts.sort(key=_coerce_source_confidence)
                     stale_ids_to_remove = {f["id"] for f in stale_facts[:max_stale]}
 
                 current_memory["facts"] = [f for f in current_memory.get("facts", []) if f.get("id") not in stale_ids_to_remove]

--- a/backend/tests/test_memory_staleness_review.py
+++ b/backend/tests/test_memory_staleness_review.py
@@ -12,6 +12,8 @@ Covers:
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from deerflow.agents.memory.updater import (
     MemoryUpdater,
     _build_staleness_section,
@@ -22,6 +24,10 @@ from deerflow.agents.memory.updater import (
 from deerflow.config.memory_config import MemoryConfig
 
 # ── Helpers ────────────────────────────────────────────────────────────────
+
+
+_ABSENT = object()
+"""Sentinel: the fact carries no ``confidence`` key at all."""
 
 
 def _memory_config(**overrides: object) -> MemoryConfig:
@@ -244,6 +250,65 @@ class TestBuildStalenessSection:
         assert 'pref<"erences>' not in section
         assert "pref&lt;&quot;erences&gt;" in section
 
+    @pytest.mark.parametrize("stored_confidence", ["0.9", None, "high", ""])
+    def test_non_float_confidence_does_not_raise(self, stored_confidence):
+        """A stored ``confidence`` that is not a float must not abort the update.
+
+        ``memory.json`` is user-editable and written across versions, which is why
+        ``_coerce_source_confidence`` exists. Formatting it raw raises ValueError on
+        a str and TypeError on None; ``_do_update_memory_sync``'s ``except Exception``
+        turns that into a silent ``return False`` that aborts the whole memory-update
+        cycle -- permanently, since the offending fact is then never rewritten.
+        """
+        fact = _make_fact("fact_x", "Some fact", "knowledge", 0.9, days_ago=120)
+        fact["confidence"] = stored_confidence
+
+        section = _build_staleness_section([fact], 90)
+
+        assert "fact_x" in section
+        assert "Some fact" in section
+
+    @pytest.mark.parametrize(
+        ("stored_confidence", "rendered"),
+        [
+            ("0.9", "0.90"),
+            ("high", "0.50"),
+            (None, "0.50"),
+            (True, "0.50"),
+            (1.5, "1.00"),
+            (-0.3, "0.00"),
+            (float("inf"), "0.50"),
+            (float("nan"), "0.50"),
+        ],
+    )
+    def test_confidence_is_normalised_like_every_other_stored_read(self, stored_confidence, rendered):
+        """Pins the mapping, not just the absence of a crash.
+
+        ``0.5`` is this module's default for an unknown confidence
+        (``create_memory_fact``, ``_normalize_memory_update_fact``,
+        ``_coerce_source_confidence``). Before this change the staleness prompt
+        rendered ``1.5`` as ``1.50``, ``inf`` as ``inf``, and a ``True`` as ``1.00``
+        -- disagreeing with the consolidation prompt, which reads the same field
+        through the same helper.
+        """
+        fact = _make_fact("fact_x", "Some fact", "knowledge", 0.9, days_ago=120)
+        fact["confidence"] = stored_confidence
+
+        section = _build_staleness_section([fact], 90)
+
+        assert f"| {rendered} |" in section
+
+    def test_missing_confidence_key_renders_unknown_not_zero(self):
+        """An absent key is *unknown* (0.50), not *worthless* (0.00).
+
+        The staleness cap removes the lowest-confidence facts first, so ranking an
+        unreadable confidence at 0.00 would make that fact the first one deleted.
+        """
+        fact = _make_fact("fact_x", "Some fact", "knowledge", 0.9, days_ago=120)
+        del fact["confidence"]
+
+        assert "| 0.50 |" in _build_staleness_section([fact], 90)
+
 
 # ── _apply_updates with staleness removals ─────────────────────────────────
 
@@ -352,6 +417,121 @@ class TestApplyUpdatesStaleness:
         assert "fact_high" in remaining_ids
         assert "fact_mid" in remaining_ids
         assert "fact_low1" in remaining_ids
+
+    def test_safety_cap_sort_survives_non_float_stored_confidence(self):
+        """The cap's ranking sort reads stored confidence and must coerce it.
+
+        ``sort(key=lambda f: f.get("confidence", 0))`` compares a str against a
+        float and raises ``TypeError``, which the caller swallows into an aborted
+        update. Fixing only the prompt formatter would move this crash rather than
+        remove it, so the sort is pinned here too. ``"0.95"`` must rank like 0.95.
+        """
+        updater = MemoryUpdater()
+        current_memory = _make_memory(
+            [
+                _make_fact("fact_str_high", confidence="0.95", days_ago=100),
+                _make_fact("fact_mid", confidence=0.80, days_ago=100),
+                _make_fact("fact_low", confidence=0.60, days_ago=100),
+            ]
+        )
+        update_data = {
+            "user": {},
+            "history": {},
+            "newFacts": [],
+            "factsToRemove": [],
+            "staleFactsToRemove": [
+                {"id": "fact_str_high", "reason": "outdated"},
+                {"id": "fact_mid", "reason": "outdated"},
+                {"id": "fact_low", "reason": "outdated"},
+            ],
+        }
+
+        with patch(
+            "deerflow.agents.memory.updater.get_memory_config",
+            return_value=_memory_config(max_facts=100, staleness_max_removals_per_cycle=1),
+        ):
+            result = updater._apply_updates(current_memory, update_data)
+
+        # Only the single lowest-confidence fact is removed; the string "0.95"
+        # ranks as the highest and survives.
+        remaining_ids = {f["id"] for f in result["facts"]}
+        assert remaining_ids == {"fact_str_high", "fact_mid"}
+
+    @pytest.mark.parametrize(
+        ("stored_confidence", "rival_confidence", "survivor"),
+        [
+            (_ABSENT, 0.1, "fact_x"),
+            (False, 0.1, "fact_x"),
+            (True, 0.9, "fact_rival"),
+            (float("inf"), 0.9, "fact_rival"),
+        ],
+    )
+    def test_safety_cap_ranks_unusable_confidence_as_unknown(self, stored_confidence, rival_confidence, survivor):
+        """The cap deletes the lowest-ranked fact, so a mis-ranked one deletes its neighbour.
+
+        Mirrors the max_facts trim's delta set with the sort reversed: here a
+        ``true``/``inf`` fact ranked *above* a genuine 0.9 and pushed it into
+        the removal slot. None of these raised under the old key, so the
+        string-coercion test above passes unchanged for all four.
+        """
+        fact_x = _make_fact("fact_x", days_ago=100)
+        if stored_confidence is _ABSENT:
+            del fact_x["confidence"]
+        else:
+            fact_x["confidence"] = stored_confidence
+        update_data = {
+            "user": {},
+            "history": {},
+            "newFacts": [],
+            "factsToRemove": [],
+            "staleFactsToRemove": [
+                {"id": "fact_x", "reason": "outdated"},
+                {"id": "fact_rival", "reason": "outdated"},
+            ],
+        }
+
+        with patch(
+            "deerflow.agents.memory.updater.get_memory_config",
+            return_value=_memory_config(max_facts=100, staleness_max_removals_per_cycle=1),
+        ):
+            result = MemoryUpdater()._apply_updates(
+                _make_memory([fact_x, _make_fact("fact_rival", confidence=rival_confidence, days_ago=100)]),
+                update_data,
+            )
+
+        assert [f["id"] for f in result["facts"]] == [survivor]
+
+    def test_safety_cap_with_nan_confidence_is_order_independent(self):
+        """Under the raw key the cap deleted either fact depending on their file order.
+
+        ``nan`` compares false against every score, so ``sort`` leaves the pair
+        untouched: with the corrupted fact stored *second*, the genuine 0.9 one
+        landed in the removal slot instead.
+        """
+        update_data = {
+            "user": {},
+            "history": {},
+            "newFacts": [],
+            "factsToRemove": [],
+            "staleFactsToRemove": [
+                {"id": "fact_nan", "reason": "outdated"},
+                {"id": "fact_rival", "reason": "outdated"},
+            ],
+        }
+
+        survivors = []
+        for nan_first in (True, False):
+            nan_fact = _make_fact("fact_nan", confidence=float("nan"), days_ago=100)
+            rival = _make_fact("fact_rival", confidence=0.9, days_ago=100)
+            facts = [nan_fact, rival] if nan_first else [rival, nan_fact]
+            with patch(
+                "deerflow.agents.memory.updater.get_memory_config",
+                return_value=_memory_config(max_facts=100, staleness_max_removals_per_cycle=1),
+            ):
+                result = MemoryUpdater()._apply_updates(_make_memory(facts), update_data)
+            survivors.append(result["facts"][0]["id"])
+
+        assert survivors == ["fact_rival", "fact_rival"]
 
     def test_empty_stale_removals_no_effect(self):
         updater = MemoryUpdater()

--- a/backend/tests/test_memory_updater.py
+++ b/backend/tests/test_memory_updater.py
@@ -2,6 +2,8 @@ import asyncio
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from deerflow.agents.memory.prompt import format_conversation_for_update
 from deerflow.agents.memory.updater import (
     MemoryUpdater,
@@ -11,6 +13,7 @@ from deerflow.agents.memory.updater import (
     create_memory_fact_with_created_fact,
     delete_memory_fact,
     import_memory_data,
+    search_memory_facts,
     update_memory_fact,
 )
 from deerflow.config.memory_config import MemoryConfig
@@ -33,6 +36,10 @@ def _make_memory(facts: list[dict[str, object]] | None = None) -> dict[str, obje
         },
         "facts": facts or [],
     }
+
+
+_ABSENT = object()
+"""Sentinel: the fact carries no ``confidence`` key at all."""
 
 
 def _memory_config(**overrides: object) -> MemoryConfig:
@@ -250,6 +257,88 @@ def test_apply_updates_preserves_threshold_and_max_facts_trimming() -> None:
     ]
     assert all(fact["content"] != "User likes noisy logs" for fact in result["facts"])
     assert result["facts"][1]["source"] == "thread-9"
+
+
+def _searchable_fact(fact_id: str, confidence: object = _ABSENT) -> dict[str, object]:
+    fact: dict[str, object] = {
+        "id": fact_id,
+        "content": f"deploy runbook {fact_id}",
+        "category": "context",
+        "createdAt": "2026-03-18T00:00:00Z",
+        "source": "t",
+    }
+    if confidence is not _ABSENT:
+        fact["confidence"] = confidence
+    return fact
+
+
+def test_search_memory_facts_sort_survives_non_float_stored_confidence() -> None:
+    """``memory_search`` ranks stored facts by confidence and must coerce it.
+
+    ``sort(key=lambda f: f.get("confidence", 0))`` compares a str against a float
+    and raises ``TypeError``, which surfaces to the model as a failed tool call.
+    The stored ``"0.95"`` must rank as 0.95 and lead the results.
+    """
+    facts = [
+        _searchable_fact("f_low", 0.10),
+        _searchable_fact("f_str", "0.95"),
+        _searchable_fact("f_mid", 0.50),
+    ]
+
+    with patch("deerflow.agents.memory.updater.get_memory_data", return_value=_make_memory(facts=facts)):
+        result = search_memory_facts("deploy runbook")
+
+    assert [fact["id"] for fact in result] == ["f_str", "f_mid", "f_low"]
+
+
+@pytest.mark.parametrize(
+    ("stored_confidence", "rival_confidence", "top"),
+    [
+        # Ranked at the bottom by the old ``f.get("confidence", 0)`` key ...
+        (_ABSENT, 0.1, "f_x"),
+        (False, 0.1, "f_x"),
+        # ... and at the very top, because ``bool`` subclasses ``int`` and
+        # ``inf`` compares above every real score. (``nan`` also falls to the
+        # default, but its old ranking was order-dependent rather than pinned
+        # to an end — see the order-independence test below.)
+        (True, 0.9, "f_rival"),
+        (float("inf"), 0.9, "f_rival"),
+    ],
+)
+def test_search_memory_facts_ranks_unusable_confidence_as_unknown(stored_confidence, rival_confidence, top) -> None:
+    """Every value that falls to the 0.5 default must rank as *unknown*, not best or worst.
+
+    The old key never raised on these — it silently mis-ranked them, so the
+    string-coercion test above cannot go red for any of them. ``true``/``inf``
+    outranked a genuine 0.9 and pushed the better fact out of a capped result
+    set; a missing key ranked below a genuine 0.1 and dropped itself. ``limit``
+    turns either mis-ranking into a wrong answer for the model.
+    """
+    facts = [_searchable_fact("f_x", stored_confidence), _searchable_fact("f_rival", rival_confidence)]
+
+    with patch("deerflow.agents.memory.updater.get_memory_data", return_value=_make_memory(facts=facts)):
+        result = search_memory_facts("deploy runbook", limit=1)
+
+    assert [fact["id"] for fact in result] == [top]
+
+
+def test_search_memory_facts_with_nan_confidence_is_order_independent() -> None:
+    """``nan`` compares false against everything, so a raw key leaves the sort undefined.
+
+    Which fact the model gets back then depends on where the corrupted one happens
+    to sit in ``memory.json`` — the same file answers the same query differently
+    across two runs. Coercing ``nan`` to the 0.5 default restores a total order.
+    """
+    tops = []
+    for nan_first in (True, False):
+        nan_fact = _searchable_fact("f_nan", float("nan"))
+        rival = _searchable_fact("f_rival", 0.9)
+        facts = [nan_fact, rival] if nan_first else [rival, nan_fact]
+        with patch("deerflow.agents.memory.updater.get_memory_data", return_value=_make_memory(facts=facts)):
+            result = search_memory_facts("deploy runbook", limit=1)
+        tops.append(result[0]["id"])
+
+    assert tops == ["f_rival", "f_rival"]
 
 
 def test_apply_updates_preserves_source_error() -> None:


### PR DESCRIPTION
> **Rebased onto `938391c1`.** #4023 (`feat(memory): add memory tool sets`) landed while this was open and reshaped one of the three sites — see [Rebase](#rebase-onto-4023) below. The site *count* is still three, but the membership changed. Everything below is re-measured against the new base, not carried over.

## Why

#3996 added `_coerce_source_confidence` to `agents/memory/updater.py`, documenting exactly why a stored `confidence` cannot be trusted:

> *"This helper guards against null, bool, non-numeric, and non-finite values from corrupted or manually edited memory files."*

`memory.json` is user-editable (served and reloaded through `/api/memory`) and has been written by more than one version of the extractor, so a non-float value is reachable — that is the premise the helper was written on. Consolidation routes every stored read through it. **Three reads of a stored fact's confidence in the same file are still raw:**

| Site | Code | Raises |
|---|---|---|
| `_build_staleness_section` | `f"{conf:.2f}"` on `fact.get("confidence", 0.0)` | `ValueError` (str) / `TypeError` (None) |
| `_apply_updates`, staleness cap | `sort(key=lambda f: f.get("confidence", 0))` | `TypeError: '<' not supported between 'str' and 'float'` |
| `search_memory_facts` (`memory_search` tool) | `sort(key=lambda f: f.get("confidence", 0), reverse=True)` | same |

`_do_update_memory_sync` wraps the whole cycle in `except Exception: return False`. So a raise at either of the first two:

1. aborts the **entire** memory-update cycle — no facts extracted, no context updated, no staleness pruning, no consolidation;
2. surfaces only as a generic `Memory update failed` log line;
3. in the `_build_staleness_section` case, happens **before** `_get_model()`, so the run never even reaches the LLM;
4. leaves the offending fact on disk, because the update that would have rewritten `memory.json` is the one that just failed.

Every subsequent cycle re-reads the same fact and aborts again. Memory updates stop permanently for that user, with `staleness_review_enabled` defaulting to `true`.

The third site is not on that path — `memory_search` is a model-facing tool, so a str confidence fails the tool call instead.

### The two sorts also mis-rank *without* raising

`str` and `None` raise. `true` / `false` / `inf` / `nan` / an absent key do **not** — `bool` subclasses `int`, and `inf`/`nan` compare against floats without error. Under the raw key each lands at an *end* of the order, so it decides which fact the cap deletes and which result `memory_search` returns first:

| stored `confidence` | old rank | new rank | effect on a neighbouring genuine fact |
|---|---|---|---|
| key absent, `false` | `0` — worst | `0.5` | deleted itself ahead of a genuine `0.1` |
| `true` | `1.0` — best | `0.5` | **deleted a genuine `0.9`** |
| `inf` | `+inf` — best | `0.5` | **deleted a genuine `1.0`** |
| `nan` | undefined (compares false against everything) | `0.5` | outcome depended on the fact's position in the file |

So the two sorts carry a second, quieter defect than the crash: **silent loss of a genuine high-confidence fact**, with no exception and no log line — and, on `memory_search`, the wrong facts handed to the model within `limit`. Both reproduced end-to-end below. This is what makes `0.5` load-bearing rather than cosmetic — it is the only rank that is neither best nor worst. The two sorts run in **opposite directions** (the cap deletes the lowest, the search returns the highest), so the default has to hold from both ends.

## What changed

All three reads now go through `_coerce_source_confidence`, which is defined in this file — no new import, three lines.

`_coerce_source_confidence` rather than `prompt.py`'s `_coerce_confidence`, because **0.5 is already this module's default for an unknown confidence** (`create_memory_fact(confidence=0.5)`, `_normalize_memory_update_fact`'s `fact.get("confidence", 0.5)`, and the helper's own docstring). The `0.0` / `0` sentinels appear only in the buggy reads. That default is not cosmetic: the staleness cap **removes the lowest-confidence facts first**, so ranking an unreadable confidence at `0.0` makes it the first fact deleted. `0.5` — unknown — is the honest rank. It also treats a JSON `true` as corrupt data (0.5) rather than as full confidence (`_coerce_confidence` would yield `1.00`, since `bool` subclasses `int`).

Reads of **LLM-produced** data are deliberately left alone (`_normalize_memory_update_fact`, `_normalize_memory_update_data`, the `newFacts` threshold check, the consolidated-confidence cap). Different trust boundary, and those values already pass through `_normalize_memory_update_fact`, which drops unparseable entries — verified, not assumed. Every read of the `confidence` field under `agents/memory/` was enumerated to confirm nothing else is left raw; `prompt.py` already routes all of its reads through `_coerce_confidence`.

Because this changes a mapping and not just a crash, the full behaviour delta on the staleness prompt is:

| stored `confidence` | before | after |
|---|---|---|
| `"0.9"` / `"high"` / `""` / `None` | raises | `0.90` / `0.50` / `0.50` / `0.50` |
| key absent | `0.00` | `0.50` |
| `True` / `False` | `1.00` / `0.00` | `0.50` / `0.50` |
| `1.5` / `-0.3` | `1.50` / `-0.30` | `1.00` / `0.00` |
| `inf` / `nan` | `inf` / `nan` | `0.50` / `0.50` |
| valid float, `int` | unchanged | unchanged |

## Rebase onto #4023

#4023 refactored `_apply_updates`, extracting the `max_facts` trim into `_trim_facts_to_max()` — and wrote that helper with `key=_coerce_source_confidence`. That was one of this PR's original three sites, so **that hunk is dropped: upstream already fixed it.** The same PR introduced `search_memory_facts` with a fresh raw read of the same field, which is **added here** in its place. Net: still three sites, different membership. The two staleness sites are untouched by #4023 and unchanged from the original submission.

The three tests that anchored the `max_facts` trim now pass on `main` without this patch — they guard nothing — so they are not kept as-is. The same delta matrix is repointed at `search_memory_facts`, where it goes red (verified per-test below).

The earlier #4028 / #3993 rebases mentioned in this thread are both merged and no longer relevant.

## Surface area

- [x] **Agents / LangGraph** — memory updater prompt section, apply-time ranking, and the `memory_search` tool (`backend/packages/harness/deerflow/agents/memory/updater.py`)
- [x] **Default behavior change** — a stored confidence outside `[0, 1]`, non-finite, boolean, or absent now normalises to the module's `0.5` / clamped value instead of being printed and ranked raw. This changes which facts the staleness cap keeps and which order `memory_search` returns. It is the intended effect (see above) and is pinned by tests, but it is a change without an opt-in, so it is flagged here.

No documentation change is needed: `backend/AGENTS.md` makes no claim about the trustworthiness or domain of the stored `confidence` field.

## Bug fix verification

Both directions are anchored, at all three sites.

- **Crash direction**
  - `tests/test_memory_staleness_review.py::TestBuildStalenessSection::test_non_float_confidence_does_not_raise` — `"0.9"`, `None`, `"high"`, `""`.
  - `tests/test_memory_staleness_review.py::TestApplyUpdatesStaleness::test_safety_cap_sort_survives_non_float_stored_confidence`.
  - `tests/test_memory_updater.py::test_search_memory_facts_sort_survives_non_float_stored_confidence`.
- **Mapping direction (prompt rendering)** — `...::TestBuildStalenessSection::test_confidence_is_normalised_like_every_other_stored_read` and `::test_missing_confidence_key_renders_unknown_not_zero`. These values format fine on `main` (they print raw), so without them the behaviour change would ship unnoticed.
- **Ranking direction (both sorts)** — the crash tests above use a `str`, which *raises* on `main`; they therefore cannot go red for any value that mis-ranks silently. Added, one per sort site:
  - `...::TestApplyUpdatesStaleness::test_safety_cap_ranks_unusable_confidence_as_unknown` and `...::test_search_memory_facts_ranks_unusable_confidence_as_unknown` — parametrized over the four inputs that fall to the `0.5` default without raising (absent, `false`, `true`, `inf`), each pitted against a genuine neighbour chosen so the survivor *flips*. The two sorts run in opposite directions, so the one matrix covers eviction from both ends.
  - `...::TestApplyUpdatesStaleness::test_safety_cap_with_nan_confidence_is_order_independent` and `...::test_search_memory_facts_with_nan_confidence_is_order_independent` — `nan` is excluded from the parametrize above on purpose: under the raw key its rank is not an end of the order but *undefined*, so a single fixed input order happens to produce the correct survivor. Pinning `nan` by outcome would have been a test that cannot go red. The property it actually has is order-independence, so that is what is asserted, across both fact orders.
- **Does every new test actually go red?** Measured per-test, not assumed. Reverting the three fixed lines back to the raw key on this branch and re-running the new tests:

  ```
  $ pytest tests/test_memory_updater.py tests/test_memory_staleness_review.py -k "confidence or normalised or unknown"
  25 failed, 5 passed, 95 deselected
  ```

  The 25 failures are **exactly** the 25 test ids this PR adds (6 on `search_memory_facts`, 19 on the staleness sites); the 5 that pass are pre-existing tests caught by the keyword filter. Restoring the fix: `149 passed` across `test_memory_updater.py`, `test_memory_staleness_review.py`, and `test_memory_tools.py`.

## Validation

- `ruff format --check` — 3 files already formatted. `ruff check` — All checks passed!
- `pytest tests/ --ignore=tests/blocking_io` — **6940 passed, 26 skipped, 8 failed**. The 8 are pre-existing `web_fetch` cases (`test_browserless_client.py`, `test_crawl4ai_tools.py`, `test_fastcrw_tools.py`) — this machine has no outbound DNS, so the SSRF guard rejects `https://example.com`. Running those three files on a pristine `origin/main` worktree gives **the same 8 failed, 52 passed**, so the failure set is unchanged in both directions.
- `git merge-tree origin/main HEAD` — no conflict.

### End-to-end, against a real on-disk `memory.json`

Real cycle, only the LLM stubbed: `_do_update_memory_sync` → `_prepare_update_prompt` → real `FileMemoryStorage` read → `_build_staleness_section` → `create_chat_model` → `_apply_updates` → real `FileMemoryStorage` write. A probe records whether the model was ever constructed.

**A. Crash path.** Three aged facts, one with `"confidence": "0.9"`:

| | `main` | this branch |
|---|---|---|
| cycle #1 / #2 `_do_update_memory_sync()` | `False` / `False` | `True` / `True` |
| LLM model constructed | **`False`** | `True` |
| `workContext` learned | `''` | `'backend eng'` |
| facts on disk | 3 | 4 |

`LLM model constructed: False` on `main` is the point: the crash precedes `_get_model()`. Cycle #2 reproduces cycle #1 exactly — the offending fact is still on disk, so the failure is self-perpetuating.

**B. Silent-loss path (staleness cap).** Two aged facts — `fact_corrupt` with a hand-edited `"confidence": true`, `fact_good` with `0.9` — the LLM proposes removing both, `staleness_max_removals_per_cycle=1` forces the cap to rank them. Nothing raises on either side; the cycle returns `True` and rewrites the file both times:

| | `main` | this branch |
|---|---|---|
| cycle returned | `True` | `True` |
| fact left on disk | **`fact_corrupt`** | `fact_good` |

On `main` the genuine `0.9` fact is the one deleted, silently. That is the defect the `str`-based tests could never have caught.

**C. `memory_search`.** Same two facts, real storage, `limit=1`:

| | `main` | this branch |
|---|---|---|
| top result | **`fact_corrupt`** | `fact_good` |

The model asks for the best-ranked fact and gets the corrupt one.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with enumerating every read of the stored `confidence` field, choosing the helper, writing the fix, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
