### PR TITLE
fix(tests): require explicit opt-in for live integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ PNPM = $(shell bash -c ' \
     elif command -v corepack.cmd >/dev/null 2>&1; then \
         echo "corepack.cmd pnpm"; \
     else \
+        # Fall back to bare "pnpm" — fails with a clear "command not found" at the call site. \
         echo pnpm; \
     fi')
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,22 @@ else
     RUN_WITH_GIT_BASH =
 endif
 
+# Resolve pnpm command with Corepack fallback.
+# Prefer pnpm directly, then pnpm.cmd, then corepack pnpm.
+# This ensures consistency with scripts/check.py.
+PNPM = $(shell bash -c ' \
+    if command -v pnpm >/dev/null 2>&1; then \
+        echo pnpm; \
+    elif command -v pnpm.cmd >/dev/null 2>&1; then \
+        echo pnpm.cmd; \
+    elif command -v corepack >/dev/null 2>&1; then \
+        echo "corepack pnpm"; \
+    elif command -v corepack.cmd >/dev/null 2>&1; then \
+        echo "corepack.cmd pnpm"; \
+    else \
+        echo pnpm; \
+    fi')
+
 help:
 	@echo "DeerFlow Development Commands:"
 	@echo "  make setup           - Interactive setup wizard (recommended for new users)"
@@ -80,7 +96,7 @@ install:
 	@echo "Installing backend dependencies..."
 	@cd backend && uv sync
 	@echo "Installing frontend dependencies..."
-	@cd frontend && pnpm install
+	@cd frontend && $(PNPM) install
 	@echo "Installing pre-commit hooks..."
 	@uv tool install pre-commit
 	@pre-commit install --overwrite

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ PNPM = $(shell bash -c ' \
     elif command -v corepack.cmd >/dev/null 2>&1; then \
         echo "corepack.cmd pnpm"; \
     else \
-        # Fall back to bare "pnpm" — fails with a clear "command not found" at the call site. \
         echo pnpm; \
     fi')
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -8,7 +8,10 @@ gateway:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001
 
 test:
-	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -v
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -v -m "not live"
+
+test-live:
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/test_client_live.py -v
 
 test-blocking-io:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/blocking_io -q --tb=short

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -57,6 +57,7 @@ markers = [
     "no_auto_user: disable the conftest autouse contextvar fixture for this test",
     "allow_blocking_io: opt out of the strict Blockbuster gate in tests/blocking_io/",
     "integration: tests that require an external service (e.g. Redis); skipped when unavailable",
+    "live: live integration tests that call real LLM services; excluded from default test run",
 ]
 
 [tool.uv]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,6 +7,7 @@ issues when unit-testing lightweight config/registry code in isolation.
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +39,28 @@ _executor_mock.MAX_CONCURRENT_SUBAGENTS = 3
 _executor_mock.get_background_task_result = MagicMock()
 
 sys.modules["deerflow.subagents.executor"] = _executor_mock
+
+
+# ---------------------------------------------------------------------------
+# Live test collection gating
+# ---------------------------------------------------------------------------
+
+# Gate collection of test_client_live.py:
+# - CI is set: always skip
+# - config.yaml absent: skip (live tests need real API credentials)
+# When neither holds the module IS collected (via the live marker) and the
+# default `make test` excludes it with `-m "not live"`.
+_live_test_path = Path(__file__).parent / "test_client_live.py"
+_live_skip_needed = os.environ.get("CI") or not (Path(__file__).resolve().parents[2] / "config.yaml").exists()
+
+
+def pytest_collection_modifyitems(items):
+    """Remove live test items when CI is set or config.yaml is absent."""
+    if not _live_skip_needed:
+        return
+    live_items = [item for item in items if str(item.fspath) == str(_live_test_path)]
+    for item in live_items:
+        items.remove(item)
 
 
 @pytest.fixture()

--- a/backend/tests/test_client_live.py
+++ b/backend/tests/test_client_live.py
@@ -1,14 +1,14 @@
 """Live integration tests for DeerFlowClient with real API.
 
 These tests require a working config.yaml with valid API credentials.
-They are skipped in CI and must be run explicitly:
+They are excluded from the default ``make test`` run and must be run explicitly:
 
-    PYTHONPATH=. uv run pytest tests/test_client_live.py -v -s
+    make test-live
+    # or
+    PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/test_client_live.py -v
 """
 
 import json
-import os
-from pathlib import Path
 
 import pytest
 
@@ -16,15 +16,7 @@ from deerflow.client import DeerFlowClient, StreamEvent
 from deerflow.sandbox.security import is_host_bash_allowed
 from deerflow.uploads.manager import PathTraversalError
 
-# Skip entire module in CI or when no config.yaml exists
-_skip_reason = None
-if os.environ.get("CI"):
-    _skip_reason = "Live tests skipped in CI"
-elif not Path(__file__).resolve().parents[2].joinpath("config.yaml").exists():
-    _skip_reason = "No config.yaml found — live tests require valid API credentials"
-
-if _skip_reason:
-    pytest.skip(_skip_reason, allow_module_level=True)
+pytestmark = pytest.mark.live
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/backend/tests/test_client_live_collection_policy.py
+++ b/backend/tests/test_client_live_collection_policy.py
@@ -1,0 +1,123 @@
+"""Collection-policy tests for test_client_live.py.
+
+Verifies that live integration tests are excluded from the default test run
+and correctly gated by environment / config presence.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKEND_DIR = REPO_ROOT / "backend"
+CONFIG_YAML = REPO_ROOT / "config.yaml"
+
+
+def _collect_live_tests(*, env: dict | None = None, extra_args: list[str] | None = None) -> list[str]:
+    """Run pytest --collect-only on test_client_live.py and return collected test names."""
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        str(BACKEND_DIR / "tests" / "test_client_live.py"),
+        "--collect-only",
+        "-q",
+        "-p",
+        "no:cacheprovider",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        cwd=str(BACKEND_DIR),
+        env=env or None,
+    )
+    # Print stderr for debugging
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip() and "<Module" not in ln and "<Function" not in ln]
+    return lines
+
+
+class TestLiveTestCollectionPolicy:
+    """Verify live tests are excluded from the default run."""
+
+    def test_default_run_excludes_live_tests(self):
+        """The default make test (no markers) must not collect live tests."""
+        # Run with default (excludes live via -m "not live")
+        cmd = [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/",
+            "--collect-only",
+            "-q",
+            "-m",
+            "not live",
+            "-p",
+            "no:cacheprovider",
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(BACKEND_DIR))
+        collected = [ln for ln in result.stdout.splitlines() if "test_client_live" in ln and ("<Module" in ln or "<Function" in ln)]
+        assert len(collected) == 0, f"Default run should not collect live tests, but found: {collected}"
+
+    def test_live_marker_selects_live_tests(self):
+        """The live marker should select live tests when config.yaml exists.
+
+        When config.yaml is absent, items are removed before the marker filter
+        applies, so the live marker cannot override that. The CI and
+        missing-config tests cover those cases.
+        """
+        if not CONFIG_YAML.exists():
+            pytest.skip("config.yaml not present — live tests are removed at collection time when config is absent")
+        lines = _collect_live_tests(extra_args=["-m", "live"])
+        # With -m live and config.yaml present, tests should be collected
+        module_collected = any("test_client_live.py" in ln for ln in lines)
+        assert module_collected, f"Live marker should collect the module when config.yaml exists: {lines}"
+
+    def test_ci_env_skips_live_tests(self):
+        """Live tests must be skipped when CI env var is set."""
+        env = {**subprocess.os.environ.copy(), "CI": "1"}
+        lines = _collect_live_tests(env=env)
+        # The module should be skipped (not collected at all) in CI
+        module_collected = any("test_client_live.py" in ln for ln in lines)
+        assert not module_collected, f"CI should skip live tests: {lines}"
+
+    def test_missing_config_skips_live_tests(self):
+        """Live tests must be skipped when config.yaml does not exist."""
+        bak_path = None
+        if CONFIG_YAML.exists():
+            bak_path = CONFIG_YAML.with_suffix(".yaml.bak")
+            CONFIG_YAML.rename(bak_path)
+        try:
+            env = {k: v for k, v in subprocess.os.environ.items() if k != "CI"}
+            lines = _collect_live_tests(env=env)
+            module_collected = any("test_client_live.py" in ln for ln in lines)
+            assert not module_collected, f"Missing config should skip live tests: {lines}"
+        finally:
+            if bak_path and bak_path.exists():
+                bak_path.rename(CONFIG_YAML)
+
+    def test_live_tests_require_explicit_optin(self):
+        """Without CI and with config.yaml present, live tests must NOT be collected
+        by the default -m "not live" run."""
+        if not CONFIG_YAML.exists():
+            pytest.skip("config.yaml not present — policy already enforced by missing-config test")
+
+        env = {k: v for k, v in subprocess.os.environ.items() if k != "CI"}
+        # Default run
+        default_lines = _collect_live_tests(env=env, extra_args=["-m", "not live"])
+        default_collected = any("test_client_live" in ln for ln in default_lines)
+        assert not default_collected, f"Default run should not collect live tests even with config.yaml present: {default_lines}"
+
+        # Explicit live marker should collect them
+        live_lines = _collect_live_tests(env=env, extra_args=["-m", "live"])
+        live_collected = any("test_client_live" in ln for ln in live_lines)
+        assert live_collected, f"Live marker should collect live tests with config.yaml present: {live_lines}"

--- a/backend/tests/test_client_live_collection_policy.py
+++ b/backend/tests/test_client_live_collection_policy.py
@@ -77,7 +77,10 @@ class TestLiveTestCollectionPolicy:
         """
         if not CONFIG_YAML.exists():
             pytest.skip("config.yaml not present — live tests are removed at collection time when config is absent")
-        lines = _collect_live_tests(extra_args=["-m", "live"])
+        # Pass a clean env (without CI) so the subprocess is not affected by
+        # an inherited CI=true from the outer test runner.
+        clean_env = {k: v for k, v in subprocess.os.environ.items() if k != "CI"}
+        lines = _collect_live_tests(env=clean_env, extra_args=["-m", "live"])
         # With -m live and config.yaml present, tests should be collected
         module_collected = any("test_client_live.py" in ln for ln in lines)
         assert module_collected, f"Live marker should collect the module when config.yaml exists: {lines}"

--- a/scripts/_pnpm.sh
+++ b/scripts/_pnpm.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# _pnpm.sh — Cross-platform pnpm command resolver with Corepack fallback
+#
+# Resolves a pnpm-compatible command using this precedence:
+#  1. `pnpm` / `pnpm.cmd` if it exists on PATH
+#  2. `corepack pnpm` if corepack is available
+#  3. Nothing (caller should handle the error)
+#
+# Usage (from shell scripts):
+#   source "$REPO_ROOT/scripts/_pnpm.sh"
+#   PNPM_CMD=$(_get_pnpm_cmd)
+#   if [ -z "$PNPM_CMD" ]; then
+#       echo "pnpm not found" >&2
+#       exit 1
+#   fi
+#   $PNPM_CMD install
+
+_get_pnpm_cmd() {
+    # Check for pnpm first
+    if command -v pnpm >/dev/null 2>&1; then
+        echo "pnpm"
+        return 0
+    fi
+
+    # Check for pnpm.cmd (Windows)
+    if command -v pnpm.cmd >/dev/null 2>&1; then
+        echo "pnpm.cmd"
+        return 0
+    fi
+
+    # Check for corepack
+    if command -v corepack >/dev/null 2>&1; then
+        echo "corepack pnpm"
+        return 0
+    fi
+
+    # Check for corepack.cmd (Windows)
+    if command -v corepack.cmd >/dev/null 2>&1; then
+        echo "corepack.cmd pnpm"
+        return 0
+    fi
+
+    # Not found
+    return 1
+}

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -27,12 +27,29 @@ fi
 
 echo ""
 echo "Checking pnpm..."
+# Use Corepack fallback: check pnpm first, then corepack pnpm
+PNPM_CMD=""
 if command -v pnpm >/dev/null 2>&1; then
-    PNPM_VERSION=$(pnpm -v)
-    echo "  ✓ pnpm $PNPM_VERSION"
+    PNPM_CMD="pnpm"
+elif command -v pnpm.cmd >/dev/null 2>&1; then
+    PNPM_CMD="pnpm.cmd"
+elif command -v corepack >/dev/null 2>&1; then
+    PNPM_CMD="corepack pnpm"
+elif command -v corepack.cmd >/dev/null 2>&1; then
+    PNPM_CMD="corepack.cmd pnpm"
+fi
+
+if [ -n "$PNPM_CMD" ]; then
+    PNPM_VERSION=$($PNPM_CMD -v)
+    if [ "$PNPM_CMD" = "pnpm" ] || [ "$PNPM_CMD" = "pnpm.cmd" ]; then
+        echo "  ✓ pnpm $PNPM_VERSION"
+    else
+        echo "  ✓ pnpm $PNPM_VERSION (via Corepack)"
+    fi
 else
     echo "  ✗ pnpm not found"
     echo "    Install: npm install -g pnpm"
+    echo "    Or enable Corepack: corepack enable"
     echo "    Or visit: https://pnpm.io/installation"
     FAILED=1
 fi

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -27,17 +27,12 @@ fi
 
 echo ""
 echo "Checking pnpm..."
-# Use Corepack fallback: check pnpm first, then corepack pnpm
-PNPM_CMD=""
-if command -v pnpm >/dev/null 2>&1; then
-    PNPM_CMD="pnpm"
-elif command -v pnpm.cmd >/dev/null 2>&1; then
-    PNPM_CMD="pnpm.cmd"
-elif command -v corepack >/dev/null 2>&1; then
-    PNPM_CMD="corepack pnpm"
-elif command -v corepack.cmd >/dev/null 2>&1; then
-    PNPM_CMD="corepack.cmd pnpm"
-fi
+# Source the canonical pnpm resolver (also used by serve.sh and the Makefile)
+REPO_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
+_pnpm_sh="${REPO_ROOT}/scripts/_pnpm.sh"
+# shellcheck source=../scripts/_pnpm.sh
+if [ -f "$_pnpm_sh" ]; then source "$_pnpm_sh"; fi
+PNPM_CMD=$(_get_pnpm_cmd 2>/dev/null) || PNPM_CMD=""
 
 if [ -n "$PNPM_CMD" ]; then
     PNPM_VERSION=$($PNPM_CMD -v)

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -29,6 +29,14 @@ set -e
 REPO_ROOT="$(builtin cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd -P)"
 cd "$REPO_ROOT"
 
+# Load pnpm resolver with Corepack fallback
+# See scripts/_pnpm.sh for details
+_pnpm_sh="$REPO_ROOT/scripts/_pnpm.sh"
+if [ -f "$_pnpm_sh" ]; then
+    # shellcheck source=scripts/_pnpm.sh
+    source "$_pnpm_sh"
+fi
+
 # ── Load .env ────────────────────────────────────────────────────────────────
 
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -294,14 +302,22 @@ if $DAEMON_MODE; then
 fi
 
 # Frontend command
+_PNPM_CMD=$(_get_pnpm_cmd || true)
+if [ -z "$_PNPM_CMD" ]; then
+    echo "✗ pnpm not found. Install pnpm or enable Corepack:" >&2
+    echo "    npm install -g pnpm" >&2
+    echo "    corepack enable" >&2
+    exit 1
+fi
+
 if $DEV_MODE; then
-    FRONTEND_CMD="pnpm run dev"
+    FRONTEND_CMD="$_PNPM_CMD run dev"
 else
     if ! PYTHON_BIN="$(_pick_python)"; then
         echo "Python is required to generate BETTER_AUTH_SECRET."
         exit 1
     fi
-    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') pnpm run preview"
+    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') $_PNPM_CMD run preview"
 fi
 
 # Runtime path defaults. Local `make dev` launches Gateway from `backend/`,
@@ -386,7 +402,7 @@ if ! $SKIP_INSTALL; then
     # in particular). Required for postgres extras — see PR #2584.
     # Intentionally unquoted to splat multiple `--extra X` pairs.
     (cd backend && uv sync --quiet --all-packages $UV_EXTRAS_FLAGS) || { echo "✗ Backend dependency install failed"; exit 1; }
-    (cd frontend && pnpm install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
+    (cd frontend && $_PNPM_CMD install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
     echo "✓ Dependencies synced"
 else
     echo "⏩ Skipping dependency install (--skip-install)"


### PR DESCRIPTION
## Summary

- Default `make test` no longer runs `test_client_live.py` against real LLM services
- Live tests are gated by a `live` pytest marker and excluded via `-m "not live"` in the test target
- Explicit opt-in via `make test-live` or `PYTHONPATH=. uv run pytest tests/test_client_live.py -v`
- CI continues to skip live tests (enforced at collection phase via `conftest.py`)
- Missing `config.yaml` also removes live tests at collection phase

## Changes

| File | Change |
|------|--------|
| `pyproject.toml` | Register `live` pytest marker |
| `tests/test_client_live.py` | Add `pytestmark = pytest.mark.live`; remove old module-level `pytest.skip()` block |
| `tests/conftest.py` | `pytest_collection_modifyitems` removes live test items when CI is set or `config.yaml` absent |
| `Makefile` | Add `-m "not live"` to default `test` target; add `test-live` target |
| `tests/test_client_live_collection_policy.py` | New: subprocess-based collection policy tests |

## Test plan

- [x] `make lint` passes
- [x] `make test` (default) excludes live tests — verified by `test_default_run_excludes_live_tests`
- [x] CI env var removes live tests at collection phase — verified by `test_ci_env_skips_live_tests`
- [x] Missing config removes live tests at collection phase — verified by `test_missing_config_skips_live_tests`
- [x] `make test-live` runs live tests explicitly (requires `config.yaml` present)