### PR TITLE
fix(channels): validate channel provider before resolving its config

### DIFF
--- a/backend/app/gateway/routers/channel_connections.py
+++ b/backend/app/gateway/routers/channel_connections.py
@@ -201,6 +201,13 @@ def _get_repository(request: Request, config: ChannelConnectionsConfig) -> Chann
 
 
 def _provider_config(config: ChannelConnectionsConfig, provider: str):
+    # Resolve provider configs only for known providers. An unrestricted
+    # getattr would let a request-supplied name that happens to match another
+    # config attribute (e.g. the "enabled" / "require_bound_identity" bool
+    # fields) slip past the 404 and return a non-provider value, which callers
+    # then dereference as a provider config (AttributeError -> HTTP 500).
+    if provider not in _PROVIDER_META:
+        raise HTTPException(status_code=404, detail="Unknown channel provider")
     provider_config = getattr(config, provider, None)
     if provider_config is None:
         raise HTTPException(status_code=404, detail="Unknown channel provider")

--- a/backend/tests/test_channel_connections_router.py
+++ b/backend/tests/test_channel_connections_router.py
@@ -598,6 +598,29 @@ def test_connect_unconfigured_runtime_channel_returns_400(tmp_path):
     anyio.run(repo.close)
 
 
+@pytest.mark.parametrize("provider", ["enabled", "require_bound_identity", "provider_status", "unknown_provider"])
+def test_connect_rejects_non_provider_config_attribute_with_404(tmp_path, provider):
+    import anyio
+
+    # A request-supplied provider name that collides with a real (non-provider)
+    # ChannelConnectionsConfig attribute -- e.g. the "enabled" /
+    # "require_bound_identity" bool fields, or the "provider_status" method --
+    # must resolve to the intended 404. Before the allowlist check, an
+    # unrestricted getattr returned that attribute instead of falling through to
+    # the 404, and the connect handler then dereferenced it as a provider config
+    # (AttributeError -> HTTP 500) for any authenticated user.
+    repo = anyio.run(_make_repo, tmp_path)
+    app = _make_app(_enabled_connections_config(), repo, _channels_config())
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.post(f"/api/channels/{provider}/connect")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Unknown channel provider"
+
+    anyio.run(repo.close)
+
+
 def test_configure_provider_runtime_credentials_enables_connect_without_file_edits(tmp_path):
     import anyio
 


### PR DESCRIPTION
## Summary

`channel_connections._provider_config` resolves a request-supplied `provider`
path parameter with an unallowlisted `getattr`:

```python
def _provider_config(config: ChannelConnectionsConfig, provider: str):
    provider_config = getattr(config, provider, None)
    if provider_config is None:
        raise HTTPException(status_code=404, detail="Unknown channel provider")
    return provider_config
```

The intent is "return the provider's sub-config, else 404". But
`ChannelConnectionsConfig` also carries **non-provider** attributes:

| Attribute | Type | `getattr(config, name, None)` |
|-----------|------|-------------------------------|
| `enabled` | `bool` (often `True`) | `True` |
| `require_bound_identity` | `bool` (default `True`) | `True` |
| `provider_status` | method | bound method |

For those names the `getattr` returns a truthy non-`None` value, so the
`is None` guard never fires and a `bool`/method is returned instead of the
intended 404. Callers then dereference it as a provider config and crash.

The most exposed path is `POST /api/channels/{provider}/connect`, which is
reachable by **any authenticated user** (not admin-gated):

```python
provider_config = _provider_config(config, provider)             # returns True (a bool)
if provider_config.enabled and _runtime_channel_configured(...):  # True.enabled -> AttributeError
```

So `POST /api/channels/enabled/connect` (or `.../require_bound_identity/connect`)
raises `AttributeError: 'bool' object has no attribute 'enabled'` and returns
HTTP 500 instead of a clean 404, once `channel_connections.enabled` is on. The
same unvalidated name also flows into the admin `runtime-config` handlers.

## Fix

Validate `provider` against the `_PROVIDER_META` allowlist (the canonical set
of real providers) before the lookup, returning the intended 404 for anything
else. This mirrors how the other helpers in this router already gate provider
names (`_credential_fields`, `_connect_instruction`, `_connect_url`), and
`_provider_config` is the single chokepoint every provider-path route resolves
through, so validating here covers `connect` and both `runtime-config` routes.

```python
if provider not in _PROVIDER_META:
    raise HTTPException(status_code=404, detail="Unknown channel provider")
```

The existing `getattr ... is None` check is kept as defense-in-depth.

## Testing

Added `test_connect_rejects_non_provider_config_attribute_with_404`, a
parametrized router test over `enabled`, `require_bound_identity`,
`provider_status`, and an unknown name, asserting `POST /{provider}/connect`
returns 404 (not a 500/`AttributeError`). Valid providers still resolve and
connect -- covered by the existing `test_connect_*` cases. Verified the two
colliding-attribute parameters return HTTP 500 on `main` and 404 after the fix.
