### PR TITLE
feat(extensions): first-class optional hook for identity/memory providers (reference: Lithtrix)

### DIFF
--- a/backend/docs/MCP_SERVER.md
+++ b/backend/docs/MCP_SERVER.md
@@ -14,6 +14,10 @@ DeerFlow supports configurable MCP servers and skills to extend its capabilities
 3. Configure each server’s command, arguments, and environment variables as needed.
 4. Restart the application to load and register MCP tools.
 
+## Optional identity hooks
+
+For external identity or memory providers, DeerFlow can optionally fire MCP tool calls at thread start via an `identityHooks` block in `extensions_config.json`. See the frontend docs subsection **Optional identity hooks** in `frontend/src/content/en/harness/mcp.mdx` for schema, Lithtrix reference integration (`skills/public/use-lithtrix/SKILL.md`, `docs/examples/lithtrix/`), and v1 scope (`sessionStart` only; failures are non-fatal).
+
 ## Routing Hints
 
 Use `routing` when an MCP server should be preferred for specific requests, such

--- a/backend/packages/harness/deerflow/agents/middlewares/identity_hooks_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/identity_hooks_middleware.py
@@ -1,0 +1,137 @@
+"""Optional identity-provider MCP hooks at thread/session start.
+
+Fires configured ``sessionStart`` tool calls against an external MCP server
+(e.g. Lithtrix) without importing provider code into DeerFlow core. Failures
+are logged and ignored so research is not blocked by substrate outages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+from typing import Any, override
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langgraph.config import get_config
+from langgraph.runtime import Runtime
+
+from deerflow.agents.middlewares._bounded_dict import BoundedDict
+from deerflow.config.extensions_config import ExtensionsConfig, get_extensions_config
+from deerflow.mcp.client import build_server_params
+from deerflow.mcp.session_pool import get_session_pool
+from deerflow.runtime.user_context import get_effective_user_id
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_thread_id(runtime: Runtime) -> str | None:
+    context = runtime.context or {}
+    thread_id = context.get("thread_id")
+    if thread_id is not None:
+        return str(thread_id)
+    try:
+        config = get_config()
+        thread_id = config.get("configurable", {}).get("thread_id")
+        return str(thread_id) if thread_id is not None else None
+    except RuntimeError:
+        return None
+
+
+async def run_session_start_hooks(
+    *,
+    config: ExtensionsConfig,
+    thread_id: str,
+    user_id: str,
+) -> None:
+    """Invoke configured sessionStart MCP tools (non-fatal on errors)."""
+    hooks = config.identity_hooks
+    if hooks is None or not hooks.enabled:
+        return
+
+    enabled_servers = config.get_enabled_mcp_servers()
+    server_config = enabled_servers.get(hooks.mcp_server_ref)
+    if server_config is None:
+        logger.warning(
+            "identity_hooks_skip server=%s reason=disabled_or_missing",
+            hooks.mcp_server_ref,
+        )
+        return
+
+    if not hooks.session_start:
+        return
+
+    try:
+        connection = build_server_params(hooks.mcp_server_ref, server_config)
+    except Exception:
+        logger.exception(
+            "identity_hooks_connection_failed server=%s",
+            hooks.mcp_server_ref,
+        )
+        return
+
+    scope_key = f"{user_id}:{thread_id}"
+    pool = get_session_pool()
+    try:
+        session = await pool.get_session(hooks.mcp_server_ref, scope_key, connection)
+    except Exception:
+        logger.exception(
+            "identity_hooks_session_failed server=%s",
+            hooks.mcp_server_ref,
+        )
+        return
+
+    call_kwargs: dict[str, Any] = {}
+    if server_config.tool_call_timeout:
+        call_kwargs["read_timeout_seconds"] = timedelta(seconds=server_config.tool_call_timeout)
+
+    for call in hooks.session_start:
+        try:
+            await session.call_tool(call.tool, call.args, **call_kwargs)
+        except Exception:
+            logger.exception("identity_hooks_call_failed tool=%s", call.tool)
+            # non-fatal — research continues
+
+
+class IdentityHooksMiddleware(AgentMiddleware[AgentState]):
+    """Fire optional identity-provider MCP hooks once per thread."""
+
+    def __init__(self, extensions_config: ExtensionsConfig | None = None) -> None:
+        super().__init__()
+        self._extensions_config = extensions_config
+        self._fired_threads: BoundedDict[str, bool] = BoundedDict(1000)
+
+    def _config(self) -> ExtensionsConfig:
+        return self._extensions_config or get_extensions_config()
+
+    async def _maybe_run_hooks(self, runtime: Runtime) -> None:
+        thread_id = _resolve_thread_id(runtime)
+        if thread_id is None:
+            logger.debug("identity_hooks_skip reason=missing_thread_id")
+            return
+        if self._fired_threads.get(thread_id):
+            return
+
+        self._fired_threads[thread_id] = True
+        user_id = get_effective_user_id() or "default"
+        await run_session_start_hooks(
+            config=self._config(),
+            thread_id=thread_id,
+            user_id=user_id,
+        )
+
+    @override
+    def before_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            asyncio.run(self._maybe_run_hooks(runtime))
+            return None
+        # Event loop is running — abefore_agent handles async path.
+        return None
+
+    @override
+    async def abefore_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
+        await self._maybe_run_hooks(runtime)
+        return None

--- a/backend/packages/harness/deerflow/agents/middlewares/identity_hooks_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/identity_hooks_middleware.py
@@ -1,29 +1,38 @@
 """Optional identity-provider MCP hooks at thread/session start.
 
 Fires configured ``sessionStart`` tool calls against an external MCP server
-(e.g. Lithtrix) without importing provider code into DeerFlow core. Failures
-are logged and ignored so research is not blocked by substrate outages.
+(e.g. Lithtrix) without importing provider code into DeerFlow core. Hook
+results are normalized into a bounded, tag-neutralized HumanMessage (never
+system-role authority) so substrate context reaches the model. Failures are
+logged and ignored so research is not blocked by substrate outages.
 """
 
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from datetime import timedelta
 from typing import Any, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage
 from langgraph.config import get_config
 from langgraph.runtime import Runtime
 
-from deerflow.agents.middlewares._bounded_dict import BoundedDict
 from deerflow.config.extensions_config import ExtensionsConfig, get_extensions_config
 from deerflow.mcp.client import build_server_params
 from deerflow.mcp.session_pool import get_session_pool
 from deerflow.runtime.user_context import get_effective_user_id
 
 logger = logging.getLogger(__name__)
+
+IDENTITY_HOOKS_CONTEXT_KEY = "identity_hooks_external_context"
+_EXTERNAL_CONTEXT_BEGIN = "--- BEGIN EXTERNAL IDENTITY CONTEXT (untrusted) ---"
+_EXTERNAL_CONTEXT_END = "--- END EXTERNAL IDENTITY CONTEXT ---"
+_IDENTITY_HOOKS_MAX_TOOL_CHARS = 16_000
+_IDENTITY_HOOKS_MAX_TOTAL_CHARS = 32_000
 
 
 def _resolve_thread_id(runtime: Runtime) -> str | None:
@@ -39,16 +48,61 @@ def _resolve_thread_id(runtime: Runtime) -> str | None:
         return None
 
 
+def _session_start_already_fired(state: AgentState | None) -> bool:
+    hooks_state = (state or {}).get("identity_hooks") or {}
+    return bool(hooks_state.get("session_start_fired"))
+
+
+def _extract_call_tool_text(call_tool_result: Any) -> str:
+    """Extract plain text from an MCP CallToolResult without LangChain conversion."""
+    from mcp.types import EmbeddedResource, TextContent, TextResourceContents
+
+    parts: list[str] = []
+    for item in getattr(call_tool_result, "content", None) or []:
+        if isinstance(item, TextContent):
+            parts.append(item.text)
+        elif isinstance(item, EmbeddedResource):
+            resource = item.resource
+            if isinstance(resource, TextResourceContents):
+                parts.append(resource.text)
+
+    structured = getattr(call_tool_result, "structuredContent", None)
+    if structured is not None and not parts:
+        parts.append(json.dumps(structured, ensure_ascii=False, separators=(",", ":")))
+
+    return "\n".join(parts).strip()
+
+
+def _sanitize_hook_text(text: str) -> str:
+    from deerflow.agents.middlewares.input_sanitization_middleware import neutralize_untrusted_tags
+
+    return neutralize_untrusted_tags(text)
+
+
+def _truncate_text(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n...[truncated]"
+
+
+def _format_tool_section(tool_name: str, body: str) -> str:
+    return f"[identity-hook tool={tool_name}]\n{body}"
+
+
+def _wrap_external_context_block(body: str) -> str:
+    return f"{_EXTERNAL_CONTEXT_BEGIN}\n{body}\n{_EXTERNAL_CONTEXT_END}"
+
+
 async def run_session_start_hooks(
     *,
     config: ExtensionsConfig,
     thread_id: str,
     user_id: str,
-) -> None:
-    """Invoke configured sessionStart MCP tools (non-fatal on errors)."""
+) -> str | None:
+    """Invoke configured sessionStart MCP tools and return sanitized context text."""
     hooks = config.identity_hooks
     if hooks is None or not hooks.enabled:
-        return
+        return None
 
     enabled_servers = config.get_enabled_mcp_servers()
     server_config = enabled_servers.get(hooks.mcp_server_ref)
@@ -57,10 +111,10 @@ async def run_session_start_hooks(
             "identity_hooks_skip server=%s reason=disabled_or_missing",
             hooks.mcp_server_ref,
         )
-        return
+        return None
 
     if not hooks.session_start:
-        return
+        return None
 
     try:
         connection = build_server_params(hooks.mcp_server_ref, server_config)
@@ -69,7 +123,7 @@ async def run_session_start_hooks(
             "identity_hooks_connection_failed server=%s",
             hooks.mcp_server_ref,
         )
-        return
+        return None
 
     scope_key = f"{user_id}:{thread_id}"
     pool = get_session_pool()
@@ -80,58 +134,93 @@ async def run_session_start_hooks(
             "identity_hooks_session_failed server=%s",
             hooks.mcp_server_ref,
         )
-        return
+        return None
 
     call_kwargs: dict[str, Any] = {}
     if server_config.tool_call_timeout:
         call_kwargs["read_timeout_seconds"] = timedelta(seconds=server_config.tool_call_timeout)
 
+    sections: list[str] = []
+    total_chars = 0
     for call in hooks.session_start:
         try:
-            await session.call_tool(call.tool, call.args, **call_kwargs)
+            call_tool_result = await session.call_tool(call.tool, call.args, **call_kwargs)
         except Exception:
             logger.exception("identity_hooks_call_failed tool=%s", call.tool)
-            # non-fatal — research continues
+            continue
+
+        raw_text = _extract_call_tool_text(call_tool_result)
+        if not raw_text:
+            continue
+
+        sanitized = _sanitize_hook_text(raw_text)
+        sanitized = _truncate_text(sanitized, _IDENTITY_HOOKS_MAX_TOOL_CHARS)
+        section = _format_tool_section(call.tool, sanitized)
+        remaining = _IDENTITY_HOOKS_MAX_TOTAL_CHARS - total_chars
+        if remaining <= 0:
+            break
+        if len(section) > remaining:
+            section = _truncate_text(section, remaining)
+        sections.append(section)
+        total_chars += len(section)
+
+    if not sections:
+        return None
+    return _wrap_external_context_block("\n\n".join(sections))
 
 
 class IdentityHooksMiddleware(AgentMiddleware[AgentState]):
-    """Fire optional identity-provider MCP hooks once per thread."""
+    """Fire optional identity-provider MCP hooks once per lead-agent thread."""
 
     def __init__(self, extensions_config: ExtensionsConfig | None = None) -> None:
         super().__init__()
         self._extensions_config = extensions_config
-        self._fired_threads: BoundedDict[str, bool] = BoundedDict(1000)
 
     def _config(self) -> ExtensionsConfig:
         return self._extensions_config or get_extensions_config()
 
-    async def _maybe_run_hooks(self, runtime: Runtime) -> None:
+    async def _prepare_hook_update(self, state: AgentState, runtime: Runtime) -> dict | None:
+        if _session_start_already_fired(state):
+            return None
+
+        config = self._config()
+        hooks = config.identity_hooks
+        if hooks is None or not hooks.enabled or not hooks.session_start:
+            return None
+
         thread_id = _resolve_thread_id(runtime)
         if thread_id is None:
             logger.debug("identity_hooks_skip reason=missing_thread_id")
-            return
-        if self._fired_threads.get(thread_id):
-            return
+            return None
 
-        self._fired_threads[thread_id] = True
         user_id = get_effective_user_id() or "default"
-        await run_session_start_hooks(
-            config=self._config(),
+        context_block = await run_session_start_hooks(
+            config=config,
             thread_id=thread_id,
             user_id=user_id,
         )
+
+        update: dict[str, Any] = {"identity_hooks": {"session_start_fired": True}}
+        if context_block:
+            update["messages"] = [
+                HumanMessage(
+                    content=context_block,
+                    additional_kwargs={
+                        IDENTITY_HOOKS_CONTEXT_KEY: True,
+                        "hide_from_ui": True,
+                    },
+                )
+            ]
+        return update
 
     @override
     def before_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
         try:
             asyncio.get_running_loop()
         except RuntimeError:
-            asyncio.run(self._maybe_run_hooks(runtime))
-            return None
-        # Event loop is running — abefore_agent handles async path.
+            return asyncio.run(self._prepare_hook_update(state, runtime))
         return None
 
     @override
     async def abefore_agent(self, state: AgentState, runtime: Runtime) -> dict | None:
-        await self._maybe_run_hooks(runtime)
-        return None
+        return await self._prepare_hook_update(state, runtime)

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -185,6 +185,9 @@ def _build_runtime_middlewares(
     thread_hooks: list[AgentMiddleware] = [
         ThreadDataMiddleware(lazy_init=lazy_init),
     ]
+    from deerflow.agents.middlewares.identity_hooks_middleware import IdentityHooksMiddleware
+
+    thread_hooks.append(IdentityHooksMiddleware())
     if include_uploads:
         from deerflow.agents.middlewares.uploads_middleware import UploadsMiddleware
 

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -185,12 +185,11 @@ def _build_runtime_middlewares(
     thread_hooks: list[AgentMiddleware] = [
         ThreadDataMiddleware(lazy_init=lazy_init),
     ]
-    from deerflow.agents.middlewares.identity_hooks_middleware import IdentityHooksMiddleware
-
-    thread_hooks.append(IdentityHooksMiddleware())
     if include_uploads:
+        from deerflow.agents.middlewares.identity_hooks_middleware import IdentityHooksMiddleware
         from deerflow.agents.middlewares.uploads_middleware import UploadsMiddleware
 
+        thread_hooks.append(IdentityHooksMiddleware())
         thread_hooks.append(UploadsMiddleware())
     thread_hooks.append(SandboxMiddleware(lazy_init=lazy_init))
 

--- a/backend/packages/harness/deerflow/agents/thread_state.py
+++ b/backend/packages/harness/deerflow/agents/thread_state.py
@@ -202,6 +202,28 @@ def _normalize_skill_entry(entry: Mapping[str, object]) -> SkillEntry:
     }
 
 
+class IdentityHooksThreadState(TypedDict):
+    session_start_fired: NotRequired[bool]
+
+
+def merge_identity_hooks_thread_state(
+    existing: IdentityHooksThreadState | None,
+    new: IdentityHooksThreadState | None,
+) -> IdentityHooksThreadState | None:
+    """Reducer for identity-hook scheduling — once fired, stays fired across checkpoints."""
+    if new is None:
+        return existing
+    if existing is None:
+        return new
+    if existing.get("session_start_fired"):
+        return existing
+    merged = dict(existing)
+    merged.update(new)
+    if merged.get("session_start_fired"):
+        return {"session_start_fired": True}
+    return merged
+
+
 def merge_skill_context(existing: list[SkillEntry] | None, new: list[SkillEntry] | None) -> list[SkillEntry]:
     """Reducer for the skill-context channel.
 
@@ -248,4 +270,5 @@ class ThreadState(AgentState):
     promoted: Annotated[PromotedTools | None, merge_promoted]
     delegations: Annotated[list[DelegationEntry], merge_delegations]
     skill_context: Annotated[list[SkillEntry], merge_skill_context]
+    identity_hooks: Annotated[IdentityHooksThreadState | None, merge_identity_hooks_thread_state]
     summary_text: NotRequired[str | None]

--- a/backend/packages/harness/deerflow/config/extensions_config.py
+++ b/backend/packages/harness/deerflow/config/extensions_config.py
@@ -129,6 +129,27 @@ class SkillStateConfig(BaseModel):
     enabled: bool = Field(default=True, description="Whether this skill is enabled")
 
 
+class IdentityHookCall(BaseModel):
+    """A single MCP tool invocation for an identity hook."""
+
+    tool: str = Field(description="MCP tool name as returned by list_tools (unprefixed)")
+    args: dict[str, Any] = Field(default_factory=dict, description="Arguments passed to the MCP tool")
+    model_config = ConfigDict(extra="forbid")
+
+
+class IdentityHooksConfig(BaseModel):
+    """Optional identity-provider hooks fired at session start."""
+
+    enabled: bool = Field(default=False, description="Whether identity hooks are active")
+    mcp_server_ref: str = Field(description="Name of an enabled mcpServers entry", alias="mcpServerRef")
+    session_start: list[IdentityHookCall] = Field(
+        default_factory=list,
+        description="Ordered MCP tool calls at thread/session start",
+        alias="sessionStart",
+    )
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
 class ExtensionsConfig(BaseModel):
     """Unified configuration for MCP servers and skills."""
 
@@ -140,6 +161,11 @@ class ExtensionsConfig(BaseModel):
     skills: dict[str, SkillStateConfig] = Field(
         default_factory=dict,
         description="Map of skill name to state configuration",
+    )
+    identity_hooks: IdentityHooksConfig | None = Field(
+        default=None,
+        description="Optional identity-provider MCP hooks at session start",
+        alias="identityHooks",
     )
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 

--- a/backend/tests/test_identity_hooks_config.py
+++ b/backend/tests/test_identity_hooks_config.py
@@ -1,0 +1,85 @@
+"""Tests for identityHooks extensions config parsing."""
+
+import json
+
+import pytest
+
+from deerflow.config.extensions_config import ExtensionsConfig, IdentityHookCall, IdentityHooksConfig
+
+
+def test_identity_hooks_absent_defaults_to_none():
+    config = ExtensionsConfig.model_validate({"mcpServers": {}, "skills": {}})
+    assert config.identity_hooks is None
+
+
+def test_identity_hooks_disabled_parses():
+    raw = {
+        "identityHooks": {
+            "enabled": False,
+            "mcpServerRef": "lithtrix",
+            "sessionStart": [],
+        }
+    }
+    config = ExtensionsConfig.model_validate(raw)
+    assert config.identity_hooks is not None
+    assert config.identity_hooks.enabled is False
+    assert config.identity_hooks.mcp_server_ref == "lithtrix"
+    assert config.identity_hooks.session_start == []
+
+
+def test_identity_hooks_reference_lithtrix_session_start():
+    raw = {
+        "mcpServers": {
+            "lithtrix": {
+                "enabled": True,
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "lithtrix-mcp@0.20.2"],
+            }
+        },
+        "identityHooks": {
+            "enabled": True,
+            "mcpServerRef": "lithtrix",
+            "sessionStart": [
+                {"tool": "lithtrix_memory_context", "args": {"limit": 10}},
+                {"tool": "lithtrix_commons_read", "args": {"page": 1, "per_page": 20}},
+            ],
+        },
+    }
+    config = ExtensionsConfig.model_validate(raw)
+    hooks = config.identity_hooks
+    assert hooks is not None
+    assert hooks.enabled is True
+    assert len(hooks.session_start) == 2
+    assert hooks.session_start[0] == IdentityHookCall(tool="lithtrix_memory_context", args={"limit": 10})
+    assert hooks.session_start[1] == IdentityHookCall(tool="lithtrix_commons_read", args={"page": 1, "per_page": 20})
+
+
+def test_identity_hooks_camel_case_aliases_round_trip():
+    hooks = IdentityHooksConfig(
+        enabled=True,
+        mcp_server_ref="lithtrix",
+        session_start=[IdentityHookCall(tool="lithtrix_memory_context", args={"limit": 5})],
+    )
+    dumped = hooks.model_dump(by_alias=True)
+    assert dumped["mcpServerRef"] == "lithtrix"
+    assert dumped["sessionStart"][0]["tool"] == "lithtrix_memory_context"
+
+
+def test_identity_hooks_from_json_file(tmp_path):
+    config_path = tmp_path / "extensions_config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "identityHooks": {
+                    "enabled": True,
+                    "mcpServerRef": "lithtrix",
+                    "sessionStart": [{"tool": "lithtrix_memory_context", "args": {"limit": 3}}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = ExtensionsConfig.from_file(str(config_path))
+    assert config.identity_hooks is not None
+    assert config.identity_hooks.session_start[0].args == {"limit": 3}

--- a/backend/tests/test_identity_hooks_middleware.py
+++ b/backend/tests/test_identity_hooks_middleware.py
@@ -1,0 +1,121 @@
+"""Tests for IdentityHooksMiddleware session-start scheduling."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from deerflow.agents.middlewares.identity_hooks_middleware import IdentityHooksMiddleware, run_session_start_hooks
+from deerflow.config.extensions_config import ExtensionsConfig, IdentityHookCall, IdentityHooksConfig, McpServerConfig
+
+
+def _lithtrix_hooks_config(*, enabled: bool = True, server_enabled: bool = True) -> ExtensionsConfig:
+    return ExtensionsConfig.model_validate(
+        {
+            "mcpServers": {
+                "lithtrix": {
+                    "enabled": server_enabled,
+                    "type": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "lithtrix-mcp@0.20.2"],
+                }
+            },
+            "identityHooks": {
+                "enabled": enabled,
+                "mcpServerRef": "lithtrix",
+                "sessionStart": [
+                    {"tool": "lithtrix_memory_context", "args": {"limit": 10}},
+                    {"tool": "lithtrix_commons_read", "args": {"page": 1, "per_page": 20}},
+                ],
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_session_start_hooks_absent_is_noop():
+    config = ExtensionsConfig.model_validate({})
+    with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
+        await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+        pool_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_session_start_hooks_disabled_is_noop():
+    config = _lithtrix_hooks_config(enabled=False)
+    with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
+        await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+        pool_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_session_start_hooks_invokes_tools_with_args():
+    config = _lithtrix_hooks_config()
+    session = AsyncMock()
+    pool = MagicMock()
+    pool.get_session = AsyncMock(return_value=session)
+
+    with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool", return_value=pool):
+        await run_session_start_hooks(config=config, thread_id="thread-1", user_id="user-1")
+
+    pool.get_session.assert_awaited_once()
+    assert session.call_tool.await_count == 2
+    session.call_tool.assert_any_await("lithtrix_memory_context", {"limit": 10})
+    session.call_tool.assert_any_await("lithtrix_commons_read", {"page": 1, "per_page": 20})
+
+
+@pytest.mark.asyncio
+async def test_run_session_start_hooks_disabled_server_warns(caplog: pytest.LogCaptureFixture):
+    config = _lithtrix_hooks_config(server_enabled=False)
+    with caplog.at_level(logging.WARNING):
+        with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
+            await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+            pool_mock.assert_not_called()
+    assert "identity_hooks_skip" in caplog.text
+    assert "lithtrix" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_session_start_hooks_malformed_args_non_fatal(caplog: pytest.LogCaptureFixture):
+    hooks = IdentityHooksConfig(
+        enabled=True,
+        mcp_server_ref="lithtrix",
+        session_start=[
+            IdentityHookCall(tool="lithtrix_memory_context", args={"limit": 10}),
+            IdentityHookCall(tool="lithtrix_commons_read", args={"bad": "args"}),
+        ],
+    )
+    config = ExtensionsConfig(
+        mcp_servers={"lithtrix": McpServerConfig(enabled=True, type="stdio", command="npx", args=["-y", "x"])},
+        identity_hooks=hooks,
+    )
+    session = AsyncMock()
+    session.call_tool = AsyncMock(side_effect=[None, ValueError("invalid args")])
+    pool = MagicMock()
+    pool.get_session = AsyncMock(return_value=session)
+
+    with caplog.at_level(logging.ERROR):
+        with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool", return_value=pool):
+            await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+
+    assert session.call_tool.await_count == 2
+    assert "identity_hooks_call_failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_middleware_fires_once_per_thread():
+    config = _lithtrix_hooks_config()
+    middleware = IdentityHooksMiddleware(extensions_config=config)
+    runtime = MagicMock()
+    runtime.context = {"thread_id": "thread-a"}
+
+    with patch(
+        "deerflow.agents.middlewares.identity_hooks_middleware.run_session_start_hooks",
+        new_callable=AsyncMock,
+    ) as run_mock:
+        await middleware.abefore_agent({}, runtime)
+        await middleware.abefore_agent({}, runtime)
+        run_mock.assert_awaited_once()

--- a/backend/tests/test_identity_hooks_middleware.py
+++ b/backend/tests/test_identity_hooks_middleware.py
@@ -7,9 +7,23 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langchain_core.messages import HumanMessage
+from mcp.types import TextContent
 
-from deerflow.agents.middlewares.identity_hooks_middleware import IdentityHooksMiddleware, run_session_start_hooks
+from deerflow.agents.middlewares.identity_hooks_middleware import (
+    IDENTITY_HOOKS_CONTEXT_KEY,
+    IdentityHooksMiddleware,
+    run_session_start_hooks,
+)
+from deerflow.agents.middlewares.tool_error_handling_middleware import (
+    build_lead_runtime_middlewares,
+    build_subagent_runtime_middlewares,
+)
+from deerflow.config.app_config import AppConfig, CircuitBreakerConfig
 from deerflow.config.extensions_config import ExtensionsConfig, IdentityHookCall, IdentityHooksConfig, McpServerConfig
+from deerflow.config.guardrails_config import GuardrailsConfig
+from deerflow.config.model_config import ModelConfig
+from deerflow.config.sandbox_config import SandboxConfig
 
 
 def _lithtrix_hooks_config(*, enabled: bool = True, server_enabled: bool = True) -> ExtensionsConfig:
@@ -35,36 +49,72 @@ def _lithtrix_hooks_config(*, enabled: bool = True, server_enabled: bool = True)
     )
 
 
+def _make_app_config() -> AppConfig:
+    return AppConfig(
+        models=[
+            ModelConfig(
+                name="test-model",
+                display_name="test-model",
+                description=None,
+                use="langchain_openai:ChatOpenAI",
+                model="test-model",
+            )
+        ],
+        sandbox=SandboxConfig(use="test"),
+        guardrails=GuardrailsConfig(enabled=False),
+        circuit_breaker=CircuitBreakerConfig(),
+    )
+
+
+class _FakeCallToolResult:
+    def __init__(self, text: str) -> None:
+        self.content = [TextContent(type="text", text=text)]
+        self.isError = False
+        self.structuredContent = None
+
+
 @pytest.mark.asyncio
 async def test_run_session_start_hooks_absent_is_noop():
     config = ExtensionsConfig.model_validate({})
     with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
-        await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+        result = await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
         pool_mock.assert_not_called()
+    assert result is None
 
 
 @pytest.mark.asyncio
 async def test_run_session_start_hooks_disabled_is_noop():
     config = _lithtrix_hooks_config(enabled=False)
     with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
-        await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+        result = await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
         pool_mock.assert_not_called()
+    assert result is None
 
 
 @pytest.mark.asyncio
-async def test_run_session_start_hooks_invokes_tools_with_args():
+async def test_run_session_start_hooks_invokes_tools_and_returns_sanitized_context():
     config = _lithtrix_hooks_config()
     session = AsyncMock()
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _FakeCallToolResult("memory: HOOK_CONTEXT_CANARY_memory"),
+            _FakeCallToolResult("commons: HOOK_CONTEXT_CANARY_commons"),
+        ]
+    )
     pool = MagicMock()
     pool.get_session = AsyncMock(return_value=session)
 
     with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool", return_value=pool):
-        await run_session_start_hooks(config=config, thread_id="thread-1", user_id="user-1")
+        result = await run_session_start_hooks(config=config, thread_id="thread-1", user_id="user-1")
 
     pool.get_session.assert_awaited_once()
     assert session.call_tool.await_count == 2
     session.call_tool.assert_any_await("lithtrix_memory_context", {"limit": 10})
     session.call_tool.assert_any_await("lithtrix_commons_read", {"page": 1, "per_page": 20})
+    assert result is not None
+    assert "HOOK_CONTEXT_CANARY_memory" in result
+    assert "HOOK_CONTEXT_CANARY_commons" in result
+    assert "BEGIN EXTERNAL IDENTITY CONTEXT" in result
 
 
 @pytest.mark.asyncio
@@ -72,8 +122,9 @@ async def test_run_session_start_hooks_disabled_server_warns(caplog: pytest.LogC
     config = _lithtrix_hooks_config(server_enabled=False)
     with caplog.at_level(logging.WARNING):
         with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool") as pool_mock:
-            await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+            result = await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
             pool_mock.assert_not_called()
+    assert result is None
     assert "identity_hooks_skip" in caplog.text
     assert "lithtrix" in caplog.text
 
@@ -93,29 +144,77 @@ async def test_run_session_start_hooks_malformed_args_non_fatal(caplog: pytest.L
         identity_hooks=hooks,
     )
     session = AsyncMock()
-    session.call_tool = AsyncMock(side_effect=[None, ValueError("invalid args")])
+    session.call_tool = AsyncMock(
+        side_effect=[
+            _FakeCallToolResult("HOOK_CONTEXT_CANARY_partial"),
+            ValueError("invalid args"),
+        ]
+    )
     pool = MagicMock()
     pool.get_session = AsyncMock(return_value=session)
 
     with caplog.at_level(logging.ERROR):
         with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool", return_value=pool):
-            await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
+            result = await run_session_start_hooks(config=config, thread_id="t1", user_id="u1")
 
     assert session.call_tool.await_count == 2
     assert "identity_hooks_call_failed" in caplog.text
+    assert result is not None
+    assert "HOOK_CONTEXT_CANARY_partial" in result
 
 
 @pytest.mark.asyncio
-async def test_middleware_fires_once_per_thread():
+async def test_middleware_injects_hook_context_into_model_messages():
     config = _lithtrix_hooks_config()
     middleware = IdentityHooksMiddleware(extensions_config=config)
     runtime = MagicMock()
     runtime.context = {"thread_id": "thread-a"}
+    canary = "HOOK_CONTEXT_CANARY_injected"
+
+    session = AsyncMock()
+    session.call_tool = AsyncMock(return_value=_FakeCallToolResult(canary))
+    pool = MagicMock()
+    pool.get_session = AsyncMock(return_value=session)
+
+    with patch("deerflow.agents.middlewares.identity_hooks_middleware.get_session_pool", return_value=pool):
+        result = await middleware.abefore_agent({"messages": [HumanMessage("hi")], "identity_hooks": None}, runtime)
+
+    assert result is not None
+    assert result["identity_hooks"] == {"session_start_fired": True}
+    assert len(result["messages"]) == 1
+    message = result["messages"][0]
+    assert canary in message.content
+    assert message.additional_kwargs.get(IDENTITY_HOOKS_CONTEXT_KEY) is True
+    assert message.additional_kwargs.get("hide_from_ui") is True
+
+
+@pytest.mark.asyncio
+async def test_middleware_fires_once_per_thread_across_instances():
+    config = _lithtrix_hooks_config()
+    middleware_a = IdentityHooksMiddleware(extensions_config=config)
+    middleware_b = IdentityHooksMiddleware(extensions_config=config)
+    runtime = MagicMock()
+    runtime.context = {"thread_id": "thread-a"}
+    state: dict[str, Any] = {"messages": [], "identity_hooks": None}
 
     with patch(
         "deerflow.agents.middlewares.identity_hooks_middleware.run_session_start_hooks",
         new_callable=AsyncMock,
+        return_value="HOOK_CONTEXT_CANARY_once",
     ) as run_mock:
-        await middleware.abefore_agent({}, runtime)
-        await middleware.abefore_agent({}, runtime)
-        run_mock.assert_awaited_once()
+        first = await middleware_a.abefore_agent(state, runtime)
+        assert first is not None
+        state["identity_hooks"] = first["identity_hooks"]
+        second = await middleware_b.abefore_agent(state, runtime)
+
+    assert second is None
+    run_mock.assert_awaited_once()
+
+
+def test_identity_hooks_middleware_is_lead_only():
+    app_config = _make_app_config()
+    lead = build_lead_runtime_middlewares(app_config=app_config, lazy_init=False)
+    subagent = build_subagent_runtime_middlewares(app_config=app_config, lazy_init=False)
+
+    assert any(isinstance(m, IdentityHooksMiddleware) for m in lead)
+    assert not any(isinstance(m, IdentityHooksMiddleware) for m in subagent)

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -91,6 +91,11 @@ def _stub_runtime_middleware_imports(monkeypatch: pytest.MonkeyPatch) -> None:
         "deerflow.agents.middlewares.sandbox_audit_middleware",
         _module("deerflow.agents.middlewares.sandbox_audit_middleware", SandboxAuditMiddleware=FakeMiddleware),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "deerflow.agents.middlewares.identity_hooks_middleware",
+        _module("deerflow.agents.middlewares.identity_hooks_middleware", IdentityHooksMiddleware=FakeMiddleware),
+    )
 
 
 def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware(monkeypatch: pytest.MonkeyPatch):
@@ -137,6 +142,11 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
     )
     monkeypatch.setitem(
         sys.modules,
+        "deerflow.agents.middlewares.identity_hooks_middleware",
+        _module("deerflow.agents.middlewares.identity_hooks_middleware", IdentityHooksMiddleware=FakeMiddleware),
+    )
+    monkeypatch.setitem(
+        sys.modules,
         "deerflow.agents.middlewares.input_sanitization_middleware",
         _module("deerflow.agents.middlewares.input_sanitization_middleware", InputSanitizationMiddleware=FakeMiddleware),
     )
@@ -145,7 +155,7 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
 
     assert captured["app_config"] is app_config
     # 9 baseline (InputSanitization, ToolOutputBudget, ToolResultSanitization,
-    # ThreadData, Sandbox, DanglingToolCall, LLMErrorHandling, SandboxAudit,
+    # ThreadData, IdentityHooks, Sandbox, DanglingToolCall, LLMErrorHandling, SandboxAudit,
     # ToolErrorHandling)
     # + 1 ReadBeforeWriteMiddleware + 1 LoopDetectionMiddleware
     # + 1 TokenBudgetMiddleware (subagents.token_budget enabled by default, #3875 Phase 2)
@@ -157,7 +167,7 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
     from deerflow.agents.middlewares.token_budget_middleware import TokenBudgetMiddleware
     from deerflow.agents.middlewares.tool_output_budget_middleware import ToolOutputBudgetMiddleware
 
-    assert len(middlewares) == 15
+    assert len(middlewares) == 16
     assert isinstance(middlewares[0], FakeMiddleware)  # InputSanitizationMiddleware stub
     assert isinstance(middlewares[1], ToolOutputBudgetMiddleware)
     assert any(isinstance(m, ToolErrorHandlingMiddleware) for m in middlewares)

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -154,20 +154,21 @@ def test_build_subagent_runtime_middlewares_threads_app_config_to_llm_middleware
     middlewares = build_subagent_runtime_middlewares(app_config=app_config, lazy_init=False)
 
     assert captured["app_config"] is app_config
-    # 9 baseline (InputSanitization, ToolOutputBudget, ToolResultSanitization,
-    # ThreadData, IdentityHooks, Sandbox, DanglingToolCall, LLMErrorHandling, SandboxAudit,
+    # 8 baseline (InputSanitization, ToolOutputBudget, ToolResultSanitization,
+    # ThreadData, Sandbox, DanglingToolCall, LLMErrorHandling, SandboxAudit,
     # ToolErrorHandling)
     # + 1 ReadBeforeWriteMiddleware + 1 LoopDetectionMiddleware
     # + 1 TokenBudgetMiddleware (subagents.token_budget enabled by default, #3875 Phase 2)
     # + 1 SafetyFinishReasonMiddleware + 1 DurableContextMiddleware
     # + 1 SystemMessageCoalescingMiddleware (all enabled by default).
+    # IdentityHooksMiddleware is lead-only (gated with UploadsMiddleware).
     from deerflow.agents.middlewares.durable_context_middleware import DurableContextMiddleware
     from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
     from deerflow.agents.middlewares.system_message_coalescing_middleware import SystemMessageCoalescingMiddleware
     from deerflow.agents.middlewares.token_budget_middleware import TokenBudgetMiddleware
     from deerflow.agents.middlewares.tool_output_budget_middleware import ToolOutputBudgetMiddleware
 
-    assert len(middlewares) == 16
+    assert len(middlewares) == 15
     assert isinstance(middlewares[0], FakeMiddleware)  # InputSanitizationMiddleware stub
     assert isinstance(middlewares[1], ToolOutputBudgetMiddleware)
     assert any(isinstance(m, ToolErrorHandlingMiddleware) for m in middlewares)

--- a/docs/examples/lithtrix/.env.example
+++ b/docs/examples/lithtrix/.env.example
@@ -1,0 +1,4 @@
+# Lithtrix reference integration (optional — for lithtrix-mcp stdio server)
+# Copy to project-root .env (gitignored) and fill in values from https://docs.lithtrix.ai/integrations/deerflow
+LITHTRIX_API_KEY=
+LITHTRIX_API_URL=https://api.lithtrix.ai

--- a/docs/examples/lithtrix/extensions_config.snippet.json
+++ b/docs/examples/lithtrix/extensions_config.snippet.json
@@ -1,0 +1,31 @@
+{
+  "mcpInterceptors": [],
+  "mcpServers": {
+    "lithtrix": {
+      "enabled": true,
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "lithtrix-mcp@0.20.2"],
+      "env": {
+        "LITHTRIX_API_KEY": "$LITHTRIX_API_KEY",
+        "LITHTRIX_API_URL": "$LITHTRIX_API_URL"
+      },
+      "description": "Lithtrix MIRC — portable identity, memory, and commons that persist across DeerFlow research runs, restarts, and other frameworks. Set LITHTRIX_API_KEY in .env (see /v1/register)."
+    }
+  },
+  "skills": {},
+  "identityHooks": {
+    "enabled": true,
+    "mcpServerRef": "lithtrix",
+    "sessionStart": [
+      {
+        "tool": "lithtrix_memory_context",
+        "args": { "limit": 10 }
+      },
+      {
+        "tool": "lithtrix_commons_read",
+        "args": { "page": 1, "per_page": 20 }
+      }
+    ]
+  }
+}

--- a/frontend/src/content/en/harness/mcp.mdx
+++ b/frontend/src/content/en/harness/mcp.mdx
@@ -105,6 +105,41 @@ When an OAuth-protected MCP server is connected, DeerFlow will:
 
 The OAuth flow is transparent to the Lead Agent — it simply calls the tool, and DeerFlow handles the authentication.
 
+## Optional identity hooks
+
+Some external identity or memory providers (for example [Lithtrix](https://docs.lithtrix.ai/integrations/deerflow)) benefit from prefetching context at the start of a research thread. DeerFlow can optionally invoke configured MCP tools automatically — without importing provider code into the harness.
+
+Add an `identityHooks` block to `extensions_config.json` (opt-in; absent or `enabled: false` is a no-op):
+
+```json
+{
+  "identityHooks": {
+    "enabled": true,
+    "mcpServerRef": "lithtrix",
+    "sessionStart": [
+      { "tool": "lithtrix_memory_context", "args": { "limit": 10 } },
+      { "tool": "lithtrix_commons_read", "args": { "page": 1, "per_page": 20 } }
+    ]
+  }
+}
+```
+
+- `mcpServerRef` must name an **enabled** entry in `mcpServers`.
+- `tool` is the MCP server's original tool name from `list_tools` (before the `<server>_` prefix added for agent binding).
+- `args` is passed verbatim to the MCP tool; hook failures are logged and ignored so research continues.
+
+**v1 scope:** `sessionStart` only. Session-end writes remain agent-driven (for example via a skill) until write-path arg templating is designed.
+
+**Reference Lithtrix integration (3 files):**
+
+| File | Purpose |
+|------|---------|
+| `extensions_config.json` | `mcpServers.lithtrix` + optional `identityHooks`; `"skills": {}` only |
+| `skills/public/use-lithtrix/SKILL.md` | Agent instructions when hooks are not enabled |
+| `.env` (gitignored) | `LITHTRIX_API_KEY`, `LITHTRIX_API_URL` — see `docs/examples/lithtrix/.env.example` |
+
+Example snippets: `docs/examples/lithtrix/extensions_config.snippet.json`. Skills are discovered from `skills/public/<name>/SKILL.md` — do **not** add `skills.<name>.path` keys.
+
 ## Managing MCP servers
 
 MCP servers can be managed in several ways:

--- a/frontend/src/content/zh/harness/mcp.mdx
+++ b/frontend/src/content/zh/harness/mcp.mdx
@@ -99,6 +99,41 @@ tool_search:
 
 OAuth 流程对 Lead Agent 是透明的——它只是调用工具，DeerFlow 处理认证。
 
+## 可选的身份钩子（identity hooks）
+
+部分外部身份或记忆提供方（例如 [Lithtrix](https://docs.lithtrix.ai/integrations/deerflow)）适合在研究线程开始时预取上下文。DeerFlow 可以可选地自动调用配置的 MCP 工具——无需将提供方代码导入 harness。
+
+在 `extensions_config.json` 中添加 `identityHooks` 块（可选；缺失或 `enabled: false` 时不做任何事）：
+
+```json
+{
+  "identityHooks": {
+    "enabled": true,
+    "mcpServerRef": "lithtrix",
+    "sessionStart": [
+      { "tool": "lithtrix_memory_context", "args": { "limit": 10 } },
+      { "tool": "lithtrix_commons_read", "args": { "page": 1, "per_page": 20 } }
+    ]
+  }
+}
+```
+
+- `mcpServerRef` 必须指向 `mcpServers` 中**已启用**的条目。
+- `tool` 是 MCP 服务器 `list_tools` 返回的原始工具名（在添加 `<server>_` 前缀供 agent 绑定之前）。
+- `args` 原样传给 MCP 工具；钩子失败仅记录日志，不阻塞研究。
+
+**v1 范围：** 仅 `sessionStart`。会话结束写入仍由 agent 驱动（例如通过 skill），待写入路径参数模板设计完成后再支持钩子。
+
+**Lithtrix 参考集成（3 个文件）：**
+
+| 文件 | 用途 |
+|------|------|
+| `extensions_config.json` | `mcpServers.lithtrix` + 可选 `identityHooks`；仅 `"skills": {}` |
+| `skills/public/use-lithtrix/SKILL.md` | 未启用钩子时给 agent 的说明 |
+| `.env`（gitignore） | `LITHTRIX_API_KEY`、`LITHTRIX_API_URL` — 见 `docs/examples/lithtrix/.env.example` |
+
+示例片段：`docs/examples/lithtrix/extensions_config.snippet.json`。Skill 从 `skills/public/<name>/SKILL.md` 自动发现——**不要**添加 `skills.<name>.path` 键。
+
 ## 管理 MCP 服务器
 
 MCP 服务器可以通过多种方式管理：

--- a/skills/public/use-lithtrix/SKILL.md
+++ b/skills/public/use-lithtrix/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: use-lithtrix
+description: Use this skill at the start and end of every research session to give this DeerFlow instance persistent memory that survives restarts and carries across frameworks. Load Lithtrix memory/commons context before starting research to skip redundant searches on already-explored topics; save vetted findings back to Lithtrix at the end of the session. Trigger whenever LITHTRIX_API_KEY is configured.
+---
+
+# ltx-ceiling: demo uses commons as a portability substrate — not a memory replacement
+
+## When to use
+
+At the **start** and **end** of every DeerFlow research session when Lithtrix compounding is enabled.
+
+**Positioning (R4):** DeerFlow already has session memory. Lithtrix gives that memory somewhere **portable** to go — across runs, instances, and frameworks. Do not frame as "DeerFlow needs memory."
+
+## Session start (Run B and later)
+
+1. **`lithtrix_memory_context`** — reload this agent's top memories (importance + recency). **Free** (MIRC base).
+2. **`lithtrix_commons_read`** — list opt-in shared entries (`page=1`, `per_page=20`). **Free** (no credit debit; rate limits apply).
+
+Use retrieved keys and commons summaries to **skip redundant searches** when a vetted source or finding already exists.
+
+## Session end (every run, including Run A)
+
+1. **`lithtrix_memory_set`** — persist vetted findings under agent-scoped keys (e.g. `deerflow:{topic_slug}:findings`). **Free**.
+2. **`lithtrix_feedback`** — one helpful signal per validated source used (batch at end; do not fire per-source during the loop unless async). **Free**.
+3. **Commons publish (optional, operator-scoped):** `lithtrix_memory_set` with `is_commons: true` on a **single high-confidence** key only when findings are operator-vetted. Requires root or `commons-publish` scoped key. **R1:** do not open unfiltered global commons write — this demo writes only under the registered demo agent's publisher identity.
+
+## Scoping (R1 — commons poisoning)
+
+| Surface | R1 scope |
+|---------|----------|
+| Memory keys | `{agent_id}`-isolated via Bearer |
+| Commons write | Publisher = this agent only; `is_commons: true` on explicit keys |
+| Commons read | Global opt-in catalog (read does not accept arbitrary writes) |
+
+No cross-operator commons poisoning in Rung 1 — each write is attributed to the demo agent DID.
+
+## Cost split (R5 — MIRC)
+
+| Lithtrix call | Metered? |
+|---------------|----------|
+| `lithtrix_memory_context` | No |
+| `lithtrix_commons_read` | No |
+| `lithtrix_memory_set` | No |
+| `lithtrix_feedback` | No |
+| `lithtrix_search` / `lithtrix_browse` (if DeerFlow calls them) | Yes — cost-bearing tools |
+
+DeerFlow's own web research tools are separate from Lithtrix MIRC base.
+
+## MCP config (DeerFlow `extensions_config.json`)
+
+See `docs/examples/lithtrix/extensions_config.snippet.json` for the `mcpServers` block. `LITHTRIX_API_KEY` and `LITHTRIX_API_URL` are referenced via `$VAR` substitution and must be set in DeerFlow's `.env` (gitignored) — never commit the raw key.
+
+**Verified working end-to-end 2026-07-11** on a real local DeerFlow Gateway install: `.env` + `extensions_config.json` + `skills/public/use-lithtrix/SKILL.md` in place, confirmed live and enabled in DeerFlow's own Settings → Tools and Settings → Skills panels after `make dev`. No manual re-registration needed on subsequent starts — DeerFlow reads the config fresh each boot.
+
+Required tools visible in `list_tools`: `lithtrix_memory_set`, `lithtrix_memory_context`, `lithtrix_commons_read`, `lithtrix_feedback`.
+
+## Multi-user isolation (R2)
+
+Do **not** claim Lithtrix solves DeerFlow multi-user isolation — DeerFlow PR #1127 addresses that natively. This skill is for **cross-run / cross-framework portability** (H4).


### PR DESCRIPTION
## Summary

This pattern already works on stock DeerFlow today, no code changes required: a `skills/public/<name>/SKILL.md` file plus an `mcpServers` entry in `extensions_config.json` is enough for an external identity/memory provider to prefetch context at session start and persist findings at session end. We've been running it against Lithtrix (`lithtrix-mcp@0.20.2`) for a few days — [writeup + the exact 3 files](https://docs.lithtrix.ai/integrations/deerflow), [community post](https://github.com/bytedance/deer-flow/discussions/4183).

This PR proposes making that pattern **first-class**: an explicit, optional `identityHooks` block so the harness fires session-start calls itself instead of relying on the agent to follow a skill's instructions. It's not a prerequisite for the pattern to work — it's a smaller, more reliable version of something already possible.

This is a **hook interface**, not a Lithtrix-specific hard dependency.

## Motivation

DeerFlow research runs are instance-local. Run N+1 doesn't inherit vetted findings from Run N across restarts or frameworks unless something outside DeerFlow carries that context forward. We measured this directly: a warm run (memory/commons prefetched before research starts) finished 48.2% faster and made 62.5% fewer search calls than a cold run, with 5 commons sources reused and directly counted. Full method and what we're *not* claiming (this isn't a full DeerFlow-UI benchmark) are in the linked writeup.

DeerFlow should not become a shared-state service. This PR exposes a minimal hook so external identity providers can plug in — Lithtrix is the reference implementation, not the only one it should support.

## What's included

- Typed `identityHooks` config block on `ExtensionsConfig` (opt-in, absent by default — zero behavior change for existing installs)
- New `IdentityHooksMiddleware` — fires configured `sessionStart` MCP tool calls once per thread; failures are non-fatal
- v1 scope is `sessionStart` only; `sessionEnd` (write-path) deferred to a follow-up once argument templating for write tools is designed
- Docs: en/zh "Optional identity hooks" subsection + cross-link from `MCP_SERVER.md`
- Reference integration example (Lithtrix): `skills/public/use-lithtrix/SKILL.md` + `extensions_config.json` snippet
- New unit tests + one existing test file updated for the new middleware count
- Full test suite passes locally, no regressions
- Live-tested against the real Lithtrix API (not mocked) — session-start hooks fire correctly, failure path is non-fatal, no metered billing or reputation side effects

## Non-goals

- No Lithtrix SDK in DeerFlow core
- No per-sub-agent passports
- No claims about multi-user isolation (that's #1127's territory)
- No `skills.<name>.path` config key — filesystem discovery under `skills/public/` only
- No requirement to enable `identityHooks` for Lithtrix — the config + skill path alone is sufficient today

## Evidence

- Writeup + the 3 files: https://docs.lithtrix.ai/integrations/deerflow
- Prior community post: https://github.com/bytedance/deer-flow/discussions/4183