### PR TITLE
fix(agents): refuse empty SOUL.md updates in update_agent

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
@@ -150,7 +150,7 @@ def update_agent(
     # otherwise a custom agent can report success while wiping a working
     # SOUL.md and leaving the next turn with an empty personality.
     if soul is not None and not soul.strip():
-        return _err("soul content is empty; refusing to update agent with an empty SOUL.md")
+        return _err("soul content is empty; refusing to update agent with an empty SOUL.md. Omit the soul field if you do not want to change it.")
 
     try:
         agent_name = validate_agent_name(agent_name_raw)

--- a/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/update_agent_tool.py
@@ -145,6 +145,13 @@ def update_agent(
     if soul is None and description is None and skills is None and tool_groups is None and model is None:
         return _err('No fields provided. Pass at least one of: soul, description, skills, tool_groups, model. Omit unchanged fields instead of passing null-like strings such as "null", "none", or "undefined".')
 
+    # Reject empty / whitespace-only soul before touching the filesystem.
+    # setup_agent already refuses this (#3553 / #3549); update_agent must too,
+    # otherwise a custom agent can report success while wiping a working
+    # SOUL.md and leaving the next turn with an empty personality.
+    if soul is not None and not soul.strip():
+        return _err("soul content is empty; refusing to update agent with an empty SOUL.md")
+
     try:
         agent_name = validate_agent_name(agent_name_raw)
     except ValueError as e:

--- a/backend/tests/test_update_agent_tool.py
+++ b/backend/tests/test_update_agent_tool.py
@@ -262,6 +262,36 @@ def test_update_agent_updates_soul_only(tmp_path, patched_paths):
     assert "soul" in result.update["messages"][0].content
 
 
+def test_update_agent_rejects_empty_soul_and_does_not_overwrite(tmp_path, patched_paths):
+    """Mirror setup_agent's empty-SOUL guard (#3553 / #3549).
+
+    setup_agent refuses empty/whitespace soul before touching the filesystem.
+    update_agent previously accepted the same input and reported success while
+    writing a blank SOUL.md, wiping a working agent personality.
+    """
+    agent_dir = _seed_agent(tmp_path, description="keep me", soul="original soul")
+
+    result = update_agent.func(runtime=_runtime(), soul="")
+
+    msg = result.update["messages"][0]
+    assert "soul content is empty" in msg.content
+    assert msg.status == "error"
+    assert (agent_dir / "SOUL.md").read_text() == "original soul"
+    cfg = yaml.safe_load((agent_dir / "config.yaml").read_text())
+    assert cfg["description"] == "keep me", "config must be untouched on empty-soul reject"
+
+
+def test_update_agent_rejects_whitespace_only_soul_and_does_not_overwrite(tmp_path, patched_paths):
+    agent_dir = _seed_agent(tmp_path, description="keep me", soul="original soul")
+
+    result = update_agent.func(runtime=_runtime(), soul="   \n\t  ")
+
+    msg = result.update["messages"][0]
+    assert "soul content is empty" in msg.content
+    assert msg.status == "error"
+    assert (agent_dir / "SOUL.md").read_text() == "original soul"
+
+
 def test_update_agent_updates_description_only(tmp_path, patched_paths):
     agent_dir = _seed_agent(tmp_path, description="old desc", soul="keep this soul")
 

--- a/backend/tests/test_update_agent_tool.py
+++ b/backend/tests/test_update_agent_tool.py
@@ -275,6 +275,9 @@ def test_update_agent_rejects_empty_soul_and_does_not_overwrite(tmp_path, patche
 
     msg = result.update["messages"][0]
     assert "soul content is empty" in msg.content
+    # Message must guide the retry (omit the field) so the model self-corrects
+    # in one step instead of retrying with another empty-ish value.
+    assert "Omit the soul field" in msg.content
     assert msg.status == "error"
     assert (agent_dir / "SOUL.md").read_text() == "original soul"
     cfg = yaml.safe_load((agent_dir / "config.yaml").read_text())
@@ -288,6 +291,7 @@ def test_update_agent_rejects_whitespace_only_soul_and_does_not_overwrite(tmp_pa
 
     msg = result.update["messages"][0]
     assert "soul content is empty" in msg.content
+    assert "Omit the soul field" in msg.content
     assert msg.status == "error"
     assert (agent_dir / "SOUL.md").read_text() == "original soul"
 


### PR DESCRIPTION
## Why

`setup_agent` refuses empty / whitespace-only `soul` before touching the
filesystem (#3553 / #3549): writing a blank SOUL.md would report success for
an unusable agent and could clobber existing content.

`update_agent` is the sibling write path for the same file. It accepted the
same empty input, reported **success**, and replaced a working `SOUL.md` with
whitespace — so the next turn loads an empty personality.

This is the same guard on the update side, not a new product rule.

## What changed

`tools/builtins/update_agent_tool.py` — before any staging/rename work, if
`soul is not None and not soul.strip()`, return an error ToolMessage and leave
the existing SOUL.md / config.yaml untouched. Message mirrors setup_agent
("soul content is empty; refusing to update…").

## Surface area

- [x] **Agents / LangGraph** — `update_agent` built-in tool under `packages/harness/deerflow/tools`
- [x] **Docs / tests / CI only** — `tests/test_update_agent_tool.py`

## Bug fix verification

- Test paths:
  - `tests/test_update_agent_tool.py::test_update_agent_rejects_empty_soul_and_does_not_overwrite`
  - `tests/test_update_agent_tool.py::test_update_agent_rejects_whitespace_only_soul_and_does_not_overwrite`
- Red on `main` / green on this branch? **yes** — both fail on unfixed main with
  `"Agent 'test-agent' updated successfully. Changed: soul..."` and a wiped SOUL;
  both pass after the guard (error status, original soul preserved).
- Red check was in place: only `update_agent_tool.py` swapped to `origin/main`
  (confirmed no empty-soul guard string), tests held fixed, then restored.
- Non-empty soul updates and description-only updates still succeed (existing
  suite + E2E).

## Validation

```
cd backend
ruff check packages/harness/deerflow/tools/builtins/update_agent_tool.py tests/test_update_agent_tool.py
# All checks passed!
ruff format --check packages/harness/deerflow/tools/builtins/update_agent_tool.py tests/test_update_agent_tool.py
# 2 files already formatted
PYTHONPATH=packages/harness:. .venv/bin/python -m pytest tests/test_update_agent_tool.py -q
# 25 passed
PYTHONPATH=packages/harness:. .venv/bin/python -m pytest \
  tests/test_update_agent_tool.py tests/test_setup_agent_tool.py tests/test_update_agent_e2e_user_isolation.py -q
# 38 passed
```

E2E through real tools (paths mocked to a temp dir, same harness as unit tests):

| call | result |
|---|---|
| `update_agent(soul="   ")` | error; SOUL stays `"good soul"` |
| `update_agent(soul="new good soul")` | success; SOUL replaced |
| `update_agent(description=...)` only | success; SOUL unchanged |
| `setup_agent(soul="   ")` | still errors (sibling unchanged) |

## AI assistance

**Tool(s) used:** Grok Build (xAI)

**How you used it:** Used an AI coding assistant to confirm the setup_agent / update_agent sibling gap against #3553, draft the mirrored guard and regression tests, and run red→green / red-check / adjacent suite verification.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
