### PR TITLE
fix(skills): inject Langfuse metadata into the standalone skill scan

### DIFF
--- a/backend/packages/harness/deerflow/skills/security_scanner.py
+++ b/backend/packages/harness/deerflow/skills/security_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -11,7 +12,9 @@ from typing import Any
 from deerflow.config import get_app_config
 from deerflow.config.app_config import AppConfig
 from deerflow.models import create_chat_model
+from deerflow.runtime.user_context import get_effective_user_id
 from deerflow.skills.types import SKILL_MD_FILE
+from deerflow.tracing import inject_langfuse_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -125,12 +128,31 @@ async def scan_skill_content(
         model_name = config.skill_evolution.moderation_model_name
         model_kwargs = {"thinking_enabled": False, "app_config": config, "attach_tracing": attach_tracing}
         model = create_chat_model(name=model_name, **model_kwargs) if model_name else create_chat_model(**model_kwargs)
+        invoke_config: dict[str, Any] = {"run_name": "security_agent"}
+        if attach_tracing:
+            # Standalone callers own the trace root, so they must inject their own
+            # Langfuse attribution -- the other half of the standalone pattern that
+            # already attaches model-level callbacks here (attach_tracing default),
+            # mirroring oneshot_llm.run_oneshot_llm / MemoryUpdater / the goal
+            # evaluator (see the Tracing System INVARIANT in backend/AGENTS.md).
+            # In-graph callers pass attach_tracing=False: the graph root already
+            # lifts session/user attribution, so injecting here is inert at best
+            # and diverges from that documented split. thread_id=None because the
+            # skill-moderation call is not thread-scoped (same as oneshot_llm).
+            inject_langfuse_metadata(
+                invoke_config,
+                thread_id=None,
+                user_id=get_effective_user_id(),
+                assistant_id="security_agent",
+                model_name=model_name,
+                environment=os.environ.get("DEER_FLOW_ENV") or os.environ.get("ENVIRONMENT"),
+            )
         response = await model.ainvoke(
             [
                 {"role": "system", "content": rubric},
                 {"role": "user", "content": prompt},
             ],
-            config={"run_name": "security_agent"},
+            config=invoke_config,
         )
         model_responded = True
         raw = str(getattr(response, "content", "") or "")

--- a/backend/tests/test_security_scanner.py
+++ b/backend/tests/test_security_scanner.py
@@ -27,6 +27,40 @@ def _make_env(monkeypatch, response_content):
     return model
 
 
+def _make_traced_env(monkeypatch, *, model_name, response_content='{"decision":"allow","reason":"ok"}'):
+    """Like ``_make_env`` but with a concrete moderation model name and a known
+    effective user, so Langfuse trace metadata (model tag + user_id) is assertable.
+    """
+    config = SimpleNamespace(skill_evolution=SimpleNamespace(moderation_model_name=model_name))
+    fake_response = SimpleNamespace(content=response_content)
+
+    class FakeModel:
+        async def ainvoke(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            return fake_response
+
+    model = FakeModel()
+
+    def _fake_create_chat_model(**kwargs):
+        model.create_kwargs = kwargs
+        return model
+
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.skills.security_scanner.create_chat_model", _fake_create_chat_model)
+    monkeypatch.setattr("deerflow.skills.security_scanner.get_effective_user_id", lambda: "scanner-user")
+    return model
+
+
+def _enable_langfuse_env(monkeypatch):
+    for name in ("LANGFUSE_TRACING", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY", "LANGFUSE_BASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("LANGFUSE_TRACING", "true")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-lf-test")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-lf-test")
+    monkeypatch.setenv("DEER_FLOW_ENV", "production")
+
+
 SKILL_CONTENT = "---\nname: demo-skill\ndescription: demo\n---\n"
 
 
@@ -178,6 +212,61 @@ async def test_scan_skill_content_attaches_model_tracing_by_default(monkeypatch)
     result = await scan_skill_content(SKILL_CONTENT, executable=False)
     assert result.decision == "allow"
     assert model.create_kwargs["attach_tracing"] is True
+
+
+@pytest.mark.anyio
+async def test_scan_skill_content_injects_langfuse_metadata_when_standalone(monkeypatch):
+    """Standalone scans (Gateway routes, installer) own the trace root, so they must
+    inject Langfuse attribution themselves -- the other half of the standalone pattern
+    that already attaches model-level callbacks here, mirroring oneshot_llm / the goal
+    evaluator / MemoryUpdater (Tracing System INVARIANT in backend/AGENTS.md). Without
+    it the skill-moderation trace has no user/session/name attribution (the #4252
+    follow-up gap).
+    """
+    from deerflow.config.tracing_config import reset_tracing_config
+
+    _enable_langfuse_env(monkeypatch)
+    reset_tracing_config()
+    model = _make_traced_env(monkeypatch, model_name="moderation-model")
+    try:
+        result = await scan_skill_content(SKILL_CONTENT, executable=False)
+    finally:
+        reset_tracing_config()
+
+    assert result.decision == "allow"
+    config = model.kwargs["config"]
+    assert config["run_name"] == "security_agent"
+    metadata = config.get("metadata") or {}
+    assert metadata.get("langfuse_user_id") == "scanner-user"
+    assert metadata.get("langfuse_trace_name") == "security_agent"
+    # Skill moderation is not thread-scoped, so session_id stays None (matches
+    # oneshot_llm's thread_id=None); the key must still be present for the handler.
+    assert "langfuse_session_id" in metadata
+    assert metadata["langfuse_session_id"] is None
+    tags = metadata.get("langfuse_tags") or []
+    assert "model:moderation-model" in tags
+    assert "env:production" in tags
+
+
+@pytest.mark.anyio
+async def test_scan_skill_content_omits_langfuse_metadata_when_in_graph(monkeypatch):
+    """In-graph scans pass attach_tracing=False and inherit attribution from the graph
+    root, so the injection must be gated on attach_tracing. Anchors the narrowing
+    direction: an unconditional inject (dropping the guard) would double-attribute
+    against the root trace and turn this red, even though Langfuse is enabled.
+    """
+    from deerflow.config.tracing_config import reset_tracing_config
+
+    _enable_langfuse_env(monkeypatch)
+    reset_tracing_config()
+    model = _make_traced_env(monkeypatch, model_name="moderation-model")
+    try:
+        result = await scan_skill_content(SKILL_CONTENT, executable=False, attach_tracing=False)
+    finally:
+        reset_tracing_config()
+
+    assert result.decision == "allow"
+    assert model.kwargs["config"] == {"run_name": "security_agent"}
 
 
 def _make_unavailable_env(monkeypatch, *, security_fail_closed):


### PR DESCRIPTION
## Why

`skills/security_scanner.py::scan_skill_content` is a dual-use call: in-graph via `tools/skill_manage_tool.py::_scan_or_raise` (passes `attach_tracing=False`, #4252), and standalone via the Gateway skill routes (`app/gateway/routers/skills.py`) and `skills/installer.py` (keep the default `attach_tracing=True`).

Per the Tracing System section of `backend/AGENTS.md`, a standalone caller — one that invokes a model outside the graph — must do **two** things: keep model-level tracing callbacks (`attach_tracing=True`) **and** inject its own Langfuse trace metadata onto the `ainvoke` call, because there is no graph root to lift `session_id` / `user_id` / trace name from. AGENTS.md names that pattern and lists `oneshot_llm.run_oneshot_llm`, the goal evaluator, and `MemoryUpdater` as following it; #4202 added it to the goal evaluator.

The standalone path of `scan_skill_content` does the first half — the callbacks are attached — but not the second: `ainvoke(config={"run_name": "security_agent"})` never calls `inject_langfuse_metadata`. So a skill-moderation LLM call from the Gateway routes / installer produces a Langfuse trace with no `langfuse_user_id`, no `langfuse_trace_name`, and no `env:` / `model:` tags — an orphan trace you can't attribute to a user or environment when auditing skill-moderation cost/usage. This is the standalone follow-up to #4252, which fixed only the in-graph half of the same function.

## What changed

`skills/security_scanner.py::scan_skill_content` — builds the invoke config as before, and when `attach_tracing` is true (the standalone callers) injects Langfuse trace metadata onto it via the shared `inject_langfuse_metadata`, mirroring `oneshot_llm.run_oneshot_llm`: `thread_id=None` (skill moderation is not thread-scoped), `user_id=get_effective_user_id()`, `assistant_id="security_agent"`, `model_name`, and `environment` from `DEER_FLOW_ENV` / `ENVIRONMENT`.

Gated on `attach_tracing`, matching #4252's in-graph/standalone split: in-graph callers pass `attach_tracing=False` and must **not** inject — they inherit attribution from the graph root, so injecting there is inert at best and diverges from the documented standalone pattern.

`inject_langfuse_metadata` returns `{}` when Langfuse is not an enabled provider, so LangSmith-only / no-tracing deployments are unaffected — the config stays `{"run_name": "security_agent"}`.

Enumerated rather than assumed: `scan_skill_content` has four non-test call sites — `routers/skills.py:266`/`:357` and `installer.py:262` (standalone, default `True`), `skill_manage_tool.py:69` (in-graph, `False`). The three sibling standalone model callers that already inject this metadata are `runtime/goal.py:314`, `utils/oneshot_llm.py:57`, and `agents/memory/manager.py:346`; this scanner was the fourth — the one that attached callbacks but skipped the metadata.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [x] **Skills** — `packages/harness/deerflow/skills/security_scanner.py`
- [ ] **Dependencies**
- [ ] **Default behavior change** — only adds trace attribution on an already-traced standalone path; no functional / decision behavior changes
- [x] **Docs / tests / CI only** — `tests/test_security_scanner.py`

## Bug fix verification

- Test paths:
  - `tests/test_security_scanner.py::test_scan_skill_content_injects_langfuse_metadata_when_standalone` — drives the **real** `scan_skill_content` with Langfuse enabled; asserts `langfuse_user_id` / `langfuse_trace_name` / `langfuse_session_id` (None) / `env:` + `model:` tags land on the invoke config.
  - `tests/test_security_scanner.py::test_scan_skill_content_omits_langfuse_metadata_when_in_graph` — `attach_tracing=False` keeps the bare `{"run_name": "security_agent"}` config.
- Red on `main` / green on this branch? **yes** — on unfixed `main` the standalone path never injects, so the first test fails (metadata absent); it passes after the change.
- Red check was **per-test**, one mutation per clause:

  | mutation | result |
  |---|---|
  | gate → `if False:` (never inject = main's shape) | `..._injects_..._when_standalone` **FAILED**, `..._omits_..._when_in_graph` passed |
  | gate → `if True:` (drop the guard = inject unconditionally) | `..._omits_..._when_in_graph` **FAILED**, `..._injects_..._when_standalone` passed |

  The second is the other direction of the change: dropping the `attach_tracing` guard would inject on the in-graph path too and double-attribute against the root trace; that test goes red if it happens.
- The pre-existing 23 tests pass **unmodified** — they run with Langfuse disabled (ambient test env), where `inject_langfuse_metadata` is a no-op, so `test_scan_skill_content_passes_run_name_to_model`'s `config == {"run_name": "security_agent"}` still holds.

## Validation

```
cd backend
make format   # 2 files left unchanged
make lint     # All checks passed!

PYTHONPATH=. uv run pytest tests/test_security_scanner.py -q
# 25 passed

PYTHONPATH=. uv run pytest tests/ -q
# 11 failed, 8168 passed, 29 skipped in 140.13s
```

The 11 failures are pre-existing and unrelated (`test_browserless_client.py`, `test_crawl4ai_tools.py`, `test_fastcrw_tools.py` — `web_fetch` / `web_capture` against a blocked address in this environment). Clean `main` fails the identical 11 (8166 passed = 2 fewer, my two new tests), so this branch adds **0** new failures.

E2E through the real `scan_skill_content` (the same entry point the Gateway skill routes and installer call), Langfuse enabled, only the LLM stubbed to observe the invoke config:

| path | injected trace metadata |
|---|---|
| standalone (`attach_tracing=True`) — this branch | `langfuse_user_id`, `langfuse_trace_name=security_agent`, tags `env:` + `model:` |
| in-graph (`attach_tracing=False`) | none — bare `run_name`, inherits the root trace |
| standalone, injection neutralized (main's shape) | none — the bug |

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Used an AI coding assistant to check the standalone vs in-graph callers of `scan_skill_content` against the Tracing System invariant in `backend/AGENTS.md`, follow the same standalone-caller pattern as `oneshot_llm` / the goal evaluator, write the regression tests, and run the red→green, per-test red check, full-suite comparison against clean `main`, and the real-function E2E.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
