### PR TITLE
Secure production mock API routes

### DIFF
--- a/frontend/src/app/mock/api/mcp/config/route.ts
+++ b/frontend/src/app/mock/api/mcp/config/route.ts
@@ -1,4 +1,9 @@
+import { rejectDisabledMockApi } from "@/core/mock-api/server-security";
+
 export function GET() {
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
   return Response.json({
     mcp_servers: {
       "mcp-github-trending": {

--- a/frontend/src/app/mock/api/models/route.ts
+++ b/frontend/src/app/mock/api/models/route.ts
@@ -1,4 +1,9 @@
+import { rejectDisabledMockApi } from "@/core/mock-api/server-security";
+
 export function GET() {
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
   return Response.json({
     models: [
       {

--- a/frontend/src/app/mock/api/skills/route.ts
+++ b/frontend/src/app/mock/api/skills/route.ts
@@ -1,4 +1,9 @@
+import { rejectDisabledMockApi } from "@/core/mock-api/server-security";
+
 export function GET() {
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
   return Response.json({
     skills: [
       {

--- a/frontend/src/app/mock/api/threads/[thread_id]/artifacts/[[...artifact_path]]/route.ts
+++ b/frontend/src/app/mock/api/threads/[thread_id]/artifacts/[[...artifact_path]]/route.ts
@@ -3,6 +3,11 @@ import path from "path";
 
 import type { NextRequest } from "next/server";
 
+import {
+  rejectDisabledMockApi,
+  resolveDemoThreadFile,
+} from "@/core/mock-api/server-security";
+
 export async function GET(
   request: NextRequest,
   {
@@ -14,36 +19,41 @@ export async function GET(
     }>;
   },
 ) {
-  const threadId = (await params).thread_id;
-  let artifactPath = (await params).artifact_path?.join("/") ?? "";
-  if (artifactPath.startsWith("mnt/")) {
-    artifactPath = path.resolve(
-      process.cwd(),
-      artifactPath.replace("mnt/", `public/demo/threads/${threadId}/`),
-    );
-    if (fs.existsSync(artifactPath)) {
-      if (request.nextUrl.searchParams.get("download") === "true") {
-        // Attach the file to the response
-        const headers = new Headers();
-        headers.set(
-          "Content-Disposition",
-          `attachment; filename="${artifactPath}"`,
-        );
-        return new Response(fs.readFileSync(artifactPath), {
-          status: 200,
-          headers,
-        });
-      }
-      if (artifactPath.endsWith(".mp4")) {
-        return new Response(fs.readFileSync(artifactPath), {
-          status: 200,
-          headers: {
-            "Content-Type": "video/mp4",
-          },
-        });
-      }
-      return new Response(fs.readFileSync(artifactPath), { status: 200 });
-    }
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
+  const { thread_id: threadId, artifact_path: artifactPath = [] } =
+    await params;
+  if (artifactPath[0] !== "mnt") {
+    return new Response("File not found", { status: 404 });
   }
-  return new Response("File not found", { status: 404 });
+
+  const resolvedArtifactPath = resolveDemoThreadFile(
+    threadId,
+    artifactPath.slice(1),
+  );
+  if (!resolvedArtifactPath) {
+    return new Response("File not found", { status: 404 });
+  }
+
+  if (request.nextUrl.searchParams.get("download") === "true") {
+    const headers = new Headers();
+    headers.set(
+      "Content-Disposition",
+      `attachment; filename="${path.basename(resolvedArtifactPath)}"`,
+    );
+    return new Response(fs.readFileSync(resolvedArtifactPath), {
+      status: 200,
+      headers,
+    });
+  }
+  if (resolvedArtifactPath.endsWith(".mp4")) {
+    return new Response(fs.readFileSync(resolvedArtifactPath), {
+      status: 200,
+      headers: {
+        "Content-Type": "video/mp4",
+      },
+    });
+  }
+  return new Response(fs.readFileSync(resolvedArtifactPath), { status: 200 });
 }

--- a/frontend/src/app/mock/api/threads/[thread_id]/history/route.ts
+++ b/frontend/src/app/mock/api/threads/[thread_id]/history/route.ts
@@ -1,17 +1,26 @@
 import fs from "fs";
-import path from "path";
 
 import type { NextRequest } from "next/server";
+
+import {
+  rejectDisabledMockApi,
+  resolveDemoThreadFile,
+} from "@/core/mock-api/server-security";
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ thread_id: string }> },
 ) {
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
   const threadId = (await params).thread_id;
-  const jsonString = fs.readFileSync(
-    path.resolve(process.cwd(), `public/demo/threads/${threadId}/thread.json`),
-    "utf8",
-  );
+  const historyPath = resolveDemoThreadFile(threadId, ["thread.json"]);
+  if (!historyPath) {
+    return new Response("Thread not found", { status: 404 });
+  }
+
+  const jsonString = fs.readFileSync(historyPath, "utf8");
   const json = JSON.parse(jsonString);
   if (Array.isArray(json.history)) {
     return Response.json(json);

--- a/frontend/src/app/mock/api/threads/search/route.ts
+++ b/frontend/src/app/mock/api/threads/search/route.ts
@@ -1,6 +1,8 @@
 import fs from "fs";
 import path from "path";
 
+import { rejectDisabledMockApi } from "@/core/mock-api/server-security";
+
 type ThreadSearchRequest = {
   limit?: number;
   offset?: number;
@@ -14,6 +16,9 @@ type MockThreadSearchResult = Record<string, unknown> & {
 };
 
 export async function POST(request: Request) {
+  const rejected = rejectDisabledMockApi();
+  if (rejected) return rejected;
+
   const body = ((await request.json().catch(() => ({}))) ??
     {}) as ThreadSearchRequest;
 

--- a/frontend/src/core/mock-api/server-security.ts
+++ b/frontend/src/core/mock-api/server-security.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import path from "path";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isContainedPath(parent: string, candidate: string): boolean {
+  const relativePath = path.relative(parent, candidate);
+  return (
+    relativePath !== "" &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
+export function rejectDisabledMockApi(): Response | null {
+  if (
+    process.env.NODE_ENV === "production" &&
+    process.env.DEER_FLOW_ENABLE_MOCK_API !== "true"
+  ) {
+    return new Response("Not found", { status: 404 });
+  }
+  return null;
+}
+
+export function resolveDemoThreadFile(
+  threadId: string,
+  relativePathSegments: string[],
+): string | null {
+  if (
+    !UUID_PATTERN.test(threadId) ||
+    relativePathSegments.length === 0 ||
+    relativePathSegments.some(
+      (segment) =>
+        segment === "" ||
+        segment === "." ||
+        segment === ".." ||
+        segment.includes("/") ||
+        segment.includes("\\") ||
+        segment.includes("\0"),
+    )
+  ) {
+    return null;
+  }
+
+  const threadsDirectory = path.resolve(
+    process.cwd(),
+    "public",
+    "demo",
+    "threads",
+  );
+  const threadDirectory = path.resolve(threadsDirectory, threadId);
+  const candidate = path.resolve(threadDirectory, ...relativePathSegments);
+
+  if (!isContainedPath(threadDirectory, candidate)) {
+    return null;
+  }
+
+  try {
+    const threadStats = fs.lstatSync(threadDirectory);
+    if (!threadStats.isDirectory() || threadStats.isSymbolicLink()) {
+      return null;
+    }
+
+    const realThreadsDirectory = fs.realpathSync(threadsDirectory);
+    const realThreadDirectory = fs.realpathSync(threadDirectory);
+    const realCandidate = fs.realpathSync(candidate);
+    if (
+      !isContainedPath(realThreadsDirectory, realThreadDirectory) ||
+      !isContainedPath(realThreadDirectory, realCandidate) ||
+      !fs.statSync(realCandidate).isFile()
+    ) {
+      return null;
+    }
+
+    return realCandidate;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/tests/unit/app/mock-api-security.test.ts
+++ b/frontend/tests/unit/app/mock-api-security.test.ts
@@ -1,0 +1,266 @@
+import { randomUUID } from "crypto";
+import fs from "fs";
+import path from "path";
+
+import { afterEach, beforeEach, describe, expect, test } from "@rstest/core";
+import { NextRequest } from "next/server";
+
+import { GET as getMcpConfig } from "@/app/mock/api/mcp/config/route";
+import { GET as getModels } from "@/app/mock/api/models/route";
+import { GET as getSkills } from "@/app/mock/api/skills/route";
+import { GET as getArtifact } from "@/app/mock/api/threads/[thread_id]/artifacts/[[...artifact_path]]/route";
+import { POST as getHistory } from "@/app/mock/api/threads/[thread_id]/history/route";
+import { POST as searchThreads } from "@/app/mock/api/threads/search/route";
+
+const DEMO_THREAD_ID = "21cfea46-34bd-4aa6-9e1f-3009452fbeb9";
+
+const savedEnv = {
+  NODE_ENV: process.env.NODE_ENV,
+  DEER_FLOW_ENABLE_MOCK_API: process.env.DEER_FLOW_ENABLE_MOCK_API,
+};
+
+function setEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}
+
+describe("mock API production boundary", () => {
+  beforeEach(() => {
+    setEnv("NODE_ENV", "production");
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", undefined);
+  });
+
+  afterEach(() => {
+    setEnv("NODE_ENV", savedEnv.NODE_ENV);
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", savedEnv.DEER_FLOW_ENABLE_MOCK_API);
+  });
+
+  test("returns 404 from every mock handler before demo data is accessed", async () => {
+    const immediateResponses = [getMcpConfig(), getModels(), getSkills()];
+    const asyncResponses = await Promise.all([
+      getHistory(new NextRequest("http://localhost/mock/history"), {
+        params: Promise.resolve({ thread_id: DEMO_THREAD_ID }),
+      }),
+      searchThreads(
+        new Request("http://localhost/mock/api/threads/search", {
+          method: "POST",
+          body: "{}",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+      getArtifact(
+        new NextRequest(
+          `http://localhost/mock/api/threads/${DEMO_THREAD_ID}/artifacts/mnt/user-data/outputs/doraemon-moe-comic.jpg`,
+        ),
+        {
+          params: Promise.resolve({
+            thread_id: DEMO_THREAD_ID,
+            artifact_path: [
+              "mnt",
+              "user-data",
+              "outputs",
+              "doraemon-moe-comic.jpg",
+            ],
+          }),
+        },
+      ),
+    ]);
+    const responses = [...immediateResponses, ...asyncResponses];
+
+    expect(responses.map((response) => response.status)).toEqual([
+      404, 404, 404, 404, 404, 404,
+    ]);
+  });
+
+  test("allows an explicit production opt-in", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+
+    const response = getModels();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      models: expect.any(Array),
+    });
+  });
+
+  test("does not serve an artifact outside its demo thread directory", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+
+    const response = await getArtifact(
+      new NextRequest(
+        `http://localhost/mock/api/threads/${DEMO_THREAD_ID}/artifacts/mnt/../../../../package.json`,
+      ),
+      {
+        params: Promise.resolve({
+          thread_id: DEMO_THREAD_ID,
+          artifact_path: ["mnt", "..", "..", "..", "..", "package.json"],
+        }),
+      },
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  test("does not read history outside a UUID thread directory", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+    const externalThreadName = `outside-thread-${randomUUID()}`;
+    const externalThreadDirectory = path.resolve(
+      process.cwd(),
+      "public",
+      "demo",
+      externalThreadName,
+    );
+    const escapedHistoryPath = path.join(
+      externalThreadDirectory,
+      "thread.json",
+    );
+    fs.mkdirSync(externalThreadDirectory);
+    fs.writeFileSync(escapedHistoryPath, JSON.stringify({ history: [] }));
+
+    try {
+      const response = await getHistory(
+        new NextRequest("http://localhost/mock/api/threads/invalid/history"),
+        {
+          params: Promise.resolve({
+            thread_id: `../${externalThreadName}`,
+          }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      fs.unlinkSync(escapedHistoryPath);
+      fs.rmdirSync(externalThreadDirectory);
+    }
+  });
+
+  test("does not follow a thread directory symlink outside the threads root", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+    const linkedThreadId = randomUUID();
+    const linkedThreadDirectory = path.resolve(
+      process.cwd(),
+      "public",
+      "demo",
+      "threads",
+      linkedThreadId,
+    );
+    const externalDirectory = path.resolve(
+      process.cwd(),
+      "public",
+      "demo",
+      `outside-thread-${linkedThreadId}`,
+    );
+    const externalArtifact = path.join(externalDirectory, "secret.txt");
+    fs.mkdirSync(externalDirectory);
+    fs.writeFileSync(externalArtifact, "not a demo thread artifact");
+    fs.symlinkSync(
+      externalDirectory,
+      linkedThreadDirectory,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    try {
+      const response = await getArtifact(
+        new NextRequest(
+          `http://localhost/mock/api/threads/${linkedThreadId}/artifacts/mnt/secret.txt`,
+        ),
+        {
+          params: Promise.resolve({
+            thread_id: linkedThreadId,
+            artifact_path: ["mnt", "secret.txt"],
+          }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      fs.unlinkSync(linkedThreadDirectory);
+      fs.unlinkSync(externalArtifact);
+      fs.rmdirSync(externalDirectory);
+    }
+  });
+
+  test("does not follow a nested symlink outside a valid thread directory", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+    const threadId = randomUUID();
+    const threadDirectory = path.resolve(
+      process.cwd(),
+      "public",
+      "demo",
+      "threads",
+      threadId,
+    );
+    const externalDirectory = path.resolve(
+      process.cwd(),
+      "public",
+      "demo",
+      `outside-thread-${threadId}`,
+    );
+    const linkedDirectory = path.join(threadDirectory, "linked");
+    const externalArtifact = path.join(externalDirectory, "secret.txt");
+    fs.mkdirSync(threadDirectory);
+    fs.mkdirSync(externalDirectory);
+    fs.writeFileSync(externalArtifact, "not a demo thread artifact");
+    fs.symlinkSync(
+      externalDirectory,
+      linkedDirectory,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+
+    try {
+      const response = await getArtifact(
+        new NextRequest(
+          `http://localhost/mock/api/threads/${threadId}/artifacts/mnt/linked/secret.txt`,
+        ),
+        {
+          params: Promise.resolve({
+            thread_id: threadId,
+            artifact_path: ["mnt", "linked", "secret.txt"],
+          }),
+        },
+      );
+
+      expect(response.status).toBe(404);
+    } finally {
+      fs.unlinkSync(linkedDirectory);
+      fs.rmdirSync(threadDirectory);
+      fs.unlinkSync(externalArtifact);
+      fs.rmdirSync(externalDirectory);
+    }
+  });
+
+  test("serves valid demo files when production mock access is enabled", async () => {
+    setEnv("DEER_FLOW_ENABLE_MOCK_API", "true");
+
+    const [historyResponse, artifactResponse] = await Promise.all([
+      getHistory(new NextRequest("http://localhost/mock/history"), {
+        params: Promise.resolve({ thread_id: DEMO_THREAD_ID }),
+      }),
+      getArtifact(
+        new NextRequest(
+          `http://localhost/mock/api/threads/${DEMO_THREAD_ID}/artifacts/mnt/user-data/outputs/doraemon-moe-comic.jpg?download=true`,
+        ),
+        {
+          params: Promise.resolve({
+            thread_id: DEMO_THREAD_ID,
+            artifact_path: [
+              "mnt",
+              "user-data",
+              "outputs",
+              "doraemon-moe-comic.jpg",
+            ],
+          }),
+        },
+      ),
+    ]);
+
+    expect(historyResponse.status).toBe(200);
+    expect(artifactResponse.status).toBe(200);
+    expect(artifactResponse.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="doraemon-moe-comic.jpg"',
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- Return `404 Not Found` from every current `/mock/api/*` handler in production unless `DEER_FLOW_ENABLE_MOCK_API` is explicitly set to `true`.
- Validate demo thread IDs as UUIDs before resolving history or artifact files.
- Constrain file access to the canonical `public/demo/threads` root and selected thread directory.
- Reject lexical traversal, unsafe path segments, thread-directory symlinks/junctions, and nested symlink escapes.
- Limit artifact download filenames to the basename so absolute server paths are not disclosed.
- Add route-level regression tests that invoke the real handlers.

## Why

The mock endpoints bypass the normal backend authentication boundary and were reachable in production. The history and artifact handlers also constructed filesystem paths from route parameters without strict containment, allowing crafted parameters to escape the intended demo-thread directory.

## Impact

Production mock routes are disabled by default. Teams that intentionally deploy the demo API must opt in with:

```text
DEER_FLOW_ENABLE_MOCK_API=true
```

Legitimate demo history and artifact access continues to work when that flag is enabled.

## Validation

- Rstest: 335/335 tests passed
- Focused security tests cover default production denial, explicit opt-in, lexical traversal, invalid thread IDs, thread-root junction escape, nested junction escape, and legitimate demo access
- TypeScript: passed
- ESLint: passed
- Prettier check: passed
- Next.js production build: passed
- Independent security review after remediation: no remaining Critical or Important findings
