### PR TITLE
perf(frontend): stop re-deriving message content on every stream chunk

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -364,7 +364,12 @@ export function extractTextFromMessage(message: Message) {
 const THINK_OPEN_TAG = "<think>";
 const THINK_TAG_RE = /<think>\s*([\s\S]*?)\s*<\/think>/g;
 
-function splitInlineReasoning(content: string) {
+interface InlineReasoningSplit {
+  content: string;
+  reasoning: string | null;
+}
+
+function splitInlineReasoning(content: string): InlineReasoningSplit {
   const reasoningParts: string[] = [];
 
   // First pass: strip every fully closed `<think>...</think>` pair and
@@ -401,11 +406,29 @@ function splitInlineReasoning(content: string) {
   };
 }
 
+// The split is re-derived on every render: `hasContent`, `hasReasoning`,
+// `extractContentFromMessage` and `extractReasoningContentFromMessage` all run
+// over the whole message list on each stream chunk, so an unmemoized scan costs
+// O(total content) per chunk — quadratic across a long run. Cache per message
+// object, keyed by the exact content string it was derived from so a message
+// whose `content` is reassigned recomputes instead of serving a stale split.
+const inlineReasoningCache = new WeakMap<
+  object,
+  { content: string; split: InlineReasoningSplit }
+>();
+
 function splitInlineReasoningFromAIMessage(message: Message) {
   if (message.type !== "ai" || typeof message.content !== "string") {
     return null;
   }
-  return splitInlineReasoning(message.content);
+  const content = message.content;
+  const cached = inlineReasoningCache.get(message);
+  if (cached?.content === content) {
+    return cached.split;
+  }
+  const split = splitInlineReasoning(content);
+  inlineReasoningCache.set(message, { content, split });
+  return split;
 }
 
 export function extractContentFromMessage(message: Message) {
@@ -454,7 +477,7 @@ export function extractReasoningContentFromMessage(message: Message) {
     }
   }
   if (typeof message.content === "string") {
-    return splitInlineReasoning(message.content).reasoning;
+    return splitInlineReasoningFromAIMessage(message)?.reasoning ?? null;
   }
   return null;
 }
@@ -507,7 +530,9 @@ export function hasReasoning(message: Message) {
     return (part as unknown as { type: "thinking" })?.type === "thinking";
   }
   if (typeof message.content === "string") {
-    return splitInlineReasoning(message.content).reasoning !== null;
+    return (
+      (splitInlineReasoningFromAIMessage(message)?.reasoning ?? null) !== null
+    );
   }
   return false;
 }
@@ -567,14 +592,26 @@ export function findToolCallResult(toolCallId: string, messages: Message[]) {
 }
 
 export function isHiddenFromUIMessage(message: Message) {
+  if (message.additional_kwargs?.hide_from_ui === true) {
+    return true;
+  }
+  if (
+    typeof message.name === "string" &&
+    HIDDEN_CONTROL_MESSAGE_NAMES.has(message.name)
+  ) {
+    return true;
+  }
+  // Only the human branch consults the text. Extracting it up front made every
+  // caller pay a full content scan for every AI message it was about to
+  // discard, and this predicate runs over the whole message list on each
+  // stream chunk (grouping, dedup, human-input state).
+  if (message.type !== "human") {
+    return false;
+  }
   const content = extractTextFromMessage(message);
   return (
-    message.additional_kwargs?.hide_from_ui === true ||
-    (typeof message.name === "string" &&
-      HIDDEN_CONTROL_MESSAGE_NAMES.has(message.name)) ||
-    (message.type === "human" &&
-      content.includes("<slash_skill_activation>") &&
-      stripUploadedFilesTag(content).length === 0)
+    content.includes("<slash_skill_activation>") &&
+    stripUploadedFilesTag(content).length === 0
   );
 }
 

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -14,6 +14,7 @@ import {
   hasContent,
   hasReasoning,
   isAssistantMessageGroupStreaming,
+  isHiddenFromUIMessage,
   parseUploadedFiles,
   stripInternalMarkers,
   stripUploadedFilesTag,
@@ -294,6 +295,96 @@ describe("inline <think> tag splitting", () => {
     const message = aiMessage("Documentation: `<think>");
     expect(extractContentFromMessage(message)).toBe("Documentation: `<think>");
     expect(extractReasoningContentFromMessage(message)).toBeNull();
+  });
+
+  test("re-splits when the same message object gets new content", () => {
+    // Streaming replaces `content` on the accumulating message, so a split
+    // cached against the message object must be keyed by the content it was
+    // derived from.
+    const message = aiMessage("<think>first</think>one");
+
+    expect(extractContentFromMessage(message)).toBe("one");
+    expect(extractReasoningContentFromMessage(message)).toBe("first");
+
+    (message as { content: string }).content = "<think>second</think>two";
+
+    expect(extractContentFromMessage(message)).toBe("two");
+    expect(extractReasoningContentFromMessage(message)).toBe("second");
+    expect(hasReasoning(message)).toBe(true);
+  });
+});
+
+describe("isHiddenFromUIMessage", () => {
+  function contentReadCounter(
+    message: Omit<Message, "content">,
+    content: string,
+  ) {
+    const counter = { reads: 0 };
+    const probe = {
+      ...message,
+      get content() {
+        counter.reads++;
+        return content;
+      },
+    } as unknown as Message;
+    return { probe, counter };
+  }
+
+  test("does not read AI content to decide visibility", () => {
+    // Only the human branch consults the text, but this predicate runs over
+    // every message on every stream chunk (grouping, dedup, human-input
+    // state), so reading AI content here costs a full content scan per
+    // message per chunk.
+    const { probe, counter } = contentReadCounter(
+      { id: "ai-visible", type: "ai" } as Message,
+      "<think>long reasoning</think>a long streamed answer",
+    );
+
+    expect(isHiddenFromUIMessage(probe)).toBe(false);
+    expect(counter.reads).toBe(0);
+  });
+
+  test("does not read content when a control message name already hides it", () => {
+    const { probe, counter } = contentReadCounter(
+      { id: "summary-1", type: "ai", name: "summary" } as Message,
+      "compressed context",
+    );
+
+    expect(isHiddenFromUIMessage(probe)).toBe(true);
+    expect(counter.reads).toBe(0);
+  });
+
+  test("still hides a human message that is only slash skill activation", () => {
+    const message = {
+      id: "slash-activation",
+      type: "human",
+      content:
+        "<slash_skill_activation>\n<skill_content># SKILL.md</skill_content>\n</slash_skill_activation>",
+    } as Message;
+
+    expect(isHiddenFromUIMessage(message)).toBe(true);
+  });
+
+  test("keeps a human message that carries real text alongside the activation", () => {
+    const message = {
+      id: "slash-activation-with-task",
+      type: "human",
+      content:
+        "<slash_skill_activation>\n<skill_content># SKILL.md</skill_content>\n</slash_skill_activation>\nreal user task",
+    } as Message;
+
+    expect(isHiddenFromUIMessage(message)).toBe(false);
+  });
+
+  test("hides any message flagged with hide_from_ui", () => {
+    const message = {
+      id: "hidden-1",
+      type: "human",
+      content: "internal reply",
+      additional_kwargs: { hide_from_ui: true },
+    } as Message;
+
+    expect(isHiddenFromUIMessage(message)).toBe(true);
   });
 });
 


### PR DESCRIPTION
Part of #4409 (frontend render-cost work item; profiled hotspot "mechanism #5"). Related to #4399, the long-task freeze this family tracks.

## Why

Two functions in `core/messages/utils.ts` re-derive per-message state that the render path recomputes on **every** stream chunk. Over a whole message list, per chunk, this is wasted work that grows with the conversation.

1. **`isHiddenFromUIMessage` scans the full text of messages it is about to discard.** Its first line is an unconditional `extractTextFromMessage(message)` — which runs the `<think>`-splitting regex over the content — but that `content` is read by **only one** of the three visibility rules (`message.type === "human"` slash-skill activation). Every `ai` and `tool` message pays a full content scan whose result is thrown away. This predicate runs across the whole message list on each chunk (message grouping, dedup, and the human-input state derived in three components), so the wasted scan is paid many times per chunk.

2. **The inline `<think>` split is recomputed on every call.** `hasContent`, `hasReasoning`, `extractContentFromMessage`, and `extractReasoningContentFromMessage` each independently re-split the same message string, so a message's split is redone several times per render even when its content has not changed.

Neither is a crash, and on an idle machine current `main` no longer drops frames at this scale — so this is a wasted-work cleanup, not a fix for a user-visible freeze. It is filed under #4409 as one profiled slice of the per-chunk render cost, and framed as such.

## What changed

- **`isHiddenFromUIMessage`**: rewritten from an `||` chain into early returns, with `extractTextFromMessage` moved inside the `human` branch that actually uses it. Behavior is bit-for-bit identical — in the old expression `content` was only ever consulted by the `human` clause — but `ai`/`tool` messages now short-circuit without touching their content.
- **`splitInlineReasoningFromAIMessage`**: memoized with a `WeakMap<message, {content, split}>`, keyed by the exact `content` string the split was derived from. A message whose `content` is reassigned mid-stream recomputes (never serves a stale split); a `WeakMap` lets the cache release when the message is GC'd. The two direct `splitInlineReasoning(message.content)` callers (`extractReasoningContentFromMessage`, `hasReasoning`) now route through this cached entry point.

No behavior change: the same content and reasoning come out; only redundant recomputation is removed.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `frontend/tests/unit/core/messages/utils.test.ts` — the new `isHiddenFromUIMessage` block asserts, via a `content` getter that counts reads, that AI messages are classified **without** reading their content (`does not read AI content to decide visibility`, `does not read content when a control message name already hides it`), plus the three behavior anchors that the visibility semantics are unchanged (slash-activation hidden, activation-with-real-text kept, `hide_from_ui` hidden). The `<think>` block adds `re-splits when the same message object gets new content` to pin the cache key.
- Red on `main`, green on this branch? Yes — the two content-read assertions fail on `main` (each AI message is scanned 3×: `expected 3 to be +0`); all pass here.
- Each surviving new test was mutation-checked to confirm it guards a real property (drop the control-name branch → 5 red; force the human branch off → 3 red; drop the `stripUploadedFilesTag` clause → 2 red; weaken the cache key to `cached` → the re-split test goes red). One draft test that guarded nothing was removed.

## Validation

- `pnpm test` — 742 passed (new tests included); the content-read tests fail on `main` (verified by restoring `origin/main`'s `utils.ts` and re-running).
- `pnpm check` (eslint + `tsc --noEmit`) — clean.
- `pnpm format` — clean.
- `pnpm build` — passes.
- End-to-end, on the #4409 deterministic replay rig (same recording, SPEED=1, production build, idle host with CPU-idle logged): median longtask over a ~16-min run 1645 ms → 1179 ms (−28%) with identical rendered output (3998 DOM nodes, same body text), zero >500 ms frame gaps in both. Reported as a no-regression cross-check, not as the motivation — the win is removing wasted work, not recovering perceptible jank.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Profiled the per-chunk render path against a recorded long run to locate the redundant content scans, then drafted the change and tests; I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
