### PR TITLE
fix(memory): treat explicit null backend_config values as omitted in DeerMemConfig

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/config.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/config.py
@@ -203,10 +203,16 @@ class DeerMemConfig(BaseModel):
         typo (e.g. ``storage_pat`` missing the ``h``) does not silently fall
         back to the default and write memory to an unintended location --
         mirrors the host layer's ``load_memory_config_from_dict`` warning.
+
+        ``None`` values are dropped so they fall back to the field default:
+        YAML renders an empty key (``model:`` with only commented children, as
+        shipped in ``config.example.yaml``) as ``None``, which non-Optional
+        fields like ``model`` would otherwise reject even though omitting the
+        key entirely is valid.
         """
         if not backend_config:
             return cls()
-        known = {k: v for k, v in backend_config.items() if k in cls.model_fields}
+        known = {k: v for k, v in backend_config.items() if k in cls.model_fields and v is not None}
         unknown = sorted(k for k in backend_config if k not in cls.model_fields)
         if unknown:
             logger.warning(

--- a/backend/tests/test_deermem_self_contained.py
+++ b/backend/tests/test_deermem_self_contained.py
@@ -396,3 +396,37 @@ def test_from_backend_config_silent_on_known_keys(caplog):
     with caplog.at_level("WARNING", logger=cfg_logger):
         DeerMemConfig.from_backend_config({"storage_path": "/tmp/x", "max_facts": 20})
     assert not any("Unknown backend_config keys" in r.message for r in caplog.records)
+
+
+def test_from_backend_config_null_values_fall_back_to_defaults():
+    """Explicit YAML ``null`` values must behave like omitted keys, not crash.
+
+    ``config.example.yaml`` ships ``backend_config.model:`` as a bare key with
+    commented children, which YAML parses to ``None`` (and ``make
+    config-upgrade`` writes it out as an explicit ``model: null``). Non-Optional
+    fields like ``model: DeerMemModelConfig`` reject an explicit ``None`` even
+    though the omitted key would use the field default — so the shipped example
+    config crashed every run with a DeerMemConfig ValidationError."""
+    from deerflow.agents.memory.backends.deermem.deermem.config import (
+        DeerMemConfig,
+        DeerMemModelConfig,
+    )
+
+    cfg = DeerMemConfig.from_backend_config({"model": None, "debounce_seconds": None, "storage_path": "/tmp/x"})
+
+    # None entries fall back to field defaults; real values still parse
+    assert isinstance(cfg.model, DeerMemModelConfig)
+    assert cfg.model.model is None  # default = no extraction LLM configured
+    assert cfg.debounce_seconds == DeerMemConfig().debounce_seconds
+    assert cfg.storage_path == "/tmp/x"
+
+
+def test_from_backend_config_null_values_do_not_warn_as_unknown(caplog):
+    """Dropped ``None`` entries are known keys — they must not trip the
+    unknown-key typo warning."""
+    from deerflow.agents.memory.backends.deermem.deermem.config import DeerMemConfig
+
+    cfg_logger = "deerflow.agents.memory.backends.deermem.deermem.config"
+    with caplog.at_level("WARNING", logger=cfg_logger):
+        DeerMemConfig.from_backend_config({"model": None})
+    assert not any("Unknown backend_config keys" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

After upgrading to the config v25 schema (#4122), **every agent run fails** with:

```
1 validation error for DeerMemConfig
model
  Input should be a valid dictionary or instance of DeerMemModelConfig [type=model_type, input_value=None, input_type=NoneType]
```

The failure is in `get_memory_manager()` → `DeerMem.__init__` → `DeerMemConfig.from_backend_config()`, so the run worker aborts before completing (`Run <id> failed: ...`).

## Root cause

`config.example.yaml` ships the memory extraction model as a bare key whose children are all comments:

```yaml
  backend_config:
    model:                      # LLM for memory extraction; omit all fields = no extraction
      # provider: openai
      # model: gpt-4o-mini
```

YAML parses this to `model: None` — and `make config-upgrade` renders it as an explicit `model: null` in the user's `config.yaml`. But `DeerMemConfig.model` is a **non-Optional** field (`model: DeerMemModelConfig = Field(default_factory=...)`): an *omitted* key gets the default, while an explicit `None` fails pydantic validation. So the shipped example and every config-upgraded install crash on their first run.

The host layer already treats `model: None` as "inject the host default LLM" (`manager.py` checks `isinstance(model_cfg, dict) and model_cfg.get("model")` before injecting `host_llm`) — the intent is clearly that empty/null means "use the default"; only the strict validator disagrees.

## Fix

Drop `None` entries in `from_backend_config()` so YAML `null` / bare keys fall back to the field default, matching the documented "empty = host default LLM" semantics. Every `DeerMemConfig` field has a default (the `Any`-typed host-hook fields default to `None` anyway), so this is semantics-preserving. Host-default hook injection in `manager.py` is unaffected: it runs before `from_backend_config` and keys on key *absence*, which this change does not alter.

## Reproduction / tests

```python
DeerMemConfig.from_backend_config({"model": None})   # before: ValidationError; after: defaults
```

Added `test_from_backend_config_null_values_fall_back_to_defaults` (explicit `None` for `model` and a scalar field fall back to defaults; real values still parse) and `test_from_backend_config_null_values_do_not_warn_as_unknown` (dropped `None` entries don't trip the unknown-key typo warning). Full `tests/test_deermem_self_contained.py` (19) and the memory test files (268) pass; `ruff format --check` and `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)