### PR TITLE
fix(sandbox): guard the output-masking regex with a segment boundary

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -692,6 +692,20 @@ def _compiled_mask_patterns(sources: tuple[tuple[str, str], ...]) -> tuple[tuple
     glob/grep match, so without this the same patterns are recompiled per
     match.
     """
+    # Same segment-boundary lookahead as ``LocalSandbox._reverse_output_patterns``
+    # (#4035), so a host base does not match inside a sibling that merely shares
+    # its prefix (``.../skills`` inside ``.../skills-extra``). Without it the
+    # regex yields the bare base, which then *equals* ``base`` in
+    # ``replace_match`` and so the sibling is rewritten to a container path that
+    # forward resolution refuses to map back.
+    #
+    # The class mirrors ``_content_pattern``'s: this runs over arbitrary command
+    # output, where a base can legitimately be followed by ``,`` ``:`` or ``\``.
+    # ``$`` is load-bearing — output ending exactly at a base would otherwise
+    # fail the lookahead and be emitted as the raw host path.
+    boundary = r"(?=/|$|[^\w./-])"
+    tail = r"(?:[/\\][^\s\"';&|<>()]*)?"
+
     compiled: list[tuple[re.Pattern[str], str, str]] = []
     for host_base, virtual_base in sources:
         seen: set[str] = set()
@@ -705,7 +719,7 @@ def _compiled_mask_patterns(sources: tuple[tuple[str, str], ...]) -> tuple[tuple
                     continue
                 seen.add(variant)
                 escaped = re.escape(variant).replace(r"\\", r"[/\\]")
-                compiled.append((re.compile(escaped + r"(?:[/\\][^\s\"';&|<>()]*)?"), variant, virtual_base))
+                compiled.append((re.compile(escaped + boundary + tail), variant, virtual_base))
     return tuple(compiled)
 
 

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -137,6 +137,43 @@ def test_mask_local_paths_does_not_match_inside_longer_sibling(suffix: str) -> N
         assert "/mnt/skills" not in masked
 
 
+@pytest.mark.parametrize("suffix", ["-backup/hello.py", "2/hello.py", ".old", "_tmp/x"])
+def test_mask_local_paths_does_not_match_inside_longer_acp_sibling(suffix: str) -> None:
+    """Same bug, second source: the ACP workspace has no enclosing virtual root.
+
+    ``_compiled_mask_patterns`` builds every source's matcher, so the ACP
+    workspace carried the same defect as skills -- and unlike user-data (see
+    below) nothing maps its parent, so ``/mnt/acp-workspace-backup/hello.py``
+    is unresolvable in both directions.
+    """
+    acp_host = "/home/user/.deer-flow/acp-workspace"
+    with patch("deerflow.sandbox.tools._get_acp_workspace_host_path", return_value=acp_host):
+        output = f"copied {acp_host}{suffix}"
+        masked = mask_local_paths_in_output(output, _THREAD_DATA)
+
+        assert masked == output
+        assert "/mnt/acp-workspace" not in masked
+
+
+@pytest.mark.parametrize("suffix", ["2/report.txt", ".bak/report.txt", "-old"])
+def test_mask_local_paths_user_data_sibling_is_carried_by_the_virtual_root(suffix: str) -> None:
+    """User-data siblings are benign -- and must stay that way.
+
+    ``_thread_virtual_to_actual_mappings`` also maps the virtual root
+    ``/mnt/user-data`` to the three dirs' common parent, so a sibling of
+    ``outputs`` is still *inside* a mount and has a real virtual path. Whichever
+    pattern wins -- the bare ``outputs`` base (pre-#4053) or the root (post-) --
+    the string is the same, so the boundary changes nothing here.
+
+    Green on ``main`` too: this is not a bug anchor, it guards the boundary from
+    being narrowed into one that would stop translating a mapped path.
+    """
+    masked = mask_local_paths_in_output(f"wrote /tmp/deer-flow/threads/t1/user-data/outputs{suffix}", _THREAD_DATA)
+
+    assert masked == f"wrote /mnt/user-data/outputs{suffix}"
+    assert replace_virtual_path(f"/mnt/user-data/outputs{suffix}", _THREAD_DATA) == f"/tmp/deer-flow/threads/t1/user-data/outputs{suffix}"
+
+
 @pytest.mark.parametrize(
     ("boundary", "expected"),
     [

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -115,6 +115,78 @@ def test_mask_local_paths_in_output_hides_skills_host_paths() -> None:
         assert "/mnt/skills/public/bootstrap/SKILL.md" in masked
 
 
+@pytest.mark.parametrize("suffix", ["-extra/data.txt", "2/x", ".bak", "foo", "_backup/y"])
+def test_mask_local_paths_does_not_match_inside_longer_sibling(suffix: str) -> None:
+    """A host base must not match inside a sibling that merely shares its prefix.
+
+    The trailing group needs a separator to consume anything, so without a
+    segment-boundary lookahead the regex matches the bare base and
+    ``replace_match`` takes its ``matched_path == base`` branch -- rewriting
+    ``.../skills-extra/data.txt`` to ``/mnt/skills-extra/data.txt``, a container
+    path forward resolution refuses to map back. Reverse-direction mirror of
+    ``LocalSandbox._reverse_output_patterns`` (#4035).
+    """
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_path", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_host_path", return_value="/home/user/deer-flow/skills"),
+    ):
+        output = f"found /home/user/deer-flow/skills{suffix}"
+        masked = mask_local_paths_in_output(output, None)
+
+        assert masked == output
+        assert "/mnt/skills" not in masked
+
+
+@pytest.mark.parametrize(
+    ("boundary", "expected"),
+    [
+        (", done", "/mnt/skills, done"),
+        (":/other", "/mnt/skills:/other"),
+        (" tail", "/mnt/skills tail"),
+        ('"quoted', '/mnt/skills"quoted'),
+        # A backslash is consumed by the trailing group (Windows paths match in
+        # full, separator normalised) rather than acting as a terminator -- but
+        # it must still reach the trailing group, which needs the lookahead to
+        # admit it first.
+        ("\\win", "/mnt/skills/win"),
+    ],
+)
+def test_mask_local_paths_still_matches_base_before_non_slash_boundaries(boundary: str, expected: str) -> None:
+    """The lookahead must not narrow away boundaries that translate today.
+
+    This runs over arbitrary command output, where a base can legitimately be
+    followed by a comma (prose), a colon (PATH-style concatenation) or a
+    backslash (Windows separator). Borrowing the shell-oriented class from
+    ``_command_pattern`` -- ``(?=/|$|[\\s"';&|<>()])`` -- admits none of the
+    three, so the lookahead would fail and the raw host path would be emitted.
+    """
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_path", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_host_path", return_value="/home/user/deer-flow/skills"),
+    ):
+        masked = mask_local_paths_in_output(f"root is /home/user/deer-flow/skills{boundary}", None)
+
+        assert masked == f"root is {expected}"
+        assert "/home/user/deer-flow/skills" not in masked
+
+
+@pytest.mark.parametrize("prefix", ["", "cwd: ", "see "])
+def test_mask_local_paths_translates_a_bare_base_at_end_of_output(prefix: str) -> None:
+    """``$`` is load-bearing: output ending exactly at a host base still masks.
+
+    Without it the lookahead fails and the raw host path is handed to the model
+    -- the leak this function exists to prevent.
+    """
+    with (
+        patch("deerflow.sandbox.tools._get_skills_container_path", return_value="/mnt/skills"),
+        patch("deerflow.sandbox.tools._get_skills_host_path", return_value="/home/user/deer-flow/skills"),
+    ):
+        masked = mask_local_paths_in_output(f"{prefix}/home/user/deer-flow/skills", None)
+
+        assert masked == f"{prefix}/mnt/skills"
+        assert "/home/user/deer-flow/skills" not in masked
+
+
 def test_mask_local_paths_compiled_patterns_are_cached() -> None:
     """The compiled patterns for a given source set are built once and reused
     (mask runs once per glob/grep match, so this avoids per-match recompiles)."""


### PR DESCRIPTION
## Why

This is the sibling site of #4035, and my own scope argument there missed it.

#4035 fixed `LocalSandbox._reverse_output_patterns`, which lacked the segment-boundary lookahead its forward counterparts carry. `sandbox/tools.py::_compiled_mask_patterns` builds the *same class* of host→virtual matcher, and lacks the same guard:

```python
# local_sandbox.py — after #4035
boundary = r"(?=/|$|[^\w./-])"
tail     = r"(?:[/\\][^\s\"';&|<>()]*)?"
re.compile(re.escape(root) + boundary + tail)

# tools.py — no boundary
re.compile(escaped + r"(?:[/\\][^\s\"';&|<>()]*)?")
```

The trailing group needs a `/` or `\` to consume anything, so when the character after a host base is `-`, `.`, `_`, a digit or a letter, the group matches empty and the regex still matches the bare base. `replace_match` then takes its `matched_path == _base` branch and substitutes the whole thing.

With `/mnt/skills` mounted at `.../skills` and a sibling `.../skills-extra` on the host, output naming the sibling is handed to the model as:

```
found /mnt/skills-extra/data.txt
```

which looks like an ordinary container path, and which forward resolution explicitly refuses to map back (pinned today by `test_segment_boundary_not_matched_inside_longer_name`). Reading it raises `FileNotFoundError`. The same shape occurs for `.../outputs.bak`, `.../outputs2`, or any two mounts whose host paths share a non-`/` prefix.

`mask_local_paths_in_output` runs on every glob/grep match and on local bash output, so this is not a narrow path.

## What changed

`_compiled_mask_patterns` gains the same lookahead #4035 added to `local_sandbox.py`, with the boundary class and trailing group lifted into named locals — the reviewed style from that PR.

The class mirrors **`_content_pattern`'s** `(?=/|$|[^\w./-])`, not `_command_pattern`'s. This regex runs over arbitrary command output, where a base can legitimately be followed by `,` (prose), `:` (PATH-style concatenation) or `\` (Windows separator). The shell-oriented class rejects all three, so copying it here would silently stop translating paths that translate today. The trailing group keeps `[/\\]` so Windows paths still match in full.

## Surface area

- [x] **Sandbox** — `backend/packages/harness/deerflow/sandbox/tools.py`

No documentation change needed: `backend/AGENTS.md` describes the virtual-path contract but makes no claim about this matcher's boundary semantics.

## Bug fix verification

Every clause of the fix is anchored, and I wrote down what each anchor should do before running the checks.

**Fix direction** — reverting only `boundary` from the compiled pattern turns exactly these red, and nothing else:

```
9 failed, 129 passed

FAILED ::test_mask_local_paths_does_not_match_inside_longer_sibling[-extra/data.txt] [2/x] [.bak] [foo] [_backup/y]
FAILED ::test_mask_local_paths_does_not_match_inside_longer_acp_sibling[-backup/hello.py] [2/hello.py] [.old] [_tmp/x]
```

**The `$` alternative** — deleting only `$` turns exactly the 3 end-of-output cases red:

```
3 failed, 128 passed

FAILED ::test_mask_local_paths_translates_a_bare_base_at_end_of_output[] [cwd: ] [see ]
```

It is not cosmetic: output ending exactly at a host base (`printf '%s' "$PWD"`, a stripped last line, a truncated capture) satisfies neither `/` nor `[^\w./-]`, so without `$` the match fails and the **raw host path is handed to the model** — the leak this function exists to prevent, and an exposure the narrowing itself would introduce.

**The boundary class** — swapping in `_command_pattern`'s shell-oriented class turns exactly the 3 regressions it would introduce red:

```
3 failed, 128 passed

FAILED ::test_mask_local_paths_still_matches_base_before_non_slash_boundaries[, done] [:/other] [\win]
```

These three assertions are green on `main` as well — they do not guard the bug, they guard the fix from being narrowed too far.

**Per source** — `_compiled_mask_patterns` builds every source's matcher in one loop, so the defect was never skills-only. Following @willem-bd's review, the anchors now cover each source, and the two behave differently:

| source | on `main` | on this branch | forward-resolvable? |
|---|---|---|---|
| ACP workspace — `<acp-host>-backup/hello.py` | `/mnt/acp-workspace-backup/hello.py` | left as the real host path | **no**, in either direction |
| user-data — `<user-data>/outputs2/report.txt` | `/mnt/user-data/outputs2/report.txt` | **byte-identical** | yes, in both |

ACP is a genuine second instance: nothing maps its parent, so the pre-fix rewrite hands the model a container path that does not exist. It is now pinned by `test_mask_local_paths_does_not_match_inside_longer_acp_sibling`, which is in the red set above.

User-data is the exception, and it is worth stating precisely rather than assuming symmetry: `_thread_virtual_to_actual_mappings` also maps the virtual root `/mnt/user-data` to the three dirs' common parent, so a sibling of `outputs` is still *inside* a mount and has a real virtual path. Whichever pattern wins — the bare `outputs` base or the root — the emitted string is the same and round-trips. `test_mask_local_paths_user_data_sibling_is_carried_by_the_virtual_root` pins that; like the three above it is green on `main`, and it guards the boundary from being narrowed into one that would stop translating a genuinely mapped path.

## Validation

- `cd backend && make lint` — `ruff check`: all checks passed; `ruff format --check`: 803 files already formatted.
- `cd backend && make test` — **6933 passed, 26 skipped, 8 failed**. The same 8 fail on a clean `origin/main` checkout (pre-existing `web_fetch` cases — `test_browserless_client`, `test_crawl4ai_tools`, `test_fastcrw_tools`; no outbound DNS on this machine). Failure set is byte-identical; this branch adds none.
- End-to-end through a real subprocess, nothing stubbed — `ls -d <host>/skills <host>/skills-extra`, real stdout fed to `mask_local_paths_in_output`:

  | line | on `main` | on this branch |
  |---|---|---|
  | `<host>/skills` (ends at the base) | `/mnt/skills` | `/mnt/skills` |
  | `<host>/skills-extra` | `/mnt/skills-extra` — unreadable | left as the real host path |

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with enumerating the host→virtual matchers across the backend (the step #4035 scoped to one file only), reproducing the sibling rewrite, writing the fix, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

