### PR TITLE
fix(config): sync _memory_config with AppConfig auto-reload + fix(frontend): strip <memory> tags in Streamdown

### DIFF
--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -102,6 +102,14 @@ _memory_config: MemoryConfig = MemoryConfig()
 
 def get_memory_config() -> MemoryConfig:
     """Get the current memory configuration."""
+    # Ensure AppConfig signature is fresh before returning _memory_config.
+    # get_app_config() auto-reloads on file change and calls
+    # load_memory_config_from_dict() during _apply_singleton_configs(),
+    # so this side effect keeps _memory_config in sync.
+    # Local import to avoid circular dependency (app_config -> memory_config).
+    from deerflow.config.app_config import get_app_config as _get_app_config
+
+    _get_app_config()
     return _memory_config
 
 

--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -57,9 +57,17 @@ export function ClipboardSafeStreamdown({
   children,
   ...props
 }: ClipboardSafeStreamdownProps) {
+  // Strip system-level memory tags (<memory>, </memory>) that would cause
+  // React to log "unrecognized tag" console errors when the markdown
+  // renderer passes them through as raw HTML.
+  const sanitizedChildren =
+    typeof children === "string"
+      ? children.replace(/<\/?memory>/g, "")
+      : children;
+
   return (
-    <StreamdownFallbackBoundary raw={children}>
-      <Streamdown {...props}>{children}</Streamdown>
+    <StreamdownFallbackBoundary raw={sanitizedChildren}>
+      <Streamdown {...props}>{sanitizedChildren}</Streamdown>
     </StreamdownFallbackBoundary>
   );
 }


### PR DESCRIPTION
Two small fixes:

## #4204 — Memory config singleton desync

`get_memory_config()` now calls `get_app_config()` before returning the cached `_memory_config` singleton. `get_app_config()` auto-reloads when the config file signature changes, and its `_apply_singleton_configs()` calls `load_memory_config_from_dict()` to populate `_memory_config`. Without this side effect, changing `memory.mode` in `config.yaml` (e.g. from `"middleware"` to `"tool"`) would never take effect at runtime because `_memory_config` retained the stale value.

## #4205 — Frontend <memory> tag console error

The `ClipboardSafeStreamdown` component renders `<memory>` and `</memory>` as raw HTML tags, causing React to log "unrecognized tag" errors. Strip them before passing content to the renderer.

## Testing

- `cd backend && uvx ruff check` — passes
- The change is minimal and scoped: 5 lines in memory_config.py (local import to avoid circular dependency), 7 lines in streamdown.tsx (strip regex).