### PR TITLE
fix(github): match allow_authors logins case-insensitively

### DIFF
--- a/backend/app/gateway/github/triggers.py
+++ b/backend/app/gateway/github/triggers.py
@@ -180,9 +180,13 @@ def event_should_fire(
 
     # allow_authors bypasses require_mention entirely. Useful so a repo
     # owner can talk to the bot without typing the handle every time.
+    # Match is case-insensitive — GitHub logins are, and the sibling gates
+    # in this module already are (``_mentions`` uses re.IGNORECASE; the
+    # self-event check lowercases both sides). A bare ``in`` membership
+    # test would drop an owner whose YAML casing differs from the payload.
     if trigger.allow_authors:
         author = _author_login(event, payload)
-        if author and author in trigger.allow_authors:
+        if author and author.lower() in {a.lower() for a in trigger.allow_authors}:
             return True, f"allow_authors:{author}"
 
     if trigger.require_mention:

--- a/backend/tests/test_github_triggers.py
+++ b/backend/tests/test_github_triggers.py
@@ -162,6 +162,44 @@ def test_allow_authors_does_not_help_other_users() -> None:
     assert fire is False
 
 
+def test_allow_authors_match_is_case_insensitive() -> None:
+    """GitHub logins are case-insensitive; allow_authors must match that.
+
+    Sibling gates already ignore case: ``_mentions`` documents
+    ``Match is case-insensitive; GitHub itself is.``, and the self-event
+    check lowercases both sides. A bare ``in`` membership test rejects an
+    owner whose YAML casing differs from the payload login, so
+    ``require_mention`` still applies and the webhook is silently dropped.
+    """
+    trigger = _resolve(
+        "issue_comment",
+        GitHubTriggerConfig(require_mention=True, allow_authors=["Alice"]),
+    )
+    fire, reason = event_should_fire(
+        "issue_comment",
+        _comment_payload("no handle here", author="alice"),
+        trigger,
+        BOT,
+    )
+    assert fire is True
+    assert "allow_authors" in reason
+
+
+def test_allow_authors_case_insensitive_still_rejects_other_users() -> None:
+    """Case-folding the allowlist must not open the gate for non-members."""
+    trigger = _resolve(
+        "issue_comment",
+        GitHubTriggerConfig(require_mention=True, allow_authors=["Alice"]),
+    )
+    fire, _ = event_should_fire(
+        "issue_comment",
+        _comment_payload("no handle", author="bob"),
+        trigger,
+        BOT,
+    )
+    assert fire is False
+
+
 # ---------------------------------------------------------------------------
 # Override: mention_login replaces default login
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_github_triggers.py
+++ b/backend/tests/test_github_triggers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.gateway.github.triggers import (
     DEFAULT_TRIGGERS,
     _resolved_trigger,
@@ -162,7 +164,16 @@ def test_allow_authors_does_not_help_other_users() -> None:
     assert fire is False
 
 
-def test_allow_authors_match_is_case_insensitive() -> None:
+@pytest.mark.parametrize(
+    ("allow_authors", "author"),
+    [
+        (["Alice"], "alice"),  # config upper / payload lower
+        (["alice"], "Alice"),  # reverse: config lower / payload upper
+        (["ALICE"], "alice"),  # all-caps config
+        (["Alice"], "Alice"),  # exact case still fires after folding
+    ],
+)
+def test_allow_authors_match_is_case_insensitive(allow_authors: list[str], author: str) -> None:
     """GitHub logins are case-insensitive; allow_authors must match that.
 
     Sibling gates already ignore case: ``_mentions`` documents
@@ -170,14 +181,18 @@ def test_allow_authors_match_is_case_insensitive() -> None:
     check lowercases both sides. A bare ``in`` membership test rejects an
     owner whose YAML casing differs from the payload login, so
     ``require_mention`` still applies and the webhook is silently dropped.
+
+    ``.lower()`` is symmetric, so both fold directions and an all-caps
+    config must fire; the exact-case pair pins that folding stays a
+    superset of the old exact match.
     """
     trigger = _resolve(
         "issue_comment",
-        GitHubTriggerConfig(require_mention=True, allow_authors=["Alice"]),
+        GitHubTriggerConfig(require_mention=True, allow_authors=allow_authors),
     )
     fire, reason = event_should_fire(
         "issue_comment",
-        _comment_payload("no handle here", author="alice"),
+        _comment_payload("no handle here", author=author),
         trigger,
         BOT,
     )


### PR DESCRIPTION
## Why

`event_should_fire` lets `allow_authors` bypass `require_mention` so a repo
owner can talk to the bot without typing the handle every time. Membership
was a bare `author in trigger.allow_authors` string compare.

That disagrees with the rest of this module and with GitHub itself:

- `_mentions` in the same file documents: **"Match is case-insensitive;
  GitHub itself is."** (and uses `re.IGNORECASE`)
- The self-event check lowercases both sides before membership
- `test_default_issue_comment_mention_case_insensitive` already pins
  mention matching as case-insensitive

So YAML `allow_authors: ["Alice"]` with payload login `alice` (or the reverse)
failed the allowlist, fell through to `require_mention`, and the webhook was
**silently dropped** even though the author is the intended owner.

## What changed

`app/gateway/github/triggers.py` — compare with `.lower()` on both sides,
matching the self-event sibling.

## Surface area

- [x] **Backend API** — GitHub webhook trigger filter under `backend/app/gateway`
- [x] **Docs / tests / CI only** — regression tests in `tests/test_github_triggers.py`

## Bug fix verification

- Test paths:
  - `tests/test_github_triggers.py::test_allow_authors_match_is_case_insensitive`
  - `tests/test_github_triggers.py::test_allow_authors_case_insensitive_still_rejects_other_users`
- Red on `main` / green on this branch? **yes**
  - `test_allow_authors_match_is_case_insensitive`: red on unfixed source
    (`assert fire is True` fails with `False`); green after the fix
  - `test_allow_authors_case_insensitive_still_rejects_other_users`: direction-2
    anchor (non-member still rejected); green on both main and branch
- Red check was in place: only `triggers.py` swapped to `origin/main`, tests held fixed
  (`grep` confirmed the bare `author in trigger.allow_authors` line), then restored.
- Existing exact-case allow_authors and non-member rejection tests remain green.

## Validation

```
cd backend
uv run ruff check app/gateway/github/triggers.py tests/test_github_triggers.py
# All checks passed!
uv run ruff format --check app/gateway/github/triggers.py tests/test_github_triggers.py
# 2 files already formatted
PYTHONPATH=packages/harness:. .venv/bin/python -m pytest tests/test_github_triggers.py -q
# 28 passed
PYTHONPATH=packages/harness:. .venv/bin/python -m pytest \
  tests/test_github_triggers.py tests/test_github_agents_config.py tests/test_github_dispatcher.py -q
# 75 passed
```

E2E matrix through real `event_should_fire`:

| allow_authors | payload login | fire |
|---|---|---|
| `["Alice"]` | `alice` | True |
| `["alice"]` | `Alice` | True |
| `["ALICE"]` | `alice` | True |
| `["Alice"]` | `Alice` | True |
| `["Alice"]` | `bob` | False |

## AI assistance

**Tool(s) used:** Grok Build (xAI)

**How you used it:** Used an AI coding assistant to locate the sibling case-insensitive gates, draft the one-line membership fix and the regression tests, and run the red→green / red-check / adjacent suite verification.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
