### PR TITLE
fix: avoid forcing frontend nginx upgrades

### DIFF
--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -12,6 +12,36 @@ def _read(path: str) -> str:
     return (REPO_ROOT / path).read_text(encoding="utf-8")
 
 
+def _extract_nginx_location_block(content: str, location: str) -> str:
+    needle = f"location {location} {{"
+    start = content.find(needle)
+    assert start != -1, f"missing nginx {needle}"
+
+    brace_start = content.find("{", start)
+    assert brace_start != -1, f"missing nginx block opener for {needle}"
+
+    depth = 0
+    for index in range(brace_start, len(content)):
+        char = content[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return content[start : index + 1]
+
+    raise AssertionError(f"missing nginx block closer for {needle}")
+
+
+def _assert_frontend_upgrade_header_is_conditional(content: str) -> None:
+    frontend_block = _extract_nginx_location_block(content, "/")
+
+    assert "map $http_upgrade $connection_upgrade" in content
+    assert "proxy_set_header Upgrade $http_upgrade;" in frontend_block
+    assert "proxy_set_header Connection $connection_upgrade;" in frontend_block
+    assert "proxy_set_header Connection 'upgrade';" not in frontend_block
+
+
 def test_root_makefile_no_longer_exposes_transition_gateway_targets():
     makefile = _read("Makefile")
 
@@ -108,10 +138,32 @@ def test_nginx_frontend_upgrade_header_is_conditional():
     for path in ("docker/nginx/nginx.local.conf", "docker/nginx/nginx.conf"):
         content = _read(path)
 
-        assert "map $http_upgrade $connection_upgrade" in content
-        assert "proxy_set_header Upgrade $http_upgrade;" in content
-        assert "proxy_set_header Connection $connection_upgrade;" in content
-        assert "proxy_set_header Connection 'upgrade';" not in content
+        _assert_frontend_upgrade_header_is_conditional(content)
+
+
+def test_nginx_frontend_upgrade_check_allows_dedicated_websocket_locations():
+    content = """
+http {
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
+    server {
+        location /api/threads/123/browser/stream {
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+        }
+
+        location / {
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+    }
+}
+"""
+
+    _assert_frontend_upgrade_header_is_conditional(content)
 
 
 def test_gateway_cors_configuration_uses_gateway_allowlist():

--- a/backend/tests/test_gateway_runtime_cleanup.py
+++ b/backend/tests/test_gateway_runtime_cleanup.py
@@ -104,6 +104,16 @@ def test_nginx_defers_cors_to_gateway_allowlist():
         assert "if ($request_method = 'OPTIONS')" not in content
 
 
+def test_nginx_frontend_upgrade_header_is_conditional():
+    for path in ("docker/nginx/nginx.local.conf", "docker/nginx/nginx.conf"):
+        content = _read(path)
+
+        assert "map $http_upgrade $connection_upgrade" in content
+        assert "proxy_set_header Upgrade $http_upgrade;" in content
+        assert "proxy_set_header Connection $connection_upgrade;" in content
+        assert "proxy_set_header Connection 'upgrade';" not in content
+
+
 def test_gateway_cors_configuration_uses_gateway_allowlist():
     gateway_config = _read("backend/app/gateway/config.py")
     gateway_app = _read("backend/app/gateway/app.py")

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -30,6 +30,15 @@ http {
         "~*^https" https;
     }
 
+    # Only mark frontend requests as connection upgrades when the browser
+    # actually requested one. Next.js dev HMR also uses long-lived HTTP
+    # streams, and forcing "Connection: upgrade" on those requests makes
+    # nginx treat the upstream response as an invalid upgrade handshake.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
     # ── Main server (path-based routing) ─────────────────────────────────
     server {
         listen 2026 default_server;
@@ -242,7 +251,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $forwarded_proto;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
+            proxy_set_header Connection $connection_upgrade;
             proxy_cache_bypass $http_upgrade;
 
             # Timeouts

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -27,6 +27,15 @@ http {
         server 127.0.0.1:3000;
     }
 
+    # Only mark frontend requests as connection upgrades when the browser
+    # actually requested one. Next.js dev HMR also uses long-lived HTTP
+    # streams, and forcing "Connection: upgrade" on those requests makes
+    # nginx treat the upstream response as an invalid upgrade handshake.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      '';
+    }
+
     server {
         listen 2026;
         listen [::]:2026;
@@ -251,7 +260,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection 'upgrade';
+            proxy_set_header Connection $connection_upgrade;
             proxy_cache_bypass $http_upgrade;
 
             # Disable response buffering for the frontend. Without this,


### PR DESCRIPTION
<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->

Fixes #4223

## Why

When accessing the Docker dev stack through a remote host/IP, the login page can appear to refresh and stay on `/login`. The issue logs show repeated failures on `/_next/webpack-hmr`, while the login POST is not reached from the failing browser session.

The frontend nginx catch-all was forwarding every frontend request with `Connection: upgrade`, even when the browser did not request an upgrade. Next.js dev HMR can use long-lived HTTP streams, so forcing upgrade semantics can make nginx treat the upstream response as an invalid upgrade handshake.

## What changed

- Make frontend nginx upgrade handling conditional on `$http_upgrade`.
- Keep real WebSocket/upgrade requests working.
- Stop sending `Connection: upgrade` for normal frontend requests and HMR HTTP streams.
- Add regression coverage for both local and Docker nginx configs.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. This changes nginx proxy behavior, not UI.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_gateway_runtime_cleanup.py::test_nginx_frontend_upgrade_header_is_conditional`

## Validation

- `uv run pytest tests/test_gateway_runtime_cleanup.py -q` — 14 passed
- `git diff --check` — passed
-  Local reproduction

## AI assistance

**Tool(s) used:** Codex

**How you used it:**  implemented the nginx config fix, and added regression coverage.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
