### PR TITLE
fix(guardrails): empty allowlist must deny all tools instead of failing open

### DIFF
--- a/backend/packages/harness/deerflow/guardrails/builtin.py
+++ b/backend/packages/harness/deerflow/guardrails/builtin.py
@@ -9,7 +9,11 @@ class AllowlistProvider:
     name = "allowlist"
 
     def __init__(self, *, allowed_tools: list[str] | None = None, denied_tools: list[str] | None = None):
-        self._allowed = set(allowed_tools) if allowed_tools else None
+        # Distinguish "no allowlist configured" (None -> allow all) from an
+        # explicitly empty allowlist ([] -> allow nothing). A truthiness test
+        # would collapse [] into None and fail open, letting every tool through
+        # when the operator intended to permit none.
+        self._allowed = set(allowed_tools) if allowed_tools is not None else None
         self._denied = set(denied_tools) if denied_tools else set()
 
     def evaluate(self, request: GuardrailRequest) -> GuardrailDecision:

--- a/backend/tests/test_guardrail_middleware.py
+++ b/backend/tests/test_guardrail_middleware.py
@@ -114,6 +114,19 @@ class TestAllowlistProvider:
         decision = provider.evaluate(req)
         assert decision.allow is True
 
+    def test_empty_allowlist_blocks_all(self):
+        """An explicitly empty allowlist means "permit no tools" and must fail closed.
+
+        Regression test: a truthiness check would collapse ``[]`` into the
+        ``None`` sentinel ("no allowlist -> allow all"), silently letting every
+        tool through when the operator intended to permit none.
+        """
+        provider = AllowlistProvider(allowed_tools=[])
+        for tool in ("bash", "web_search", "read_file"):
+            decision = provider.evaluate(GuardrailRequest(tool_name=tool, tool_input={}))
+            assert decision.allow is False, f"empty allowlist should block {tool!r}"
+            assert decision.reasons[0].code == "oap.tool_not_allowed"
+
     def test_both_allowed_and_denied(self):
         provider = AllowlistProvider(allowed_tools=["bash", "web_search"], denied_tools=["bash"])
         # bash is in both: allowlist passes, denylist blocks


### PR DESCRIPTION
## Summary

`AllowlistProvider` treats an explicitly empty allow-list (`allowed_tools: []`) as if **no** allow-list were configured, which fails **open** and permits every tool — the opposite of the operator's intent to permit none.

## Root cause

`backend/packages/harness/deerflow/guardrails/builtin.py`

```python
self._allowed = set(allowed_tools) if allowed_tools else None
```

`None` is the sentinel meaning "no allow-list → allow all" (used in `evaluate`: `if self._allowed is not None and request.tool_name not in self._allowed`). The truthiness test `if allowed_tools` collapses an empty list `[]` into that same `None` sentinel, so an allow-list that should permit **nothing** instead permits **everything**.

Provider config flows straight through as kwargs (`GuardrailProviderConfig.config` -> provider `__init__`), so a locked-down configuration such as:

```yaml
guardrails:
  enabled: true
  provider:
    use: deerflow.guardrails.builtin:AllowlistProvider
    config:
      allowed_tools: []
```

silently authorizes all tool calls.

`denied_tools` is unaffected: for a deny-list both `None` and `[]` correctly mean "deny nothing", so `set()` is the right normalization there.

## Fix

```python
self._allowed = set(allowed_tools) if allowed_tools is not None else None
```

An explicit empty list now becomes an empty `set()` ("allow-list present, permits nothing"), while an omitted list stays `None` ("no allow-list, allow all").

## Verification

- Reproduced the fail-open and confirmed the fix by executing the exact `AllowlistProvider` / `provider.py` source in isolation:
  - before: `AllowlistProvider(allowed_tools=[])` allows `bash` (internal `_allowed` is `None`)
  - after: it denies `bash`, `web_search`, `read_file` with code `oap.tool_not_allowed`
  - no regression: `AllowlistProvider()` still allows all; a non-empty allow-list still allows only listed tools; deny-list behavior unchanged
- `python -m py_compile` passes on both changed files.
- Added regression test `TestAllowlistProvider.test_empty_allowlist_blocks_all`. Its assertions were executed against the real (fixed) provider source; the full `test_guardrail_middleware.py` module was not run end-to-end in this environment because `langchain`/`langgraph` (imported by the middleware) are not installed here.
