### PR TITLE
perf(frontend): coalesce streaming renders to a frame budget instead of per chunk

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -125,6 +125,10 @@ export function buildThreadSubmitMessages({
   ];
 }
 
+// Stable identity for "no optimistic messages" so the merged-messages memo
+// below is not invalidated by a fresh empty array on every render.
+const EMPTY_MESSAGES: Message[] = [];
+
 const EMPTY_THREAD_VALUES: AgentThreadState = {
   title: "",
   messages: [],
@@ -738,6 +742,111 @@ export function getSummarizationMiddlewareMessages(
   return undefined;
 }
 
+export const STREAM_RENDER_COALESCE_MS = 80;
+
+export type CoalesceDecision =
+  | { action: "flush-now" }
+  | { action: "schedule"; delayMs: number }
+  | { action: "wait" };
+
+/**
+ * Decide how an incoming stream update reaches the rendered snapshot: flush
+ * immediately once a full interval has elapsed (leading edge), otherwise
+ * schedule exactly one trailing flush for the interval remainder. Unlike a
+ * debounce, the delay never extends past the interval, so a dense stream can
+ * never starve rendering.
+ */
+export function decideCoalesce(
+  nowMs: number,
+  lastFlushMs: number,
+  intervalMs: number,
+  hasPendingTimer: boolean,
+): CoalesceDecision {
+  if (nowMs - lastFlushMs >= intervalMs) {
+    return { action: "flush-now" };
+  }
+  if (hasPendingTimer) {
+    return { action: "wait" };
+  }
+  return { action: "schedule", delayMs: intervalMs - (nowMs - lastFlushMs) };
+}
+
+/**
+ * While a run is streaming, expose the messages array as a snapshot that
+ * updates at most once per interval instead of once per SSE chunk, so the
+ * merge/group/render pipeline runs per frame budget rather than per token
+ * (#4409 Phase 1). When the stream is idle the latest array passes straight
+ * through, keeping non-stream updates immediate.
+ */
+function sameMessageArray(a: Message[], b: Message[]): boolean {
+  return (
+    a === b ||
+    (a.length === b.length && a.every((message, index) => message === b[index]))
+  );
+}
+
+export function useCoalescedStreamMessages(
+  messages: Message[],
+  isStreaming: boolean,
+  intervalMs: number = STREAM_RENDER_COALESCE_MS,
+): Message[] {
+  const [snapshot, setSnapshot] = useState<Message[]>(messages);
+  const latestRef = useRef(messages);
+  latestRef.current = messages;
+  const lastFlushRef = useRef(0);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Every publication goes through the shallow-equality guard: inputs whose
+  // identity churns without content change (the SDK getter mints fresh arrays)
+  // must not re-trigger renders, or this effect would setState-loop.
+  const publish = useCallback(() => {
+    setSnapshot((previous) =>
+      sameMessageArray(previous, latestRef.current)
+        ? previous
+        : latestRef.current,
+    );
+  }, []);
+
+  useEffect(() => {
+    if (!isStreaming) {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      // Keep the snapshot current so the next stream starts from a fresh base.
+      publish();
+      return;
+    }
+    const decision = decideCoalesce(
+      Date.now(),
+      lastFlushRef.current,
+      intervalMs,
+      timerRef.current !== null,
+    );
+    if (decision.action === "flush-now") {
+      lastFlushRef.current = Date.now();
+      publish();
+    } else if (decision.action === "schedule") {
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        lastFlushRef.current = Date.now();
+        publish();
+      }, decision.delayMs);
+    }
+  }, [messages, isStreaming, intervalMs, publish]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+
+  return isStreaming ? snapshot : messages;
+}
+
 export function upsertThreadInSearchCache(
   queryClient: QueryClient,
   thread: AgentThread,
@@ -1060,6 +1169,10 @@ export function useThreadStream({
     threadId: onStreamThreadId,
     reconnectOnMount: true,
     fetchStateHistory: { limit: 1 },
+    // Coalesce same-tick stream events into one React notification. Only the
+    // boolean tier is safe: the SDK's numeric tier is a trailing debounce that
+    // starves UI updates while chunks keep arriving faster than the window.
+    throttle: true,
     onCreated(meta) {
       handleStreamStart(meta.thread_id, meta.run_id);
       const now = new Date().toISOString();
@@ -1266,16 +1379,18 @@ export function useThreadStream({
 
   const hasVisibleStreamState =
     Boolean(threadId) || liveMessagesThreadId === currentViewThreadId;
-  const persistedMessages = useMemo(
-    () =>
-      hasVisibleStreamState
-        ? thread.messages.filter(
-            (message) =>
-              !message.id || !pendingSupersededMessageIds.has(message.id),
-          )
-        : [],
-    [hasVisibleStreamState, pendingSupersededMessageIds, thread.messages],
-  );
+  const persistedMessages = useMemo(() => {
+    if (!hasVisibleStreamState) {
+      return EMPTY_MESSAGES;
+    }
+    const filtered = thread.messages.filter(
+      (message) => !message.id || !pendingSupersededMessageIds.has(message.id),
+    );
+    // The SDK getter mints a fresh [] on every read while the stream has no
+    // values; normalize to a stable identity so downstream effects keyed on
+    // this array cannot re-fire (and setState-loop) on idle renders.
+    return filtered.length === 0 ? EMPTY_MESSAGES : filtered;
+  }, [hasVisibleStreamState, pendingSupersededMessageIds, thread.messages]);
   const visibleHistory = useMemo(
     () => (threadId ? history : []),
     [history, threadId],
@@ -1698,11 +1813,23 @@ export function useThreadStream({
     messagesRef.current = persistedMessages;
   }
 
-  const visibleOptimisticMessages = getVisibleOptimisticMessages(
+  // Render-facing coalesced snapshot. Refs, counters and usage tracking keep
+  // consuming the per-chunk array above so lifecycle semantics (optimistic
+  // clearing, summarization capture, token-usage baselines) are unchanged.
+  const renderMessages = useCoalescedStreamMessages(
+    persistedMessages,
+    thread.isLoading,
+  );
+
+  const rawVisibleOptimisticMessages = getVisibleOptimisticMessages(
     optimisticThreadId === currentViewThreadId ? optimisticMessages : [],
     prevHumanMsgCountRef.current,
     humanMessageCount,
   );
+  const visibleOptimisticMessages =
+    rawVisibleOptimisticMessages.length === 0
+      ? EMPTY_MESSAGES
+      : rawVisibleOptimisticMessages;
 
   const transientHistoryOrder =
     transientHistoryBridgeRef.current.length > 0 &&
@@ -1728,18 +1855,30 @@ export function useThreadStream({
     }
   }, [persistedMessages, threadId]);
 
-  const effectiveHistory = resolveThreadTransientHistoryBridge(
-    visibleHistory,
-    transientHistoryBridgeRef.current,
-    transientHistoryThreadIdRef.current,
+  // The transient-bridge refs mutate in lockstep with stream/history updates
+  // already captured by these deps, and resolveTransientHistoryBridge is
+  // idempotent for entries canonical history has absorbed, so memoizing on the
+  // coalesced snapshot cannot pin a stale bridge.
+  const mergedMessages = useMemo(() => {
+    const effectiveHistory = resolveThreadTransientHistoryBridge(
+      visibleHistory,
+      transientHistoryBridgeRef.current,
+      transientHistoryThreadIdRef.current,
+      threadId,
+      transientHistoryOrder,
+    );
+    return mergeMessages(
+      effectiveHistory,
+      renderMessages,
+      visibleOptimisticMessages,
+    );
+  }, [
+    renderMessages,
     threadId,
     transientHistoryOrder,
-  );
-  const mergedMessages = mergeMessages(
-    effectiveHistory,
-    persistedMessages,
+    visibleHistory,
     visibleOptimisticMessages,
-  );
+  ]);
   const pendingUsageMessages = thread.isLoading
     ? getMessagesAfterBaseline(
         persistedMessages,

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -796,7 +796,11 @@ export function useCoalescedStreamMessages(
   const [snapshot, setSnapshot] = useState<Message[]>(messages);
   const latestRef = useRef(messages);
   latestRef.current = messages;
-  const lastFlushRef = useRef(0);
+  // Monotonic clock: a wall-clock step (NTP, sleep/wake) between two reads
+  // would otherwise be added to the remaining interval and stall the flush for
+  // the length of the jump. -Infinity means "never flushed", so the first
+  // update of a stream always takes the leading edge.
+  const lastFlushRef = useRef(Number.NEGATIVE_INFINITY);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Every publication goes through the shallow-equality guard: inputs whose
@@ -820,19 +824,22 @@ export function useCoalescedStreamMessages(
       publish();
       return;
     }
+    const now = performance.now();
     const decision = decideCoalesce(
-      Date.now(),
+      now,
       lastFlushRef.current,
       intervalMs,
       timerRef.current !== null,
     );
     if (decision.action === "flush-now") {
-      lastFlushRef.current = Date.now();
+      lastFlushRef.current = now;
       publish();
     } else if (decision.action === "schedule") {
       timerRef.current = setTimeout(() => {
         timerRef.current = null;
-        lastFlushRef.current = Date.now();
+        // Read the clock again: timers fire late under load, and the next
+        // interval must start from the real flush.
+        lastFlushRef.current = performance.now();
         publish();
       }, decision.delayMs);
     }

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -820,7 +820,11 @@ export function useCoalescedStreamMessages(
         clearTimeout(timerRef.current);
         timerRef.current = null;
       }
-      // Keep the snapshot current so the next stream starts from a fresh base.
+      // Keep the snapshot current so the next stream starts from a fresh base,
+      // and drop the flush baseline so the leading edge is per stream rather
+      // than per hook instance: a run starting within one interval of the
+      // previous one must not have its first frame deferred.
+      lastFlushRef.current = Number.NEGATIVE_INFINITY;
       publish();
       return;
     }

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -793,7 +793,12 @@ export function useCoalescedStreamMessages(
   isStreaming: boolean,
   intervalMs: number = STREAM_RENDER_COALESCE_MS,
 ): Message[] {
-  const [snapshot, setSnapshot] = useState<Message[]>(messages);
+  // `null` means "no snapshot belongs to the current stream": the live array is
+  // returned until the leading-edge flush lands, so a snapshot left over from an
+  // earlier stream can never be painted. This hook outlives thread switches (the
+  // chat page deliberately avoids re-mounting, see its `onStart` comment), so a
+  // retained snapshot would otherwise be another thread's messages.
+  const [snapshot, setSnapshot] = useState<Message[] | null>(null);
   const latestRef = useRef(messages);
   latestRef.current = messages;
   // Monotonic clock: a wall-clock step (NTP, sleep/wake) between two reads
@@ -808,7 +813,7 @@ export function useCoalescedStreamMessages(
   // must not re-trigger renders, or this effect would setState-loop.
   const publish = useCallback(() => {
     setSnapshot((previous) =>
-      sameMessageArray(previous, latestRef.current)
+      previous !== null && sameMessageArray(previous, latestRef.current)
         ? previous
         : latestRef.current,
     );
@@ -824,12 +829,13 @@ export function useCoalescedStreamMessages(
   useEffect(() => {
     if (!isStreaming) {
       clearPendingFlush();
-      // Keep the snapshot current so the next stream starts from a fresh base,
-      // and drop the flush baseline so the leading edge is per stream rather
-      // than per hook instance: a run starting within one interval of the
-      // previous one must not have its first frame deferred.
+      // Drop the flush baseline so the leading edge is per stream rather than
+      // per hook instance: a run starting within one interval of the previous
+      // one must not have its first frame deferred. Dropping the snapshot with
+      // it costs one render per stream end, versus one per idle message change
+      // if the snapshot were instead kept in sync while nothing reads it.
       lastFlushRef.current = Number.NEGATIVE_INFINITY;
-      publish();
+      setSnapshot((previous) => (previous === null ? previous : null));
       return;
     }
     const now = performance.now();
@@ -866,7 +872,7 @@ export function useCoalescedStreamMessages(
     [],
   );
 
-  return isStreaming ? snapshot : messages;
+  return isStreaming && snapshot !== null ? snapshot : messages;
 }
 
 export function upsertThreadInSearchCache(

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -639,19 +639,22 @@ export function mergeTransientHistoryBridge(
 export function mergeTransientHistoryBridgeOrder(
   currentOrder: readonly string[],
   capturedMessages: Message[],
-): string[] {
+): readonly string[] {
   const capturedOrder = dedupeMessagesByIdentity(capturedMessages)
     .map(messageIdentity)
     .filter(isNonEmptyString);
-  const merged = [...currentOrder];
+  // Clone lazily and return the input when nothing is appended: this runs per
+  // render while the bridge is active, and a fresh array would invalidate the
+  // coalesced render memo on every chunk (#4409 Phase 1).
+  let merged: string[] | null = null;
   const seen = new Set(currentOrder);
   for (const identity of capturedOrder) {
     if (!seen.has(identity)) {
       seen.add(identity);
-      merged.push(identity);
+      (merged ??= [...currentOrder]).push(identity);
     }
   }
-  return merged;
+  return merged ?? currentOrder;
 }
 
 export function resolveThreadTransientHistoryBridge(
@@ -1408,7 +1411,7 @@ export function useThreadStream({
   // Full identity order of each captured checkpoint. Confirmed bridge entries
   // are pruned from the message buffer, but remain here as non-rendering
   // anchors so an older rescue can be placed before a newest-first page.
-  const transientHistoryOrderRef = useRef<string[]>([]);
+  const transientHistoryOrderRef = useRef<readonly string[]>([]);
   const transientHistoryThreadIdRef = useRef<string | null>(null);
   const summarizedRef = useRef<Set<string>>(null);
   // Track human message count before sending to prevent clearing optimistic

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -814,12 +814,16 @@ export function useCoalescedStreamMessages(
     );
   }, []);
 
+  const clearPendingFlush = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
   useEffect(() => {
     if (!isStreaming) {
-      if (timerRef.current !== null) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
+      clearPendingFlush();
       // Keep the snapshot current so the next stream starts from a fresh base,
       // and drop the flush baseline so the leading edge is per stream rather
       // than per hook instance: a run starting within one interval of the
@@ -836,6 +840,10 @@ export function useCoalescedStreamMessages(
       timerRef.current !== null,
     );
     if (decision.action === "flush-now") {
+      // A trailing timer can still be armed here: timers fire late under
+      // main-thread load, which is exactly when a chunk overtakes one. Leaving
+      // it would publish a second time and slip the next interval forward.
+      clearPendingFlush();
       lastFlushRef.current = now;
       publish();
     } else if (decision.action === "schedule") {
@@ -847,7 +855,7 @@ export function useCoalescedStreamMessages(
         publish();
       }, decision.delayMs);
     }
-  }, [messages, isStreaming, intervalMs, publish]);
+  }, [messages, isStreaming, intervalMs, publish, clearPendingFlush]);
 
   useEffect(
     () => () => {

--- a/frontend/tests/e2e/artifact-stream-state.spec.ts
+++ b/frontend/tests/e2e/artifact-stream-state.spec.ts
@@ -17,6 +17,18 @@ const THREAD_MESSAGES = [
     content: "Created a markdown report.",
   },
 ];
+const FOLLOW_UP_MESSAGES = [
+  {
+    type: "human",
+    id: "msg-human-artifact-follow-up",
+    content: [{ type: "text", text: "Continue" }],
+  },
+  {
+    type: "ai",
+    id: "msg-ai-artifact-follow-up",
+    content: "Updated response while the artifact list is omitted.",
+  },
+];
 
 function streamWithoutArtifacts(route: Route) {
   const events = [
@@ -27,18 +39,7 @@ function streamWithoutArtifacts(route: Route) {
     {
       event: "values",
       data: {
-        messages: [
-          {
-            type: "human",
-            id: "msg-human-artifact-follow-up",
-            content: [{ type: "text", text: "Continue" }],
-          },
-          {
-            type: "ai",
-            id: "msg-ai-artifact-follow-up",
-            content: "Updated response while the artifact list is omitted.",
-          },
-        ],
+        messages: FOLLOW_UP_MESSAGES,
       },
     },
   ];
@@ -68,7 +69,60 @@ test("keeps artifact trigger after stream values omit artifacts", async ({
     ],
   });
 
+  // A real gateway persists the run's messages, so the SDK's end-of-run state
+  // refetch returns them. This spec's stream route bypasses the shared mock's
+  // thread upsert, which would otherwise leave post-run state looking like the
+  // run never happened — an impossible backend state that only a same-tick
+  // render could paper over. Serve the persisted turn once the run has started;
+  // stream values still omit artifacts, which is the invariant under test.
+  let runStarted = false;
+  await page.route("**/api/langgraph/threads/*/history", (route) => {
+    if (!runStarted) {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        {
+          values: {
+            title: "Artifact stream state",
+            goal: null,
+            messages: [...THREAD_MESSAGES, ...FOLLOW_UP_MESSAGES],
+            artifacts: [ARTIFACT_PATH],
+          },
+          next: [],
+          metadata: {},
+          created_at: "2025-01-01T00:00:00Z",
+          parent_config: null,
+        },
+      ]),
+    });
+  });
+  await page.route(/\/api\/threads\/([^/]+)\/messages\/page/, (route) => {
+    if (!runStarted) {
+      return route.fallback();
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [...THREAD_MESSAGES, ...FOLLOW_UP_MESSAGES].map(
+          (message, index) => ({
+            run_id: RUN_ID,
+            seq: index + 1,
+            content: message,
+            metadata: { caller: "lead_agent" },
+            created_at: `2025-01-01T00:00:${String(index).padStart(2, "0")}Z`,
+          }),
+        ),
+        has_more: false,
+        next_before_seq: null,
+      }),
+    });
+  });
   await page.route("**/api/langgraph/threads/*/runs/stream", (route) => {
+    runStarted = true;
     return streamWithoutArtifacts(route);
   });
 

--- a/frontend/tests/unit/core/threads/coalesce.test.ts
+++ b/frontend/tests/unit/core/threads/coalesce.test.ts
@@ -60,6 +60,26 @@ describe("decideCoalesce", () => {
     }
   });
 
+  it("takes the leading edge when nothing has flushed yet", () => {
+    // The hook seeds lastFlush with -Infinity on a monotonic clock whose epoch
+    // is page load, so the first update of a stream must not be deferred.
+    expect(decideCoalesce(5, Number.NEGATIVE_INFINITY, 80, false)).toEqual({
+      action: "flush-now",
+    });
+  });
+
+  it("keeps the scheduled delay inside the interval", () => {
+    // Holds for every elapsed value a monotonic clock can produce, which is why
+    // the call site needs no clamp on the timeout delay.
+    for (let elapsed = 0; elapsed < 80; elapsed++) {
+      const decision = decideCoalesce(1000, 1000 - elapsed, 80, false);
+      expect(decision.action).toBe("schedule");
+      if (decision.action !== "schedule") continue;
+      expect(decision.delayMs).toBeGreaterThan(0);
+      expect(decision.delayMs).toBeLessThanOrEqual(80);
+    }
+  });
+
   it("exports a frame-scale default interval", () => {
     expect(STREAM_RENDER_COALESCE_MS).toBeGreaterThanOrEqual(50);
     expect(STREAM_RENDER_COALESCE_MS).toBeLessThanOrEqual(100);

--- a/frontend/tests/unit/core/threads/coalesce.test.ts
+++ b/frontend/tests/unit/core/threads/coalesce.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@rstest/core";
+
+import {
+  decideCoalesce,
+  STREAM_RENDER_COALESCE_MS,
+} from "@/core/threads/hooks";
+
+describe("decideCoalesce", () => {
+  it("flushes immediately once a full interval has elapsed (leading edge)", () => {
+    expect(decideCoalesce(1000, 900, 80, false)).toEqual({
+      action: "flush-now",
+    });
+    expect(decideCoalesce(1000, 920, 80, false)).toEqual({
+      action: "flush-now",
+    });
+  });
+
+  it("schedules exactly one trailing flush for the interval remainder", () => {
+    expect(decideCoalesce(1000, 950, 80, false)).toEqual({
+      action: "schedule",
+      delayMs: 30,
+    });
+  });
+
+  it("waits while a trailing flush is already pending", () => {
+    expect(decideCoalesce(1000, 950, 80, true)).toEqual({ action: "wait" });
+  });
+
+  it("never delays a flush beyond the interval, unlike a debounce", () => {
+    // Simulate a dense stream: updates every 10ms. A debounce would keep
+    // resetting its timer and never fire; here the trailing flush scheduled at
+    // the first update stays put and every later update just waits on it.
+    let lastFlush = 0;
+    let pendingUntil: number | null = null;
+    const flushes: number[] = [];
+    for (let now = 10; now <= 400; now += 10) {
+      if (pendingUntil !== null && now >= pendingUntil) {
+        flushes.push(pendingUntil);
+        lastFlush = pendingUntil;
+        pendingUntil = null;
+      }
+      const decision = decideCoalesce(
+        now,
+        lastFlush,
+        80,
+        pendingUntil !== null,
+      );
+      if (decision.action === "flush-now") {
+        flushes.push(now);
+        lastFlush = now;
+      } else if (decision.action === "schedule") {
+        pendingUntil = now + decision.delayMs;
+      }
+    }
+    expect(flushes.length).toBeGreaterThanOrEqual(4);
+    for (let i = 1; i < flushes.length; i++) {
+      const gap = flushes[i]! - flushes[i - 1]!;
+      expect(gap).toBeGreaterThanOrEqual(80);
+      expect(gap).toBeLessThanOrEqual(90);
+    }
+  });
+
+  it("exports a frame-scale default interval", () => {
+    expect(STREAM_RENDER_COALESCE_MS).toBeGreaterThanOrEqual(50);
+    expect(STREAM_RENDER_COALESCE_MS).toBeLessThanOrEqual(100);
+  });
+});

--- a/frontend/tests/unit/core/threads/coalesce.test.ts
+++ b/frontend/tests/unit/core/threads/coalesce.test.ts
@@ -26,6 +26,16 @@ describe("decideCoalesce", () => {
     expect(decideCoalesce(1000, 950, 80, true)).toEqual({ action: "wait" });
   });
 
+  it("still takes the leading edge when a late trailing flush is pending", () => {
+    // Timer callbacks queue behind long tasks, so an update can arrive past the
+    // interval while the trailing flush is still armed. The decision is
+    // flush-now, which obliges the call site to disarm that timer — otherwise
+    // it publishes a second time and slips the next interval forward.
+    expect(decideCoalesce(1000, 900, 80, true)).toEqual({
+      action: "flush-now",
+    });
+  });
+
   it("never delays a flush beyond the interval, unlike a debounce", () => {
     // Simulate a dense stream: updates every 10ms. A debounce would keep
     // resetting its timer and never fire; here the trailing flush scheduled at

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -911,6 +911,29 @@ test("mergeTransientHistoryBridgeOrder retains confirmed overlap as a non-render
   ]);
 });
 
+test("mergeTransientHistoryBridgeOrder returns the same array when nothing is new", () => {
+  const order = mergeTransientHistoryBridgeOrder(
+    [],
+    [summarizationHuman1, summarizationAi1],
+  );
+
+  // Identity, not just equality: this runs per render while the bridge is
+  // active and feeds the coalesced render memo (#4409 Phase 1).
+  expect(mergeTransientHistoryBridgeOrder(order, [summarizationAi1])).toBe(
+    order,
+  );
+  expect(
+    mergeTransientHistoryBridgeOrder(order, [
+      summarizationHuman1,
+      summarizationAi1,
+    ]),
+  ).toBe(order);
+  expect(mergeTransientHistoryBridgeOrder(order, [])).toBe(order);
+  expect(
+    mergeTransientHistoryBridgeOrder(order, [summarizationHuman2]),
+  ).not.toBe(order);
+});
+
 test("mergeTransientHistoryBridgeOrder keeps a recaptured protected prefix in place", () => {
   const protectedInput = {
     id: "protected-input",


### PR DESCRIPTION
Part of #4409 — Phase 1 of the plan. Methodology, baseline and attribution data are in the Phase 0 comment: https://github.com/bytedance/deer-flow/issues/4409#issuecomment-5059467546

> **Measurement update:** the A/B table below was re-measured on an idle host with CPU-idle logged, and the numbers replace an earlier run whose absolute figures were inflated by background CPU load on the measuring machine. The core result — long-task time cut by ~83%, ramp eliminated — reproduces; but on an idle host the baseline already holds a single-frame budget with zero dropped frames, so this is a reduction of per-chunk work, not a recovery from visible jank. The revised framing and honest per-metric deltas are in Validation.

## Why

Phase 0 attribution showed the streaming frontend cost is dominated by "full tree re-render × render frequency", not by any single hot function: while a run streams, every SSE chunk becomes its own React update (~60/s in the standard repro), so the merge/group/render pipeline runs at token-arrival rate. Phase 1 decouples render frequency from token arrival — the cheapest, largest lever identified in the plan.

## What changed

- `useStream` gets `throttle: true` (the SDK coalesces same-tick updates; the millisecond variants are a trailing debounce that would starve a dense stream, so they are not used).
- New `useCoalescedStreamMessages` hook: while a run is streaming, the render-facing messages snapshot updates at most once per 80 ms (leading edge + trailing flush, so the final chunk always lands). `mergeMessages` and the transient-history resolve moved into a `useMemo` keyed on that snapshot, so between flushes the downstream pipeline (grouping, memo chains) reuses identities instead of recomputing.
- Lifecycle semantics unchanged: optimistic clearing, summarization capture and token-usage baselines keep reading the per-chunk array; when the stream is idle the array passes straight through with today's immediate behavior.

User-visible effect: streamed text arrives in ≤80 ms batches instead of per token, and the per-chunk merge/group/render work that accumulates over a long run is cut to once per frame budget.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

No visual change intended or observed: end-of-replay output is identical between baseline and this branch (same thread content, 3998 → 3988 DOM nodes, ~14.5K body-text chars in both).

## Validation

**A/B on the #4409 replay rig** — same recorded run (16 min, 5 parallel subagents, 1.42M tokens), replayed at 1× real-time against production builds. Baseline = current `main` (which already includes #4407 and #4408). Measured on an idle host: alternating rounds baseline/PR/baseline/PR, medians reported, CPU-idle sampled throughout (median 88.5%; the only dips fall in the per-round `pnpm build`, not the 972 s replay).

| metric | baseline (current main) | this PR | Δ |
|---|---|---|---|
| long tasks (total) | 1645 ms / 25 tasks | **276 ms / 3–4 tasks** | **−83% / −86%** |
| worst single minute | 522 ms | **176 ms** | **−66%** |
| degradation ramp m8–m13 (longtask/min) | 0 → 214 ms, rising | **0 → 0 ms, flat** | ramp eliminated |
| p99 frame gap | 18.6 ms | 18.6 ms | unchanged — baseline is already at a single-frame budget on an idle host |
| max frame gap | 150 ms | 124 ms | −17% |
| total frames (~972 s) | 57,651 | 58,237 | +1% (fewer drops) |
| gaps >500 ms / >2 s | 0 / 0 | 0 / 0 | unchanged |

Reading of the table: on an idle machine current `main` no longer drops frames at this scale, so the win is not "recovering from a freeze" — it is removing per-chunk work (long-task time −83%, the mid-run ramp flattened to zero). The freeze family this targets (#4399 etc.) shows up under real load / weaker devices, where that same per-chunk work is what the machine cannot keep up with; the throttle removes it regardless.

**Checks run** (all green):

- `pnpm format` · `pnpm lint` · `pnpm typecheck` · `pnpm build` · `pnpm test` (full unit suite) · `pnpm test:e2e` (109/109)
- New unit tests `tests/unit/core/threads/coalesce.test.ts` pin the coalescing semantics: leading-edge flush, exactly one trailing flush, and an anti-starvation property — under a dense update train the flush gap never exceeds the interval. Mutation-checked: rewriting the logic into a debounce turns the anti-starvation test red.
- Full-stream crash check: the entire recording replayed at 20× against this branch with zero page errors.

**Regression the rig caught during validation** (fixed in this PR, worth recording): the first version crashed on page load with React #185 (maximum update depth) — the SDK's `thread.messages` getter returns a fresh `[]` on every read while the stream has no values, and publishing that identity-unstable value into state loops forever. Fixed by normalizing empty arrays to a stable identity and shallow-equality-guarding every snapshot publication. Unit tests and typecheck were completely blind to this; only the full replay exposed it — which is also why the A/B numbers above are measured on the rig rather than asserted.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI implemented the change and tests from the #4409 Phase 0 plan and drove the replay-rig A/B measurements under my direction; I reviewed the diff and the methodology.
- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
