### PR TITLE
fix(sandbox): guard the reverse path-translation regex with a segment boundary

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -220,7 +220,18 @@ class LocalSandbox(Sandbox):
     @cached_property
     def _reverse_output_patterns(self) -> list[re.Pattern[str]]:
         """Compiled matchers for local paths in command output (longest local path first)."""
-        return [re.compile(re.escape(self._resolved_local_paths[m]) + r"(?:[/\\][^\s\"';&|<>()]*)?") for m in self._mappings_by_local_specificity]
+        # Same segment-boundary lookahead as the forward patterns above, so a mount
+        # root does not match inside a sibling that merely shares its prefix
+        # (``.../skills`` inside ``.../skills-extra``). Without it the regex yields
+        # the bare root, which then *equals* the mount root and so satisfies
+        # ``_reverse_resolve_path``'s own ``+ "/"`` guard — the sibling is rewritten
+        # to a container path that forward resolution refuses to map back.
+        #
+        # The boundary class mirrors ``_content_pattern``'s, not ``_command_pattern``'s:
+        # this runs over arbitrary command output, where a root can legitimately be
+        # followed by ``,`` ``:`` or ``\`` — all of which the shell-oriented class
+        # would reject. The trailing group keeps ``[/\\]`` so Windows paths still match.
+        return [re.compile(re.escape(self._resolved_local_paths[m]) + r"(?=/|$|[^\w./-])(?:[/\\][^\s\"';&|<>()]*)?") for m in self._mappings_by_local_specificity]
 
     @cached_property
     def _resolved_local_paths(self) -> dict[PathMapping, str]:

--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -231,7 +231,12 @@ class LocalSandbox(Sandbox):
         # this runs over arbitrary command output, where a root can legitimately be
         # followed by ``,`` ``:`` or ``\`` — all of which the shell-oriented class
         # would reject. The trailing group keeps ``[/\\]`` so Windows paths still match.
-        return [re.compile(re.escape(self._resolved_local_paths[m]) + r"(?=/|$|[^\w./-])(?:[/\\][^\s\"';&|<>()]*)?") for m in self._mappings_by_local_specificity]
+        #
+        # ``$`` is load-bearing: output ending exactly at a mount root would
+        # otherwise fail the lookahead and be emitted as the raw host path.
+        boundary = r"(?=/|$|[^\w./-])"
+        tail = r"(?:[/\\][^\s\"';&|<>()]*)?"
+        return [re.compile(re.escape(self._resolved_local_paths[m]) + boundary + tail) for m in self._mappings_by_local_specificity]
 
     @cached_property
     def _resolved_local_paths(self) -> dict[PathMapping, str]:

--- a/backend/tests/test_local_sandbox_path_regex_cache.py
+++ b/backend/tests/test_local_sandbox_path_regex_cache.py
@@ -115,6 +115,26 @@ def test_reverse_resolve_still_matches_root_before_non_slash_boundaries(tmp_path
     assert out == f"/mnt/skills{expected_trailer}"
 
 
+@pytest.mark.parametrize("prefix", ["", "cwd: ", "see "])
+def test_reverse_resolve_translates_a_bare_root_at_end_of_output(tmp_path, prefix):
+    """The lookahead's ``$`` alternative, pinned on its own.
+
+    Output ending exactly at a mount root (no trailing separator, no newline —
+    ``printf '%s' "$PWD"``, a stripped last line, a truncated buffer) satisfies
+    neither ``/`` nor ``[^\\w./-]``. Drop ``$`` and the match fails, so the raw
+    host path is handed to the model instead of the container path: the leak
+    this whole function exists to prevent. The suite is otherwise blind to it —
+    removing ``$`` leaves all 6866 tests green.
+    """
+    sb = _make_sandbox(tmp_path)
+    skills_local = str((tmp_path / "skills").resolve())
+
+    out = sb._reverse_resolve_paths_in_output(f"{prefix}{skills_local}")
+
+    assert out == f"{prefix}/mnt/skills"
+    assert skills_local not in out
+
+
 def test_resolved_paths_and_sorted_views_are_cached(tmp_path):
     sb = _make_sandbox(tmp_path)
     # Resolved-local map and sorted views are computed once and reused.

--- a/backend/tests/test_local_sandbox_path_regex_cache.py
+++ b/backend/tests/test_local_sandbox_path_regex_cache.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 
 
@@ -65,6 +67,52 @@ def test_reverse_resolve_output_maps_local_back_to_container(tmp_path):
     ws_local = str((tmp_path / "workspace").resolve())
     out = sb._reverse_resolve_paths_in_output(f"wrote {ws_local}/foo.txt ok")
     assert out == "wrote /mnt/user-data/workspace/foo.txt ok"
+
+
+@pytest.mark.parametrize("suffix", ["-extra/data.txt", "2/x", ".bak", "foo", "_backup/y"])
+def test_reverse_resolve_does_not_match_inside_longer_sibling(tmp_path, suffix):
+    """Mirror of test_segment_boundary_not_matched_inside_longer_name, reverse direction.
+
+    Without a segment-boundary lookahead the pattern matches the bare mount root
+    inside a sibling that shares its prefix. The extracted text then *equals* the
+    mount root, so ``_reverse_resolve_path``'s own ``+ "/"`` guard is satisfied and
+    the sibling is rewritten to ``/mnt/skills<suffix>`` — a container path forward
+    resolution refuses to map back, so the model can never read it.
+    """
+    sb = _make_sandbox(tmp_path)
+    skills_local = str((tmp_path / "skills").resolve())
+    sibling = f"{skills_local}{suffix}"
+
+    out = sb._reverse_resolve_paths_in_output(f"see {sibling}")
+
+    assert out == f"see {sibling}"
+    assert "/mnt/skills" not in out
+
+
+@pytest.mark.parametrize(
+    ("trailer", "expected_trailer"),
+    [
+        (", ok", ", ok"),  # comma — a path can end a clause in prose output
+        (":/other", ":/other"),  # colon — PATH-style concatenation
+        ("\\win\\p", "/win/p"),  # backslash — Windows-style separator
+        (" done", " done"),  # whitespace
+        ("' ", "' "),  # quote
+    ],
+)
+def test_reverse_resolve_still_matches_root_before_non_slash_boundaries(tmp_path, trailer, expected_trailer):
+    """The narrowing must not drop boundaries the old pattern accepted.
+
+    ``_reverse_output_patterns`` runs over arbitrary command output, so the mount
+    root can legitimately be followed by ``,``, ``:`` or ``\\``. Copying
+    ``_command_pattern``'s shell-oriented boundary class here would silently stop
+    translating all three; this pins the ``_content_pattern`` class that does not.
+    """
+    sb = _make_sandbox(tmp_path)
+    skills_local = str((tmp_path / "skills").resolve())
+
+    out = sb._reverse_resolve_paths_in_output(f"{skills_local}{trailer}")
+
+    assert out == f"/mnt/skills{expected_trailer}"
 
 
 def test_resolved_paths_and_sorted_views_are_cached(tmp_path):


### PR DESCRIPTION
## Why

`LocalSandbox` rewrites host paths back to container paths in every bash `stdout`/`stderr` (`execute_command`) and in `read_file` content. The matcher it uses, `_reverse_output_patterns`, is the only prefix match in the file without a segment-boundary guard:

| Site | Kind | Boundary guard |
|---|---|---|
| `_command_pattern` | regex | `(?=/\|$\|[\s"';&\|<>()])` |
| `_content_pattern` | regex | `(?=/\|$\|[^\w./-])` |
| **`_reverse_output_patterns`** | regex | **none** |
| `_find_path_mapping` | string prefix | `== root or startswith(root + "/")` |
| `_reverse_resolve_path` | string prefix | same |
| `_is_read_only_path` | string prefix | `startswith(root + os.sep)` |

The optional trailing group `(?:[/\\]…)?` needs a `/` or `\` to consume anything, so when the character after the mount root is `-`, `.`, `_`, a digit or a letter, the group matches empty and the regex still matches the bare root inside a sibling directory.

That is not merely a wider match — it **defeats the downstream guard**. The extracted text is exactly the mount root, so `_reverse_resolve_path`'s `path_str == local_path_resolved` branch is taken and the sibling is rewritten.

With `/mnt/skills` mounted at `…/skills` and a sibling `…/skills-extra` on the host, a command that prints `…/skills-extra/data.txt` hands the model:

```
found /mnt/skills-extra/data.txt
```

which looks like an ordinary container path, and which forward resolution explicitly refuses to map back (pinned today by `test_segment_boundary_not_matched_inside_longer_name`). Reading it raises `FileNotFoundError`. The same shape occurs for `…/outputs.bak`, `…/outputs2`, or any two custom mounts whose host paths share a non-`/` prefix (`/srv/data` vs `/srv/database`).

## What changed

`_reverse_output_patterns` gains the same segment-boundary lookahead the forward patterns carry.

It mirrors **`_content_pattern`'s** class `(?=/|$|[^\w./-])`, not `_command_pattern`'s. This regex runs over arbitrary command output, where a mount root can legitimately be followed by `,` (prose), `:` (PATH-style concatenation) or `\` (Windows separator). The shell-oriented class rejects all three, so copying it here would silently stop translating paths that translate today — a regression I verified before rejecting that option, and which the second test below pins. The trailing group keeps `[/\\]` so Windows paths still match in full.

Per review, the boundary class and trailing group are lifted into named locals (`boundary`, `tail`) rather than inlined in a ~175-char comprehension. The compiled pattern is byte-identical; correctness hinges entirely on `boundary`, so making it visually prominent is the point.

## Surface area

- [x] **Sandbox** — sandboxed execution (`backend/packages/harness/deerflow/sandbox/local/local_sandbox.py`)

No documentation change is needed: `backend/AGENTS.md` describes the virtual-path contract but makes no claim about the reverse matcher's boundary semantics.

## Bug fix verification

Both directions are anchored, and each anchor is demonstrably able to fail.

- **Fix direction** — `tests/test_local_sandbox_path_regex_cache.py::test_reverse_resolve_does_not_match_inside_longer_sibling`, parametrized over `-extra/data.txt`, `2/x`, `.bak`, `foo`, `_backup/y`. **Red on `main`** (5 failures — the sibling is rewritten), green here. It is the reverse-direction mirror of the existing `test_segment_boundary_not_matched_inside_longer_name`.
- **Over-narrowing direction** — `::test_reverse_resolve_still_matches_root_before_non_slash_boundaries`, parametrized over `,` `:` `\` whitespace and quote. This one is **green on `main` as well**, because `main`'s pattern already matches these; it does not guard the bug. It guards the fix from being narrowed too far: swapping in `_command_pattern`'s boundary class makes it **red on `,`, `:` and `\`**, which is exactly the regression that class would introduce. Verified by running the suite against that variant.
- **Leak direction (added after review)** — `::test_reverse_resolve_translates_a_bare_root_at_end_of_output`. The lookahead's `$` alternative was the one clause with **no test at all**: I removed it and the entire suite stayed green (**6866 passed, 0 new failures**). It is not cosmetic — output that ends exactly at a mount root (`printf '%s' "$PWD"`, a stripped last line, a truncated capture) satisfies neither `/` nor `[^\w./-]`, so without `$` the match fails and the **raw host path is handed to the model** instead of the container path. That is the leak this function exists to prevent, and the narrowing in this PR is what introduced the exposure. Now pinned: deleting only `$` turns exactly those 3 parametrizations red and leaves the other 18 green.

- End-to-end through a real `bash` subprocess: on `main` the model is shown `found /mnt/skills-extra/data.txt` and `read_file` on it raises `FileNotFoundError`; on this branch the sibling is left as its real host path, the in-mount `/mnt/skills/real.txt` still translates and reads, and `root is /mnt/skills, done` (comma boundary) still translates.

## Validation

- `cd backend && make format` — `All checks passed!`, 802 files left unchanged.
- `cd backend && make lint` — `All checks passed!`, 802 files already formatted.
- `cd backend && make test` — **6866 passed, 26 skipped, 8 failed**. The 8 are pre-existing `web_fetch` cases (`test_browserless_client.py`, `test_crawl4ai_tools.py`, `test_fastcrw_tools.py`); I ran all eight on a clean `origin/main` worktree and they fail identically — this machine has no outbound DNS, so the SSRF guard rejects `https://example.com`. Baseline on `main`: **6856 passed / the same 8 failed**. The delta of +10 is exactly the 10 parametrizations added here.
- All sandbox suites (`pytest tests/test_*sandbox*.py`): 462 passed, 4 skipped — including `test_sandbox_windows_path_normalization.py` and `test_local_sandbox_virtual_path_contract.py`, which matter because the trailing group still accepts `\`.

Follow-up to review (`$` anchor + named locals):

- `cd backend && make format` / `make lint` — clean, 802 files unchanged.
- `cd backend && make test` — **6869 passed, 26 skipped, 8 failed**; the branch's own baseline before this commit was **6866 passed / the same 8 failed** (pre-existing `web_fetch` cases, no outbound DNS on this machine). +3 passed, failure count unchanged.
- Second end-to-end, real `LocalSandbox.execute_command` subprocess, nothing stubbed. `printf '%s' /mnt/skills` forward-resolves to the host root and prints it with no trailing newline:

  | | with `$` | `$` deleted |
  |---|---|---|
  | returned to the model | `/mnt/skills` | `/private/var/folders/.../skills` |

  The host path leaks on the right. That is what the new test pins.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with enumerating the prefix-match sites, computing the behaviour delta of the two candidate boundary classes, writing the fix, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

