### PR TITLE
build: resolve pnpm consistently across host-side entry points (#4404)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,13 @@ else
     RUN_WITH_GIT_BASH =
 endif
 
+# Resolve pnpm through a single helper (scripts/pnpm_resolver.py) so `make
+# install`, `make dev` and `make start` agree with `make check` even when only
+# Corepack is available and no `pnpm` shim is on PATH. Falls back to a bare
+# `pnpm` if the resolver itself is unavailable (e.g. fresh checkout with no
+# Python yet) to preserve the historical behaviour. See issue #4404.
+PNPM := $(shell $(PYTHON) ./scripts/pnpm_resolver.py 2>/dev/null || echo pnpm)
+
 help:
 	@echo "DeerFlow Development Commands:"
 	@echo "  make setup           - Interactive setup wizard (recommended for new users)"
@@ -80,7 +87,7 @@ install:
 	@echo "Installing backend dependencies..."
 	@cd backend && uv sync
 	@echo "Installing frontend dependencies..."
-	@cd frontend && pnpm install
+	@cd frontend && $(PNPM) install
 	@echo "Installing pre-commit hooks..."
 	@uv tool install pre-commit
 	@pre-commit install --overwrite

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -8,6 +8,10 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Shared with the Makefile / serve.sh / doctor.py / support_bundle.py so the
+# check path and the execution path resolve pnpm identically (issue #4404).
+from pnpm_resolver import find_pnpm_command
+
 
 def configure_stdio() -> None:
     """Prefer UTF-8 output so Unicode status markers render on Windows."""
@@ -27,24 +31,6 @@ def run_command(command: list[str]) -> str | None:
     except (OSError, subprocess.CalledProcessError):
         return None
     return result.stdout.strip() or result.stderr.strip()
-
-
-def find_pnpm_command() -> list[str] | None:
-    """Return a pnpm-compatible command that exists on this machine."""
-    pnpm_path = shutil.which("pnpm")
-    if pnpm_path:
-        return [str(Path(pnpm_path))]
-
-    pnpm_cmd_path = shutil.which("pnpm.cmd")
-    if pnpm_cmd_path:
-        return [str(Path(pnpm_cmd_path))]
-
-    corepack_path = shutil.which("corepack")
-    if not corepack_path:
-        corepack_path = shutil.which("corepack.cmd")
-    if corepack_path:
-        return [str(Path(corepack_path)), "pnpm"]
-    return None
 
 
 def parse_node_major(version_text: str) -> int | None:

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -19,6 +19,9 @@ from importlib import import_module
 from pathlib import Path
 from typing import Literal
 
+# Shared pnpm resolver — same logic as check.py / Makefile / serve.sh (#4404).
+from pnpm_resolver import find_pnpm_command
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -165,13 +168,10 @@ def check_node() -> CheckResult:
 
 
 def check_pnpm() -> CheckResult:
-    candidates = [["pnpm"], ["pnpm.cmd"]]
-    if shutil.which("corepack"):
-        candidates.append(["corepack", "pnpm"])
-    for cmd in candidates:
-        if shutil.which(cmd[0]):
-            out = _run([*cmd, "-v"]) or ""
-            return CheckResult("pnpm", "ok", out)
+    cmd = find_pnpm_command()
+    if cmd:
+        out = _run([*cmd, "-v"]) or ""
+        return CheckResult("pnpm", "ok", out)
     return CheckResult(
         "pnpm",
         "fail",

--- a/scripts/pnpm_resolver.py
+++ b/scripts/pnpm_resolver.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Shared pnpm command resolver for all host-side entry points.
+
+Why this exists
+---------------
+``make check`` historically resolved pnpm through ``find_pnpm_command`` in
+``scripts/check.py`` (with a Corepack fallback), while ``make install``,
+``make dev`` and ``scripts/serve.sh`` all invoked a bare ``pnpm``. In a
+Corepack-only environment (Corepack shipped with Node, but
+``corepack enable`` never run so no ``pnpm`` shim exists on ``PATH``),
+``make check`` passed while every execution entry point failed with
+``pnpm: command not found``. See issue #4404.
+
+This module is the single source of truth. Every host-side consumer —
+``scripts/check.py``, ``scripts/doctor.py``, ``scripts/support_bundle.py``,
+the ``Makefile`` and ``scripts/serve.sh`` — resolves pnpm through it so the
+check path and the execution path can never drift again.
+
+CLI usage (Makefile + shell scripts):
+
+    $ python3 scripts/pnpm_resolver.py
+    pnpm                       # when ``pnpm``/``pnpm.cmd`` is on PATH
+    /opt/homebrew/bin/pnpm     # absolute paths are returned verbatim
+    corepack pnpm              # fallback when only Corepack is available
+
+    Exit code 1 + a stderr message when neither pnpm nor Corepack is on PATH.
+
+Module usage (check.py / doctor.py / support_bundle.py):
+
+    from pnpm_resolver import find_pnpm_command
+    cmd = find_pnpm_command()  # list[str] | None
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+from shlex import join as _shlex_join
+
+
+def find_pnpm_command() -> list[str] | None:
+    """Return a pnpm-compatible command argv, or ``None`` if none is available.
+
+    Resolution order — every host-side entry point must honour this same order
+    so install/check/start agree:
+
+    1. ``pnpm`` on ``PATH`` (preferred — what users typically have).
+    2. ``pnpm.cmd`` on ``PATH`` (Windows).
+    3. ``corepack`` (or ``corepack.cmd``) on ``PATH`` → invoke as
+       ``corepack pnpm`` so a Corepack-only machine still works without
+       ``corepack enable``.
+    """
+    for candidate in ("pnpm", "pnpm.cmd"):
+        path = shutil.which(candidate)
+        if path:
+            return [str(Path(path))]
+
+    for candidate in ("corepack", "corepack.cmd"):
+        path = shutil.which(candidate)
+        if path:
+            return [str(Path(path)), "pnpm"]
+
+    return None
+
+
+def shell_string(argv: list[str]) -> str:
+    """Render an argv as a shell string ready for ``$(...)`` substitution.
+
+    ``shlex.join`` keeps each token separate and shell-safe; consumers
+    (``Makefile``'s ``$(PNPM)``, ``serve.sh``'s ``$PNPM_CMD``) word-split it
+    back into the original argv, so ``["corepack", "pnpm"]`` round-trips as
+    ``corepack pnpm`` rather than a single ``'corepack pnpm'`` token.
+    """
+    return _shlex_join(argv)
+
+
+def main() -> int:
+    command = find_pnpm_command()
+    if not command:
+        print(
+            "pnpm: not found. Install pnpm (npm install -g pnpm) or enable "
+            "Corepack (corepack enable); see https://pnpm.io/installation",
+            file=sys.stderr,
+        )
+        return 1
+    print(shell_string(command))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -48,6 +48,41 @@ _pick_python() {
     return 1
 }
 
+# Resolve the pnpm argv through the SAME helper that `make check`, the
+# Makefile (`$(PNPM)`), doctor.py and support_bundle.py use — so `make dev`
+# / `make start` can never disagree with `make check` on whether pnpm exists.
+# Issue #4404: a Corepack-only machine (no `pnpm` shim on PATH) previously
+# passed `make check` but failed here with `pnpm: command not found`.
+_resolve_pnpm() {
+    local python_bin out
+    python_bin="$(_pick_python || true)"
+    if [ -n "$python_bin" ]; then
+        out="$("$python_bin" "$REPO_ROOT/scripts/pnpm_resolver.py" 2>/dev/null || true)"
+        if [ -n "$out" ]; then
+            printf '%s\n' "$out"
+            return 0
+        fi
+    fi
+    # Shell fallback mirrors scripts/pnpm_resolver.py if Python itself is
+    # unavailable; preserves the historical bare-`pnpm` behaviour.
+    if command -v pnpm >/dev/null 2>&1; then
+        printf '%s\n' pnpm
+    elif command -v pnpm.cmd >/dev/null 2>&1; then
+        printf '%s\n' pnpm.cmd
+    elif command -v corepack >/dev/null 2>&1; then
+        printf '%s\n' corepack pnpm
+    else
+        return 1
+    fi
+}
+
+PNPM_CMD="$(_resolve_pnpm || true)"
+if [ -z "$PNPM_CMD" ]; then
+    echo "✗ pnpm not found. Install pnpm (npm install -g pnpm) or enable"
+    echo "  Corepack (corepack enable); see https://pnpm.io/installation"
+    exit 1
+fi
+
 # ── Argument parsing ─────────────────────────────────────────────────────────
 
 DEV_MODE=true
@@ -295,13 +330,13 @@ fi
 
 # Frontend command
 if $DEV_MODE; then
-    FRONTEND_CMD="pnpm run dev"
+    FRONTEND_CMD="$PNPM_CMD run dev"
 else
     if ! PYTHON_BIN="$(_pick_python)"; then
         echo "Python is required to generate BETTER_AUTH_SECRET."
         exit 1
     fi
-    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') pnpm run preview"
+    FRONTEND_CMD="env BETTER_AUTH_SECRET=$($PYTHON_BIN -c 'import secrets; print(secrets.token_hex(16))') $PNPM_CMD run preview"
 fi
 
 # Runtime path defaults. Local `make dev` launches Gateway from `backend/`,
@@ -386,7 +421,7 @@ if ! $SKIP_INSTALL; then
     # in particular). Required for postgres extras — see PR #2584.
     # Intentionally unquoted to splat multiple `--extra X` pairs.
     (cd backend && uv sync --quiet --all-packages $UV_EXTRAS_FLAGS) || { echo "✗ Backend dependency install failed"; exit 1; }
-    (cd frontend && pnpm install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
+    (cd frontend && $PNPM_CMD install --silent) || { echo "✗ Frontend dependency install failed"; exit 1; }
     echo "✓ Dependencies synced"
 else
     echo "⏩ Skipping dependency install (--skip-install)"

--- a/scripts/support_bundle.py
+++ b/scripts/support_bundle.py
@@ -14,6 +14,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+# Shared pnpm resolver — same logic as check.py / Makefile / serve.sh (#4404).
+from pnpm_resolver import find_pnpm_command
+
 try:
     import yaml
 except Exception:  # pragma: no cover - exercised only in broken environments
@@ -200,6 +203,9 @@ def _version_command(name: str, args: list[str], cwd: Path) -> dict[str, Any]:
 
 def collect_environment(project_root: Path) -> dict[str, Any]:
     """Collect non-secret environment and toolchain metadata."""
+    # Resolve pnpm through the shared helper so a Corepack-only machine still
+    # reports a version instead of ``pnpm: command not found`` (issue #4404).
+    pnpm_command = find_pnpm_command() or ["pnpm"]
     return {
         "generated_at": datetime.now(UTC).isoformat(),
         "platform": {
@@ -210,7 +216,7 @@ def collect_environment(project_root: Path) -> dict[str, Any]:
         },
         "commands": [
             _version_command("node", ["node", "--version"], project_root),
-            _version_command("pnpm", ["pnpm", "--version"], project_root),
+            _version_command("pnpm", [*pnpm_command, "--version"], project_root),
             _version_command("uv", ["uv", "--version"], project_root),
             _version_command("nginx", ["nginx", "-v"], project_root),
             _version_command("docker", ["docker", "--version"], project_root),


### PR DESCRIPTION
Fixes #4404

## Why

`make check` resolved pnpm through `scripts/check.py` (with a Corepack fallback), but `make install`, `make dev`, `make start` and `scripts/serve.sh` all invoked a bare `pnpm`. In a **Corepack-only environment** (Corepack shipped with Node, but `corepack enable` never run, so no `pnpm` shim on `PATH`), `make check` passed while every execution entry point failed with `pnpm: command not found`. The check path and the execution path could drift apart.

## What changed

- New **`scripts/pnpm_resolver.py`** — single source of truth for resolving a pnpm-compatible command. Resolution order: `pnpm` on `PATH` → `pnpm.cmd` (Windows) → `corepack pnpm` (Corepack-only fallback). Usable both as a **CLI** (Makefile `$(shell …)` and shell `$(…)`) and as a Python **module** (`find_pnpm_command()`).
- All host-side consumers now resolve through it: `Makefile` (`PNPM := $(shell $(PYTHON) ./scripts/pnpm_resolver.py 2>/dev/null || echo pnpm)`), `scripts/serve.sh` (`_resolve_pnpm` helper + `PNPM_CMD` evaluated once), `scripts/check.py`, `scripts/doctor.py`, `scripts/support_bundle.py`. Check and execution paths can no longer disagree.

## Surface area

- [x] **Config / setup** — Makefile, `scripts/`

## How verified

- Resolver CLI: `pnpm` on PATH → `pnpm`; corepack-only (constructed PATH with only `python3` + `corepack`) → `corepack pnpm`; neither → exit 1 + stderr.
- `make -n install` expands via the resolver in both a real PATH and a corepack-only PATH.
- `serve.sh _resolve_pnpm`: 4 cases (pnpm-present / corepack-only [the #4404 scenario] / no-python-shell-fallback / none) — all correct.
- `make check` — no regression (pnpm check reports `OK`).
- Python imports for the `make doctor` / `make check` paths OK; `check_pnpm().status == 'ok'`.
- `ruff check` clean; `shellcheck` shows **zero new warnings** vs pristine `main`; `bash -n scripts/serve.sh` OK.
- Note: no live frontend e2e (`pnpm install` + `pnpm run dev`); resolver unit + dry-run cover the key paths. Windows (`pnpm.cmd` / `corepack.cmd`) mirrors the already-merged `check.py` behaviour.
