### PR TITLE
fix(tui): register /goal-first threads for Web UI visibility

### DIFF
--- a/backend/packages/harness/deerflow/tui/app.py
+++ b/backend/packages/harness/deerflow/tui/app.py
@@ -481,6 +481,14 @@ class DeerFlowTUI(App):
         if self._conv_thread_id is None:
             self._conv_thread_id = str(uuid.uuid4())
             self._refresh_header()
+            # /goal can be the very first action in a brand-new session, before any
+            # chat message ever reaches _stream_worker (the only other place that
+            # registers a thread). Without this, the thread would stay invisible in
+            # the Web UI sidebar until — if ever — a later chat message was sent in
+            # the same thread. Mirrors _stream_worker's call exactly.
+            writer = getattr(self.session, "writer", None)
+            if writer is not None:
+                writer.ensure_created(self._conv_thread_id, assistant_id="lead-agent", metadata={"source": "tui"})
         try:
             goal = self.session.client.set_goal(self._conv_thread_id, command.objective).get("goal")
         except Exception:  # noqa: BLE001

--- a/backend/tests/test_tui_app.py
+++ b/backend/tests/test_tui_app.py
@@ -180,6 +180,27 @@ class _GoalSession(_FakeSession):
         self.client = _GoalClient()
 
 
+class _RecordingWriter:
+    """Fake ThreadMetaWriter that records ensure_created calls (Web UI visibility)."""
+
+    def __init__(self):
+        self.ensure_created_calls: list[tuple] = []
+
+    def ensure_created(self, thread_id, *, assistant_id=None, metadata=None):
+        self.ensure_created_calls.append((thread_id, assistant_id, metadata))
+
+    def set_title(self, thread_id, title):
+        pass
+
+
+class _GoalSessionWithWriter(_GoalSession):
+    """A _GoalSession wired with a writer, like the real session's `.writer`."""
+
+    def __init__(self):
+        super().__init__()
+        self.writer = _RecordingWriter()
+
+
 def _system_rows(app):
     return [r for r in app.state.rows if r.kind == "system"]
 
@@ -255,3 +276,46 @@ async def test_goal_set_failure_shows_error_tone():
         await pilot.pause()
     errors = [r for r in _system_rows(app) if r.tone == "error"]
     assert any("Could not set goal." in r.text for r in errors)
+
+
+@pytest.mark.asyncio
+async def test_goal_as_first_action_registers_thread_for_web_ui():
+    """/goal as the very first action must make the new thread Web-UI-visible.
+
+    Regression test: minting a thread id inside _handle_goal used to skip the
+    threads_meta registration that _stream_worker performs for chat turns, so a
+    TUI session that only ever used /goal stayed invisible in the Web UI sidebar
+    (see AGENTS.md's "Web UI visibility" note).
+    """
+    session = _GoalSessionWithWriter()
+    app = DeerFlowTUI(session, LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app._conv_thread_id is None
+        app._handle_goal("finish the work")
+        await pilot.pause()
+    assert app._conv_thread_id is not None
+    # Same call shape _stream_worker uses, so the thread is immediately Web-UI-visible.
+    assert session.writer.ensure_created_calls == [(app._conv_thread_id, "lead-agent", {"source": "tui"})]
+
+
+@pytest.mark.asyncio
+async def test_goal_after_chat_message_does_not_duplicate_thread_registration():
+    """Normal order (chat first, /goal after) must be unaffected: no extra/duplicate
+    ensure_created call once the thread is already registered."""
+    session = _GoalSessionWithWriter()
+    app = DeerFlowTUI(session, LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        for ch in "hi":
+            await pilot.press(ch)
+        await pilot.press("enter")
+        await _wait_until(lambda: not app._streaming and app._conv_thread_id is not None, pilot)
+        thread_id_after_chat = app._conv_thread_id
+        assert len(session.writer.ensure_created_calls) == 1
+
+        app._handle_goal("finish the work")
+        await pilot.pause()
+    assert app._conv_thread_id == thread_id_after_chat
+    # No new/duplicate ensure_created call from the /goal path once a thread already exists.
+    assert len(session.writer.ensure_created_calls) == 1


### PR DESCRIPTION
## Why

`/goal` can be the very first action in a brand-new TUI session, minting a new thread id in the process. That code path never called `session.writer.ensure_created(...)` — that call only happens in `_stream_worker`, i.e. only after an actual chat message is sent on the thread.

Per `backend/AGENTS.md`'s "Web UI visibility" note:

> the Web UI lists threads from the `threads_meta` SQL table (user-scoped), not the checkpointer. `persistence.py` writes a `threads_meta` row under the default user (`"default"`) into the same DB the Gateway reads ... so TUI sessions appear in the Web UI sidebar **without** running the Gateway.

Skipping `ensure_created` for the `/goal`-first case meant the thread worked fine inside the TUI itself, but stayed completely invisible in the Web UI sidebar until (if ever) a separate chat message was later sent in the same thread.

## What changed

- `_handle_goal` now calls `session.writer.ensure_created(...)` right after minting a new thread id — the same `assistant_id="lead-agent"`, `metadata={"source": "tui"}` call `_stream_worker` already makes for chat turns — so a thread created via `/goal` is immediately Web-UI-visible.
- The call is gated on the existing `if self._conv_thread_id is None:` branch, so it only fires when `/goal` is genuinely the first action of the session. When a chat message runs first (the normal order), `_stream_worker` has already registered the thread and this branch is skipped entirely — no duplicate/conflicting `ensure_created` call.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

(Harness-layer TUI fix, `backend/packages/harness/deerflow/tui/app.py` — closes a Web UI visibility gap, no other surface affected.)

## Bug fix verification

- Test path: `backend/tests/test_tui_app.py::test_goal_as_first_action_registers_thread_for_web_ui`
- Red on main / green on this branch: **yes.** Isolated the `app.py` hunk into a patch, reverted it, and reran — the test failed (`ensure_created_calls == []` instead of the expected `[(thread_id, "lead-agent", {"source": "tui"})]`). Reapplied the patch and the test passed again.
- A second test, `test_goal_after_chat_message_does_not_duplicate_thread_registration`, pins the normal order (chat message first, `/goal` after) to a single `ensure_created` call, so this fix can't regress into a duplicate-write bug later. It already passed pre-fix (nothing to discriminate there) and still passes post-fix.

## Validation

```
cd backend
PYTHONPATH=packages/harness python -m pytest tests/test_tui_app.py tests/test_tui_cli.py tests/test_tui_cli_main.py \
  tests/test_tui_command_registry.py tests/test_tui_composer.py tests/test_tui_input_history.py \
  tests/test_tui_message_format.py tests/test_tui_overlays.py tests/test_tui_palette.py \
  tests/test_tui_palette_render.py tests/test_tui_persistence.py tests/test_tui_render.py \
  tests/test_tui_runtime.py tests/test_tui_session.py tests/test_tui_view_state.py
# 151 passed

ruff check packages/harness/deerflow/tui/app.py tests/test_tui_app.py
ruff format --check packages/harness/deerflow/tui/app.py tests/test_tui_app.py
# All checks passed! / 2 files already formatted
```