### PR TITLE
fix(setup): detect browser extra in indentless YAML

### DIFF
--- a/backend/tests/test_detect_uv_extras.py
+++ b/backend/tests/test_detect_uv_extras.py
@@ -157,6 +157,14 @@ def test_detect_from_config_browser_via_browser_navigate_tool(tmp_path):
     assert detect.detect_from_config(cfg) == ["browser"]
 
 
+def test_detect_from_config_browser_via_indentless_tools_list(tmp_path):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text(
+        "tools:\n- name: web_fetch\n  group: web\n- name: browser_navigate\n  group: browser\n",
+    )
+    assert detect.detect_from_config(cfg) == ["browser"]
+
+
 def test_detect_from_config_ignores_commented_browser_tool(tmp_path):
     cfg = tmp_path / "config.yaml"
     cfg.write_text(

--- a/scripts/detect_uv_extras.py
+++ b/scripts/detect_uv_extras.py
@@ -237,14 +237,16 @@ def tools_include_name(lines: list[str], tool_name: str) -> bool:
             continue
         if not inside:
             continue
+        name_match = _LIST_ITEM_NAME_RE.match(line)
+        if name_match:
+            if _unquote(name_match.group(1).strip()) == tool_name:
+                return True
+            continue
         stripped = line.lstrip()
         indent = len(line) - len(stripped)
         if indent == 0:
             inside = False
             continue
-        name_match = _LIST_ITEM_NAME_RE.match(line)
-        if name_match and _unquote(name_match.group(1).strip()) == tool_name:
-            return True
     return False
 
 


### PR DESCRIPTION
## Summary

Fix optional browser dependency detection for DeerFlow configuration files that use valid indentless YAML sequences.

This change:

- recognizes `browser_navigate` in both indented and indentless `tools:` lists;
- ensures `make dev` includes `--extra browser` when synchronizing backend dependencies;
- prevents `uv sync` from unintentionally removing Playwright after browser control has been enabled;
- adds regression coverage matching the YAML style generated and accepted by DeerFlow.

## Problem

Browser control can be enabled with valid indentless YAML:

```yaml
tools:
- name: image_search
  group: web
- name: browser_navigate
  group: browser
  use: deerflow.community.browser_automation.tools:browser_navigate_tool
```

Although DeerFlow's normal configuration loader accepts this syntax, `scripts/detect_uv_extras.py` did not recognize `browser_navigate`.

Consequently, `make dev` synchronized backend dependencies without `--extra browser`. Because Playwright is optional, `uv sync` removed it from `backend/.venv`, and Gateway startup failed with:

```text
Playwright is not installed; install the backend browser extra and run `playwright install chromium`
```

This could happen even after the user had installed the browser extra successfully: the next `make dev` synchronization removed the Python package again.

## Root cause

`tools_include_name()` entered the `tools:` section correctly, but treated any zero-indented line as the end of that section before checking whether the line was a `- name:` list item.

That ordering works for conventionally indented sequences:

```yaml
tools:
  - name: browser_navigate
```

It fails for equally valid indentless sequences:

```yaml
tools:
- name: browser_navigate
```

The detector also needs to remain inside the list after a non-matching entry, because `browser_navigate` may appear after another tool. Existing tests covered only the indented form, so the generated-style configuration was missed.

## Implementation

Check for a tool-list item before applying the zero-indentation section boundary. When a `- name:` item is found, return if it matches the requested tool; otherwise continue scanning the current tools list.

Top-level section detection still happens first, so real section boundaries remain unchanged. Comment stripping and quoted-name normalization are also preserved. The fix stays within the existing standard-library parser and adds no YAML dependency.

## Behavior

Before this change, an indentless tools list containing `browser_navigate` produced no detected extras. After the change, the same configuration produces:

```text
--extra browser
```

`make dev` therefore preserves or installs Playwright through its existing `uv sync --all-packages --extra browser` path. Indented lists continue to work, and commented browser tool entries remain ignored.

## Regression coverage

Add `test_detect_from_config_browser_via_indentless_tools_list`, using an indentless `tools:` sequence with a non-browser tool before `browser_navigate`. Before the implementation, it failed with `assert [] == ["browser"]`; it passes with the parser fix.

## Validation

- `backend/.venv/bin/python -m pytest backend/tests/test_detect_uv_extras.py -q` — 29 passed
- `backend/.venv/bin/ruff check scripts/detect_uv_extras.py backend/tests/test_detect_uv_extras.py` — passed
- `git diff --check origin/main...HEAD` — passed

## Impact and risk

The change affects only optional-dependency detection during startup. It does not modify browser automation, Gateway behavior, the configuration schema, or runtime tool execution. Both supported YAML list styles are covered, and no new dependency or parser abstraction is introduced.
