### PR TITLE
fix(nginx): allow long chat prompts through /api/langgraph/ without a raw 500

### DIFF
--- a/backend/tests/test_nginx_langgraph_body_size.py
+++ b/backend/tests/test_nginx_langgraph_body_size.py
@@ -1,0 +1,130 @@
+"""Regression coverage for issue #3952: long chat prompts through nginx's
+``/api/langgraph/`` route failing with a raw HTTP 500 (or 413) before the
+request ever reaches Gateway's application-level error handling.
+
+Root cause (confirmed by a live nginx reproduction during triage, not just
+config reading): nginx's defaults are unfit for a text-chat proxy route.
+
+- ``client_max_body_size`` defaults to ``1m``, well under a long pasted
+  prompt -- nginx rejects anything larger with a 413 before the body is
+  even read.
+- ``proxy_request_buffering`` defaults to ``on``, which spools any request
+  body larger than the in-memory ``client_body_buffer_size`` (~16k) to a
+  temp file (``client_body_temp``, under the nginx ``-p`` prefix) before
+  proxying it upstream. On a non-root local run -- the common ``make dev``
+  case, and the same class of problem already documented elsewhere in these
+  same config files for *response* buffering -- that temp directory can be
+  unwritable, which makes nginx fail the request with a raw
+  "500 Internal Server Error" page and a "Permission denied" line in the
+  error log, matching the reporter's exact symptom (nginx error page, no
+  DeerFlow JSON/SSE error) and reproduced independently while diagnosing
+  this issue.
+
+The uploads location (``/api/threads/{id}/uploads``) already carries both
+settings for file uploads. This locks the same settings onto
+``/api/langgraph/`` for chat prompts, sized for text rather than binary
+uploads (see the range check below), across all three places this nginx
+config is maintained: the Docker production config, the local-dev config
+used by ``make dev``, and the Kubernetes/Helm ConfigMap template.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NGINX_CONFIGS = (
+    "docker/nginx/nginx.conf",
+    "docker/nginx/nginx.local.conf",
+    "deploy/helm/deer-flow/templates/configmap-nginx.yaml",
+)
+
+# Text prompts never carry binary file attachments (those go through the
+# dedicated uploads route), so the ceiling here is intentionally well below
+# the uploads route's 100M -- generous for even a very long pasted document,
+# while avoiding needlessly letting one chat request force Gateway to buffer
+# and JSON-parse an arbitrarily large body in memory.
+_MIN_EXPECTED_BODY_SIZE_BYTES = 5 * 1024 * 1024
+_MAX_EXPECTED_BODY_SIZE_BYTES = 100 * 1024 * 1024
+
+_SIZE_MULTIPLIERS = {"": 1, "k": 1024, "m": 1024**2, "g": 1024**3}
+
+
+def _read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def _extract_location_block(content: str, location_selector: str) -> str:
+    """Extract a single nginx ``location <location_selector> { ... }`` block
+    by brace-depth matching, so assertions target only that location and
+    can't be satisfied by a directive that merely appears elsewhere in the
+    file (e.g. the neighboring uploads location, which already has both
+    settings and must not make the langgraph-route assertions pass by
+    accident)."""
+    marker = re.compile(r"location\s+" + re.escape(location_selector) + r"\s*\{")
+    match = marker.search(content)
+    assert match, f"could not find `location {location_selector}` block"
+
+    start = match.end() - 1  # index of the opening brace
+    depth = 0
+    for i, ch in enumerate(content[start:], start=start):
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return content[start : i + 1]
+
+    raise AssertionError(f"unbalanced braces in `location {location_selector}` block")
+
+
+def _parse_body_size_bytes(block: str) -> int:
+    match = re.search(r"client_max_body_size\s+(\d+)\s*([mMkKgG]?)\s*;", block)
+    assert match, "client_max_body_size value not found or not parseable"
+    value, unit = match.groups()
+    return int(value) * _SIZE_MULTIPLIERS[unit.lower()]
+
+
+@pytest.mark.parametrize("path", NGINX_CONFIGS)
+def test_langgraph_route_disables_request_buffering(path):
+    content = _read(path)
+    block = _extract_location_block(content, "/api/langgraph/")
+
+    assert "proxy_request_buffering off;" in block, (
+        f"{path}: /api/langgraph/ does not disable request buffering, so nginx "
+        "spools long chat-prompt request bodies to a temp file before proxying "
+        "them to Gateway, which can 500 with a permission error on non-root "
+        "local runs -- see issue #3952"
+    )
+
+
+@pytest.mark.parametrize("path", NGINX_CONFIGS)
+def test_langgraph_route_raises_body_size_limit_for_text_prompts(path):
+    content = _read(path)
+    block = _extract_location_block(content, "/api/langgraph/")
+
+    size_bytes = _parse_body_size_bytes(block)
+
+    assert _MIN_EXPECTED_BODY_SIZE_BYTES <= size_bytes <= _MAX_EXPECTED_BODY_SIZE_BYTES, (
+        f"{path}: /api/langgraph/ client_max_body_size is {size_bytes} bytes, "
+        f"expected between {_MIN_EXPECTED_BODY_SIZE_BYTES} and "
+        f"{_MAX_EXPECTED_BODY_SIZE_BYTES} bytes -- comfortably above nginx's 1m "
+        "default (the actual bug) but below the uploads route's 100M, since "
+        "this route only ever carries JSON chat text, never binary files"
+    )
+
+
+@pytest.mark.parametrize("path", NGINX_CONFIGS)
+def test_uploads_route_still_has_its_own_body_size_settings(path):
+    """Non-regression guard: confirms the extraction helper is precise (the
+    uploads location has both directives with its own, larger value) and that
+    fixing the langgraph route does not accidentally touch the upload route's
+    existing configuration."""
+    content = _read(path)
+    block = _extract_location_block(content, r"~ ^/api/threads/[^/]+/uploads")
+
+    assert "client_max_body_size 100M;" in block
+    assert "proxy_request_buffering off;" in block

--- a/deploy/helm/deer-flow/templates/configmap-nginx.yaml
+++ b/deploy/helm/deer-flow/templates/configmap-nginx.yaml
@@ -74,6 +74,11 @@ data:
                 proxy_set_header X-Forwarded-Proto $forwarded_proto;
                 proxy_set_header Connection '';
                 proxy_set_header X-Accel-Buffering no;
+                # Long chat/text-prompt support (issue #3952): matches the
+                # uploads location's buffering fix below, sized for text
+                # prompts rather than binary file uploads.
+                client_max_body_size 20M;
+                proxy_request_buffering off;
                 proxy_connect_timeout 600s;
                 proxy_send_timeout 600s;
                 proxy_read_timeout 600s;

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -68,6 +68,17 @@ http {
             # SSE/Streaming support
             proxy_set_header X-Accel-Buffering no;
 
+            # Long chat/text-prompt support (issue #3952): a sufficiently long
+            # pasted prompt otherwise exceeds nginx's default 1m
+            # client_max_body_size, or gets spooled to a temp file via
+            # proxy_request_buffering before reaching Gateway -- on a non-root
+            # local run that temp directory may not be writable, producing a
+            # raw nginx 500 instead of a graceful application error. Mirrors
+            # the uploads location's fix below (same mechanism, sized for text
+            # prompts rather than binary file uploads).
+            client_max_body_size 20M;
+            proxy_request_buffering off;
+
             # Timeouts for long-running requests
             proxy_connect_timeout 600s;
             proxy_send_timeout 600s;

--- a/docker/nginx/nginx.local.conf
+++ b/docker/nginx/nginx.local.conf
@@ -57,6 +57,17 @@ http {
             proxy_cache off;
             proxy_set_header X-Accel-Buffering no;
 
+            # Long chat/text-prompt support (issue #3952): a sufficiently long
+            # pasted prompt otherwise exceeds nginx's default 1m
+            # client_max_body_size, or gets spooled to a temp file via
+            # proxy_request_buffering before reaching Gateway -- on a non-root
+            # local run that temp directory may not be writable, producing a
+            # raw nginx 500 instead of a graceful application error. Mirrors
+            # the uploads location's fix below (same mechanism, sized for text
+            # prompts rather than binary file uploads).
+            client_max_body_size 20M;
+            proxy_request_buffering off;
+
             # Timeouts for long-running requests
             proxy_connect_timeout 600s;
             proxy_send_timeout 600s;


### PR DESCRIPTION
Closes #3952

## Why

Issue #3952: a real user reported that a sufficiently long pasted chat prompt
fails with a raw `HTTP 500` — nginx's own generic error page
(`<center><h1>500 Internal Server Error</h1></center> ... nginx/1.28.3`), not
a DeerFlow JSON/SSE error. Short prompts in the same thread work fine; only
long pastes fail.

@fancyboi999 did the root-cause diagnostic legwork in the issue thread: nginx
already carries `client_max_body_size 100M` + `proxy_request_buffering off`
for the file-upload route, but the chat/`/api/langgraph/` route only has the
response-streaming settings — no body-size override and no request-buffering
override. The theory was that a long pasted prompt gets buffered/spooled by
local nginx before it reaches Gateway, and on a non-root local run that can
fail before DeerFlow's own error handling ever sees the request. The reporter
never came back with the requested nginx error-log lines, so this was still
unconfirmed as of this PR — I reproduced it independently before writing the
fix (see **Bug fix verification** below), and the theory holds up exactly as
described.

## What changed

`/api/langgraph/` (the chat/LangGraph API route proxied by nginx) now carries
the same `proxy_request_buffering off` plus a `client_max_body_size`
override that the upload route already has, in all three places this nginx
config is maintained:

- `docker/nginx/nginx.conf` (Docker production)
- `docker/nginx/nginx.local.conf` (local `make dev`, incl. the reporter's setup)
- `deploy/helm/deer-flow/templates/configmap-nginx.yaml` (Kubernetes/Helm)

Users can now paste/send long prompts through the chat route without hitting
a raw nginx 500 or 413. I intentionally used **20M** rather than the upload
route's 100M: this route only ever carries JSON chat text (file attachments
already go through the dedicated `/api/threads/{id}/uploads` route), so 20M
is comfortably above any realistic pasted document while staying well below
the ceiling meant for binary uploads — it avoids letting one chat request
force Gateway to buffer/parse an arbitrarily large JSON body in memory.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change** — nginx now accepts larger request bodies
      and streams them straight through (no disk buffering) on the chat
      route, for every deployment mode, with no opt-in required
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `backend/tests/test_nginx_langgraph_body_size.py` (parses all
  three nginx config files, extracts the `/api/langgraph/` location block by
  brace-depth matching so it can't be satisfied by the neighboring uploads
  location, and asserts `proxy_request_buffering off` plus a
  `client_max_body_size` in the expected 5M-100M range).
- Red on main / green on this branch: **yes**, verified directly — I
  extracted the pre-fix file content via `git show` and ran the test's
  helper functions against it: `proxy_request_buffering off` is absent and
  `client_max_body_size` parsing raises, exactly as the committed test
  expects when the fix is missing.
- This is a static config-content test (matching the existing pattern used
  by `test_gateway_runtime_cleanup.py` / `test_serve_nginx_stop.py` for this
  same nginx config), not a live HTTP integration test — CI doesn't bundle a
  real nginx + Gateway stack. To close that gap I did a **live functional
  reproduction** outside the automated suite, since the task called for
  confirming the theory rather than assuming it:
  - Compiled nginx **1.28.3 from source** (matching the reporter's exact
    `Server: nginx/1.28.3` version) in a native Linux filesystem (WSL2
    Ubuntu, not a Windows-mounted drive, so real POSIX permission semantics
    apply), using the repo's actual, byte-for-byte unmodified
    `docker/nginx/nginx.local.conf` and the same directory layout
    `scripts/nginx.sh` creates.
  - Stood up a stub upstream on `127.0.0.1:8001` standing in for Gateway.
  - Confirmed nginx's real default `client_body_temp_path` resolves to
    `client_body_temp` directly under the `-p` prefix (not the
    `temp/client_body_temp` that `scripts/nginx.sh` pre-creates — those
    directories aren't actually referenced by `nginx.local.conf` and go
    unused; nginx auto-creates its own default temp dirs at startup instead).
  - With that default directory made unwritable (simulating a non-root run
    where the process can't write there — the same class of problem this
    repo has already fixed for response buffering on the uploads and
    frontend routes), a mid-size request body (~160 KB — over nginx's
    ~16 KB in-memory buffer, under the 1M default limit) through the
    **unfixed** `/api/langgraph/` produced:
    - `HTTP status: 500`, with a response body **byte-for-byte identical**
      to the reporter's, including the nginx version string, and
    - an error log line matching exactly what @fancyboi999 asked the
      reporter for: `open() ".../client_body_temp/0000000002" failed
      (13: Permission denied)`.
  - The **already-fixed** uploads location handled the identical broken-
    permission condition and the same body with `HTTP 200`, since
    `proxy_request_buffering off` streams straight through without ever
    touching the temp directory — direct proof the existing upload-route
    fix is the right mechanism to mirror.
  - A larger 2.2 MB body against the unfixed route separately reproduced the
    default `client_max_body_size` limit as `HTTP 413` (a related but
    distinct failure mode from the same missing settings).
  - After patching `/api/langgraph/` with the same fix (tested against the
    actual worktree-edited file, not a hand copy), both the 500 (broken
    permissions + mid-size body) and the 413 (2.2 MB body) resolved to
    `HTTP 200`, with the responses correctly reaching the stub Gateway.
  - `nginx.conf` (the Docker/production variant) was syntax-validated with
    `nginx -t` (parses cleanly with the same inserted directives); its
    `/dev/stdout` logging target isn't writable outside an actual Docker
    container regardless of this change — confirmed by reproducing the same
    `[emerg] open() "/dev/stdout" failed` on the untouched original file, so
    it's a pre-existing artifact of testing a Docker-oriented config outside
    Docker, unrelated to this fix. The functional (not just syntax) live
    reproduction above used `nginx.local.conf`, since that's the config
    implicated by the reporter's own setup (`make dev`).

## Validation

```
cd backend
uv run ruff format --check tests/test_nginx_langgraph_body_size.py   # already formatted
uv run ruff check tests/test_nginx_langgraph_body_size.py            # all checks passed
PYTHONPATH=. uv run pytest tests/test_nginx_langgraph_body_size.py tests/test_gateway_runtime_cleanup.py tests/test_serve_nginx_stop.py -v
  # this branch:            25 passed, 1 failed
  # unmodified main (same two pre-existing files; the new test file doesn't
  # exist there so it was run from a temporary copy to confirm red-on-main,
  # then removed):          16 passed, 1 failed (+ the new file: 6 failed /
  # 3 passed, i.e. red exactly on the assertions this fix addresses)
  # The one failure is IDENTICAL on both sides -- test_serve_nginx_stop.py::
  # test_repo_nginx_pid_accepts_macos_rewritten_master_command, a pre-existing
  # macOS-argv-vs-Windows-path test artifact of the local dev machine, unrelated
  # to this change. CI (.github/workflows/backend-unit-tests.yml) runs on
  # ubuntu-latest, where this doesn't apply.
```
