### PR TITLE
fix(ci): lock the ruff version from the backend Makefile

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -14,11 +14,11 @@ test-blocking-io:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/blocking_io -q --tb=short
 
 lint:
-	uvx ruff check .
-	uvx ruff format --check .
+	uv run ruff check .
+	uv run ruff format --check .
 
 format:
-	uvx ruff check . --fix && uvx ruff format .
+	uv run ruff check . --fix && uv run ruff format .
 
 detect-blocking-io:
 	@PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run python ../scripts/detect_blocking_io_static.py --output ../.deer-flow/blocking-io-findings.json


### PR DESCRIPTION
<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Fixes #4433 

## Summary

backend/Makefile lint/format now use uv run ruff instead of uvx ruff:

```
lint:
      uv run ruff check .
      uv run ruff format --check .

format:
      uv run ruff check . --fix && uv run ruff format .

```
Why it works:
- uvx ruff runs the latest ruff from PyPI in a throwaway environment — it ignores uv.lock entirely, which is how your lint could drift from CI/teammates.
- uv run ruff runs the ruff installed in the project .venv, which uv sync resolves from uv.lock (ruff is a dev group dependency in the workspace root pyproject.toml:42).

Verified: uv.lock pins ruff == 0.15.12, and make lint now resolves exactly ruff 0.15.12.

One caveat: unlike uvx (which auto-fetches), uv run ruff requires the env to be synced once via make install (uv sync). CI already does uv sync, and the make install target covers local dev, so this is the same precondition the other targets (dev, test) already rely on.