### PR TITLE
fix(tui): make ctrl+u clear the whole composer, not just left of cursor

### DIFF
--- a/backend/packages/harness/deerflow/tui/app.py
+++ b/backend/packages/harness/deerflow/tui/app.py
@@ -144,7 +144,12 @@ class DeerFlowTUI(App):
     BINDINGS = [
         Binding("ctrl+c", "interrupt", "Interrupt / Quit", priority=True, show=True),
         Binding("ctrl+l", "redraw", "Redraw", show=False),
-        Binding("ctrl+u", "clear_composer", "Clear input", show=False),
+        # priority=True: Input's own BINDINGS already map ctrl+u to delete_left_all,
+        # which otherwise wins outright while the composer has focus (a focused
+        # widget's own bindings are checked before the App's non-priority ones).
+        # check_action gates this the same way as the other priority bindings below
+        # so it doesn't reach into the composer while a modal overlay is open.
+        Binding("ctrl+u", "clear_composer", "Clear input", show=False, priority=True),
         # Up/Down drive the palette when it's open, otherwise input history.
         # Tab/Enter/Esc only act when the palette is open. check_action gates all
         # of these so they never steal keys from a modal overlay or the composer.
@@ -241,16 +246,21 @@ class DeerFlowTUI(App):
     # ----- slash command palette ----------------------------------------- #
 
     def check_action(self, action: str, parameters):  # noqa: D401 - Textual hook
-        custom = {"nav_up", "nav_down", "palette_complete", "palette_accept", "escape"}
+        custom = {"nav_up", "nav_down", "palette_complete", "palette_accept", "escape", "clear_composer"}
         if action in custom:
             # A modal overlay (e.g. the model/thread picker) is on top — never
-            # intercept its keys; let the overlay handle them natively.
+            # intercept its keys; let the overlay handle them natively. This
+            # matters even for priority bindings: Textual's own modal-safety
+            # truncation (Screen._modal_binding_chain) only applies to the
+            # non-priority key pass, so a priority binding on the App (e.g.
+            # ctrl+u) would otherwise still fire while a modal is on top.
             if len(self.screen_stack) > 1:
                 return None
-            # nav (history), Tab and Esc are always consumed (Tab can't move focus
-            # off the composer; Esc closes the palette or interrupts a run). Enter
+            # nav (history), Tab, Esc and clear_composer are always consumed (Tab
+            # can't move focus off the composer; Esc closes the palette or
+            # interrupts a run; clear_composer isn't palette-dependent). Enter
             # falls through to the Input when the palette is closed so it submits.
-            if action in {"nav_up", "nav_down", "palette_complete", "escape"}:
+            if action in {"nav_up", "nav_down", "palette_complete", "escape", "clear_composer"}:
                 return True
             return True if self._palette_open else None
         return True

--- a/backend/tests/test_tui_app.py
+++ b/backend/tests/test_tui_app.py
@@ -108,6 +108,27 @@ async def test_up_arrow_recalls_previous_input_from_history():
 
 
 @pytest.mark.asyncio
+async def test_ctrl_u_clears_full_composer_not_just_left_of_cursor():
+    app = DeerFlowTUI(_FakeSession(), LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        composer = app.query_one("#composer")
+        for ch in "hello world":
+            await pilot.press("space" if ch == " " else ch)
+        assert composer.value == "hello world"
+        # Move the cursor left of the end so a left-of-cursor-only clear (Input's
+        # own ctrl+u -> delete_left_all binding) is observably different from a
+        # full composer clear (the app's intended clear_composer action).
+        await pilot.press("left", "left", "left")
+        await pilot.pause()
+        assert composer.cursor_position == len("hello world") - 3
+        await pilot.press("ctrl+u")
+        await pilot.pause()
+    # Input's shadowing binding would only remove "hello wo", leaving "rld".
+    assert composer.value == ""
+
+
+@pytest.mark.asyncio
 async def test_escape_interrupts_an_active_run():
     app = DeerFlowTUI(_FakeSession(), LaunchPlan(mode="tui"))
     async with app.run_test() as pilot:

--- a/backend/tests/test_tui_overlays.py
+++ b/backend/tests/test_tui_overlays.py
@@ -113,6 +113,28 @@ async def test_threads_command_opens_switcher_and_resumes():
 
 
 @pytest.mark.asyncio
+async def test_ctrl_u_does_not_leak_into_composer_while_modal_open():
+    # ctrl+u -> clear_composer is a priority binding so it can win over Input's
+    # own ctrl+u binding while the composer has focus (see app.py BINDINGS). But
+    # App-level priority bindings are still visible to check_action even while a
+    # modal is on top (Screen._modal_binding_chain only truncates the *non*
+    # priority pass), so check_action must keep gating it out like the other
+    # priority bindings — otherwise it would reach past the overlay and silently
+    # wipe the composer while the user is interacting with the picker.
+    app = DeerFlowTUI(_FakeSession(), LaunchPlan(mode="tui"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        composer = app.query_one("#composer")
+        composer.value = "keep me"
+        app._open_model_picker()
+        await _settle(pilot, lambda: isinstance(app.screen, SelectScreen))
+        await pilot.press("ctrl+u")
+        await pilot.pause()
+        assert isinstance(app.screen, SelectScreen)
+    assert composer.value == "keep me"
+
+
+@pytest.mark.asyncio
 async def test_picker_escape_cancels_without_change():
     app = DeerFlowTUI(_FakeSession(), LaunchPlan(mode="tui"))
     async with app.run_test() as pilot:


### PR DESCRIPTION
## Problem

`DeerFlowTUI.BINDINGS` maps `ctrl+u` to `clear_composer` (intended to wipe the
whole composer), but Textual's built-in `Input` widget already has its own
`ctrl+u -> delete_left_all` binding. A focused widget's own (non-priority)
bindings are checked before the App's non-priority bindings, so while the
composer has focus — the normal state while typing — `Input`'s binding always
won the race and `action_clear_composer` never actually fired. In practice,
Ctrl+U only deleted text left of the cursor instead of clearing the composer.

## Fix

Mark the binding `priority=True`, matching the pattern already used for
`ctrl+c`, `up`/`down`, `tab`, `escape`, and `enter` in the same `BINDINGS`
list. Priority bindings on the App are checked before the event is even
forwarded to the focused widget, so `clear_composer` now wins outright.

This interacts with the existing `check_action` modal-overlay gate. Textual's
own modal-safety truncation (`Screen._modal_binding_chain`) only applies to
the *non*-priority key-resolution pass — the priority pass walks the full
chain up to the App regardless of whether a modal screen (e.g. the `/model`
or `/threads` picker) is on top. So a bare `priority=True` would let Ctrl+U
reach past an open overlay and silently clear the (hidden) composer's text
while the user is interacting with the picker. `check_action` now includes
`clear_composer` in the same modal-gated set as the other priority bindings
(`nav_up`/`nav_down`/`palette_complete`/`escape`), so it's suppressed while
`len(self.screen_stack) > 1`, consistent with the existing "never steal keys
from a modal overlay or the composer" invariant.

## Tests

- `test_ctrl_u_clears_full_composer_not_just_left_of_cursor` (`test_tui_app.py`):
  types text, moves the cursor left of the end, presses Ctrl+U, and asserts
  the composer is fully empty rather than only missing the text left of the
  cursor.
- `test_ctrl_u_does_not_leak_into_composer_while_modal_open` (`test_tui_overlays.py`):
  opens the model picker, presses Ctrl+U, and asserts the composer text and
  the open overlay are both undisturbed.

Verified both halves of the fix are independently load-bearing: with only
`priority=True` and no `check_action` change, the first test passes but the
second fails (composer is wiped while the picker is open); with the full fix,
both pass. Reverting the whole change reproduces the original bug (only text
left of the cursor is removed). Full TUI suite (`tests/test_tui_*.py`, 151
tests) passes with no regressions.

`ruff check` / `ruff format --check` clean.