### PR TITLE
fix(goal): stop continuation_count double-bump in thread_changed_before_continuation stand-down

### DIFF
--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -993,11 +993,18 @@ async def _prepare_goal_continuation_input(
     if not _goal_instance_matches(updated_goal, latest_goal) or latest_checkpoint_tuple is None:
         return None
     if visible_conversation_signature(_read_checkpoint_messages(latest_checkpoint_tuple)) != conversation_signature_before:
+        # Do not pass continuation_count here: the persist above already
+        # committed it (as next_count). Re-passing next_count would make
+        # _persist_goal_evaluation's race guard (#4088) see that same write as
+        # a "current_count" bump and add another +1 on top of it, silently
+        # double-counting this single continuation attempt against the
+        # continuation budget even though it is being stood down, not
+        # delivered. Omitting it leaves the already-committed count untouched,
+        # matching every other stand-down call site in this function.
         await _persist(
             latest_goal,
             evaluation,
             no_progress_count,
-            continuation_count=next_count,
             stand_down_reason="thread_changed_before_continuation",
         )
         return None

--- a/backend/tests/test_goal_worker.py
+++ b/backend/tests/test_goal_worker.py
@@ -48,6 +48,47 @@ class _ClearBeforeSecondGoalReadCheckpointer:
         return await self.inner.aput(*args, **kwargs)
 
 
+class _RaceAfterFirstContinuationCommitCheckpointer:
+    """Wrap a saver and inject a racing user message right after the first
+    goal-continuation commit lands.
+
+    ``_prepare_goal_continuation_input``'s real continuation commit (the
+    ``_persist(..., continuation_count=next_count)`` call that records the
+    evaluator's decision to continue) performs this scenario's first
+    ``aput``. Injecting a racing visible message immediately after that write
+    lands lets the worker's trailing visible-conversation-signature re-check
+    observe a thread change that happened *after* the continuation was
+    committed but *before* that re-check runs -- modelling the
+    ``thread_changed_before_continuation`` race.
+    """
+
+    def __init__(self, inner: InMemorySaver, thread_id: str) -> None:
+        self.inner = inner
+        self.thread_id = thread_id
+        self.put_count = 0
+
+    def get_next_version(self, current, channel):
+        return self.inner.get_next_version(current, channel)
+
+    async def aget_tuple(self, config):
+        return await self.inner.aget_tuple(config)
+
+    async def aput(self, *args, **kwargs):
+        result = await self.inner.aput(*args, **kwargs)
+        self.put_count += 1
+        if self.put_count == 1:
+            checkpoint_tuple = await self.inner.aget_tuple({"configurable": {"thread_id": self.thread_id, "checkpoint_ns": ""}})
+            checkpoint = getattr(checkpoint_tuple, "checkpoint", {}) or {}
+            channel_values = checkpoint.get("channel_values", {}) or {}
+            current_messages = channel_values.get("messages", []) or []
+            await _write_messages(
+                self.inner,
+                thread_id=self.thread_id,
+                messages=[*current_messages, HumanMessage(content="Actually, stop and wait.")],
+            )
+        return result
+
+
 async def _seed_goal_thread(
     checkpointer: InMemorySaver,
     *,
@@ -382,6 +423,60 @@ async def test_goal_worker_stands_down_when_thread_changes_after_evaluation(monk
     assert latest_goal is not None
     assert latest_goal["continuation_count"] == 0
     assert latest_goal["last_evaluation"]["stand_down_reason"] == "thread_changed_after_evaluation"
+
+
+@pytest.mark.asyncio
+async def test_goal_worker_stands_down_when_thread_changes_before_continuation(monkeypatch):
+    """A user message racing in right after the continuation commits must not
+    double-bump continuation_count.
+
+    Sibling scenario to ``..._after_evaluation`` above, but the race lands
+    later: after the evaluator runs and after _prepare_goal_continuation_input
+    commits the real continuation (``_persist(..., continuation_count=next_count)``),
+    a racing visible message arrives before the function's trailing re-check.
+    That re-check detects the changed thread and stands down via a second
+    ``_persist(..., continuation_count=next_count, stand_down_reason=...)``
+    call using the *same* next_count as the first, already-successful call.
+
+    Without the fix, that second call re-triggers PR #4088's
+    max(continuation_count, current_count + 1) guard against its own sibling
+    call's prior write (current_count is already next_count from the first
+    call), bumping continuation_count to next_count + 1 a second time --
+    consuming 2 units of the continuation budget for a cycle that delivered
+    zero actual continuations. The fix must leave it at next_count (1).
+    """
+    inner = InMemorySaver()
+    thread_id = "race-before-continuation-thread"
+    await _seed_goal_thread(inner, thread_id=thread_id, goal_text="Finish all tests")
+    checkpointer = _RaceAfterFirstContinuationCommitCheckpointer(inner, thread_id)
+    bridge = _CollectingBridge()
+
+    async def fake_evaluate_goal_completion(_goal, _messages, **_kwargs):
+        return GoalEvaluation(
+            satisfied=False,
+            blocker="goal_not_met_yet",
+            reason="More work remains.",
+            evidence_summary="Work remains.",
+        )
+
+    monkeypatch.setattr(worker, "evaluate_goal_completion", fake_evaluate_goal_completion)
+
+    continuation = await worker._prepare_goal_continuation_input(
+        bridge=bridge,
+        checkpointer=checkpointer,
+        thread_id=thread_id,
+        run_id="run-race-before-continuation",
+        model_name="test-model",
+        app_config=None,
+    )
+
+    assert continuation is None
+    latest_goal = await read_thread_goal(inner, thread_id)
+    assert latest_goal is not None
+    # Without the fix this is 2 (double-bumped). It must be 1: one real
+    # continuation attempt was committed and then stood down, not two.
+    assert latest_goal["continuation_count"] == 1
+    assert latest_goal["last_evaluation"]["stand_down_reason"] == "thread_changed_before_continuation"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`_prepare_goal_continuation_input` (`backend/packages/harness/deerflow/runtime/runs/worker.py`) calls its local `_persist` closure (wrapping `_persist_goal_evaluation`) **twice with the identical `continuation_count=next_count`** during a single evaluation cycle:

1. `updated_goal = await _persist(goal, evaluation, no_progress_count, continuation_count=next_count)` — commits the real continuation.
2. If a race is then detected (a visible user message landed between that commit and the trailing re-check), a second call records the stand-down: `await _persist(latest_goal, evaluation, no_progress_count, continuation_count=next_count, stand_down_reason="thread_changed_before_continuation")`.

#4088 added a defensive guard inside `_persist_goal_evaluation` for a genuine race between two **independent concurrent continuations**:

```python
if continuation_count is not None:
    current_count = int(current_goal.get("continuation_count", 0))
    continuation_count = max(continuation_count, current_count + 1)
```

That guard is correct for the race it targets. But the second call above isn't an independent continuation — it's the *same* evaluation cycle recording that its own just-committed continuation is being stood down. By the time this second call re-reads `current_goal` inside the lock, it sees the count the **first call itself just wrote** (`next_count`), and the guard treats that as "a racing continuation already bumped it," computing `max(next_count, next_count + 1) = next_count + 1`. So `continuation_count` ends up `next_count + 1` (e.g. 2) even though `continuation` is `None` — zero continuations were actually delivered to the user.

Net effect: the documented hard maximum of 8 continuations (`runs/worker.py` / `backend/AGENTS.md`) can silently shrink by 1 extra unit every time this race fires, for a cycle where the user got nothing.

To be clear: **this is not a flaw in #4088.** Its guard is correct for the two-independent-continuations race it was written for, and the two test cases it added (`test_persist_goal_evaluation_does_not_regress_continuation_count_on_race`, `test_persist_goal_evaluation_no_race_uses_caller_count`) both still pass unmodified. This is a separate call site (added earlier, in #3858) that happens to re-trigger that same guard against its own prior write.

## Fix

The second (`thread_changed_before_continuation`) `_persist` call no longer passes `continuation_count`. The count was already correctly committed by the first call, so this now matches every other stand-down call site in the function (`no_durable_end_of_turn`, `thread_changed_after_evaluation`, and the plain cap-reached `stand_down_reason` call), none of which re-pass `continuation_count` either.

## Testing

Added `test_goal_worker_stands_down_when_thread_changes_before_continuation` to `backend/tests/test_goal_worker.py`, mirroring the existing `test_goal_worker_stands_down_when_thread_changes_after_evaluation`'s technique for the sibling (already-covered) branch. Since the race here needs to land *after* the first commit rather than during evaluation, it uses a small checkpointer wrapper (`_RaceAfterFirstContinuationCommitCheckpointer`) that injects a racing visible message right after the first `aput` (the real continuation commit), instead of monkeypatching the evaluator.

- Confirmed `thread_changed_before_continuation` had zero prior test coverage (`grep -rn "thread_changed_before_continuation" tests/` matched nothing before this PR).
- Fail-before/pass-after verified via patch-file revert: with the fix reverted (test unchanged), the new test fails with `assert 2 == 1`; reapplying the fix makes it pass.
- Full `test_goal_worker.py` suite: 16/16 pass, including the sibling `test_goal_worker_stands_down_when_thread_changes_after_evaluation` and both of #4088's own regression tests (unaffected by this change).
- `ruff check --line-length 240` and `ruff format --check --line-length 240` clean on both changed files.
