### PR TITLE
fix(frontend): avoid highlighting code while streaming

### DIFF
--- a/frontend/src/components/workspace/messages/markdown-content.tsx
+++ b/frontend/src/components/workspace/messages/markdown-content.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { type ComponentProps, type ReactNode, useMemo } from "react";
+import {
+  createContext,
+  type ComponentProps,
+  isValidElement,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from "react";
 
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
 import {
@@ -22,26 +29,48 @@ export type MarkdownContentProps = {
 };
 
 type StreamingCodeProps = ComponentProps<"code"> & {
-  node?: {
-    position?: {
-      start: { line: number };
-      end: { line: number };
-    };
-  };
+  node?: unknown;
   children?: ReactNode;
 };
+
+const StreamingCodeBlockContext = createContext(false);
+
+function StreamingPre({ children }: ComponentProps<"pre">) {
+  const childClassName = isValidElement<{ className?: string }>(children)
+    ? children.props.className
+    : undefined;
+  const language =
+    /(?:^|\s)language-([^\s]+)/.exec(childClassName ?? "")?.[1] ?? "";
+
+  return (
+    <div
+      className="my-4 w-full overflow-hidden rounded-xl border"
+      data-language={language}
+      data-streaming-code-block="true"
+    >
+      {language && (
+        <div className="bg-muted/80 text-muted-foreground p-3 text-xs">
+          <span className="ml-1 font-mono lowercase">{language}</span>
+        </div>
+      )}
+      <pre className="bg-muted/40 overflow-x-auto border-t p-4 font-mono text-xs">
+        <StreamingCodeBlockContext.Provider value={true}>
+          {children}
+        </StreamingCodeBlockContext.Provider>
+      </pre>
+    </div>
+  );
+}
 
 function StreamingCode({
   children,
   className,
-  node,
+  node: _node,
   ...props
 }: StreamingCodeProps) {
-  const isInline =
-    node?.position?.start.line === node?.position?.end.line &&
-    !className?.includes("language-");
+  const isBlock = useContext(StreamingCodeBlockContext);
 
-  if (isInline) {
+  if (!isBlock) {
     return (
       <code
         {...props}
@@ -56,24 +85,10 @@ function StreamingCode({
     );
   }
 
-  const language = /(?:^|\s)language-([^\s]+)/.exec(className ?? "")?.[1] ?? "";
   return (
-    <div
-      className="my-4 w-full overflow-hidden rounded-xl border"
-      data-language={language}
-      data-streaming-code-block="true"
-    >
-      {language && (
-        <div className="bg-muted/80 text-muted-foreground p-3 text-xs">
-          <span className="ml-1 font-mono lowercase">{language}</span>
-        </div>
-      )}
-      <pre className="bg-muted/40 overflow-x-auto border-t p-4 font-mono text-xs">
-        <code {...props} className={className}>
-          {children}
-        </code>
-      </pre>
-    </div>
+    <code {...props} className={className}>
+      {children}
+    </code>
   );
 }
 
@@ -105,7 +120,8 @@ export function MarkdownContent({
     }
     return {
       ...baseComponents,
-      code: StreamingCode,
+      code: componentsFromProps?.code ?? StreamingCode,
+      pre: componentsFromProps?.pre ?? StreamingPre,
     };
   }, [componentsFromProps, isLoading]);
 

--- a/frontend/src/components/workspace/messages/markdown-content.tsx
+++ b/frontend/src/components/workspace/messages/markdown-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { type ComponentProps, type ReactNode, useMemo } from "react";
 
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
 import {
@@ -8,6 +8,7 @@ import {
   streamdownPluginsWithoutRawHtml,
 } from "@/core/streamdown";
 import { SafeMessageResponse } from "@/core/streamdown/components";
+import { cn } from "@/lib/utils";
 
 import { createMarkdownLinkComponent } from "./markdown-link";
 
@@ -19,6 +20,62 @@ export type MarkdownContentProps = {
   remarkPlugins?: ClipboardSafeStreamdownProps["remarkPlugins"];
   components?: ClipboardSafeStreamdownProps["components"];
 };
+
+type StreamingCodeProps = ComponentProps<"code"> & {
+  node?: {
+    position?: {
+      start: { line: number };
+      end: { line: number };
+    };
+  };
+  children?: ReactNode;
+};
+
+function StreamingCode({
+  children,
+  className,
+  node,
+  ...props
+}: StreamingCodeProps) {
+  const isInline =
+    node?.position?.start.line === node?.position?.end.line &&
+    !className?.includes("language-");
+
+  if (isInline) {
+    return (
+      <code
+        {...props}
+        className={cn(
+          "bg-muted rounded px-1.5 py-0.5 font-mono text-sm",
+          className,
+        )}
+        data-streaming-inline-code="true"
+      >
+        {children}
+      </code>
+    );
+  }
+
+  const language = /(?:^|\s)language-([^\s]+)/.exec(className ?? "")?.[1] ?? "";
+  return (
+    <div
+      className="my-4 w-full overflow-hidden rounded-xl border"
+      data-language={language}
+      data-streaming-code-block="true"
+    >
+      {language && (
+        <div className="bg-muted/80 text-muted-foreground p-3 text-xs">
+          <span className="ml-1 font-mono lowercase">{language}</span>
+        </div>
+      )}
+      <pre className="bg-muted/40 overflow-x-auto border-t p-4 font-mono text-xs">
+        <code {...props} className={className}>
+          {children}
+        </code>
+      </pre>
+    </div>
+  );
+}
 
 /** Renders markdown content. */
 export function MarkdownContent({
@@ -39,11 +96,18 @@ export function MarkdownContent({
     return [...base, ...extra] as ClipboardSafeStreamdownProps["rehypePlugins"];
   }, [rehypePlugins]);
   const components = useMemo(() => {
-    return {
+    const baseComponents = {
       a: createMarkdownLinkComponent(),
       ...componentsFromProps,
     };
-  }, [componentsFromProps]);
+    if (!isLoading) {
+      return baseComponents;
+    }
+    return {
+      ...baseComponents,
+      code: StreamingCode,
+    };
+  }, [componentsFromProps, isLoading]);
 
   if (!content) return null;
 

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
@@ -36,6 +36,13 @@ describe("MarkdownContent streaming code blocks", () => {
     expect(html).not.toContain("data-streaming-code-block");
   });
 
+  it("keeps an unlabeled single-line fence as a block while streaming", () => {
+    const html = renderMarkdown(["```", "x", "```"].join("\n"), true);
+
+    expect(html).toContain("data-streaming-code-block");
+    expect(html).not.toContain('data-streaming-inline-code="true"');
+  });
+
   it("restores Streamdown highlighting after streaming finishes", () => {
     const html = renderMarkdown(
       ["```html", '<main class="report">Hello</main>', "```"].join("\n"),
@@ -60,5 +67,19 @@ describe("MarkdownContent streaming code blocks", () => {
 
     expect(html).toContain('data-custom-link="true"');
     expect(html).toContain('data-custom-image="true"');
+  });
+
+  it("preserves a caller-provided code renderer while streaming", () => {
+    const html = renderMarkdown(
+      ["```html", "<main />", "```"].join("\n"),
+      true,
+      {
+        code: ({ children }) =>
+          createElement("code", { "data-custom-code": true }, children),
+      },
+    );
+
+    expect(html).toContain('data-custom-code="true"');
+    expect(html).toContain("data-streaming-code-block");
   });
 });

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "@rstest/core";
+import { createElement, type ImgHTMLAttributes } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MarkdownContent } from "@/components/workspace/messages/markdown-content";
+
+function renderMarkdown(
+  content: string,
+  isLoading: boolean,
+  components?: Parameters<typeof MarkdownContent>[0]["components"],
+) {
+  return renderToStaticMarkup(
+    createElement(MarkdownContent, { content, isLoading, components }),
+  );
+}
+
+describe("MarkdownContent streaming code blocks", () => {
+  it("renders fenced code without Streamdown highlighting while streaming", () => {
+    const html = renderMarkdown(
+      ["```html", '<main class="report">Hello</main>', "```"].join("\n"),
+      true,
+    );
+
+    expect(html).toContain("data-streaming-code-block");
+    expect(html).toContain('data-language="html"');
+    expect(html).toContain(
+      "&lt;main class=&quot;report&quot;&gt;Hello&lt;/main&gt;",
+    );
+    expect(html).not.toContain('data-streamdown="code-block"');
+  });
+
+  it("keeps inline code inline while streaming", () => {
+    const html = renderMarkdown("Use `const answer = 42` here.", true);
+
+    expect(html).toContain('data-streaming-inline-code="true"');
+    expect(html).not.toContain("data-streaming-code-block");
+  });
+
+  it("restores Streamdown highlighting after streaming finishes", () => {
+    const html = renderMarkdown(
+      ["```html", '<main class="report">Hello</main>', "```"].join("\n"),
+      false,
+    );
+
+    expect(html).toContain('data-streamdown="code-block"');
+    expect(html).not.toContain("data-streaming-code-block");
+  });
+
+  it("preserves custom non-code renderers while streaming", () => {
+    const html = renderMarkdown(
+      "[Docs](https://example.com)\n\n![Chart](chart.png)",
+      true,
+      {
+        a: ({ children, href }) =>
+          createElement("a", { "data-custom-link": true, href }, children),
+        img: (props: ImgHTMLAttributes<HTMLImageElement>) =>
+          createElement("img", { ...props, "data-custom-image": true }),
+      },
+    );
+
+    expect(html).toContain('data-custom-link="true"');
+    expect(html).toContain('data-custom-image="true"');
+  });
+});


### PR DESCRIPTION
Fixes #4061

## Why

During long-running tasks that generate complex HTML reports, the assistant may stream a large fenced code block over many updates.

Previously, every streaming update caused Streamdown to re-render the growing code block and Shiki to regenerate both light and dark syntax-highlighted HTML. When the page returned from a background browser tab, the accumulated rendering work could make the entire DeerFlow workspace unresponsive or appear blank until refreshed.

## What changed

- Render fenced code blocks as lightweight plain `<pre><code>` content while the assistant response is still streaming.
- Preserve inline-code rendering and custom Markdown link/image components during streaming.
- Restore the existing Streamdown and Shiki syntax highlighting after streaming finishes.
- Add regression coverage for streaming fenced code, inline code, completed-response highlighting, and custom renderers.

This does not change response content, backend streaming, task execution, or artifact rendering.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

The original behavior and blank workspace screenshot are available in #4061.

The issue occurs while a long HTML response is actively streaming, so a short before/after recording is more representative than a static screenshot. Manual verification used the original reproduction flow: generate a complex HTML report, switch browser tabs during execution, and return while the response is still streaming.

## Bug fix verification

- Test path that reproduces the bug:
  `frontend/tests/unit/components/workspace/messages/markdown-content.test.ts`
- Did it go red on `main` and green on this branch? **Yes**
- Before the fix, streaming fenced HTML produced Streamdown/Shiki code-block containers. After the fix, streaming uses the lightweight renderer and restores the default highlighted renderer once the response finishes.
- A Docker-based manual reproduction also confirmed that large HTML streaming could make Chrome report the page as unresponsive.

## Validation

Executed:

```bash
cd frontend
pnpm exec rstest tests/unit/components/workspace/messages/markdown-content.test.ts
pnpm test
pnpm format
pnpm check
cd ..
git diff --check

Results:
Targeted regression tests: 4 passed
Full frontend unit suite: 608 passed
Prettier: passed
ESLint: passed
TypeScript: passed
git diff --check: passed