### PR TITLE
fix(skills): cap archive entry count in safe_extract_skill_archive

### DIFF
--- a/backend/packages/harness/deerflow/skills/installer.py
+++ b/backend/packages/harness/deerflow/skills/installer.py
@@ -118,6 +118,7 @@ def safe_extract_skill_archive(
     zip_ref: zipfile.ZipFile,
     dest_path: Path,
     max_total_size: int = 512 * 1024 * 1024,
+    max_entries: int = 4096,
 ) -> None:
     """Safely extract a skill archive with security protections.
 
@@ -125,15 +126,28 @@ def safe_extract_skill_archive(
     - Reject absolute paths and directory traversal (..).
     - Skip symlink entries instead of materialising them.
     - Enforce a hard limit on total uncompressed size (zip bomb defence).
+    - Enforce a hard limit on member count (zip bomb defence by entry count —
+      a huge number of tiny/empty members can be cheap to store yet still
+      slow to extract, independent of total size).
     - Reject executable binaries (ELF/PE/Mach-O) by magic bytes.
 
     Raises:
-        ValueError: If unsafe members, executable binaries, or size limit exceeded.
+        ValueError: If unsafe members, executable binaries, entry count, or size limit exceeded.
     """
     dest_root = dest_path.resolve()
     total_written = 0
 
-    for info in zip_ref.infolist():
+    infos = zip_ref.infolist()
+    if len(infos) > max_entries:
+        # Early-abort before any per-member work below — mirrors the same
+        # early-abort in skillscan/orchestrator.py::scan_archive_preflight
+        # (its comment: "a huge member count is a bounded DoS vector even
+        # when the total size is small"). That scan is optional
+        # (skill_scan.enabled); this check must hold unconditionally since
+        # it lives in the extraction path every install goes through.
+        raise ValueError(f"Skill archive contains too many entries ({len(infos)} > {max_entries}).")
+
+    for info in infos:
         if is_unsafe_zip_member(info):
             raise ValueError(f"Archive contains unsafe member path: {info.filename!r}")
 

--- a/backend/tests/test_skills_installer.py
+++ b/backend/tests/test_skills_installer.py
@@ -153,6 +153,25 @@ class TestSafeExtract:
         assert (dest / "normal.txt").exists()
         assert not (dest / "link.txt").exists()
 
+    def test_rejects_too_many_entries(self, tmp_path):
+        """Entry-count cap is independent of total size: 4 tiny files still trips a low max_entries."""
+        zip_path = self._make_zip(tmp_path, {f"file-{i}.txt": "x" for i in range(4)})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            with pytest.raises(ValueError, match="too many entries"):
+                safe_extract_skill_archive(zf, dest, max_entries=3)
+        assert not any(dest.iterdir())
+
+    def test_allows_entries_at_the_cap(self, tmp_path):
+        """The cap is inclusive: exactly max_entries members is not rejected."""
+        zip_path = self._make_zip(tmp_path, {f"file-{i}.txt": "x" for i in range(5)})
+        dest = tmp_path / "out"
+        dest.mkdir()
+        with zipfile.ZipFile(zip_path) as zf:
+            safe_extract_skill_archive(zf, dest, max_entries=5)
+        assert len(list(dest.iterdir())) == 5
+
     def test_normal_archive(self, tmp_path):
         zip_path = self._make_zip(
             tmp_path,
@@ -225,6 +244,86 @@ class TestSafeExtract:
         with zipfile.ZipFile(zip_path) as zf:
             safe_extract_skill_archive(zf, dest)
         assert (dest / "my-skill" / "assets" / "blob.bin").exists()
+
+
+# ---------------------------------------------------------------------------
+# Entry-count cap must apply unconditionally, independent of skill_scan.enabled.
+#
+# scan_archive_preflight() (skillscan/orchestrator.py) already caps member
+# count at 4096, but only runs as part of the optional native scanner
+# (skill_scan.enabled, default true). When that scanner is disabled,
+# safe_extract_skill_archive was the only remaining guard on the extraction
+# path, and it only capped total bytes — not entry count. These tests pin
+# the fix: the cap now lives in extraction itself, so it holds regardless of
+# skill_scan.enabled.
+# ---------------------------------------------------------------------------
+
+
+class TestEntryCountCapAppliesRegardlessOfSkillScan:
+    @pytest.fixture(autouse=True)
+    def _allow_security_scan(self, monkeypatch):
+        async def _scan(*args, **kwargs):
+            return ScanResult(decision="allow", reason="ok")
+
+        monkeypatch.setattr("deerflow.skills.installer.scan_skill_content", _scan)
+
+    def _make_storage(self, skills_root: Path, *, skill_scan_enabled: bool):
+        from types import SimpleNamespace
+
+        from deerflow.skills.storage.local_skill_storage import LocalSkillStorage
+
+        return LocalSkillStorage(
+            host_path=str(skills_root),
+            app_config=SimpleNamespace(skill_scan=SimpleNamespace(enabled=skill_scan_enabled)),
+        )
+
+    def _make_many_entry_zip(self, tmp_path: Path, *, entry_count: int, skill_name: str = "test-skill") -> Path:
+        """A real archive with ``entry_count`` tiny members and a small total size —
+        matches the reported shape (50,000 entries, ~5MB total)."""
+        zip_path = tmp_path / f"{skill_name}.skill"
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr(f"{skill_name}/SKILL.md", f"---\nname: {skill_name}\ndescription: A test skill\n---\n\n# {skill_name}\n")
+            for i in range(entry_count):
+                zf.writestr(f"{skill_name}/pad-{i:06d}.txt", "")
+        return zip_path
+
+    def test_rejects_high_entry_count_archive_even_with_skill_scan_disabled(self, tmp_path):
+        """The previously-vulnerable configuration: skill_scan disabled, so
+        scan_archive_preflight's member cap never runs. safe_extract_skill_archive
+        must still reject the archive unconditionally, on its own."""
+        zip_path = self._make_many_entry_zip(tmp_path, entry_count=50_000)
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        storage = self._make_storage(skills_root, skill_scan_enabled=False)
+
+        with pytest.raises(ValueError, match="too many entries"):
+            storage.install_skill_from_archive(zip_path)
+
+        assert not (skills_root / "custom" / "test-skill").exists()
+
+    def test_scan_archive_preflight_independently_flags_the_same_archive(self, tmp_path):
+        """Cross-check tying the two protections together: the pre-existing optional
+        scanner also flags this exact archive by member count when it does run."""
+        from deerflow.skills.skillscan.orchestrator import scan_archive_preflight
+
+        zip_path = self._make_many_entry_zip(tmp_path, entry_count=50_000)
+
+        result = scan_archive_preflight(zip_path)
+
+        assert result["blocked"] is True
+        assert any(finding["rule_id"] == "package-too-many-members" for finding in result["findings"])
+
+    def test_normal_skill_archive_still_installs_with_skill_scan_disabled(self, tmp_path):
+        """Same disabled-scan configuration, but a small, legitimate skill: must still install."""
+        zip_path = self._make_many_entry_zip(tmp_path, entry_count=5, skill_name="small-skill")
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        storage = self._make_storage(skills_root, skill_scan_enabled=False)
+
+        result = storage.install_skill_from_archive(zip_path)
+
+        assert result["success"] is True
+        assert (skills_root / "custom" / "small-skill" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1362,8 +1362,10 @@ skills:
 # Native deterministic skill safety scanning. This runs before the LLM skill
 # scanner on skill install/update and agent-managed skill writes.
 skill_scan:
-  # Set false to disable the new deterministic analyzers. Safe archive
-  # extraction and the LLM skill scanner still run.
+  # Set false to disable the new deterministic analyzers (nested-archive,
+  # secret-pattern, and other content-level checks). Safe archive extraction
+  # (path traversal, symlinks, executable-binary, total-size, and entry-count
+  # limits) and the LLM skill scanner still run unconditionally.
   enabled: true
 
 # Note: To restrict which skills are loaded for a specific custom agent,


### PR DESCRIPTION
## Why

`safe_extract_skill_archive()` (`backend/packages/harness/deerflow/skills/installer.py`) is the always-on extraction path every `.skill` install goes through. It caps total uncompressed bytes (zip bomb defence) but had no limit on member/entry count, so a small archive containing tens of thousands of tiny/empty entries extracts with zero errors — a zip-bomb-by-**entry-count** vector, distinct from the by-**size** vector the function already guards against.

`scan_archive_preflight()` (`backend/packages/harness/deerflow/skills/skillscan/orchestrator.py`) already caps entry count at 4096, with its own comment acknowledging exactly this risk:

> Early-abort before the per-member reads below: a huge member count is a bounded DoS vector even when the total size is small.

But that scan only runs when the optional `skill_scan.enabled` kill switch is on (default `true`, but operator-configurable). Disabling it silently drops this specific protection, while `config.example.yaml`'s own comment claimed "Safe archive extraction... still run[s]" when disabled — true in general, but not for entry-count protection specifically, since that protection never actually lived in "safe archive extraction" to begin with.

**Prior art:** issue #2618 ("Harden .skill archive installation") explicitly asked for an entry-count limit among other hardening, and PR #2619 implemented a broader version of this hardening — including this exact cap — directly in `safe_extract_skill_archive`. Both were closed unmerged by the PR's own author in April, with no review/comments from a maintainer, so the underlying gap was never actually addressed. In the months since, the codebase gained a separate, more general SkillScan scanner as an independent effort, which happens to cover entry count too — but only when enabled. This PR re-targets just the entry-count piece, scoped to the current codebase.

## What changed

- `safe_extract_skill_archive()` gains a `max_entries` parameter (default `4096`, matching `scan_archive_preflight`'s existing cap) and rejects archives with more members than that — unconditionally, as an early-abort before any per-member work, mirroring `scan_archive_preflight`'s own early-abort pattern.
- `config.example.yaml`'s `skill_scan.enabled` comment now explicitly lists what "safe archive extraction" covers (path traversal, symlinks, executable-binary, total-size, **and entry-count**), so the claim that it still runs when the optional scanner is disabled is accurate for every protection it names.

## Is `scan_archive_preflight`'s cap now redundant?

Left both in place (defense in depth), not simplified into one:

- They serve different roles. `scan_archive_preflight` is a **preflight** check that runs before extraction starts and produces a structured `SecurityFinding` (rule id, severity, remediation) for reporting/audit. `safe_extract_skill_archive`'s new check is a **hard extraction-time guard** that raises a plain `ValueError`. The install pipeline (`local_skill_storage.py::_prepare_skill_archive`) calls `scan_archive_preflight_or_raise()` before `safe_extract_skill_archive()`, so when SkillScan is enabled, the structured finding still surfaces first for anything that consumes it (e.g. an admin/report UI).
- Removing `scan_archive_preflight`'s cap to avoid "duplication" would make the CRITICAL `package-too-many-members` finding unreachable even with the scanner enabled — a worse outcome for any caller that relies on structured findings rather than catching a bare exception.
- Both limits are simple integers (`4096`) with an explicit cross-reference comment in each file pointing at the other, so a future change to one is likely to prompt checking the other. A follow-up could extract a single shared constant if desired; I kept this PR scoped to closing the gap rather than refactoring the (already-working) preflight scanner.

## Bug fix verification

- Test path: `backend/tests/test_skills_installer.py::TestEntryCountCapAppliesRegardlessOfSkillScan::test_rejects_high_entry_count_archive_even_with_skill_scan_disabled` (plus the lower-level `TestSafeExtract::test_rejects_too_many_entries` / `test_allows_entries_at_the_cap`).
- Red on main / green on this branch: **yes**, confirmed via a local patch-file revert of just the `installer.py` change (tests kept in place). Reverted: `test_rejects_too_many_entries` and `test_allows_entries_at_the_cap` fail with `TypeError` (no `max_entries` param yet), and — the significant one — `test_rejects_high_entry_count_archive_even_with_skill_scan_disabled` fails with **"DID NOT RAISE ValueError"**: the full install pipeline (`LocalSkillStorage.install_skill_from_archive`, `skill_scan.enabled=False`) successfully installs a 50,000-entry, ~6MB `.skill` archive end to end. Re-applying the fix: all pass again.
- Manual reproduction (ad hoc, not part of the committed suite): building a real 50,000-tiny-file, ~6.25MB archive and running it through the unpatched `safe_extract_skill_archive` completes with **no error in ~21s**, fully extracting all 50,001 members (cleanup of the resulting temp directory afterwards was slow enough to hit the install's own cleanup timeout). `scan_archive_preflight()` on the exact same archive blocks it in ~0.14s with a `package-too-many-members` CRITICAL finding — concrete evidence the two protections previously lived at different layers with different unconditional guarantees.

## Validation

```
cd backend
PYTHONPATH=packages/harness python -m pytest tests/test_skills_installer.py tests/test_skill_storage_lifecycle.py tests/test_skillscan_native.py tests/blocking_io/test_skills_install.py -v
# 101 passed

make lint    # ruff check -- all checks passed
make format  # ruff format --check -- 2 files already formatted, no changes needed
```

`tests/test_client.py` and `tests/test_skills_custom_router.py` also exercise the install path (through the embedded client / Gateway router) but require the `app` extras (`fastapi`) not present in the harness-only environment used to validate this change; nothing in this diff touches `app/*`, so risk there is low.

## Surface area

- [ ] Frontend UI
- [ ] Backend API — endpoint / SSE event / request-response shape under `backend/app`
- [ ] Agents / LangGraph
- [ ] Sandbox
- [x] Skills — change under `skills/`
- [ ] Dependencies
- [x] Default behavior change — archives with more than 4096 members are now rejected during extraction unconditionally (no config opt-out); previously only rejected when the optional `skill_scan` scanner was enabled
- [ ] Docs / tests / CI only
