### PR TITLE
fix(channels): don't treat a bare "connect" as a bind command

### DIFF
--- a/backend/app/channels/commands.py
+++ b/backend/app/channels/commands.py
@@ -77,7 +77,7 @@ def extract_connect_code(text: str) -> str | None:
     if index + 1 >= len(parts):
         return None
     command = parts[index].lower()
-    if command in {"/connect", "connect"}:
+    if command == "/connect":
         return parts[index + 1]
     return None
 

--- a/backend/tests/test_additional_channel_connections.py
+++ b/backend/tests/test_additional_channel_connections.py
@@ -60,6 +60,23 @@ def test_pending_connect_code_accepts_leading_platform_mentions():
     assert channel._pending_connect_code("@_user_1 /connect via-base") == "via-base"
 
 
+def test_bare_connect_without_slash_does_not_bind():
+    """A message that merely starts with the word "connect" is normal chat.
+
+    Every other channel control command requires a leading slash
+    (``is_known_channel_command`` only matches ``/``-prefixed tokens, and
+    ``KNOWN_CHANNEL_COMMANDS`` holds only slash forms), so a bare ``connect``
+    must not be treated as ``/connect <code>`` and swallow the next word as a
+    bind code — otherwise "connect the database to the api" binds to "the".
+    """
+    assert extract_connect_code("connect the database to the api") is None
+    assert extract_connect_code("connect abc") is None
+    assert extract_connect_code("@bot connect abc") is None
+    # The real slash command still binds, including after a mention prefix.
+    assert extract_connect_code("/connect abc") == "abc"
+    assert extract_connect_code("@bot /connect abc") == "abc"
+
+
 def test_pending_connect_code_is_none_when_connections_disabled():
     # With no connection repo, binding is not configured and connect codes are
     # ignored so the message falls through to normal handling.


### PR DESCRIPTION
## Why

While reading the IM-channel connect-command parser I found that
`extract_connect_code` treats a bare `connect` (no leading slash) as the connect
command. Any ordinary message whose first word is "connect" is therefore parsed
as `/connect <code>`, its next word is consumed as a one-time bind code, and the
message never reaches the agent — a silent false-positive bind on normal chat.

## What changed

For channels with user connections enabled, a message like `connect the
database to the api` used to be interpreted as a bind attempt (binding to the
word `the`); it now falls through to the agent as normal chat. Only `/connect
<code>` (optionally behind a mention, e.g. `@bot /connect <code>`) binds.
No config or API shape changes.

## Surface area

- [x] **Backend API** — inbound IM-channel message classification under `backend/app/channels`

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_additional_channel_connections.py::test_bare_connect_without_slash_does_not_bind`
- Did it go red on `main` and green on this branch? **yes** — on `main`, `extract_connect_code("connect the database to the api")` returns `"the"`, so the new test's `is None` assertion fails; with the one-line fix it returns `None` and the test passes.

## Validation

`cd backend && make lint` (ruff check + format, clean) and the affected suites:

```
cd backend
PYTHONPATH=. .venv/bin/pytest tests/test_additional_channel_connections.py tests/test_channels.py
# 9 + 253 passed
```

Ran `ruff format`/`ruff check` on both changed files — no changes, all checks passed.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted code review surfaced the bare-`connect` false-positive; I confirmed it with a standalone repro against `main`, wrote the failing regression test first (red → green), traced the callers (`_pending_connect_code` → the six channel adapters), and read the diff before opening this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
