### PR TITLE
fix(skills): reuse the resolved app config in the no-arg skills prompt section

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -809,10 +809,16 @@ def get_skills_prompt_section(
         try:
             from deerflow.config import get_app_config
 
-            config = get_app_config()
-            container_base_path = config.skills.container_path
-            skill_evolution_enabled = config.skill_evolution.enabled
+            # Rebind so the storage/enabled-skills loads below use this resolved
+            # config too. Reading only container_path here and then letting
+            # get_enabled_skills_for_config(None) fall back to the warm cache
+            # rendered an empty enabled-skills list on a cold start while the
+            # synchronously-loaded disabled section was populated (#4144).
+            app_config = get_app_config()
+            container_base_path = app_config.skills.container_path
+            skill_evolution_enabled = app_config.skill_evolution.enabled
         except Exception:
+            app_config = None
             container_base_path = DEFAULT_SKILLS_CONTAINER_PATH
             skill_evolution_enabled = False
     else:

--- a/backend/tests/test_lead_agent_skills.py
+++ b/backend/tests/test_lead_agent_skills.py
@@ -11,7 +11,7 @@ class NamedTool:
         self.name = name
 
 
-def _make_skill(name: str, allowed_tools: list[str] | None = None) -> Skill:
+def _make_skill(name: str, allowed_tools: list[str] | None = None, *, enabled: bool = True) -> Skill:
     return Skill(
         name=name,
         description=f"Description for {name}",
@@ -21,7 +21,7 @@ def _make_skill(name: str, allowed_tools: list[str] | None = None) -> Skill:
         relative_path=Path(name),
         category="public",
         allowed_tools=tuple(allowed_tools) if allowed_tools is not None else None,
-        enabled=True,
+        enabled=enabled,
     )
 
 
@@ -78,6 +78,36 @@ def test_get_skills_prompt_section_returns_all_when_available_skills_is_none(mon
     result = get_skills_prompt_section(available_skills=None)
     assert "skill1" in result
     assert "skill2" in result
+
+
+def test_get_skills_prompt_section_no_arg_cold_cache_loads_enabled_skills(monkeypatch):
+    """#4144: a fresh process calling the no-arg helper must not render an empty
+    enabled-skills list while the synchronously-loaded disabled section is populated."""
+    import threading
+
+    from deerflow.agents.lead_agent import prompt as prompt_mod
+
+    skills = [_make_skill("skill1"), _make_skill("skill2", enabled=False)]
+    mock_storage = SimpleNamespace(load_skills=lambda *, enabled_only: [s for s in skills if s.enabled or not enabled_only])
+    monkeypatch.setattr("deerflow.agents.lead_agent.prompt.get_or_new_skill_storage", lambda **kwargs: mock_storage)
+    monkeypatch.setattr("deerflow.agents.lead_agent.prompt.get_or_new_user_skill_storage", lambda user_id, **kwargs: mock_storage)
+    monkeypatch.setattr(
+        "deerflow.config.get_app_config",
+        lambda: SimpleNamespace(
+            skills=SimpleNamespace(container_path="/mnt/skills", use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage", get_skills_path=lambda: Path("/tmp/skills")),
+            skill_evolution=SimpleNamespace(enabled=False),
+        ),
+    )
+    # Cold cache: no warmed enabled-skills list, and the background refresh must
+    # not fill it mid-test — the reporter's cold start loses exactly this race.
+    monkeypatch.setattr(prompt_mod, "_enabled_skills_cache", None)
+    monkeypatch.setattr(prompt_mod, "_ensure_enabled_skills_cache", lambda: threading.Event())
+
+    result = get_skills_prompt_section(available_skills=None)
+
+    assert "<available_skills>" in result
+    assert "skill1" in result
+    assert "<disabled_skills>" in result
 
 
 def test_get_skills_prompt_section_includes_slash_activation_guidance(monkeypatch):


### PR DESCRIPTION
Fixes #4144

## Why

#4144: agents assembled manually via `create_deerflow_agent` get a system prompt with **no enabled skills** on a cold start, even though `skills.path` is configured correctly and `load_skills()` sees them. Root cause (triaged on the issue): `get_skills_prompt_section()` without `app_config` resolves `get_app_config()` only to read `container_path`, then lets the enabled-skills load fall through to `get_enabled_skills_for_config(None)` → the warm cache, which is empty on first call and returns `[]` while kicking off a background refresh. The disabled-skills section in the same function loads synchronously, so the reporter saw `all_skills` populated but `skills` empty — one function, two inconsistent config sources.

## What changed

- `get_skills_prompt_section()` called without `app_config` now reuses the config it already resolved for the skill loads below it: the first call in a fresh process returns the real enabled-skills section instead of an empty one.
- Gateway/embedded paths that pass `app_config` explicitly are untouched. When no config is resolvable at all (no `config.yaml`), the previous cache-only fallback behavior is unchanged.
- No blocking-IO regression on the no-arg path: it already loads `all_skills` synchronously on every call for the disabled section; the enabled load additionally caches by config identity (`_enabled_skills_by_config_cache`), so only the first call per config generation touches disk.

## Surface area

- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change

## Bug fix verification

- Test path: `backend/tests/test_lead_agent_skills.py::test_get_skills_prompt_section_no_arg_cold_cache_loads_enabled_skills`
- Red on `main`, green on this branch? **yes** — on main it fails with exactly the reported symptom (`<disabled_skills>` rendered, `<available_skills>` missing).

Real-path check on top of the unit test — cold process, repo `skills/` + `config.example.yaml`, calling `get_skills_prompt_section()` immediately after import:

| | `<available_skills>` | section length |
|---|---|---|
| main | absent | 0 |
| this branch | present (all public skills) | 14588 |

## Validation

- `cd backend && make lint && make format` — clean
- `cd backend && make test` — 7391 passed, 23 skipped; one `test_checkpointer.py` failure during the run was caused by a stray `config.yaml` I had created in the repo root for the repro (the test asserts unconfigured behavior); after removing it, `tests/test_checkpointer.py` passes 50/50. Not related to this change.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** wrote the failing regression test and the fix from the root-cause triage on the issue; I reviewed the diff and ran all validation locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
