### PR TITLE
fix(sandbox): stop glob/grep/ls from surfacing disabled skills' files

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -173,8 +173,10 @@ def _extract_skill_name_from_skills_path(path: str) -> str | None:
     if not relative:
         return None
     # Expected patterns: "public/<name>/...", "custom/<name>/...", "legacy/<name>/..."
-    # or "<name>/..." (direct skill access)
-    parts = relative.split("/")
+    # or "<name>/..." (direct skill access). Empty segments are dropped so a
+    # directory entry ("public/", as `ls` emits for dirs) is still recognized as
+    # a category root rather than yielding an empty skill name.
+    parts = [part for part in relative.split("/") if part]
     if len(parts) >= 2 and parts[0] in ("public", "custom", "legacy"):
         return parts[1]
     if len(parts) == 1 and parts[0] in ("public", "custom", "legacy"):
@@ -1773,8 +1775,9 @@ def ls_tool(runtime: Runtime, description: str, path: str) -> str:
         path: The **absolute** path to the directory to list.
     """
     try:
+        user_id = resolve_runtime_user_id(runtime)
         # Block access to disabled skill directories
-        if _is_disabled_skill_path(path, user_id=resolve_runtime_user_id(runtime)):
+        if _is_disabled_skill_path(path, user_id=user_id):
             skill_name = _extract_skill_name_from_skills_path(path) or "unknown"
             return f"Error: Skill '{skill_name}' is disabled. Access to its files is blocked. Enable the skill in settings before using it."
         sandbox = ensure_sandbox_initialized(runtime)
@@ -1802,7 +1805,7 @@ def ls_tool(runtime: Runtime, description: str, path: str) -> str:
             output = mask_local_paths_in_output(output, thread_data)
         # The gate above only covers `path` itself; the listing descends into
         # children, so a root above a disabled skill still exposes its files.
-        entries = _drop_disabled_skill_paths(output.splitlines(), user_id=resolve_runtime_user_id(runtime))
+        entries = _drop_disabled_skill_paths(output.splitlines(), user_id=user_id)
         if not entries:
             return "(empty)"
         output = "\n".join(entries)

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -241,6 +241,39 @@ def _is_disabled_skill_path(path: str, *, user_id: str | None = None) -> bool:
         return True
 
 
+def _drop_disabled_skill_paths(paths: list[str], *, user_id: str | None = None) -> list[str]:
+    """Filter out paths that belong to a disabled skill.
+
+    ``_is_disabled_skill_path`` gates the *requested* path, which is enough for
+    ``read_file`` but not for the tools that descend: ``ls``, ``glob`` and
+    ``grep`` return paths other than the one they were given, so a root anywhere
+    above a disabled skill still surfaces its files.  This applies the same check
+    to the results.
+
+    The enabled-state lookup re-reads ``extensions_config.json`` (or the per-user
+    skill state) on every call, so the verdict is memoized per skill — a 100-match
+    grep must not become 100 config reads.
+    """
+    skills_prefix = _get_skills_container_path()
+    verdicts: dict[tuple[str, str], bool] = {}
+    kept: list[str] = []
+    for path in paths:
+        skill_name = _extract_skill_name_from_skills_path(path)
+        if skill_name is None:
+            kept.append(path)
+            continue
+        # Leading segment (the category, or the skill itself in the direct
+        # layout) plus the name identifies the skill the same way
+        # _is_disabled_skill_path does, so paths sharing a key share a verdict.
+        category = path[len(skills_prefix) :].lstrip("/").split("/")[0]
+        key = (category, skill_name)
+        if key not in verdicts:
+            verdicts[key] = _is_disabled_skill_path(path, user_id=user_id)
+        if not verdicts[key]:
+            kept.append(path)
+    return kept
+
+
 def _resolve_skills_path(path: str) -> str:
     """Resolve a virtual skills path to a host filesystem path.
 
@@ -1767,6 +1800,12 @@ def ls_tool(runtime: Runtime, description: str, path: str) -> str:
         output = "\n".join(children)
         if thread_data is not None:
             output = mask_local_paths_in_output(output, thread_data)
+        # The gate above only covers `path` itself; the listing descends into
+        # children, so a root above a disabled skill still exposes its files.
+        entries = _drop_disabled_skill_paths(output.splitlines(), user_id=resolve_runtime_user_id(runtime))
+        if not entries:
+            return "(empty)"
+        output = "\n".join(entries)
         try:
             from deerflow.config.app_config import get_app_config
 
@@ -1811,6 +1850,11 @@ def glob_tool(
         max_results: Maximum number of paths to return. Default is 200.
     """
     try:
+        user_id = resolve_runtime_user_id(runtime)
+        # Block access to disabled skill directories
+        if _is_disabled_skill_path(path, user_id=user_id):
+            skill_name = _extract_skill_name_from_skills_path(path) or "unknown"
+            return f"Error: Skill '{skill_name}' is disabled. Access to its files is blocked. Enable the skill in settings before using it."
         sandbox = ensure_sandbox_initialized(runtime)
         ensure_thread_directories_exist(runtime)
         requested_path = path
@@ -1829,6 +1873,9 @@ def glob_tool(
         matches, truncated = sandbox.glob(path, pattern, include_dirs=include_dirs, max_results=effective_max_results)
         if thread_data is not None:
             matches = [mask_local_paths_in_output(match, thread_data) for match in matches]
+        # The gate above only covers `path` itself; the search descends into it,
+        # so a root above a disabled skill still surfaces its files.
+        matches = _drop_disabled_skill_paths(matches, user_id=user_id)
         return _format_glob_results(requested_path, matches, truncated)
     except SandboxError as e:
         return f"Error: {e}"
@@ -1887,6 +1934,11 @@ def grep_tool(
         max_results: Maximum number of matching lines to return. Default is 100.
     """
     try:
+        user_id = resolve_runtime_user_id(runtime)
+        # Block access to disabled skill directories
+        if _is_disabled_skill_path(path, user_id=user_id):
+            skill_name = _extract_skill_name_from_skills_path(path) or "unknown"
+            return f"Error: Skill '{skill_name}' is disabled. Access to its files is blocked. Enable the skill in settings before using it."
         sandbox = ensure_sandbox_initialized(runtime)
         ensure_thread_directories_exist(runtime)
         requested_path = path
@@ -1919,6 +1971,10 @@ def grep_tool(
                 )
                 for match in matches
             ]
+        # The gate above only covers `path` itself; the search descends into it,
+        # so a root above a disabled skill still surfaces its file contents.
+        allowed = set(_drop_disabled_skill_paths([match.path for match in matches], user_id=user_id))
+        matches = [match for match in matches if match.path in allowed]
         return _format_grep_results(requested_path, matches, truncated)
     except SandboxError as e:
         return f"Error: {e}"

--- a/backend/tests/test_sandbox_search_tools.py
+++ b/backend/tests/test_sandbox_search_tools.py
@@ -1,7 +1,9 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from deerflow.community.aio_sandbox.aio_sandbox import AioSandbox
+from deerflow.config.paths import Paths
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 from deerflow.sandbox.search import GrepMatch, find_glob_matches, find_grep_matches
 from deerflow.sandbox.tools import glob_tool, grep_tool, ls_tool
@@ -500,16 +502,33 @@ def test_ls_tool_skills_path_uses_sandbox_mapping_user_id_not_contextvar(tmp_pat
     )
     monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
 
+    # Listing a category root descends into the skills below it, so the
+    # disabled-skill gate now resolves each one's enabled state. That lookup
+    # needs app config; without it the gate fails closed (see PR #3889) and the
+    # listing would be empty for a reason unrelated to what this test asserts.
+    skills_root = tmp_path / "skills"
+    (skills_root / "custom").mkdir(parents=True)
+    app_config = SimpleNamespace(
+        skills=SimpleNamespace(
+            get_skills_path=lambda: skills_root,
+            container_path="/mnt/skills",
+            use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage",
+        ),
+        skill_evolution=SimpleNamespace(enabled=False),
+    )
+
     # Leave contextvar unset → get_effective_user_id() returns "default"
     # Before the fix, _resolve_skills_path would resolve to default_custom (empty)
     # After the fix, the sandbox PathMapping resolves to user-abc_custom (has my-skill)
     token = set_current_user(SimpleNamespace(id="default"))  # contextvar says "default"
     try:
-        result = ls_tool.func(
-            runtime=_make_runtime(tmp_path),
-            description="list custom skills",
-            path="/mnt/skills/custom",
-        )
+        with patch("deerflow.config.paths.get_paths", return_value=Paths(base_dir=base_dir)):
+            with patch("deerflow.config.get_app_config", return_value=app_config):
+                result = ls_tool.func(
+                    runtime=_make_runtime(tmp_path),
+                    description="list custom skills",
+                    path="/mnt/skills/custom",
+                )
 
         # Must show user-abc's skill (sandbox mapping), NOT default's empty dir (contextvar)
         assert "my-skill" in result
@@ -536,3 +555,112 @@ def test_ls_tool_filters_upload_staging_files(tmp_path, monkeypatch) -> None:
     assert "/mnt/user-data/uploads/report.txt" in result
     assert "/mnt/user-data/uploads/.upload-note.txt" in result
     assert ".upload-active.part" not in result
+
+
+def _make_skills_sandbox(tmp_path, monkeypatch, *, disabled: str):
+    """Skills tree with one disabled and one enabled public skill.
+
+    Drives the real `_is_disabled_skill_path` gate through a real
+    extensions_config.json rather than stubbing the gate out.
+    """
+    skills_dir = tmp_path / "skills"
+    for name, body in [(disabled, "SECRET_PROCEDURE = step-1-step-2\n"), ("open-skill", "PUBLIC_PROCEDURE = hello\n")]:
+        (skills_dir / "public" / name).mkdir(parents=True)
+        (skills_dir / "public" / name / "SKILL.md").write_text(f"---\nname: {name}\n---\n\n{body}", encoding="utf-8")
+
+    ext = tmp_path / "extensions_config.json"
+    ext.write_text(
+        json.dumps({"mcpServers": {}, "skills": {disabled: {"enabled": False}, "open-skill": {"enabled": True}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(ext))
+
+    sandbox = LocalSandbox(
+        id="local",
+        path_mappings=[PathMapping(container_path="/mnt/skills", local_path=str(skills_dir), read_only=True)],
+    )
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    return sandbox
+
+
+def test_glob_tool_blocks_disabled_skill_root(tmp_path, monkeypatch) -> None:
+    """glob must refuse a disabled skill's own directory, like ls and read_file do."""
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = glob_tool.func(
+        runtime=runtime,
+        description="list skill files",
+        pattern="**/*.md",
+        path="/mnt/skills/public/secret-skill",
+    )
+
+    assert "Skill 'secret-skill' is disabled" in result
+    assert "SKILL.md" not in result
+
+
+def test_grep_tool_blocks_disabled_skill_root(tmp_path, monkeypatch) -> None:
+    """grep must refuse a disabled skill's own directory, like ls and read_file do."""
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = grep_tool.func(
+        runtime=runtime,
+        description="search skill files",
+        pattern="SECRET_PROCEDURE",
+        path="/mnt/skills/public/secret-skill",
+    )
+
+    assert "Skill 'secret-skill' is disabled" in result
+    assert "SECRET_PROCEDURE = step-1-step-2" not in result
+
+
+def test_glob_tool_does_not_surface_disabled_skill_from_ancestor_root(tmp_path, monkeypatch) -> None:
+    """A root above the skill must not surface it: glob descends past the path gate."""
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = glob_tool.func(
+        runtime=runtime,
+        description="find skills",
+        pattern="**/SKILL.md",
+        path="/mnt/skills",
+    )
+
+    assert "secret-skill" not in result
+    # ...while the enabled sibling is still returned.
+    assert "/mnt/skills/public/open-skill/SKILL.md" in result
+
+
+def test_grep_tool_does_not_surface_disabled_skill_content_from_ancestor_root(tmp_path, monkeypatch) -> None:
+    """The strongest leak: grep from /mnt/skills printed a disabled skill's file contents."""
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = grep_tool.func(
+        runtime=runtime,
+        description="search skills",
+        pattern="PROCEDURE",
+        path="/mnt/skills",
+    )
+
+    assert "SECRET_PROCEDURE = step-1-step-2" not in result
+    assert "secret-skill" not in result
+    # ...while the enabled sibling still matches.
+    assert "PUBLIC_PROCEDURE = hello" in result
+
+
+def test_ls_tool_does_not_surface_disabled_skill_from_category_root(tmp_path, monkeypatch) -> None:
+    """ls gates the requested path but descends two levels, so the category root leaked."""
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = ls_tool.func(
+        runtime=runtime,
+        description="list public skills",
+        path="/mnt/skills/public",
+    )
+
+    assert "secret-skill" not in result
+    # ...while the enabled sibling is still listed.
+    assert "open-skill" in result

--- a/backend/tests/test_sandbox_search_tools.py
+++ b/backend/tests/test_sandbox_search_tools.py
@@ -664,3 +664,139 @@ def test_ls_tool_does_not_surface_disabled_skill_from_category_root(tmp_path, mo
     assert "secret-skill" not in result
     # ...while the enabled sibling is still listed.
     assert "open-skill" in result
+
+
+def test_ls_tool_keeps_category_dirs_when_listing_skills_root(tmp_path, monkeypatch) -> None:
+    """`ls /mnt/skills` lists dirs with a trailing slash ("public/"), which the
+    skill-name extractor must read as a category root, not as a skill named "".
+
+    An empty name skips the `skill_name is None` short-circuit and falls through
+    to a config read; it currently lands on "keep" only because unknown skills
+    default to enabled. This pins the intended outcome directly: category dirs
+    stay visible while the disabled skill below them does not.
+    """
+    runtime = _make_runtime(tmp_path)
+    _make_skills_sandbox(tmp_path, monkeypatch, disabled="secret-skill")
+
+    result = ls_tool.func(
+        runtime=runtime,
+        description="list skills root",
+        path="/mnt/skills",
+    )
+
+    assert "/mnt/skills/public" in result
+    assert "open-skill" in result
+    assert "secret-skill" not in result
+
+
+def test_extract_skill_name_treats_category_dir_with_trailing_slash_as_root() -> None:
+    """LocalSandbox.list_dir appends "/" to directories, so the gate sees
+    "/mnt/skills/public/" — which must resolve to None (category root), not "".
+    """
+    from deerflow.sandbox.tools import _extract_skill_name_from_skills_path as extract
+
+    # Changed direction: trailing-slash category roots used to yield "".
+    assert extract("/mnt/skills/public/") is None
+    assert extract("/mnt/skills/custom/") is None
+    assert extract("/mnt/skills/legacy/") is None
+    # Unchanged directions: real skills still resolve, with or without the slash.
+    assert extract("/mnt/skills/public") is None
+    assert extract("/mnt/skills/public/bootstrap") == "bootstrap"
+    assert extract("/mnt/skills/public/bootstrap/") == "bootstrap"
+    assert extract("/mnt/skills/public/bootstrap/SKILL.md") == "bootstrap"
+    assert extract("/mnt/skills/my-skill/") == "my-skill"
+    assert extract("/mnt/user-data/workspace/file.md") is None
+
+
+def _make_custom_skills_sandbox(tmp_path, monkeypatch, *, user_id: str, disabled: str):
+    """Per-user CUSTOM skills tree with one disabled and one enabled skill.
+
+    CUSTOM/LEGACY enabled state lives in the per-user ``_skill_states.json``
+    (``UserScopedSkillStorage``), a different store from the public skills'
+    ``extensions_config.json`` — so the public fixture above does not exercise
+    this branch of ``_is_disabled_skill_path``.
+    """
+    from deerflow.skills.storage import reset_skill_storage
+
+    base_dir = tmp_path / ".deer-flow"
+    user_skills = base_dir / "users" / user_id / "skills"
+    user_custom = user_skills / "custom"
+    for name, body in [(disabled, "SECRET_PROCEDURE = step-1-step-2\n"), ("open-custom", "PUBLIC_PROCEDURE = hello\n")]:
+        (user_custom / name).mkdir(parents=True)
+        (user_custom / name / "SKILL.md").write_text(f"---\nname: {name}\n---\n\n{body}", encoding="utf-8")
+
+    (user_skills / "_skill_states.json").write_text(
+        json.dumps({disabled: {"enabled": False}, "open-custom": {"enabled": True}}),
+        encoding="utf-8",
+    )
+
+    skills_root = tmp_path / "skills"
+    (skills_root / "public").mkdir(parents=True)
+    (skills_root / "custom").mkdir(parents=True)
+    app_config = SimpleNamespace(
+        skills=SimpleNamespace(
+            get_skills_path=lambda: skills_root,
+            container_path="/mnt/skills",
+            use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage",
+        ),
+        skill_evolution=SimpleNamespace(enabled=False),
+    )
+
+    sandbox = LocalSandbox(
+        id=f"local:{user_id}:thread-1",
+        path_mappings=[PathMapping(container_path="/mnt/skills/custom", local_path=str(user_custom), read_only=True)],
+    )
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: sandbox)
+    # The storage cache is keyed by user id, not by base_dir: a cached instance
+    # from another test would read the wrong _skill_states.json.
+    reset_skill_storage()
+    monkeypatch.setattr("deerflow.sandbox.tools.resolve_runtime_user_id", lambda runtime: user_id)
+    return base_dir, app_config
+
+
+def test_grep_tool_does_not_surface_disabled_custom_skill(tmp_path, monkeypatch) -> None:
+    """CUSTOM skills resolve enabled state through the per-user _skill_states.json,
+    not extensions_config.json — the store the public-skill tests never touch."""
+    from deerflow.skills.storage import reset_skill_storage
+
+    runtime = _make_runtime(tmp_path)
+    base_dir, app_config = _make_custom_skills_sandbox(tmp_path, monkeypatch, user_id="user-abc", disabled="secret-custom")
+
+    try:
+        with patch("deerflow.config.paths.get_paths", return_value=Paths(base_dir=base_dir)):
+            with patch("deerflow.config.get_app_config", return_value=app_config):
+                result = grep_tool.func(
+                    runtime=runtime,
+                    description="search custom skills",
+                    pattern="PROCEDURE",
+                    path="/mnt/skills/custom",
+                )
+    finally:
+        reset_skill_storage()
+
+    assert "SECRET_PROCEDURE = step-1-step-2" not in result
+    assert "secret-custom" not in result
+    # ...while the enabled sibling still matches.
+    assert "PUBLIC_PROCEDURE = hello" in result
+
+
+def test_ls_tool_does_not_surface_disabled_custom_skill(tmp_path, monkeypatch) -> None:
+    """Same per-user store, via the descending ls listing."""
+    from deerflow.skills.storage import reset_skill_storage
+
+    runtime = _make_runtime(tmp_path)
+    base_dir, app_config = _make_custom_skills_sandbox(tmp_path, monkeypatch, user_id="user-abc", disabled="secret-custom")
+
+    try:
+        with patch("deerflow.config.paths.get_paths", return_value=Paths(base_dir=base_dir)):
+            with patch("deerflow.config.get_app_config", return_value=app_config):
+                result = ls_tool.func(
+                    runtime=runtime,
+                    description="list custom skills",
+                    path="/mnt/skills/custom",
+                )
+    finally:
+        reset_skill_storage()
+
+    assert "secret-custom" not in result
+    assert "open-custom" in result


### PR DESCRIPTION
## Why

`_is_disabled_skill_path` gates the path a tool is **given**. `ls`, `glob` and `grep` all **descend** from that path and return paths other than the one they were given, so a root anywhere above a disabled skill still serves its files.

`glob` and `grep` never call the gate at all, and `ls` calls it only on its own argument. Driving all four read tools against a real disabled skill (real `extensions_config.json`, real `LocalSandbox`, nothing stubbed):

| root | `ls` | `glob` | `grep` | `read_file` |
|---|---|---|---|---|
| `/mnt/skills` | dir name only | **leaks file paths** | **leaks paths + contents** | n/a |
| `/mnt/skills/public` | **leaks file paths** | **leaks file paths** | **leaks paths + contents** | n/a |
| `/mnt/skills/public/secret-skill` | blocked | **leaks file paths** | **leaks paths + contents** | blocked |

```
$ grep SECRET_PROCEDURE /mnt/skills          # secret-skill is disabled
/mnt/skills/public/secret-skill/SKILL.md:5: SECRET_PROCEDURE = step-1-step-2
```

The error message the gate hands back is the repo's own words — *"Access to its **files** is blocked"* — and `grep` prints those files. The fail-closed comment added in #3889's review is more explicit still:

> Access-control check must fail closed … refuse access rather than **silently serving a disabled skill's files**.

`read_file` is the only one of the four whose gate is complete, because it does not descend: the path it is given *is* the path it reads.

## What changed

**Two clauses, because one root gate cannot cover a recursive tool.**

1. `glob` and `grep` gain the entry gate `ls`/`read_file` already carry, so pointing straight at a disabled skill returns the same actionable error instead of results.
2. `ls`, `glob` and `grep` filter their **results** through `_drop_disabled_skill_paths`.

The filter adds no new authorization logic — it reuses `_is_disabled_skill_path` verbatim, including its fail-closed behaviour, and just applies that existing decision to the paths being returned rather than only to the path requested.

Clause 2 is what actually closes the leak; clause 1 exists so the direct case still explains *why* it was refused, instead of degrading to "no matches found".

**Memoization is required, not an optimization.** `ExtensionsConfig.from_file()` re-reads and re-parses the file on every call — it is not cached — so a per-match gate call would turn a 100-match grep into 100 config reads. Keying the verdict on the skill makes the cost track distinct skills instead of results:

| call | config reads | results |
|---|---|---|
| `glob **/*.py` under `/mnt/user-data/workspace` | **0** | 96 |
| `glob **/*.md` under `/mnt/skills` (12 skills) | **12** | 88 |

Non-skills paths never reach the gate, so the ordinary workspace path pays nothing. The tool bodies run under `await asyncio.to_thread(...)`, so these reads are off the event loop; `make test-blocking-io` stays green.

## Surface area

- [x] **Sandbox** — `backend/packages/harness/deerflow/sandbox/tools.py`

No documentation change needed: `backend/AGENTS.md` does not describe this gate (its Sandbox Tools list does not cover `glob`/`grep` at all), so there is no claim to bring back in line.

## Bug fix verification

Both clauses are anchored separately, and I wrote down what each anchor should do before running it.

**Fix direction** — reverting only `tools.py` turns exactly these five red, each checked individually rather than in aggregate:

```
5 failed, 23 deselected

FAILED ::test_glob_tool_blocks_disabled_skill_root
FAILED ::test_grep_tool_blocks_disabled_skill_root
FAILED ::test_glob_tool_does_not_surface_disabled_skill_from_ancestor_root
FAILED ::test_grep_tool_does_not_surface_disabled_skill_content_from_ancestor_root
FAILED ::test_ls_tool_does_not_surface_disabled_skill_from_category_root
```

The first two guard the entry gate; the last three guard the result filter — reverting only the filter leaves the first two green, which is why both clauses needed their own tests.

**Over-blocking direction** — this narrows what the tools return, so the other side has to be pinned too. Mutating the filter to deny every skill turns six red, and **three of them are tests that already existed**:

```
FAILED ::test_glob_tool_supports_skills_virtual_paths                          ← pre-existing
FAILED ::test_ls_tool_masks_skills_host_paths                                  ← pre-existing
FAILED ::test_ls_tool_skills_path_uses_sandbox_mapping_user_id_not_contextvar  ← pre-existing
FAILED ::test_glob_tool_does_not_surface_disabled_skill_from_ancestor_root
FAILED ::test_grep_tool_does_not_surface_disabled_skill_content_from_ancestor_root
FAILED ::test_ls_tool_does_not_surface_disabled_skill_from_category_root
```

Each of my three new tests asserts the *enabled* sibling skill is still returned from the same root that no longer surfaces the disabled one — those assertions are green on `main` too. They do not guard the bug; they guard the fix from over-reaching.

**Delta set** — running the old and new predicates over a candidate list that deliberately includes names I expected *not* to be dropped:

```
DROPPED  /mnt/skills/public/secret-skill/SKILL.md
DROPPED  /mnt/skills/public/secret-skill/
DROPPED  /mnt/skills/public/secret-skill/references/deep/notes.txt
DROPPED  /mnt/skills/custom/priv-skill/SKILL.md          (per-user disabled custom skill)

kept     /mnt/skills/public/secret-skill-2/SKILL.md      ← name-prefix of the disabled skill
kept     /mnt/skills-extra/data.txt                      ← sibling dir sharing the /mnt/skills prefix
kept     /mnt/skills/public/open-skill/SKILL.md          ← enabled sibling
kept     /mnt/skills/custom/open-custom/SKILL.md
kept     /mnt/skills/public/   /mnt/skills/custom/   /mnt/skills/     (category roots, not skills)
kept     /mnt/user-data/workspace/app.py   /mnt/acp-workspace/notes.md
kept     /mnt/skills/public/nonexistent/SKILL.md
```

Nothing is withheld except a disabled skill's own paths. The two boundary cases (`secret-skill-2`, `skills-extra`) survive because the check keys on path segments, not on a string prefix.

**One pre-existing test needed a fixture, and it is worth saying why rather than burying it.** `test_ls_tool_skills_path_uses_sandbox_mapping_user_id_not_contextvar` lists a *category root*, which now descends into the skills beneath it and resolves each one's enabled state. That lookup needs app config, and the test provided none — so the gate hit its existing fail-closed branch and the listing came back empty, for a reason unrelated to what the test asserts. It now patches `get_paths` / `get_app_config` the way `TestSkillToggleIsolation` already does; **its assertions are unchanged**. It still passes on a clean `main` with the fixture added (so it is not being bent to accommodate this change), and it is one of the three pre-existing tests in the over-blocking red set above (so it is still a live guard).

## Validation

- `cd backend && make format` — all checks passed, 829 files left unchanged.
- `cd backend && make lint` — `ruff check`: all checks passed; `ruff format --check`: 829 files already formatted.
- `cd backend && make test` — **7109 passed, 26 skipped, 8 failed**. The same 8 fail on a clean `origin/main` checkout (pre-existing `web_fetch` cases — `test_browserless_client`, `test_crawl4ai_tools`, `test_fastcrw_tools`; no outbound DNS on this machine). The failure sets are byte-identical; this branch adds none. Passing count is `main`'s 7104 plus the five new tests.
- `cd backend && make test-blocking-io` — 36 passed. The added config reads run inside the sync tool body, which the async wrappers dispatch via `asyncio.to_thread`, so nothing new touches the event loop.
- End-to-end, nothing stubbed — a real `extensions_config.json` marking `secret-skill` disabled, a real `LocalSandbox` with `/mnt/skills` mapped, driving the real `ls` / `glob` / `grep` / `read_file`. On `main` the matrix at the top of this PR reproduces; on this branch every cell is clean, while the enabled sibling `open-skill/SKILL.md` is still returned from every root.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with driving the four read tools against a real disabled skill to map which access shapes actually leak (this is what showed the bug was not simply "two missing call sites" — `ls` carries the gate and still leaked from a category root), writing the fix, measuring the config-read cost, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
