### PR TITLE
fix(channels): scope the slash-skill whitelist check to the run's owner

### DIFF
--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -1062,7 +1062,11 @@ class ChannelManager:
         if not isinstance(agent_name, str) or not agent_name.strip():
             return None
 
-        agent_config = load_agent_config(_normalize_custom_agent_name(agent_name))
+        # Read the agent config from the same owner bucket the run uses:
+        # ``run_context["user_id"]`` is the resolved owner (``_channel_storage_user_id``),
+        # but without it ``load_agent_config`` falls back to the dispatch loop's unset
+        # contextvar (``"default"``), reading the wrong user's per-user custom agent.
+        agent_config = load_agent_config(_normalize_custom_agent_name(agent_name), user_id=run_context.get("user_id"))
         if agent_config and agent_config.skills is not None:
             return set(agent_config.skills)
         return None

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -2412,7 +2412,7 @@ class TestChannelManager:
     def test_handle_command_slash_skill_respects_custom_agent_skill_whitelist(self, monkeypatch, tmp_path):
         from app.channels.manager import ChannelManager
 
-        monkeypatch.setattr("app.channels.manager.load_agent_config", lambda name: SimpleNamespace(skills=["frontend-design"]))
+        monkeypatch.setattr("app.channels.manager.load_agent_config", lambda name, *, user_id=None: SimpleNamespace(skills=["frontend-design"]))
 
         async def go():
             bus = MessageBus()
@@ -2450,6 +2450,47 @@ class TestChannelManager:
             assert outbound_received[0].text == "Skill `/data-analysis` is not available for this agent."
 
         _run(go())
+
+    def test_slash_skill_whitelist_loads_agent_config_for_the_resolved_owner(self, monkeypatch):
+        """The per-user custom agent whitelist must be read from the same owner
+        bucket the run uses. ``_resolve_run_params`` resolves that owner into
+        ``run_context["user_id"]`` (per ``_channel_storage_user_id``, the single
+        source of truth for run identity and storage), but the whitelist
+        pre-check dropped it, so ``load_agent_config`` fell back to the dispatch
+        loop's unset contextvar (``"default"``) — reading, or failing to find,
+        the wrong user's agent config.
+        """
+        from app.channels.manager import ChannelManager
+
+        captured: dict[str, object] = {}
+
+        def spy_load_agent_config(name, *, user_id=None):
+            captured["name"] = name
+            captured["user_id"] = user_id
+            return SimpleNamespace(skills=["data-analysis"])
+
+        monkeypatch.setattr("app.channels.manager.load_agent_config", spy_load_agent_config)
+
+        bus = MessageBus()
+        store = ChannelStore(path=Path(tempfile.mkdtemp()) / "store.json")
+        manager = ChannelManager(bus=bus, store=store, default_session={"assistant_id": "analyst-agent"})
+
+        # A bound connection: the owner resolves to a real, non-default bucket.
+        msg = InboundMessage(
+            channel_name="test",
+            chat_id="chat1",
+            user_id="platform-user",
+            owner_user_id="owner-alice",
+            text="/data-analysis go",
+            msg_type=InboundMessageType.COMMAND,
+        )
+
+        expected_owner = manager._resolve_run_params(msg, "")[2].get("user_id")
+
+        manager._resolve_available_skill_names(msg)
+
+        assert expected_owner and expected_owner != "default"
+        assert captured["user_id"] == expected_owner
 
     def test_handle_command_slash_skill_reports_disabled_skill(self, tmp_path):
         from app.channels.manager import ChannelManager


### PR DESCRIPTION
### Why

`_channel_storage_user_id` declares itself, in its own docstring, the **single source of truth** for a channel run's identity:

> Single source of truth for both the agent **run identity** (`_resolve_run_params` → `run_context["user_id"]`) and the **file/artifact storage bucket** … so the bucket the agent reads/writes always matches where channel files are staged. … Returns `None` only when neither identity is available, leaving the caller to fall back to the contextvar/default user.

It even names the exact hazard: falling back to "the dispatcher task's unset contextvar → `default`".

`_resolve_available_skill_names` (the `/skill` whitelist pre-check for a per-user custom agent) resolves that owner — it calls `_resolve_run_params`, which sets `run_context["user_id"]` — and then **drops it**, calling `load_agent_config(name)` with no `user_id`:

```python
_, _, run_context = self._resolve_run_params(msg, thread_id)   # run_context["user_id"] = the owner
...
agent_config = load_agent_config(_normalize_custom_agent_name(agent_name))   # owner dropped
```

`load_agent_config(name, *, user_id=None)` then falls back to `get_effective_user_id()`. This runs on the `ChannelManager` dispatch loop (via `asyncio.to_thread`), a long-lived background task — the `_current_user` contextvar is set per-HTTP-request by the Gateway, never here — so it resolves `"default"`. AGENTS.md: "Custom agent definitions … are per-user at `{base_dir}/users/{user_id}/agents/{agent_name}/`."

So a bound IM user's `/skill` command against their per-user custom agent reads `users/default/agents/{name}/` instead of `users/{owner}/agents/{name}/`:

- **Common case** — `users/default/agents/{name}/` does not exist → `load_agent_config` raises `FileNotFoundError`, which the dispatch loop's `except Exception` turns into **"An internal error occurred. Please try again."** on every `/skill` command.
- **Collision case** — a different user's agent (or a legacy shared `agents/{name}/`) with the same name exists → the whitelist is decided by a **foreign agent's `skills` list** (a cross-user read): a skill the user's own agent allows is rejected, or vice-versa.

Every other `load_agent_config` caller threads the owner explicitly (`gateway/routers/agents.py` ×4, `update_agent_tool.py`, `github/registry.py`) — N−1 obey; this one site is the exception.

**One-sentence stakes:** if unfixed, a bound IM user's `/skill` against a per-user custom agent either errors out or is authorized against the wrong user's whitelist, on any auth-enabled channel deployment that routes to a custom agent.

### What changed

One line — pass the already-resolved owner to `load_agent_config`:

```python
agent_config = load_agent_config(_normalize_custom_agent_name(agent_name), user_id=run_context.get("user_id"))
```

`run_context.get("user_id")` is the value `_resolve_run_params` already computed for run identity, so the whitelist pre-check and the actual run now read the same bucket. When no owner is resolvable it's `None`, preserving the prior default-user behavior for unbound/no-auth channels.

### Surface area

Enumerated by concept ("channel-path resolution of a per-user custom agent config"): `load_agent_config` is called **once** in `app/channels/` (`manager.py`), and this is it. The `_make_lead_agent` call (`agents/lead_agent/agent.py`) is deliberately **out of scope** — it runs on the Gateway request path where the auth middleware has set the `_current_user` contextvar, so its fallback resolves correctly; I could not construct a channel-path repro for it.

No documentation change needed: AGENTS.md already states the per-user custom-agent layout and the `run_context["user_id"]` single-source rule this restores.

### Bug fix verification

**New test** `test_slash_skill_whitelist_loads_agent_config_for_the_resolved_owner` (in `test_channels.py`): a bound message (`owner_user_id="owner-alice"`) drives the real `_resolve_available_skill_names` → `_resolve_run_params`, spies the `user_id` passed to `load_agent_config`, and asserts it equals the run-identity owner (`run_context["user_id"]`, non-`default`).

**Red check** — reverting only `manager.py` to `main` turns it red (`AssertionError: assert None == 'owner-alice'` — the owner is resolvable but dropped); restoring turns it green.

**End-to-end with real `load_agent_config`** — a real custom agent config placed only under `users/owner-alice/agents/analyst-agent/`:

```
FIX  load_agent_config(name, user_id='owner-alice') -> skills = ['data-analysis']
BUG  load_agent_config(name)                        -> FileNotFoundError: Agent directory not found
```

The BUG line is exactly what the dispatch loop's `except Exception` turns into the user-facing "internal error".

**Pinned-to-the-bug test updated** — `test_handle_command_slash_skill_respects_custom_agent_skill_whitelist` monkeypatched `load_agent_config` with a single-arg `lambda name:`, which locked in the arity of the buggy call. Updated to `lambda name, *, user_id=None:` so it accepts the owner the fix now threads (it still asserts the same whitelist-rejection behavior). No other test mocks this call site (`test_lead_agent_skills.py` patches the separate `agent.py` caller, untouched).

**Full suite** — `8 failed, 7201 passed, 26 skipped`. The 8 are pre-existing, network-dependent `web_fetch` tests — byte-identical to clean `origin/main`; new failures = 0. `make lint` clean, `ruff format --check` clean.

### AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code assisted with tracing the owner-resolution chain from `_channel_storage_user_id`/`_resolve_run_params` into the whitelist pre-check, enumerating the `load_agent_config` call sites, and writing the regression test + real-`load_agent_config` end-to-end check. The contributor reviewed every line and takes responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
