### PR TITLE
fix(uploads): claim the converted markdown filename before writing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,13 @@ This section accumulates work toward the **2.1.0** milestone
   blocking filesystem IO in artifact serving, gateway uploads, and the Discord
   channel; limit the uploaded-file context manifest; and live-tail malformed
   Redis reconnect ids. ([#3651], [#3551], [#3935], [#3927], [#3917], [#4012])
+- **uploads:** Claim the converted-Markdown companion filename before writing
+  it, so two convertible uploads sharing a stem (or a convertible plus a
+  same-stem `.md` upload) no longer silently clobber each other within one
+  request. When `uploads.auto_convert_documents` is on, the companion `.md` now
+  gets a unique name (e.g. `a_1.md`); `POST /threads/{id}/uploads` and
+  `DeerFlowClient.upload_files` both report the actual name in `markdown_file`.
+  ([#4288])
 - **config:** Coerce null object config sections to their defaults; honor the
   unified database configuration in the store and sync checkpointer; and have
   legacy DB backfill create missing `Index` objects on existing tables. ([#3573],
@@ -1087,3 +1094,4 @@ with **180 merged pull requests** since the first 2.0 milestone tag.
 [#4246]: https://github.com/bytedance/deer-flow/pull/4246
 [#4251]: https://github.com/bytedance/deer-flow/pull/4251
 [#4264]: https://github.com/bytedance/deer-flow/pull/4264
+[#4288]: https://github.com/bytedance/deer-flow/pull/4288

--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -379,7 +379,13 @@ async def upload_files(
 
             file_ext = file_path.suffix.lower()
             if auto_convert_documents and file_ext in CONVERTIBLE_EXTENSIONS:
-                md_path = await convert_file_to_markdown(file_path)
+                # Reserve the companion .md name in this request's seen set
+                # before writing so conversion cannot silently truncate another
+                # uploaded or derived file (same invariant as form-part dedupe).
+                provisional_md_name = Path(safe_filename).with_suffix(".md").name
+                unique_md_name = claim_unique_filename(provisional_md_name, seen_filenames)
+                md_output = file_path.with_name(unique_md_name)
+                md_path = await convert_file_to_markdown(file_path, output_path=md_output)
                 if md_path:
                     written_paths.append(md_path)
                     md_virtual_path = upload_virtual_path(md_path.name)

--- a/backend/app/gateway/routers/uploads.py
+++ b/backend/app/gateway/routers/uploads.py
@@ -397,6 +397,11 @@ async def upload_files(
                     file_info["markdown_path"] = str(sandbox_uploads / md_path.name)
                     file_info["markdown_virtual_path"] = md_virtual_path
                     file_info["markdown_artifact_url"] = upload_artifact_url(thread_id, md_path.name)
+                else:
+                    # Conversion failed and wrote nothing, so release the claim;
+                    # holding it would rename a later same-stem upload against
+                    # a name nothing occupies.
+                    seen_filenames.discard(unique_md_name)
 
             uploaded_files.append(file_info)
 

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -1455,6 +1455,11 @@ class DeerFlowClient:
                         info["markdown_path"] = str(uploads_dir / md_path.name)
                         info["markdown_virtual_path"] = upload_virtual_path(md_path.name)
                         info["markdown_artifact_url"] = upload_artifact_url(thread_id, md_path.name)
+                    else:
+                        # Conversion failed and wrote nothing, so release the
+                        # claim; holding it would rename a later same-stem
+                        # upload against a name nothing occupies.
+                        seen_names.discard(unique_md_name)
 
                 uploaded_files.append(info)
         finally:

--- a/backend/packages/harness/deerflow/client.py
+++ b/backend/packages/harness/deerflow/client.py
@@ -1412,8 +1412,8 @@ class DeerFlowClient:
                 # creating a new ThreadPoolExecutor per converted file.
                 conversion_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
-        def _convert_in_thread(path: Path):
-            return asyncio.run(convert_file_to_markdown(path))
+        def _convert_in_thread(path: Path, output_path: Path | None = None):
+            return asyncio.run(convert_file_to_markdown(path, output_path=output_path))
 
         try:
             for src_path, dest_name in resolved_files:
@@ -1431,11 +1431,17 @@ class DeerFlowClient:
                     info["original_filename"] = src_path.name
 
                 if src_path.suffix.lower() in CONVERTIBLE_EXTENSIONS:
+                    # Reserve companion .md name before convert so two stems
+                    # that collapse to the same .md (or a prior .md upload)
+                    # cannot silently overwrite each other.
+                    provisional_md_name = Path(dest_name).with_suffix(".md").name
+                    unique_md_name = claim_unique_filename(provisional_md_name, seen_names)
+                    md_output = dest.with_name(unique_md_name)
                     try:
                         if conversion_pool is not None:
-                            md_path = conversion_pool.submit(_convert_in_thread, dest).result()
+                            md_path = conversion_pool.submit(_convert_in_thread, dest, md_output).result()
                         else:
-                            md_path = asyncio.run(convert_file_to_markdown(dest))
+                            md_path = asyncio.run(convert_file_to_markdown(dest, output_path=md_output))
                     except Exception:
                         logger.warning(
                             "Failed to convert %s to markdown",

--- a/backend/packages/harness/deerflow/utils/file_conversion.py
+++ b/backend/packages/harness/deerflow/utils/file_conversion.py
@@ -135,7 +135,7 @@ def _do_convert(file_path: Path, pdf_converter: str) -> str:
     return _convert_with_markitdown(file_path)
 
 
-async def convert_file_to_markdown(file_path: Path) -> Path | None:
+async def convert_file_to_markdown(file_path: Path, output_path: Path | None = None) -> Path | None:
     """Convert a supported document file to Markdown.
 
     PDF files are handled with a two-converter strategy (see module docstring).
@@ -144,6 +144,10 @@ async def convert_file_to_markdown(file_path: Path) -> Path | None:
 
     Args:
         file_path: Path to the file to convert.
+        output_path: Optional destination for the generated ``.md`` file.
+            When omitted, writes to ``file_path`` with a ``.md`` suffix.
+            Callers that track per-request filename uniqueness should pass a
+            pre-claimed path so companion markdown cannot clobber other uploads.
 
     Returns:
         Path to the generated .md file, or None if conversion failed.
@@ -157,7 +161,7 @@ async def convert_file_to_markdown(file_path: Path) -> Path | None:
         else:
             text = _do_convert(file_path, pdf_converter)
 
-        md_path = file_path.with_suffix(".md")
+        md_path = output_path if output_path is not None else file_path.with_suffix(".md")
         md_path.write_text(text, encoding="utf-8")
 
         logger.info("Converted %s to markdown: %s (%d chars)", file_path.name, md_path.name, len(text))

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1830,6 +1830,44 @@ class TestUploads:
             assert (uploads_dir / "a.md").read_text(encoding="utf-8") == "FROM:a.docx"
             assert (uploads_dir / "a_1.md").read_text(encoding="utf-8") == "FROM:a.pdf"
 
+    def test_upload_files_failed_conversion_releases_the_claimed_markdown_name(self, client):
+        """A conversion that writes nothing must not reserve stem.md against a later companion.
+
+        Destination names are claimed upfront, so a same-stem ``.md`` upload
+        always wins ``a.md``; the only reachable victim of a stale claim is the
+        next convertible's companion.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            uploads_dir = tmp_path / "uploads"
+            uploads_dir.mkdir()
+
+            docx = tmp_path / "a.docx"
+            pdf = tmp_path / "a.pdf"
+            docx.write_bytes(b"DOCX")
+            pdf.write_bytes(b"PDF")
+
+            async def convert_failing_on_docx(path: Path, output_path: Path | None = None) -> Path | None:
+                if path.suffix.lower() == ".docx":
+                    return None
+                md_path = output_path if output_path is not None else path.with_suffix(".md")
+                md_path.write_text(f"FROM:{path.name}", encoding="utf-8")
+                return md_path
+
+            with (
+                patch("deerflow.client.get_uploads_dir", return_value=uploads_dir),
+                patch("deerflow.client.ensure_uploads_dir", return_value=uploads_dir),
+                patch("deerflow.utils.file_conversion.CONVERTIBLE_EXTENSIONS", {".docx", ".pdf"}),
+                patch("deerflow.utils.file_conversion.convert_file_to_markdown", side_effect=convert_failing_on_docx),
+            ):
+                result = client.upload_files("thread-1", [docx, pdf])
+
+            assert result["success"] is True
+            assert result["files"][0].get("markdown_file") is None
+            assert result["files"][1]["markdown_file"] == "a.md"
+            assert (uploads_dir / "a.md").read_text(encoding="utf-8") == "FROM:a.pdf"
+            assert not (uploads_dir / "a_1.md").exists()
+
     def test_list_uploads(self, client):
         with tempfile.TemporaryDirectory() as tmp:
             uploads_dir = Path(tmp)

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1760,8 +1760,8 @@ class TestUploads:
             created_executors = []
             real_executor_cls = concurrent.futures.ThreadPoolExecutor
 
-            async def fake_convert(path: Path) -> Path:
-                md_path = path.with_suffix(".md")
+            async def fake_convert(path: Path, output_path: Path | None = None) -> Path:
+                md_path = output_path if output_path is not None else path.with_suffix(".md")
                 md_path.write_text(f"converted {path.name}")
                 return md_path
 
@@ -1798,6 +1798,37 @@ class TestUploads:
             assert created_executors[0].shutdown_calls == [True]
             assert result["files"][0]["markdown_file"] == "first.md"
             assert result["files"][1]["markdown_file"] == "second.md"
+
+    def test_upload_files_converted_markdown_uses_unique_names_on_stem_collision(self, client):
+        """Companion .md from convert must not clobber another same-stem companion."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            uploads_dir = tmp_path / "uploads"
+            uploads_dir.mkdir()
+
+            docx = tmp_path / "a.docx"
+            pdf = tmp_path / "a.pdf"
+            docx.write_bytes(b"DOCX")
+            pdf.write_bytes(b"PDF")
+
+            async def fake_convert(path: Path, output_path: Path | None = None) -> Path:
+                md_path = output_path if output_path is not None else path.with_suffix(".md")
+                md_path.write_text(f"FROM:{path.name}", encoding="utf-8")
+                return md_path
+
+            with (
+                patch("deerflow.client.get_uploads_dir", return_value=uploads_dir),
+                patch("deerflow.client.ensure_uploads_dir", return_value=uploads_dir),
+                patch("deerflow.utils.file_conversion.CONVERTIBLE_EXTENSIONS", {".docx", ".pdf"}),
+                patch("deerflow.utils.file_conversion.convert_file_to_markdown", side_effect=fake_convert),
+            ):
+                result = client.upload_files("thread-1", [docx, pdf])
+
+            assert result["success"] is True
+            assert result["files"][0]["markdown_file"] == "a.md"
+            assert result["files"][1]["markdown_file"] == "a_1.md"
+            assert (uploads_dir / "a.md").read_text(encoding="utf-8") == "FROM:a.docx"
+            assert (uploads_dir / "a_1.md").read_text(encoding="utf-8") == "FROM:a.pdf"
 
     def test_list_uploads(self, client):
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -951,3 +951,75 @@ def test_upload_files_user_markdown_after_convertible_is_renamed_not_overwritten
     assert result.files[1].original_filename == "notes.md"
     assert (thread_uploads_dir / "notes.md").read_text(encoding="utf-8") == "FROM_DOCX"
     assert (thread_uploads_dir / "notes_1.md").read_bytes() == b"USER_MARKDOWN"
+
+
+def test_upload_files_failed_conversion_releases_the_claimed_markdown_name(tmp_path):
+    """A conversion that writes nothing must not reserve stem.md against later uploads."""
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=_mounted_provider()),
+        patch.object(uploads, "_auto_convert_documents_enabled", return_value=True),
+        patch.object(uploads, "convert_file_to_markdown", AsyncMock(return_value=None)),
+    ):
+        result = asyncio.run(
+            call_unwrapped(
+                uploads.upload_files,
+                "thread-local",
+                request=MagicMock(),
+                files=[
+                    UploadFile(filename="notes.docx", file=BytesIO(b"DOCX")),
+                    UploadFile(filename="notes.md", file=BytesIO(b"USER_MARKDOWN")),
+                ],
+                config=SimpleNamespace(),
+            )
+        )
+
+    assert result.success is True
+    assert result.files[0].markdown_file is None
+    assert result.files[1].filename == "notes.md"
+    assert result.files[1].original_filename is None
+    assert (thread_uploads_dir / "notes.md").read_bytes() == b"USER_MARKDOWN"
+    assert not (thread_uploads_dir / "notes_1.md").exists()
+
+
+def test_upload_files_failed_conversion_does_not_push_the_next_companion_to_suffix(tmp_path):
+    """The second victim of a stale claim: a later convertible's companion."""
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+
+    async def convert_failing_on_docx(file_path: Path, output_path: Path | None = None) -> Path | None:
+        if file_path.suffix.lower() == ".docx":
+            return None
+        md_path = output_path if output_path is not None else file_path.with_suffix(".md")
+        md_path.write_text(f"FROM:{file_path.name}", encoding="utf-8")
+        return md_path
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=_mounted_provider()),
+        patch.object(uploads, "_auto_convert_documents_enabled", return_value=True),
+        patch.object(uploads, "convert_file_to_markdown", AsyncMock(side_effect=convert_failing_on_docx)),
+    ):
+        result = asyncio.run(
+            call_unwrapped(
+                uploads.upload_files,
+                "thread-local",
+                request=MagicMock(),
+                files=[
+                    UploadFile(filename="notes.docx", file=BytesIO(b"DOCX")),
+                    UploadFile(filename="notes.pdf", file=BytesIO(b"PDF")),
+                ],
+                config=SimpleNamespace(),
+            )
+        )
+
+    assert result.success is True
+    assert result.files[0].markdown_file is None
+    assert result.files[1].markdown_file == "notes.md"
+    assert (thread_uploads_dir / "notes.md").read_text(encoding="utf-8") == "FROM:notes.pdf"
+    assert not (thread_uploads_dir / "notes_1.md").exists()

--- a/backend/tests/test_uploads_router.py
+++ b/backend/tests/test_uploads_router.py
@@ -192,8 +192,8 @@ def test_upload_files_syncs_non_local_sandbox_and_marks_markdown_file(tmp_path):
     sandbox = MagicMock()
     provider.get.return_value = sandbox
 
-    async def fake_convert(file_path: Path) -> Path:
-        md_path = file_path.with_suffix(".md")
+    async def fake_convert(file_path: Path, output_path: Path | None = None) -> Path:
+        md_path = output_path if output_path is not None else file_path.with_suffix(".md")
         md_path.write_text("converted", encoding="utf-8")
         return md_path
 
@@ -231,8 +231,8 @@ def test_upload_files_makes_non_local_files_sandbox_writable(tmp_path):
     sandbox = MagicMock()
     provider.get.return_value = sandbox
 
-    async def fake_convert(file_path: Path) -> Path:
-        md_path = file_path.with_suffix(".md")
+    async def fake_convert(file_path: Path, output_path: Path | None = None) -> Path:
+        md_path = output_path if output_path is not None else file_path.with_suffix(".md")
         md_path.write_text("converted", encoding="utf-8")
         return md_path
 
@@ -815,3 +815,139 @@ def test_upload_files_uses_configured_file_count_limit(tmp_path):
             asyncio.run(call_unwrapped(uploads.upload_files, "thread-local", request=MagicMock(), files=files, config=cfg))
 
     assert exc_info.value.status_code == 413
+
+
+def _fake_convert_honoring_output_path(content_by_source: dict[str, str] | None = None):
+    """Mimic convert_file_to_markdown, including optional output_path."""
+
+    async def fake_convert(file_path: Path, output_path: Path | None = None) -> Path:
+        md_path = output_path if output_path is not None else file_path.with_suffix(".md")
+        if content_by_source is not None and file_path.name in content_by_source:
+            text = content_by_source[file_path.name]
+        else:
+            text = f"converted-from:{file_path.name}"
+        md_path.write_text(text, encoding="utf-8")
+        return md_path
+
+    return fake_convert
+
+
+def test_upload_files_converted_markdown_does_not_overwrite_user_markdown(tmp_path):
+    """Companion .md from auto-convert must not clobber a same-request .md upload.
+
+    Declared invariant (upload_files): filenames within one request must not
+    silently truncate each other. convert_file_to_markdown used to write
+    stem.md unconditionally, bypassing claim_unique_filename.
+    """
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=_mounted_provider()),
+        patch.object(uploads, "_auto_convert_documents_enabled", return_value=True),
+        patch.object(
+            uploads,
+            "convert_file_to_markdown",
+            AsyncMock(side_effect=_fake_convert_honoring_output_path({"notes.docx": "FROM_DOCX"})),
+        ),
+    ):
+        result = asyncio.run(
+            call_unwrapped(
+                uploads.upload_files,
+                "thread-local",
+                request=MagicMock(),
+                files=[
+                    UploadFile(filename="notes.md", file=BytesIO(b"USER_MARKDOWN")),
+                    UploadFile(filename="notes.docx", file=BytesIO(b"DOCX")),
+                ],
+                config=SimpleNamespace(),
+            )
+        )
+
+    assert result.success is True
+    assert [f.filename for f in result.files] == ["notes.md", "notes.docx"]
+    # User upload preserved
+    assert (thread_uploads_dir / "notes.md").read_bytes() == b"USER_MARKDOWN"
+    # Converted companion got a unique name instead of overwriting
+    assert result.files[1].markdown_file == "notes_1.md"
+    assert (thread_uploads_dir / "notes_1.md").read_text(encoding="utf-8") == "FROM_DOCX"
+    assert not (thread_uploads_dir / "notes.md").read_text(encoding="utf-8") == "FROM_DOCX"
+
+
+def test_upload_files_two_convertibles_get_distinct_markdown_companions(tmp_path):
+    """Two convertible files sharing a stem must not share one .md path."""
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=_mounted_provider()),
+        patch.object(uploads, "_auto_convert_documents_enabled", return_value=True),
+        patch.object(
+            uploads,
+            "convert_file_to_markdown",
+            AsyncMock(side_effect=_fake_convert_honoring_output_path({"a.docx": "FROM_DOCX", "a.pdf": "FROM_PDF"})),
+        ),
+    ):
+        result = asyncio.run(
+            call_unwrapped(
+                uploads.upload_files,
+                "thread-local",
+                request=MagicMock(),
+                files=[
+                    UploadFile(filename="a.docx", file=BytesIO(b"DOCX")),
+                    UploadFile(filename="a.pdf", file=BytesIO(b"PDF")),
+                ],
+                config=SimpleNamespace(),
+            )
+        )
+
+    assert result.success is True
+    assert result.files[0].markdown_file == "a.md"
+    assert result.files[1].markdown_file == "a_1.md"
+    assert (thread_uploads_dir / "a.md").read_text(encoding="utf-8") == "FROM_DOCX"
+    assert (thread_uploads_dir / "a_1.md").read_text(encoding="utf-8") == "FROM_PDF"
+    # Each response entry points at content that belongs to that source
+    assert (thread_uploads_dir / result.files[0].markdown_file).read_text(encoding="utf-8") == "FROM_DOCX"
+    assert (thread_uploads_dir / result.files[1].markdown_file).read_text(encoding="utf-8") == "FROM_PDF"
+
+
+def test_upload_files_user_markdown_after_convertible_is_renamed_not_overwritten(tmp_path):
+    """If convert claims stem.md first, a later same-request .md is renamed."""
+    thread_uploads_dir = tmp_path / "uploads"
+    thread_uploads_dir.mkdir(parents=True)
+
+    with (
+        patch.object(uploads, "get_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "ensure_uploads_dir", return_value=thread_uploads_dir),
+        patch.object(uploads, "get_sandbox_provider", return_value=_mounted_provider()),
+        patch.object(uploads, "_auto_convert_documents_enabled", return_value=True),
+        patch.object(
+            uploads,
+            "convert_file_to_markdown",
+            AsyncMock(side_effect=_fake_convert_honoring_output_path({"notes.docx": "FROM_DOCX"})),
+        ),
+    ):
+        result = asyncio.run(
+            call_unwrapped(
+                uploads.upload_files,
+                "thread-local",
+                request=MagicMock(),
+                files=[
+                    UploadFile(filename="notes.docx", file=BytesIO(b"DOCX")),
+                    UploadFile(filename="notes.md", file=BytesIO(b"USER_MARKDOWN")),
+                ],
+                config=SimpleNamespace(),
+            )
+        )
+
+    assert result.success is True
+    assert result.files[0].filename == "notes.docx"
+    assert result.files[0].markdown_file == "notes.md"
+    assert result.files[1].filename == "notes_1.md"
+    assert result.files[1].original_filename == "notes.md"
+    assert (thread_uploads_dir / "notes.md").read_text(encoding="utf-8") == "FROM_DOCX"
+    assert (thread_uploads_dir / "notes_1.md").read_bytes() == b"USER_MARKDOWN"


### PR DESCRIPTION
## Why

Uploads already guarantee that files in one request cannot silently destroy each other.
#2789 introduced that guarantee, and its comment still states it:

> Track filenames within this request so duplicate form parts do not silently truncate
> each other. Existing uploads keep the historical overwrite behavior for a single
> replacement upload.
> — `app/gateway/routers/uploads.py`

Every uploaded form part goes through `claim_unique_filename(...)`, which renames on
collision and records the name in `seen_filenames`.

The companion Markdown produced by auto-conversion does not. `convert_file_to_markdown`
writes to `file_path.with_suffix(".md")` unconditionally, and that name is neither claimed
nor recorded. Auto-conversion (#1727) predates the guarantee (#2789), so this path was
simply never brought under it.

Within a single upload request that means real, silent data loss:

- `notes.md` + `notes.docx` → converting the `.docx` overwrites the user's own `notes.md`.
- `a.docx` + `a.pdf` → both convert to `a.md`; the second silently replaces the first.
- `a.docx` + `a.md` (in that order) → the uploaded `a.md` overwrites the companion the
  response is still pointing at.

In each case the API response happily reports `markdown_file: "a.md"` for a document
whose conversion output is no longer there, and `written_paths` can contain the same
path twice.

Severity, stated honestly: `uploads.auto_convert_documents` is **off by default**
(#2332 made host-side conversion explicit opt-in), so only deployments that turned it on
are affected. The consequence for those deployments is lost file content with no error,
which is why this is worth fixing rather than documenting.

## What changed

Both call sites now claim the companion name **before** conversion writes it, using the
same `claim_unique_filename` / `seen` bookkeeping as the uploaded parts:

- `app/gateway/routers/uploads.py` — the gateway upload endpoint.
- `packages/harness/deerflow/client.py::DeerFlowClient.upload_files` — the SDK path, which
  has the identical concept (`claim_unique_filename` over `seen_names`) and the identical gap.

To let a caller say where the Markdown goes, `convert_file_to_markdown` takes an optional
`output_path`. When it is omitted the behavior is exactly as before
(`file_path.with_suffix(".md")`), so no other caller changes.

I kept the parameter rather than converting first and renaming afterwards: renaming after
the fact still lets the write land on the victim's path, so the clobber would happen and
then be papered over. Reserving the name up front is what makes the guarantee hold.

Out of scope, deliberately: cross-request overwrites. The comment above declares those
intentional ("Existing uploads keep the historical overwrite behavior"), and this change
does not touch them.

## Surface area

- [ ] **Frontend UI**
- [x] **Backend API** — `POST /threads/{id}/uploads` may now report `markdown_file: "a_1.md"`
      where it previously reported `a.md` and silently lost one of the two files.
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change** — `uploads.auto_convert_documents` is off by default;
      deployments that have not enabled it are unaffected.
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test paths that reproduce the bug:
  - `backend/tests/test_uploads_router.py::test_upload_files_converted_markdown_does_not_overwrite_user_markdown`
  - `backend/tests/test_uploads_router.py::test_upload_files_two_convertibles_get_distinct_markdown_companions`
  - `backend/tests/test_uploads_router.py::test_upload_files_user_markdown_after_convertible_is_renamed_not_overwritten`
  - `backend/tests/test_client.py::TestUploads::test_upload_files_converted_markdown_uses_unique_names_on_stem_collision`
- Did they go red on `main` and green on this branch? **yes** — verified by restoring only
  the three source files to `origin/main` (tests untouched) and running each test
  individually. They drive the real upload path with real files on disk and assert the
  victim's content survives, not just that the names differ.
- The two call sites are anchored separately: restoring only `routers/uploads.py` reds the
  three router tests and leaves the client test green; restoring only `client.py` reds the
  client test and leaves the router tests green. Neither site is covered only by the other.

## Validation

```
cd backend
PYTHONPATH=. uv run pytest tests/test_uploads_router.py tests/test_client.py -q  # 190 passed
PYTHONPATH=. uv run pytest tests/ -q                    # 8 failed, 7828 passed, 28 skipped
uvx ruff check . && uvx ruff format --check .           # clean
```

The 8 failures are pre-existing on `origin/main` (the `web_fetch` suites refuse
private-network addresses in this environment); the failure set is byte-for-byte identical
before and after this change, so this branch adds none.

## AI assistance

**Tool(s) used:** Grok (xAI, headless agent) and Claude Code.

**How you used it:** Grok ran the investigation and produced the change in an isolated
worktree — the sibling-site enumeration that found the SDK path, the failing tests, and the
fix. Claude Code was then used to review it: I re-ran the red check myself with the sources
rolled back to `origin/main`, re-ran the per-call-site isolation checks, re-ran the full
suite against a clean baseline, and checked the history (#1727 / #2332 / #2789) rather than
taking the tool's framing. Neither tool committed or pushed.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
