### PR TITLE
fix(frontend): keep leading orphan tool messages visible

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -92,13 +92,18 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
           if (lastGroup) {
             lastGroup.messages.push(message);
           } else {
-            // groups is empty (shouldn't happen — the outer for loop is guarded
-            // by `messages.length === 0 -> return []`), but keep the diagnostic
-            // just in case.
-            console.error(
-              "Unexpected tool message with no preceding group",
-              message,
-            );
+            // Leading orphan: history pagination cuts by event seq, not turn
+            // boundaries, so the first loaded page can begin mid-turn with a
+            // tool result whose AI tool-call message sits on an unloaded older
+            // page (#4399). Open a processing group so the message stays
+            // grouped and visible instead of being dropped with a console
+            // error on every render; loading the older page re-groups it
+            // under its real turn.
+            groups.push({
+              id: message.id,
+              type: "assistant:processing",
+              messages: [message],
+            });
           }
         }
       }

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -92,13 +92,22 @@ export function getMessageGroups(messages: Message[]): MessageGroup[] {
           if (lastGroup) {
             lastGroup.messages.push(message);
           } else {
-            // Leading orphan: history pagination cuts by event seq, not turn
-            // boundaries, so the first loaded page can begin mid-turn with a
-            // tool result whose AI tool-call message sits on an unloaded older
-            // page (#4399). Open a processing group so the message stays
-            // grouped and visible instead of being dropped with a console
-            // error on every render; loading the older page re-groups it
-            // under its real turn.
+            // Leading orphan: `groups` is empty when this tool message
+            // arrives. Two paths reach here: (1) history pagination cuts by
+            // event seq, not turn boundaries, so the first loaded page begins
+            // mid-turn with a tool result whose AI tool-call sits on an
+            // unloaded older page (#4399); (2) the tool message is preceded
+            // only by hidden control messages. Open a processing group so it
+            // stays visible instead of being dropped with a per-render console
+            // error.
+            //
+            // Only case (1) self-heals — loading the older page re-groups the
+            // tool under its real turn. Case (2), and any truly orphaned tool
+            // with no AI antecedent, has no page to load: the group persists
+            // and renders as an empty ChainOfThought shell (convertToSteps
+            // emits steps only for `type === "ai"`). That empty shell is an
+            // accepted degradation — still a net win over dropping the result
+            // and firing console.error every render.
             groups.push({
               id: message.id,
               type: "assistant:processing",

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -724,6 +724,67 @@ describe("orphan tool messages", () => {
     expect(t2?.type).toBe("tool");
   });
 
+  test("opens a processing group for a leading orphan tool message", () => {
+    // History pagination cuts by event seq, not turn boundaries, so the first
+    // loaded page can begin mid-turn with tool results whose AI tool-call
+    // message sits on an unloaded older page (#4399). They must stay visible
+    // in a processing group, not be dropped with a console error per render.
+    const messages = [
+      {
+        id: "t-lead-1",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-old-1",
+        content: "output from unloaded turn",
+      },
+      {
+        id: "t-lead-2",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-old-2",
+        content: "second output",
+      },
+      { id: "ai-1", type: "ai", content: "Done." },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    expect(groups.map((g) => g.type)).toEqual([
+      "assistant:processing",
+      "assistant",
+    ]);
+    // Both leading orphans cluster into the same processing group.
+    expect(groups[0]?.messages.map((m) => m.id)).toEqual([
+      "t-lead-1",
+      "t-lead-2",
+    ]);
+  });
+
+  test("tool message preceded only by hidden messages gets a group", () => {
+    // messages is non-empty, but every earlier message is hidden from the UI —
+    // groups is still empty when the tool message arrives.
+    const messages = [
+      {
+        id: "hidden-1",
+        type: "human",
+        content:
+          "<slash_skill_activation>\n<skill_content># SKILL.md</skill_content>\n</slash_skill_activation>",
+      },
+      {
+        id: "t-1",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-1",
+        content: "output",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    expect(groups.map((g) => g.type)).toEqual(["assistant:processing"]);
+    expect(groups[0]?.messages.map((m) => m.id)).toEqual(["t-1"]);
+  });
+
   test("replayed tool with same tool_call_id is not lost (duplicate stream events)", () => {
     // LangGraph subagent state restoration can replay tool-result events. The
     // frontend log shows the same tool_call_id arriving twice. Both occurrences

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -760,6 +760,44 @@ describe("orphan tool messages", () => {
     ]);
   });
 
+  test("leading orphan absorbs the following real AI turn into one processing group", () => {
+    // A leading orphan followed by a real tool-call turn must accumulate into
+    // a single processing group via the assistant:processing branch, not
+    // strand the orphan as a separate empty group beside the real turn.
+    const messages = [
+      {
+        id: "t-lead",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-old",
+        content: "output from unloaded turn",
+      },
+      {
+        id: "ai-1",
+        type: "ai",
+        content: "running",
+        tool_calls: [{ id: "call-1", name: "bash", args: {} }],
+      },
+      {
+        id: "t-1",
+        type: "tool",
+        name: "bash",
+        tool_call_id: "call-1",
+        content: "output-1",
+      },
+    ] as Message[];
+
+    const groups = getMessageGroups(messages);
+
+    // One processing group holds the orphan, the AI turn, and its tool result.
+    expect(groups.map((g) => g.type)).toEqual(["assistant:processing"]);
+    expect(groups[0]?.messages.map((m) => m.id)).toEqual([
+      "t-lead",
+      "ai-1",
+      "t-1",
+    ]);
+  });
+
   test("tool message preceded only by hidden messages gets a group", () => {
     // messages is non-empty, but every earlier message is hidden from the UI —
     // groups is still empty when the tool message arrives.


### PR DESCRIPTION
Part of #4399 (the `Unexpected tool message with no preceding group` console-error overlay in the issue body); sibling gap left by #3880 (#3879).

## Why

Long tool-heavy runs make the dev overlay pop a full-screen "Console Error: Unexpected tool message with no preceding group" panel (screenshots in #4399; the reporter confirmed every error on the panel was this same diagnostic). The diagnostic branch in `getMessageGroups` claimed the case "shouldn't happen", but the justification is wrong: `messages` being non-empty does not make `groups` non-empty. It is reachable in two ways — history pagination cuts by event seq, not turn boundaries, so the first loaded page can begin mid-turn with tool results whose AI tool-call message sits on an unloaded older page; and a tool message preceded only by hidden control messages. In both cases the tool message was silently dropped and the console.error fired on every render.

## What changed

A leading orphan tool message now opens an `assistant:processing` group — the same "orphan tool messages stay visible" invariant #3880 established for the mid-list case — instead of being dropped with a per-render console.error. Consecutive leading orphans cluster into that group; once the older history page loads, grouping recomputes and the message lands under its real turn. The dev overlay no longer fires.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before: the full-screen dev overlay in #4399's issue body. After: the branch no longer logs, so the overlay has nothing to show; the previously-dropped tool result is kept in a processing group (renders as an empty shell at the top of the loaded window until the older page loads — same visual as before, minus the error and the drop).

## Bug fix verification

- Test path that reproduces the bug: `frontend/tests/unit/core/messages/utils.test.ts` — "opens a processing group for a leading orphan tool message", "tool message preceded only by hidden messages gets a group".
- Did it go red on `main` and green on this branch? yes (2 failed on `main`, all pass here).

## Validation

- `pnpm test` — 732 passed (2 new); the new tests fail on `main` (verified by stashing the src change)
- `pnpm check` (eslint + `tsc --noEmit`) — clean
- `pnpm format` — clean
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — passes
- `make test-e2e` — 109 passed

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Used it to trace why the "shouldn't happen" branch fires (history page boundaries vs turn boundaries) and draft the fix and tests; I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
