### PR TITLE
feat(omnigent-mcp): FastMCP stdio server wrapping DeerFlow REST API for Omnigent/polly

### DIFF
--- a/omnigent-mcp/README.md
+++ b/omnigent-mcp/README.md
@@ -1,0 +1,83 @@
+# DeerFlow MCP Server
+
+An MCP (Model Context Protocol) stdio server that wraps DeerFlow's REST API as tools so that Omnigent/polly can call DeerFlow directly.
+
+## What it is
+
+This server exposes three tools over the MCP stdio protocol:
+
+| Tool | Description |
+|------|-------------|
+| `deerflow_run` | Submit a prompt to DeerFlow, wait up to 300 s, return the last assistant message |
+| `deerflow_create_thread` | Create a new conversation thread; returns `thread_id` for multi-turn use |
+| `deerflow_health` | GET /health — no auth required; returns JSON health status |
+
+## Requirements
+
+- Python ≥ 3.11
+- `mcp >= 1.0.0` and `httpx >= 0.28.0` (install via `pip install mcp httpx` or `uv sync`)
+- DeerFlow running locally at `http://localhost:2026` (or set `DEERFLOW_URL`)
+
+## Required environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `DEERFLOW_EMAIL` | Email address used to log in to DeerFlow |
+| `DEERFLOW_PASSWORD` | Password for the above account |
+| `DEERFLOW_URL` | *(optional)* Base URL; defaults to `http://localhost:2026` |
+
+## How to run
+
+```bash
+export DEERFLOW_EMAIL="your@email.com"
+export DEERFLOW_PASSWORD="yourpassword"
+python3 /Users/lquintela/projects/deer-flow/omnigent-mcp/server.py
+```
+
+The server speaks MCP over stdin/stdout and is intended to be launched by an MCP host (Omnigent, Claude Desktop, etc.), not run interactively.
+
+## Adding as an Omnigent MCP server
+
+In your Omnigent / Claude settings, add a stdio MCP server entry:
+
+```json
+{
+  "type": "stdio",
+  "command": "python3",
+  "args": ["/Users/lquintela/projects/deer-flow/omnigent-mcp/server.py"],
+  "env": {
+    "DEERFLOW_EMAIL": "your@email.com",
+    "DEERFLOW_PASSWORD": "yourpassword",
+    "DEERFLOW_URL": "http://localhost:2026"
+  }
+}
+```
+
+## Tool examples
+
+### One-shot research task
+
+```
+deerflow_run(prompt="What are the latest breakthroughs in quantum computing?")
+```
+
+### Multi-turn conversation
+
+```python
+thread_id = deerflow_create_thread()
+# → "abc123..."
+
+deerflow_run(prompt="Summarize the paper on LLM agents", thread_id=thread_id)
+deerflow_run(prompt="Now focus on the limitations section", thread_id=thread_id)
+```
+
+### Health check
+
+```
+deerflow_health()
+# → {"status": "ok"}
+```
+
+## How auth works
+
+On the first tool call the server POSTs credentials to `/api/v1/auth/login/local` using the HTTP form-encoded format DeerFlow expects. The session cookie is stored in the `httpx.AsyncClient`. Every state-changing request includes the `X-CSRF-Token` header taken from the `csrf_token` cookie (Double Submit Cookie pattern). On a 401/403 the server re-authenticates once and retries automatically.

--- a/omnigent-mcp/pyproject.toml
+++ b/omnigent-mcp/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "deerflow-mcp"
+version = "0.1.0"
+description = "MCP server wrapping DeerFlow REST API for Omnigent/polly"
+requires-python = ">=3.11"
+dependencies = ["mcp>=1.0.0", "httpx>=0.28.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/omnigent-mcp/server.py
+++ b/omnigent-mcp/server.py
@@ -1,0 +1,174 @@
+"""FastMCP stdio server wrapping DeerFlow REST API."""
+
+import asyncio
+import json
+import os
+from typing import Optional
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("deerflow")
+
+DEERFLOW_URL = os.environ.get("DEERFLOW_URL", "http://localhost:2026")
+DEERFLOW_EMAIL = os.environ.get("DEERFLOW_EMAIL", "")
+DEERFLOW_PASSWORD = os.environ.get("DEERFLOW_PASSWORD", "")
+
+_client: Optional[httpx.AsyncClient] = None
+_csrf_token: str = ""
+
+
+def _make_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url=DEERFLOW_URL,
+        timeout=310.0,
+        follow_redirects=True,
+    )
+
+
+async def _login(client: httpx.AsyncClient) -> None:
+    global _csrf_token
+    resp = await client.post(
+        "/api/v1/auth/login/local",
+        data={"username": DEERFLOW_EMAIL, "password": DEERFLOW_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    resp.raise_for_status()
+    _csrf_token = client.cookies.get("csrf_token", "")
+
+
+async def _get_client() -> tuple[httpx.AsyncClient, str]:
+    """Return (client, csrf_token), creating and logging in on first call."""
+    global _client, _csrf_token
+    if _client is None:
+        _client = _make_client()
+        await _login(_client)
+    return _client, _csrf_token
+
+
+async def _authed_request(method: str, path: str, **kwargs) -> httpx.Response:
+    """Make an authenticated request, re-authing once on 401/403."""
+    global _client, _csrf_token
+    client, csrf = await _get_client()
+    headers = kwargs.pop("headers", {})
+    headers["X-CSRF-Token"] = csrf
+    resp = await client.request(method, path, headers=headers, **kwargs)
+    if resp.status_code in (401, 403):
+        # Re-auth once and retry
+        await _login(client)
+        headers["X-CSRF-Token"] = _csrf_token
+        resp = await client.request(method, path, headers=headers, **kwargs)
+    return resp
+
+
+def _creds_missing() -> Optional[str]:
+    if not DEERFLOW_EMAIL or not DEERFLOW_PASSWORD:
+        return (
+            "Error: DEERFLOW_EMAIL and DEERFLOW_PASSWORD env vars must be set. "
+            "Export them before starting the server."
+        )
+    return None
+
+
+def _extract_last_assistant_message(data: dict) -> str:
+    """Pull the final assistant text from a /runs/wait response."""
+    # The response may be a list of messages or a dict with a 'messages' key
+    messages = []
+    if isinstance(data, list):
+        messages = data
+    elif isinstance(data, dict):
+        messages = data.get("messages", [])
+
+    for msg in reversed(messages):
+        role = msg.get("role", "")
+        content = msg.get("content", "")
+        if role == "assistant":
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                parts = [
+                    block.get("text", "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                ]
+                return "\n".join(p for p in parts if p)
+    return json.dumps(data)
+
+
+@mcp.tool()
+async def deerflow_run(prompt: str, thread_id: str = "") -> str:
+    """Submit a prompt to DeerFlow and wait for the response (up to 300 s).
+
+    Args:
+        prompt: The user message to send.
+        thread_id: Optional existing thread ID for multi-turn conversation.
+                   Leave empty for a fresh stateless run.
+
+    Returns:
+        The last assistant message text, or an error string.
+    """
+    err = _creds_missing()
+    if err:
+        return err
+
+    body = {
+        "assistant_id": "lead_agent",
+        "input": {"messages": [{"role": "user", "content": prompt}]},
+    }
+
+    if thread_id:
+        path = f"/api/threads/{thread_id}/runs/wait"
+    else:
+        path = "/api/runs/wait"
+
+    try:
+        resp = await _authed_request("POST", path, json=body)
+        resp.raise_for_status()
+        data = resp.json()
+        return _extract_last_assistant_message(data)
+    except httpx.HTTPStatusError as e:
+        return f"HTTP error {e.response.status_code}: {e.response.text[:500]}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool()
+async def deerflow_create_thread() -> str:
+    """Create a new DeerFlow thread for multi-turn conversations.
+
+    Returns:
+        The thread_id string, or an error string.
+    """
+    err = _creds_missing()
+    if err:
+        return err
+
+    try:
+        resp = await _authed_request("POST", "/api/threads", json={})
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("thread_id", json.dumps(data))
+    except httpx.HTTPStatusError as e:
+        return f"HTTP error {e.response.status_code}: {e.response.text[:500]}"
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.tool()
+async def deerflow_health() -> str:
+    """Check DeerFlow service health (no auth required).
+
+    Returns:
+        JSON string with health status.
+    """
+    try:
+        async with httpx.AsyncClient(base_url=DEERFLOW_URL, timeout=10.0) as client:
+            resp = await client.get("/health")
+            resp.raise_for_status()
+            return resp.text
+    except Exception as e:
+        return f"Error: {e}"
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary

- Adds `omnigent-mcp/server.py` — a Python MCP stdio server that exposes DeerFlow's REST API as three MCP tools (`deerflow_run`, `deerflow_create_thread`, `deerflow_health`) so Omnigent/polly can call DeerFlow directly without bespoke HTTP plumbing
- Handles session-cookie auth (POST form-encoded to `/api/v1/auth/login/local`), CSRF Double Submit Cookie pattern (`X-CSRF-Token` header), lazy client init, and automatic re-auth on 401/403
- Includes `omnigent-mcp/pyproject.toml` for dependency pinning and `omnigent-mcp/README.md` documenting setup, required env vars, and Omnigent stdio config snippet

## Tools exposed

| Tool | Endpoint | Notes |
|------|----------|-------|
| `deerflow_run(prompt, thread_id?)` | `POST /api/runs/wait` or `POST /api/threads/{id}/runs/wait` | Waits up to 300 s; returns last assistant message |
| `deerflow_create_thread()` | `POST /api/threads` | Returns `thread_id` for multi-turn use |
| `deerflow_health()` | `GET /health` | No auth; returns health JSON |

## Test plan

- [ ] `cd omnigent-mcp && python3 -c "from server import mcp; print('ok')"` passes
- [ ] Set `DEERFLOW_EMAIL` / `DEERFLOW_PASSWORD`, run `python3 server.py`, connect an MCP client and call `deerflow_health` — should return `{"status":"ok"}`
- [ ] Call `deerflow_run` with a simple prompt while DeerFlow is running — should return assistant response text
- [ ] Unset credentials, call any tool — should return a clear error string (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)