### PR TITLE
fix(front): stabilize artifact paths during streaming

### DIFF
--- a/frontend/src/components/workspace/messages/message-list.tsx
+++ b/frontend/src/components/workspace/messages/message-list.tsx
@@ -691,6 +691,8 @@ export function MessageList({
     return <MessageListSkeleton />;
   }
 
+  const artifactPaths = extractArtifactsFromThread(thread);
+
   return (
     <>
       <Conversation
@@ -731,7 +733,7 @@ export function MessageList({
                           groupIndex === groupedMessages.length - 1
                         }
                         threadId={threadId}
-                        artifactPaths={extractArtifactsFromThread(thread)}
+                        artifactPaths={artifactPaths}
                         runId={
                           group.type === "assistant"
                             ? (msg as { run_id?: string }).run_id

--- a/frontend/src/core/artifacts/utils.ts
+++ b/frontend/src/core/artifacts/utils.ts
@@ -2,6 +2,8 @@ import { getBackendBaseURL } from "../config";
 import { isStaticWebsiteOnly } from "../static-mode";
 import type { AgentThreadState } from "../threads";
 
+const EMPTY_ARTIFACT_PATHS: readonly string[] = [];
+
 export function urlOfArtifact({
   filepath,
   threadId,
@@ -25,7 +27,7 @@ export function urlOfArtifact({
 export function extractArtifactsFromThread(thread: {
   values: Pick<AgentThreadState, "artifacts">;
 }) {
-  return thread.values.artifacts ?? [];
+  return thread.values.artifacts ?? EMPTY_ARTIFACT_PATHS;
 }
 
 export function resolveArtifactURL(absolutePath: string, threadId: string) {

--- a/frontend/tests/unit/core/artifacts/utils.test.ts
+++ b/frontend/tests/unit/core/artifacts/utils.test.ts
@@ -74,6 +74,19 @@ describe("artifact URL helpers", () => {
     ).toBe("/demo/threads/thread-1/user-data/outputs/style.css");
   });
 
+  test("returns stable artifact path references", async () => {
+    const { extractArtifactsFromThread } = await loadFreshArtifactUtils();
+    const threadWithoutArtifacts = { values: {} };
+    const artifacts = ["/mnt/user-data/outputs/chart.png"];
+
+    expect(extractArtifactsFromThread(threadWithoutArtifacts)).toBe(
+      extractArtifactsFromThread(threadWithoutArtifacts),
+    );
+    expect(extractArtifactsFromThread({ values: { artifacts } })).toBe(
+      artifacts,
+    );
+  });
+
   test("resolves a relative message image when it uniquely matches an artifact", async () => {
     const { resolveMessageImageURL } = await loadFreshArtifactUtils();
     const artifacts = [


### PR DESCRIPTION
Fixes #4091

## Why

The relative artifact image support introduced in #4038 passes artifact paths into memoized message content.

When a thread checkpoint omits `values.artifacts`, `extractArtifactsFromThread()` returned a newly allocated empty array on every call. During streaming, this changed the `artifactPaths` prop reference on every render, preventing historical `MessageContent` instances from benefiting from React memoization and recreating their Markdown component maps for every token delta.

## What changed

- Reuse a module-level immutable empty artifact-path array when a thread has no artifacts.
- Extract artifact paths once per `MessageList` render and share the same reference across all message items.
- Add regression coverage for stable empty-array references and preservation of existing artifact-array references.
- Preserve the relative artifact image resolution behavior introduced by #4038.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable. This change fixes render performance without changing visible UI behavior.

## Bug fix verification

- Test path that reproduces the bug: `frontend/tests/unit/core/artifacts/utils.test.ts`
- Did it go red on `main` and green on this branch? No — it was not separately executed on `main`. The regression assertion directly checks reference identity and would fail against `main`, where each nullish extraction returns a newly allocated `[]`.
- The test confirms that repeated extraction for a thread without artifacts returns the same reference and that a defined artifacts array is returned unchanged.

## Validation

- `cd frontend && pnpm test` — 613 tests passed across 68 files
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm check`
- `cd frontend && pnpm format`
- `git diff --check`