### PR TITLE
fix(sandbox): make an empty old_str a no-op in str_replace on any file

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -2279,11 +2279,11 @@ def str_replace_tool(
             # Custom mount paths are resolved by LocalSandbox._resolve_path()
         with get_file_operation_lock(sandbox, path):
             content = sandbox.read_file(path)
-            if not content:
-                if not old_str:
-                    return "OK"
-                return f"Error: String to replace not found in file: {requested_path}"
-            if old_str not in content:
+            if not old_str:
+                # A no-op edit. str.replace("", new_str) would insert new_str at
+                # every character boundary, so this cannot fall through.
+                return "OK"
+            if not content or old_str not in content:
                 return f"Error: String to replace not found in file: {requested_path}"
             if replace_all:
                 content = content.replace(old_str, new_str)

--- a/backend/tests/test_str_replace_empty_file.py
+++ b/backend/tests/test_str_replace_empty_file.py
@@ -1,10 +1,16 @@
-"""str_replace tool behaviour on empty files.
+"""str_replace tool behaviour with an empty file or an empty ``old_str``.
 
 An empty file used to short-circuit to ``"OK"`` regardless of ``old_str``,
 so a real substring replacement silently "succeeded" without changing anything
 and without telling the model the target was missing. The fix only returns
 ``"OK"`` on an empty file when ``old_str`` is itself empty (a no-op edit);
 a non-empty ``old_str`` now reports the string was not found.
+
+The mirror case is an empty ``old_str`` against a *non-empty* file. ``old_str
+not in content`` cannot reject ``""`` because ``"" in content`` is always true,
+so it reached ``str.replace("", new_str)``, which inserts at every character
+boundary and rewrote the file while still returning ``"OK"``. An empty
+``old_str`` is now a no-op whatever the file holds.
 """
 
 from pathlib import Path
@@ -28,27 +34,54 @@ def _local_runtime(tmp_path: Path) -> SimpleNamespace:
     )
 
 
-def _str_replace(tmp_path, monkeypatch, *, old_str: str, new_str: str = "x") -> str:
+def _str_replace(
+    tmp_path,
+    monkeypatch,
+    *,
+    old_str: str,
+    new_str: str = "x",
+    content: str = "",
+    replace_all: bool = False,
+) -> tuple[str, str]:
     runtime = _local_runtime(tmp_path)
-    (tmp_path / "outputs" / "empty.txt").write_text("", encoding="utf-8")
+    target = tmp_path / "outputs" / "empty.txt"
+    target.write_text(content, encoding="utf-8")
     monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
     monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
-    return str_replace_tool.func(
+    result = str_replace_tool.func(
         runtime=runtime,
         description="replace in empty file",
         path="/mnt/user-data/outputs/empty.txt",
         old_str=old_str,
         new_str=new_str,
+        replace_all=replace_all,
     )
+    return result, target.read_text(encoding="utf-8")
 
 
 def test_empty_file_with_non_empty_old_str_reports_not_found(tmp_path, monkeypatch) -> None:
-    result = _str_replace(tmp_path, monkeypatch, old_str="something")
+    result, _ = _str_replace(tmp_path, monkeypatch, old_str="something")
     assert result.startswith("Error: String to replace not found in file")
     assert "empty.txt" in result
 
 
 def test_empty_file_with_empty_old_str_returns_ok(tmp_path, monkeypatch) -> None:
     # An empty old_str is a no-op edit and remains a benign "OK" on an empty file.
-    result = _str_replace(tmp_path, monkeypatch, old_str="")
+    result, _ = _str_replace(tmp_path, monkeypatch, old_str="")
     assert result == "OK"
+
+
+def test_non_empty_file_with_empty_old_str_is_a_no_op(tmp_path, monkeypatch) -> None:
+    # The same no-op contract has to hold once the file has content: str.replace("")
+    # would otherwise insert new_str at every character boundary.
+    source = "def main():\n    return 1\n"
+    result, after = _str_replace(tmp_path, monkeypatch, old_str="", new_str="# header\n", content=source)
+    assert result == "OK"
+    assert after == source
+
+
+def test_non_empty_file_with_empty_old_str_and_replace_all_is_a_no_op(tmp_path, monkeypatch) -> None:
+    source = "def main():\n    return 1\n"
+    result, after = _str_replace(tmp_path, monkeypatch, old_str="", new_str="X", content=source, replace_all=True)
+    assert result == "OK"
+    assert after == source


### PR DESCRIPTION
## Why

`str_replace` can silently rewrite a user's file and still report `OK`.

The guard is `if old_str not in content`, which cannot reject an empty `old_str` — `"" in content` is always true. So an empty `old_str` reaches `str.replace("", new_str)`, which inserts `new_str` at **every character boundary**:

```
old_str='', new_str='# H\n'           -> OK, file silently prepended
old_str='', new_str='X', replace_all  -> OK, 'XdXeXfX XmXaXiXnX(X)X:X\nX X X X XrXeXtXuXrXnX X1X\nX'
```

The tool is registered by default (`config.example.yaml`) and its schema declares `old_str` as a plain string with **no `minLength`**, so a model can emit `""` legitimately. Read-before-write only compares a hash, so nothing downstream catches it.

The empty-**file** branch right above already handles this exact case (`if not content: if not old_str: return "OK"`), and `tests/test_str_replace_empty_file.py` states the intent directly:

> `# An empty old_str is a no-op edit and remains a benign "OK" on an empty file.`

That contract just never held once the file had content.

## What changed

An empty `old_str` is now a no-op on any file, not only an empty one — the tool returns `OK` and leaves the file untouched. A non-empty `old_str` against an empty file keeps reporting "String to replace not found", with the same message as before.

I picked "no-op + OK" because it's what the existing test and its comment already describe. If you'd rather it be an explicit error — so the model learns to use `write_file` instead of an empty-`old_str` edit — that's a reasonable call too; it would mean changing `test_empty_file_with_empty_old_str_returns_ok`. Happy to switch.

## Surface area

- [x] **Sandbox** — `docker/` or sandboxed execution

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_str_replace_empty_file.py::test_non_empty_file_with_empty_old_str_is_a_no_op` and `::test_non_empty_file_with_empty_old_str_and_replace_all_is_a_no_op`
- Did it go red on `main` and green on this branch? **yes** — both new tests fail on `main` (2 failed, 2 passed) and pass here (4 passed). The two pre-existing tests in that file pass on both.

## Validation

- `backend/tests/test_str_replace_empty_file.py` — 4 passed
- `pytest -k "str_replace or sandbox_tools"` — 156 passed, 3 skipped
- `ruff check` on both changed files — All checks passed; `ruff format` applied

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** A hunt agent surfaced the empty-`old_str` case; I reproduced it myself through the real `str_replace_tool.func` (building the fixture from this file's own `_local_runtime`/`_str_replace` helpers), confirmed the empty-file branch was the asymmetric twin, wrote the fix and the two regression tests, and verified red-on-main/green-here by stashing the fix and re-running the same command.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
