### PR TITLE
test: require explicit opt-in for live LLM integration tests (#4481)

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,8 +7,18 @@ dev:
 gateway:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001
 
+# Default test target. Live tests (pytest marker `live`) call real configured
+# LLM services and are deselected by default via the `addopts` setting in
+# pyproject.toml, so even a bare `uv run pytest tests/` never collects them.
+# Use `make test-live` to opt in. CI always skips live tests regardless of
+# opt-in (see tests/test_client_live.py).
 test:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/ -v
+
+# Live integration tests against real configured LLM services. Requires a valid
+# ../config.yaml and is always skipped in CI. May incur provider charges.
+test-live:
+	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/test_client_live.py -v -s -m live
 
 test-blocking-io:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/blocking_io -q --tb=short

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -53,10 +53,12 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+addopts = ["-m", "not live"]
 markers = [
     "no_auto_user: disable the conftest autouse contextvar fixture for this test",
     "allow_blocking_io: opt out of the strict Blockbuster gate in tests/blocking_io/",
     "integration: tests that require an external service (e.g. Redis); skipped when unavailable",
+    "live: tests that call real external services (e.g. configured LLMs); require an explicit opt-in (make test-live or -m live) and are always skipped in CI",
 ]
 
 [tool.uv]

--- a/backend/tests/test_client_live.py
+++ b/backend/tests/test_client_live.py
@@ -26,6 +26,12 @@ elif not Path(__file__).resolve().parents[2].joinpath("config.yaml").exists():
 if _skip_reason:
     pytest.skip(_skip_reason, allow_module_level=True)
 
+# Collected only with an explicit opt-in (`pytest -m live` or `make
+# test-live`); deselected by default via the `addopts` setting in
+# pyproject.toml. The CI / missing-config guards above still skip
+# this module regardless of the marker.
+pytestmark = pytest.mark.live
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_live_test_policy.py
+++ b/backend/tests/test_live_test_policy.py
@@ -1,0 +1,116 @@
+"""Collection-policy tests for the live test marker (issue #4481).
+
+These tests verify the selection policy:
+
+* the default pytest invocation never *collects* live tests that talk to real
+  external services;
+* an explicit opt-in (``-m live``) plus a valid repo-root ``config.yaml`` is
+  required to collect them;
+* CI always skips the live module even when the opt-in marker is requested.
+
+They drive pytest in a subprocess from the backend directory so the real
+``addopts`` / marker / module-skip machinery is exercised end to end.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = BACKEND_DIR.parent
+LIVE_MODULE = "tests/test_client_live.py"
+
+
+def _run_pytest(*args: str, env_overrides: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    # Default subprocess behaves like a developer shell, not CI.
+    env.pop("CI", None)
+    env.update(
+        {
+            "PYTHONPATH": ".",
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+        }
+    )
+    if env_overrides:
+        env.update(env_overrides)
+    cmd = [sys.executable, "-m", "pytest", *args]
+    return subprocess.run(cmd, cwd=BACKEND_DIR, env=env, capture_output=True, text=True, timeout=180)
+
+
+@pytest.fixture
+def repo_config_yaml():
+    """Temporarily provide a repo-root config.yaml.
+
+    ``test_client_live`` only checks existence (it does not parse contents), so
+    an empty file is enough to clear the missing-config guard without the test
+    needing real credentials. The file is removed afterwards if we created it.
+    """
+    cfg = REPO_ROOT / "config.yaml"
+    created = False
+    if not cfg.exists():
+        cfg.write_text("# transient fixture for live-test collection policy\n")
+        created = True
+    try:
+        yield cfg
+    finally:
+        if created:
+            try:
+                cfg.unlink()
+            except OSError:
+                pass
+
+
+def test_live_marker_is_registered():
+    """The `live` marker must be registered so `-m live` can select it."""
+    result = _run_pytest("--markers")
+    assert result.returncode == 0, result.stdout + result.stderr
+    out = result.stdout
+    assert "live" in out, "live marker not registered in pyproject.toml"
+
+
+def test_default_never_collects_live_tests():
+    """Without an explicit opt-in the live test bodies must not be collected.
+
+    Covers both guards at once: with config.yaml present they are deselected by
+    the ``addopts`` ``-m "not live"`` filter; without config.yaml the module is
+    skipped. Either way no live test body is collected.
+    """
+    result = _run_pytest(LIVE_MODULE, "--collect-only", "-q")
+    combined = result.stdout + result.stderr
+    assert "test_chat_returns_nonempty_string" not in combined, combined
+
+
+def test_explicit_opt_in_collects_live_when_config_present(repo_config_yaml):
+    """`-m live` + valid config.yaml collects the live tests (explicit opt-in).
+
+    Uses --collect-only so no test body runs and no real LLM is called.
+    """
+    result = _run_pytest(LIVE_MODULE, "--collect-only", "-q", "-m", "live")
+    combined = result.stdout + result.stderr
+    assert "test_chat_returns_nonempty_string" in combined, combined
+
+
+def test_ci_skips_live_even_with_opt_in(repo_config_yaml):
+    """CI must skip live tests even when the opt-in marker and config exist.
+
+    Uses a real run (not ``--collect-only``): the module-level skip fires at
+    import time, so no live test body executes and pytest reports SKIPPED with
+    the CI reason. Asserting on a run (rather than collection) is what lets us
+    observe the skip reason text.
+    """
+    result = _run_pytest(
+        LIVE_MODULE,
+        "-v",
+        "-m",
+        "live",
+        env_overrides={"CI": "1"},
+    )
+    combined = result.stdout + result.stderr
+    lowered = combined.lower()
+    assert "skipped" in lowered, combined


### PR DESCRIPTION
Fixes #4481

## Why

The default backend `make test` command collected and ran the 19 live `DeerFlowClient` integration tests whenever a repo-root `config.yaml` existed. The module docstring said the tests "must be run explicitly", but nothing enforced it — a developer who finished the normal local setup could unintentionally trigger real LLM calls (and provider charges / nondeterministic failures) through the documented default test command.

## What changed

- Registered a `live` pytest marker in `backend/pyproject.toml`.
- Added `addopts = ["-m", "not live"]` so a bare `uv run pytest tests/` (and `make test`) never collects live tests; direct invocation stays safe.
- Marked `tests/test_client_live.py` with `pytestmark = pytest.mark.live`. The existing CI / missing-config module guards still skip it first, so CI always skips live tests even if an opt-in is accidentally present.
- Added a `make test-live` target as the explicit opt-in (`pytest tests/test_client_live.py -m live`).
- Added `tests/test_live_test_policy.py`, subprocess collection-policy tests covering the opt-in, CI-always-skip, and config-guard cases.

## Surface area

- [x] **Backend API** — test infra / Makefile / `backend/pyproject.toml`
- CI infra, Docs

## How verified

- `pytest --markers` lists `@pytest.mark.live`.
- Default `pytest tests/test_client_live.py --collect-only` collects **0** live tests (deselected by `addopts`, or module-skipped without config).
- `pytest -m live` collects them only when `config.yaml` exists.
- `CI=1 pytest -m live` still skips.
- New policy tests: **4 passed**.
- Existing tests unaffected (`tests/test_client.py`: 169 collected; `make test` / `make test-live` / `make test-blocking-io` targets all parse).
