### PR TITLE
feat(skill): add first-principles system change workflow

### DIFF
--- a/.agent/skills/engineer-system-change/SKILL.md
+++ b/.agent/skills/engineer-system-change/SKILL.md
@@ -55,13 +55,13 @@ Consider solutions in this order and stop at the first one that fully satisfies 
 6. Introduce a new abstraction
 7. Introduce a new subsystem or migration path
 
-- Minimize concepts, states, interfaces, irreversible decisions, and maintenance surface—not literal line count.
+- Minimize concepts, states, interfaces, irreversible decisions, and maintenance surface, not literal line count.
 - Require a second current consumer, a demonstrated variation, or a hard boundary before generalizing a local solution.
 - Prefer independently reversible slices over a comprehensive architecture rollout.
 - Distinguish a real problem from an oversized solution. A valid verdict is: “The problem is real; reduce the proposal to this smaller change.”
 - Apply these gates recursively to your own recommendation. Do not propose a new field, contract, abstraction, migration, or validation system without naming its consumer, checking existing mechanisms, and showing why a smaller change is insufficient.
 
-### 4. Map Consequences Proportionally
+### 4. Map Consequences and Verification Proportionally
 
 Inspect only relevant dimensions, but do not omit a dimension merely because the proposal omits it:
 
@@ -75,6 +75,9 @@ Inspect only relevant dimensions, but do not omit a dimension merely because the
 
 For state replay or retry features, explicitly distinguish restored application state from external side effects that cannot be undone.
 Label material risk claims as `VERIFIED`, `INFERENCE`, or `UNKNOWN`. Use an inference to request a focused check, not to require new architecture as though the claim were already proven.
+Evidence labels classify individual claims; verdicts classify the overall decision. An `UNKNOWN` requires `NEEDS_EVIDENCE` only when the unknown blocks a material decision.
+
+Before implementation, require observed evidence for the current-system claims that justify the decision and a proportional, executable verification plan. Treat proposed checks as a verification plan, not observed evidence.
 
 ### 5. Implement Only the Justified Slice
 
@@ -88,10 +91,7 @@ When implementation is authorized:
 
 ### 6. Prove the Result
 
-Before implementation, require observed evidence for the current-system claims that justify the decision and a proportional, executable verification plan. After implementation, require observed evidence for claims about the result.
-
 - Map each important result claim to observed evidence: tests, contract checks, static analysis, runtime traces, benchmarks, or a reproducible manual check.
-- Treat proposed checks as a verification plan, not observed evidence.
 - Do not use the agent's own summary as proof.
 - Verify negative boundaries and failure behavior, not only the happy path.
 - State what remains unverified and how that uncertainty affects the verdict.
@@ -108,7 +108,8 @@ Before implementation, require observed evidence for the current-system claims t
 - `NEEDS_EVIDENCE`: a decision would be guesswork until a specific fact, code path, incident, or consumer is verified.
 
 Do not force a binary approve/reject judgment when evidence is incomplete.
-Choose the verdict for the earliest blocked gate. When more than one condition applies, give one primary verdict and list the other required changes without inventing a compound status.
+Choose the verdict from the condition blocking the earliest gate, not from the gate number: affirmative evidence that no change is needed maps to `STOP`; a decision-blocking unknown maps to `NEEDS_EVIDENCE`; a real problem with unsupported scope or no committed consumer maps to `REDUCE`; and a confirmed correctness, contract, or failure-semantics defect maps to `REVISE`. Use `PROCEED` only when no gate is blocked.
+When more than one condition applies, give one primary verdict and list the other required changes without inventing a compound status.
 A verdict records the decision gate and never expands authorization. After authorized implementation, separately report the implemented slice, observed verification, and remaining uncertainty.
 
 ## Keep the Output Proportional

--- a/.agent/skills/engineer-system-change/SKILL.md
+++ b/.agent/skills/engineer-system-change/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: engineer-system-change
+description: Evaluate and carry out non-trivial software-system changes from first principles. Use when assessing RFCs, issues, designs, features, refactors, migrations, dependency changes, or proposed fields, events, APIs, modules, and services whose need, consumers, system fit, validation, or rollback require scrutiny. Read the actual system, identify the concrete problem and named semantic consumers, choose the smallest sufficient solution, reject pseudo-requirements and speculative abstractions, and require evidence proportional to risk. Do not use for mechanical edits, source-code explanation, or a dedicated review of an already-complete diff.
+---
+
+# Engineer System Change
+
+Treat every proposed change as a hypothesis about a real system, not as an implementation checklist. Establish whether the change should exist before designing or building it, then keep the solution and the process proportional to the risk.
+
+## Preserve the Task Boundary
+
+- If asked only to assess, review, or plan, make no project or external-state changes.
+- If explicitly asked to implement, including after an assessment, pass the decision gates before editing and verify the result afterward.
+- Treat implementation permission as separate from permission to commit, push, deploy, publish, or update issues and pull requests.
+- If repository truth matters, inspect the current target revision and relevant discussion. Do not rely on a stale checkout, an RFC alone, or remembered architecture.
+- Separate verified facts, inferences, and unknowns. Do not turn missing evidence into a confident conclusion.
+
+## Apply the Decision Gates
+
+### 1. Ground the Problem
+
+- Trace the current user workflow, failure, or code path before proposing a solution.
+- State the undesirable observable behavior and the invariant or outcome that should replace it.
+- Identify who is affected and which concrete decision or action changes.
+- Check whether the existing system, configuration, documentation, or operating procedure already solves the problem.
+- Enumerate adjacent product paths and workarounds, not only the proposed target surface. Explain precisely which accepted outcome each alternative fails; do not claim “the only option” from one missing UI control or code path.
+- Treat an absent field, interface, abstraction, or standard as an observation, not proof of a requirement.
+
+Return `STOP` only when evidence affirmatively shows that no change is needed or the affected workflow already achieves the outcome. Return `NEEDS_EVIDENCE` when an unverified fact prevents the decision.
+
+### 2. Name Semantic Consumers
+
+For every proposed durable field, event, API, table, store, module, service, or workflow, establish:
+
+| Question | Required answer |
+| --- | --- |
+| Producer or lifecycle owner | What creates, updates, or owns it? |
+| Committed consumer | Which named caller, component, operator, or user reads or acts on it now or as part of this same accepted slice? |
+| Semantic use | What behavior, decision, or externally visible result changes after consumption? |
+| Reachable path | Where does production reach consumption in the current system or proposed slice? |
+| Absence test | Which verified scenario or accepted outcome fails if the addition is removed? |
+
+Accept a proposed consumer only when it is tied to a verified current need and committed integration in the same change. Do not accept a roadmap, possible future evaluator, generic read/debug API, storage alone, or “future flexibility” as a semantic consumer. If an addition has no such consumer, remove or defer it.
+Treat a public or externally consumed contract as a compatibility boundary even when no in-repository caller is visible. Absence of a discoverable caller is uncertainty, not proof that no consumer exists.
+
+### 3. Choose the Smallest Sufficient Change
+
+Consider solutions in this order and stop at the first one that fully satisfies the verified outcome and invariants without shifting disproportionate recurring cost, coupling, or risk downstream:
+
+1. No product or code change
+2. Documentation, configuration, or operating procedure
+3. Reuse an existing capability
+4. Make a local behavior fix
+5. Extend an existing abstraction
+6. Introduce a new abstraction
+7. Introduce a new subsystem or migration path
+
+- Minimize concepts, states, interfaces, irreversible decisions, and maintenance surface—not literal line count.
+- Require a second current consumer, a demonstrated variation, or a hard boundary before generalizing a local solution.
+- Prefer independently reversible slices over a comprehensive architecture rollout.
+- Distinguish a real problem from an oversized solution. A valid verdict is: “The problem is real; reduce the proposal to this smaller change.”
+- Apply these gates recursively to your own recommendation. Do not propose a new field, contract, abstraction, migration, or validation system without naming its consumer, checking existing mechanisms, and showing why a smaller change is insufficient.
+
+### 4. Map Consequences Proportionally
+
+Inspect only relevant dimensions, but do not omit a dimension merely because the proposal omits it:
+
+- callers and downstream consumers
+- API, data, event, and UI contracts
+- authorization, ownership, privacy, and trust boundaries
+- persistence, migrations, replay, and side effects
+- concurrency, ordering, retries, idempotency, and failure recovery
+- compatibility, dependencies, performance, deployment, and operations
+- observability and rollback
+
+For state replay or retry features, explicitly distinguish restored application state from external side effects that cannot be undone.
+Label material risk claims as `VERIFIED`, `INFERENCE`, or `UNKNOWN`. Use an inference to request a focused check, not to require new architecture as though the claim were already proven.
+
+### 5. Implement Only the Justified Slice
+
+When implementation is authorized:
+
+- Reproduce the baseline first. Encode it as a failing behavioral test when executable; otherwise state why and record a reproducible check.
+- Change only the paths required by the accepted outcome and consumers.
+- Reuse existing execution paths and contracts when they preserve the required semantics.
+- Avoid speculative compatibility layers, selectors, shadow systems, canaries, or dual stacks unless an irreversible or high-risk transition requires them.
+- Update repository guidance only when architecture, commands, or durable conventions actually change.
+
+### 6. Prove the Result
+
+Before implementation, require observed evidence for the current-system claims that justify the decision and a proportional, executable verification plan. After implementation, require observed evidence for claims about the result.
+
+- Map each important result claim to observed evidence: tests, contract checks, static analysis, runtime traces, benchmarks, or a reproducible manual check.
+- Treat proposed checks as a verification plan, not observed evidence.
+- Do not use the agent's own summary as proof.
+- Verify negative boundaries and failure behavior, not only the happy path.
+- State what remains unverified and how that uncertainty affects the verdict.
+- Use focused regression checks for local reversible changes.
+- Add targeted integration and adversarial checks for contract, persistence, security, concurrency, replay, or cross-component changes.
+- Require a production-like rehearsal plus executable containment or rollback for irreversible changes or materially high-risk external side effects.
+
+## Use Explicit Verdicts
+
+- `STOP`: evidence affirmatively shows that no current change is needed, or that existing capability already achieves the accepted outcome.
+- `REDUCE`: the problem is real, but the proposed scope or abstraction exceeds the evidence.
+- `REVISE`: the problem and approximate scope are justified, but a correctness, contract, or failure-semantics defect must change before proceeding.
+- `PROCEED`: the problem, consumers, minimum solution, consequences, and proportional verification plan are sufficiently established.
+- `NEEDS_EVIDENCE`: a decision would be guesswork until a specific fact, code path, incident, or consumer is verified.
+
+Do not force a binary approve/reject judgment when evidence is incomplete.
+Choose the verdict for the earliest blocked gate. When more than one condition applies, give one primary verdict and list the other required changes without inventing a compound status.
+A verdict records the decision gate and never expands authorization. After authorized implementation, separately report the implemented slice, observed verification, and remaining uncertainty.
+
+## Keep the Output Proportional
+
+For a simple change, report only:
+
+1. Problem and desired behavior
+2. Named semantic consumer
+3. Smallest sufficient change
+4. Observed evidence and, before implementation, the verification plan
+5. Verdict
+
+For a cross-boundary change or RFC, add:
+
+- verified current-system facts
+- existing alternatives and why they do not meet the accepted outcome
+- consumer ledger for proposed additions
+- affected contracts and side effects
+- rejected or deferred scope with reasons
+- failure, observation, and rollback strategy
+
+Do not create ceremonial documents or exhaustive matrices when a short evidence-backed answer is sufficient. The workflow itself must not become overengineering.


### PR DESCRIPTION
## Why

DeerFlow maintainers regularly need to decide whether an RFC, issue, design, refactor, migration, dependency change, or proposed API/schema addition should exist before discussing implementation details. Those decisions are easy to distort when a proposal is treated as an implementation checklist: an absent field becomes evidence of a requirement, a possible future caller is treated as a committed consumer, or a broad abstraction is accepted before the current code path and existing alternatives have been checked.

The repository already has specialized maintainer workflows, but they serve different boundaries. `deerflow-maintainer-orchestrator` is a comment-plane workflow for issue and PR handling and skips RFC issues by default; dedicated code-review workflows evaluate an already-complete diff. Neither provides a reusable decision process for establishing whether a non-trivial system change is justified, identifying its real consumers, reducing it to the smallest sufficient slice, and then carrying out only that slice when implementation is separately authorized.

This skill fills that gap. Its goal is not to reject change or demand more ceremony. Its goal is to help maintainers distinguish a real problem from an oversized solution, make uncertainty explicit, and require evidence proportional to the actual risk.

## Intended usage

The `engineer-system-change` skill is intended for maintainers and contributors working on non-trivial system changes, including:

1. **RFC and issue assessment**
   - Trace the current user workflow, failure, or code path at the current target revision.
   - Check existing product paths, configuration, documentation, and workarounds before accepting the proposed surface as necessary.
   - Separate verified facts, inferences, and unknowns instead of turning a proposal or remembered architecture into repository truth.

2. **Fields, events, APIs, stores, modules, and services**
   - Name the producer or lifecycle owner and the committed semantic consumer.
   - Show the reachable production path and the behavior or decision that changes after consumption.
   - Apply an absence test: identify the verified scenario or accepted outcome that fails if the addition is removed.
   - Defer roadmap-only fields, generic debug/read APIs, storage without a current consumer, and abstractions justified only by future flexibility.
   - Treat public or externally consumed contracts as compatibility boundaries even when an in-repository caller is not visible.

3. **Refactors, migrations, and dependency changes**
   - Consider no code change, documentation/configuration, reuse, local fixes, and extension of existing abstractions before introducing a new subsystem or migration path.
   - Minimize concepts, states, irreversible decisions, coupling, and maintenance surface rather than optimizing only for line count.
   - Prefer independently reversible slices and require real variation or a hard boundary before generalizing a local solution.

4. **Cross-component, replay, retry, and side-effecting changes**
   - Inspect relevant contracts, authorization and trust boundaries, persistence, ordering, retries, idempotency, compatibility, operations, observability, and rollback.
   - Distinguish restored application state from external side effects that cannot be undone.
   - Label material risks as `VERIFIED`, `INFERENCE`, or `UNKNOWN`, using an inference to request a focused check rather than to justify speculative architecture.

5. **Authorized implementation**
   - Preserve the distinction between permission to assess, implement, commit, push, deploy, publish, or update GitHub artifacts.
   - Reproduce the baseline, change only the accepted slice, reuse existing execution paths where semantics are preserved, and verify negative and failure boundaries as well as the happy path.
   - Distinguish pre-implementation evidence and an executable verification plan from post-implementation observed results.

The skill is intentionally not used for mechanical edits, source-code explanation, or a dedicated review of an already-complete diff.

Example requests include:

- “Use `engineer-system-change` to assess whether this RFC solves a verified DeerFlow problem and reduce it to the smallest justified change.”
- “Before implementing this new persistent field, identify its producer, committed consumer, reachable path, and absence test.”
- “Evaluate whether this local behavior should become a new abstraction, or whether the current use case should remain local.”
- “Implement this accepted change using the smallest reversible slice, then report observed verification separately from remaining uncertainty.”

## What changed

- Add `.agent/skills/engineer-system-change/SKILL.md` following DeerFlow's existing repository convention for maintainer and contributor skills.
- Define six decision gates: ground the problem, name semantic consumers, choose the smallest sufficient change, map consequences proportionally, implement only the justified slice, and prove the result.
- Define explicit verdicts so incomplete evidence is not collapsed into a binary approval decision:
  - `STOP`: evidence affirmatively shows that no current change is needed or an existing capability already achieves the outcome.
  - `NEEDS_EVIDENCE`: a specific unresolved fact prevents a responsible decision.
  - `REDUCE`: the problem is real, but the proposed scope exceeds the evidence.
  - `REVISE`: the approximate scope is justified, but correctness, contract, or failure semantics must change.
  - `PROCEED`: the problem, consumers, minimum solution, consequences, and proportional verification plan are established.
- Scale the required output to the change: a five-item summary for simple decisions and additional consumer, contract, side-effect, and rollback analysis only for cross-boundary changes or RFCs.
- Keep the skill instruction-only. It adds no scripts, runtime dependencies, application configuration, automatic GitHub actions, or mirrored documentation.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or runtime prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [x] **Skills** — repository-scoped maintainer/contributor skill
- [ ] **Dependencies** — no dependencies added or upgraded
- [ ] **Default behavior change** — no DeerFlow runtime default changes
- [x] **Docs / tests / CI only** — instruction-only repository tooling; no application runtime behavior

## Screenshots / Recording

Not applicable. This is an instruction-only maintainer workflow with no UI change.

## Validation

- `python3 skills/public/skill-creator/scripts/quick_validate.py .agent/skills/engineer-system-change`
- `git diff --check`
- Forward-tested in a fresh agent context against [RFC #4378](https://github.com/bytedance/deer-flow/issues/4378) and [PR #4377](https://github.com/bytedance/deer-flow/pull/4377), using `upstream/main@a38b1daec392a335016e41f052ae42d90c9ceccd` and PR head `12955b5def6f53dccf163901adcb6920f65b8220`. The final run returned `REDUCE`: it established the latest-prompt editing gap from current UI and regenerate/branch paths, retained the real user-facing capability, recommended removing proposed fields without a current semantic consumer, and separated verified replay defects from concurrency inferences.
- Independently reviewed the final instructions for trigger boundaries, authorization, verdict consistency, proportionality, and evidence semantics. The review initially found three ambiguities in decision-stage versus result evidence, the `STOP` threshold, and side-effect rehearsal requirements; those were corrected and the revised skill received `APPROVE` with no remaining blocking or important findings.

## Risk / rollback

This PR changes no DeerFlow runtime behavior. The risk is limited to the quality of agent guidance when a maintainer chooses to use the skill: an overly strict workflow could slow small changes, while an overly permissive verdict could accept unsupported scope. The skill mitigates those risks by excluding mechanical work, requiring proportional output, separating uncertainty from rejection, and applying its own consumer and minimum-solution tests recursively to its recommendations.

Rollback is removal of `.agent/skills/engineer-system-change/SKILL.md`; there is no data migration, compatibility commitment, or runtime state to restore.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex distilled the workflow from the supplied engineering principles, inspected current DeerFlow code and repository conventions, forward-tested the skill through independent fresh-context agents on a real RFC/PR, and performed a separate final content and integration review. The contributor reviewed a complete Chinese rendering of the core skill; the final semantic corrections were summarized in the publishing thread before submission.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
