### PR TITLE
fix(tools): stop capping tool_search's select: at MAX_RESULTS

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/tool_search.py
+++ b/backend/packages/harness/deerflow/tools/builtins/tool_search.py
@@ -81,8 +81,12 @@ class DeferredToolCatalog:
             return []
 
         if query.startswith("select:"):
+            # No cap: ``select:`` names the tools explicitly, so returning a
+            # subset silently drops schemas the model asked for by name. Mirrors
+            # ``SkillCatalog.search`` (``skills/catalog.py``); the ranked modes
+            # below stay capped at ``MAX_RESULTS``.
             wanted = {n.strip() for n in query[7:].split(",")}
-            return [t for t in self.tools if t.name in wanted][:MAX_RESULTS]
+            return [t for t in self.tools if t.name in wanted]
 
         if query.startswith("+"):
             parts = query[1:].split(None, 1)
@@ -150,7 +154,7 @@ def build_tool_search_tool(catalog: DeferredToolCatalog) -> BaseTool:
           - "notebook jupyter" -- keyword search, up to max_results best matches
           - "+slack send" -- require "slack" in the name, rank by remaining terms
         """
-        matched = catalog.search(query)[:MAX_RESULTS]
+        matched = catalog.search(query)
         if not matched:
             content, names = f"No tools found matching: {query}", []
         else:

--- a/backend/tests/test_deferred_catalog.py
+++ b/backend/tests/test_deferred_catalog.py
@@ -1,7 +1,7 @@
 import pytest
 from langchain_core.tools import tool as as_tool
 
-from deerflow.tools.builtins.tool_search import DeferredToolCatalog
+from deerflow.tools.builtins.tool_search import MAX_RESULTS, DeferredToolCatalog
 
 
 @as_tool
@@ -28,6 +28,48 @@ def test_names(catalog):
 def test_search_select(catalog):
     got = catalog.search("select:alpha_search")
     assert [t.name for t in got] == ["alpha_search"]
+
+
+def _make_tool(name: str):
+    @as_tool(name)
+    def _t(query: str) -> str:
+        "A searchable deferred tool."
+        return query
+
+    return _t
+
+
+@pytest.fixture
+def wide_catalog() -> DeferredToolCatalog:
+    """More tools than ``MAX_RESULTS`` so the cap boundary is reachable."""
+    return DeferredToolCatalog(tuple(_make_tool(f"tool_{c}") for c in "abcdefgh"))
+
+
+def test_search_select_returns_all_requested(wide_catalog):
+    """``select:`` returns every named tool without capping.
+
+    Mirrors ``test_skill_catalog.py::test_select_returns_all_requested``. The
+    two catalogs share the same query grammar and the same ``MAX_RESULTS = 5``;
+    ``select:`` names its targets explicitly, so capping it silently drops
+    schemas the model asked for by name -- and picks the survivors by catalog
+    order, not request order.
+    """
+    wanted = [f"tool_{c}" for c in "abcdef"]  # 6 > MAX_RESULTS
+    got = [t.name for t in wide_catalog.search("select:" + ",".join(wanted))]
+
+    assert got == wanted
+
+
+@pytest.mark.parametrize("query", ["+tool_", "searchable"])
+def test_search_ranked_modes_stay_capped(wide_catalog, query):
+    """Only ``select:`` is uncapped; the ranked modes keep their ``MAX_RESULTS`` cap.
+
+    Guards the fix from being widened into the branches whose docstring does
+    promise "up to max_results best matches".
+    """
+    got = wide_catalog.search(query)
+
+    assert len(got) == MAX_RESULTS
 
 
 def test_search_plus_keyword(catalog):

--- a/backend/tests/test_deferred_setup.py
+++ b/backend/tests/test_deferred_setup.py
@@ -55,6 +55,33 @@ def test_tool_search_returns_command_with_hash_scoped_promotion():
     assert "mcp_calc" in msg.content
 
 
+def test_tool_search_promotes_every_selected_tool():
+    """``select:`` promotes all named tools -- the tool closure must not re-cap.
+
+    ``DeferredToolCatalog.search`` already caps the ranked modes internally, so
+    a second ``[:MAX_RESULTS]`` in the closure only truncates ``select:``. Its
+    sibling closure, ``skills/describe.py::describe_skill``, calls
+    ``catalog.search(name)`` with no slice. Without this test, dropping the cap
+    inside ``search`` alone would still leave ``select:`` capped here.
+    """
+
+    def _t(name: str):
+        @as_tool(name)
+        def _f(query: str) -> str:
+            "A deferred tool."
+            return query
+
+        return _f
+
+    names = [f"mcp_t{i}" for i in range(6)]  # 6 > MAX_RESULTS
+    catalog = DeferredToolCatalog(tuple(_t(n) for n in names))
+    ts = build_tool_search_tool(catalog)
+
+    out = ts.invoke({"type": "tool_call", "name": "tool_search", "args": {"query": "select:" + ",".join(names)}, "id": "tc3"})
+
+    assert out.update["promoted"]["names"] == names
+
+
 def test_tool_search_no_match_empty_names():
     catalog = DeferredToolCatalog((mcp_calc,))
     ts = build_tool_search_tool(catalog)


### PR DESCRIPTION
## Why

`select:` names its targets explicitly. Capping it silently drops schemas the model asked for **by name** — and picks the survivors by *catalog* order, not request order. Nothing tells the model its tool was dropped; it then tries to call a tool that is still deferred.

The rule is already stated three times in this repo. This is the one place that breaks it.

**1. `backend/AGENTS.md:447`**

> `select:` returns all requested skills without a result cap; other modes cap at `MAX_RESULTS=5`.

**2. The parallel implementation** — `DeferredToolCatalog` shares `SkillCatalog`'s query grammar (`select:`, `+prefix`, free-text regex) and its `MAX_RESULTS = 5`. The one carve-out did not come across:

```python
# skills/catalog.py:71
if query.startswith("select:"):
    wanted = {n.strip() for n in query[7:].split(",")}
    return [s for s in self.skills if s.name in wanted]            # no cap

# tools/builtins/tool_search.py:85
if query.startswith("select:"):
    wanted = {n.strip() for n in query[7:].split(",")}
    return [t for t in self.tools if t.name in wanted][:MAX_RESULTS]   # capped
```

**3. `tool_search`'s own docstring** distinguishes the two modes:

> - `"select:Read,Edit"` — fetch **these exact tools** by name
> - `"notebook jupyter"` — keyword search, **up to max_results** best matches

Only the ranked form promises a cap.

Measured on `main`, a model naming six deferred tools:

```
requested (6): mcp_tool_0 … mcp_tool_5
promoted  (5): mcp_tool_0 … mcp_tool_4
dropped   (1): mcp_tool_5     ← no error, no message
```

Reachable whenever a task needs more than five MCP tools at once.

## What changed

The cap is applied **twice** — once inside `DeferredToolCatalog.search`, and again in the tool closure:

```python
matched = catalog.search(query)[:MAX_RESULTS]
```

`search` already caps its ranked branches internally, so the closure's slice is redundant for them — and, once the first cap is removed, it is the **only** thing still capping `select:`. Fixing one site alone changes nothing the model can observe. Its sibling closure, `skills/describe.py::describe_skill`, calls `catalog.search(name)` with no slice.

Both slices are removed. The ranked modes keep their cap.

## Surface area

- [x] **Tools / MCP** — `backend/packages/harness/deerflow/tools/builtins/tool_search.py`

No documentation change needed: `backend/AGENTS.md:447` already documents the intended behaviour — this change makes the code match it.

## Bug fix verification

Both removals are anchored independently, which is the point: a single-site fix passes a catalog-level test and still ships the bug.

| reverted | `test_search_select_returns_all_requested` | `test_tool_search_promotes_every_selected_tool` | ranked-mode tests |
|---|---|---|---|
| cap in `search` only | **RED** | **RED** | green |
| cap in the closure only | green | **RED** | green |
| both (= `main`) | **RED** | **RED** | green |

The middle row is the one that matters: restoring only the closure's slice leaves the catalog-level test **green** while `select:` is still capped for the tool the model actually calls. Without `test_tool_search_promotes_every_selected_tool`, a fix confined to `search` would look complete.

- `test_search_select_returns_all_requested` mirrors the existing `test_skill_catalog.py::test_select_returns_all_requested`, whose docstring already states the rule: *"select: returns all requested names without capping — exact selection, not ranked search."*
- `test_search_ranked_modes_stay_capped` (`+prefix` and free-text) is green on `main` too. It does not guard the bug; it guards the fix from being widened into the branches whose docstring *does* promise "up to max_results best matches".

## Validation

- `cd backend && make lint` — `ruff check`: all checks passed; `ruff format --check`: 803 files already formatted.
- `cd backend && make test` — **6917 passed, 26 skipped, 8 failed**. The same 8 fail on a clean `origin/main` checkout (pre-existing `web_fetch` cases — `test_browserless_client`, `test_crawl4ai_tools`, `test_fastcrw_tools`; no outbound DNS on this machine). Failure set is byte-identical; this branch adds none.
- End-to-end through the real tool, nothing stubbed — `build_tool_search_tool(catalog).invoke(...)` with `select:` over six tools:

  | | `main` | this branch |
  |---|---|---|
  | `promoted.names` | 5 of 6 | 6 of 6 |
  | schemas in the ToolMessage | 5 of 6 | 6 of 6 |

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with comparing the two catalog implementations, reproducing the silent drop, writing the fix, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
