### PR TITLE
persistence: serialize concurrent thread metadata merges (#4488)

### DIFF
--- a/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
+++ b/backend/packages/harness/deerflow/persistence/thread_meta/sql.py
@@ -6,7 +6,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import case, select, update
+from sqlalchemy import case, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -204,16 +204,52 @@ class ThreadMetaRepository(ThreadMetaStore):
     ) -> None:
         """Merge ``metadata`` into ``metadata_json``.
 
-        Read-modify-write inside a single session/transaction so concurrent
-        callers see consistent state. No-op if the row does not exist or
-        the user_id check fails.
+        The merge is a read-modify-write, so concurrent callers must serialise
+        on the row -- otherwise the second commit silently overwrites the
+        first (issue #4488: 96/100 lost patches under concurrency on the SQL
+        backend, while the in-memory store masked the race by not yielding
+        between its get/put).
+
+        Serialisation is dialect-aware:
+
+        - PostgreSQL: ``SELECT ... FOR UPDATE`` takes a row-level lock inside
+          the current transaction. The second worker blocks until the first
+          commits, then re-reads the merged JSON and applies its own patch on
+          top. This is the same pattern used by ``RunEventRepository`` for
+          monotonic seq assignment.
+        - SQLite: ``BEGIN IMMEDIATE`` acquires a RESERVED lock *before* the
+          read. SQLite (even under WAL) is single-writer per file, and the
+          default DEFERRED transaction only takes the write lock on the first
+          DML -- which lets two sessions read the same pre-merge JSON and
+          clobber each other. Forcing IMMEDIATE up front makes the second
+          connection's begin block (within the 30s ``busy_timeout`` set in
+          ``persistence/engine.py``) until the first commits, so its read
+          observes the merged row. ``with_for_update`` is a no-op on SQLite,
+          hence the branch.
 
         ``touch`` refreshes ``updated_at`` (default); pass ``touch=False`` to
         preserve recency ordering for metadata-only changes such as pin/unpin.
+        No-op if the row does not exist or the user_id check fails.
         """
         resolved_user_id = resolve_user_id(user_id, method_name="ThreadMetaRepository.update_metadata")
         async with self._sf() as session:
-            row = await session.get(ThreadMetaRow, thread_id)
+            bind = session.get_bind()
+            dialect_name = bind.dialect.name if bind is not None else ""
+
+            if dialect_name == "sqlite":
+                # Acquire the RESERVED write lock before the read so a second
+                # connection/process cannot read the pre-merge JSON and then
+                # overwrite us (or vice versa). SQLite serialises BEGIN
+                # IMMEDIATE across connections via the file lock; the 30s
+                # busy_timeout turns contention into orderly queueing.
+                await session.execute(text("BEGIN IMMEDIATE"))
+                row = await session.get(ThreadMetaRow, thread_id)
+            else:
+                # PostgreSQL (and any other dialect that understands row
+                # locking): hold the row until commit so concurrent workers
+                # serialise on it.
+                row = await session.get(ThreadMetaRow, thread_id, with_for_update=True)
+
             if row is None:
                 return
             if resolved_user_id is not None and row.user_id != resolved_user_id:

--- a/backend/tests/test_thread_meta_concurrent.py
+++ b/backend/tests/test_thread_meta_concurrent.py
@@ -1,0 +1,87 @@
+"""Regression tests for issue #4488: concurrent thread metadata patches must
+not lose keys to a read-modify-write race.
+
+The SQL-backed ``ThreadMetaRepository.update_metadata`` performs a
+read-modify-write on ``metadata_json``. Without row locking two concurrent
+calls that patch disjoint keys silently clobber each other on commit (the
+second commit overwrites the first). The in-memory store hides this because
+it does not yield control between its get and put; the SQL path does, so
+this module exercises the repository with genuinely concurrent calls
+(``asyncio.gather``) and asserts both keys survive -- across many rounds to
+catch the interleavings a single shot would miss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from deerflow.persistence.thread_meta import THREAD_PINNED_METADATA_KEY, ThreadMetaRepository
+
+
+@pytest.fixture
+async def repo(tmp_path):
+    from deerflow.persistence.engine import close_engine, get_session_factory, init_engine
+
+    url = f"sqlite+aiosqlite:///{tmp_path / 'concurrent.db'}"
+    await init_engine("sqlite", url=url, sqlite_dir=str(tmp_path))
+    yield ThreadMetaRepository(get_session_factory())
+    await close_engine()
+
+
+@pytest.mark.anyio
+async def test_concurrent_disjoint_metadata_patches_preserve_both_keys(repo):
+    """Two concurrent ``update_metadata`` calls merging disjoint keys must
+    both land -- no lost update.
+
+    The race window is scheduler-dependent, so a single shot can pass by
+    luck even on the buggy implementation (issue #4488 measured ~4/100
+    accidental passes). Iterating many rounds with fresh threads makes the
+    interleaving deterministic enough to fail reliably without the fix.
+    """
+    rounds = 20
+    for i in range(rounds):
+        thread_id = f"t-{i}"
+        await repo.create(thread_id, metadata={"seed": i})
+
+        await asyncio.gather(
+            repo.update_metadata(thread_id, {"left": 1}),
+            repo.update_metadata(thread_id, {"right": 2}),
+        )
+
+        record = await repo.get(thread_id)
+        assert record["metadata"] == {"seed": i, "left": 1, "right": 2}, (
+            f"round {i}: concurrent disjoint patches must both survive "
+            f"(got {record['metadata']!r})"
+        )
+
+
+@pytest.mark.anyio
+async def test_concurrent_touch_false_patch_does_not_lose_keys(repo):
+    """Pin/unpin (``touch=False``) racing another metadata write must still
+    merge both payloads without losing keys, while ``updated_at`` stays
+    pinned.
+
+    This is the user-visible symptom reported in issue #4488: a pin toggle
+    raced with another metadata write and one of them disappeared.
+    """
+    rounds = 10
+    for i in range(rounds):
+        thread_id = f"pin-{i}"
+        await repo.create(thread_id, metadata={"keep": i})
+        original = (await repo.get(thread_id))["updated_at"]
+
+        await asyncio.gather(
+            repo.update_metadata(thread_id, {THREAD_PINNED_METADATA_KEY: True}, touch=False),
+            repo.update_metadata(thread_id, {"note": f"n{i}"}, touch=False),
+        )
+
+        record = await repo.get(thread_id)
+        assert record["metadata"] == {
+            "keep": i,
+            THREAD_PINNED_METADATA_KEY: True,
+            "note": f"n{i}",
+        }, f"round {i}: {record['metadata']!r}"
+        # touch=False must continue to preserve updated_at under concurrency.
+        assert record["updated_at"] == original, f"round {i}: updated_at moved unexpectedly"


### PR DESCRIPTION
Fixes #4488

## Why

`ThreadMetaRepository.update_metadata()` documented its read-modify-write as concurrency-safe, but the row was read without a lock. Two requests could read the same JSON object, merge different keys locally, and commit whole-object replacements — the later commit silently dropped the first request's keys. The issue reproduces it at 96/100 lost patches on the SQL backend, and it is user-visible when pin/unpin races another metadata update (either `deerflow_pinned` or the unrelated metadata disappears). The in-memory store masked the race because its `aget`/`aput` path does not yield between those operations; only the SQL path reproduces.

## What changed

`update_metadata()` now serialises on the row, dialect-aware (same `session.get_bind()` → `dialect.name` branching pattern already used by `RunEventRepository._max_seq_for_thread`):

- **PostgreSQL**: `SELECT ... FOR UPDATE` via `session.get(..., with_for_update=True)` — the second worker blocks until the first commits, then re-reads the merged JSON and patches on top.
- **SQLite**: `BEGIN IMMEDIATE` before the read acquires the RESERVED write lock (`with_for_update` is a no-op on SQLite). The 30s `busy_timeout` configured in `persistence/engine.py` turns contention into orderly queueing rather than `database is locked`.

`touch=False` behaviour (preserve `updated_at` for pin/unpin) is unchanged.

New `tests/test_thread_meta_concurrent.py`:
- concurrent disjoint patches preserve both keys (20 rounds of `asyncio.gather(left, right)`),
- concurrent `touch=False` patches don't lose keys and don't shift `updated_at`.

## Surface area

- [x] **Backend API** — persistence (`backend/packages/harness/deerflow/persistence/thread_meta/`)

## How verified

- Bug reproduced pre-fix (concurrent gather lost one key).
- Post-fix: **59 passed** (new concurrent tests + existing `test_thread_meta_repo` + `test_persistence_bootstrap_sqlite_lock`), 5 consecutive runs stable, no flake.
- `ruff check` clean.
- Note: the PostgreSQL path reuses the project's existing `with_for_update` idiom (`RunEventRepository` / `RunRepository`); only SQLite was live-testable in this environment.
