### PR TITLE
fix(channels): isolate per-message failures in WeChat poll loop

### DIFF
--- a/backend/app/channels/wechat.py
+++ b/backend/app/channels/wechat.py
@@ -581,13 +581,30 @@ class WechatChannel(Channel):
 
                 self._update_longpoll_timeout(data)
 
+                # Each message is isolated in its own try/except: one message that
+                # fails to process (e.g. an attachment that fails to decrypt) must
+                # not abort the whole batch and strand every message after it.
+                for raw_message in data.get("msgs", []):
+                    try:
+                        await self._handle_update(raw_message)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception:
+                        message_id = raw_message.get("message_id") or raw_message.get("msg_id") if isinstance(raw_message, dict) else None
+                        logger.exception(
+                            "[WeChat] failed to handle inbound message message_id=%s; skipping it and continuing with the rest of the batch",
+                            message_id,
+                        )
+
+                # The cursor is advanced only after the whole batch has been
+                # attempted (not before the loop above), so a hard crash mid-batch
+                # leaves it unmoved -- the worst case on restart is re-fetching and
+                # re-processing this batch, not silently skipping past messages
+                # that were never actually handled.
                 next_buf = data.get("get_updates_buf")
                 if isinstance(next_buf, str) and next_buf != self._get_updates_buf:
                     self._get_updates_buf = next_buf
                     await asyncio.to_thread(self._save_state)
-
-                for raw_message in data.get("msgs", []):
-                    await self._handle_update(raw_message)
             except asyncio.CancelledError:
                 raise
             except Exception:

--- a/backend/tests/test_wechat_channel.py
+++ b/backend/tests/test_wechat_channel.py
@@ -1234,6 +1234,139 @@ def test_poll_loop_updates_server_timeout(monkeypatch):
     _run(go())
 
 
+def test_poll_loop_one_bad_message_does_not_permanently_lose_its_siblings(monkeypatch, tmp_path: Path, caplog):
+    """A single message that fails to process must not sink the rest of its batch.
+
+    Regression test for a permanent message-loss bug: the long-poll cursor was
+    persisted for the *whole* batch before the per-message loop ran, and the loop
+    had no per-message error isolation, so one bad message (e.g. an attachment
+    that fails to decrypt) aborted processing of every message after it in the
+    same batch. Because the cursor had already advanced past the whole batch,
+    the next poll would never re-fetch the unprocessed tail -- silent, permanent
+    loss of every message after the first failure in a batch.
+
+    This test sends a real 3-message batch through the *real* (unstubbed)
+    ``_handle_update`` -- message 1 is fine, message 2 is a WeChat image item
+    whose "encrypted" bytes are deliberately not a multiple of the AES block
+    size, so ``_decrypt_aes_128_ecb`` raises a genuine ``cryptography`` library
+    ``ValueError`` (matching how a real corrupt/undecryptable attachment would
+    fail), and message 3 is fine again. The fix must:
+      - still deliver message 1 and message 3 to the bus despite message 2's
+        failure (per-message isolation instead of one bad apple aborting the
+        for loop), and
+      - log message 2's failure instead of swallowing it silently, and
+      - only advance/persist the cursor once the whole batch has been
+        attempted (so a crash mid-batch re-delivers rather than silently
+        drops).
+    """
+    from app.channels.wechat import WechatChannel
+
+    async def go():
+        bus = MessageBus()
+        published: list[Any] = []
+
+        async def capture(msg):
+            published.append(msg)
+
+        bus.publish_inbound = capture  # type: ignore[method-assign]
+
+        aes_key = b"1234567890abcdef"
+        non_block_aligned_ciphertext = b"\x01\x02\x03\x04\x05"  # 5 bytes: not a multiple of 16
+
+        msg_good_1 = {
+            "message_type": 1,
+            "message_id": "msg-1-good",
+            "from_user_id": "wx-user-1",
+            "context_token": "ctx-1",
+            "item_list": [{"type": 1, "text_item": {"text": "message one"}}],
+        }
+        msg_bad_2 = {
+            "message_type": 1,
+            "message_id": "msg-2-bad",
+            "from_user_id": "wx-user-1",
+            "context_token": "ctx-2",
+            "item_list": [
+                {
+                    "type": 2,
+                    "image_item": {
+                        "aeskey": aes_key.hex(),
+                        "media": {"full_url": "https://cdn.example/corrupt-attachment.bin"},
+                    },
+                }
+            ],
+        }
+        msg_good_3 = {
+            "message_type": 1,
+            "message_id": "msg-3-good",
+            "from_user_id": "wx-user-1",
+            "context_token": "ctx-3",
+            "item_list": [{"type": 1, "text_item": {"text": "message three"}}],
+        }
+
+        state_dir = tmp_path / "wechat-state"
+
+        def _client_factory(*args, **kwargs):
+            return _MockAsyncClient(
+                post_responses=[
+                    {
+                        "ret": 0,
+                        "msgs": [msg_good_1, msg_bad_2, msg_good_3],
+                        "get_updates_buf": "cursor-after-batch",
+                    }
+                ],
+                **kwargs,
+            )
+
+        monkeypatch.setattr("app.channels.wechat.httpx.AsyncClient", _client_factory)
+
+        channel = WechatChannel(
+            bus=bus,
+            config={"bot_token": "test-token", "state_dir": str(state_dir), "polling_retry_delay": 0.001},
+        )
+
+        async def _fake_download(_url: str, *, timeout: float | None = None) -> bytes:
+            return non_block_aligned_ciphertext
+
+        channel._download_cdn_bytes = _fake_download  # type: ignore[method-assign]
+
+        # _handle_update is intentionally left as the REAL implementation so
+        # message 2 hits the genuine cryptography ValueError. To keep the test
+        # deterministic without depending on the bug/fix under test, force the
+        # poll loop to stop after exactly one getupdates cycle via
+        # _ensure_authenticated (called at the top of every iteration, before
+        # any message is processed) rather than via message content.
+        real_ensure_authenticated = channel._ensure_authenticated
+        auth_calls = {"n": 0}
+
+        async def _ensure_auth_then_stop() -> bool:
+            auth_calls["n"] += 1
+            if auth_calls["n"] > 1:
+                channel._running = False
+                return False
+            return await real_ensure_authenticated()
+
+        channel._ensure_authenticated = _ensure_auth_then_stop  # type: ignore[method-assign]
+        channel._running = True
+
+        with caplog.at_level(logging.INFO, logger="app.channels.wechat"):
+            await channel._poll_loop()
+
+        # Message 1 and message 3 must both survive message 2's failure.
+        assert [m.text for m in published] == ["message one", "message three"]
+
+        # Message 2's failure must be logged, not silently swallowed.
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("msg-2-bad" in message for message in messages)
+
+        # The cursor must reflect that the whole batch was attempted -- both
+        # in memory and in the persisted state file used to resume polling.
+        assert channel._get_updates_buf == "cursor-after-batch"
+        persisted = json.loads((state_dir / "wechat-getupdates.json").read_text(encoding="utf-8"))
+        assert persisted["get_updates_buf"] == "cursor-after-batch"
+
+    _run(go())
+
+
 def test_state_cursor_is_loaded_from_disk(tmp_path: Path):
     from app.channels.wechat import WechatChannel
 


### PR DESCRIPTION
## Why

Auditing the WeChat channel's long-poll loop (`backend/app/channels/wechat.py`) for control-flow correctness around batch processing turned up a silent, permanent message-loss bug: `_poll_loop` persists the `get_updates_buf` cursor for the *entire* batch immediately on receipt, then iterates `data["msgs"]` with no per-message error isolation. If any single message's processing raises (a corrupt/undecryptable attachment is a realistic real-world trigger, e.g. a truncated or tampered encrypted image/file payload), the `for` loop aborts and every message *after* the failing one in that batch is dropped -- but because the cursor already advanced past the whole batch, the next poll never re-fetches them. This isn't a delay or a retry; the messages are gone for good.

## What changed

- `_handle_update` is now called inside a per-message `try`/`except` in the poll loop, so a single message that raises (e.g. an attachment that fails to decrypt) is logged with its message id and skipped, instead of aborting every message after it in the same batch.
- The cursor (`get_updates_buf`) is now advanced and persisted only *after* the per-message loop finishes, instead of before it starts. If the process crashes mid-batch (before the try/except even runs -- e.g. the poll task is killed outright), the cursor stays put and the whole batch is safely re-fetched and re-processed on restart. That trades in a possible duplicate-processing edge case for what was previously silent, permanent data loss -- a strictly safer failure mode.

No other behavior changes: message parsing, dispatch, and the long-poll request/response shape are untouched.

## Surface area

- [x] **Backend API** -- change is under `backend/app/channels/wechat.py`'s internal poll loop; no endpoint / SSE event / request-response shape change.

## Bug fix verification

- Test path: `backend/tests/test_wechat_channel.py::test_poll_loop_one_bad_message_does_not_permanently_lose_its_siblings`
- Red on `main` / green on this branch: yes. The test drives the real (unstubbed) `_handle_update` over a 3-message batch where the middle message is a WeChat image item whose "encrypted" bytes are deliberately not a multiple of the AES block size, so decryption raises a genuine `cryptography` `ValueError` (`The length of the provided data is not a multiple of the block length.`) -- the same failure shape a real corrupt attachment would produce. On `main`, only the first message reaches the bus; the third is silently and permanently lost even though the cursor already advances past the whole batch. On this branch, both the first and third messages reach the bus, the second message's failure is logged with its message id, and the cursor still advances correctly once the batch is fully attempted.

## Validation

- `cd backend && uv run ruff check app/channels/wechat.py tests/test_wechat_channel.py` -> clean
- `cd backend && uv run ruff format --check app/channels/wechat.py tests/test_wechat_channel.py` -> clean
- `cd backend && uv run pytest tests/test_wechat_channel.py -v` -> 31/33 pass; the 2 pre-existing failures on this file are POSIX `0o600` permission assertions that are no-ops on Windows/NTFS, unrelated to this change (already called out in #3925)
- `cd backend && uv run pytest tests/blocking_io/test_wechat_channel_state.py -v` -> 3/3 pass, confirming no interference with the blocking-IO offload from #3925
