### PR TITLE
docs(deployment-guide): fix stale userdata PVC subPath

### DIFF
--- a/frontend/src/content/en/application/deployment-guide.mdx
+++ b/frontend/src/content/en/application/deployment-guide.mdx
@@ -180,7 +180,7 @@ USERDATA_PVC_NAME=deer-flow-userdata-pvc
 SKILLS_PVC_NAME=deer-flow-skills-pvc
 ```
 
-When `USERDATA_PVC_NAME` is set, the provisioner automatically uses subPath (`threads/{thread_id}/user-data`) so each thread gets its own directory in the PVC.
+When `USERDATA_PVC_NAME` is set, the provisioner automatically uses subPath (`deer-flow/users/{user_id}/threads/{thread_id}/user-data`) so each user's threads get their own directories in the PVC.
 
 </Steps>
 

--- a/frontend/src/content/zh/application/deployment-guide.mdx
+++ b/frontend/src/content/zh/application/deployment-guide.mdx
@@ -175,7 +175,7 @@ USERDATA_PVC_NAME=deer-flow-userdata-pvc
 SKILLS_PVC_NAME=deer-flow-skills-pvc
 ```
 
-当设置 `USERDATA_PVC_NAME` 时，Provisioner 自动使用子路径（`threads/{thread_id}/user-data`），每个线程在 PVC 中获得自己的目录。
+当设置 `USERDATA_PVC_NAME` 时，Provisioner 自动使用子路径（`deer-flow/users/{user_id}/threads/{thread_id}/user-data`），每个用户的每个线程在 PVC 中获得自己的目录。
 
 </Steps>
 


### PR DESCRIPTION
## What

Phase 0 of #4030 (docs drift called out in the issue's "Also worth fixing alongside" section): `deployment-guide.mdx` (en + zh) still documents the pre-user-scoping userdata PVC subPath.

- Docs said: `threads/{thread_id}/user-data`
- Provisioner actually uses: `deer-flow/users/{user_id}/threads/{thread_id}/user-data` (`docker/provisioner/app.py`, `_build_volume_mounts` — `userdata_mount.sub_path`)

An operator provisioning a PVC against the documented path would look for thread data in the wrong place (or pre-create a layout the provisioner never reads).

## Scope note

A repo-wide grep also shows `.deer-flow/threads/{thread_id}/user-data/` in `backend/docs/*` and other content pages — those describe the gateway's **local** dual-mode layout, where `threads/{thread_id}` is still the legitimate no-auth fallback (`config/paths.py`, `thread_dir()`), so they're incomplete rather than wrong. Left out of this PR deliberately; the layout story is part of the contract work tracked in #4030.

## Verification

Doc-only change; both locales updated symmetrically; the path string matches `app.py` verbatim.
