### PR TITLE
fix(tui): interrupt an active run before /quit exits

### DIFF
--- a/backend/packages/harness/deerflow/tui/app.py
+++ b/backend/packages/harness/deerflow/tui/app.py
@@ -355,6 +355,13 @@ class DeerFlowTUI(App):
 
     def _handle_builtin(self, name: str, args: str) -> None:
         if name == "quit":
+            # Mirror action_interrupt (Ctrl+C): an active run must be interrupted
+            # before we tear the app down. Otherwise the worker thread is left
+            # running against an app that no longer exists — its next
+            # call_from_thread fails silently and the in-flight turn (plus any
+            # post-run persistence, e.g. thread title) is quietly abandoned.
+            if self._streaming:
+                self._interrupt_run()
             self.exit()
         elif name == "help":
             self._dispatch(SystemMessage(_HELP_TEXT))

--- a/backend/tests/test_tui_app.py
+++ b/backend/tests/test_tui_app.py
@@ -5,6 +5,7 @@ loop: keypress -> submit -> worker thread -> stream_actions -> reducer -> state.
 """
 
 import asyncio
+import threading
 
 import pytest
 
@@ -118,6 +119,89 @@ async def test_escape_interrupts_an_active_run():
         await pilot.pause()
     assert app._streaming is False
     assert any(r.kind == "system" and "Interrupt" in r.text for r in app.state.rows)
+
+
+# --------------------------------------------------------------------------- #
+# /quit vs. Ctrl+C during an active stream
+# --------------------------------------------------------------------------- #
+
+
+class _BlockedClient(_FakeClient):
+    """A client whose stream() blocks mid-run until the test releases it.
+
+    Unlike ``_FakeClient``, which finishes a turn synchronously, this lets a
+    test catch the app while a real worker thread is genuinely stuck inside
+    the streaming generator — the same shape as a live agent turn — instead
+    of only flipping the ``_streaming`` flag by hand.
+    """
+
+    def __init__(self):
+        self.release = threading.Event()
+
+    def stream(self, message, *, thread_id=None, **kwargs):
+        self.release.wait(timeout=5)
+        yield StreamEvent(type="messages-tuple", data={"type": "ai", "content": "done", "id": "m1"})
+        yield StreamEvent(type="end", data={"usage": {"total_tokens": 1}})
+
+
+class _BlockedSession(_FakeSession):
+    def __init__(self):
+        self.client = _BlockedClient()
+
+
+@pytest.mark.asyncio
+async def test_quit_interrupts_an_active_stream_before_exiting():
+    """/quit during a run must interrupt first, mirroring Ctrl+C.
+
+    Regression test: ``_handle_builtin``'s "quit" branch used to call
+    ``self.exit()`` unconditionally, unlike ``action_interrupt`` (Ctrl+C),
+    which checks ``self._streaming`` and interrupts before any teardown.
+    Left unfixed, the worker thread survives the app's exit; its next
+    ``call_from_thread`` call then fails silently and the in-flight turn is
+    abandoned without a trace.
+    """
+    session = _BlockedSession()
+    app = DeerFlowTUI(session, LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await _wait_until(lambda: app._streaming, pilot)
+
+        for ch in "/quit":
+            await pilot.press(ch)
+        await pilot.press("enter")
+        await pilot.pause()
+
+        # The run must be interrupted (state cleaned up, message surfaced)
+        # before the app is allowed to exit — /quit still quits, but safely.
+        assert app._streaming is False
+        assert any(r.kind == "system" and "Interrupt" in r.text for r in app.state.rows)
+        assert app._exit is True
+
+    # Unblock the worker thread so it doesn't leak past the test.
+    session.client.release.set()
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_interrupts_an_active_stream_without_exiting():
+    """Contrast/control: Ctrl+C on a real blocked worker interrupts but stays open."""
+    session = _BlockedSession()
+    app = DeerFlowTUI(session, LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("h", "i")
+        await pilot.press("enter")
+        await _wait_until(lambda: app._streaming, pilot)
+
+        await pilot.press("ctrl+c")
+        await pilot.pause()
+
+        assert app._streaming is False
+        assert any(r.kind == "system" and "Interrupt" in r.text for r in app.state.rows)
+        assert app._exit is False
+
+    session.client.release.set()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`_handle_builtin`'s `"quit"` branch in `backend/packages/harness/deerflow/tui/app.py` calls `self.exit()` unconditionally:

```python
def _handle_builtin(self, name: str, args: str) -> None:
    if name == "quit":
        self.exit()
```

Ctrl+C's handler, `action_interrupt` (same file), does the opposite — it checks whether a run is in flight before deciding what to do:

```python
def action_interrupt(self) -> None:
    if self._streaming:
        self._interrupt_run()
    else:
        self.exit()
```

`/quit` skips this check entirely. If the user types `/quit` while an agent turn is streaming, the app tears itself down (`self.exit()` -> `ExitApp` -> shutdown) while `_stream_worker`'s background thread is still live, blocked mid-generator on `client.stream(...)`.

Textual doesn't wait for that thread on shutdown — `App.exit()` just posts `ExitApp`; the worker's own `Worker.cancel()` (invoked during teardown) can't preempt a thread that's synchronously blocked, so it just requests cancellation and moves on. When the streaming generator eventually resumes (the model produces its next chunk) and `_stream_worker` calls `self.call_from_thread(self._on_action, action)` against the already-exited app, that call fails — and because the worker's asyncio task was already marked cancelled during shutdown, the failure is discarded by Textual's own cancellation handling rather than surfacing anywhere: `app._exception` stays `None`, nothing is logged, nothing is visible. The in-flight message and any post-run persistence (e.g. the thread-title write at the end of `_stream_worker`) are silently abandoned.

I confirmed this with a fake client whose `stream()` blocks on a `threading.Event` mid-run (simulating a genuinely stuck turn, not just a hand-flipped flag):

- `/quit` while streaming: the app exits immediately; `self._streaming` stays `True` at exit time (the interrupt never ran). Releasing the blocked generator afterward lets the worker resume and call `call_from_thread` against the torn-down app — `app._exception` stays `None` throughout; the failure never surfaces anywhere.
- Ctrl+C under the identical setup: `self._streaming` correctly flips to `False`, an "Interrupted." row appears, and the app stays open (working control/contrast case).

## Fix

Mirror `action_interrupt`'s check inside the `"quit"` branch: if a run is active, interrupt it (the same `_interrupt_run()` cleanup Ctrl+C uses) before exiting.

```python
def _handle_builtin(self, name: str, args: str) -> None:
    if name == "quit":
        if self._streaming:
            self._interrupt_run()
        self.exit()
```

Unlike Ctrl+C (which only interrupts and leaves the app open while busy), `/quit` still always exits afterward — a user typing `/quit` clearly wants the app to close, not just cancel the current turn. The fix only makes that exit safe by cleaning up first.

## Tests

Added to `backend/tests/test_tui_app.py`, using a `_BlockedClient`/`_BlockedSession` pair whose `stream()` blocks on a real `threading.Event` — so the worker thread is genuinely stuck mid-turn, the same shape as a live agent run, instead of a hand-set flag:

- `test_quit_interrupts_an_active_stream_before_exiting` — regression test: sends a message, waits for streaming to start, presses `/quit`, and asserts the run was interrupted (`_streaming is False`, an "Interrupted." row present) before the app exits (`app._exit is True`).
- `test_ctrl_c_interrupts_an_active_stream_without_exiting` — contrast/control under the identical blocked-worker setup: Ctrl+C interrupts but the app does not exit.

Verified fail-before/pass-after via a source-only patch revert of `app.py` (tests untouched): with the old unconditional `self.exit()`, `test_quit_interrupts_an_active_stream_before_exiting` fails (`assert app._streaming is False` -> `AssertionError: assert True is False`) while the Ctrl+C contrast test still passes; with the fix restored, both pass.

Full TUI suite: 151 passed, 0 failed (`backend/tests/test_tui_*.py`).

`ruff check` / `ruff format --check` clean (line-length 240).
