### PR TITLE
test(front): cover artifact image path variants

### DIFF
--- a/frontend/tests/unit/core/artifacts/utils.test.ts
+++ b/frontend/tests/unit/core/artifacts/utils.test.ts
@@ -87,11 +87,12 @@ describe("artifact URL helpers", () => {
     );
   });
 
-  test("resolves a relative message image when it uniquely matches an artifact", async () => {
+  test("resolves absolute and relative message image paths", async () => {
     const { resolveMessageImageURL } = await loadFreshArtifactUtils();
     const artifacts = [
       "/mnt/user-data/outputs/aws-agent-overview.png",
       "/mnt/user-data/outputs/aws-agent-console-config.png",
+      "/mnt/user-data/outputs/chart.png",
     ];
 
     expect(
@@ -108,6 +109,16 @@ describe("artifact URL helpers", () => {
     ).toBe(
       "/api/threads/thread-1/artifacts/mnt/user-data/outputs/aws-agent-overview.png#detail",
     );
+    expect(
+      resolveMessageImageURL(
+        "/mnt/user-data/outputs/chart.png",
+        "thread-1",
+        artifacts,
+      ),
+    ).toBe("/api/threads/thread-1/artifacts/mnt/user-data/outputs/chart.png");
+    expect(
+      resolveMessageImageURL("outputs/chart.png", "thread-1", artifacts),
+    ).toBe("/api/threads/thread-1/artifacts/mnt/user-data/outputs/chart.png");
   });
 
   test("does not rewrite unregistered, ambiguous, or external message images", async () => {


### PR DESCRIPTION
## Why

A post-merge review of #4038 identified two untested
`resolveMessageImageURL` branches: absolute `/mnt/...` artifact paths and
multi-segment relative paths.

Review context:
https://github.com/bytedance/deer-flow/pull/4038#discussion_r3564482494

## What changed

- Add coverage for absolute `/mnt/user-data/outputs/...` image paths.
- Add coverage for multi-segment relative paths such as `outputs/chart.png`.
- No runtime behavior changes.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [x] **Docs / tests / CI only**

## Screenshots / Recording

Not applicable. This is a test-only change.

## Validation

- `pnpm exec rstest run tests/unit/core/artifacts/utils.test.ts`
- `pnpm typecheck`
- `pnpm check`
- `pnpm format`
- `git diff --check`

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex helped trace the post-merge review feedback and draft the regression assertions. I reviewed and validated the final change.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.