### PR TITLE
fix(makefile): add Corepack fallback for pnpm resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ PNPM = $(shell bash -c ' \
     elif command -v corepack.cmd >/dev/null 2>&1; then \
         echo "corepack.cmd pnpm"; \
     else \
+        # Fall back to bare "pnpm" — fails with a clear "command not found" at the call site. \
         echo pnpm; \
     fi')
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,22 @@ else
     RUN_WITH_GIT_BASH =
 endif
 
+# Resolve pnpm command with Corepack fallback.
+# Prefer pnpm directly, then pnpm.cmd, then corepack pnpm.
+# This ensures consistency with scripts/check.py.
+PNPM = $(shell bash -c ' \
+    if command -v pnpm >/dev/null 2>&1; then \
+        echo pnpm; \
+    elif command -v pnpm.cmd >/dev/null 2>&1; then \
+        echo pnpm.cmd; \
+    elif command -v corepack >/dev/null 2>&1; then \
+        echo "corepack pnpm"; \
+    elif command -v corepack.cmd >/dev/null 2>&1; then \
+        echo "corepack.cmd pnpm"; \
+    else \
+        echo pnpm; \
+    fi')
+
 help:
 	@echo "DeerFlow Development Commands:"
 	@echo "  make setup           - Interactive setup wizard (recommended for new users)"
@@ -80,7 +96,7 @@ install:
 	@echo "Installing backend dependencies..."
 	@cd backend && uv sync
 	@echo "Installing frontend dependencies..."
-	@cd frontend && pnpm install
+	@cd frontend && $(PNPM) install
 	@echo "Installing pre-commit hooks..."
 	@uv tool install pre-commit
 	@pre-commit install --overwrite

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ endif
 
 # Resolve pnpm command with Corepack fallback.
 # Prefer pnpm directly, then pnpm.cmd, then corepack pnpm.
-# This ensures consistency with scripts/check.py.
+# When no pnpm/corepack shim is on PATH, fall back to bare "pnpm" so the
+# failure surfaces at the call site as a clear "command not found".
 PNPM = $(shell bash -c ' \
     if command -v pnpm >/dev/null 2>&1; then \
         echo pnpm; \
@@ -29,7 +30,6 @@ PNPM = $(shell bash -c ' \
     elif command -v corepack.cmd >/dev/null 2>&1; then \
         echo "corepack.cmd pnpm"; \
     else \
-        # Fall back to bare "pnpm" — fails with a clear "command not found" at the call site. \
         echo pnpm; \
     fi')
 

--- a/scripts/_pnpm.sh
+++ b/scripts/_pnpm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# _pnpm.sh — Cross-platform pnpm command resolver with Corepack fallback
+#
+# Resolves a pnpm-compatible command using this precedence:
+#  1. `pnpm` / `pnpm.cmd` if it exists on PATH
+#  2. `corepack pnpm` if corepack is available
+#  3. Nothing (caller should handle the error)
+#
+# Usage (from shell scripts):
+#   source "$REPO_ROOT/scripts/_pnpm.sh"
+#   PNPM_CMD=$(_get_pnpm_cmd)
+#   if [ -z "$PNPM_CMD" ]; then
+#       echo "pnpm not found" >&2
+#       exit 1
+#   fi
+#   $PNPM_CMD install
+
+_get_pnpm_cmd() {
+    # Check for pnpm first
+    if command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm"
+        return 0
+    fi
+
+    # Check for pnpm.cmd (Windows)
+    if command -v pnpm.cmd >/dev/null 2>&1; then
+        echo "pnpm.cmd"
+        return 0
+    fi
+
+    # Check for corepack
+    if command -v corepack >/dev/null 2>&1; then
+        echo "corepack pnpm"
+        return 0
+    fi
+
+    # Check for corepack.cmd (Windows)
+    if command -v corepack.cmd >/dev/null 2>&1; then
+        echo "corepack.cmd pnpm"
+        return 0
+    fi
+
+    # Not found
+    return 1
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -27,12 +27,29 @@ fi
 
 echo ""
 echo "Checking pnpm..."
+# Use Corepack fallback: check pnpm first, then corepack pnpm
+PNPM_CMD=""
 if command -v pnpm >/dev/null 2>&1; then
-    PNPM_VERSION=$(pnpm -v)
-    echo "  ✓ pnpm $PNPM_VERSION"
+    PNPM_CMD="pnpm"
+elif command -v pnpm.cmd >/dev/null 2>&1; then
+    PNPM_CMD="pnpm.cmd"
+elif command -v corepack >/dev/null 2>&1; then
+    PNPM_CMD="corepack pnpm"
+elif command -v corepack.cmd >/dev/null 2>&1; then
+    PNPM_CMD="corepack.cmd pnpm"
+fi
+
+if [ -n "$PNPM_CMD" ]; then
+    PNPM_VERSION=$($PNPM_CMD -v)
+    if [ "$PNPM_CMD" = "pnpm" ] || [ "$PNPM_CMD" = "pnpm.cmd" ]; then
+        echo "  ✓ pnpm $PNPM_VERSION"
+    else
+        echo "  ✓ pnpm $PNPM_VERSION (via Corepack)"
+    fi
 else
     echo "  ✗ pnpm not found"
     echo "    Install: npm install -g pnpm"
+    echo "    Or enable Corepack: corepack enable"
     echo "    Or visit: https://pnpm.io/installation"
     FAILED=1
 fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -27,17 +27,12 @@ fi
 
 echo ""
 echo "Checking pnpm..."
-# Use Corepack fallback: check pnpm first, then corepack pnpm
-PNPM_CMD=""
-if command -v pnpm >/dev/null 2>&1; then
-    PNPM_CMD="pnpm"
-elif command -v pnpm.cmd >/dev/null 2>&1; then
-    PNPM_CMD="pnpm.cmd"
-elif command -v corepack >/dev/null 2>&1; then
-    PNPM_CMD="corepack pnpm"
-elif command -v corepack.cmd >/dev/null 2>&1; then
-    PNPM_CMD="corepack.cmd pnpm"
-fi
+# Source the canonical pnpm resolver (also used by serve.sh and the Makefile)
+REPO_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
+_pnpm_sh="${REPO_ROOT}/scripts/_pnpm.sh"
+# shellcheck source=../scripts/_pnpm.sh
+if [ -f "$_pnpm_sh" ]; then source "$_pnpm_sh"; fi
+PNPM_CMD=$(_get_pnpm_cmd 2>/dev/null) || PNPM_CMD=""
 
 if [ -n "$PNPM_CMD" ]; then
     PNPM_VERSION=$($PNPM_CMD -v)

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -29,6 +29,14 @@ set -e
 REPO_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
 cd "$REPO_ROOT"
 
+# Load pnpm resolver with Corepack fallback
+# See scripts/_pnpm.sh for details
+_pnpm_sh="$REPO_ROOT/scripts/_pnpm.sh"
+if [ -f "$_pnpm_sh" ]; then
+    # shellcheck source=scripts/_pnpm.sh
+    source "$_pnpm_sh"
+fi
+
 # ── Load .env ────────────────────────────────────────────────────────────────
 
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -294,14 +302,22 @@ if $DAEMON_MODE; then
 fi
 
 # Frontend command
+_PNPM_CMD=$(_get_pnpm_cmd || true)
+if [ -z "$_PNPM_CMD" ]; then
+    echo "✗ pnpm not found. Install pnpm or enable Corepack:" >&2
+    echo "    npm install -g pnpm" >&2
+    echo "    corepack enable" >&2
+    exit 1
+fi
+
 if $DEV_MODE; then
-    FRONTEND_CMD="pnpm run dev"
+    FRONTEND_CMD="$_PNPM_CMD run dev"
 else
     if ! PYTHON_BIN="$(_pick_python)"; then
         echo "Python is required to generate BETTER_AUTH_SECRET."
         exit 1
     fi
-    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') pnpm run preview"
+    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') $_PNPM_CMD run preview"
 fi
 
 # Runtime path defaults. Local `make dev` launches Gateway from `backend/`,
@@ -386,7 +402,7 @@ if ! $SKIP_INSTALL; then
     # in particular). Required for postgres extras — see PR #2584.
     # Intentionally unquoted to splat multiple `--extra X` pairs.
     (cd backend && uv sync --quiet --all-packages $UV_EXTRAS_FLAGS) || { echo "✗ Backend dependency install failed"; exit 1; }
-    (cd frontend && pnpm install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
+    (cd frontend && $_PNPM_CMD install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
     echo "✓ Dependencies synced"
 else
     echo "⏩ Skipping dependency install (--skip-install)"


### PR DESCRIPTION
## Summary

当 Corepack 可用但 pnpm shim 未启用时，`make check` 会使用 Corepack fallback，但 `make install` 和 `serve.sh` 直接调用 pnpm，导致 Corepack-only 环境下失败。

## Changes

- **Makefile**: 添加 `PNPM` 变量，带有 Corepack fallback
- **scripts/serve.sh**: source `_pnpm.sh` 并使用解析后的 pnpm 命令
- **scripts/check.sh**: 显示 "(via Corepack)" 指示器
- **scripts/_pnpm.sh**: 新文件，封装 pnpm 解析逻辑

## Test plan

- [x] 所有 shell 脚本语法检查通过
- [x] Makefile 语法检查通过
- [x] pnpm 解析逻辑验证正确

## Related Issue

Fixes #4404