### PR TITLE
fix(frontend): allow dev-server access from non-localhost hosts

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -20,3 +20,12 @@
 # Defaults to localhost — only override for non-local deployments.
 # DEER_FLOW_INTERNAL_GATEWAY_BASE_URL="http://localhost:8001"
 # DEER_FLOW_TRUSTED_ORIGINS="http://localhost:3000,http://localhost:2026"
+
+# Extra hosts allowed to load Next.js dev-server resources (`/_next/*`, fonts,
+# HMR). Development only — production builds ignore it.
+# Needed to open `pnpm dev` / `make docker-start` on anything other than
+# localhost, such as a LAN address or a proxied hostname: without it Next.js
+# answers those requests with 403, so the page renders server-side but never
+# hydrates and no interaction (including the login form) works.
+# Comma-separated; a full URL is reduced to its host.
+# DEER_FLOW_DEV_ALLOWED_ORIGINS="192.168.1.10,*.local"

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -127,6 +127,8 @@ NEXT_PUBLIC_LANGGRAPH_BASE_URL=http://localhost:8001/api
 
 Leave these unset for the standard `make dev` / Docker flow, where nginx serves the public `/api/langgraph/*` prefix and rewrites it to Gateway's native `/api/*` routes.
 
+To reach a dev server on anything other than localhost — a LAN address, or a proxied hostname — list the host in `DEER_FLOW_DEV_ALLOWED_ORIGINS` (comma-separated; a full URL is reduced to its host). It feeds Next's `allowedDevOrigins`, which gates `/_next/*`, fonts, and HMR. Without it those requests get a 403 and the page renders server-side but never hydrates, so nothing on it — including the login form — responds. Development only; production builds ignore it.
+
 ## Resources
 
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -3,6 +3,7 @@
  * for Docker builds.
  */
 import "./src/env.js";
+import { getAllowedDevOrigins } from "./src/dev-origins.js";
 
 function getInternalServiceURL(envKey, fallbackURL) {
   const configured = process.env[envKey]?.trim();
@@ -25,6 +26,7 @@ const config = {
     defaultLocale: "en",
   },
   devIndicators: false,
+  allowedDevOrigins: getAllowedDevOrigins(),
   async rewrites() {
     const rewrites = [];
     const gatewayURL = getInternalServiceURL(

--- a/frontend/src/dev-origins.js
+++ b/frontend/src/dev-origins.js
@@ -1,0 +1,59 @@
+/**
+ * Hosts allowed to load Next.js dev-server resources (`/_next/*`,
+ * `/__nextjs_font/*`, HMR) from an origin other than the one `pnpm dev` was
+ * started on.
+ *
+ * Next.js answers those requests with 403 unless the host is listed, so a dev
+ * stack opened on a LAN address or a proxied hostname serves the SSR HTML but
+ * never hydrates: the page renders and nothing on it responds.
+ *
+ * Dev-only — Next ignores `allowedDevOrigins` in production builds.
+ */
+
+/**
+ * Reduce one entry to the bare host `allowedDevOrigins` matches against.
+ *
+ * Next matches on host alone, so an entry that still carries a scheme, port, or
+ * path matches nothing and leaves the caller with the same 403 they were trying
+ * to fix. Accept the URL people naturally copy out of the address bar.
+ *
+ * @param {string} value
+ * @returns {string} bare host, or `""` if the entry was empty
+ */
+function normalizeHost(value) {
+  let host = value.trim();
+  if (!host) return "";
+
+  host = host.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
+  host = host.replace(/[/?#].*$/, "");
+
+  const bracketedIpv6 = /^\[([^\]]+)\](?::\d+)?$/.exec(host);
+  if (bracketedIpv6) return bracketedIpv6[1];
+
+  // A bare IPv6 literal has several colons and no port to strip; only a single
+  // colon can be a `host:port` separator.
+  if ((host.match(/:/g) ?? []).length === 1) {
+    host = host.replace(/:\d+$/, "");
+  }
+  return host;
+}
+
+/**
+ * Parse a comma-separated host list into the shape `allowedDevOrigins` expects.
+ *
+ * @param {string | undefined} raw
+ * @returns {string[]}
+ */
+export function parseAllowedDevOrigins(raw) {
+  return (raw ?? "").split(",").map(normalizeHost).filter(Boolean);
+}
+
+/**
+ * Read the configured hosts from the environment.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {string[]}
+ */
+export function getAllowedDevOrigins(env = process.env) {
+  return parseAllowedDevOrigins(env.DEER_FLOW_DEV_ALLOWED_ORIGINS);
+}

--- a/frontend/tests/unit/dev-origins.test.ts
+++ b/frontend/tests/unit/dev-origins.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "@rstest/core";
+
+import { getAllowedDevOrigins, parseAllowedDevOrigins } from "@/dev-origins";
+
+describe("parseAllowedDevOrigins", () => {
+  test("returns an empty list when unset or empty", () => {
+    expect(parseAllowedDevOrigins(undefined)).toEqual([]);
+    expect(parseAllowedDevOrigins("")).toEqual([]);
+    expect(parseAllowedDevOrigins("   ")).toEqual([]);
+  });
+
+  test("splits a comma-separated list and trims each entry", () => {
+    expect(parseAllowedDevOrigins(" 192.168.1.10 , dev.example.com ")).toEqual([
+      "192.168.1.10",
+      "dev.example.com",
+    ]);
+  });
+
+  test("drops empty entries from trailing or doubled commas", () => {
+    expect(parseAllowedDevOrigins("a.example,,b.example,")).toEqual([
+      "a.example",
+      "b.example",
+    ]);
+  });
+
+  test("reduces a pasted URL to the bare host Next matches on", () => {
+    expect(parseAllowedDevOrigins("http://192.168.1.10:2026")).toEqual([
+      "192.168.1.10",
+    ]);
+    expect(parseAllowedDevOrigins("https://dev.example.com/")).toEqual([
+      "dev.example.com",
+    ]);
+    expect(parseAllowedDevOrigins("http://dev.example.com/login?x=1")).toEqual([
+      "dev.example.com",
+    ]);
+  });
+
+  test("preserves wildcard patterns", () => {
+    expect(parseAllowedDevOrigins("*.local, *.example.com")).toEqual([
+      "*.local",
+      "*.example.com",
+    ]);
+  });
+
+  test("strips the port from a bracketed IPv6 host without mangling the address", () => {
+    expect(parseAllowedDevOrigins("[::1]:2026")).toEqual(["::1"]);
+    expect(parseAllowedDevOrigins("http://[fe80::1]:3000")).toEqual([
+      "fe80::1",
+    ]);
+  });
+
+  test("leaves a bare IPv6 literal intact", () => {
+    // Several colons and no port to strip — treating the last group as a port
+    // would corrupt the address.
+    expect(parseAllowedDevOrigins("fe80::1")).toEqual(["fe80::1"]);
+  });
+});
+
+describe("getAllowedDevOrigins", () => {
+  test("reads DEER_FLOW_DEV_ALLOWED_ORIGINS", () => {
+    expect(
+      getAllowedDevOrigins({ DEER_FLOW_DEV_ALLOWED_ORIGINS: "192.168.1.10" }),
+    ).toEqual(["192.168.1.10"]);
+  });
+
+  test("defaults to an empty list, keeping localhost-only the default", () => {
+    expect(getAllowedDevOrigins({})).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #54

## Why

Opening the dev stack on anything other than `localhost` — a LAN address so a
phone or another machine can reach it, or a proxied hostname — appears to break
login.

The page loads and looks normal, but nothing on it responds: typing credentials
and pressing "Sign in" does nothing at all. The natural reading is that auth is
broken, so the search starts in the wrong place (CORS, CSRF, cookie flags).

The real cause is that Next.js answers `/_next/*`, `/__nextjs_font/*`, and HMR
with **403** for any host the dev server was not started on. The SSR HTML still
returns 200 — hence a page that renders — but no client chunk loads, React never
hydrates, and the login form's `onSubmit` is never attached. The only signal is
a warning buried in the dev-server log:

```
⚠ Blocked cross-origin request to Next.js dev resource /__nextjs_font/geist-latin.woff2 from "192.168.1.10".
```

Measured against `main`, same box, two origins:

| Request | `Origin: http://localhost:2026` | `Origin: http://192.168.1.10:2026` |
| --- | --- | --- |
| `/_next/static/chunks/*.js` | 200 | **403** |
| `/__nextjs_font/geist-latin.woff2` | 200 | **403** |
| `POST /api/v1/auth/login/local` | 401 `invalid_credentials` | 401 `invalid_credentials` |

The identical 401 on both origins is the useful part: the Gateway is fine, and
CORS/CSRF are fine. `nginx` forwards `Host $http_host`, so the origin check in
`is_allowed_auth_origin()` passes. Only the dev assets are blocked.

Reported twice already: #54 (open) and #203.

Prior art: an earlier revision of the auth branch (`27b66d67`) carried this same
config knob as `NEXT_DEV_ALLOWED_ORIGINS`, but it did not survive the squash onto
`main`. This restores the capability under a name consistent with the existing
`DEER_FLOW_*` server-side vars.

## What changed

New optional env var, **unset by default** — the localhost-only default is
unchanged, and Next ignores `allowedDevOrigins` in production builds, so this is
dev-only:

```bash
DEER_FLOW_DEV_ALLOWED_ORIGINS="192.168.1.10,*.local"
```

Entries are reduced to the bare host that `allowedDevOrigins` actually matches
against. Next matches on host alone, so a value pasted from the address bar as
`http://192.168.1.10:2026` would otherwise match nothing and leave the operator
staring at the same 403 — the exact failure this flag exists to fix. Scheme,
port, and path are stripped; wildcards and IPv6 literals are preserved.

Documented in `frontend/.env.example` and `frontend/AGENTS.md`.

## Surface area

- [x] **Frontend UI** — dev-server config only; no component or page changes
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change** — the var is unset by default; localhost-only behavior is unchanged
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

No visual change. The user-visible effect is that an already-existing page
becomes interactive on a non-localhost origin; the before/after is the HTTP
status table above.

## Bug fix verification

- Test path: `frontend/tests/unit/dev-origins.test.ts`
- Red on `main`, green on this branch: **yes** — on `main` the module under test
  does not exist, so the suite fails at import (`Cannot find module
  '@/dev-origins'`). The 9 cases then pass on this branch.
- End-to-end, against a running dev stack on a LAN address:

  | | before | after |
  | --- | --- | --- |
  | chunk w/ LAN `Origin` | 403 | **200** |
  | font w/ LAN `Origin` | 403 | **200** |
  | font w/ `localhost` `Origin` | 200 | 200 (unchanged) |

  Login then completes normally in the browser over the LAN address.

## Validation

Run in the dev container (Node 22.23.1, pnpm 10.26.2):

- `pnpm exec prettier --check .` — clean (only untracked `dist/` build artifacts warn)
- `pnpm exec eslint . --ext .ts,.tsx` — clean
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec rstest run` — **90 files / 790 tests passed**
- `next build` — fails identically on this branch and on unmodified `main`, at
  `Error occurred prerendering page "/zh/docs/..."` in the nextra docs route
  (`TypeError: Cannot read properties of undefined (reading 'length')`). Verified
  by stashing this change and rebuilding: pre-existing on `main`, unrelated to
  this PR, and untouched by it. Compilation itself succeeds
  (`✓ Compiled successfully`); only the docs prerender step fails.

Note for reviewers: `pnpm test` fails in the dev container for two unrelated
files (`slash-contract`, `subtask-result`) because `docker-compose-dev.yaml` does
not mount `/app/contracts`. Both pass once that directory is present, as it is in
CI's full checkout. Unrelated to this change, but it may be worth a follow-up
mount.

## AI assistance

**Tool(s) used:** Claude Code (Opus 4.5)

**How you used it:** Used to investigate a login failure on a LAN address. It
ruled out the CORS/CSRF hypothesis empirically by comparing the login POST across
both origins, located the actual 403 in the dev-server log, confirmed the failing
requests with `curl`, then wrote the fix, the tests, and the docs. It also caught
that the same knob had existed in `27b66d67` and been lost in the squash, and
verified the `next build` failure was pre-existing by rebuilding on a stashed
tree. Every claim in this PR was checked against a running stack rather than
assumed.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
