### PR TITLE
fix(dingtalk): drop inbound messages that carry no conversation identity

### DIFF
--- a/backend/app/channels/dingtalk.py
+++ b/backend/app/channels/dingtalk.py
@@ -416,6 +416,19 @@ class DingTalkChannel(Channel):
             # chat_id uses conversation_id for groups, sender_staff_id for P2P
             chat_id = conversation_id if conversation_type == _CONVERSATION_TYPE_GROUP else sender_staff_id
 
+            # An empty chat_id does not identify a conversation, and ChannelStore keys on it:
+            # a P2P message with no sender keys to the literal "dingtalk:", so every such
+            # message from every user shares one thread and one history. Mirrors the guard the
+            # WeChat channel already applies (wechat.py, `if not chat_id: return`) and the one
+            # this file's own bind path applies before persisting a connection.
+            if not chat_id:
+                logger.warning(
+                    "[DingTalk] ignoring message with no conversation identity: conv_type=%s, msg_id=%s",
+                    conversation_type,
+                    msg_id,
+                )
+                return
+
             inbound = self._make_inbound(
                 chat_id=chat_id,
                 user_id=sender_staff_id,

--- a/backend/tests/test_dingtalk_channel.py
+++ b/backend/tests/test_dingtalk_channel.py
@@ -334,6 +334,102 @@ class TestOnChatbotMessage:
 
         _run(go())
 
+    @pytest.mark.parametrize("sender_staff_id", ["", None])
+    def test_p2p_message_without_sender_is_dropped(self, sender_staff_id):
+        """A P2P chat_id *is* the sender, so an empty one keys every user to one thread.
+
+        ``ChannelStore._key`` builds ``f"{channel}:{chat_id}"`` for a topic-less conversation,
+        so publishing this would put every senderless P2P message under the literal
+        ``"dingtalk:"`` — one shared thread, one shared history, across users.
+        """
+
+        async def go():
+            bus = MessageBus()
+            bus.publish_inbound = AsyncMock()
+            channel = DingTalkChannel(bus, config={})
+            channel._client_id = "test_key"
+            channel._main_loop = asyncio.get_event_loop()
+            channel._running = True
+
+            msg = _make_chatbot_message(
+                text="hello",
+                conversation_type=_CONVERSATION_TYPE_P2P,
+                sender_staff_id=sender_staff_id,
+                message_id="msg_no_sender",
+            )
+
+            channel._send_running_reply = AsyncMock()
+            channel._on_chatbot_message(msg)
+
+            await asyncio.sleep(0.1)
+
+            bus.publish_inbound.assert_not_awaited()
+
+        _run(go())
+
+    def test_group_message_without_conversation_id_is_dropped(self):
+        """The group route reaches the same degenerate key from the other side."""
+
+        async def go():
+            bus = MessageBus()
+            bus.publish_inbound = AsyncMock()
+            channel = DingTalkChannel(bus, config={})
+            channel._client_id = "test_key"
+            channel._main_loop = asyncio.get_event_loop()
+            channel._running = True
+
+            msg = _make_chatbot_message(
+                text="hello group",
+                conversation_type=_CONVERSATION_TYPE_GROUP,
+                sender_staff_id="user_002",
+                conversation_id="",
+                message_id="msg_no_conv",
+            )
+
+            channel._send_running_reply = AsyncMock()
+            channel._on_chatbot_message(msg)
+
+            await asyncio.sleep(0.1)
+
+            bus.publish_inbound.assert_not_awaited()
+
+        _run(go())
+
+    def test_group_message_with_unknown_sender_is_still_delivered(self):
+        """Reverse anchor: the guard is on the conversation identity, not on the sender.
+
+        A group message identifies its conversation through ``conversation_id``, so an
+        unknown sender must not cost the whole message.
+        """
+
+        async def go():
+            bus = MessageBus()
+            bus.publish_inbound = AsyncMock()
+            channel = DingTalkChannel(bus, config={})
+            channel._client_id = "test_key"
+            channel._main_loop = asyncio.get_event_loop()
+            channel._running = True
+
+            msg = _make_chatbot_message(
+                text="hello group",
+                conversation_type=_CONVERSATION_TYPE_GROUP,
+                sender_staff_id="",
+                conversation_id="conv_group_003",
+                message_id="msg_group_003",
+            )
+
+            channel._send_running_reply = AsyncMock()
+            channel._on_chatbot_message(msg)
+
+            await asyncio.sleep(0.1)
+
+            bus.publish_inbound.assert_awaited_once()
+            inbound = bus.publish_inbound.await_args.args[0]
+            assert inbound.chat_id == "conv_group_003"
+            assert inbound.topic_id == "msg_group_003"
+
+        _run(go())
+
     def test_command_classified_correctly(self):
         async def go():
             bus = MessageBus()


### PR DESCRIPTION
## Why

For a DingTalk P2P conversation the `chat_id` **is** the sender:

```python
chat_id = conversation_id if conversation_type == _CONVERSATION_TYPE_GROUP else sender_staff_id
```

`ChannelStore._key()` builds `f"{channel_name}:{chat_id}"` for a topic-less conversation, so
a P2P message whose `sender_staff_id` is empty keys to the literal string `"dingtalk:"` —
and every senderless P2P message from every user resolves to that one key, therefore to one
thread and one shared history.

Measured on `cd34a1a5` by driving the real `_on_chatbot_message` into a real `ChannelStore`:

| | `main` | this branch |
|---|---|---|
| named user A | `thread-2fa8cf55-dacf` | unchanged |
| named user B | `thread-8a593c1b-e301` | unchanged |
| senderless message 1 | `thread-9810dac2-b956` | dropped |
| senderless message 2 | `thread-9810dac2-b956` — **the same thread** | dropped |

The same file already refuses this value on the other path it uses it. `_bind_connection_from_connect_code`:

```python
if not sender_staff_id:
    await self._send_connection_reply(..., "DingTalk connection could not be completed from this message.")
    return True
```

The bind path will not persist a connection for an unidentified sender; the publish path
hands the same value straight to the conversation key. The WeChat channel guards the same
way for the same reason (`wechat.py`, `if not chat_id: return`).

## What changed

One guard in `_on_chatbot_message`, placed on `chat_id` rather than on `sender_staff_id`:

```python
if not chat_id:
    logger.warning("[DingTalk] ignoring message with no conversation identity: conv_type=%s, msg_id=%s", conversation_type, msg_id)
    return
```

Guarding the conversation identity rather than the sender is deliberate, and I enumerated
both routes to a degenerate key before choosing:

| input | published on `main` | resulting store key |
|---|---|---|
| `sender="staff_alice"` (control) | yes | `dingtalk:staff_alice` |
| `sender=""` | yes | **`dingtalk:`** — collapse |
| `sender=None` | yes | **`dingtalk:`** — collapse |
| group, empty sender, valid `conversation_id` | yes | `dingtalk:conv_group_1:m1` — fine |
| group, empty `conversation_id` | yes | **`dingtalk::m1`** — second route |

The group route is a different failure (a topic id keeps the messages apart, so it is lost
continuity rather than cross-user bleed) but the same root cause: a segment of the key is
empty. One guard on `chat_id` covers both, and by construction it cannot drop a group message
that has a usable `conversation_id` merely because the sender is unknown — a guard on
`sender_staff_id` would.

The connect-code path returns earlier and is unaffected, so a browser-initiated bind still
works exactly as before.

## Scope of the claim

I can show the code path is reachable — the SDK field defaults to `None`, and this file's own
`message.sender_staff_id or ""` shows absence was anticipated — and I can show what the
consequence is when it happens, which is measured above. I **cannot** show from this
repository that DingTalk production actually delivers an empty `senderStaffId`. If you read
that as "cannot happen", this is defence in depth rather than a live defect; I would rather
state the limit than imply an incident I have not observed.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change** — a DingTalk message carrying no conversation identity is
      now dropped with a warning instead of being published into a shared `"dingtalk:"`
      thread. Messages that identify their conversation are untouched.
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test paths (`backend/tests/test_dingtalk_channel.py::TestOnChatbotMessage`):
  - `test_p2p_message_without_sender_is_dropped` (`""` and `None`)
  - `test_group_message_without_conversation_id_is_dropped`
  - `test_group_message_with_unknown_sender_is_still_delivered` — the reverse anchor
- Red on `main`, green on this branch: **yes** — verified by restoring only
  `app/channels/dingtalk.py` to `origin/main` (tests untouched, revert confirmed by anchor
  count rather than by reading an empty diff as success). Three go red; the reverse anchor is
  green on both sides by design.
- The choice of guard is anchored, not just the guard: changing it to `if not
  sender_staff_id` reds both the group-without-`conversation_id` test **and** the
  unknown-sender-in-a-group test, and narrowing it to the P2P route alone reds the former. So
  the reverse anchor is doing work rather than passing vacuously.

## Validation

```
cd backend
PYTHONPATH=. uv run pytest tests/test_dingtalk_channel.py -q                  # 94 passed
PYTHONPATH=. uv run pytest tests/test_dingtalk_channel.py tests/test_channels.py \
                          tests/test_wecom_ws_text.py -q                      # 361 passed
PYTHONPATH=. uv run pytest tests/ -q       # 11 failed, 8063 passed, 29 skipped
uvx ruff check . && uvx ruff format --check .                                 # clean
```

The 11 failures are pre-existing on `origin/main` (the `web_fetch` provider suites refuse
private-network addresses in this environment); the failure set is byte-for-byte identical
before and after, so this branch adds none.

## Note on overlap with #4196

#4196 (`fix(dingtalk): stop inline-code pass from corrupting fenced-block backticks`) touches
the same two files, but at `_code_block_to_quote` (~line 110, outbound markdown rendering);
this change is in `_on_chatbot_message` (~line 417, inbound parsing). Different function,
different direction. They should not conflict; if #4196 lands first I'll rebase.

## AI assistance

**Tool(s) used:** Claude Code.

**How you used it:** Used to write the change and drive verification. The finding was
re-verified from scratch on `cd34a1a5` rather than taken from an earlier note — an earlier
note of mine claimed Slack had the same shape, and driving it showed that was wrong (Slack
keys on `slack:{channel}:{ts}` and filters bot frames), so this PR is DingTalk-only. Every
probe carries a positive control so a silently broken harness cannot read as a finding. I ran
the red check with the source rolled back to `origin/main` and ran mutations on the guard
itself to confirm the reverse anchor is not vacuous.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
