### PR TITLE
fix landing hero background positioning

### DIFF
--- a/frontend/src/components/landing/hero.tsx
+++ b/frontend/src/components/landing/hero.tsx
@@ -32,7 +32,7 @@ export function Hero({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "flex size-full flex-col items-center justify-center",
+        "relative flex size-full flex-col items-center justify-center",
         className,
       )}
     >
@@ -47,7 +47,7 @@ export function Hero({ className }: { className?: string }) {
         />
       </div>
       <FlickeringGrid
-        className="absolute inset-0 z-0 translate-y-8 mask-[url(/images/deer.svg)] mask-size-[100vw] mask-center mask-no-repeat md:mask-size-[72vh]"
+        className="absolute inset-0 z-0 mask-[url(/images/deer.svg)] mask-size-[100vw] mask-center mask-no-repeat md:mask-size-[72vh]"
         squareSize={4}
         gridGap={4}
         color={"white"}


### PR DESCRIPTION
## What changed

- establish the Hero root as the positioning context for its absolute background layers
- remove the vertical translation from the deer-shaped flickering grid

## Why

The absolute Galaxy and FlickeringGrid layers had no positioned Hero ancestor, so they were positioned against a higher containing block. The grid was also shifted downward by `translate-y-8`.

This keeps both background layers aligned to the Hero bounds and centers the deer mask without an extra offset.

## Validation

- `pnpm --dir frontend test` — 604 tests passed
- ESLint on `src/components/landing/hero.tsx`
- Prettier check on `src/components/landing/hero.tsx`
- `pnpm typecheck`
- `git diff --check`
