### PR TITLE
fix(frontend): localize conversation export failures

### DIFF
--- a/frontend/src/components/workspace/export-trigger.tsx
+++ b/frontend/src/components/workspace/export-trigger.tsx
@@ -12,10 +12,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useI18n } from "@/core/i18n/hooks";
-import {
-  exportThreadAsJSON,
-  exportThreadAsMarkdown,
-} from "@/core/threads/export";
+import { exportThread, type ThreadExportFormat } from "@/core/threads/export";
 import type { AgentThread } from "@/core/threads/types";
 
 import { useThread } from "./messages/context";
@@ -28,23 +25,23 @@ export function ExportTrigger({ threadId }: { threadId: string }) {
   const messages = thread.messages;
 
   const handleExport = useCallback(
-    (format: "markdown" | "json") => {
+    (format: ThreadExportFormat) => {
       if (messages.length === 0) {
         toast.error(t.conversation.noMessages);
         return;
       }
-      const agentThread = {
-        thread_id: threadId,
-        updated_at: new Date().toISOString(),
-        values: thread.values,
-      } as AgentThread;
+      try {
+        const agentThread = {
+          thread_id: threadId,
+          updated_at: new Date().toISOString(),
+          values: thread.values,
+        } as AgentThread;
 
-      if (format === "markdown") {
-        exportThreadAsMarkdown(agentThread, messages);
-      } else {
-        exportThreadAsJSON(agentThread, messages);
+        exportThread(agentThread, messages, format);
+        toast.success(t.common.exportSuccess);
+      } catch {
+        toast.error(t.common.exportFailed);
       }
-      toast.success(t.common.exportSuccess);
     },
     [messages, thread.values, threadId, t],
   );

--- a/frontend/src/components/workspace/recent-chat-list.tsx
+++ b/frontend/src/components/workspace/recent-chat-list.tsx
@@ -48,10 +48,7 @@ import { resetThreadChatAfterDelete } from "@/components/workspace/chats/use-thr
 import { getAPIClient } from "@/core/api";
 import { writeTextToClipboard } from "@/core/clipboard";
 import { useI18n } from "@/core/i18n/hooks";
-import {
-  exportThreadAsJSON,
-  exportThreadAsMarkdown,
-} from "@/core/threads/export";
+import { exportThread, type ThreadExportFormat } from "@/core/threads/export";
 import {
   useDeleteThread,
   useInfiniteThreads,
@@ -239,7 +236,7 @@ export function RecentChatList() {
   );
 
   const handleExport = useCallback(
-    async (thread: AgentThread, format: "markdown" | "json") => {
+    async (thread: AgentThread, format: ThreadExportFormat) => {
       try {
         const apiClient = getAPIClient();
         const state = await apiClient.threads.getState<AgentThreadState>(
@@ -250,14 +247,10 @@ export function RecentChatList() {
           toast.error(t.conversation.noMessages);
           return;
         }
-        if (format === "markdown") {
-          exportThreadAsMarkdown(thread, messages);
-        } else {
-          exportThreadAsJSON(thread, messages);
-        }
+        exportThread(thread, messages, format);
         toast.success(t.common.exportSuccess);
       } catch {
-        toast.error("Failed to export conversation");
+        toast.error(t.common.exportFailed);
       }
     },
     [t],

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -51,6 +51,7 @@ export const enUS: Translations = {
     exportAsMarkdown: "Export as Markdown",
     exportAsJSON: "Export as JSON",
     exportSuccess: "Conversation exported",
+    exportFailed: "Failed to export conversation.",
     regenerate: "Regenerate",
     branch: "Branch conversation",
     showArtifacts: "Show artifacts of this conversation",

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -40,6 +40,7 @@ export interface Translations {
     exportAsMarkdown: string;
     exportAsJSON: string;
     exportSuccess: string;
+    exportFailed: string;
     regenerate: string;
     branch: string;
     showArtifacts: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -51,6 +51,7 @@ export const zhCN: Translations = {
     exportAsMarkdown: "导出为 Markdown",
     exportAsJSON: "导出为 JSON",
     exportSuccess: "对话已导出",
+    exportFailed: "导出对话失败。",
     regenerate: "重新生成",
     branch: "分叉",
     showArtifacts: "查看此对话的文件",

--- a/frontend/src/core/threads/export.ts
+++ b/frontend/src/core/threads/export.ts
@@ -30,6 +30,8 @@ export interface ExportOptions {
   includeHidden?: boolean;
 }
 
+export type ThreadExportFormat = "markdown" | "json";
+
 function visibleMessages(
   messages: Message[],
   options: ExportOptions,
@@ -221,4 +223,16 @@ export function exportThreadAsJSON(thread: AgentThread, messages: Message[]) {
   const json = formatThreadAsJSON(thread, messages);
   const filename = `${sanitizeFilename(titleOfThread(thread))}.json`;
   downloadAsFile(json, filename, "application/json;charset=utf-8");
+}
+
+export function exportThread(
+  thread: AgentThread,
+  messages: Message[],
+  format: ThreadExportFormat,
+) {
+  if (format === "markdown") {
+    exportThreadAsMarkdown(thread, messages);
+  } else {
+    exportThreadAsJSON(thread, messages);
+  }
 }


### PR DESCRIPTION
## Summary
- add localized `common.exportFailed` copy for conversation export failures
- route both sidebar and chat header export actions through a shared `exportThread` helper
- show localized failure toast when export throws instead of hard-coded English or silent failure

## Verification
- `pnpm exec eslint src/components/workspace/export-trigger.tsx src/components/workspace/recent-chat-list.tsx src/core/threads/export.ts src/core/i18n/locales/types.ts src/core/i18n/locales/en-US.ts src/core/i18n/locales/zh-CN.ts`
- `pnpm exec rstest tests/unit/core/threads/export.test.ts`
- `git diff --check`

## Notes
- Full `pnpm exec tsc --noEmit --pretty false` is currently blocked in this workspace by missing `@testing-library/react` used by existing DOM tests.