### PR TITLE
fix(workspace-changes): count diff body lines starting with "-- "/"++ "

### DIFF
--- a/backend/packages/harness/deerflow/workspace_changes/diff.py
+++ b/backend/packages/harness/deerflow/workspace_changes/diff.py
@@ -183,12 +183,12 @@ def _snapshot_text(file: FileSnapshot | None) -> str | None:
 def _count_diff_lines(lines: list[str]) -> tuple[int, int]:
     additions = 0
     deletions = 0
-    for line in lines:
-        # Unified-diff file headers are "+++ " / "--- " with a trailing space;
-        # a bare "+++"/"---" prefix would also swallow real content lines whose
-        # text begins with those sequences (e.g. an added line "+++foo").
-        if line.startswith("+++ ") or line.startswith("--- "):
-            continue
+    # difflib.unified_diff always emits the two file headers ("--- a/…" then
+    # "+++ b/…") first; skip them by position. A prefix test can't tell them
+    # apart from a hunk-body line whose content starts with "-- "/"++ " (e.g. a
+    # deleted SQL comment "-- get users" becomes the diff line "--- get users"),
+    # which would then be dropped from the count.
+    for line in lines[2:]:
         if line.startswith("+"):
             additions += 1
         elif line.startswith("-"):

--- a/backend/tests/test_workspace_changes.py
+++ b/backend/tests/test_workspace_changes.py
@@ -182,6 +182,33 @@ def test_count_diff_lines_ignores_only_real_headers():
     assert deletions == 2
 
 
+def test_count_diff_lines_counts_content_starting_with_dashes_or_pluses():
+    """Hunk-body lines whose content starts with '-- '/'++ ' must be counted.
+
+    difflib prefixes a deleted line "-- get users" to "--- get users"; the old
+    prefix skip mistook that for a file header and dropped it, undercounting
+    deletions in the user-visible +N/-M summary.
+    """
+    import difflib
+
+    from deerflow.workspace_changes.diff import _count_diff_lines
+
+    lines = list(
+        difflib.unified_diff(
+            ["SELECT 1", "-- get users"],
+            ["SELECT 1", "SELECT 2"],
+            fromfile="a/x.sql",
+            tofile="b/x.sql",
+            lineterm="",
+        )
+    )
+
+    additions, deletions = _count_diff_lines(lines)
+
+    assert additions == 1
+    assert deletions == 1
+
+
 def test_scan_workspace_roots_skips_excluded_directories(tmp_path):
     roots = _roots(tmp_path)
     workspace = roots[0].host_path


### PR DESCRIPTION
## Why

The workspace-change summary (`+N -M`) under-counts edits to files whose lines start with `-- ` or `++ ` — SQL files are the common case (`-- comment`). `_count_diff_lines` drops difflib's two file headers by skipping any line starting with `+++ `/`--- `, but a deleted body line `-- get users` becomes the diff line `--- get users` (and an added `++ x` becomes `+++ x`), so those real edits get dropped from the count too. The existing comment already anticipated the `+++foo` (no-space) form and switched to a trailing-space prefix — but that left the with-space form (`-- `/`++ `) broken.

## What changed

The `+N -M` change summary now counts deletions/additions of lines that start with `-- ` or `++ ` (e.g. SQL comments). No change for any diff that didn't contain such lines.

## Surface area

- [x] **Backend API** — the counts feed `WorkspaceChangeSummary` / `WorkspaceFileChange` and the run-event summary string
- [ ] **Default behavior change** — only the previously-miscounted case changes

## Bug fix verification

- Test path: `backend/tests/test_workspace_changes.py::test_count_diff_lines_counts_content_starting_with_dashes_or_pluses`
- Red on `main`, green on this branch? **yes** — deleting `-- get users` and adding `SELECT 2` counts `+1 -0` before (the deletion is dropped) and `+1 -1` after. The existing `test_count_diff_lines_ignores_only_real_headers` still passes (its `+++added`/`---removed` body lines are counted, real headers are the first two lines).

Fix: `difflib.unified_diff` always emits the two file headers first, so skip them by position (`lines[2:]`) rather than by prefix. `@@` hunk headers start with `@` and remain uncounted.

## Validation

- `python -m pytest tests/test_workspace_changes.py -k count_diff_lines` → **2 passed**.
- `ruff check` on the two changed files → clean.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** An AI coding agent (Claude Code) running on this account found the bug, wrote the repro and the regression test, and wrote this description. The human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
