### PR TITLE
fix(tool_search): remove MAX_RESULTS cap on select: exact-name lookups

### DIFF
--- a/backend/tests/test_deferred_catalog.py
+++ b/backend/tests/test_deferred_catalog.py
@@ -1,4 +1,5 @@
 import pytest
+from langchain_core.tools import StructuredTool
 from langchain_core.tools import tool as as_tool
 
 from deerflow.tools.builtins.tool_search import MAX_RESULTS, DeferredToolCatalog
@@ -123,3 +124,13 @@ def test_hash_changes_with_membership():
     c1 = DeferredToolCatalog((alpha_search, beta_translate))
     c2 = DeferredToolCatalog((alpha_search,))
     assert c1.hash != c2.hash
+
+
+def test_search_select_not_capped_at_max_results():
+    """select: must return ALL requested tools, even when >MAX_RESULTS."""
+    tools = tuple(StructuredTool.from_function(func=lambda q="": q, name=f"tool_{i:02d}", description=f"Tool {i}") for i in range(8))
+    cat = DeferredToolCatalog(tools)
+    names_csv = ",".join(f"tool_{i:02d}" for i in range(8))
+    got = cat.search(f"select:{names_csv}")
+    assert len(got) == 8
+    assert [t.name for t in got] == [f"tool_{i:02d}" for i in range(8)]


### PR DESCRIPTION
## Problem

The `select:` query form in `DeferredToolCatalog.search()` lets the model explicitly name the tools it wants to promote. However, the result was capped at `MAX_RESULTS` (5), silently dropping valid selections when more than 5 deferred tools were requested at once.

For example, `select:tool_a,tool_b,tool_c,tool_d,tool_e,tool_f,tool_g` would only return the first 5, leaving `tool_f` and `tool_g` unfindable without additional `tool_search` calls.

## Fix

- **`DeferredToolCatalog.search()`**: Removed `[:MAX_RESULTS]` slice from the `select:` branch — exact-by-name lookups should return every matched tool.
- **`build_tool_search_tool()`**: Removed redundant `[:MAX_RESULTS]` re-cap after `catalog.search()` — `search()` already caps non-select query forms internally, and the re-cap would re-introduce the select: cap.

## Test

- `test_deferred_catalog.py`: Added `test_search_select_not_capped_at_max_results` — 8 deferred tools, select all 8 by name, verify all 8 returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)