### PR TITLE
fix(skills): handle non-string frontmatter keys

### DIFF
--- a/backend/packages/harness/deerflow/skills/frontmatter.py
+++ b/backend/packages/harness/deerflow/skills/frontmatter.py
@@ -57,6 +57,10 @@ def split_skill_markdown(content: str) -> tuple[SkillMarkdownParts | None, str |
     if not isinstance(metadata, dict):
         return None, "Frontmatter must be a YAML dictionary"
 
+    # YAML permits non-string keys, but downstream validation expects field
+    # names to be strings.
+    metadata = {str(key): value for key, value in metadata.items()}
+
     return (
         SkillMarkdownParts(
             metadata=metadata,

--- a/backend/tests/test_skill_review_core.py
+++ b/backend/tests/test_skill_review_core.py
@@ -56,6 +56,22 @@ def test_review_core_reports_missing_description_blocker(tmp_path):
     assert any(f["rule_id"] == "structure.missing-description" for f in facts["findings"])
 
 
+def test_review_core_reports_non_string_frontmatter_key_as_unknown_field(tmp_path):
+    _write(
+        tmp_path / "SKILL.md",
+        "---\nname: demo-skill\ndescription: Demo skill. Invoke when testing review.\n42: stray-value\nunexpected-field: another-value\n---\n\n# Demo\n\nFollow the steps and stop.\n",
+    )
+
+    facts = analyze_skill_package(LocalDirectoryReader(tmp_path).read())
+
+    assert facts["summary"]["blockers"] == 0
+    finding = next(f for f in facts["findings"] if f["rule_id"] == "structure.unknown-frontmatter-field")
+    assert finding["severity"] == "warning"
+    assert finding["evidence"] == ["42", "unexpected-field"]
+    assert "42" in finding["message"]
+    assert "unexpected-field" in finding["message"]
+
+
 def test_resource_graph_reports_unreferenced_resource(tmp_path):
     _write(tmp_path / "SKILL.md", _valid_skill())
     _write(tmp_path / "references" / "unused.md", "# Unused\n")
@@ -275,6 +291,20 @@ def test_cli_fail_on_error(tmp_path, capsys):
 
     assert exit_code == 1
     assert "structure.missing-description" in output
+
+
+def test_cli_reports_non_string_frontmatter_key_without_crashing(tmp_path, capsys):
+    _write(
+        tmp_path / "SKILL.md",
+        "---\nname: demo-skill\ndescription: Demo skill. Invoke when testing review.\n42: stray-value\nunexpected-field: another-value\n---\n\n# Demo\n\nFollow the steps and stop.\n",
+    )
+
+    exit_code = review_cli_main([str(tmp_path), "--format", "text", "--fail-on", "error", "--fail-on-incomplete"])
+    output = capsys.readouterr().out
+
+    assert exit_code == 0
+    assert "structure.unknown-frontmatter-field" in output
+    assert "Unknown frontmatter field(s): 42, unexpected-field" in output
 
 
 def test_cli_fail_on_incomplete_package(tmp_path, capsys):

--- a/backend/tests/test_skills_validation.py
+++ b/backend/tests/test_skills_validation.py
@@ -116,6 +116,17 @@ class TestValidateSkillFrontmatter:
         assert valid is False
         assert "custom-field" in msg
 
+    def test_non_string_frontmatter_key_reports_cleanly_instead_of_crashing(self, tmp_path):
+        skill_dir = _write_skill(
+            tmp_path,
+            "---\nname: my-skill\ndescription: test\n42: bad\ncustom-field: bad\n---\n\nBody\n",
+        )
+        valid, msg, name = _validate_skill_frontmatter(skill_dir)
+        assert valid is False
+        assert "custom-field" in msg
+        assert "42" in msg
+        assert name is None
+
     def test_name_must_be_hyphen_case(self, tmp_path):
         skill_dir = _write_skill(
             tmp_path,


### PR DESCRIPTION
## Summary

YAML frontmatter can contain non-string mapping keys. Mixed string and numeric keys previously reached `sorted()` in both review and install validation and raised `TypeError` instead of returning a normal validation finding.

`split_skill_markdown`, the shared parser for both paths, now converts mapping keys to strings once. Review and install validation therefore report the malformed fields consistently without crashing.

## Tests

The focused review and install-validation suites pass (40 tests); ruff check and format are clean.