### PR TITLE
fix(mcp): ignore malformed path-like text

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -70,7 +70,10 @@ def _local_path_from_uri(uri: str, *, base_dir: Path | None = None) -> Path | No
     """
     if not uri:
         return None
-    parsed = urlparse(uri)
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        return None
     if parsed.scheme == "file":
         raw = unquote(parsed.path)
     elif parsed.scheme == "":

--- a/backend/tests/test_mcp_file_migration.py
+++ b/backend/tests/test_mcp_file_migration.py
@@ -46,6 +46,9 @@ class TestLocalPathFromUri:
         assert mcp_tools._local_path_from_uri("https://example.com/a.png") is None
         assert mcp_tools._local_path_from_uri("data:image/png;base64,AAAA") is None
 
+    def test_malformed_uri_is_ignored(self):
+        assert mcp_tools._local_path_from_uri("//[::1/foo.png") is None
+
     def test_relative_path_is_ignored_without_base_dir(self):
         assert mcp_tools._local_path_from_uri("relative/path.txt") is None
 
@@ -186,6 +189,14 @@ class TestRewriteLocalPathsInText:
         src.parent.mkdir()
         src.write_bytes(b"png")
         text = f"Saved to {src}"
+
+        with _patch_paths(paths):
+            result = mcp_tools._rewrite_local_paths_in_text(text, thread_id="t1", user_id="u1")
+
+        assert result == text
+
+    def test_malformed_path_like_text_is_left_untouched(self, paths: Paths):
+        text = "Saved at //[::1/foo.png"
 
         with _patch_paths(paths):
             result = mcp_tools._rewrite_local_paths_in_text(text, thread_id="t1", user_id="u1")
@@ -507,6 +518,15 @@ class TestConvertCallToolResultRewrites:
 
         assert content[0]["type"] == "text"
         assert content[0]["text"] == "hello"
+
+    def test_malformed_path_like_text_result_does_not_raise(self, paths: Paths):
+        result = CallToolResult(content=[TextContent(type="text", text="Saved at //[::1/foo.png")], isError=False)
+
+        with _patch_paths(paths):
+            content, _ = mcp_tools._convert_call_tool_result(result, thread_id="t1", user_id="u1")
+
+        assert content[0]["type"] == "text"
+        assert content[0]["text"] == "Saved at //[::1/foo.png"
 
     def test_image_content_passthrough(self, paths: Paths):
         from mcp.types import ImageContent


### PR DESCRIPTION
## Why

MCP tool results can include free-text file paths that are parsed by DeerFlow so local stdio MCP outputs can be rewritten into `/mnt/user-data/...` virtual artifact paths. That rewrite is intentionally best-effort: text that is not a real resolvable local file should be left untouched.

A malformed path-like token such as:

```text
Saved at //[::1/foo.png
```

breaks that contract today. The free-text path regex captures `//[::1/foo.png`, `_local_path_from_uri()` passes it directly to `urllib.parse.urlparse()`, and Python raises:

```text
ValueError: Invalid IPv6 URL
```

That exception bubbles through `_rewrite_local_paths_in_text()` and `_convert_call_tool_result()`, so one malformed provider/server text result can fail the whole MCP tool result conversion instead of being ignored as an unresolvable local path candidate.

Call chain:

```text
MCP server text result
  -> _convert_call_tool_result(...)
  -> _rewrite_local_paths_in_text(...)
  -> _local_uri_to_virtual_path(...)
  -> _local_path_from_uri(...)
  -> urlparse(uri)
  -> ValueError: Invalid IPv6 URL
```

## What changed

- `_local_path_from_uri()` now treats `urlparse()` `ValueError`s the same way it treats remote, missing, relative-without-base, or otherwise non-local candidates: return `None`.
- Free-text path rewriting keeps malformed path-like text unchanged instead of aborting result conversion.
- Added regression coverage at the parser helper, free-text rewrite helper, and full `CallToolResult` conversion boundary.

This does not broaden what gets rewritten. Valid local paths, valid `file://` URIs, remote URLs, missing files, and existing virtual path behavior stay unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [ ] **Backend API** - endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** - MCP tool result normalization under `backend/packages/harness/deerflow/mcp`
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** - changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** - no runtime behavior change

## Screenshots / Recording

N/A. This is a backend MCP result-normalization fix with command-line reproduction and unit coverage.

## Bug fix verification

- Test path that reproduces the bug:
  - `backend/tests/test_mcp_file_migration.py::TestLocalPathFromUri::test_malformed_uri_is_ignored`
  - `backend/tests/test_mcp_file_migration.py::TestRewriteLocalPathsInText::test_malformed_path_like_text_is_left_untouched`
  - `backend/tests/test_mcp_file_migration.py::TestConvertCallToolResultRewrites::test_malformed_path_like_text_result_does_not_raise`
- Did it go red on `main` and green on this branch? Yes for the same behavior. A focused pre-fix reproduction raised `ValueError: Invalid IPv6 URL`; after the fix, the same payload returns a text block with the original text unchanged.

Focused reproduction:

```powershell
uv run --project backend python -c "from deerflow.mcp import tools as mcp_tools; from mcp.types import CallToolResult, TextContent; result = CallToolResult(content=[TextContent(type='text', text='Saved at //[::1/foo.png')], isError=False); print(mcp_tools._convert_call_tool_result(result, thread_id='t1', user_id='u1'))"
```

Before the fix, this raised from `urlparse()`:

```text
ValueError: Invalid IPv6 URL
```

After the fix, it returns the text unchanged:

```text
([{'type': 'text', 'text': 'Saved at //[::1/foo.png', 'id': '...'}], None)
```

## Validation

- `uv run --project backend pytest backend/tests/test_mcp_file_migration.py::TestLocalPathFromUri::test_malformed_uri_is_ignored backend/tests/test_mcp_file_migration.py::TestRewriteLocalPathsInText::test_malformed_path_like_text_is_left_untouched backend/tests/test_mcp_file_migration.py::TestConvertCallToolResultRewrites::test_malformed_path_like_text_result_does_not_raise` - passed, 3 tests.
- `uv run --project backend python -c "...malformed //[::1/foo.png reproduction..."` - passed after the fix; returned unchanged text content.
- `uv run --project backend ruff check backend/packages/harness/deerflow/mcp/tools.py backend/tests/test_mcp_file_migration.py` - passed.
- `uv run --project backend ruff format --check backend/packages/harness/deerflow/mcp/tools.py backend/tests/test_mcp_file_migration.py` - passed.
- `git diff --check` - passed.
- Additional attempted check: `uv run --project backend pytest backend/tests/test_mcp_file_migration.py` on Windows reported existing POSIX path expectation failures unrelated to this patch (`15 failed, 43 passed, 1 skipped`). The three new malformed-URI regressions passed in the focused run.
- Additional attempted check: WSL/Linux rerun was blocked while rebuilding `backend/.venv` on the mounted `D:` drive by an environment copy I/O error before tests executed.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex inspected the MCP result conversion path, reproduced the malformed URI failure, implemented the small guard, added regression tests, and ran focused validation. I reviewed the final diff and validation output.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
