### PR TITLE
fix(frontend): harden artifact and markdown rendering

### DIFF
--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -45,6 +45,7 @@ import {
   type HumanInputResponse,
 } from "@/core/messages/human-input";
 import { isHiddenFromUIMessage } from "@/core/messages/utils";
+import { safeLocalStorage } from "@/core/settings/local";
 import { useThreadStream } from "@/core/threads/hooks";
 import { uuid } from "@/core/utils/uuid";
 import { isIMEComposing } from "@/lib/ime";
@@ -130,11 +131,11 @@ export default function NewAgentPage() {
     if (typeof window === "undefined" || step !== "chat") {
       return;
     }
-    if (window.localStorage.getItem(SAVE_HINT_STORAGE_KEY) === "1") {
+    if (safeLocalStorage.getItem(SAVE_HINT_STORAGE_KEY) === "1") {
       return;
     }
     setShowSaveHint(true);
-    window.localStorage.setItem(SAVE_HINT_STORAGE_KEY, "1");
+    safeLocalStorage.setItem(SAVE_HINT_STORAGE_KEY, "1");
   }, [step]);
 
   const handleConfirmName = useCallback(async () => {

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -360,6 +360,7 @@ export function ArtifactFileDetail({
         {!isCodeFile && canPreviewInBrowser && (
           <iframe
             className="size-full"
+            sandbox=""
             src={urlOfArtifact({ filepath, threadId, isMock })}
           />
         )}
@@ -528,7 +529,8 @@ export function ArtifactFilePreview({
         ref={iframeRef}
         className="size-full"
         title="Artifact preview"
-        sandbox="allow-scripts allow-forms"
+        // Artifact HTML is untrusted. Keep all iframe capabilities disabled.
+        sandbox=""
         src={htmlPreviewUrl}
       />
     );

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -529,8 +529,12 @@ export function ArtifactFilePreview({
         ref={iframeRef}
         className="size-full"
         title="Artifact preview"
-        // Artifact HTML is untrusted. Keep all iframe capabilities disabled.
-        sandbox=""
+        // allow-scripts is needed for the scroll-restoration injected
+        // script (appendHtmlPreviewScrollRestoration) which communicates
+        // via postMessage. allow-same-origin is deliberately omitted: the
+        // opaque origin prevents access to parent.document and cookies,
+        // and postMessage(..., "*") works fine from it.
+        sandbox="allow-scripts allow-forms"
         src={htmlPreviewUrl}
       />
     );

--- a/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
+++ b/frontend/src/components/workspace/artifacts/artifact-file-detail.tsx
@@ -129,7 +129,13 @@ export function ArtifactFileDetail({
   }, [filepath]);
   const { isCodeFile, language } = useMemo(() => {
     if (isWriteFile) {
-      let language = checkCodeFile(filepath).language;
+      const codeResult = checkCodeFile(filepath);
+      // Non-code browser-previewable files (PDF, images, audio, video)
+      // should render in the sandboxed iframe, not the code editor.
+      if (!codeResult.isCodeFile && canBrowserPreviewFile(filepath)) {
+        return codeResult;
+      }
+      let language = codeResult.language;
       language ??= "text";
       return { isCodeFile: true, language };
     }

--- a/frontend/src/components/workspace/citations/artifact-link.tsx
+++ b/frontend/src/components/workspace/citations/artifact-link.tsx
@@ -2,6 +2,8 @@ import type { AnchorHTMLAttributes } from "react";
 
 import { cn } from "@/lib/utils";
 
+import { isSafeHref } from "../messages/markdown-link";
+
 import { CitationLink } from "./citation-link";
 
 function isExternalUrl(href: string | undefined): boolean {
@@ -10,6 +12,25 @@ function isExternalUrl(href: string | undefined): boolean {
 
 /** Link renderer for artifact markdown: citation: prefix → CitationLink, otherwise underlined text. */
 export function ArtifactLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
+  // Reject unsafe schemes so prompt-injected [label](javascript:...) in a .md
+  // artifact preview cannot execute in the main document, matching the guard in
+  // createMarkdownLinkComponent (markdown-link.tsx).
+  if (props.href !== undefined && !isSafeHref(props.href)) {
+    const { className, children, target, rel, ...rest } = props;
+    return (
+      <span
+        {...rest}
+        className={cn(
+          "text-muted-foreground cursor-not-allowed underline decoration-dotted underline-offset-2",
+          className,
+        )}
+        aria-label="Unsafe link omitted"
+        title={`Unsafe link scheme in ${props.href}`}
+      >
+        {children}
+      </span>
+    );
+  }
   if (typeof props.children === "string") {
     const match = /^citation:(.+)$/.exec(props.children);
     if (match) {

--- a/frontend/src/components/workspace/citations/artifact-link.tsx
+++ b/frontend/src/components/workspace/citations/artifact-link.tsx
@@ -16,10 +16,12 @@ export function ArtifactLink(props: AnchorHTMLAttributes<HTMLAnchorElement>) {
   // artifact preview cannot execute in the main document, matching the guard in
   // createMarkdownLinkComponent (markdown-link.tsx).
   if (props.href !== undefined && !isSafeHref(props.href)) {
-    const { className, children, target, rel, ...rest } = props;
+    // Intentionally no {...props} spread: anchor-only attributes (href,
+    // target, rel) are not valid on a <span> and would leak the unsafe URL
+    // into the DOM / trigger React DOM warnings.
+    const { className, children } = props;
     return (
       <span
-        {...rest}
         className={cn(
           "text-muted-foreground cursor-not-allowed underline decoration-dotted underline-offset-2",
           className,

--- a/frontend/src/components/workspace/messages/markdown-link.tsx
+++ b/frontend/src/components/workspace/messages/markdown-link.tsx
@@ -16,7 +16,7 @@ import { CitationLink } from "../citations/citation-link";
  * branch below and ``resolveArtifactURL``) — relative ``/…`` URLs are
  * inherently safe and pass through ``URL.protocol === ""``.
  */
-const SAFE_HREF_PROTOCOLS = ["http:", "https:"] as const;
+const SAFE_HREF_PROTOCOLS = ["http:", "https:", "mailto:", "tel:"] as const;
 
 export function isSafeHref(href: string | undefined): boolean {
   if (typeof href !== "string" || href.length === 0) {
@@ -57,22 +57,14 @@ export function createMarkdownLinkComponent(threadId?: string) {
     href,
     ...props
   }: AnchorHTMLAttributes<HTMLAnchorElement>) {
-    if (typeof props.children === "string") {
-      const match = /^citation:(.+)$/.exec(props.children);
-      if (match) {
-        const [, text] = match;
-        return (
-          <CitationLink {...props} href={href}>
-            {text}
-          </CitationLink>
-        );
-      }
-    }
     // Reject unsafe schemes up front so a prompt-injected / pasted href can
-    // never reach the rendered anchor. Keep the visible label so the user
-    // can still see what the link claimed to point at.
+    // never reach the rendered anchor — including through the citation
+    // branch (which renders <a href={href}> directly). Check before the
+    // citation block so prompt-injected [citation:x](javascript:...) is
+    // blocked. Keep the visible label so the user can still see what the
+    // link claimed to point at.
     if (href !== undefined && !isSafeHref(href)) {
-      const { className, children, ...rest } = props;
+      const { className, children, target, rel, ...rest } = props;
       return (
         <span
           {...rest}
@@ -86,6 +78,18 @@ export function createMarkdownLinkComponent(threadId?: string) {
           {children}
         </span>
       );
+    }
+    // Safe-href check passed — citation links now route through CitationLink.
+    if (typeof props.children === "string") {
+      const match = /^citation:(.+)$/.exec(props.children);
+      if (match) {
+        const [, text] = match;
+        return (
+          <CitationLink {...props} href={href}>
+            {text}
+          </CitationLink>
+        );
+      }
     }
     if (threadId && href?.startsWith("/mnt/")) {
       return (

--- a/frontend/src/components/workspace/messages/markdown-link.tsx
+++ b/frontend/src/components/workspace/messages/markdown-link.tsx
@@ -13,8 +13,9 @@ import { CitationLink } from "../citations/citation-link";
  * browser happily executes the payload in the chat surface where
  * sessionStorage / CSRF cookies are reachable. We accept ``http(s)``
  * plus the non-executing ``mailto:`` / ``tel:`` schemes; same-origin
- * relative paths (``/…``) and in-document anchors (``#…``) are allowed
- * by the explicit prefix checks in ``isSafeHref`` before URL parsing.
+ * absolute paths (``/…``), scheme-less relative references (``report.md``,
+ * ``./…``, ``../…``), and in-document anchors (``#…``) are also allowed
+ * — they all resolve under the current HTTP(S) origin.
  */
 const SAFE_HREF_PROTOCOLS = ["http:", "https:", "mailto:", "tel:"] as const;
 
@@ -22,16 +23,24 @@ export function isSafeHref(href: string | undefined): boolean {
   if (typeof href !== "string" || href.length === 0) {
     return false;
   }
-  // Allow relative same-origin paths (no protocol — e.g. "/workspace/foo").
-  if (href.startsWith("/") && !href.startsWith("//")) {
-    return true;
-  }
-  // Allow same-document anchors (e.g. "#section").
+  // Same-document anchors (e.g. "#section").
   if (href.startsWith("#")) {
     return true;
   }
+  // Protocol-relative URLs (//evil.com/path) would inherit the current
+  // page's scheme and navigate to an unknown host. Also reject
+  // backslash-normalised variants (\\evil.com → //evil.com) because
+  // browsers treat backslash as a path separator in URLs.
+  if (/^(\/\/|\\\\)/.test(href)) {
+    return false;
+  }
+  // Parse the href so we can inspect its scheme. Items without an explicit
+  // protocol (report.md, ./report.md, ../assets/chart.png, /workspace/foo)
+  // resolve relative to the dummy HTTPS base, producing an https: URL.
+  // Explicitly-schemed URLs (https://…, mailto:, javascript:, data:, …)
+  // keep their native scheme, which we then check against the allowlist.
   try {
-    const parsed = new URL(href);
+    const parsed = new URL(href, "https://dummy.example/");
     return (SAFE_HREF_PROTOCOLS as ReadonlyArray<string>).includes(
       parsed.protocol,
     );

--- a/frontend/src/components/workspace/messages/markdown-link.tsx
+++ b/frontend/src/components/workspace/messages/markdown-link.tsx
@@ -5,8 +5,46 @@ import { cn } from "@/lib/utils";
 
 import { CitationLink } from "../citations/citation-link";
 
+/**
+ * Schemes we are willing to render as a navigable ``<a href=...>``.
+ *
+ * Anything else (``javascript:``, ``data:text/html``, ``vbscript:``,
+ * ``file:``, …) is blocked because once it lands in a real anchor the
+ * browser happily executes the payload in the chat surface where
+ * sessionStorage / CSRF cookies are reachable. We accept only ``http`` /
+ * ``https`` plus same-origin paths (which are governed by the artifact
+ * branch below and ``resolveArtifactURL``) — relative ``/…`` URLs are
+ * inherently safe and pass through ``URL.protocol === ""``.
+ */
+const SAFE_HREF_PROTOCOLS = ["http:", "https:"] as const;
+
+export function isSafeHref(href: string | undefined): boolean {
+  if (typeof href !== "string" || href.length === 0) {
+    return false;
+  }
+  // Allow relative same-origin paths (no protocol — e.g. "/workspace/foo").
+  if (href.startsWith("/") && !href.startsWith("//")) {
+    return true;
+  }
+  // Allow same-document anchors (e.g. "#section").
+  if (href.startsWith("#")) {
+    return true;
+  }
+  try {
+    const parsed = new URL(href);
+    return (SAFE_HREF_PROTOCOLS as ReadonlyArray<string>).includes(
+      parsed.protocol,
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isExternalUrl(href: string | undefined): boolean {
-  return !!href && /^https?:\/\//.test(href);
+  if (typeof href !== "string") {
+    return false;
+  }
+  return /^https?:\/\//.test(href);
 }
 
 /**
@@ -29,6 +67,25 @@ export function createMarkdownLinkComponent(threadId?: string) {
           </CitationLink>
         );
       }
+    }
+    // Reject unsafe schemes up front so a prompt-injected / pasted href can
+    // never reach the rendered anchor. Keep the visible label so the user
+    // can still see what the link claimed to point at.
+    if (href !== undefined && !isSafeHref(href)) {
+      const { className, children, ...rest } = props;
+      return (
+        <span
+          {...rest}
+          className={cn(
+            "text-muted-foreground cursor-not-allowed underline decoration-dotted underline-offset-2",
+            className,
+          )}
+          aria-label="Unsafe link omitted"
+          title={`Unsafe link scheme in ${href}`}
+        >
+          {children}
+        </span>
+      );
     }
     if (threadId && href?.startsWith("/mnt/")) {
       return (

--- a/frontend/src/components/workspace/messages/markdown-link.tsx
+++ b/frontend/src/components/workspace/messages/markdown-link.tsx
@@ -11,10 +11,10 @@ import { CitationLink } from "../citations/citation-link";
  * Anything else (``javascript:``, ``data:text/html``, ``vbscript:``,
  * ``file:``, …) is blocked because once it lands in a real anchor the
  * browser happily executes the payload in the chat surface where
- * sessionStorage / CSRF cookies are reachable. We accept only ``http`` /
- * ``https`` plus same-origin paths (which are governed by the artifact
- * branch below and ``resolveArtifactURL``) — relative ``/…`` URLs are
- * inherently safe and pass through ``URL.protocol === ""``.
+ * sessionStorage / CSRF cookies are reachable. We accept ``http(s)``
+ * plus the non-executing ``mailto:`` / ``tel:`` schemes; same-origin
+ * relative paths (``/…``) and in-document anchors (``#…``) are allowed
+ * by the explicit prefix checks in ``isSafeHref`` before URL parsing.
  */
 const SAFE_HREF_PROTOCOLS = ["http:", "https:", "mailto:", "tel:"] as const;
 
@@ -64,10 +64,12 @@ export function createMarkdownLinkComponent(threadId?: string) {
     // blocked. Keep the visible label so the user can still see what the
     // link claimed to point at.
     if (href !== undefined && !isSafeHref(href)) {
-      const { className, children, target, rel, ...rest } = props;
+      // Intentionally no {...props} spread: react-markdown props like `node`
+      // (and anchor-only attributes such as target/rel) are not valid on a
+      // <span> and would trigger React DOM warnings.
+      const { className, children } = props;
       return (
         <span
-          {...rest}
           className={cn(
             "text-muted-foreground cursor-not-allowed underline decoration-dotted underline-offset-2",
             className,

--- a/frontend/src/core/settings/local.ts
+++ b/frontend/src/core/settings/local.ts
@@ -33,7 +33,7 @@ function isBrowser(): boolean {
  * settings panel. This wrapper traps every storage exception so callers can
  * always fall back to a sane default.
  */
-const safeLocalStorage = {
+export const safeLocalStorage = {
   getItem(key: string): string | null {
     if (!isBrowser()) return null;
     try {

--- a/frontend/src/core/settings/local.ts
+++ b/frontend/src/core/settings/local.ts
@@ -23,6 +23,45 @@ function isBrowser(): boolean {
   return typeof window !== "undefined";
 }
 
+/**
+ * Best-effort localStorage facade.
+ *
+ * Safari private mode, Firefox strict containers, some embedded WebViews, and
+ * quotas already filled by sibling tabs throw ``SecurityError`` or
+ * ``QuotaExceededError`` from ``getItem``/``setItem``. Without a guard those
+ * exceptions bubble into React render handlers and break the composer /
+ * settings panel. This wrapper traps every storage exception so callers can
+ * always fall back to a sane default.
+ */
+const safeLocalStorage = {
+  getItem(key: string): string | null {
+    if (!isBrowser()) return null;
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): boolean {
+    if (!isBrowser()) return false;
+    try {
+      window.localStorage.setItem(key, value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  removeItem(key: string): boolean {
+    if (!isBrowser()) return false;
+    try {
+      window.localStorage.removeItem(key);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
 export interface LocalSettings {
   notification: {
     enabled: boolean;
@@ -72,7 +111,9 @@ export function getThreadModelName(threadId: string): string | undefined {
   if (!isBrowser()) {
     return undefined;
   }
-  return localStorage.getItem(getThreadModelStorageKey(threadId)) ?? undefined;
+  return (
+    safeLocalStorage.getItem(getThreadModelStorageKey(threadId)) ?? undefined
+  );
 }
 
 export function saveThreadModelName(
@@ -84,10 +125,10 @@ export function saveThreadModelName(
   }
   const key = getThreadModelStorageKey(threadId);
   if (!modelName) {
-    localStorage.removeItem(key);
+    safeLocalStorage.removeItem(key);
     return;
   }
-  localStorage.setItem(key, modelName);
+  safeLocalStorage.setItem(key, modelName);
 }
 
 export function applyThreadModelOverride(
@@ -110,7 +151,7 @@ export function getLocalSettings(): LocalSettings {
   if (!isBrowser()) {
     return DEFAULT_LOCAL_SETTINGS;
   }
-  const json = localStorage.getItem(LOCAL_SETTINGS_KEY);
+  const json = safeLocalStorage.getItem(LOCAL_SETTINGS_KEY);
   try {
     if (json) {
       const settings = JSON.parse(json) as Partial<LocalSettings>;
@@ -124,5 +165,5 @@ export function saveLocalSettings(settings: LocalSettings) {
   if (!isBrowser()) {
     return;
   }
-  localStorage.setItem(LOCAL_SETTINGS_KEY, JSON.stringify(settings));
+  safeLocalStorage.setItem(LOCAL_SETTINGS_KEY, JSON.stringify(settings));
 }

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -6,12 +6,14 @@ const ARTIFACT_PATH = "/artifact-fixtures/report.html";
 const MARKDOWN_ARTIFACT_PATH = "/artifact-fixtures/report.md";
 const JSON_ARTIFACT_PATH = "/artifact-fixtures/report.json";
 const PRESENTED_ARTIFACT_PATH = "/mnt/user-data/outputs/presented-report.md";
+const PDF_ARTIFACT_PATH = "/artifact-fixtures/report.pdf";
 const IN_PROGRESS_THREAD_ID = "00000000-0000-0000-0000-000000003119";
 const COMPLETE_THREAD_ID = "00000000-0000-0000-0000-000000003120";
 const MARKDOWN_THREAD_ID = "00000000-0000-0000-0000-000000003121";
 const MARKDOWN_ANCHOR_THREAD_ID = "00000000-0000-0000-0000-000000003123";
 const JSON_THREAD_ID = "00000000-0000-0000-0000-000000003122";
 const PRESENTED_THREAD_ID = "00000000-0000-0000-0000-000000003123";
+const PDF_THREAD_ID = "00000000-0000-0000-0000-000000003124";
 
 function writeFileMessages({
   path = ARTIFACT_PATH,
@@ -322,5 +324,45 @@ test.describe("Artifact preview stability", () => {
     await expect(presentedOption).toBeVisible();
     await presentedOption.click();
     await expect(artifactsPanel.getByText("Presented Report")).toBeVisible();
+  });
+
+  test("renders sandboxed iframe for a browser-previewable non-code file (urlOfArtifact path)", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: PDF_THREAD_ID,
+          title: "PDF artifact preview",
+          messages: writeFileMessages({
+            path: PDF_ARTIFACT_PATH,
+            content: "%PDF-fake-content",
+          }),
+        },
+      ],
+    });
+    await page.route(
+      `**/mock/api/threads/${PDF_THREAD_ID}/artifacts${PDF_ARTIFACT_PATH}`,
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: "application/pdf",
+          body: "%PDF-1.4 fake pdf",
+        }),
+    );
+
+    await page.goto(`/workspace/chats/${PDF_THREAD_ID}`);
+
+    await expect(page.getByText(PDF_ARTIFACT_PATH)).toBeVisible({
+      timeout: 15_000,
+    });
+    await page.getByText(PDF_ARTIFACT_PATH).click();
+
+    const artifactsPanel = page.locator("#artifacts");
+    await expect(artifactsPanel.getByText("report.pdf")).toBeVisible();
+
+    const urlOfArtifactIframe = artifactsPanel.locator("iframe:not([title])");
+    await expect(urlOfArtifactIframe).toBeVisible();
+    await expect(urlOfArtifactIframe).toHaveAttribute("sandbox", "");
   });
 });

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -109,6 +109,9 @@ test.describe("Artifact preview stability", () => {
     await expect(
       artifactsPanel.locator('iframe[title="Artifact preview"]'),
     ).toBeVisible();
+    await expect(
+      artifactsPanel.locator('iframe[title="Artifact preview"]'),
+    ).toHaveAttribute("sandbox", "");
   });
 
   test("renders preview iframe after the write artifact succeeds", async ({

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -111,7 +111,7 @@ test.describe("Artifact preview stability", () => {
     ).toBeVisible();
     await expect(
       artifactsPanel.locator('iframe[title="Artifact preview"]'),
-    ).toHaveAttribute("sandbox", "");
+    ).toHaveAttribute("sandbox", "allow-scripts allow-forms");
   });
 
   test("renders preview iframe after the write artifact succeeds", async ({

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -342,7 +342,7 @@ test.describe("Artifact preview stability", () => {
       ],
     });
     await page.route(
-      `**/mock/api/threads/${PDF_THREAD_ID}/artifacts${PDF_ARTIFACT_PATH}`,
+      `**/api/threads/${PDF_THREAD_ID}/artifacts${PDF_ARTIFACT_PATH}`,
       (route) =>
         route.fulfill({
           status: 200,

--- a/frontend/tests/unit/components/workspace/citations/artifact-link.test.ts
+++ b/frontend/tests/unit/components/workspace/citations/artifact-link.test.ts
@@ -27,4 +27,15 @@ describe("ArtifactLink rendering", () => {
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener noreferrer"');
   });
+
+  it("renders scheme-less relative hrefs as navigable anchors", () => {
+    const tests = ["report.md", "./report.md", "../assets/chart.png"];
+    for (const href of tests) {
+      const html = renderToStaticMarkup(
+        createElement(ArtifactLink, { href }, "doc"),
+      );
+      expect(html).toContain("<a");
+      expect(html).toContain(`href="${href}"`);
+    }
+  });
 });

--- a/frontend/tests/unit/components/workspace/citations/artifact-link.test.ts
+++ b/frontend/tests/unit/components/workspace/citations/artifact-link.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "@rstest/core";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ArtifactLink } from "@/components/workspace/citations/artifact-link";
+
+// Render-level coverage for the .md artifact preview link renderer: a
+// prompt-injected javascript:/data: href must never reach a real anchor in
+// the main document (mirrors the MarkdownLink guard).
+describe("ArtifactLink rendering", () => {
+  it("renders an unsafe href as a disabled span, never an anchor", () => {
+    const html = renderToStaticMarkup(
+      createElement(ArtifactLink, { href: "javascript:alert(1)" }, "click me"),
+    );
+    expect(html).not.toContain("<a");
+    expect(html).toContain("<span");
+    expect(html).toContain("click me");
+    expect(html).not.toContain("href=");
+  });
+
+  it("renders a safe https href as a hardened anchor", () => {
+    const html = renderToStaticMarkup(
+      createElement(ArtifactLink, { href: "https://example.com/x" }, "site"),
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="https://example.com/x"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
@@ -15,17 +15,23 @@ describe("isSafeHref", () => {
     expect(isSafeHref("#section")).toBe(true);
   });
 
+  it("allows scheme-less relative references", () => {
+    expect(isSafeHref("report.md")).toBe(true);
+    expect(isSafeHref("./report.md")).toBe(true);
+    expect(isSafeHref("../assets/chart.png")).toBe(true);
+  });
+
   it("allows non-executing contact schemes", () => {
     expect(isSafeHref("mailto:someone@example.com")).toBe(true);
     expect(isSafeHref("tel:+15551234567")).toBe(true);
   });
 
-  it("rejects executable, local, and malformed URLs", () => {
+  it("rejects executable, local, and protocol-relative URLs", () => {
     expect(isSafeHref("javascript:alert(1)")).toBe(false);
     expect(isSafeHref("data:text/html,<script>alert(1)</script>")).toBe(false);
     expect(isSafeHref("file:///etc/passwd")).toBe(false);
     expect(isSafeHref("//example.com/path")).toBe(false);
-    expect(isSafeHref("relative/path")).toBe(false);
+    expect(isSafeHref("\\\\evil.com")).toBe(false);
     expect(isSafeHref(undefined)).toBe(false);
   });
 });
@@ -70,5 +76,16 @@ describe("MarkdownLink rendering", () => {
     expect(html).toContain('href="https://example.com/report"');
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener noreferrer"');
+  });
+
+  it("renders a scheme-less relative href as a navigable anchor", () => {
+    const tests = ["report.md", "./report.md", "../assets/chart.png"];
+    for (const href of tests) {
+      const html = renderToStaticMarkup(
+        createElement(MarkdownLink, { href }, "doc"),
+      );
+      expect(html).toContain("<a");
+      expect(html).toContain(`href="${href}"`);
+    }
   });
 });

--- a/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "@rstest/core";
+
+import { isSafeHref } from "@/components/workspace/messages/markdown-link";
+
+describe("isSafeHref", () => {
+  it("allows web URLs and same-origin paths", () => {
+    expect(isSafeHref("https://example.com/path")).toBe(true);
+    expect(isSafeHref("http://example.com/path")).toBe(true);
+    expect(isSafeHref("/workspace/chats/1")).toBe(true);
+    expect(isSafeHref("#section")).toBe(true);
+  });
+
+  it("rejects executable, local, and malformed URLs", () => {
+    expect(isSafeHref("javascript:alert(1)")).toBe(false);
+    expect(isSafeHref("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isSafeHref("file:///etc/passwd")).toBe(false);
+    expect(isSafeHref("//example.com/path")).toBe(false);
+    expect(isSafeHref("relative/path")).toBe(false);
+    expect(isSafeHref(undefined)).toBe(false);
+  });
+});

--- a/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-link.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "@rstest/core";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import { isSafeHref } from "@/components/workspace/messages/markdown-link";
+import {
+  createMarkdownLinkComponent,
+  isSafeHref,
+} from "@/components/workspace/messages/markdown-link";
 
 describe("isSafeHref", () => {
   it("allows web URLs and same-origin paths", () => {
@@ -10,6 +15,11 @@ describe("isSafeHref", () => {
     expect(isSafeHref("#section")).toBe(true);
   });
 
+  it("allows non-executing contact schemes", () => {
+    expect(isSafeHref("mailto:someone@example.com")).toBe(true);
+    expect(isSafeHref("tel:+15551234567")).toBe(true);
+  });
+
   it("rejects executable, local, and malformed URLs", () => {
     expect(isSafeHref("javascript:alert(1)")).toBe(false);
     expect(isSafeHref("data:text/html,<script>alert(1)</script>")).toBe(false);
@@ -17,5 +27,48 @@ describe("isSafeHref", () => {
     expect(isSafeHref("//example.com/path")).toBe(false);
     expect(isSafeHref("relative/path")).toBe(false);
     expect(isSafeHref(undefined)).toBe(false);
+  });
+});
+
+// Render-level coverage: these tests exercise the component itself, so
+// removing (or inverting) the isSafeHref guard inside MarkdownLink fails
+// them even though isSafeHref stays untouched.
+describe("MarkdownLink rendering", () => {
+  const MarkdownLink = createMarkdownLinkComponent();
+
+  it("renders an unsafe href as a disabled span, never an anchor", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownLink, { href: "javascript:alert(1)" }, "click me"),
+    );
+    expect(html).not.toContain("<a");
+    expect(html).toContain("<span");
+    expect(html).toContain("click me");
+    expect(html).not.toContain("href=");
+  });
+
+  it("blocks unsafe hrefs before the citation branch", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        MarkdownLink,
+        { href: "javascript:alert(1)" },
+        "citation:evil",
+      ),
+    );
+    expect(html).not.toContain("<a");
+    expect(html).not.toContain("href=");
+  });
+
+  it("renders a safe https href as a hardened anchor", () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        MarkdownLink,
+        { href: "https://example.com/report" },
+        "report",
+      ),
+    );
+    expect(html).toContain("<a");
+    expect(html).toContain('href="https://example.com/report"');
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
   });
 });

--- a/frontend/tests/unit/core/settings/local.test.ts
+++ b/frontend/tests/unit/core/settings/local.test.ts
@@ -1,10 +1,33 @@
-import { expect, test } from "@rstest/core";
+import { afterEach, expect, rs, test } from "@rstest/core";
 
-import { DEFAULT_LOCAL_SETTINGS } from "@/core/settings/local";
+import {
+  DEFAULT_LOCAL_SETTINGS,
+  getLocalSettings,
+  getThreadModelName,
+  saveLocalSettings,
+  saveThreadModelName,
+} from "@/core/settings/local";
+
+afterEach(() => {
+  rs.unstubAllGlobals();
+});
 
 test("defaults token usage to header total plus per-turn breakdown", () => {
   expect(DEFAULT_LOCAL_SETTINGS.tokenUsage).toEqual({
     headerTotal: true,
     inlineMode: "per_turn",
   });
+});
+
+test("falls back when localStorage access is blocked", () => {
+  rs.stubGlobal("window", {
+    get localStorage() {
+      throw new DOMException("Blocked", "SecurityError");
+    },
+  });
+
+  expect(getLocalSettings()).toEqual(DEFAULT_LOCAL_SETTINGS);
+  expect(getThreadModelName("thread-1")).toBeUndefined();
+  expect(() => saveLocalSettings(DEFAULT_LOCAL_SETTINGS)).not.toThrow();
+  expect(() => saveThreadModelName("thread-1", "model-1")).not.toThrow();
 });


### PR DESCRIPTION
## Summary
- sandbox browser-rendered artifact iframes: the HTML preview keeps `sandbox="allow-scripts allow-forms"` (opaque origin; scripts are required by the injected scroll-restoration `postMessage` bridge) and the `urlOfArtifact` iframe (PDF/images/audio/video) gets an empty `sandbox`
- let non-code browser-previewable `write_file` artifacts (e.g. PDF) render in the sandboxed iframe instead of being forced into the code editor
- reject unsafe markdown link schemes (`javascript:`, `data:`, `file:`, …) before rendering anchors — in chat messages (`MarkdownLink`, including the citation branch) and in `.md` artifact previews (`ArtifactLink`); `mailto:`/`tel:` stay allowed
- make local-settings and agent save-hint storage best-effort when browser storage is unavailable (Safari private mode, strict containers)
- add render-level link-component tests, URL/storage regressions, and artifact iframe sandbox e2e assertions

## Scope notes
The thread-history error-surfacing changes were dropped while rebasing: upstream #4065 rewrote `useThreadHistory` as a TanStack `useInfiniteQuery` whose queryFn already throws on `!response.ok` and toasts the failure, so this PR no longer touches `core/threads/hooks.ts`.

## Validation
- `pnpm check` (eslint + tsc) — clean
- `pnpm test` — 653 unit tests pass
- `pnpm format` — clean
- full Playwright e2e suite locally — 95 passed, including the previously failing PDF `urlOfArtifact` sandbox test
