### PR TITLE
fix(tools): exclude injected runtime from list_uploaded_files schema (#4375)

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
@@ -12,7 +12,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Annotated, Any
 
-from langchain.tools import InjectedToolArg, tool
+from langchain.tools import tool
 from langgraph.config import get_config
 
 from deerflow.agents.middlewares.input_sanitization_middleware import neutralize_untrusted_tags
@@ -187,6 +187,7 @@ def _list_uploaded_files_impl(
 
 @tool
 def list_uploaded_files(
+    runtime: Runtime,
     include_outline: Annotated[
         bool | list[str],
         "Control which files get their document outline (headings/preview) returned. "
@@ -198,7 +199,6 @@ def list_uploaded_files(
         int,
         "Maximum number of files to return (default 20, max 100).",
     ] = _DEFAULT_MAX_RESULTS,
-    runtime: Annotated[Runtime, InjectedToolArg] | None = None,
 ) -> dict:
     """Discover historical uploaded files available in this thread.
 

--- a/backend/tests/test_list_uploaded_files_tool.py
+++ b/backend/tests/test_list_uploaded_files_tool.py
@@ -840,3 +840,33 @@ def test_all_string_fields_in_result_are_neutralized(tmp_path):
     # Sanity: the result is non-empty and well-formed
     assert len(result["files"]) == 1
     assert result["total_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# @tool schema — regression for #4375
+# ---------------------------------------------------------------------------
+class TestToolSchema:
+    """Guard the model-facing schema of the @tool wrapper.
+
+    The injected ``runtime`` argument must not leak into the schema sent to the
+    LLM. Declaring it as ``Annotated[Runtime, InjectedToolArg] | None`` (issue
+    #4375) made the top-level annotation a Union, so LangChain no longer treated
+    it as injected and pydantic raised ``PydanticInvalidForJsonSchema`` on the
+    ToolRuntime dataclass the moment the tool was bound to a model.
+    """
+
+    def test_runtime_excluded_from_model_facing_args(self):
+        from deerflow.tools.builtins.list_uploaded_files_tool import list_uploaded_files
+
+        assert set(list_uploaded_files.args) == {"include_outline", "max_results"}
+        assert "runtime" not in list_uploaded_files.args
+
+    def test_openai_schema_generation_succeeds(self):
+        from langchain_core.utils.function_calling import convert_to_openai_tool
+
+        from deerflow.tools.builtins.list_uploaded_files_tool import list_uploaded_files
+
+        # This raised PydanticInvalidForJsonSchema before the fix.
+        oai = convert_to_openai_tool(list_uploaded_files)
+        params = oai["function"]["parameters"]["properties"]
+        assert set(params) == {"include_outline", "max_results"}


### PR DESCRIPTION
Fixes #4375

## Why

`list_uploaded_files` (added in #4174, the same day this issue was filed) raises `PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.CallableSchema` the moment it is bound to a model — exactly the reporter's traceback.

Root cause: the injected `runtime` arg was declared `runtime: Annotated[Runtime, InjectedToolArg] | None = None`. The outer `| None` makes the *top-level* annotation a `Union`, so LangChain's injected-arg detection (which expects a top-level bare `ToolRuntime` or `Annotated[..., InjectedToolArg]`) no longer recognizes it. `runtime` then leaks into the model-facing schema, and pydantic cannot serialize the `ToolRuntime` dataclass (it has `Callable` fields).

The tool is added to the lead agent's built-ins **by default** (`include_upload_tool=True`), so any default run on an OpenAI-compatible provider fails at tool-bind time (`ChatOpenAI(...).bind_tools([...])` raises). The reporter is just the first to hit it.

## What changed

Declare `runtime` as a **bare** `Runtime` first parameter, matching every other built-in tool (`present_files`, `view_image`, `task`, `setup_agent`, …) — LangChain auto-injects it and auto-excludes it from the schema. No change to the model-facing arguments (`include_outline`, `max_results`). `_list_uploaded_files_impl` is untouched.

## Surface area

- [x] **Agents / LangGraph** — built-in agent tool signature

## Bug fix verification

- Test path: `backend/tests/test_list_uploaded_files_tool.py::TestToolSchema`
- Red on `main`, green on this branch: **yes** — pre-fix, `convert_to_openai_tool(list_uploaded_files)` and `.args` both raise `PydanticInvalidForJsonSchema`; post-fix both return `{include_outline, max_results}`.

## Validation

`cd backend`, then:
- `uv run ruff format …` → unchanged; `uv run ruff check <changed>` → All checks passed
- `pytest tests/test_list_uploaded_files_tool.py` → 38 passed (incl. 2 new regression tests)
- End-to-end: `get_available_tools(...)` (full default toolset, incl. `list_uploaded_files`) now binds via `bind_tools(tools)` — the path that broke.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Diagnosed the root cause, wrote the one-line signature fix, and added the schema regression tests. I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
