### PR TITLE
docs: fix scheduled-task source links

### DIFF
--- a/docs/superpowers/specs/2026-07-01-scheduled-tasks-mvp-design.md
+++ b/docs/superpowers/specs/2026-07-01-scheduled-tasks-mvp-design.md
@@ -274,8 +274,8 @@ For each poll cycle:
 
 MVP must extract or reuse a non-router helper based on existing logic in:
 
-- [backend/app/gateway/services.py](/Users/nowcoder/Desktop/auto-code-work/deer-flow/.worktrees/scheduled-tasks-mvp/backend/app/gateway/services.py)
-- [backend/app/gateway/routers/thread_runs.py](/Users/nowcoder/Desktop/auto-code-work/deer-flow/.worktrees/scheduled-tasks-mvp/backend/app/gateway/routers/thread_runs.py)
+- [backend/app/gateway/services.py](../../../backend/app/gateway/services.py)
+- [backend/app/gateway/routers/thread_runs.py](../../../backend/app/gateway/routers/thread_runs.py)
 
 Required property:
 


### PR DESCRIPTION
## Why

The scheduled-tasks MVP design linked two current source files through an absolute path from the original author's local worktree. Those links are broken for every GitHub reader and every other checkout.

## What changed

- Replaced both machine-specific paths with repository-relative Markdown links.
- Kept the link labels and target source files unchanged.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded dependency
- [ ] **Default behavior change** — changes existing behavior without opt-in
- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

- Resolved both links from the document directory and confirmed both target files exist.
- Searched tracked Markdown for remaining local absolute `/Users`, `/home`, `/opt`, `/tmp`, or `/var` link targets: none.
- `git diff --check`

## AI assistance

**Tool(s) used:** OpenAI coding assistant through Pi

**How you used it:** The assistant scanned local Markdown links, identified the two machine-specific targets, applied the minimal replacement, and ran the validation listed above. The account owner must review the two-line diff before marking this draft ready.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
