### PR TITLE
fix(config): normalize the postgres:// short scheme for the async ORM engine

### DIFF
--- a/backend/packages/harness/deerflow/config/database_config.py
+++ b/backend/packages/harness/deerflow/config/database_config.py
@@ -98,5 +98,8 @@ class DatabaseConfig(BaseModel):
             url = self.postgres_url
             if url.startswith("postgresql://"):
                 url = url.replace("postgresql://", "postgresql+asyncpg://", 1)
+            elif url.startswith("postgres://"):
+                # libpq's short alias: accepted by the psycopg checkpointer, but not a SQLAlchemy dialect.
+                url = url.replace("postgres://", "postgresql+asyncpg://", 1)
             return url
         raise ValueError(f"No SQLAlchemy URL for backend={self.backend!r}")

--- a/backend/tests/test_persistence_scaffold.py
+++ b/backend/tests/test_persistence_scaffold.py
@@ -49,6 +49,15 @@ class TestDatabaseConfig:
         assert url.startswith("postgresql+asyncpg://")
         assert "u:p@h:5432/db" in url
 
+    def test_app_sqlalchemy_url_postgres_short_scheme(self):
+        c = DatabaseConfig(
+            backend="postgres",
+            postgres_url="postgres://u:p@h:5432/db",
+        )
+        url = c.app_sqlalchemy_url
+        assert url.startswith("postgresql+asyncpg://")
+        assert "u:p@h:5432/db" in url
+
     def test_app_sqlalchemy_url_postgres_already_asyncpg(self):
         c = DatabaseConfig(
             backend="postgres",


### PR DESCRIPTION
## Why

`DatabaseConfig.app_sqlalchemy_url` normalizes `postgresql://` to
`postgresql+asyncpg://` but leaves libpq's `postgres://` short alias untouched.
That URL reaches `create_async_engine` verbatim and raises
`NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres` (SQLAlchemy
dropped the `postgres` dialect alias in 2.0), so the application ORM engine fails
to start.

The same `database.postgres_url` is consumed in two places that disagree about
that scheme, which is what makes this a partial, backend-only failure rather than
a clean config error:

- the checkpointer and store pass the raw URL to psycopg
  (`runtime/checkpointer/provider.py`, `runtime/store/provider.py`), and psycopg's
  `conninfo_to_dict` accepts `postgres://` and `postgresql://` identically — so
  the checkpointer comes up fine;
- the ORM engine goes through `app_sqlalchemy_url` (`persistence/engine.py`) and
  crashes.

`postgres://` is a legal libpq URI scheme, not a typo, and is the form
`$DATABASE_URL` commonly takes on managed Postgres providers (Heroku, Render,
Supabase, Fly) — which is exactly what the module docstring recommends
configuring (`postgres_url: $DATABASE_URL`). The `postgres_url` field docstring
already promises the fix's behavior: "the +asyncpg driver suffix is added
automatically where needed".

## What changed

A `database.backend: postgres` config whose `postgres_url` uses the `postgres://`
short scheme now brings the async ORM engine up instead of crashing on startup;
it is rewritten to `postgresql+asyncpg://`, the same normalization already applied
to `postgresql://`. No config or API shape changes; URLs that already use
`postgresql://` or `postgresql+asyncpg://` are unaffected.

## Surface area

- [x] **Backend API** — persistence/config layer: `app_sqlalchemy_url` in `backend/packages/harness/deerflow/config/database_config.py`, consumed by the async ORM engine startup

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_persistence_scaffold.py::TestDatabaseConfig::test_app_sqlalchemy_url_postgres_short_scheme`
- Did it go red on `main` and green on this branch? **yes** — on `main`, `DatabaseConfig(backend="postgres", postgres_url="postgres://u:p@h:5432/db").app_sqlalchemy_url` returns `postgres://u:p@h:5432/db`, and feeding that to `create_async_engine` raises `NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres`; the new test's `startswith("postgresql+asyncpg://")` assertion fails. With the fix it returns `postgresql+asyncpg://u:p@h:5432/db` and the test passes. The existing tests covered `postgresql://` and `postgresql+asyncpg://` but not the short scheme.

## Validation

```
cd backend
PYTHONPATH=packages/harness:. .venv/bin/pytest tests/test_persistence_scaffold.py tests/test_checkpointer.py tests/test_persistence_bootstrap.py
# 107 passed, 1 failed
```

The single failure is `test_persistence_bootstrap.py::test_create_all_and_alembic_upgrade_produce_same_schema`; it also fails on a clean `main` with the identical batch command (106 passed there vs 107 here — the difference is exactly the new test), i.e. it is a pre-existing batch-level failure unrelated to this change. `ruff check` and `ruff format --check` are clean on both changed files.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** This PR was authored by an AI coding agent (Claude Code) running on this account — the AI found the bug, ran the repro on `main`, wrote the failing regression test first (red → green), traced the two consumers of `postgres_url` (the psycopg checkpointer/store vs. the SQLAlchemy ORM engine), and wrote this description. The verification above is real and re-runnable from the diff. The human account holder reviews every change and is accountable for it. If this isn't the kind of contribution you want, say so and I'll close it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
