### PR TITLE
fix(frontend): preserve single tildes in markdown

### DIFF
--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -12,11 +12,13 @@ const katexOptions = {
   strict: false,
 } as const;
 
+const sharedRemarkPlugins = [
+  [remarkGfm, { singleTilde: false }],
+  [remarkMath, { singleDollarTextMath: true }],
+] as StreamdownProps["remarkPlugins"];
+
 export const streamdownPlugins = {
-  remarkPlugins: [
-    remarkGfm,
-    [remarkMath, { singleDollarTextMath: true }],
-  ] as StreamdownProps["remarkPlugins"],
+  remarkPlugins: sharedRemarkPlugins,
   rehypePlugins: [
     rehypeRaw,
     [rehypeKatex, katexOptions],
@@ -24,10 +26,7 @@ export const streamdownPlugins = {
 };
 
 export const streamdownPluginsWithWordAnimation = {
-  remarkPlugins: [
-    remarkGfm,
-    [remarkMath, { singleDollarTextMath: true }],
-  ] as StreamdownProps["remarkPlugins"],
+  remarkPlugins: sharedRemarkPlugins,
   rehypePlugins: [
     [rehypeKatex, katexOptions],
     rehypeSplitWordsIntoSpans,

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
@@ -83,3 +83,18 @@ describe("MarkdownContent streaming code blocks", () => {
     expect(html).toContain("data-streaming-code-block");
   });
 });
+
+describe("MarkdownContent strikethrough", () => {
+  it("preserves single tildes in temperature ranges", () => {
+    const html = renderMarkdown("周六23~30℃；周日22~30℃", false);
+
+    expect(html).toContain("周六23~30℃；周日22~30℃");
+    expect(html).not.toContain("<del>");
+  });
+
+  it("continues to render double-tilde strikethrough", () => {
+    const html = renderMarkdown("状态：~~已取消~~", false);
+
+    expect(html).toContain("<del>已取消</del>");
+  });
+});

--- a/frontend/tests/unit/core/streamdown/plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown/plugins.test.ts
@@ -1,7 +1,21 @@
 import { expect, test } from "@rstest/core";
 import rehypeRaw from "rehype-raw";
+import remarkGfm from "remark-gfm";
 
-import { reasoningPlugins, streamdownPlugins } from "@/core/streamdown/plugins";
+import {
+  reasoningPlugins,
+  streamdownPlugins,
+  streamdownPluginsWithWordAnimation,
+} from "@/core/streamdown/plugins";
+
+test("shared streamdown configs disable single-tilde strikethrough", () => {
+  const expectedGfmPlugin = [remarkGfm, { singleTilde: false }];
+
+  expect(streamdownPlugins.remarkPlugins).toContainEqual(expectedGfmPlugin);
+  expect(streamdownPluginsWithWordAnimation.remarkPlugins).toContainEqual(
+    expectedGfmPlugin,
+  );
+});
 
 test("streamdownPlugins includes rehypeRaw", () => {
   expect(streamdownPlugins.rehypePlugins).toContain(rehypeRaw);


### PR DESCRIPTION
Fixes #4226

## Why

`remark-gfm` enables single-tilde strikethrough by default. When an assistant response contains two temperature ranges on the same line, such as `23~30℃` and `22~30℃`, the parser treats the text between the two tildes as strikethrough content.

This removes the visible range separators and incorrectly renders the intervening text with a deletion line.

## What changed

- Configure the shared `remark-gfm` plugin with `singleTilde: false`.
- Reuse the same Remark plugin configuration across normal and word-animated Streamdown renderers.
- Preserve standard double-tilde strikethrough such as `~~deleted~~`.
- Add regression coverage for temperature ranges and shared Streamdown configurations.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — single tildes are now rendered as literal text; standard double-tilde strikethrough remains supported
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before: see the reproduction screenshot in #4226.

<img width="2378" height="706" alt="image" src="https://github.com/user-attachments/assets/82c1e44e-1d3a-493c-b41d-59036061b850" />


## Bug fix verification

- Test path that reproduces the bug:
  - `frontend/tests/unit/components/workspace/messages/markdown-content.test.ts`
  - `frontend/tests/unit/core/streamdown/plugins.test.ts`
- Did it go red on `main` and green on this branch? **Yes**
  - On `main`, `周六23~30℃；周日22~30℃` rendered as `周六23<del>30℃；周日22</del>30℃`.
  - On this branch, both single tildes remain visible and `~~已取消~~` still renders as strikethrough.

## Validation

- `pnpm format` — passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — passed
- `make test` — passed, 71 files / 644 tests
- Targeted Streamdown regression tests — passed, 11/11
- `git diff --check` — passed
- Docker browser verification — passed:
  - Both temperature range tildes remain visible.
  - Only the double-tilde text renders with strikethrough.
- Full E2E verification is deferred to CI.

