### PR TITLE
fix(uploads): inject list_uploaded_files runtime instead of exposing it to the model

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
@@ -12,7 +12,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Annotated, Any
 
-from langchain.tools import InjectedToolArg, tool
+from langchain.tools import tool
 from langgraph.config import get_config
 
 from deerflow.agents.middlewares.input_sanitization_middleware import neutralize_untrusted_tags
@@ -198,7 +198,7 @@ def list_uploaded_files(
         int,
         "Maximum number of files to return (default 20, max 100).",
     ] = _DEFAULT_MAX_RESULTS,
-    runtime: Annotated[Runtime, InjectedToolArg] | None = None,
+    runtime: Runtime = None,
 ) -> dict:
     """Discover historical uploaded files available in this thread.
 

--- a/backend/tests/test_list_uploaded_files_tool.py
+++ b/backend/tests/test_list_uploaded_files_tool.py
@@ -9,7 +9,7 @@ import pytest
 from langchain_core.messages import HumanMessage, ToolMessage
 
 from deerflow.config.paths import Paths
-from deerflow.tools.builtins.list_uploaded_files_tool import _format_omitted_summary, _list_uploaded_files_impl, _resolve_thread_id
+from deerflow.tools.builtins.list_uploaded_files_tool import _format_omitted_summary, _list_uploaded_files_impl, _resolve_thread_id, list_uploaded_files
 
 
 def _paths(tmp_path):
@@ -840,3 +840,29 @@ def test_all_string_fields_in_result_are_neutralized(tmp_path):
     # Sanity: the result is non-empty and well-formed
     assert len(result["files"]) == 1
     assert result["total_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool schema — runtime parameter must be injected, not exposed to the model
+# ---------------------------------------------------------------------------
+
+
+def test_list_uploaded_files_runtime_is_injected_not_in_schema():
+    """The ``runtime`` parameter is a ``ToolRuntime`` and must be auto-injected.
+
+    Regression: annotating it as ``Annotated[Runtime, InjectedToolArg] | None``
+    wrapped the type in ``Union``, so LangChain's ``_is_directly_injected_arg_type``
+    no longer recognized it as a ``ToolRuntime`` injection. The runtime then leaked
+    into the model-facing schema, and generating its JSON schema failed with
+    ``Cannot generate a JsonSchema for core_schema.CallableSchema`` (ThreadState
+    carries Callable reducers), which aborted every agent LLM call.
+    """
+    # The model-facing schema must build without raising (it currently raises
+    # PydanticInvalidForJsonSchema when runtime leaks in).
+    schema = list_uploaded_files.tool_call_schema.model_json_schema()
+
+    # runtime is injected at call time and must never reach the model.
+    properties = set(schema.get("properties", {}).keys())
+    assert "runtime" not in properties, f"runtime leaked into model-facing schema: {sorted(properties)}; it must be a bare ToolRuntime annotation so LangChain injects it."
+    # The user-facing knobs must still be present.
+    assert {"include_outline", "max_results"}.issubset(properties)


### PR DESCRIPTION
## Problem

Sending **any** message to the agent fails immediately with:

```
LLM request failed: Failed to generate JSON schema for 'list_uploaded_files':
Cannot generate a JsonSchema for core_schema.CallableSchema
```

The agent is completely unusable — even \`hello\` fails.

## Root Cause

\`list_uploaded_files\` annotated its \`runtime\` parameter as:

\`\`\`python
runtime: Annotated[Runtime, InjectedToolArg] | None = None,
\`\`\`

The \`| None\` wraps the type in \`Union[Annotated[Runtime, InjectedToolArg], NoneType]\`. LangChain identifies \`ToolRuntime\` injections via \`_is_directly_injected_arg_type()\`, which checks \`get_origin(annotation)\` — but the origin of a \`Union\` is \`Union\`, **not** \`ToolRuntime\`, so the injection is no longer recognized.

As a result, \`runtime\` (= \`ToolRuntime[dict, ThreadState]\`) **leaks into the model-facing schema**. Generating its JSON schema fails because \`ThreadState\` carries \`Callable\` reducers → \`core_schema.CallableSchema\`. Since tool schemas are serialized up front for every LLM call, a single broken tool aborts the whole agent run.

## Fix

Annotate \`runtime\` as a bare \`Runtime\` (= \`ToolRuntime[...]\`), matching \`present_files\`, \`view_image\`, and \`task\` tools. LangChain then auto-injects it and keeps it out of the model-facing schema. The redundant \`InjectedToolArg\` import is removed.

## Test

Added a regression test (\`test_list_uploaded_files_runtime_is_injected_not_in_schema\`) asserting \`runtime\` never appears in \`list_uploaded_files.tool_call_schema\` and the schema builds without raising. Verified failing before / passing after the fix; full \`test_list_uploaded_files_tool.py\` suite (37 tests) passes.

Co-Authored-By: Claude <noreply@anthropic.com>