### PR TITLE
fix(agents): require config.yaml in update_agent's legacy-agent guard

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -301,7 +301,15 @@ async def update_agent(name: str, request: AgentUpdateRequest) -> AgentResponse:
 
     paths = get_paths()
     agent_dir = paths.user_agent_dir(user_id, name)
-    if not agent_dir.exists() and paths.agent_dir(name).exists():
+    legacy_dir = paths.agent_dir(name)
+    # Require config.yaml, not bare directory existence — a per-user agent
+    # directory can exist containing only memory.json (written the first
+    # time this user chats with a legacy shared agent, before this route
+    # is ever called). Bare .exists() would miss that case and let this
+    # fall through to a silent fork of a brand-new config.yaml/SOUL.md
+    # into the memory-only directory instead of blocking (mirrors
+    # resolve_agent_dir's guard, see #3390).
+    if not (agent_dir / "config.yaml").exists() and (legacy_dir / "config.yaml").exists():
         raise HTTPException(
             status_code=409,
             detail=(f"Agent '{name}' only exists in the legacy shared layout and is not scoped to a user. Run scripts/migrate_user_isolation.py to move legacy agents into the per-user layout before updating."),

--- a/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
@@ -170,7 +170,16 @@ def update_agent(
 
     paths = get_paths()
     agent_dir = paths.user_agent_dir(user_id, agent_name)
-    if not agent_dir.exists() and paths.agent_dir(agent_name).exists():
+    legacy_dir = paths.agent_dir(agent_name)
+    # Require config.yaml, not bare directory existence — a per-user agent
+    # directory can exist containing only memory.json (written the first
+    # time this user chats with a legacy shared agent, before update_agent
+    # is ever called). Bare .exists() would miss that case and let this
+    # fall through to load_agent_config, which correctly resolves through
+    # to the legacy shared config via resolve_agent_dir, silently forking
+    # a brand-new config.yaml/SOUL.md into the memory-only directory
+    # instead of blocking (mirrors resolve_agent_dir's guard, see #3390).
+    if not (agent_dir / "config.yaml").exists() and (legacy_dir / "config.yaml").exists():
         return _err(f"Agent '{agent_name}' only exists in the legacy shared layout and is not scoped to a user. Run scripts/migrate_user_isolation.py to move legacy agents into the per-user layout before updating.")
 
     try:

--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -695,6 +695,32 @@ class TestAgentsAPI:
             ],
         }
 
+    def test_update_memory_only_user_dir_with_legacy_agent_returns_409(self, agent_client, tmp_path):
+        """Regression for #3390's PUT /api/agents/{name} guard.
+
+        A per-user agent directory can exist containing only memory.json
+        (written the first time this user chats with a legacy shared
+        agent). The stale guard checked bare directory existence and
+        missed this case, letting the route silently fork a brand-new
+        config.yaml/SOUL.md into the memory-only directory instead of
+        blocking with the migration-script guidance.
+        """
+        legacy_dir = tmp_path / "agents" / "legacy-agent"
+        legacy_dir.mkdir(parents=True)
+        (legacy_dir / "config.yaml").write_text("name: legacy-agent\ndescription: legacy\n", encoding="utf-8")
+        (legacy_dir / "SOUL.md").write_text("legacy soul", encoding="utf-8")
+
+        user_agent_dir = tmp_path / "users" / "test-user-autouse" / "agents" / "legacy-agent"
+        user_agent_dir.mkdir(parents=True)
+        (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+        response = agent_client.put("/api/agents/legacy-agent", json={"soul": "should not write"})
+
+        assert response.status_code == 409
+        assert not (user_agent_dir / "config.yaml").exists()
+        assert not (user_agent_dir / "SOUL.md").exists()
+        assert (user_agent_dir / "memory.json").exists(), "the user's existing memory must be left untouched"
+
     def test_update_missing_agent_404(self, agent_client):
         response = agent_client.put("/api/agents/ghost-agent", json={"soul": "new"})
         assert response.status_code == 404

--- a/backend/tests/test_update_agent_tool.py
+++ b/backend/tests/test_update_agent_tool.py
@@ -124,6 +124,37 @@ def test_update_agent_rejects_unknown_agent(tmp_path, patched_paths):
     assert not _user_agent_dir(tmp_path, "ghost").exists()
 
 
+def test_update_agent_rejects_legacy_agent_when_user_dir_has_only_memory(tmp_path, patched_paths):
+    """Regression for #3390's update_agent guard.
+
+    A per-user agent directory can exist containing only memory.json —
+    written automatically the first time this user chats with a legacy
+    shared agent, before update_agent is ever called. The stale guard
+    checked bare directory existence, so it missed this case, fell
+    through to load_agent_config (which correctly resolves through to
+    the legacy shared config via resolve_agent_dir), and then silently
+    forked a brand-new config.yaml/SOUL.md into the memory-only
+    directory — splitting the agent for just this user with no warning.
+    """
+    legacy_dir = tmp_path / "agents" / "legacy-agent"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "config.yaml").write_text(yaml.safe_dump({"name": "legacy-agent", "description": "legacy"}), encoding="utf-8")
+    (legacy_dir / "SOUL.md").write_text("legacy soul", encoding="utf-8")
+
+    user_agent_dir = _user_agent_dir(tmp_path, "legacy-agent")
+    user_agent_dir.mkdir(parents=True)
+    (user_agent_dir / "memory.json").write_text("{}", encoding="utf-8")
+
+    result = update_agent.func(runtime=_runtime(agent_name="legacy-agent"), soul="should not write")
+
+    msg = result.update["messages"][0]
+    assert "only exists in the legacy shared layout" in msg.content
+    assert msg.status == "error"
+    assert not (user_agent_dir / "config.yaml").exists()
+    assert not (user_agent_dir / "SOUL.md").exists()
+    assert (user_agent_dir / "memory.json").exists(), "the user's existing memory must be left untouched"
+
+
 def test_update_agent_requires_at_least_one_field(tmp_path, patched_paths):
     _seed_agent(tmp_path)
 


### PR DESCRIPTION
## Summary

`update_agent` (the harness tool) and `PUT /api/agents/{name}` (the same operation over HTTP) share an identical guard meant to block updates to an agent that only exists in the legacy shared layout:

```python
agent_dir = paths.user_agent_dir(user_id, name)
if not agent_dir.exists() and paths.agent_dir(name).exists():
    ...  # block with a 409 / tool error
```

This checks bare **directory** existence. But when memory is enabled, the first time a user chats with a legacy shared custom agent, the memory writer creates `{base}/users/{user}/agents/{name}/memory.json` — a per-user directory that exists but has no `config.yaml`. `agent_dir.exists()` is then `True`, so the guard never fires.

Both surfaces then fall through and proceed:
- The tool calls `load_agent_config`, which (via the already-hardened `resolve_agent_dir`) correctly resolves through to the legacy shared config, and then writes a **brand-new** `config.yaml`/`SOUL.md` into the memory-only per-user directory.
- The router's `PUT` handler does the same on its own write path.

The result is a silent, permanent fork: that one user gets their own private copy of the agent from that point on, while every other user keeps reading the original shared config forever — with no error or warning anywhere.

## Why this wasn't already covered

`resolve_agent_dir` (`agents_config.py`) was hardened against exactly this failure mode in #3481: it now requires `config.yaml` to exist, not just the directory, before treating a per-user (or legacy) directory as resolved. But `update_agent`'s own pre-check and the router's identical copy were never updated to match, so the two call sites that decide *whether to update at all* still ran the old, weaker directory check even though the config-loading path underneath them had already been fixed.

## Fix

Mirror `resolve_agent_dir`'s condition at both call sites: require `config.yaml` specifically, not bare directory existence.

```python
if not (agent_dir / "config.yaml").exists() and (legacy_dir / "config.yaml").exists():
    ...
```

## Prior art

#3448 drafted a complete fix touching all three sites (`update_agent_tool.py`, the router, and `agents_config.py`) plus tests, but was closed unmerged. Only the `agents_config.py` portion of that shape later landed independently via #3481 — the tool and router guards this PR fixes were left stale. This PR completes that gap for the `update_agent` surfaces, adapted to the current code (which has moved on in the meantime — e.g. `load_agent_soul` gained unrelated hardening of its own in #4136).

Context: #3390 was the original report of this failure mode (a legacy agent becoming unreadable on the second turn); #3481 fixed the read path, and this PR fixes the corresponding guards on the write path.

## Testing

Added a regression test at each surface, reproducing the exact scenario (a legacy shared `config.yaml` plus a per-user directory containing only `memory.json`):

- `backend/tests/test_update_agent_tool.py::test_update_agent_rejects_legacy_agent_when_user_dir_has_only_memory`
- `backend/tests/test_custom_agent.py::TestAgentsAPI::test_update_memory_only_user_dir_with_legacy_agent_returns_409`

Both fail on `main` — the tool reports "updated successfully" and the route returns 200, in both cases after already having written a fresh `config.yaml`/`SOUL.md` into the memory-only directory — and pass with this fix (blocked with the existing 409 / tool error, files untouched, the user's `memory.json` left alone).

```
PYTHONPATH=. uv run pytest tests/test_update_agent_tool.py tests/test_custom_agent.py -v
# 23 passed (test_update_agent_tool.py)
# 63 passed (test_custom_agent.py)
```

`ruff check` / `ruff format --check` clean on all changed files.
