### PR TITLE
fix(browserless): surface target-page error status in web_fetch_tool

### DIFF
--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -47,8 +47,55 @@ class BrowserlessClient:
         wait_for_selector_timeout_ms: int = 5000,
         reject_resource_types: list[str] | None = None,
         reject_request_pattern: list[str] | None = None,
-    ) -> BrowserlessFetchResult | str:
+    ) -> str:
         """Fetch the rendered HTML of a page using Browserless.
+
+        Public string contract: this always returns either the rendered HTML or
+        an "Error: ..." string, never a richer result object. Callers that also
+        need the target page's real status (Browserless returns HTTP 200 for the
+        render request itself even when the target page responded with a 4xx/5xx
+        or an anti-bot block page) should use fetch_html_with_status() instead.
+
+        Args:
+            url: The URL to fetch.
+            wait_for_event: Wait for a page event (e.g. "networkidle", "load").
+            wait_for_timeout_ms: Extra wait after page load.
+            wait_for_selector: CSS selector to wait for.
+            wait_for_selector_timeout_ms: Timeout for selector wait.
+            reject_resource_types: Resource types to block (e.g. ["image"]).
+            reject_request_pattern: URL patterns to block.
+
+        Returns:
+            Rendered HTML content, or an "Error: ..." string on failure.
+        """
+        result = await self.fetch_html_with_status(
+            url=url,
+            wait_for_event=wait_for_event,
+            wait_for_timeout_ms=wait_for_timeout_ms,
+            wait_for_selector=wait_for_selector,
+            wait_for_selector_timeout_ms=wait_for_selector_timeout_ms,
+            reject_resource_types=reject_resource_types,
+            reject_request_pattern=reject_request_pattern,
+        )
+        return result.html if isinstance(result, BrowserlessFetchResult) else result
+
+    async def fetch_html_with_status(
+        self,
+        url: str,
+        wait_for_event: str = "",
+        wait_for_timeout_ms: int = 0,
+        wait_for_selector: str = "",
+        wait_for_selector_timeout_ms: int = 5000,
+        reject_resource_types: list[str] | None = None,
+        reject_request_pattern: list[str] | None = None,
+    ) -> BrowserlessFetchResult | str:
+        """Fetch the rendered HTML of a page using Browserless, with target status.
+
+        Same request/response handling as fetch_html(), except a successful fetch
+        returns a BrowserlessFetchResult carrying the target page's real status
+        headers instead of a bare string, so a caller can tell a genuine 200 apart
+        from a render-succeeded-but-target-errored (or anti-bot blocked) response.
+        Use fetch_html() instead when only the HTML/error string is needed.
 
         Only sends accepted parameters for the current Browserless API version.
         Sets a default navigation timeout (30s) via query param.
@@ -64,7 +111,7 @@ class BrowserlessClient:
 
         Returns:
             Fetch result with the rendered HTML and target-page status headers,
-            or an error string.
+            or an "Error: ..." string on failure.
         """
         payload: dict[str, Any] = {
             "url": url,

--- a/backend/packages/harness/deerflow/community/browserless/browserless_client.py
+++ b/backend/packages/harness/deerflow/community/browserless/browserless_client.py
@@ -8,6 +8,13 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class BrowserlessFetchResult:
+    html: str
+    target_status_code: str
+    target_status: str
+
+
+@dataclass(frozen=True)
 class BrowserlessScreenshotResult:
     content: bytes
     content_type: str
@@ -40,7 +47,7 @@ class BrowserlessClient:
         wait_for_selector_timeout_ms: int = 5000,
         reject_resource_types: list[str] | None = None,
         reject_request_pattern: list[str] | None = None,
-    ) -> str:
+    ) -> BrowserlessFetchResult | str:
         """Fetch the rendered HTML of a page using Browserless.
 
         Only sends accepted parameters for the current Browserless API version.
@@ -56,7 +63,8 @@ class BrowserlessClient:
             reject_request_pattern: URL patterns to block.
 
         Returns:
-            Rendered HTML content.
+            Fetch result with the rendered HTML and target-page status headers,
+            or an error string.
         """
         payload: dict[str, Any] = {
             "url": url,
@@ -103,7 +111,11 @@ class BrowserlessClient:
                 if not html or not html.strip():
                     return "Error: Browserless returned empty response"
 
-                return html
+                return BrowserlessFetchResult(
+                    html=html,
+                    target_status_code=_get_header(resp.headers, "X-Response-Code"),
+                    target_status=_get_header(resp.headers, "X-Response-Status"),
+                )
 
         except httpx.TimeoutException:
             return f"Error: Browserless request timed out after {self.timeout_s}s"

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -18,7 +18,7 @@ from deerflow.config.paths import VIRTUAL_PATH_PREFIX
 from deerflow.tools.types import Runtime
 from deerflow.utils.readability import ReadabilityExtractor
 
-from .browserless_client import BrowserlessClient, BrowserlessScreenshotResult
+from .browserless_client import BrowserlessClient, BrowserlessFetchResult, BrowserlessScreenshotResult
 
 logger = logging.getLogger(__name__)
 
@@ -173,13 +173,13 @@ def _write_capture_output(outputs_path: Path, output_name: str, content: bytes) 
     return final_name
 
 
-def _target_status_warning(result: BrowserlessScreenshotResult) -> str:
-    """Return a human-readable warning when the captured page itself errored.
+def _target_status_warning(result: BrowserlessScreenshotResult | BrowserlessFetchResult) -> str:
+    """Return a human-readable warning when the fetched/captured page itself errored.
 
     Browserless returns HTTP 200 for the render request even when the target
     page responded with a 4xx/5xx (or was an error/anti-bot page), so the raw
-    image alone cannot be trusted as valid visual evidence. The target's real
-    status is surfaced via the X-Response-Code header.
+    content alone cannot be trusted as a normal successful response. The
+    target's real status is surfaced via the X-Response-Code header.
     """
     code = result.target_status_code.strip()
     if not code or code.startswith(("2", "3")):
@@ -224,7 +224,7 @@ async def web_fetch_tool(url: str) -> str:
         wait_for_selector = cfg.get("wait_for_selector", wait_for_selector)
 
         client = _get_browserless_client("web_fetch")
-        html = await client.fetch_html(
+        result = await client.fetch_html(
             url=url,
             wait_for_event=wait_for_event,
             wait_for_timeout_ms=wait_for_timeout_ms,
@@ -234,11 +234,11 @@ async def web_fetch_tool(url: str) -> str:
             reject_request_pattern=reject_request_pattern,
         )
 
-        if html.startswith("Error:"):
-            return html
+        if isinstance(result, str):
+            return result
 
-        article = await asyncio.to_thread(_readability_extractor.extract_article, html)
-        return article.to_markdown()[:4096]
+        article = await asyncio.to_thread(_readability_extractor.extract_article, result.html)
+        return f"{article.to_markdown()[:4096]}{_target_status_warning(result)}"
 
     except Exception as e:
         logger.error(f"Error in web_fetch_tool: {e}")

--- a/backend/packages/harness/deerflow/community/browserless/tools.py
+++ b/backend/packages/harness/deerflow/community/browserless/tools.py
@@ -224,7 +224,7 @@ async def web_fetch_tool(url: str) -> str:
         wait_for_selector = cfg.get("wait_for_selector", wait_for_selector)
 
         client = _get_browserless_client("web_fetch")
-        result = await client.fetch_html(
+        result = await client.fetch_html_with_status(
             url=url,
             wait_for_event=wait_for_event,
             wait_for_timeout_ms=wait_for_timeout_ms,

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -22,7 +22,15 @@ class TestBrowserlessClient:
     """Tests for the BrowserlessClient class."""
 
     async def test_fetch_html_success(self):
-        """fetch_html returns a BrowserlessFetchResult with the rendered HTML on success."""
+        """fetch_html returns the rendered HTML as a plain string on success.
+
+        Regression guard for the fetch_html() public string contract:
+        BrowserlessClient is re-exported from deerflow.community.browserless.__all__,
+        so harness consumers that call string methods, compare the result, or pass
+        it directly to a parser must keep getting a str back. Status-aware callers
+        (e.g. web_fetch_tool) use fetch_html_with_status() instead - see
+        test_fetch_html_with_status_surfaces_target_status_headers below.
+        """
         with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
             mock_cls.return_value.__aenter__.return_value = mock_ctx
@@ -36,20 +44,25 @@ class TestBrowserlessClient:
             client = BrowserlessClient(base_url="http://browserless:3000")
             result = await client.fetch_html("https://example.com")
 
-            assert isinstance(result, BrowserlessFetchResult)
-            assert result.html == "<html><body>Page content</body></html>"
+            assert isinstance(result, str)
+            assert result == "<html><body>Page content</body></html>"
             call_kwargs = mock_ctx.post.call_args.kwargs
             assert call_kwargs["json"]["url"] == "https://example.com"
             assert "waitUntil" not in call_kwargs["json"]
             assert "gotoTimeout" not in call_kwargs["json"]
             assert "bestAttempt" not in call_kwargs["json"]
 
-    async def test_fetch_html_surfaces_target_status_headers(self):
-        """fetch_html carries the target page's real status headers on the result.
+    async def test_fetch_html_returns_plain_string_even_when_target_page_errored(self):
+        """fetch_html stays a plain string even when the target page itself errored.
 
         Browserless returns HTTP 200 for the render request itself even when the
-        target page responded with a 404 (or an anti-bot block page), so callers
-        need the X-Response-Code/X-Response-Status headers to tell the two apart.
+        target page responded with a 404 (or an anti-bot block page). Before this
+        fix, a successful fetch_html() call started returning a BrowserlessFetchResult
+        object instead of a string in exactly this case, breaking existing callers
+        (.lower(), string concatenation, parsers expecting str) even though their
+        fetch technically succeeded. fetch_html() must keep unwrapping to the plain
+        HTML string regardless of the target status; only fetch_html_with_status()
+        exposes the richer result.
         """
         with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
@@ -66,6 +79,34 @@ class TestBrowserlessClient:
 
             client = BrowserlessClient(base_url="http://browserless:3000")
             result = await client.fetch_html("https://example.com/blocked")
+
+            assert isinstance(result, str)
+            assert result == "<html><body>Access Denied</body></html>"
+
+    async def test_fetch_html_with_status_surfaces_target_status_headers(self):
+        """fetch_html_with_status carries the target page's real status headers on the result.
+
+        Browserless returns HTTP 200 for the render request itself even when the
+        target page responded with a 404 (or an anti-bot block page), so status-aware
+        callers need the X-Response-Code/X-Response-Status headers to tell the two
+        apart. This richer result is opt-in via fetch_html_with_status(); plain
+        fetch_html() stays a str (see test_fetch_html_success above).
+        """
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html><body>Access Denied</body></html>"
+            mock_resp.headers = {
+                "X-Response-Code": "404",
+                "X-Response-Status": "Not Found",
+            }
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            result = await client.fetch_html_with_status("https://example.com/blocked")
 
             assert isinstance(result, BrowserlessFetchResult)
             assert result.html == "<html><body>Access Denied</body></html>"
@@ -282,7 +323,7 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_success(self, mock_get_client):
         """web_fetch_tool successfully fetches and extracts content."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(
+        mock_client.fetch_html_with_status = AsyncMock(
             return_value=BrowserlessFetchResult(
                 html="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>",
                 target_status_code="200",
@@ -301,7 +342,7 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_error(self, mock_get_client):
         """web_fetch_tool returns error when fetch fails."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(return_value="Error: Browserless returned empty response")
+        mock_client.fetch_html_with_status = AsyncMock(return_value="Error: Browserless returned empty response")
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
@@ -313,7 +354,7 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_exception(self, mock_get_client):
         """web_fetch_tool returns error when client raises exception."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(side_effect=Exception("Unexpected error"))
+        mock_client.fetch_html_with_status = AsyncMock(side_effect=Exception("Unexpected error"))
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
@@ -347,7 +388,7 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_allows_private_when_opted_in(self, mock_get_client):
         """web_fetch_tool allows internal targets only when explicitly configured."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(
+        mock_client.fetch_html_with_status = AsyncMock(
             return_value=BrowserlessFetchResult(
                 html="<html><body><article><p>internal</p></article></body></html>",
                 target_status_code="200",
@@ -360,7 +401,7 @@ class TestBrowserlessTools:
             result = await tools.web_fetch_tool.ainvoke("http://10.0.0.5/dashboard")
 
         assert "Error:" not in result
-        mock_client.fetch_html.assert_called_once()
+        mock_client.fetch_html_with_status.assert_called_once()
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
     async def test_web_fetch_tool_warns_on_target_error_status(self, mock_get_client):
@@ -368,12 +409,12 @@ class TestBrowserlessTools:
 
         Mirrors test_web_capture_tool_warns_on_target_error_status below:
         Browserless returns HTTP 200 for the render request even when the target
-        page is a 404 or an anti-bot block page, so fetch_html's target-status
-        headers must produce the same visible warning web_capture_tool already
-        gives via _target_status_warning.
+        page is a 404 or an anti-bot block page, so fetch_html_with_status's
+        target-status headers must produce the same visible warning
+        web_capture_tool already gives via _target_status_warning.
         """
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(
+        mock_client.fetch_html_with_status = AsyncMock(
             return_value=BrowserlessFetchResult(
                 html="<html><body><article><h1>Not Found</h1><p>The page does not exist.</p></article></body></html>",
                 target_status_code="404",
@@ -396,7 +437,7 @@ class TestBrowserlessTools:
         by the target-status warning added for error/blocked pages.
         """
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(
+        mock_client.fetch_html_with_status = AsyncMock(
             return_value=BrowserlessFetchResult(
                 html="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>",
                 target_status_code="200",
@@ -417,17 +458,17 @@ class TestBrowserlessTools:
         Both tools sit on top of the same Browserless target-status headers
         (X-Response-Code / X-Response-Status). Before this fix, only
         web_capture_tool (via capture_screenshot + _target_status_warning)
-        surfaced them; web_fetch_tool (via fetch_html) silently returned the
-        blocked page's raw content with no indication anything was wrong. This
-        drives both real tool functions with the same headers and asserts they
-        now agree.
+        surfaced them; web_fetch_tool (via fetch_html_with_status) silently
+        returned the blocked page's raw content with no indication anything was
+        wrong. This drives both real tool functions with the same headers and
+        asserts they now agree.
         """
         outputs_dir = tmp_path / "outputs"
         outputs_dir.mkdir()
         runtime = SimpleNamespace(state={"thread_data": {"outputs_path": str(outputs_dir)}})
 
         fetch_client = MagicMock()
-        fetch_client.fetch_html = AsyncMock(
+        fetch_client.fetch_html_with_status = AsyncMock(
             return_value=BrowserlessFetchResult(
                 html="<html><body><article><h1>Blocked</h1><p>Access denied.</p></article></body></html>",
                 target_status_code="404",

--- a/backend/tests/test_browserless_client.py
+++ b/backend/tests/test_browserless_client.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deerflow.community.browserless import tools
-from deerflow.community.browserless.browserless_client import BrowserlessClient, BrowserlessScreenshotResult
+from deerflow.community.browserless.browserless_client import BrowserlessClient, BrowserlessFetchResult, BrowserlessScreenshotResult
 
 
 class AsyncMock(MagicMock):
@@ -22,7 +22,7 @@ class TestBrowserlessClient:
     """Tests for the BrowserlessClient class."""
 
     async def test_fetch_html_success(self):
-        """fetch_html returns HTML content on success."""
+        """fetch_html returns a BrowserlessFetchResult with the rendered HTML on success."""
         with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
             mock_ctx = MagicMock()
             mock_cls.return_value.__aenter__.return_value = mock_ctx
@@ -36,12 +36,41 @@ class TestBrowserlessClient:
             client = BrowserlessClient(base_url="http://browserless:3000")
             result = await client.fetch_html("https://example.com")
 
-            assert result == "<html><body>Page content</body></html>"
+            assert isinstance(result, BrowserlessFetchResult)
+            assert result.html == "<html><body>Page content</body></html>"
             call_kwargs = mock_ctx.post.call_args.kwargs
             assert call_kwargs["json"]["url"] == "https://example.com"
             assert "waitUntil" not in call_kwargs["json"]
             assert "gotoTimeout" not in call_kwargs["json"]
             assert "bestAttempt" not in call_kwargs["json"]
+
+    async def test_fetch_html_surfaces_target_status_headers(self):
+        """fetch_html carries the target page's real status headers on the result.
+
+        Browserless returns HTTP 200 for the render request itself even when the
+        target page responded with a 404 (or an anti-bot block page), so callers
+        need the X-Response-Code/X-Response-Status headers to tell the two apart.
+        """
+        with patch("deerflow.community.browserless.browserless_client.httpx.AsyncClient") as mock_cls:
+            mock_ctx = MagicMock()
+            mock_cls.return_value.__aenter__.return_value = mock_ctx
+
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.text = "<html><body>Access Denied</body></html>"
+            mock_resp.headers = {
+                "X-Response-Code": "404",
+                "X-Response-Status": "Not Found",
+            }
+            mock_ctx.post = AsyncMock(return_value=mock_resp)
+
+            client = BrowserlessClient(base_url="http://browserless:3000")
+            result = await client.fetch_html("https://example.com/blocked")
+
+            assert isinstance(result, BrowserlessFetchResult)
+            assert result.html == "<html><body>Access Denied</body></html>"
+            assert result.target_status_code == "404"
+            assert result.target_status == "Not Found"
 
     async def test_fetch_html_empty_response(self):
         """fetch_html returns error for empty response."""
@@ -253,13 +282,20 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_success(self, mock_get_client):
         """web_fetch_tool successfully fetches and extracts content."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(return_value="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>")
+        mock_client.fetch_html = AsyncMock(
+            return_value=BrowserlessFetchResult(
+                html="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>",
+                target_status_code="200",
+                target_status="OK",
+            )
+        )
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
             result = await tools.web_fetch_tool.ainvoke("https://example.com/article")
 
         assert "Error:" not in result
+        assert "warning:" not in result
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
     async def test_web_fetch_tool_error(self, mock_get_client):
@@ -311,7 +347,13 @@ class TestBrowserlessTools:
     async def test_web_fetch_tool_allows_private_when_opted_in(self, mock_get_client):
         """web_fetch_tool allows internal targets only when explicitly configured."""
         mock_client = MagicMock()
-        mock_client.fetch_html = AsyncMock(return_value="<html><body><article><p>internal</p></article></body></html>")
+        mock_client.fetch_html = AsyncMock(
+            return_value=BrowserlessFetchResult(
+                html="<html><body><article><p>internal</p></article></body></html>",
+                target_status_code="200",
+                target_status="OK",
+            )
+        )
         mock_get_client.return_value = mock_client
 
         with patch("deerflow.community.browserless.tools._get_tool_config", return_value={"allow_private_addresses": True}):
@@ -319,6 +361,110 @@ class TestBrowserlessTools:
 
         assert "Error:" not in result
         mock_client.fetch_html.assert_called_once()
+
+    @patch("deerflow.community.browserless.tools._get_browserless_client")
+    async def test_web_fetch_tool_warns_on_target_error_status(self, mock_get_client):
+        """web_fetch_tool surfaces a warning when the fetched page itself errored.
+
+        Mirrors test_web_capture_tool_warns_on_target_error_status below:
+        Browserless returns HTTP 200 for the render request even when the target
+        page is a 404 or an anti-bot block page, so fetch_html's target-status
+        headers must produce the same visible warning web_capture_tool already
+        gives via _target_status_warning.
+        """
+        mock_client = MagicMock()
+        mock_client.fetch_html = AsyncMock(
+            return_value=BrowserlessFetchResult(
+                html="<html><body><article><h1>Not Found</h1><p>The page does not exist.</p></article></body></html>",
+                target_status_code="404",
+                target_status="Not Found",
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            result = await tools.web_fetch_tool.ainvoke("https://example.com/missing")
+
+        assert "Error:" not in result
+        assert "warning: target page responded 404 Not Found" in result
+
+    @patch("deerflow.community.browserless.tools._get_browserless_client")
+    async def test_web_fetch_tool_no_warning_for_normal_target_status(self, mock_get_client):
+        """web_fetch_tool does not warn when the target page responded normally.
+
+        Regression guard: a legitimate 200-target-page fetch must be unaffected
+        by the target-status warning added for error/blocked pages.
+        """
+        mock_client = MagicMock()
+        mock_client.fetch_html = AsyncMock(
+            return_value=BrowserlessFetchResult(
+                html="<html><body><article><h1>Title</h1><p>Content</p></article></body></html>",
+                target_status_code="200",
+                target_status="OK",
+            )
+        )
+        mock_get_client.return_value = mock_client
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            result = await tools.web_fetch_tool.ainvoke("https://example.com/article")
+
+        assert "Error:" not in result
+        assert "warning:" not in result
+
+    async def test_web_fetch_and_web_capture_tools_agree_on_target_error_warning(self, tmp_path):
+        """web_fetch_tool and web_capture_tool surface the identical warning for identical target-error headers.
+
+        Both tools sit on top of the same Browserless target-status headers
+        (X-Response-Code / X-Response-Status). Before this fix, only
+        web_capture_tool (via capture_screenshot + _target_status_warning)
+        surfaced them; web_fetch_tool (via fetch_html) silently returned the
+        blocked page's raw content with no indication anything was wrong. This
+        drives both real tool functions with the same headers and asserts they
+        now agree.
+        """
+        outputs_dir = tmp_path / "outputs"
+        outputs_dir.mkdir()
+        runtime = SimpleNamespace(state={"thread_data": {"outputs_path": str(outputs_dir)}})
+
+        fetch_client = MagicMock()
+        fetch_client.fetch_html = AsyncMock(
+            return_value=BrowserlessFetchResult(
+                html="<html><body><article><h1>Blocked</h1><p>Access denied.</p></article></body></html>",
+                target_status_code="404",
+                target_status="Not Found",
+            )
+        )
+
+        capture_client = MagicMock()
+        capture_client.capture_screenshot = AsyncMock(
+            return_value=BrowserlessScreenshotResult(
+                content=b"\x89PNG\r\n\x1a\nimage",
+                content_type="image/png",
+                target_status_code="404",
+                target_status="Not Found",
+                final_url="https://example.com/missing",
+            )
+        )
+
+        with patch("deerflow.community.browserless.tools._get_tool_config", return_value=None):
+            with patch("deerflow.community.browserless.tools._get_browserless_client", return_value=fetch_client):
+                fetch_result = await tools.web_fetch_tool.ainvoke("https://example.com/missing")
+
+            with patch(
+                "deerflow.community.browserless.tools._resolve_host_addresses",
+                return_value=[ipaddress.ip_address("93.184.216.34")],
+            ):
+                with patch("deerflow.community.browserless.tools._get_browserless_client", return_value=capture_client):
+                    capture_command = await tools.web_capture_tool.coroutine(
+                        runtime=runtime,
+                        url="https://example.com/missing",
+                        tool_call_id="tool-1",
+                    )
+
+        capture_message = capture_command.update["messages"][0].content
+
+        assert "warning: target page responded 404 Not Found" in fetch_result
+        assert "warning: target page responded 404 Not Found" in capture_message
 
     @patch("deerflow.community.browserless.tools._get_browserless_client")
     async def test_web_capture_tool_writes_artifact(self, mock_get_client, tmp_path):


### PR DESCRIPTION
## Problem

Browserless returns HTTP 200 for the render request itself even when the
target page responded with a 4xx/5xx, or served an anti-bot block page.
The real target status is exposed via the `X-Response-Code` /
`X-Response-Status` response headers.

`capture_screenshot` (and `web_capture_tool` on top of it) already handles
this correctly: the headers are threaded into `BrowserlessScreenshotResult`,
and `_target_status_warning()` turns a non-2xx/3xx target status into a
visible `(warning: target page responded ...)` suffix on the tool result.

`fetch_html` does not follow the same pattern. It reads the same two
headers, but only `logger.debug`s them and then returns the raw
`resp.text` unconditionally whenever the Browserless render request itself
was HTTP 200 — regardless of what the target page actually returned. As a
result, `web_fetch_tool` silently hands the model a 404 page or an
anti-bot block page as if it were a normal, successful fetch, with no
warning or error indication at all.

## Fix

Apply the same pattern `capture_screenshot`/`web_capture_tool` already
establish, to `fetch_html`/`web_fetch_tool`:

- `fetch_html` now returns a new `BrowserlessFetchResult` frozen dataclass
  (`html`, `target_status_code`, `target_status`) on success instead of a
  bare `str`, mirroring `BrowserlessScreenshotResult`. Error paths
  (non-200 render response, empty response, timeout, request failure) are
  unchanged and still return a plain `"Error: ..."` string.
- `_target_status_warning()` is widened to accept either result type
  (`BrowserlessScreenshotResult | BrowserlessFetchResult`), since both
  expose the same `target_status_code` / `target_status` fields.
- `web_fetch_tool` checks `isinstance(result, str)` for the error case
  (same shape as `web_capture_tool`), then appends
  `_target_status_warning(result)` to the extracted markdown when the
  target page's real status is an error/block.

A legitimate 200-target-page fetch is unaffected: no warning is appended,
and the extracted content is unchanged.

## Testing

Added/updated coverage in `backend/tests/test_browserless_client.py`:

- `test_fetch_html_success` / `test_fetch_html_with_*` updated for the new
  `BrowserlessFetchResult` return shape.
- `test_fetch_html_surfaces_target_status_headers` — `fetch_html` carries
  the target-page status headers on its result.
- `test_web_fetch_tool_warns_on_target_error_status` — `web_fetch_tool`
  now surfaces the warning for a 404 target page.
- `test_web_fetch_tool_no_warning_for_normal_target_status` — regression
  guard: a legitimate 200-target fetch is unaffected.
- `test_web_fetch_and_web_capture_tools_agree_on_target_error_warning` —
  drives both `web_fetch_tool` and `web_capture_tool` with identical
  target-error headers and asserts they now produce the same warning.

Full `backend/tests/test_browserless_client.py` suite: 30 passed.

### Before / after

With the source change reverted (tests unchanged), the suite fails to even
collect, since `BrowserlessFetchResult` does not exist yet on the
unfixed `fetch_html`:

```
ImportError: cannot import name 'BrowserlessFetchResult' from
'deerflow.community.browserless.browserless_client'
```

With the fix restored, all 30 tests pass.

## Before submitting

- [x] Ran `ruff check` / `ruff format --check` on all changed files — clean.
- [x] Ran the full `backend/tests/test_browserless_client.py` suite — 30 passed.
- [x] Ran the full backend test suite before/after this change (excluding
      pre-existing, unrelated collection gaps in this environment) —
      identical failure/error signature on both, only delta is the new
      tests added here passing.
