### PR TITLE
fix(sandbox): use os.sep in reverse-resolve containment check on Windows

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -344,9 +344,20 @@ class LocalSandbox(Sandbox):
         # Try each mapping (longest local path first for more specific matches)
         for mapping in self._mappings_by_local_specificity:
             local_path_resolved = self._resolved_local_paths[mapping]
-            if path_str == local_path_resolved or path_str.startswith(local_path_resolved + "/"):
-                # Replace the local path prefix with container path
-                relative = path_str[len(local_path_resolved) :].lstrip("/")
+            # ``Path.resolve()`` always renders with the native separator
+            # (backslash on Windows), regardless of the forward-slash
+            # normalization above, so the containment check must compare with
+            # ``os.sep`` here too -- mirroring ``_is_read_only_path`` -- instead
+            # of a hardcoded "/". A hardcoded "/" can never match a
+            # backslash-joined nested path on Windows, so every nested path
+            # silently fell through to the "no mapping found" branch below and
+            # leaked the raw host path (real username, full directory tree).
+            if path_str == local_path_resolved or path_str.startswith(local_path_resolved + os.sep):
+                # Replace the local path prefix with container path. Container
+                # paths are always POSIX-style, so the extracted relative
+                # portion (native-separated on Windows) is normalized to
+                # forward slashes before being spliced in.
+                relative = path_str[len(local_path_resolved) :].lstrip(os.sep).replace(os.sep, "/")
                 resolved = f"{mapping.container_path}/{relative}" if relative else mapping.container_path
                 return resolved
 
@@ -650,8 +661,14 @@ class LocalSandbox(Sandbox):
             # 2. It is NOT already present in the result (was skipped by list_dir)
             if mapping.container_path.startswith(container_path + "/"):
                 child_rel = mapping.container_path[len(container_path) + 1 :]
-                # Only direct children (no further slashes), e.g. "public", "custom"
-                if "/" not in child_rel and child_rel not in existing_dirs:
+                # Only direct children (no further slashes), e.g. "public", "custom".
+                # Compare the mapping's full container path -- not the bare child
+                # name -- against existing_dirs, which holds full paths (e.g.
+                # "/mnt/user-data/workspace"). Comparing the bare name here would
+                # never match, so an already-listed mount (the common case: real
+                # nested workspace/uploads/outputs subdirectories under
+                # /mnt/user-data) would be appended a second time.
+                if "/" not in child_rel and mapping.container_path.rstrip("/") not in existing_dirs:
                     # Verify the host path exists so we don't add phantom entries
                     try:
                         if Path(mapping.local_path).resolve().is_dir():

--- a/backend/tests/test_local_sandbox_path_regex_cache.py
+++ b/backend/tests/test_local_sandbox_path_regex_cache.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from deerflow.sandbox.local import local_sandbox as local_sandbox_module
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 
 
@@ -133,6 +134,61 @@ def test_reverse_resolve_translates_a_bare_root_at_end_of_output(tmp_path, prefi
 
     assert out == f"{prefix}/mnt/skills"
     assert skills_local not in out
+
+
+def test_reverse_resolve_path_matches_windows_backslash_containment(monkeypatch):
+    """Regression for the os.sep containment fix in ``_reverse_resolve_path``.
+
+    ``Path.resolve()`` always renders with the native separator (backslash on
+    Windows). The containment check used to hardcode a ``"/"`` suffix, so a
+    backslash-joined nested path could never satisfy
+    ``path_str.startswith(local_path_resolved + "/")`` on Windows and silently
+    fell through to the "no mapping found" branch, leaking the raw host path
+    (real username, full directory tree) instead of the virtual
+    ``/mnt/user-data/...`` path.
+
+    CI runs only on ``ubuntu-latest`` (``os.sep == "/"``), where the pre-fix and
+    post-fix code are observationally identical -- neither the hardcoded ``"/"``
+    nor ``os.sep`` behave any differently there, so a test that just calls
+    ``_reverse_resolve_path`` on real POSIX paths cannot discriminate. To force
+    the Windows code path independent of host OS, ``os.sep`` is monkeypatched to
+    ``"\\"`` and both the module's ``Path`` name and the sandbox's cached
+    ``_resolved_local_paths`` are stubbed to return backslash-joined strings --
+    exactly what real ``WindowsPath.resolve()`` produces -- without touching the
+    real filesystem or requiring an actual Windows host.
+    """
+    sb = LocalSandbox(
+        id="windows-sep-test",
+        path_mappings=[
+            PathMapping(container_path="/mnt/user-data/workspace", local_path="C:\\Users\\test\\workspace"),
+        ],
+    )
+    mapping = sb.path_mappings[0]
+
+    monkeypatch.setattr(local_sandbox_module.os, "sep", "\\")
+    # Bypass the real (POSIX) filesystem resolution this cached_property would
+    # otherwise perform and pin it directly to the Windows-resolved root.
+    sb._resolved_local_paths = {mapping: "C:\\Users\\test\\workspace"}
+
+    class _FakeWindowsPath:
+        """Stand-in for ``Path`` inside ``_reverse_resolve_path``. Mimics
+        ``WindowsPath.resolve()`` -- a backslash-joined ``str()`` -- without
+        touching the real filesystem, so this runs identically on Linux CI."""
+
+        def __init__(self, raw: str) -> None:
+            self._raw = raw
+
+        def resolve(self) -> _FakeWindowsPath:
+            return _FakeWindowsPath(self._raw.replace("/", "\\"))
+
+        def __str__(self) -> str:
+            return self._raw
+
+    monkeypatch.setattr(local_sandbox_module, "Path", _FakeWindowsPath)
+
+    result = sb._reverse_resolve_path("C:\\Users\\test\\workspace\\sub\\f.txt")
+
+    assert result == "/mnt/user-data/workspace/sub/f.txt"
 
 
 def test_resolved_paths_and_sorted_views_are_cached(tmp_path):

--- a/backend/tests/test_local_sandbox_virtual_path_contract.py
+++ b/backend/tests/test_local_sandbox_virtual_path_contract.py
@@ -143,6 +143,31 @@ def test_execute_command_lists_aggregate_user_data_root(provider):
     assert "outputs" in output
 
 
+def test_list_dir_on_user_data_root_does_not_duplicate_subdir_mounts(provider):
+    """Regression: ``list_dir``'s virtual sub-directory overlay must not
+    double-list a mount that the underlying scan already found.
+
+    The overlay compared a bare child name (e.g. "workspace") against
+    ``existing_dirs``, which holds full container paths (e.g.
+    "/mnt/user-data/workspace") -- so the containment guard never matched and
+    each of workspace/uploads/outputs (real nested subdirectories the plain
+    scan already discovers) was appended a second time.
+    """
+    sandbox_id = provider.acquire("alpha")
+    sbx = provider.get(sandbox_id)
+    # Touch all three subdirs so they materialise on disk and are found by the
+    # underlying (non-overlay) directory scan.
+    sbx.write_file("/mnt/user-data/workspace/.keep", "")
+    sbx.write_file("/mnt/user-data/uploads/.keep", "")
+    sbx.write_file("/mnt/user-data/outputs/.keep", "")
+
+    entries = sbx.list_dir("/mnt/user-data")
+
+    for subdir in ("workspace", "uploads", "outputs"):
+        matches = [e for e in entries if e.rstrip("/") == f"/mnt/user-data/{subdir}"]
+        assert len(matches) == 1, f"{subdir} listed {len(matches)} time(s), expected exactly 1: {entries}"
+
+
 def test_update_file_with_virtual_path_for_remote_sync_scenario(provider):
     """This is the exact code path used by ``uploads.py:282`` and ``feishu.py:389``.
 


### PR DESCRIPTION
## Summary

`LocalSandbox._reverse_resolve_path` leaks the raw host path (real username, full directory tree) instead of the virtual `/mnt/user-data/...` path on Windows, for any nested path. This function backs `list_dir`, `glob`, `grep`, and bash-output masking.

## The bug

```python
normalized_path = path.replace("\\", "/")
path_str = str(Path(normalized_path).resolve())

for mapping in self._mappings_by_local_specificity:
    local_path_resolved = self._resolved_local_paths[mapping]
    if path_str == local_path_resolved or path_str.startswith(local_path_resolved + "/"):
        ...
```

`Path.resolve()` always renders with the native separator regardless of the forward-slash normalization a few lines above -- on Windows that's a backslash. `local_path_resolved` (`_resolved_local_paths`, also built via `Path(...).resolve()`) is backslash-separated too. So the containment check's hardcoded `+ "/"` can never match: `path_str.startswith(local_path_resolved + "/")` compares a backslash-joined string against a forward-slash-suffixed prefix. Only the exact-root case (`path_str == local_path_resolved`, no separator involved) ever matches. Every nested path falls through to `return path_str` at the bottom, returning the raw host path.

`_is_read_only_path` does the equivalent containment check correctly, via `os.sep`:

```python
if resolved == local_resolved or resolved.startswith(local_resolved + os.sep):
```

## The fix

Align `_reverse_resolve_path` with `_is_read_only_path`'s pattern: compare with `os.sep` instead of a hardcoded `"/"`. Since the extracted relative portion is native-separated on Windows but container paths are always POSIX-style, it's additionally normalized to forward slashes before being spliced into the result:

```python
if path_str == local_path_resolved or path_str.startswith(local_path_resolved + os.sep):
    relative = path_str[len(local_path_resolved) :].lstrip(os.sep).replace(os.sep, "/")
    resolved = f"{mapping.container_path}/{relative}" if relative else mapping.container_path
    return resolved
```

On POSIX `os.sep == "/"`, so this is behavior-identical there.

## Same-file cosmetic bug (`list_dir` overlay)

While auditing this function I found `list_dir`'s "virtual sub-directory overlay" (added to backfill mount children that the underlying scan skips) has a related but separate bug:

```python
existing_dirs = {e.rstrip("/") for e in result if e.endswith("/")}
for mapping in self.path_mappings:
    if mapping.container_path.startswith(container_path + "/"):
        child_rel = mapping.container_path[len(container_path) + 1 :]
        if "/" not in child_rel and child_rel not in existing_dirs:
            ...
            result.append(f"{mapping.container_path}/")
```

`existing_dirs` holds full container paths (e.g. `/mnt/user-data/workspace`), but `child_rel` is the bare child name (e.g. `workspace`). The comparison never matches, so the "already listed" guard is a no-op. For the standard `/mnt/user-data` mount (aggregate parent + workspace/uploads/outputs as real nested subdirectories, all found by the plain scan), each of the three gets appended a second time by the overlay. Fixed by comparing the mapping's full container path instead of the bare name.

## Context

Same separator-bug class already fixed in this file by #3869 (forward-direction command-string resolution) and #4035 (reverse-direction regex segment boundary). Neither touches this containment check -- #3869 fixes `_resolve_paths_in_command`, and #4035 fixes which substring `_reverse_output_patterns` extracts from output, not what `_reverse_resolve_path` does with it once extracted.

## Tests

Fail-before / pass-after, on the pre-existing suite (no mocking -- real per-thread `LocalSandboxProvider` mappings and real filesystem paths):

- `tests/test_local_sandbox_virtual_path_contract.py::test_list_dir_via_public_api_with_virtual_path`, `test_glob_with_virtual_path`, `test_grep_with_virtual_path` -- all failed before (host path leaked, e.g. `matches[0].path` was `C:\Users\...\workspace\findme.txt` instead of ending in `/mnt/user-data/workspace/findme.txt`), pass after.
- `tests/test_local_sandbox_path_regex_cache.py::test_reverse_resolve_output_maps_local_back_to_container` and the `\win\p` case of `test_reverse_resolve_still_matches_root_before_non_slash_boundaries` -- same failure shape, pass after.

Added `test_list_dir_on_user_data_root_does_not_duplicate_subdir_mounts` for the overlay bug (no existing test called `list_dir` on the aggregate `/mnt/user-data` parent directly); confirmed it fails with `workspace listed 2 time(s)` etc. against the old comparison and passes with the fix.

Full `test_local_sandbox_virtual_path_contract.py` + `test_local_sandbox_path_regex_cache.py`: 45 tests, 43 passed. The remaining 2 (`test_command_paths_resolved_to_local`, `test_forward_resolution_behavior_unchanged`) fail identically with or without this change -- they assert forward-direction (`_resolve_path`/`_resolve_paths_in_command`) output against a hardcoded expected string built from a native-separator `tmp_path`, unrelated to the reverse-direction code this PR touches.

`ruff check` and `ruff format --check` are clean on both changed files.