### PR TITLE
fix(sandbox): guard the command path-translation regex with a segment boundary

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1209,7 +1209,21 @@ def replace_virtual_paths_in_command(command: str, thread_data: ThreadDataState 
 
     # Replace user-data paths
     if VIRTUAL_PATH_PREFIX in result and thread_data is not None:
-        pattern = re.compile(rf"{re.escape(VIRTUAL_PATH_PREFIX)}(/[^\s\"';&|<>()]*)?")
+        # The segment-boundary lookahead is what keeps the virtual root from
+        # matching inside a sibling that merely shares its prefix
+        # (``/mnt/user-data`` inside ``/mnt/user-data-backup``). The trailing
+        # group needs a ``/`` to consume anything, so without the lookahead the
+        # bare root still matches and the sibling is rewritten into the thread's
+        # host directory — a real path outside the mount contract. Same defect as
+        # #4035 (reverse patterns) and #4053 (masking patterns), mirrored into
+        # this direction.
+        #
+        # The class mirrors ``LocalSandbox._content_pattern``'s rather than
+        # ``_command_pattern``'s: a virtual root can legitimately be followed by
+        # ``:`` (PATH-style concatenation) or ``,``, which the shell-oriented
+        # class rejects — narrowing to it would stop translating paths that
+        # translate today. ``$`` covers a command ending exactly at the root.
+        pattern = re.compile(rf"{re.escape(VIRTUAL_PATH_PREFIX)}(?=/|$|[^\w./-])(/[^\s\"';&|<>()]*)?")
 
         def replace_user_data_match(match: re.Match) -> str:
             return replace_virtual_path(match.group(0), thread_data).replace("\\", "/")

--- a/backend/tests/test_sandbox_tools_security.py
+++ b/backend/tests/test_sandbox_tools_security.py
@@ -451,6 +451,53 @@ def test_replace_virtual_paths_in_command_replaces_user_data_only() -> None:
         assert "/tmp/deer-flow/threads/t1/user-data/workspace/out.txt" in result
 
 
+@pytest.mark.parametrize(
+    "sibling",
+    [
+        "/mnt/user-data-backup/secret.txt",
+        "/mnt/user-data2/report.txt",
+        "/mnt/user-data.bak",
+        "/mnt/user-data_old/x",
+    ],
+)
+def test_replace_virtual_paths_in_command_does_not_rewrite_prefix_siblings(sibling: str) -> None:
+    """A path that merely starts with the virtual root is not a virtual path.
+
+    The matcher's trailing group needs a ``/`` to consume anything, so when the
+    character after ``/mnt/user-data`` is ``-``, ``.``, ``_``, a digit or a
+    letter, the group matches empty and the bare root still matches. The
+    substitution then rewrites it to the thread's host directory, and the rest of
+    the sibling name rides along — handing the command a real host path outside
+    the mount contract (``.../user-data-backup``), which the agent then reads or
+    writes.
+
+    Same defect as #4035 (reverse patterns) and #4053 (masking patterns),
+    mirrored into the virtual→host command direction.
+    """
+    result = replace_virtual_paths_in_command(f"cat {sibling}", _THREAD_DATA)
+
+    assert result == f"cat {sibling}"
+    assert "/tmp/deer-flow/threads/t1" not in result
+
+
+@pytest.mark.parametrize(
+    ("command", "expected"),
+    [
+        # The bare root, at end of string and before shell/text punctuation, must
+        # keep translating — these guard the boundary from being narrowed too far.
+        ("ls /mnt/user-data", "ls /tmp/deer-flow/threads/t1/user-data"),
+        ("ls /mnt/user-data && pwd", "ls /tmp/deer-flow/threads/t1/user-data && pwd"),
+        ("PYTHONPATH=/mnt/user-data:/opt x", "PYTHONPATH=/tmp/deer-flow/threads/t1/user-data:/opt x"),
+        ("echo '/mnt/user-data, done'", "echo '/tmp/deer-flow/threads/t1/user-data, done'"),
+        # Real children still translate.
+        ("cat /mnt/user-data/workspace/a.txt", "cat /tmp/deer-flow/threads/t1/user-data/workspace/a.txt"),
+    ],
+)
+def test_replace_virtual_paths_in_command_still_translates_genuine_paths(command: str, expected: str) -> None:
+    """The narrowing must not stop translating paths that translate today."""
+    assert replace_virtual_paths_in_command(command, _THREAD_DATA) == expected
+
+
 # ---------- validate_local_bash_command_paths ----------
 
 


### PR DESCRIPTION
## Why

This is the last unguarded member of the family #4035 and #4053 fixed, mirrored into the other direction. I found it while enumerating that family for #4108 (the shared-helper extraction), and it is a behavior change, so it is here rather than folded into that refactor.

`replace_virtual_paths_in_command` matches the virtual root with no segment-boundary lookahead:

```python
pattern = re.compile(rf"{re.escape(VIRTUAL_PATH_PREFIX)}(/[^\s\"';&|<>()]*)?")
```

The trailing group needs a `/` to consume anything. When the character after `/mnt/user-data` is `-`, `.`, `_`, a digit or a letter, the group matches empty and the **bare root still matches**. `replace_virtual_path` then takes its `path == virtual_base` branch — `_thread_virtual_to_actual_mappings` maps the virtual root to the three dirs' common parent — and substitutes the host directory, with the rest of the sibling name riding along:

```
cat /mnt/user-data-backup/secret.txt   ->   cat <host>/threads/t1/user-data-backup/secret.txt
ls  /mnt/user-data2                    ->   ls  <host>/threads/t1/user-data2
```

So a command naming a prefix sibling of the mount root is silently pointed at a **real host directory outside the mount contract**, and the agent reads or writes it. End-to-end on `main`, with a host sibling directory next to the thread's `user-data`:

```
$ cat /mnt/user-data-backup/secret.txt
  translated: cat <tmp>/user-data-backup/secret.txt
  bash says : HOST-ONLY SECRET
```

On this branch the path is left untranslated and the command fails honestly:

```
  translated: cat /mnt/user-data-backup/secret.txt
  bash says : cat: /mnt/user-data-backup/secret.txt: No such file or directory
```

`bash` runs every command through this function on the local sandbox, so this is not a narrow path.

## What changed

One lookahead, mirroring the guard its siblings already carry:

```python
pattern = re.compile(rf"{re.escape(VIRTUAL_PATH_PREFIX)}(?=/|$|[^\w./-])(/[^\s\"';&|<>()]*)?")
```

The class mirrors **`LocalSandbox._content_pattern`'s** `(?=/|$|[^\w./-])`, not `_command_pattern`'s shell-oriented `(?=/|$|[\s\"';&|<>()])`. Despite this running over a command string, a virtual root can legitimately be followed by `:` (PATH-style concatenation: `PYTHONPATH=/mnt/user-data:/opt`) or `,`, both of which the shell class rejects — narrowing to it would stop translating paths that translate today. `$` covers a command ending exactly at the root (`ls /mnt/user-data`).

## Surface area

- [x] **Sandbox** — `backend/packages/harness/deerflow/sandbox/tools.py`

No documentation change needed: `backend/AGENTS.md` describes the virtual-path contract but makes no claim about this matcher's boundary semantics.

## Bug fix verification

**The delta set, enumerated in both directions** (this is a narrowing change, so the risk is silently *losing* a translation). Old and new patterns run over a candidate list that deliberately includes the shapes I bet would not be affected:

```
newly_missed (old matched, new does not):
  '/mnt/user-data-backup/secret.txt'   old=['/mnt/user-data']  new=[]
  '/mnt/user-data2/report.txt'         old=['/mnt/user-data']  new=[]
  '/mnt/user-data.bak'                 old=['/mnt/user-data']  new=[]
  '/mnt/user-data_old/x'               old=['/mnt/user-data']  new=[]
  '/mnt/user-dataX'                    old=['/mnt/user-data']  new=[]

newly_caught (new matches, old did not): none
unaffected: 15/20
```

`newly_missed` is exactly the prefix-sibling family — the bug — and nothing else. The 15 unaffected include the cases the narrowing could plausibly have broken: `PYTHONPATH=/mnt/user-data:/opt`, `echo '/mnt/user-data, done'`, `cd /mnt/user-data; ls`, `echo /mnt/user-data\file`, a quoted path with spaces, and a trailing slash.

**Per-clause red check** — each clause of the new lookahead broken in turn:

| mutation | red |
|---|---|
| drop the lookahead entirely (i.e. `main`) | the 4 `..._does_not_rewrite_prefix_siblings` cases |
| swap in `_command_pattern`'s shell class | the 2 `..._still_translates_genuine_paths` cases for `:` and `,` |
| delete only `$` | the 1 `..._still_translates_genuine_paths` case for a command ending at the root |

Each clause has an anchor that fails without it, and no test in the new set stays green under every mutation.

The `..._still_translates_genuine_paths` cases are green on `main` as well — they do not guard the bug, they guard the fix from being narrowed too far, which is what the second and third mutations demonstrate.

## Validation

- `cd backend && make lint` — `ruff check`: all checks passed; `ruff format --check`: 830 files already formatted.
- `cd backend && make test` — **7128 passed, 26 skipped, 8 failed**. The same 8 fail on a clean `origin/main` checkout (pre-existing `web_fetch` cases — `test_browserless_client`, `test_crawl4ai_tools`, `test_fastcrw_tools`; no outbound DNS on this machine). Failure sets are byte-identical; this branch adds none.
- End-to-end through real `bash`, nothing stubbed — the `main` vs branch transcript is quoted under **Why** above: on `main` the sibling command prints the host file's contents; on this branch it is never translated and fails with `No such file or directory`.

## Related

- #4035 — same boundary added to `LocalSandbox._reverse_output_patterns`
- #4053 — same boundary added to `sandbox/tools.py::_compiled_mask_patterns`
- #4108 — extracts the host→virtual masking rule into one shared helper. This site is *not* a user of that helper: it runs in the opposite direction and its tail is POSIX-only (`(/...)`, no `\`), so it keeps its own pattern. The two PRs are independent and do not conflict.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with enumerating the boundary-guard family across the sandbox layer (which is how this site surfaced), reproducing the host read through real bash, computing the delta set, and writing the regression tests. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
