### PR TITLE
fix(frontend): strip and parse the <current_uploads> upload context tag

### DIFF
--- a/frontend/src/components/workspace/messages/message-list-item.tsx
+++ b/frontend/src/components/workspace/messages/message-list-item.tsx
@@ -319,8 +319,11 @@ function MessageContent_({
   const files = useMemo(() => {
     const files = message.additional_kwargs?.files;
     if (!Array.isArray(files) || files.length === 0) {
-      if (rawContent.includes("<uploaded_files>")) {
-        // If the content contains the <uploaded_files> tag, we return the parsed files from the content for backward compatibility.
+      if (
+        rawContent.includes("<current_uploads>") ||
+        rawContent.includes("<uploaded_files>")
+      ) {
+        // If the content contains an upload context tag, we return the parsed files from the content for backward compatibility.
         return parseUploadedFiles(rawContent);
       }
       return null;

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -582,7 +582,10 @@ export interface FileInMessage {
  */
 export function stripUploadedFilesTag(content: string): string {
   return content
-    .replace(/<(uploaded_files|slash_skill_activation)>[\s\S]*?<\/\1>/g, "")
+    .replace(
+      /<(current_uploads|uploaded_files|slash_skill_activation)>[\s\S]*?<\/\1>/g,
+      "",
+    )
     .trim();
 }
 
@@ -592,7 +595,8 @@ export function stripUploadedFilesTag(content: string): string {
  *
  * These markers are *not* user copy — they come from:
  *
- * - ``UploadsMiddleware`` → ``<uploaded_files>``
+ * - ``UploadsMiddleware`` → ``<current_uploads>`` (``<uploaded_files>``
+ *   before #4174; still emitted by IM channels and present in history)
  * - ``SkillActivationMiddleware`` → ``<slash_skill_activation>``
  * - ``DynamicContextMiddleware`` → ``<system-reminder>`` (carrying
  *   ``<memory>`` / ``<current_date>`` inside)
@@ -606,6 +610,7 @@ export function stripUploadedFilesTag(content: string): string {
  * its ``hide_from_ui`` flag set.
  */
 export const INTERNAL_MARKER_TAGS = [
+  "current_uploads",
   "uploaded_files",
   "slash_skill_activation",
   "system-reminder",
@@ -633,8 +638,10 @@ export function stripInternalMarkers(content: string): string {
 }
 
 export function parseUploadedFiles(content: string): FileInMessage[] {
-  // Match <uploaded_files>...</uploaded_files> tag
-  const uploadedFilesRegex = /<uploaded_files>([\s\S]*?)<\/uploaded_files>/;
+  // Match the upload context block; the tag name depends on backend version
+  // (<current_uploads> since #4174, <uploaded_files> before / on IM paths).
+  const uploadedFilesRegex =
+    /<(current_uploads|uploaded_files)>([\s\S]*?)<\/\1>/;
   // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
   const match = content.match(uploadedFilesRegex);
 
@@ -642,7 +649,7 @@ export function parseUploadedFiles(content: string): FileInMessage[] {
     return [];
   }
 
-  const uploadedFilesContent = match[1];
+  const uploadedFilesContent = match[2];
 
   // Check if it's "No files have been uploaded yet."
   if (uploadedFilesContent?.includes("No files have been uploaded yet.")) {

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -637,6 +637,27 @@ export function stripInternalMarkers(content: string): string {
   return content.replace(INTERNAL_MARKER_RE, "").trim();
 }
 
+// The upload context block renders sizes as human-readable strings
+// (uploads_middleware.py::_format_file_entry emits "<n> KB" / "<n> MB",
+// mirroring formatBytes). Convert them back to bytes so the parsed
+// FileInMessage.size honours its bytes contract and chips re-render at the
+// original magnitude instead of e.g. treating "177.6 KB" as 177 bytes.
+function parseHumanReadableSize(raw: string): number {
+  const match = /([\d.]+)\s*(B|KB|MB|GB|TB)?/i.exec(raw.trim());
+  if (!match) return 0;
+  const value = parseFloat(match[1] ?? "");
+  if (!Number.isFinite(value)) return 0;
+  const multipliers: Record<string, number> = {
+    B: 1,
+    KB: 1024,
+    MB: 1024 ** 2,
+    GB: 1024 ** 3,
+    TB: 1024 ** 4,
+  };
+  const unit = (match[2] ?? "B").toUpperCase();
+  return Math.round(value * (multipliers[unit] ?? 1));
+}
+
 export function parseUploadedFiles(content: string): FileInMessage[] {
   // Match the upload context block; the tag name depends on backend version
   // (<current_uploads> since #4174, <uploaded_files> before / on IM paths).
@@ -670,7 +691,7 @@ export function parseUploadedFiles(content: string): FileInMessage[] {
   while ((fileMatch = fileRegex.exec(uploadedFilesContent ?? "")) !== null) {
     files.push({
       filename: fileMatch[1].trim(),
-      size: parseInt(fileMatch[2].trim(), 10) ?? 0,
+      size: parseHumanReadableSize(fileMatch[2]),
       path: fileMatch[3].trim(),
     });
   }

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -14,6 +14,8 @@ import {
   hasContent,
   hasReasoning,
   isAssistantMessageGroupStreaming,
+  parseUploadedFiles,
+  stripInternalMarkers,
   stripUploadedFilesTag,
 } from "@/core/messages/utils";
 
@@ -305,6 +307,44 @@ describe("human message internal context stripping", () => {
     } as Message;
 
     expect(getMessageCopyData(message)).toBe("Summarize this paper");
+  });
+
+  test("strips current_uploads context from copy data", () => {
+    // Mirrors the block UploadsMiddleware emits since #4174, including the
+    // trailing usage-guidance lines.
+    const message = {
+      id: "human-with-current-uploads",
+      type: "human",
+      content:
+        "<current_uploads>\nThe following files were uploaded in this message:\n\n- paper.docx (177.6 KB)\n  Path: /mnt/user-data/uploads/paper.docx\n\nTo work with these files:\n- Use `grep` to search for keywords\n  (e.g. `grep(pattern='revenue', path='/mnt/user-data/uploads/')`).\n</current_uploads>\n\nMake a slide deck from this",
+    } as Message;
+
+    expect(getMessageCopyData(message)).toBe("Make a slide deck from this");
+  });
+
+  test("parses uploaded files from a current_uploads block", () => {
+    const content =
+      "<current_uploads>\nThe following files were uploaded in this message:\n\n- paper.docx (177.6 KB)\n  Path: /mnt/user-data/uploads/paper.docx\n  Document outline (use `read_file` with line ranges to read sections):\n    L1: Introduction\n- data.xlsx (12.0 KB)\n  Path: /mnt/user-data/uploads/data.xlsx\n</current_uploads>\n\nSummarize";
+
+    expect(parseUploadedFiles(content)).toEqual([
+      {
+        filename: "paper.docx",
+        size: 177,
+        path: "/mnt/user-data/uploads/paper.docx",
+      },
+      {
+        filename: "data.xlsx",
+        size: 12,
+        path: "/mnt/user-data/uploads/data.xlsx",
+      },
+    ]);
+  });
+
+  test("stripInternalMarkers removes current_uploads blocks on export", () => {
+    const content =
+      "<current_uploads>\n- paper.docx (177.6 KB)\n  Path: /mnt/user-data/uploads/paper.docx\n</current_uploads>\n\nExport me";
+
+    expect(stripInternalMarkers(content)).toBe("Export me");
   });
 
   test("strips slash skill activation context from display content", () => {

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -326,15 +326,18 @@ describe("human message internal context stripping", () => {
     const content =
       "<current_uploads>\nThe following files were uploaded in this message:\n\n- paper.docx (177.6 KB)\n  Path: /mnt/user-data/uploads/paper.docx\n  Document outline (use `read_file` with line ranges to read sections):\n    L1: Introduction\n- data.xlsx (12.0 KB)\n  Path: /mnt/user-data/uploads/data.xlsx\n</current_uploads>\n\nSummarize";
 
+    // size is bytes (FileInMessage contract): the block's "177.6 KB" /
+    // "12.0 KB" are converted back from the human-readable form the backend
+    // emits, so formatBytes re-renders them at the original magnitude.
     expect(parseUploadedFiles(content)).toEqual([
       {
         filename: "paper.docx",
-        size: 177,
+        size: Math.round(177.6 * 1024), // 181862
         path: "/mnt/user-data/uploads/paper.docx",
       },
       {
         filename: "data.xlsx",
-        size: 12,
+        size: 12 * 1024, // 12288
         path: "/mnt/user-data/uploads/data.xlsx",
       },
     ]);


### PR DESCRIPTION
Part of #4399 (the `<current_uploads>` leak reported in the comments); regression from #4174, related to #4212.

## Why

Since #4174, uploading a document makes the raw `<current_uploads>` block — the file list plus the grep/glob usage guidance meant for the model — render inside the user's chat bubble (reported by @gnftau in #4399). #4174 renamed the upload context tag that `UploadsMiddleware` prepends to the user message from `<uploaded_files>` to `<current_uploads>` and updated the backend consumers (input sanitization, deermem), but the frontend strip/parse tag vocabulary was not updated. This also invalidates the note in #4212 that "nothing is broken": the web UI display path was.

## What changed

- The user bubble no longer shows the raw upload context block; copy/export paths strip it too.
- The file-chip fallback (for messages whose file list only exists in content, e.g. history/IM paths without `additional_kwargs.files`) matches the new tag again.
- `<uploaded_files>` stays supported — history rows and IM channels (until #4212 unifies them) still carry it.

Touched: `core/messages/utils.ts` (`stripUploadedFilesTag`, `INTERNAL_MARKER_TAGS` — which also covers `streamdown/preprocess.ts` and `threads/export.ts` since they derive from it — and `parseUploadedFiles`), `components/workspace/messages/message-list-item.tsx` (chip fallback detection).

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before: the raw `<current_uploads>` block (file list plus grep/glob guidance) rendered inside the user bubble, as described in [gnftau's report](https://github.com/bytedance/deer-flow/issues/4399#issuecomment-5055624893) (point 4).

After (local `make dev`, docx upload + message, checked after run completion): the bubble shows only the typed text plus the file chip; the block is stripped.

## Bug fix verification

- Test path that reproduces the bug: `frontend/tests/unit/core/messages/utils.test.ts` — "strips current_uploads context from copy data", "parses uploaded files from a current_uploads block", "stripInternalMarkers removes current_uploads blocks on export" (fixtures mirror `uploads_middleware.py::_create_files_message` output).
- Did it go red on `main` and green on this branch? yes (3 failed on `main`, all pass here).

## Validation

- `pnpm test` — full unit suite passes; the 3 new tests fail on `main` (verified by stashing the src changes) and pass on this branch
- `pnpm check` (eslint + `tsc --noEmit`) — clean
- `pnpm format` — clean
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — passes
- `make test-e2e` — 109 passed
- Manual: local `make dev`, uploaded a docx with a message; after the run completed the bubble shows only the message text + file chip, and the assistant's reply confirms the model still received the upload context

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Used it to locate the regression (sweeping frontend consumers of the old tag) and draft the fix and tests; I reviewed every line and verified the behavior manually in a local `make dev` session.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
