### PR TITLE
fix(frontend): strip <memory> tags in Streamdown to avoid React console error

### DIFF
--- a/frontend/src/components/ai-elements/streamdown.tsx
+++ b/frontend/src/components/ai-elements/streamdown.tsx
@@ -3,6 +3,7 @@
 import { Component, type ComponentProps, type ReactNode } from "react";
 import { Streamdown } from "streamdown";
 
+import { stripLeakedSystemTags } from "@/core/streamdown/preprocess";
 import { installClipboardFallback } from "@/core/clipboard";
 
 export type ClipboardSafeStreamdownProps = ComponentProps<typeof Streamdown>;
@@ -57,9 +58,15 @@ export function ClipboardSafeStreamdown({
   children,
   ...props
 }: ClipboardSafeStreamdownProps) {
+  // Strip leaked system-internal tags (<memory>, <system-reminder>, etc.)
+  // that would cause React to log "unrecognized tag" console errors when
+  // the markdown renderer passes them through as raw HTML.
+  const sanitizedChildren =
+    typeof children === "string" ? stripLeakedSystemTags(children) : children;
+
   return (
-    <StreamdownFallbackBoundary raw={children}>
-      <Streamdown {...props}>{children}</Streamdown>
+    <StreamdownFallbackBoundary raw={sanitizedChildren}>
+      <Streamdown {...props}>{sanitizedChildren}</Streamdown>
     </StreamdownFallbackBoundary>
   );
 }

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -357,12 +357,12 @@ export function stripLeakedSystemTags(markdown: string): string {
     .map((line) => {
       const fenceMatch = FENCE_MARKER_RE.exec(line);
       if (fenceMatch) {
-        const marker = fenceMatch[1];
+        const marker = fenceMatch[1]!;
         if (fenceMarker === null) {
           // Opening a fenced code block
           fenceMarker = marker;
         } else if (
-          marker[0] === fenceMarker[0] &&
+          marker.startsWith(fenceMarker.charAt(0)) &&
           marker.length >= fenceMarker.length
         ) {
           // Closing fence: same character and at least as long as opener

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -326,6 +326,10 @@ const _INTERNAL_TAG_RE = new RegExp(
   "g",
 );
 
+// Regex matching the start/end of a fenced code block (3+ backticks or tildes).
+// Captures the marker string so we can compare character and length.
+const FENCE_MARKER_RE = /^ {0,3}(`{3,}|~{3,})/;
+
 /**
  * Strip leaked system-internal HTML tags from markdown content.
  *
@@ -339,18 +343,36 @@ const _INTERNAL_TAG_RE = new RegExp(
  * Code-aware: tags inside fenced code blocks (````` `````) and indented code
  * blocks (4-space indent) are left untouched, so user-written meta-discussions
  * about the memory system are not silently stripped.
+ *
+ * Fence tracking is marker-aware (tracking the opening character and run
+ * length) so that a tilde-fenced block containing a shorter backtick run, or a
+ * 4-backtick block containing a 3-backtick run, does not prematurely close the
+ * fence.
  */
 export function stripLeakedSystemTags(markdown: string): string {
   const lines = markdown.split("\n");
-  let insideFence = false;
+  let fenceMarker: string | null = null;
 
   return lines
     .map((line) => {
-      if (CODE_FENCE_RE.test(line)) {
-        insideFence = !insideFence;
+      const fenceMatch = FENCE_MARKER_RE.exec(line);
+      if (fenceMatch) {
+        const marker = fenceMatch[1];
+        if (fenceMarker === null) {
+          // Opening a fenced code block
+          fenceMarker = marker;
+        } else if (
+          marker[0] === fenceMarker[0] &&
+          marker.length >= fenceMarker.length
+        ) {
+          // Closing fence: same character and at least as long as opener
+          fenceMarker = null;
+        }
+        // Otherwise: different fence type or shorter run inside a fence
+        // (e.g. ``` inside ~~~~, or `` inside `````) — stay inside.
         return line;
       }
-      if (insideFence || INDENTED_CODE_RE.test(line)) {
+      if (fenceMarker !== null || INDENTED_CODE_RE.test(line)) {
         return line;
       }
       return line.replace(_INTERNAL_TAG_RE, "");

--- a/frontend/src/core/streamdown/preprocess.ts
+++ b/frontend/src/core/streamdown/preprocess.ts
@@ -1,3 +1,5 @@
+import { INTERNAL_MARKER_TAGS } from "@/core/messages/utils";
+
 import { normalizeMermaidMarkdown } from "./mermaid";
 
 const MERMAID_BLOCK_HINT_RE = /mermaid/i;
@@ -315,6 +317,45 @@ export function compactDisplayMathBlocks(markdown: string): string {
 
 export function normalizeStreamdownMathMarkdown(markdown: string): string {
   return compactDisplayMathBlocks(normalizeLatexMathDelimiters(markdown));
+}
+
+// Regex matching any opening, closing, or self-closing internal marker tag.
+// e.g. <memory>, </memory>, <memory attr="x">, <memory/>
+const _INTERNAL_TAG_RE = new RegExp(
+  `</?(?:${INTERNAL_MARKER_TAGS.join("|")})(?:\\s[^>]*)?/?>`,
+  "g",
+);
+
+/**
+ * Strip leaked system-internal HTML tags from markdown content.
+ *
+ * Backend-injected markers like ``<memory>…</memory>`` can occasionally
+ * reach the UI renderer (e.g. when a ``hide_from_ui`` reminder leaks through
+ * the filter).  React's DOM renderer logs "unrecognized tag" console errors
+ * for unknown HTML elements.  This function strips the tag markers while
+ * preserving the inner content — unlike {@link stripInternalMarkers} in
+ * ``utils.ts``, which removes the entire block.
+ *
+ * Code-aware: tags inside fenced code blocks (````` `````) and indented code
+ * blocks (4-space indent) are left untouched, so user-written meta-discussions
+ * about the memory system are not silently stripped.
+ */
+export function stripLeakedSystemTags(markdown: string): string {
+  const lines = markdown.split("\n");
+  let insideFence = false;
+
+  return lines
+    .map((line) => {
+      if (CODE_FENCE_RE.test(line)) {
+        insideFence = !insideFence;
+        return line;
+      }
+      if (insideFence || INDENTED_CODE_RE.test(line)) {
+        return line;
+      }
+      return line.replace(_INTERNAL_TAG_RE, "");
+    })
+    .join("\n");
 }
 
 export function preprocessStreamdownMarkdown(markdown: string): string {

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -7,6 +7,7 @@ import {
   compactDisplayMathBlocks,
   normalizeStreamdownMathMarkdown,
   preprocessStreamdownMarkdown,
+  stripLeakedSystemTags,
 } from "@/core/streamdown/preprocess";
 
 test("capBlockquoteNesting returns normal content unchanged", () => {
@@ -246,4 +247,122 @@ test("normalizeStreamdownMathMarkdown requires matching backtick run to close co
   const input = "Use ``\\(literal\\)` and still code`` then \\(x\\)";
   const expected = "Use ``\\(literal\\)` and still code`` then $x$";
   expect(normalizeStreamdownMathMarkdown(input)).toBe(expected);
+});
+
+// ---------------------------------------------------------------------------
+// stripLeakedSystemTags
+// ---------------------------------------------------------------------------
+
+test("stripLeakedSystemTags strips <memory> tags preserving content", () => {
+  expect(stripLeakedSystemTags("<memory>hello</memory>")).toBe("hello");
+});
+
+test("stripLeakedSystemTags strips all internal marker tags", () => {
+  expect(
+    stripLeakedSystemTags(
+      "<system-reminder>reminder</system-reminder> <current_date>2024</current_date>",
+    ),
+  ).toBe("reminder 2024");
+});
+
+test("stripLeakedSystemTags strips self-closing tags", () => {
+  expect(stripLeakedSystemTags("text<memory/>more")).toBe("textmore");
+});
+
+test("stripLeakedSystemTags strips tags with attributes", () => {
+  expect(stripLeakedSystemTags('<memory class="x">text</memory>')).toBe("text");
+});
+
+test("stripLeakedSystemTags handles multiple occurrences", () => {
+  expect(
+    stripLeakedSystemTags(
+      "<memory>a</memory> <memory>b</memory> <memory>c</memory>",
+    ),
+  ).toBe("a b c");
+});
+
+test("stripLeakedSystemTags leaves fenced code content untouched", () => {
+  const input = [
+    "<memory>outside</memory>",
+    "```text",
+    "<memory>inside code</memory>",
+    "```",
+    "<memory>after</memory>",
+  ].join("\n");
+  const expected = [
+    "outside",
+    "```text",
+    "<memory>inside code</memory>",
+    "```",
+    "after",
+  ].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});
+
+test("stripLeakedSystemTags leaves indented code content untouched", () => {
+  const input = [
+    "<memory>outside</memory>",
+    "    <memory>indented code</memory>",
+  ].join("\n");
+  const expected = ["outside", "    <memory>indented code</memory>"].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});
+
+test("stripLeakedSystemTags passes plain text unchanged", () => {
+  expect(stripLeakedSystemTags("plain text")).toBe("plain text");
+});
+
+test("stripLeakedSystemTags returns empty string unchanged", () => {
+  expect(stripLeakedSystemTags("")).toBe("");
+});
+
+test("stripLeakedSystemTags handles no tags present", () => {
+  const input = "normal text with **bold** and `code`";
+  expect(stripLeakedSystemTags(input)).toBe(input);
+});
+
+test("stripLeakedSystemTags strips <uploaded_files> tag", () => {
+  expect(
+    stripLeakedSystemTags("<uploaded_files>file.pdf</uploaded_files>"),
+  ).toBe("file.pdf");
+});
+
+test("stripLeakedSystemTags strips <slash_skill_activation> tag", () => {
+  expect(
+    stripLeakedSystemTags(
+      "<slash_skill_activation>skill</slash_skill_activation>",
+    ),
+  ).toBe("skill");
+});
+
+test("stripLeakedSystemTags handles mixed tags on same line", () => {
+  expect(
+    stripLeakedSystemTags(
+      "<memory>a</memory><system-reminder>b</system-reminder>",
+    ),
+  ).toBe("ab");
+});
+
+test("stripLeakedSystemTags handles multiple fences correctly", () => {
+  const input = [
+    "<memory>a</memory>",
+    "```",
+    "<memory>inside 1</memory>",
+    "```",
+    "<memory>b</memory>",
+    "```",
+    "<memory>inside 2</memory>",
+    "```",
+  ].join("\n");
+  const expected = [
+    "a",
+    "```",
+    "<memory>inside 1</memory>",
+    "```",
+    "b",
+    "```",
+    "<memory>inside 2</memory>",
+    "```",
+  ].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
 });

--- a/frontend/tests/unit/core/streamdown/preprocess.test.ts
+++ b/frontend/tests/unit/core/streamdown/preprocess.test.ts
@@ -366,3 +366,82 @@ test("stripLeakedSystemTags handles multiple fences correctly", () => {
   ].join("\n");
   expect(stripLeakedSystemTags(input)).toBe(expected);
 });
+
+test("stripLeakedSystemTags preserves tags inside tilde fence with inner backtick fence", () => {
+  const input = [
+    "<memory>outside</memory>",
+    "~~~~",
+    "```",
+    "<memory>inside tilde</memory>",
+    "```",
+    "~~~~",
+    "<memory>after</memory>",
+  ].join("\n");
+  const expected = [
+    "outside",
+    "~~~~",
+    "```",
+    "<memory>inside tilde</memory>",
+    "```",
+    "~~~~",
+    "after",
+  ].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});
+
+test("stripLeakedSystemTags preserves tags inside 4-backtick fence with inner 3-backtick fence", () => {
+  const input = [
+    "<memory>outside</memory>",
+    "````",
+    "```",
+    "<memory>inside 4-backtick</memory>",
+    "```",
+    "````",
+    "<memory>after</memory>",
+  ].join("\n");
+  const expected = [
+    "outside",
+    "````",
+    "```",
+    "<memory>inside 4-backtick</memory>",
+    "```",
+    "````",
+    "after",
+  ].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});
+
+test("stripLeakedSystemTags handles backtick fence inside tilde fence with shorter tilde closing", () => {
+  // A 4-tilde fence containing a 3-backtick sub-fence; the closing tilde run
+  // is shorter (3 vs 4) so it should NOT close the fence.
+  const input = [
+    "<memory>outside</memory>",
+    "~~~~",
+    "```",
+    "<memory>inside</memory>",
+    "```",
+    "~~~",
+  ].join("\n");
+  const expected = [
+    "outside",
+    "~~~~",
+    "```",
+    "<memory>inside</memory>",
+    "```",
+    "~~~",
+  ].join("\n");
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});
+
+test("stripLeakedSystemTags strips tags after real closing fence", () => {
+  const input = [
+    "~~~~",
+    "<memory>inside</memory>",
+    "~~~~",
+    "<memory>after</memory>",
+  ].join("\n");
+  const expected = ["~~~~", "<memory>inside</memory>", "~~~~", "after"].join(
+    "\n",
+  );
+  expect(stripLeakedSystemTags(input)).toBe(expected);
+});


### PR DESCRIPTION
The `ClipboardSafeStreamdown` component passes `<memory>` and `</memory>` tags through to the renderer, which React interprets as unknown HTML elements and logs a console error:

> The tag `<memory>` is unrecognized in this browser.

Strip this system-level tag from the content before passing it to the Streamdown component. The tag is only used in the memory system prompt format and has no semantic meaning in rendered output.

Closes #4205