### PR TITLE
docs: correct frontend pre-check guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -71,8 +71,7 @@ Run from `frontend/`.
 Recommended reliable sequence:
 
 ```bash
-pnpm lint
-pnpm typecheck
+pnpm check
 BETTER_AUTH_SECRET=local-dev-secret pnpm build
 ```
 
@@ -81,7 +80,7 @@ Observed failure modes and workarounds:
 - `pnpm build` fails without `BETTER_AUTH_SECRET` in production-mode env validation.
 - Workaround: set `BETTER_AUTH_SECRET` (best) or set `SKIP_ENV_VALIDATION=1`.
 - Even with `SKIP_ENV_VALIDATION=1`, Better Auth can still warn/error in logs about default secret; prefer setting a real non-default secret.
-- `pnpm check` currently fails (`next lint` invocation is incompatible here and resolves to an invalid directory). Do not rely on `pnpm check`; run `pnpm lint` and `pnpm typecheck` explicitly.
+- `pnpm check` runs the project's ESLint and TypeScript checks with the locked toolchain. Use it as the standard frontend pre-check.
 
 ### D. Run locally (all services)
 
@@ -126,7 +125,7 @@ Use this exact order for local code changes:
 1. `make check`
 2. `make install` (if frontend fails with proxy errors, rerun frontend install with proxy vars unset)
 3. Backend checks: `cd backend && make lint && make test`
-4. Frontend checks: `cd frontend && pnpm lint && pnpm typecheck`
+4. Frontend checks: `cd frontend && pnpm check`
 5. Frontend build (if UI changes or release-sensitive changes): `BETTER_AUTH_SECRET=... pnpm build`
 
 Always run backend lint/tests before opening PRs because that is what CI enforces.
@@ -172,7 +171,7 @@ Skills and assets:
 Before submitting changes, run at minimum:
 
 - Backend: `cd backend && make lint && make test`
-- Frontend (if touched): `cd frontend && pnpm lint && pnpm typecheck`
+- Frontend (if touched): `cd frontend && pnpm check`
 - Frontend build when changing env/auth/routing/build-sensitive files: `BETTER_AUTH_SECRET=... pnpm build`
 
 If touching orchestration/config (`Makefile`, `docker/*`, `config*.yaml`), also run `make dev` and verify the four services start.


### PR DESCRIPTION
## Why

`.github/copilot-instructions.md` said that `pnpm check` was broken even though the locked frontend toolchain runs it successfully. That guidance sent contributors toward an inconsistent pre-check path.

## What changed

The contributor instructions now describe `pnpm check` as the standard frontend pre-check and use it consistently in the recommended command sequences.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this changes contributor guidance only.

## Validation

- `cd frontend && corepack pnpm check`
- `git diff --check`

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Audited the repository's locked frontend scripts, verified the documented check command, and updated the stale guidance. Codex also ran the listed validation.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.