### PR TITLE
fix(frontend): encode uploaded filenames in delete requests

### DIFF
--- a/frontend/src/core/uploads/api.ts
+++ b/frontend/src/core/uploads/api.ts
@@ -116,8 +116,9 @@ export async function deleteUploadedFile(
   threadId: string,
   filename: string,
 ): Promise<{ success: boolean; message: string }> {
+  const encodedFilename = encodeURIComponent(filename);
   const response = await fetch(
-    `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${filename}`,
+    `${getBackendBaseURL()}/api/threads/${threadId}/uploads/${encodedFilename}`,
     {
       method: "DELETE",
     },

--- a/frontend/tests/unit/core/uploads/api.test.ts
+++ b/frontend/tests/unit/core/uploads/api.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, rs, test } from "@rstest/core";
+
+rs.mock("@/core/api/fetcher", () => ({
+  fetch: rs.fn(),
+}));
+
+rs.mock("@/core/config", () => ({
+  getBackendBaseURL: () => "/backend",
+}));
+
+import { fetch as fetcher } from "@/core/api/fetcher";
+import { deleteUploadedFile } from "@/core/uploads/api";
+
+const mockedFetch = rs.mocked(fetcher);
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    statusText: status >= 400 ? "Error" : "OK",
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockedFetch.mockReset();
+});
+
+describe("uploads api", () => {
+  test("encodes uploaded filenames in delete request paths", async () => {
+    mockedFetch.mockResolvedValueOnce(
+      jsonResponse(200, {
+        success: true,
+        message: "Deleted report#1?.txt",
+      }),
+    );
+
+    await expect(
+      deleteUploadedFile("thread-1", "report#1?.txt"),
+    ).resolves.toEqual({
+      success: true,
+      message: "Deleted report#1?.txt",
+    });
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      "/backend/api/threads/thread-1/uploads/report%231%3F.txt",
+      { method: "DELETE" },
+    );
+  });
+});


### PR DESCRIPTION
## Why

Uploaded files whose names contain URL-reserved characters such as `#` or `?` can be uploaded and viewed, but deletion fails because the frontend interpolates the raw filename into the DELETE URL path. Browsers parse those characters as fragment or query delimiters before the request reaches the gateway, so the backend receives a truncated filename.

## How

- Encode the uploaded filename as a single URL path segment with `encodeURIComponent` before building the DELETE request URL.
- Add a unit test covering a filename with both `#` and `?` to prevent regressions.

## Validation

- `pnpm test tests/unit/core/uploads/api.test.ts`
- `pnpm test tests/unit/core/uploads tests/unit/core/threads/send-message.test.ts`
- `pnpm check`
- `uv run pytest tests/test_uploads_router.py`