### PR TITLE
fix(skills): recognize fully deleted skill packages in review CI

### DIFF
--- a/backend/tests/test_review_changed_public_skills.py
+++ b/backend/tests/test_review_changed_public_skills.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 import review_changed_public_skills as runner
 
@@ -109,6 +109,98 @@ def test_main_reviews_changed_public_skill_and_skips_deleted_skill_md(
     assert "Queued package: skills/public/alpha" in output
     assert "Skipping deleted SKILL.md: skills/public/deleted/SKILL.md" in output
     assert "All changed public skill packages passed review." in output
+
+
+def test_main_skips_fully_deleted_skill_package(tmp_path: Path, monkeypatch, capsys) -> None:
+    # Nothing is written to tmp_path for "removed": the whole package (SKILL.md and its
+    # other files) was deleted, so the package directory does not exist on disk anymore.
+    diff_output = b"\0".join(
+        [
+            b"D",
+            b"skills/public/removed/SKILL.md",
+            b"D",
+            b"skills/public/removed/scripts/helper.py",
+            b"D",
+            b"skills/public/removed/assets/logo.png",
+            b"",
+        ]
+    )
+
+    def fake_git_diff(command, **kwargs):
+        return _completed(command, stdout=diff_output)
+
+    def fail_review(*args, **kwargs):
+        raise AssertionError("review should not run for a fully deleted skill package")
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_git_diff)
+    monkeypatch.setattr(runner, "run_review", fail_review)
+
+    exit_code = runner.main(
+        [
+            "--before",
+            "before",
+            "--after",
+            "after",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Skipping deleted SKILL.md: skills/public/removed/SKILL.md" in output
+    assert "Skipping fully removed package: skills/public/removed" in output
+    assert "No changed public skill package files; skipping review." in output
+
+
+def test_main_reviews_package_when_skill_md_deleted_but_sibling_file_remains(
+    tmp_path: Path,
+    monkeypatch,
+    capsys,
+) -> None:
+    # SKILL.md was deleted but a sibling package file still exists on disk: this is a
+    # broken/partial package, not a full removal, and must still be queued for review.
+    skill_dir = tmp_path / "skills" / "public" / "broken"
+    (skill_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (skill_dir / "scripts" / "helper.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+
+    diff_output = b"\0".join(
+        [
+            b"D",
+            b"skills/public/broken/SKILL.md",
+            b"M",
+            b"skills/public/broken/scripts/helper.py",
+            b"",
+        ]
+    )
+    reviewed: list[str] = []
+
+    def fake_git_diff(command, **kwargs):
+        return _completed(command, stdout=diff_output)
+
+    def fake_review(package: Path, repo_root: Path, python_executable: str) -> int:
+        reviewed.append(package.relative_to(repo_root).as_posix())
+        return 1
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_git_diff)
+    monkeypatch.setattr(runner, "run_review", fake_review)
+
+    exit_code = runner.main(
+        [
+            "--before",
+            "before",
+            "--after",
+            "after",
+            "--repo-root",
+            str(tmp_path),
+        ]
+    )
+
+    output = capsys.readouterr().out
+    assert exit_code == 1
+    assert reviewed == ["skills/public/broken"]
+    assert "Queued package: skills/public/broken" in output
+    assert "One or more skill reviews failed." in output
 
 
 def test_main_reviews_package_when_only_support_file_changed(
@@ -265,6 +357,22 @@ def test_main_falls_back_to_empty_tree_when_push_before_is_missing(tmp_path: Pat
     assert reviewed == ["skills/public/alpha"]
     assert calls[1][4:6] == [runner.EMPTY_TREE_SHA, "a" * 40]
     assert "Fallback diff:" in output
+
+
+def test_is_fully_removed_package_true_when_all_deletions_and_directory_missing(tmp_path: Path) -> None:
+    package_rel = PurePosixPath("skills/public/removed")
+    assert runner.is_fully_removed_package(package_rel, ["D", "D"], tmp_path) is True
+
+
+def test_is_fully_removed_package_false_when_directory_still_exists(tmp_path: Path) -> None:
+    package_rel = PurePosixPath("skills/public/broken")
+    (tmp_path / package_rel).mkdir(parents=True)
+    assert runner.is_fully_removed_package(package_rel, ["D", "D"], tmp_path) is False
+
+
+def test_is_fully_removed_package_false_when_any_status_is_not_a_deletion(tmp_path: Path) -> None:
+    package_rel = PurePosixPath("skills/public/partial")
+    assert runner.is_fully_removed_package(package_rel, ["D", "M"], tmp_path) is False
 
 
 def test_is_zero_sha_requires_full_sha_length() -> None:

--- a/scripts/review_changed_public_skills.py
+++ b/scripts/review_changed_public_skills.py
@@ -161,8 +161,8 @@ def parse_name_status(output: bytes) -> list[ChangedPath]:
 
 
 def select_skill_packages(changes: Sequence[ChangedPath], repo_root: Path) -> list[Path]:
-    packages: list[Path] = []
-    seen: set[PurePosixPath] = set()
+    package_statuses: dict[PurePosixPath, list[str]] = {}
+    resolutions: list[tuple[ChangedPath, PurePosixPath]] = []
 
     for change in changes:
         if not is_public_skill_package_path(change.path):
@@ -177,15 +177,40 @@ def select_skill_packages(changes: Sequence[ChangedPath], repo_root: Path) -> li
             print(f"[skill-review] Skipping path outside public skill package: {change.path}")
             continue
 
+        package_statuses.setdefault(package_rel, []).append(change.status)
+        resolutions.append((change, package_rel))
+
+    packages: list[Path] = []
+    seen: set[PurePosixPath] = set()
+
+    for _, package_rel in resolutions:
         if package_rel in seen:
             print(f"[skill-review] Already queued package: {package_rel}")
             continue
-
         seen.add(package_rel)
+
+        if is_fully_removed_package(package_rel, package_statuses[package_rel], repo_root):
+            print(f"[skill-review] Skipping fully removed package: {package_rel}")
+            continue
+
         packages.append(repo_root / package_rel)
         print(f"[skill-review] Queued package: {package_rel}")
 
     return packages
+
+
+def is_fully_removed_package(package_rel: PurePosixPath, statuses: Sequence[str], repo_root: Path) -> bool:
+    """Whether every changed file that resolved to ``package_rel`` was a deletion and the
+    package directory itself no longer exists on disk.
+
+    This identifies a whole public skill package being intentionally deleted (all of its
+    files removed, not just SKILL.md), as distinct from a package left in a broken/partial
+    state (e.g. SKILL.md deleted while other package files remain on disk) — the latter
+    must still be reviewed and flagged.
+    """
+    if not all(status.startswith("D") for status in statuses):
+        return False
+    return not (repo_root / package_rel).is_dir()
 
 
 def is_public_skill_md(path: PurePosixPath) -> bool:


### PR DESCRIPTION
## Summary

`scripts/review_changed_public_skills.py` maps each git-diff-changed file under `skills/public/**` back to its owning skill package directory via `find_public_skill_package()`. When a PR deletes an entire public skill package (`SKILL.md` **and** its other files, e.g. `scripts/`, `assets/`), that mapping still resolves through an unconditional depth-3 fallback to the package's directory path — even though that directory no longer exists on disk. The review CLI is then invoked against a path that isn't there, which reports a `structure.missing-skill-md` blocker and fails CI on a routine, correct "delete a whole skill package" cleanup PR.

## 1. The bug: depth-3 fallback assumes the package still exists

`find_public_skill_package()` walks up from a changed file's path looking for a `SKILL.md` that still exists on disk; if it reaches depth 3 (`skills/public/<name>`) without finding one, it returns that path anyway:

```python
current = path.parent if path.name else path
while len(current.parts) >= 3:
    skill_md_rel = current / "SKILL.md"
    if not _is_eval_fixture_skill_md(skill_md_rel) and (repo_root / skill_md_rel).is_file():
        return current
    if len(current.parts) == 3:
        return current            # <- unconditional fallback
    current = current.parent
```

`select_skill_packages()` already special-cases a deleted `SKILL.md` path itself (skipping it directly, since removing just the frontmatter file isn't independently reviewable), but any *other* deleted file from the same package (e.g. `scripts/helper.py`) still resolves through this fallback and gets queued for review at `skills/public/<name>` — a path that, for a full-package deletion, no longer exists on disk.

## 2. Impact

`run_review()` invokes `python -m deerflow.skills.review.cli skills/public/<name> --fail-on error --fail-on-incomplete` against the deleted directory. `LocalDirectoryReader.read()` reports `root_not_found`, so `analyze_skill_package()` finds no `SKILL.md` and emits a `structure.missing-skill-md` **blocker**, which `--fail-on error` turns into exit 1. The Skill Review CI workflow (`.github/workflows/skill-review-ci.yml`) then fails red on a PR that did nothing wrong — it just deleted a skill package it no longer needed.

Reproduced on a synthetic repo built from `main`: committing a two-file skill package (`SKILL.md` + `scripts/helper.py`) and then deleting both files in a second commit, then running the script with `--before`/`--after` against those two commits currently prints:

```
[skill-review] Skipping deleted SKILL.md: skills/public/demo-skill/SKILL.md
[skill-review] Queued package: skills/public/demo-skill
...
- blocker structure.missing-skill-md at <package>: Package root does not contain SKILL.md.
[skill-review] Failed: skills/public/demo-skill (exit 1)
```

and the script exits 1 for a change that deleted the entire package correctly.

## 3. The fix

Skip a resolved package only when **both** hold: every changed file that resolved to it was a deletion, and the package directory itself is gone from disk (`is_fully_removed_package()`). That combination only occurs when the whole package was removed — a package left in a genuinely broken/partial state (e.g. `SKILL.md` deleted while a sibling file is still modified/present) still has a directory on disk, so it is unaffected and continues to be queued and reviewed exactly as before.

```python
def is_fully_removed_package(package_rel, statuses, repo_root) -> bool:
    if not all(status.startswith("D") for status in statuses):
        return False
    return not (repo_root / package_rel).is_dir()
```

`select_skill_packages()` now groups resolved changes by package before deciding, so it can see every status touching a package before ruling it fully removed or not.

## 4. Tests (`backend/tests/test_review_changed_public_skills.py`)

| Test | Asserts |
|------|---------|
| `test_main_skips_fully_deleted_skill_package` | full package deletion (`SKILL.md` + other files, directory gone) → `run_review` never invoked, exit 0 |
| `test_main_reviews_package_when_skill_md_deleted_but_sibling_file_remains` | **non-regression**: `SKILL.md` deleted but a sibling file still on disk → still queued, still reviewed, exit code propagates the reviewer's failure |
| `test_is_fully_removed_package_true_when_all_deletions_and_directory_missing` | all-deletions + missing directory → `True` |
| `test_is_fully_removed_package_false_when_directory_still_exists` | all-deletions but directory still present → `False` |
| `test_is_fully_removed_package_false_when_any_status_is_not_a_deletion` | mixed statuses → `False` |

Confirmed via patch-file revert (not `git stash`) that the fix-targeting tests fail against pre-fix code (`AssertionError` from the "review should not run" guard, plus `AttributeError` for the not-yet-added `is_fully_removed_package`), and all pass after re-applying the fix. The partial-deletion non-regression test passes both before and after, since that behavior was already correct and must not change.

Separately re-ran the full synthetic repro end-to-end with a real subprocess invocation of `deerflow.skills.review.cli` (not mocked): the full-package-deletion scenario now exits 0 (`Skipping fully removed package: skills/public/demo-skill`), while a second synthetic scenario with `SKILL.md` deleted but a sibling file left behind still exits 1 with the genuine `structure.missing-skill-md` blocker, unchanged from before the fix.

## Notes

`ruff check` / `ruff format --check` clean (line-length 240). No other callers of `select_skill_packages()` or `find_public_skill_package()` exist outside this script and its test file.
