### PR TITLE
fix: prevent lost thread metadata updates

### DIFF
--- a/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
+++ b/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import case, select, update
+from sqlalchemy import case, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -204,16 +204,27 @@ class ThreadMetaRepository(ThreadMetaStore):
     ) -> None:
         """Merge ``metadata`` into ``metadata_json``.
 
-        Read-modify-write inside a single session/transaction so concurrent
-        callers see consistent state. No-op if the row does not exist or
-        the user_id check fails.
+        The row is locked before the read-modify-write merge so concurrent
+        callers cannot replace each other's keys. SQLite acquires its write
+        transaction before reading; databases with row-level locking use
+        ``SELECT ... FOR UPDATE``. No-op if the row does not exist or the
+        user_id check fails.
 
         ``touch`` refreshes ``updated_at`` (default); pass ``touch=False`` to
         preserve recency ordering for metadata-only changes such as pin/unpin.
         """
         resolved_user_id = resolve_user_id(user_id, method_name="ThreadMetaRepository.update_metadata")
         async with self._sf() as session:
-            row = await session.get(ThreadMetaRow, thread_id)
+            if session.get_bind().dialect.name == "sqlite":
+                # A deferred SQLite transaction does not reserve the writer
+                # until the UPDATE, which is too late for a read-modify-write
+                # merge. BEGIN IMMEDIATE serializes writers before the read,
+                # including writers in other processes using the same file.
+                await session.execute(text("BEGIN IMMEDIATE"))
+                row = await session.get(ThreadMetaRow, thread_id)
+            else:
+                result = await session.execute(select(ThreadMetaRow).where(ThreadMetaRow.thread_id == thread_id).with_for_update())
+                row = result.scalar_one_or_none()
             if row is None:
                 return
             if resolved_user_id is not None and row.user_id != resolved_user_id:

--- a/backend/tests/test_thread_meta_repo.py
+++ b/backend/tests/test_thread_meta_repo.py
@@ -1,5 +1,6 @@
 """Tests for ThreadMetaRepository (SQLAlchemy-backed)."""
 
+import asyncio
 import logging
 
 import pytest
@@ -159,6 +160,20 @@ class TestThreadMetaRepository:
         record = await repo.get("t1")
         assert record["metadata"] == {"a": 1, THREAD_PINNED_METADATA_KEY: True}
         assert record["updated_at"] == original
+
+    @pytest.mark.anyio
+    async def test_concurrent_metadata_updates_preserve_disjoint_keys(self, repo):
+        for index in range(10):
+            thread_id = f"concurrent-{index}"
+            await repo.create(thread_id, metadata={"base": index}, user_id=None)
+
+            await asyncio.gather(
+                repo.update_metadata(thread_id, {"left": index}, user_id=None),
+                repo.update_metadata(thread_id, {"right": index}, user_id=None),
+            )
+
+            record = await repo.get(thread_id, user_id=None)
+            assert record["metadata"] == {"base": index, "left": index, "right": index}
 
     @pytest.mark.anyio
     async def test_search_orders_pinned_threads_before_newer_unpinned_threads(self, repo):


### PR DESCRIPTION
Fixes #4488

## Why

`ThreadMetaRepository.update_metadata()` reads and replaces the complete metadata object. Concurrent callers can therefore read the same value and silently overwrite each other's disjoint keys.

## What changed

- Serialize SQLite metadata writers with `BEGIN IMMEDIATE`.
- Lock the selected row with `SELECT ... FOR UPDATE` on databases that support row-level locking.
- Add a concurrent regression test that preserves both disjoint updates.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — concurrent metadata patches are now merged without lost updates
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Test path: `backend/tests/test_thread_meta_repo.py::TestThreadMetaRepository::test_concurrent_metadata_updates_preserve_disjoint_keys`
- The test failed on `main` and passes with this change.

## Validation

- `python -m pytest backend/tests/test_thread_meta_repo.py -q` — 52 passed
- `python -m ruff check backend/packages/harness/deerflow/persistence/thread_meta/sql.py backend/tests/test_thread_meta_repo.py`
- `python -m ruff format --check backend/packages/harness/deerflow/persistence/thread_meta/sql.py backend/tests/test_thread_meta_repo.py`

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Inspected the concurrent write path, prepared the lock-before-read fix and regression test, and ran the checks above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
