### PR TITLE
fix(skills): close AST literal-only shell=True bypass in SkillScan

### DIFF
--- a/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
+++ b/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
@@ -369,7 +369,7 @@ def _scan_python(rel_path: str, text: str) -> list[SecurityFinding]:
         call_name = _python_call_name(node, aliases)
         if call_name in {"eval", "exec"} or (call_name == "compile" and _compile_mode_is_exec(node)):
             findings.append(_finding_for_node("python-dynamic-exec", rel_path, node, call_name))
-        elif call_name in {"os.system", "os.popen"} or (call_name.startswith("subprocess.") and _call_has_shell_true(node)):
+        elif call_name in {"os.system", "os.popen"} or (call_name.startswith("subprocess.") and _call_shell_may_be_true(node)):
             findings.append(_finding_for_node("python-shell-exec", rel_path, node, call_name))
         elif call_name.startswith("subprocess."):
             findings.append(_finding_for_node("python-subprocess", rel_path, node, call_name))
@@ -649,8 +649,18 @@ def _compile_mode_is_exec(node: ast.Call) -> bool:
     return any(keyword.arg == "mode" and isinstance(keyword.value, ast.Constant) and keyword.value.value == "exec" for keyword in node.keywords)
 
 
-def _call_has_shell_true(node: ast.Call) -> bool:
-    return any(keyword.arg == "shell" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True for keyword in node.keywords)
+def _call_shell_may_be_true(node: ast.Call) -> bool:
+    # Fail closed on ambiguity: a ``shell=`` keyword is only safe when it is a
+    # literal, statically-provable ``False``. Any other value under that keyword,
+    # the literal ``True``, any other literal, or a non-literal expression such as
+    # a variable or a function call (``shell=shell_flag``, ``shell=bool(1)``),
+    # cannot be proven safe by static analysis, so it is treated the same as an
+    # explicit ``shell=True`` rather than silently falling through to the
+    # non-blocking ``python-subprocess`` classification.
+    for keyword in node.keywords:
+        if keyword.arg == "shell":
+            return not (isinstance(keyword.value, ast.Constant) and keyword.value.value is False)
+    return False
 
 
 def _call_is_network_sink(call_name: str) -> bool:

--- a/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
+++ b/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
@@ -658,6 +658,15 @@ def _call_shell_may_be_true(node: ast.Call) -> bool:
     # explicit ``shell=True`` rather than silently falling through to the
     # non-blocking ``python-subprocess`` classification.
     for keyword in node.keywords:
+        if keyword.arg is None:
+            # ``**mapping`` / ``**kwargs`` unpacking: represented in the AST as a
+            # keyword with ``arg is None``. The mapping's contents (and whether it
+            # even carries a ``shell`` key) are not knowable by static analysis, so
+            # this fails closed the same as a variable/expression shell= value.
+            # Deliberate, documented over-block: a harmless kwargs-unpack with no
+            # ``shell`` key also blocks, since the alternative (inspecting the
+            # unpacked mapping's contents) is not generally possible statically.
+            return True
         if keyword.arg == "shell":
             return not (isinstance(keyword.value, ast.Constant) and keyword.value.value is False)
     return False

--- a/backend/tests/test_skillscan_native.py
+++ b/backend/tests/test_skillscan_native.py
@@ -189,6 +189,55 @@ def test_python_subprocess_shell_via_expression_blocks(tmp_path: Path) -> None:
     assert _finding_by_rule(excinfo.value.findings, "python-shell-exec")["severity"] == "CRITICAL"
 
 
+def test_python_subprocess_shell_via_kwargs_unpacking_blocks(tmp_path: Path) -> None:
+    # A ``**``-unpacked mapping can carry a ``shell=True`` key that is invisible
+    # to a plain ``keyword.arg == "shell"`` scan: in the AST, a ``**mapping``
+    # argument is represented as a keyword with ``arg is None``. Its effect is
+    # statically indistinguishable from a literal ``shell=True``, so it must be
+    # classified and blocked the same way, not silently downgraded to the
+    # non-blocking python-subprocess warning.
+    skill_dir = tmp_path / "demo-skill"
+    _write_skill(skill_dir)
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text(
+        "import subprocess\nopts = {'shell': True}\nsubprocess.run(['whoami'], **opts)\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_skill_dir(skill_dir)["findings"]
+
+    assert _finding_by_rule(findings, "python-shell-exec")["severity"] == "CRITICAL"
+    assert not [item for item in findings if item["rule_id"] == "python-subprocess"]
+
+    with pytest.raises(StaticScanBlockedError) as excinfo:
+        enforce_static_scan(skill_dir, skill_name="demo-skill")
+    assert _finding_by_rule(excinfo.value.findings, "python-shell-exec")["severity"] == "CRITICAL"
+
+
+def test_python_subprocess_kwargs_unpacking_without_shell_key_still_blocks(tmp_path: Path) -> None:
+    # Known, deliberate over-block, documented here rather than in a code
+    # comment alone: a ``**``-unpacked mapping that provably carries no
+    # ``shell`` key (only ``check`` below) is still treated as shell-ambiguous
+    # and blocked, because what a ``**``-unpacked mapping contains is not
+    # knowable by static analysis in general. Failing closed on every
+    # ``**``-unpack is the conservative, defensible choice over trying to
+    # inspect the unpacked mapping's contents.
+    skill_dir = tmp_path / "demo-skill"
+    _write_skill(skill_dir)
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text(
+        "import subprocess\nopts = {'check': True}\nsubprocess.run(['whoami'], **opts)\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_skill_dir(skill_dir)["findings"]
+
+    assert _finding_by_rule(findings, "python-shell-exec")["severity"] == "CRITICAL"
+    assert not [item for item in findings if item["rule_id"] == "python-subprocess"]
+
+
 def test_cloud_metadata_access_is_reported_by_one_rule(tmp_path: Path) -> None:
     skill_dir = tmp_path / "demo-skill"
     _write_skill(skill_dir)

--- a/backend/tests/test_skillscan_native.py
+++ b/backend/tests/test_skillscan_native.py
@@ -132,6 +132,63 @@ def test_python_subprocess_without_shell_warns(tmp_path: Path) -> None:
     assert not [item for item in findings if item["severity"] == "CRITICAL"]
 
 
+def test_python_subprocess_shell_false_literal_warns_not_block(tmp_path: Path) -> None:
+    skill_dir = tmp_path / "demo-skill"
+    _write_skill(skill_dir)
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text("import subprocess\nsubprocess.run(['whoami'], shell=False)\n", encoding="utf-8")
+
+    findings = scan_skill_dir(skill_dir)["findings"]
+
+    finding = _finding_by_rule(findings, "python-subprocess")
+    assert finding["severity"] == "HIGH"
+    assert not [item for item in findings if item["severity"] == "CRITICAL"]
+
+
+def test_python_subprocess_shell_via_variable_blocks(tmp_path: Path) -> None:
+    # A non-literal shell= value (a variable) is statically indistinguishable
+    # from shell=True in its effect at runtime, so it must be classified and
+    # blocked the same way, not silently downgraded to the non-blocking
+    # python-subprocess warning.
+    skill_dir = tmp_path / "demo-skill"
+    _write_skill(skill_dir)
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text(
+        "import subprocess\nshell_flag = True\nsubprocess.run(['whoami'], shell=shell_flag)\n",
+        encoding="utf-8",
+    )
+
+    findings = scan_skill_dir(skill_dir)["findings"]
+
+    assert _finding_by_rule(findings, "python-shell-exec")["severity"] == "CRITICAL"
+    assert not [item for item in findings if item["rule_id"] == "python-subprocess"]
+
+    with pytest.raises(StaticScanBlockedError) as excinfo:
+        enforce_static_scan(skill_dir, skill_name="demo-skill")
+    assert _finding_by_rule(excinfo.value.findings, "python-shell-exec")["severity"] == "CRITICAL"
+
+
+def test_python_subprocess_shell_via_expression_blocks(tmp_path: Path) -> None:
+    # Same bypass shape as the variable case above, but via a call expression
+    # (shell=bool(1)) instead of a bare name.
+    skill_dir = tmp_path / "demo-skill"
+    _write_skill(skill_dir)
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text("import subprocess\nsubprocess.run(['whoami'], shell=bool(1))\n", encoding="utf-8")
+
+    findings = scan_skill_dir(skill_dir)["findings"]
+
+    assert _finding_by_rule(findings, "python-shell-exec")["severity"] == "CRITICAL"
+    assert not [item for item in findings if item["rule_id"] == "python-subprocess"]
+
+    with pytest.raises(StaticScanBlockedError) as excinfo:
+        enforce_static_scan(skill_dir, skill_name="demo-skill")
+    assert _finding_by_rule(excinfo.value.findings, "python-shell-exec")["severity"] == "CRITICAL"
+
+
 def test_cloud_metadata_access_is_reported_by_one_rule(tmp_path: Path) -> None:
     skill_dir = tmp_path / "demo-skill"
     _write_skill(skill_dir)


### PR DESCRIPTION
## Summary

SkillScan's Python analyzer only classifies a `subprocess.*(...)` call as the CRITICAL, hard-blocked `python-shell-exec` rule when its `shell=` keyword is the literal AST constant `True`. Any other value that behaves identically at runtime - a variable or a call expression - falls through to the HIGH, non-blocking `python-subprocess` classification instead, which is reviewed only by the probabilistic LLM scanner rather than being hard-blocked by `enforce_static_scan`.

## The bug

`_scan_python()` decides the rule for a `subprocess.*` call like this:

```python
elif call_name in {"os.system", "os.popen"} or (call_name.startswith("subprocess.") and _call_has_shell_true(node)):
    findings.append(_finding_for_node("python-shell-exec", rel_path, node, call_name))
elif call_name.startswith("subprocess."):
    findings.append(_finding_for_node("python-subprocess", rel_path, node, call_name))
```

and the old `_call_has_shell_true()` only matched a literal:

```python
def _call_has_shell_true(node: ast.Call) -> bool:
    return any(keyword.arg == "shell" and isinstance(keyword.value, ast.Constant) and keyword.value.value is True for keyword in node.keywords)
```

`isinstance(keyword.value, ast.Constant)` is `False` for a `Name` node or a `Call` node, so:

```python
shell_flag = True
subprocess.run(cmd, shell=shell_flag)   # -> python-subprocess (HIGH, not blocked)

subprocess.run(cmd, shell=bool(1))      # -> python-subprocess (HIGH, not blocked)
```

both classify as the non-blocking `python-subprocess` HIGH finding instead of `python-shell-exec` CRITICAL, even though both execute through the shell exactly like `shell=True` at runtime. `enforce_static_scan()` only raises `StaticScanBlockedError` on `CRITICAL` findings, so a skill using either form installs and runs without ever hitting the deterministic gate - the whole point of a static, hard-blocking check is defeated by a one-line indirection.

## The fix

`_call_has_shell_true` is renamed to `_call_shell_may_be_true` and inverts the check to fail closed on ambiguity: a `shell=` keyword is only safe when it is the literal, statically-provable constant `False`; any other value under that keyword (`True`, any other literal, or a non-literal expression) is treated the same as `shell=True`. A call with no `shell=` keyword at all is unaffected, since `subprocess.*` already defaults to `shell=False` in that form.

```python
def _call_shell_may_be_true(node: ast.Call) -> bool:
    for keyword in node.keywords:
        if keyword.arg == "shell":
            return not (isinstance(keyword.value, ast.Constant) and keyword.value.value is False)
    return False
```

The lookup stays scoped to the `shell=` keyword of the specific `Call` node already gated by `call_name.startswith("subprocess.")`, so it cannot pick up unrelated `shell=` usage elsewhere (dict literals, kwargs on non-subprocess calls, etc.).

## Tests

Adds to `backend/tests/test_skillscan_native.py`:
- `test_python_subprocess_shell_via_variable_blocks` - `shell=shell_flag` (`shell_flag = True` assigned nearby) now classifies as `python-shell-exec` / CRITICAL and `enforce_static_scan` raises.
- `test_python_subprocess_shell_via_expression_blocks` - `shell=bool(1))` likewise.
- `test_python_subprocess_shell_false_literal_warns_not_block` - locks in that literal `shell=False` still classifies as the non-blocking `python-subprocess` HIGH finding, so the fix doesn't over-block legitimate `shell=False` usage.

Verified fail-before / pass-after: with the fix reverted, the two bypass tests fail (`python-shell-exec` missing from findings, `enforce_static_scan` does not raise); with the fix applied, both pass. The existing literal `shell=True` coverage in `test_enforce_static_scan_blocks_only_critical_findings` continues to pass unchanged, as does `test_python_subprocess_without_shell_warns` (no `shell=` keyword at all still warns, not blocks) and `test_bundled_public_skills_have_no_critical_findings` (no false positives on the real bundled skills). Full file: `24 passed`.

```
cd backend && PYTHONPATH=. pytest tests/test_skillscan_native.py
```

`ruff check --line-length 240` and `ruff format --check --line-length 240` are clean on both changed files.
