### PR TITLE
fix(workspace-changes): offload blocking filesystem IO in text-cache lifecycle

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -142,10 +142,13 @@ Blocking-IO runtime gate (`tests/blocking_io/`):
   `test_jsonl_run_event_store.py` (locks `JsonlRunEventStore`'s async
   API offloading its file IO via `asyncio.to_thread`);
   `test_uploads_middleware.py` (locks `UploadsMiddleware.abefore_agent`
-  offloading the uploads-directory scan off the event loop); and
+  offloading the uploads-directory scan off the event loop);
   `test_uploads_router.py` (locks Gateway upload/list/delete endpoints
   offloading upload directory creation, staged writes, chmod/cleanup,
-  directory scans/deletes, and remote sandbox sync off the event loop).
+  directory scans/deletes, and remote sandbox sync off the event loop); and
+  `test_workspace_changes_recorder.py` (locks the offload around the snapshot
+  text cache lifecycle — roots resolution, `mkdtemp`, and the `shutil.rmtree`
+  on both the capture-failure branch and `record_workspace_changes`' `finally`).
 - `test_gate_smoke.py` is a meta-test asserting the gate actually catches
   unoffloaded blocking IO and that the `@pytest.mark.allow_blocking_io`
   opt-out works.

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -66,7 +66,22 @@ async def capture_workspace_snapshot(
     limits: WorkspaceChangeLimits | None = None,
     include_text: bool = True,
 ) -> WorkspaceSnapshot:
-    roots, text_cache_dir = await asyncio.to_thread(_prepare_capture, thread_id, user_id=user_id, include_text=include_text)
+    # `_prepare_capture` creates the text cache dir inside the worker, so the
+    # handoff must be cancellation-safe: if the run is cancelled after mkdtemp
+    # but before we receive the path, the shielded worker still finishes and we
+    # reclaim its result to remove the orphaned dir before re-raising.
+    prepare = asyncio.ensure_future(asyncio.to_thread(_prepare_capture, thread_id, user_id=user_id, include_text=include_text))
+    try:
+        roots, text_cache_dir = await asyncio.shield(prepare)
+    except asyncio.CancelledError:
+        orphaned = None
+        try:
+            _, orphaned = await asyncio.shield(prepare)
+        except Exception:
+            orphaned = None  # prepare failed before creating a dir; nothing to reclaim
+        if orphaned is not None:
+            await asyncio.shield(_remove_text_cache_dir(orphaned))
+        raise
     try:
         return await asyncio.to_thread(
             scan_workspace_roots,

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -59,6 +59,21 @@ async def _remove_text_cache_dir(text_cache_dir: str | Path) -> None:
         logger.warning("Failed to remove workspace text cache %s", text_cache_dir, exc_info=True)
 
 
+async def _reclaim_prepare_and_cleanup(prepare: asyncio.Future[tuple[list[WorkspaceRoot], Path | None]]) -> None:
+    """Await a cancelled prepare handoff and remove any dir it created.
+
+    Owned by its own task so that caller cancellation during reclaim can interrupt
+    the *await* but never abandon a just-created text cache dir. Best-effort,
+    mirroring `_remove_text_cache_dir`.
+    """
+    try:
+        _, orphaned = await prepare
+    except Exception:
+        return  # prepare failed before creating a dir; nothing to reclaim
+    if orphaned is not None:
+        await _remove_text_cache_dir(orphaned)
+
+
 async def capture_workspace_snapshot(
     thread_id: str,
     *,
@@ -74,13 +89,18 @@ async def capture_workspace_snapshot(
     try:
         roots, text_cache_dir = await asyncio.shield(prepare)
     except asyncio.CancelledError:
-        orphaned = None
-        try:
-            _, orphaned = await asyncio.shield(prepare)
-        except Exception:
-            orphaned = None  # prepare failed before creating a dir; nothing to reclaim
-        if orphaned is not None:
-            await asyncio.shield(_remove_text_cache_dir(orphaned))
+        # `prepare` is shielded, so it keeps running and may still create the dir
+        # after this cancel. Own the reclaim+remove in a task the caller cannot
+        # abandon: a repeat cancel can interrupt our await but not the task, so we
+        # drain repeated cancellation until cleanup finishes, then restore it. A
+        # second `shield()` on the await alone would let a re-cancel skip the
+        # reclaim and orphan the dir.
+        cleanup = asyncio.ensure_future(_reclaim_prepare_and_cleanup(prepare))
+        while not cleanup.done():
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                pass
         raise
     try:
         return await asyncio.to_thread(

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -38,6 +38,27 @@ def build_thread_workspace_roots(thread_id: str, *, user_id: str | None = None) 
     ]
 
 
+def _prepare_capture(thread_id: str, *, user_id: str | None, include_text: bool) -> tuple[list[WorkspaceRoot], Path | None]:
+    # Worker thread: resolving the sandbox roots hits the filesystem, and mkdtemp
+    # creates the text cache directory — both blocking IO that must stay off the
+    # event loop.
+    roots = build_thread_workspace_roots(thread_id, user_id=user_id)
+    text_cache_dir = Path(tempfile.mkdtemp(prefix="deerflow-workspace-changes-")) if include_text else None
+    return roots, text_cache_dir
+
+
+async def _remove_text_cache_dir(text_cache_dir: str | Path) -> None:
+    """Remove a snapshot's text cache off the event loop.
+
+    Best-effort by contract: every caller is a failure or teardown path, so a
+    cleanup error must never replace the exception or result already in flight.
+    """
+    try:
+        await asyncio.to_thread(shutil.rmtree, text_cache_dir, ignore_errors=True)
+    except Exception:
+        logger.warning("Failed to remove workspace text cache %s", text_cache_dir, exc_info=True)
+
+
 async def capture_workspace_snapshot(
     thread_id: str,
     *,
@@ -45,8 +66,7 @@ async def capture_workspace_snapshot(
     limits: WorkspaceChangeLimits | None = None,
     include_text: bool = True,
 ) -> WorkspaceSnapshot:
-    roots = build_thread_workspace_roots(thread_id, user_id=user_id)
-    text_cache_dir = Path(tempfile.mkdtemp(prefix="deerflow-workspace-changes-")) if include_text else None
+    roots, text_cache_dir = await asyncio.to_thread(_prepare_capture, thread_id, user_id=user_id, include_text=include_text)
     try:
         return await asyncio.to_thread(
             scan_workspace_roots,
@@ -57,7 +77,7 @@ async def capture_workspace_snapshot(
         )
     except Exception:
         if text_cache_dir is not None:
-            shutil.rmtree(text_cache_dir, ignore_errors=True)
+            await _remove_text_cache_dir(text_cache_dir)
         raise
 
 
@@ -71,7 +91,7 @@ async def record_workspace_changes(
     limits: WorkspaceChangeLimits | None = None,
 ) -> dict | None:
     try:
-        roots = build_thread_workspace_roots(thread_id, user_id=user_id)
+        roots = await asyncio.to_thread(build_thread_workspace_roots, thread_id, user_id=user_id)
         after_metadata = await asyncio.to_thread(
             scan_workspace_roots,
             roots,
@@ -103,9 +123,9 @@ async def record_workspace_changes(
             metadata={WORKSPACE_CHANGES_METADATA_KEY: payload},
         )
     finally:
-        _cleanup_snapshot_text_cache(before)
+        await _cleanup_snapshot_text_cache(before)
 
 
-def _cleanup_snapshot_text_cache(snapshot: WorkspaceSnapshot) -> None:
+async def _cleanup_snapshot_text_cache(snapshot: WorkspaceSnapshot) -> None:
     if snapshot.text_cache_dir:
-        shutil.rmtree(snapshot.text_cache_dir, ignore_errors=True)
+        await _remove_text_cache_dir(snapshot.text_cache_dir)

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -1,0 +1,108 @@
+"""Regression anchor: workspace snapshot text-cache cleanup must not block the event loop.
+
+``capture_workspace_snapshot`` offloads the scan itself via ``asyncio.to_thread``
+but owns a ``tempfile.mkdtemp`` text cache whose lifecycle runs on the async
+path: the directory is created up front, removed on the scan-failure branch, and
+removed again by ``record_workspace_changes``' ``finally`` after every run. Those
+create/delete calls are blocking filesystem IO (``shutil.rmtree`` walks and
+unlinks up to ``max_files`` cached texts). If any of them regresses back onto the
+event loop, the strict Blockbuster gate raises ``BlockingError`` and these tests
+fail.
+
+Both cleanup branches are driven explicitly — the failure branch of
+``capture_workspace_snapshot`` and the always-run ``finally`` of
+``record_workspace_changes`` — because the happy path alone never reaches the
+rmtree this anchor exists to guard.
+
+Imports are kept at module top so any import-time IO runs at collection (outside
+the gate); the surface under test runs on the event loop inside the gated test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deerflow.workspace_changes import recorder
+from deerflow.workspace_changes.types import WorkspaceSnapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+class _RecordingEventStore:
+    """Stand-in for the real event store: the external boundary, not the offload."""
+
+    def __init__(self) -> None:
+        self.puts: list[dict[str, Any]] = []
+
+    async def put(self, **kwargs: Any) -> dict[str, Any]:
+        self.puts.append(kwargs)
+        return kwargs
+
+
+def _seed_workspace(tmp_path: Path) -> None:
+    """Create a real on-disk workspace so the scan has something to walk."""
+    work = tmp_path / "work"
+    work.mkdir(parents=True, exist_ok=True)
+    (work / "note.txt").write_text("hello\n", encoding="utf-8")
+
+
+async def test_capture_workspace_snapshot_cleanup_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    """The scan-failure branch removes the text cache; that rmtree must be offloaded."""
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    # Pin mkdtemp's parent so the assertion below sees this test's cache dir and
+    # nothing else (the platform temp root is shared and macOS is not /tmp).
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    # Force the failure branch. This mocks the scan (a separate, already-offloaded
+    # call), never the text-cache cleanup this anchor guards.
+    def _boom(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError("scan failed")
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _boom)
+
+    with pytest.raises(RuntimeError, match="scan failed"):
+        await recorder.capture_workspace_snapshot("t1", include_text=True)
+
+    # The cache dir was really created, then really removed — cleanup still runs,
+    # it merely moved off the loop.
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"text cache dir leaked on the failure branch: {leftovers}"
+
+
+async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    """``record_workspace_changes`` rmtrees the snapshot text cache in its ``finally``."""
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    _seed_workspace(tmp_path)
+
+    # A real text cache dir holding real files, so rmtree does real filesystem work.
+    cache_dir = tmp_path / "text-cache"
+    cache_dir.mkdir()
+    for i in range(5):
+        (cache_dir / f"cached_{i}.txt").write_text("cached\n", encoding="utf-8")
+
+    before = WorkspaceSnapshot(files={}, truncated=False, text_cache_dir=str(cache_dir))
+
+    await recorder.record_workspace_changes(
+        _RecordingEventStore(),
+        "t1",
+        "r1",
+        before,
+    )
+
+    still_there = await asyncio.to_thread(cache_dir.exists)
+    assert not still_there, "record_workspace_changes must remove the snapshot text cache"

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -14,6 +14,11 @@ Both cleanup branches are driven explicitly — the failure branch of
 ``record_workspace_changes`` — because the happy path alone never reaches the
 rmtree this anchor exists to guard.
 
+Because ``mkdtemp`` must be offloaded, its worker handoff is also a cancellation
+hazard: a run cancelled after ``mkdtemp`` but before the coroutine receives the
+path would orphan the dir. The last test pins the shield+reclaim guard that
+removes such a dir instead of leaking it.
+
 Imports are kept at module top so any import-time IO runs at collection (outside
 the gate); the surface under test runs on the event loop inside the gated test.
 """
@@ -22,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -106,3 +112,46 @@ async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_pa
 
     still_there = await asyncio.to_thread(cache_dir.exists)
     assert not still_there, "record_workspace_changes must remove the snapshot text cache"
+
+
+async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
+    """A run cancelled during the mkdtemp handoff must not orphan the text cache.
+
+    ``mkdtemp`` runs in the ``_prepare_capture`` worker, so if the run is
+    cancelled after the dir is created but before the coroutine receives the
+    path, nothing downstream owns it. The shield+reclaim guard waits for the
+    worker and removes the dir; without it the dir leaks into the temp root.
+    """
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    entered = threading.Event()
+    release = threading.Event()
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
+        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
+        entered.set()
+        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
+        return created
+
+    monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
+
+    task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
+    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
+    parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert parked, "text cache dir should exist while the worker is parked mid-handoff"
+
+    task.cancel()
+    release.set()  # let the worker finish and hand its result to the reclaim path
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"cancelled capture leaked a text cache dir: {leftovers}"

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -155,3 +155,55 @@ async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(
 
     leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"cancelled capture leaked a text cache dir: {leftovers}"
+
+
+async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
+    """A *second* cancellation during the reclaim await must not orphan the cache.
+
+    After the first cancel enters the reclaim path, the coroutine awaits the
+    shielded worker's result. A second cancel lands on that await: because the
+    reclaim+remove is owned by a task the caller cannot abandon, the guard drains
+    the repeated cancellation until the dir is removed, then restores the
+    cancellation. A plain re-await would let the second ``CancelledError`` skip
+    the reclaim (``except Exception`` does not catch it) while the shielded worker
+    still finishes and leaks its dir.
+    """
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    entered = threading.Event()
+    release = threading.Event()
+    real_mkdtemp = tempfile.mkdtemp
+
+    def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
+        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
+        entered.set()
+        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
+        return created
+
+    monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
+
+    task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
+    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
+    parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert parked, "text cache dir should exist while the worker is parked mid-handoff"
+
+    task.cancel()  # cancel #1 -> enters reclaim, awaits the shielded cleanup task
+    for _ in range(5):
+        await asyncio.sleep(0)  # let the reclaim path reach its await while the worker is still parked
+    task.cancel()  # cancel #2 -> lands on the reclaim await
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    release.set()  # worker finishes; the drained cleanup reclaims and removes the dir
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"repeated-cancel capture leaked a text cache dir: {leftovers}"


### PR DESCRIPTION
## Why

`workspace_changes/recorder.py`'s two async entry points — `capture_workspace_snapshot` and `record_workspace_changes`, both awaited by `runtime/runs/worker.py` on every agent run — already offload their scans via `asyncio.to_thread`, but ran the snapshot **text cache's whole lifecycle** on the event loop:

| Site | Blocking call | When |
|---|---|---|
| `capture_workspace_snapshot` | `build_thread_workspace_roots` → `os.path.abspath` | every run |
| `capture_workspace_snapshot` | `tempfile.mkdtemp` → `os.mkdir` | every run (`include_text=True`) |
| `capture_workspace_snapshot` | `shutil.rmtree` | scan-failure branch |
| `record_workspace_changes` | `build_thread_workspace_roots` → `os.path.abspath` | every run |
| `record_workspace_changes` | `shutil.rmtree` (in `finally`) | **every run, incl. abort paths** |

The last one is the notable one: `_cleanup_snapshot_text_cache` sits in a `finally`, so it is not an error path — every agent run removed up to `max_files` (200) cached text files on the loop.

`make detect-blocking-io` flagged the two `shutil.rmtree` calls as **HIGH** — the last 2 HIGH findings in the repo. After this change the scanner reports **zero HIGH**, which per `.agent/skills/blocking-io-guard/SKILL.md`'s batching policy ("do not start MEDIUM until every HIGH is dispositioned") also unblocks the MEDIUM rounds.

Same class as the already-merged #3457, #1917, #3084, and #3529; this is the runtime-side counterpart of #3529's inbound-ingestion fix and reuses its `_prepare_uploads_dir()` single-worker-hop shape.

## What changed

- `_prepare_capture()` runs roots resolution + `mkdtemp` in one worker thread, returning `(roots, text_cache_dir)`.
- The `_prepare_capture` handoff is cancellation-safe, including under **repeated** cancellation: `capture_workspace_snapshot` shields the prepare future, and on `CancelledError` hands the reclaim+remove to a task the caller cannot abandon, draining repeated cancellation until it completes before re-raising. Otherwise a cancel between `mkdtemp` and the coroutine receiving the path would orphan the dir — and a second cancel landing on the reclaim await would do so again (thanks @fancyboi999).
- `record_workspace_changes` offloads its own `build_thread_workspace_roots` call.
- Both `shutil.rmtree` sites now route through `_remove_text_cache_dir()`, offloaded via `asyncio.to_thread`.
- Cleanup stays **best-effort**: `_remove_text_cache_dir` swallows and logs, so a failing cleanup cannot replace the exception or result already in flight (SOP Step 2's requirement for `finally`/cleanup paths).

Externally observable behavior is unchanged: same cleanup timing, same `ignore_errors=True` semantics, same return values.

Two scoping notes worth surfacing for review:

1. **The roots resolution is not in the scanner's output**, but it is in this diff. `build_thread_workspace_roots` is a sync helper whose blocking call lives in `paths.sandbox_work_dir` (another file), so it falls in the documented `ASYNC_REACHABLE_SAME_FILE` blind spot. It blocks the same async path, and — concretely — the anchor cannot reach the `rmtree` without it: against pre-fix code the gate fires on `os.path.abspath` first.

2. **`asyncio.shield` — cleanup vs creation are different questions.** For *cleanup* (rmtree) no shield is needed: `asyncio.to_thread` submits immediately, so cancelling the future does not stop the running thread and the cache is still removed (measured under single and repeated cancellation — naive and sync versions all clean up). For the *creation* handoff it is needed: `_prepare_capture` builds the cache dir in the worker, so a cancel between `mkdtemp` and receiving the path would drop the path and orphan the dir. `capture_workspace_snapshot` shields the prepare future and, on cancellation, reclaims its result to remove the dir. Because that reclaim `await` is itself cancellable, the reclaim+remove is owned by a task the caller cannot abandon and repeated cancellation is drained until it finishes, then the cancellation is restored — a second `shield()` on the await alone would let a re-cancel skip the reclaim and orphan the dir (regressions: `test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache`, `test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_cache`). Note: the symmetric window during the *scan* await (`except Exception` does not catch `CancelledError`) is pre-existing — the branch's `except Exception` is byte-identical to `main`, which leaks the same way — and is left as a follow-up because fixing it correctly requires ordering the rmtree after the still-running scan worker.

## Surface area

- **Backend** — `packages/harness/deerflow/workspace_changes/recorder.py` (+62/−7) + new `tests/blocking_io` anchor + `backend/AGENTS.md` anchor-list entry. No API / schema change.

## Validation

- New `tests/blocking_io/test_workspace_changes_recorder.py` (4 tests), driving the **capture-failure branch**, the **record `finally`**, and the **cancelled `mkdtemp` handoff** under both single and repeated cancellation — not the happy path, which never reaches the rmtree.
- **Teeth verified per clause** under the strict Blockbuster gate — each offload reverted *alone*, confirming each test reddens on its own call rather than being rescued by a sibling:

  | Reverted clause | Test | Reddens on |
  |---|---|---|
  | `rmtree` offload | `test_capture_..._cleanup` | `capture_workspace_snapshot` → `_remove_text_cache_dir` → `BlockingError: os.path.samestat` |
  | `rmtree` offload | `test_record_..._cleanup` | `_remove_text_cache_dir` → `BlockingError: os.path.samestat` |
  | `_prepare_capture` offload | `test_capture_..._cleanup` | `_prepare_capture` → `BlockingError: os.path.abspath` |
  | `record` roots offload | `test_record_..._cleanup` | `build_thread_workspace_roots` → `BlockingError: os.path.abspath` |

  All GREEN after the fix. Blockbuster already has rules covering `rmtree`'s internals, so no new rule is needed (coverage opening, not the RULE route).
- Re-scan (Step 2): `make detect-blocking-io` → `recorder.py` findings **0**, HIGH remaining repo-wide **0** (was `2 HIGH / 20 MEDIUM / 16 LOW`).
- `make test-blocking-io` → **43 passed** (39 before + 4).
- Workspace-changes regression (`-k "workspace_change or recorder"`) → **31 passed, 3 skipped**.
- Full `make test` (round-1 baseline; round 2 re-ran the blocking-io gate + workspace-changes regression above, not the full suite) → **7761 passed, 8 failed, 28 skipped**. The 8 failures are **pre-existing and unrelated** — verified by re-running the same three files against unmodified `origin/main`: **8 failed / 52 passed on both**. 6 of the 8 share one mechanism (`Error: Refusing to fetch a private, loopback, or metadata address` — the SSRF guard in the web-fetch tools, environment/DNS dependent); none of `test_crawl4ai_tools.py`, `test_fastcrw_tools.py`, `test_browserless_client.py` reference `workspace_changes`.
- `uvx ruff check .` → All checks passed! · `uvx ruff format --check .` → 873 files already formatted.

## AI assistance

**Tool(s) used:** Claude Code (Claude Opus 4.8)

**How you used it:** AI ran `make detect-blocking-io`, routed the two HIGH findings per the `blocking-io-guard` SOP, implemented the `asyncio.to_thread` offloads, and wrote the anchor (teeth verified red→green per clause). After review feedback it reproduced the `mkdtemp`-handoff cancellation leak, added the shield+reclaim guard and its regression, and verified the pre-existing scan-await window against `origin/main`. In a second review round it reproduced the repeated-cancellation leak in the reclaim path, moved reclaim into a drained task the caller cannot abandon, and added the double-cancel regression. I reviewed the change.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.


