### PR TITLE
fix(memory): follow config reload in get_memory_config

### DIFF
--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -119,7 +119,28 @@ _memory_config: MemoryConfig = MemoryConfig()
 
 
 def get_memory_config() -> MemoryConfig:
-    """Get the current memory configuration."""
+    """Get the current memory configuration.
+
+    ``_memory_config`` is only refreshed as a side effect of ``get_app_config()``
+    reloading (via ``_apply_singleton_configs`` -> ``load_memory_config_from_dict``).
+    A reader that reaches memory config without going through ``get_app_config()``
+    first -- e.g. the agent factory deciding whether to bind the memory tools --
+    would otherwise see a stale ``memory.mode`` after a ``config.yaml`` edit, even
+    though ``memory.*`` is documented as hot-reloadable. Trigger the same
+    signature-checked reload here so the singleton follows the config file.
+
+    If no config file is on disk (tests, or a minimal deployment running purely
+    on defaults / ``set_memory_config``), there is nothing to reload from, so we
+    keep the pre-existing behavior of returning the in-memory singleton instead of
+    becoming more fragile than before.
+    """
+    # Lazy import: app_config imports this module, so a top-level import cycles.
+    from .app_config import get_app_config
+
+    try:
+        get_app_config()
+    except FileNotFoundError:
+        pass
     return _memory_config
 
 

--- a/backend/packages/harness/deerflow/config/memory_config.py
+++ b/backend/packages/harness/deerflow/config/memory_config.py
@@ -132,7 +132,10 @@ def get_memory_config() -> MemoryConfig:
     If no config file is on disk (tests, or a minimal deployment running purely
     on defaults / ``set_memory_config``), there is nothing to reload from, so we
     keep the pre-existing behavior of returning the in-memory singleton instead of
-    becoming more fragile than before.
+    becoming more fragile than before. The catch is deliberately narrow: a config
+    file that exists but fails to load (malformed YAML, failed validation) is a
+    real error and is surfaced here just as it is at every other unguarded
+    ``get_app_config()`` call site, leaving the last-good singleton untouched.
     """
     # Lazy import: app_config imports this module, so a top-level import cycles.
     from .app_config import get_app_config

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -530,3 +530,34 @@ def test_get_app_config_does_not_mutate_singletons_when_reload_validation_fails(
         assert get_store() is initial_store
     finally:
         _reset_config_singletons()
+
+
+def test_get_memory_config_follows_config_file_reload(tmp_path, monkeypatch):
+    """get_memory_config() picks up a config.yaml memory.mode edit on its own (#4204).
+
+    ``_memory_config`` used to refresh only as a side effect of ``get_app_config()``,
+    so a reader reaching memory config directly (e.g. the agent factory deciding
+    whether to bind the memory tools) saw a stale mode after a config edit even
+    though ``memory.*`` is documented as hot-reloadable.
+    """
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    _write_config_with_sections(config_path, {"memory": {"enabled": True, "mode": "middleware"}})
+
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+    _reset_config_singletons()
+
+    try:
+        assert get_memory_config().mode == "middleware"
+
+        _write_config_with_sections(config_path, {"memory": {"enabled": True, "mode": "tool"}})
+        next_mtime = config_path.stat().st_mtime + 5
+        os.utime(config_path, (next_mtime, next_mtime))
+
+        # No explicit get_app_config() call: get_memory_config() must reflect the
+        # new mode on its own.
+        assert get_memory_config().mode == "tool"
+    finally:
+        _reset_config_singletons()

--- a/backend/tests/test_app_config_reload.py
+++ b/backend/tests/test_app_config_reload.py
@@ -561,3 +561,44 @@ def test_get_memory_config_follows_config_file_reload(tmp_path, monkeypatch):
         assert get_memory_config().mode == "tool"
     finally:
         _reset_config_singletons()
+
+
+def test_get_memory_config_surfaces_malformed_config_edit(tmp_path, monkeypatch):
+    """A malformed config edit surfaces through get_memory_config() rather than
+    being swallowed.
+
+    The ``except FileNotFoundError`` guard is deliberately narrow: it covers only
+    the genuinely-absent file (tests, or a defaults-only deployment) where there
+    is nothing to reload from. A file that exists but fails validation is a real
+    error and propagates -- consistent with every other unguarded
+    ``get_app_config()`` caller -- and the last-good singleton is left intact
+    rather than cleared or half-applied.
+    """
+    import deerflow.config.memory_config as memory_config_module
+
+    config_path = tmp_path / "config.yaml"
+    extensions_path = tmp_path / "extensions_config.json"
+    _write_extensions_config(extensions_path)
+    _write_config_with_sections(config_path, {"memory": {"enabled": True, "mode": "middleware"}})
+
+    monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(extensions_path))
+    _reset_config_singletons()
+
+    try:
+        assert get_memory_config().mode == "middleware"
+
+        # Same file, now invalid: `title: false` fails AppConfig validation while
+        # the edit also flips memory.mode -- so a half-applied reload would leak
+        # "tool" into the singleton.
+        _write_config_with_sections(config_path, {"memory": {"enabled": True, "mode": "tool"}, "title": False})
+        next_mtime = config_path.stat().st_mtime + 5
+        os.utime(config_path, (next_mtime, next_mtime))
+
+        with pytest.raises(ValidationError):
+            get_memory_config()
+
+        # Failed reload: the last-good singleton stays "middleware", not "tool".
+        assert memory_config_module._memory_config.mode == "middleware"
+    finally:
+        _reset_config_singletons()


### PR DESCRIPTION
## Summary

`get_memory_config()` returned the `_memory_config` singleton directly, but that singleton is only refreshed as a *side effect* of `get_app_config()` reloading (via `_apply_singleton_configs` → `load_memory_config_from_dict`). Any reader that reaches memory config without first going through `get_app_config()` — most importantly the agent factory deciding whether to bind the memory tools (`feat.memory_config or get_memory_config()` in `agents/factory.py`) — sees a stale `memory.mode` after a `config.yaml` edit, even though `memory.*` is documented as hot-reloadable in `backend/AGENTS.md`. The agent keeps the old mode (memory tools bound / not bound) until some unrelated `get_app_config()` call happens to refresh the singleton.

## Fix

Trigger the same signature-checked reload inside `get_memory_config()` so the singleton follows the config file, mirroring how the other config getters already resolve through `get_app_config()` (same shape as the skills-prompt fix in #4160). When no config file is on disk — tests, or a minimal deployment running purely on defaults / `set_memory_config` — `get_app_config()` raises `FileNotFoundError`; that is swallowed and we fall back to the in-memory singleton, so the accessor is never more fragile than before.

## Test

`test_get_memory_config_follows_config_file_reload` writes a config with `memory.mode: middleware`, reads it back through `get_memory_config()`, edits the file to `mode: tool` (bumping mtime), then asserts `get_memory_config().mode == "tool"` without an intervening `get_app_config()` call. It fails on `main` (`AssertionError: 'middleware' == 'tool'`) and passes with this change. `test_app_config_reload.py` (15) and `test_memory_manager_pluggable.py` (16 — covers the no-config-file fallback and `set_memory_config` injection) stay green; `ruff format --check` / `ruff check` are clean.

## Relation to #4208

#4208 targets the same issue with the same `get_app_config()` lever. This PR additionally guards the no-config-file path so `get_memory_config()` stays a total function: the backend suite and CI run without a `config.yaml` (`make test` is `pytest tests/` with none generated), so an unconditional `get_app_config()` makes `get_memory_config()` raise `FileNotFoundError`, which is what breaks `test_memory_manager_pluggable.py` (autouse fixture) and `test_create_deerflow_agent.py` (factory reaches memory config via `feat.memory_config or get_memory_config()`). The `try/except FileNotFoundError` fallback here keeps those green, and the change ships with the regression test above per the backend TDD guidance in `AGENTS.md`. Happy to defer or fold these two pieces into #4208 if the maintainers prefer a single PR.

Fixes #4204
