### PR TITLE
fix(frontend): default reasoning-effort label to Medium when unset

### DIFF
--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -2492,7 +2492,8 @@ export function InputBox({
                       " " + t.inputBox.reasoningEffortMinimal}
                     {context.reasoning_effort === "low" &&
                       " " + t.inputBox.reasoningEffortLow}
-                    {context.reasoning_effort === "medium" &&
+                    {(context.reasoning_effort === "medium" ||
+                      !context.reasoning_effort) &&
                       " " + t.inputBox.reasoningEffortMedium}
                     {context.reasoning_effort === "high" &&
                       " " + t.inputBox.reasoningEffortHigh}


### PR DESCRIPTION
## Why

The reasoning-effort selector in the composer showed an empty value when no
effort had been picked yet: the trigger read `Reasoning Effort:` with nothing
after it (see the "before" screenshot). This is confusing — it looks like no
effort is set, even though the model runs with a default.

The empty label also disagrees with the selector's own menu: the dropdown
already treats an unset effort as **medium** (that item is highlighted and shows
the checkmark). So the two surfaces rendered the same state differently — the
menu said "Medium", the trigger said nothing.

## What changed

When `reasoning_effort` is unset, the trigger label now reads
`Reasoning Effort: Medium` instead of being blank — matching the dropdown's
existing default and what the model actually runs with. Display-only change; the
effective reasoning effort is unchanged (unset was already medium).

## Surface area

- [x] **Frontend UI** — composer reasoning-effort selector under `frontend/`
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change** — no; the effective default (medium) is unchanged, only its label was missing
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

<img width="684" height="251" alt="截屏2026-07-22 19 46 37" src="https://github.com/user-attachments/assets/76c6fc6b-826f-40a8-98d0-7b5b675f3001" />

## Bug fix verification

A red-first unit test wasn't cheap here: the label is inline JSX deep inside the
~2600-line `input-box.tsx` client component, and the frontend unit suite has no
render harness for it (existing tests cover pure `core/` helpers). Instead I
verified:

- **Invariant alignment** — the dropdown already encodes the default at
  `input-box.tsx` (`reasoning_effort === "medium" || !reasoning_effort` for the
  Medium item's highlight + checkmark). The fix makes the trigger use the same
  condition, so the two can no longer disagree.
- **Live UI** — ran the app and confirmed the trigger now shows
  `Reasoning Effort: Medium` on a fresh composer with a reasoning-effort-capable
  model selected (see "after" screenshot).

## Validation

Run in `frontend/` on the changed content:

- `pnpm typecheck` — pass
- `pnpm lint` — pass
- `pnpm format` (prettier --check) — pass
- Manual: verified the rendered label in the running dev stack (`make dev`).

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude located the inconsistency between the trigger label
and the dropdown's default handling, made the one-line change, and I verified it
in the running UI.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
