### PR TITLE
fix(agent): reserve ellipsis room so the local title respects max_chars

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -162,7 +162,11 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         config = self._get_title_config()
         fallback_chars = min(config.max_chars, 50)
         if len(user_msg) > fallback_chars:
-            return user_msg[:fallback_chars].rstrip() + "..."
+            # Reserve room for the ellipsis so this path honours ``max_chars``
+            # exactly as ``_parse_title`` does on the model path.
+            ellipsis = "..."
+            body = min(fallback_chars, config.max_chars - len(ellipsis))
+            return user_msg[:body].rstrip() + ellipsis
         return user_msg if user_msg else "New Conversation"
 
     def _get_runnable_config(self) -> dict[str, Any]:

--- a/backend/tests/test_title_middleware_core_logic.py
+++ b/backend/tests/test_title_middleware_core_logic.py
@@ -4,6 +4,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.constants import TAG_NOSTREAM
 
@@ -319,6 +320,51 @@ class TestTitleMiddlewareCoreLogic:
         result = middleware._generate_title_result(state)
         assert result["title"].endswith("...")
         assert result["title"].startswith("这是一个非常长的问题描述")
+        assert len(result["title"]) <= 50
+
+    @pytest.mark.parametrize("max_chars", [10, 20, 40, 49, 50, 52, 53, 60, 200])
+    def test_fallback_title_never_exceeds_max_chars(self, max_chars):
+        """``max_chars`` bounds the fallback title, not just its body.
+
+        The ellipsis is part of the returned title, so a body of exactly
+        ``min(max_chars, 50)`` characters overshot the configured cap by three.
+        ``model_name: null`` is the shipped default, so this is the path every
+        title takes out of the box -- not an error branch.
+        """
+        _set_test_title_config(max_chars=max_chars, model_name=None)
+        middleware = TitleMiddleware()
+
+        title = middleware._fallback_title("x" * 200)
+
+        assert len(title) <= max_chars
+        assert title.endswith("...")
+
+    @pytest.mark.parametrize("max_chars", [10, 20, 50])
+    def test_fallback_title_honours_the_same_cap_as_the_model_path(self, max_chars):
+        """Both title paths read ``config.max_chars``; both must respect it.
+
+        ``_parse_title`` slices the model's answer to ``max_chars`` exactly. The
+        local path is the other half of the same contract.
+        """
+        _set_test_title_config(max_chars=max_chars, model_name=None)
+        middleware = TitleMiddleware()
+        long_text = "x" * 200
+
+        assert len(middleware._parse_title(long_text)) <= max_chars
+        assert len(middleware._fallback_title(long_text)) <= max_chars
+
+    def test_fallback_title_keeps_default_config_output_unchanged(self):
+        """The default ``max_chars=60`` leaves room for the ellipsis already.
+
+        Reserving that room must not shorten titles that were never over the
+        cap, so the shipped configuration keeps emitting a 50-character body.
+        """
+        _set_test_title_config(max_chars=60, model_name=None)
+        middleware = TitleMiddleware()
+
+        title = middleware._fallback_title("x" * 200)
+
+        assert title == "x" * 50 + "..."
 
     def test_parse_title_strips_think_tags(self):
         """Title model responses with <think>...</think> blocks are stripped before use."""


### PR DESCRIPTION
## Why

`TitleConfig.max_chars` is described as "Maximum number of characters in the generated title". Two functions in `title_middleware.py`, six lines apart, read it. Only one honours it.

```python
153:    def _parse_title(self, content: object) -> str:          # model path
159:        return title[: config.max_chars] if len(title) > config.max_chars else title

161:    def _fallback_title(self, user_msg: str) -> str:         # local path
163:        fallback_chars = min(config.max_chars, 50)
165:            return user_msg[:fallback_chars].rstrip() + "..."
```

The ellipsis is part of the returned title, but only the *body* is bounded. `_fallback_title` can return `max_chars + 3` characters.

**This is the default path, not an error branch.** `config.example.yaml` ships:

```yaml
title:
  max_chars: 60
  model_name: null # null = fast local fallback; set a model name to use LLM title generation
```

and the middleware branches on it:

```python
if not config.model_name:
    return {"title": self._fallback_title(user_msg)}
```

So unless the operator opts into a title model, **every** thread title is produced here. `max_chars` is a documented key with a pydantic range of `10..200`; `AppConfig.from_file()` loads it via `load_title_config_from_dict`. Any configured value in `10..52` makes a long first message overshoot its own cap:

| `max_chars` | title length | |
|---|---|---|
| 60 (shipped default) | 53 | within cap — which is why nobody hit this |
| 52 | 53 | **over by 1** |
| 40 | 43 | **over by 3** |
| 10 | 13 | **over by 3** |

## The existing test already claimed this invariant

`tests/test_title_middleware_core_logic.py` has:

```python
def test_sync_generate_title_respects_fallback_truncation(self):
    """Sync fallback path still respects max_chars truncation rules."""
    _set_test_title_config(max_chars=50)
    ...
    assert result["title"].endswith("...")
    assert result["title"].startswith("这是一个非常长的问题描述")
```

At its own `max_chars=50` the title it produces is **53 characters long**. The test asserts the *shape* of the truncation and never its *length*, so it passes. This PR adds the one assertion it is named after.

## What changed

Reserve room for the ellipsis before slicing:

```python
ellipsis = "..."
body = min(fallback_chars, config.max_chars - len(ellipsis))
return user_msg[:body].rstrip() + ellipsis
```

Chosen over the more obvious `user_msg[:fallback_chars - 3]` because that one also shortens the **default** configuration (53 → 50) for no benefit. With `min(...)`, `max_chars=60` still yields a 50-character body — the shipped configuration's output is byte-identical to today's.

I enumerated the behaviour delta across the full pydantic range (`max_chars` 10..200 × 6 message shapes = 1146 combinations):

```
output changed:   148   — all of them in max_chars ∈ [10, 52]
output unchanged: 998
changed at the default max_chars=60?   No
changed at any max_chars >= 53?        No
```

## Scope: this is the only fallback path in the backend that does this

Every `*fallback*` path in `backend/` was checked against the cap its primary path respects:

| fallback | corresponding cap | honours it? |
|---|---|---|
| `memory/prompt.py::_fallback_format_facts` | `max_injection_tokens` | yes — computes a line budget and reuses the primary's `_select_fact_lines` |
| `tool_output_budget_middleware::_build_fallback` | `fallback_max_chars` | yes — brute-forced over 30,240 input combinations, 0 violations |
| `runtime/journal.py` (3 sites) | hardcoded `[:2000]` | yes — all three consistent |
| `llm_error_handling_middleware` fallbacks | no cap involved | n/a |
| `dingtalk::_send_markdown_fallback` | neither path truncates | n/a |
| **`title_middleware::_fallback_title`** | `TitleConfig.max_chars` | **no** |

## Conscious accept: `"New Conversation"`

When `user_msg` is empty, `_fallback_title` returns the literal `"New Conversation"` — 16 characters, so it also exceeds `max_chars ∈ [10, 15]`.

**Deliberately not changed here.** It is a placeholder constant, not a *generated* title, and truncating it to `"New Conver"` is strictly worse for the user with nothing gained. Whether a placeholder should be subject to the cap is a design question, not the overflow bug this PR fixes; folding it in would widen the behaviour delta for a case nobody benefits from. Happy to address it separately if you disagree.

## Surface area

- [x] **Agent / middleware** — `backend/packages/harness/deerflow/agents/middlewares/title_middleware.py`

No documentation change needed: `backend/AGENTS.md` documents `title.model_name: null` as the local-fallback switch, which remains true.

## Bug fix verification

Both directions are anchored, and I wrote down what each anchor should do *before* running the red check.

**Fix direction** — reverting only the source hunk turns exactly these red:

```
10 failed, 34 passed

FAILED ::test_sync_generate_title_respects_fallback_truncation        (max_chars=50 → 53 chars)
FAILED ::test_fallback_title_never_exceeds_max_chars[10] [20] [40] [49] [50] [52]
FAILED ::test_fallback_title_honours_the_same_cap_as_the_model_path[10] [20] [50]
```

**Over-narrowing direction** — two of the new assertions are *designed* to stay green on `main`, and do:

- `test_fallback_title_never_exceeds_max_chars[53] [60] [200]` — above the violating range, so there is no bug to catch there. They pin the boundary at 52.
- `test_fallback_title_keeps_default_config_output_unchanged` — asserts `max_chars=60` still emits a 50-character body plus the ellipsis. This guards the fix from being *widened*: the naive `fallback_chars - 3` variant turns it red.

## Validation

- `cd backend && make lint` — `ruff check`: all checks passed; `ruff format --check`: 803 files already formatted.
- `cd backend && make test` — **6926 passed, 26 skipped, 8 failed**. The same 8 fail on a clean `origin/main` checkout (pre-existing `web_fetch` cases — `test_browserless_client`, `test_crawl4ai_tools`, `test_fastcrw_tools`; no outbound DNS on this machine). Failure set is byte-identical; this branch adds none.
- End-to-end through the real config loader and the real middleware — `load_title_config_from_dict({...})` → `TitleMiddleware()._fallback_title(...)`, nothing stubbed:

  | `max_chars` | title length | result |
  |---|---|---|
  | 60 (shipped default) | 53 | unchanged from `main`, byte for byte |
  | 40 | 40 | was 43 on `main` |
  | 10 | 9 | was 13 on `main` |

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with enumerating the backend's fallback paths against their caps, computing the behaviour delta across the full `max_chars` range, writing the fix, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
