### PR TITLE
fix(subagents): classify recursion-capped LLM error fallbacks as failed

### DIFF
--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -865,30 +865,46 @@ class SubagentExecutor:
             # consistent and pops the reason so it is not orphaned in the dict.
             max_turns = self.config.max_turns
             logger.warning(f"[trace={self.trace_id}] Subagent {self.config.name} reached max_turns={max_turns} (GraphRecursionError); recovering partial result")
-            messages = (final_state or {}).get("messages", [])
-            usable_partial: str | None = None
-            for m in reversed(messages):
-                if isinstance(m, AIMessage):
-                    text = message_content_to_text(m.content).strip()
-                    if text:
-                        usable_partial = text
-                    break
             records = collector.snapshot_records() if collector is not None else None
             stop_reason = self._consume_guard_stop_reason() or "turn_capped"
-            if usable_partial is not None:
+
+            # A handled LLM provider failure (#4042) carries non-empty
+            # user-facing text on its terminal ``AIMessage`` just like genuine
+            # partial output, so it must be checked here too or it is
+            # indistinguishable from the raw-text scan below and gets
+            # misclassified as a completed task. Consult the same marker the
+            # normal-completion path above uses, before falling back to that scan.
+            llm_error = _extract_llm_error_fallback(final_state)
+            if llm_error is not None:
                 result.try_set_terminal(
-                    SubagentStatus.COMPLETED,
-                    result=usable_partial,
+                    SubagentStatus.FAILED,
+                    error=llm_error,
                     stop_reason=stop_reason,
                     token_usage_records=records,
                 )
             else:
-                result.try_set_terminal(
-                    SubagentStatus.FAILED,
-                    error=f"Reached max_turns={max_turns}",
-                    stop_reason=stop_reason,
-                    token_usage_records=records,
-                )
+                messages = (final_state or {}).get("messages", [])
+                usable_partial: str | None = None
+                for m in reversed(messages):
+                    if isinstance(m, AIMessage):
+                        text = message_content_to_text(m.content).strip()
+                        if text:
+                            usable_partial = text
+                        break
+                if usable_partial is not None:
+                    result.try_set_terminal(
+                        SubagentStatus.COMPLETED,
+                        result=usable_partial,
+                        stop_reason=stop_reason,
+                        token_usage_records=records,
+                    )
+                else:
+                    result.try_set_terminal(
+                        SubagentStatus.FAILED,
+                        error=f"Reached max_turns={max_turns}",
+                        stop_reason=stop_reason,
+                        token_usage_records=records,
+                    )
 
         except Exception as e:
             logger.exception(f"[trace={self.trace_id}] Subagent {self.config.name} async execution failed")

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -1143,6 +1143,56 @@ class TestAsyncExecutionPath:
         assert result.completed_at is not None
 
     @pytest.mark.anyio
+    async def test_aexecute_recursion_error_with_llm_error_fallback_surfaces_failed(self, classes, base_config, mock_agent, msg):
+        """A structured LLM error fallback that coincides with hitting
+        ``max_turns`` must still classify as ``failed``, not ``completed``.
+
+        ``_extract_llm_error_fallback`` (#4042) marks a terminal ``AIMessage``
+        as a handled provider failure via
+        ``additional_kwargs.deerflow_error_fallback``, and the
+        normal-completion branch above already consults it before falling
+        back to ``_extract_final_result``. This except-block must apply the
+        same check before recovering ``usable_partial`` from raw non-empty
+        ``AIMessage`` text: a fallback message always carries non-empty
+        user-facing text, so without checking the marker first it is
+        indistinguishable from genuine partial output and gets misclassified
+        as a completed task rather than the failed provider error it is.
+        """
+        from langgraph.errors import GraphRecursionError
+
+        AIMessage = classes["AIMessage"]
+        SubagentExecutor = classes["SubagentExecutor"]
+        SubagentStatus = classes["SubagentStatus"]
+
+        fallback_text = "LLM request failed: provider rejected the request"
+        fallback_message = AIMessage(
+            content=fallback_text,
+            additional_kwargs={
+                "deerflow_error_fallback": True,
+                "error_type": "BadRequestError",
+                "error_reason": "generic",
+                "error_detail": "Error code: 400 - InvalidParameter",
+            },
+        )
+        fallback_state = {"messages": [msg.human("Task"), fallback_message]}
+
+        async def mock_astream(*args, **kwargs):
+            yield fallback_state
+            raise GraphRecursionError("Recursion limit reached right after the LLM error fallback")
+
+        mock_agent.astream = mock_astream
+
+        executor = SubagentExecutor(config=base_config, tools=[], thread_id="test-thread")
+
+        with patch.object(executor, "_create_agent", return_value=mock_agent):
+            result = await executor._aexecute("Task")
+
+        assert result.status == SubagentStatus.FAILED
+        assert result.error == fallback_text
+        assert result.result is None
+        assert result.stop_reason == "turn_capped"
+
+    @pytest.mark.anyio
     async def test_aexecute_token_capped_surfaces_completed_token_capped(self, classes, base_config, mock_agent, msg):
         """#3875 Phase 2: the token-budget hard-stop does not raise — it strips
         tool_calls so the run completes with a final answer. When the captured


### PR DESCRIPTION
## Summary

#4042 taught `SubagentExecutor._aexecute`'s normal-completion path to recognize a terminal `AIMessage` marked by `LLMErrorHandlingMiddleware` (`additional_kwargs.deerflow_error_fallback=True`) via `_extract_llm_error_fallback`, and classify the run as `SubagentStatus.FAILED` instead of `COMPLETED`. The sibling `except GraphRecursionError:` block — hit when a subagent exhausts its `max_turns` budget — has its own, older logic that never calls `_extract_llm_error_fallback`, so the same fallback message is still misclassified as a completed task when it coincides with hitting the turn cap.

## The bug

`_aexecute`'s `except GraphRecursionError:` block decides `usable_partial` purely from whether the trailing `AIMessage` has non-empty text:

```python
messages = (final_state or {}).get("messages", [])
usable_partial: str | None = None
for m in reversed(messages):
    if isinstance(m, AIMessage):
        text = message_content_to_text(m.content).strip()
        if text:
            usable_partial = text
        break
records = collector.snapshot_records() if collector is not None else None
stop_reason = self._consume_guard_stop_reason() or "turn_capped"
if usable_partial is not None:
    result.try_set_terminal(
        SubagentStatus.COMPLETED,
        result=usable_partial,
        stop_reason=stop_reason,
        token_usage_records=records,
    )
else:
    ...
```

`_extract_llm_error_fallback` is never consulted here, unlike the normal-completion branch a few lines above it. A fallback `AIMessage` stamped by `LLMErrorHandlingMiddleware` always carries non-empty user-facing text (it's a rendered error explanation, e.g. `"LLM request failed: ..."`), so when the subagent's last turn before hitting `GraphRecursionError` happens to be that fallback, `usable_partial` is set to the fallback text and the run is classified `COMPLETED` — the exact bug #4042 fixed for the normal-completion path, still present on this one.

## The fix

Consult `_extract_llm_error_fallback` in this except-block too, before falling back to the raw-text scan, and classify `FAILED` with the same `stop_reason` (`turn_capped`, or a guard's reason if one already fired) the block already computes for its other branches:

```python
llm_error = _extract_llm_error_fallback(final_state)
if llm_error is not None:
    result.try_set_terminal(
        SubagentStatus.FAILED,
        error=llm_error,
        stop_reason=stop_reason,
        token_usage_records=records,
    )
else:
    messages = (final_state or {}).get("messages", [])
    usable_partial: str | None = None
    ...
```

Same contract #4042 established for the normal-completion path — only the structured marker is authoritative, ordinary error-looking prose without it still counts as a completed result — just applied to the second terminalization path that missed it.

## Tests

Adds `test_aexecute_recursion_error_with_llm_error_fallback_surfaces_failed`: streams a fallback `AIMessage` (`additional_kwargs={"deerflow_error_fallback": True, ...}`) and then raises `GraphRecursionError` on the next step, mirroring the existing `test_aexecute_recursion_error_with_partial_surfaces_completed_turn_capped` fixture style.

Verified fail-before / pass-after: the test asserts `SubagentStatus.FAILED`; without the fix it gets `COMPLETED` with the fallback text as `result.result` and `result.error is None`, and passes with the fix.

```
cd backend && PYTHONPATH=. pytest tests/test_subagent_executor.py tests/test_task_tool_core_logic.py tests/test_subagent_status_contract.py -q
```

128 passed (the same three suites #4042 validated with, plus this PR's new test).

`ruff format --check --line-length 240` and `ruff check --line-length 240` are clean on the changed files.
