### PR TITLE
fix(sandbox): handle one-sided line ranges in read_file

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1994,8 +1994,15 @@ def read_file_tool(
         content = read_current_file_content(runtime, path)
         if not content:
             return "(empty)"
-        if start_line is not None and end_line is not None:
-            content = "\n".join(content.splitlines()[start_line - 1 : end_line])
+        if start_line is not None or end_line is not None:
+            lines = content.splitlines()
+            s = max(start_line, 1) if start_line is not None else 1
+            e = end_line if end_line is not None else len(lines)
+            if s > len(lines):
+                return "(start_line exceeds file length)"
+            if start_line is not None and end_line is not None and s > e:
+                return "(start_line > end_line — no lines in range)"
+            content = "\n".join(lines[s - 1 : e])
         try:
             from deerflow.config.app_config import get_app_config
 

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1998,9 +1998,11 @@ def read_file_tool(
             lines = content.splitlines()
             s = max(start_line, 1) if start_line is not None else 1
             e = end_line if end_line is not None else len(lines)
+            if e < 1:
+                return "(end_line must be >= 1)"
             if s > len(lines):
                 return "(start_line exceeds file length)"
-            if start_line is not None and end_line is not None and s > e:
+            if s > e:
                 return "(start_line > end_line — no lines in range)"
             content = "\n".join(lines[s - 1 : e])
         try:

--- a/backend/tests/test_read_file_line_range.py
+++ b/backend/tests/test_read_file_line_range.py
@@ -74,3 +74,21 @@ def test_start_line_beyond_eof_returns_clean_error(tmp_path, monkeypatch) -> Non
 def test_both_bounds_still_slice_inclusive_range(tmp_path, monkeypatch) -> None:
     result = _read(tmp_path, monkeypatch, start_line=2, end_line=4)
     assert result == "line2\nline3\nline4"
+
+
+def test_only_end_line_zero_returns_clean_error(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, end_line=0)
+    assert "end_line must be >= 1" in result
+    # No leaked line content in the error.
+    assert "line1" not in result
+
+
+def test_only_end_line_negative_returns_clean_error(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, end_line=-1)
+    assert "end_line must be >= 1" in result
+    assert "line4" not in result
+
+
+def test_end_line_past_eof_clamps_to_last_line(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, end_line=99)
+    assert result == _FIVE_LINES

--- a/backend/tests/test_read_file_line_range.py
+++ b/backend/tests/test_read_file_line_range.py
@@ -1,0 +1,76 @@
+"""read_file tool line-range handling for one-sided (single-bound) ranges.
+
+Previously ``read_file`` only sliced when BOTH ``start_line`` and ``end_line``
+were supplied; a lone ``start_line`` (or lone ``end_line``) was silently ignored
+and the whole file was returned. These tests pin the one-sided range contract:
+tail-from-start, head-to-end, clamping of ``start_line=0``, and clean error
+strings for an inverted range or a start beyond EOF (instead of an empty/garbage
+slice).
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from deerflow.sandbox.local.local_sandbox import LocalSandbox
+from deerflow.sandbox.tools import read_file_tool
+
+_FIVE_LINES = "line1\nline2\nline3\nline4\nline5"
+
+
+def _local_runtime(tmp_path: Path) -> SimpleNamespace:
+    for sub in ("workspace", "uploads", "outputs"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    thread_data = {
+        "workspace_path": str(tmp_path / "workspace"),
+        "uploads_path": str(tmp_path / "uploads"),
+        "outputs_path": str(tmp_path / "outputs"),
+    }
+    return SimpleNamespace(
+        state={"sandbox": {"sandbox_id": "local:t1"}, "thread_data": thread_data},
+        context={"thread_id": "t1"},
+    )
+
+
+def _read(tmp_path, monkeypatch, **kwargs) -> str:
+    runtime = _local_runtime(tmp_path)
+    (tmp_path / "uploads" / "five.txt").write_text(_FIVE_LINES, encoding="utf-8")
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    return read_file_tool.func(
+        runtime=runtime,
+        description="read a line range",
+        path="/mnt/user-data/uploads/five.txt",
+        **kwargs,
+    )
+
+
+def test_only_start_line_returns_tail_from_that_line(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, start_line=3)
+    assert result == "line3\nline4\nline5"
+
+
+def test_only_end_line_returns_head_up_to_that_line(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, end_line=2)
+    assert result == "line1\nline2"
+
+
+def test_start_line_zero_is_clamped_to_first_line(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, start_line=0)
+    assert result == _FIVE_LINES
+
+
+def test_start_line_greater_than_end_line_returns_clean_error(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, start_line=4, end_line=2)
+    assert "start_line > end_line" in result
+    # No garbage slice content leaked into the error.
+    assert "line4" not in result
+
+
+def test_start_line_beyond_eof_returns_clean_error(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, start_line=99)
+    assert "start_line exceeds file length" in result
+
+
+def test_both_bounds_still_slice_inclusive_range(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, start_line=2, end_line=4)
+    assert result == "line2\nline3\nline4"


### PR DESCRIPTION
## Summary
The sandbox `read_file` tool mishandled one-sided line ranges (only a start or only an end bound), returning wrong slices or errors instead of the intuitive open-ended range.

## Problem
Range handling assumed both bounds were present, so `[start:]` and `[:end]` requests were not honored correctly.

## Fix
Handle single-bound ranges explicitly: clamp an open start/end to file bounds, and return a clear error for genuinely invalid ranges, so `read_file` honors `[start:]` and `[:end]` semantics.

## Test
`backend/tests/test_read_file_line_range.py` covers start-only, end-only, and out-of-range cases (6 passed).

TDD: regression tests included per AGENTS.md.
