### PR TITLE
fix(channels): escape Slack reserved chars before mrkdwn conversion

### DIFF
--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import html
 import logging
+import re
 from typing import Any
 
 from markdown_to_mrkdwn import SlackMarkdownConverter
@@ -20,7 +21,8 @@ _slack_md_converter = SlackMarkdownConverter()
 
 
 def _escape_slack_text(text: str) -> str:
-    """Escape Slack's reserved characters (``&``, ``<``, ``>``) in raw message text.
+    """Escape Slack's reserved characters (``&``, ``<``, ``>``) in raw message text,
+    except a ``>`` at the very start of a line -- Slack's own blockquote marker.
 
     Slack requires callers to replace these with their HTML entity equivalents
     (``&amp;``, ``&lt;``, ``&gt;``) before sending message text -- an unescaped
@@ -35,8 +37,16 @@ def _escape_slack_text(text: str) -> str:
     alone -- satisfies both requirements. ``html.escape(..., quote=False)``
     replaces ``&`` before ``<``/``>``, so the entities it introduces are never
     re-escaped.
+
+    Only ``&`` and ``<`` neutralize Slack's ``<...>`` mention/link syntax; a
+    ``>`` is special to Slack only at the start of a line, where the mrkdwn
+    converter passes it through unchanged as a blockquote marker. Escaping
+    every ``>`` would turn a quoted line into visible ``&gt;`` text instead of
+    a rendered blockquote, so a line-leading ``>`` is restored to a literal
+    ``>`` after escaping; a ``>`` anywhere else in the text still escapes.
     """
-    return html.escape(text, quote=False)
+    escaped = html.escape(text, quote=False)
+    return re.sub(r"(?m)^&gt;", ">", escaped)
 
 
 def _normalize_allowed_users(allowed_users: Any) -> set[str]:

--- a/backend/app/channels/slack.py
+++ b/backend/app/channels/slack.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import html
 import logging
 from typing import Any
 
@@ -16,6 +17,26 @@ from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMes
 logger = logging.getLogger(__name__)
 
 _slack_md_converter = SlackMarkdownConverter()
+
+
+def _escape_slack_text(text: str) -> str:
+    """Escape Slack's reserved characters (``&``, ``<``, ``>``) in raw message text.
+
+    Slack requires callers to replace these with their HTML entity equivalents
+    (``&amp;``, ``&lt;``, ``&gt;``) before sending message text -- an unescaped
+    ``<...>`` triggers Slack's own mention/link syntax (e.g. ``<@USERID>``,
+    ``<http://url|label>``). See:
+    https://api.slack.com/reference/surfaces/formatting#escaping
+
+    This MUST run before ``_slack_md_converter.convert()``, not after: the
+    converter emits its own mrkdwn link syntax (``<url|label>``) for real
+    markdown links, and that generated syntax must reach Slack unescaped.
+    Escaping the raw input first -- and leaving the converter's own output
+    alone -- satisfies both requirements. ``html.escape(..., quote=False)``
+    replaces ``&`` before ``<``/``>``, so the entities it introduces are never
+    re-escaped.
+    """
+    return html.escape(text, quote=False)
 
 
 def _normalize_allowed_users(allowed_users: Any) -> set[str]:
@@ -128,7 +149,7 @@ class SlackChannel(Channel):
 
         kwargs: dict[str, Any] = {
             "channel": msg.chat_id,
-            "text": _slack_md_converter.convert(msg.text),
+            "text": _slack_md_converter.convert(_escape_slack_text(msg.text)),
         }
         if msg.thread_ts:
             kwargs["thread_ts"] = msg.thread_ts

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6809,6 +6809,28 @@ class TestSlackTextEscaping:
         sent = self._sent_text("[Search](https://example.com?a=1&b=2)")
         assert "<https://example.com?a=1&amp;b=2|Search>" in sent
 
+    def test_blockquote_marker_at_line_start_is_preserved(self):
+        # A ">" at the very start of a line is Slack's own blockquote marker
+        # (the mrkdwn converter passes it through unchanged), not part of the
+        # <...> mention/link syntax that & and < neutralize. Escaping it would
+        # turn a quoted line into visible "&gt;" text instead of a rendered
+        # blockquote.
+        sent = self._sent_text("> quoted text")
+        assert sent == "> quoted text"
+
+    def test_blockquote_marker_exemption_is_line_start_only(self):
+        # The line-start exemption must not widen into "never escape '>'":
+        # a "<"/"&" anywhere, and a ">" that is NOT at the start of a line,
+        # still escape -- only the leading marker is restored.
+        sent = self._sent_text("> a < b & c > d")
+        assert sent == "> a &lt; b &amp; c &gt; d"
+
+    def test_blockquote_marker_restored_on_every_line(self):
+        # The restoration must apply per-line (re.MULTILINE), not just once
+        # at the start of the whole string.
+        sent = self._sent_text("intro\n> first quote\nmiddle\n> second quote")
+        assert sent == "intro\n> first quote\nmiddle\n> second quote"
+
 
 # ---------------------------------------------------------------------------
 # Telegram streaming tests

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6727,6 +6727,88 @@ class TestSlackMarkdownConversion:
         assert "*Title*" in result
         assert "#" not in result
 
+    def test_converter_passes_reserved_characters_through_unchanged(self):
+        # The library itself never escapes Slack's reserved characters -- this
+        # pins that assumption so SlackChannel.send() knows it must do so itself.
+        from app.channels.slack import _slack_md_converter
+
+        result = _slack_md_converter.convert("if a < b && b > c:")
+        assert result == "if a < b && b > c:"
+
+
+# ---------------------------------------------------------------------------
+# Slack outbound text escaping tests (Slack's &/</> HTML-entity requirement)
+#
+# Slack requires callers to replace &, <, and > with their HTML entity
+# equivalents before sending message text, because an unescaped `<...>`
+# triggers Slack's own mention/link syntax (e.g. `<@USERID>`,
+# `<http://url|label>`). See:
+# https://api.slack.com/reference/surfaces/formatting#escaping
+# ---------------------------------------------------------------------------
+
+
+class TestSlackTextEscaping:
+    @staticmethod
+    def _sent_text(text: str) -> str:
+        """Send *text* through SlackChannel.send() and return the resulting
+        Slack API ``text`` kwarg, without actually hitting the network."""
+        from app.channels.slack import SlackChannel
+
+        captured: dict[str, object] = {}
+
+        async def go():
+            bus = MessageBus()
+            ch = SlackChannel(bus=bus, config={"bot_token": "xoxb-test", "app_token": "xapp-test"})
+
+            mock_web = MagicMock()
+
+            def post_message(**kwargs):
+                captured.update(kwargs)
+                return MagicMock()
+
+            mock_web.chat_postMessage = post_message
+            ch._web_client = mock_web
+
+            msg = OutboundMessage(channel_name="slack", chat_id="C123", thread_id="t1", text=text)
+            await ch.send(msg)
+
+        _run(go())
+        return captured["text"]
+
+    def test_raw_angle_brackets_and_ampersand_are_escaped(self):
+        # Realistic technical/code content containing all three reserved
+        # characters must arrive escaped, so Slack renders it as literal text
+        # instead of attempting to parse a broken mention/link.
+        sent = self._sent_text("if a < b && b > c:")
+        assert sent == "if a &lt; b &amp;&amp; b &gt; c:"
+        assert "<" not in sent
+        assert ">" not in sent
+
+    def test_bot_mention_syntax_is_neutralized_not_interpreted(self):
+        # Raw text that happens to look like a mention must not survive as
+        # live `<@...>` syntax -- Slack would otherwise try to resolve it.
+        sent = self._sent_text("please ask <@U12345> for review")
+        assert sent == "please ask &lt;@U12345&gt; for review"
+
+    def test_real_markdown_link_still_converts_without_double_escaping(self):
+        # Critical non-regression case: escaping must run BEFORE mrkdwn
+        # conversion, not after. The converter's own generated `<url|label>`
+        # syntax for a real markdown link must survive untouched -- if
+        # escaping ran after conversion instead, this would corrupt into
+        # `&lt;url|label&gt;` and Slack would render a dead link.
+        sent = self._sent_text("See [DeerFlow docs](https://example.com/docs) for more.")
+        assert "<https://example.com/docs|DeerFlow docs>" in sent
+        assert "&lt;" not in sent
+        assert "&gt;" not in sent
+
+    def test_ampersand_in_link_url_is_escaped_before_conversion(self):
+        # & must be escaped first (before < and >) so it doesn't double-escape
+        # the &amp;/&lt;/&gt; entities being introduced, and a literal '&' in a
+        # URL must still come through as &amp; per Slack's escaping rule --
+        # even inside the converter's own generated <url|label> syntax.
+        sent = self._sent_text("[Search](https://example.com?a=1&b=2)")
+        assert "<https://example.com?a=1&amp;b=2|Search>" in sent
+
 
 # ---------------------------------------------------------------------------
 # Telegram streaming tests


### PR DESCRIPTION
## Summary

Slack requires callers to replace `&`, `<`, and `>` with their HTML entity equivalents before sending message text, because an unescaped `<...>` triggers Slack's own mention/link syntax (e.g. `<@USERID>`, `<http://url|label>`). `SlackChannel.send()` never did this, so any outbound message containing those characters -- code snippets, shell conditionals, URL query strings -- reaches Slack's API unescaped.

## The bug

```python
kwargs: dict[str, Any] = {
    "channel": msg.chat_id,
    "text": _slack_md_converter.convert(msg.text),
}
```

`msg.text` goes through the markdown-to-mrkdwn converter (`_slack_md_converter`, from the `markdown_to_mrkdwn` library) and the result is handed straight to `chat_postMessage`. The converter only rewrites markdown syntax (`**bold**`, `[text](url)`, headings, lists, ...) -- it passes `&`, `<`, and `>` through completely unchanged (added `test_converter_passes_reserved_characters_through_unchanged` to pin this).

Concretely, a reply containing `if a < b && b > c:` is sent to Slack's API byte-for-byte as-is. Slack's renderer sees a literal `<` and tries to parse `<@U12345>`-style mention/link syntax out of whatever follows it, so the text renders broken or misinterpreted instead of the literal code the agent wrote. The same applies to any raw `<@...>`/`<#...>`-shaped substring in agent output (e.g. quoting a user's own message back).

## The fix

Escaping has to run **before** the mrkdwn conversion, not after. The converter itself emits mrkdwn link syntax -- `[text](url)` becomes `<url|text>`, `![alt](url)` becomes `<url>` -- and that generated `<...>` is exactly what must reach Slack unescaped. If escaping ran after conversion, it would re-escape the converter's own output and turn every real link into a dead `&lt;url|text&gt;`.

So the fix escapes the raw input first, then lets the converter run on the escaped text and emit its own unescaped link syntax on top:

```python
"text": _slack_md_converter.convert(_escape_slack_text(msg.text)),
```

`_escape_slack_text` is `html.escape(text, quote=False)` -- stdlib `html.escape` already replaces `&` before `<`/`>` internally, which matters here: escaping `&` first avoids double-escaping the `&` inside the `&amp;`/`&lt;`/`&gt;` entities being introduced. `quote=False` skips quote-escaping, since Slack's own escaping rule only covers `&`/`<`/`>`.

This ordering is safe for real links: markdown link syntax (`[label](url)`) uses `[`, `]`, `(`, `)`, none of which are touched by escaping, so the converter's link-detection regex still matches the escaped text unchanged. A literal `&` inside a URL's query string (e.g. `?a=1&b=2`) is still escaped to `&amp;` per Slack's rule, including inside the converter's generated `<url|label>` -- Slack unescapes entities anywhere in the message when rendering, links included.

## Testing

New `TestSlackTextEscaping` in `backend/tests/test_channels.py` drives `SlackChannel.send()` end-to-end against a mocked `chat_postMessage` and asserts on the actual `text` payload:

- `test_raw_angle_brackets_and_ampersand_are_escaped` -- `"if a < b && b > c:"` arrives as `"if a &lt; b &amp;&amp; b &gt; c:"`.
- `test_bot_mention_syntax_is_neutralized_not_interpreted` -- a raw `<@U12345>`-shaped substring no longer survives as live mention syntax.
- `test_real_markdown_link_still_converts_without_double_escaping` -- critical non-regression case: `[DeerFlow docs](https://example.com/docs)` still converts to `<https://example.com/docs|DeerFlow docs>` with no extra escaping corrupting it.
- `test_ampersand_in_link_url_is_escaped_before_conversion` -- a literal `&` inside a link URL's query string still comes through as `&amp;` inside the generated `<url|label>`.

Verification performed:
- Fail-before/pass-after via patch-file revert: reverted just the source fix (tests untouched) and reran -- the three bug-covering tests failed on unfixed `main`-equivalent code; reapplying the fix turned them green again.
- Confirmed the non-regression test actually discriminates the ordering choice: temporarily swapped the implementation to escape *after* conversion (the wrong order) and reran -- `test_real_markdown_link_still_converts_without_double_escaping` and the URL-ampersand test both failed as expected (`<https://example.com/docs|DeerFlow docs>` corrupted into `&lt;https://example.com/docs|DeerFlow docs&gt;`), confirming the test isn't a tautology.
- Full `backend/tests/test_channels.py` (all channels, not just Slack): `256 passed`.
- `backend/tests/test_slack_channel_connections.py`: `3 passed`.
- `ruff check --line-length 240` and `ruff format --check --line-length 240` on both changed files: clean.