### PR TITLE
docs(config): Crawl4AI >= 0.9 requires a bearer token

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -763,10 +763,16 @@ tools:
   #   # wait_for_timeout_ms: 2000        # Extra wait after page load in milliseconds
   #   # wait_for_selector: "article"     # CSS selector to wait for before returning
 
-  # Web fetch tool (uses Crawl4AI - self-hosted headless Chromium, no API key)
+  # Web fetch tool (uses Crawl4AI - self-hosted headless Chromium, no third-party API key)
   # Crawl4AI returns server-cleaned "fit" markdown directly (no readability step needed),
-  # ideal for JavaScript-heavy sites. Self-host (JWT auth is off by default, no key):
-  #   docker run -d -p 11235:11235 --shm-size=1g unclecode/crawl4ai:0.8.6
+  # ideal for JavaScript-heavy sites. Self-host it:
+  #   docker run -d -p 11235:11235 --shm-size=1g \
+  #     -e CRAWL4AI_API_TOKEN=$CRAWL4AI_TOKEN unclecode/crawl4ai:0.9.2
+  # Crawl4AI >= 0.9 is secure-by-default: a bearer token is REQUIRED on every request
+  # except GET /health, and a server started without CRAWL4AI_API_TOKEN binds 127.0.0.1
+  # only (so a container/remote DeerFlow cannot reach it at all). Set the same value in
+  # the server env and in `token:` below, or requests fail with HTTP 401.
+  # Use >= 0.8.7: earlier images, including 0.8.6, carry known pre-auth RCEs.
   # For Docker deployments, use the Docker service name instead of localhost.
   # NOTE: Only one web_fetch provider can be active at a time.
   # Comment out the Jina AI web_fetch entry below before enabling this one.
@@ -774,10 +780,10 @@ tools:
   #   group: web
   #   use: deerflow.community.crawl4ai.tools:web_fetch_tool
   #   base_url: http://localhost:11235   # Crawl4AI server URL (Docker: http://crawl4ai:11235)
+  #   token: $CRAWL4AI_TOKEN              # Bearer token; required by Crawl4AI >= 0.9
   #   timeout: 30                         # Request timeout in seconds
   #   # allow_private_addresses: false     # SSRF guard: keep false in production. Set true ONLY for intentional internal targets.
   #   # filter: fit                       # Markdown filter: fit (default) | raw | bm25 | llm
-  #   # token: $CRAWL4AI_TOKEN            # Bearer token (only if the server has JWT auth enabled)
 
   # Web capture tool (uses Browserless /screenshot to render a page as an artifact)
   # Browserless captures JavaScript-heavy pages with a real headless Chrome and


### PR DESCRIPTION
## Problem

The commented Crawl4AI `web_fetch` example in `config.example.yaml` still describes the pre-0.9 server:

- *"JWT auth is off by default, no key"*
- `# token: $CRAWL4AI_TOKEN  # Bearer token (only if the server has JWT auth enabled)`
- `docker run ... unclecode/crawl4ai:0.8.6`

Crawl4AI **0.9.0** (2026-06-18) made the Docker API server secure-by-default. From its changelog / `deploy/docker/MIGRATION.md`:

> **Authentication on by default, loopback bind**: the server no longer serves an unauthenticated API on `0.0.0.0`. With no token it binds `127.0.0.1` and prints a one-off local token; exposing it requires `CRAWL4AI_API_TOKEN` and `Authorization: Bearer <token>` on every request except `GET /health`.

So a user who follows the current example against a current image gets one of two confusing outcomes:

1. Sets a token on the server but leaves `token:` commented out (as the example implies is fine) → **every fetch returns HTTP 401**.
2. Starts the server with no token at all → it **binds loopback only**, and a containerised/remote DeerFlow cannot reach it, with nothing pointing at auth as the cause.

Verified against `unclecode/crawl4ai:0.9.2`: a tokenless `POST /md` returns `401`, and the same request with the bearer header succeeds.

Secondly, the pinned `0.8.6` is worth moving off regardless of auth: **0.8.7** fixed two pre-auth RCEs (CVSS 9.8 — AST sandbox escape and hook sandbox escape) plus a hardcoded JWT secret, and 0.8.8/0.8.9 closed SSRF gaps in the same server.

## Change

Comment-only update to the Crawl4AI block in `config.example.yaml`:

- `docker run` line bumped to `0.9.2` and given `-e CRAWL4AI_API_TOKEN=...`
- explains that auth is mandatory on >= 0.9 and that a tokenless server binds loopback
- notes >= 0.8.7 for the RCE fixes
- moves `token:` from the commented "optional" group up into the active example fields, next to `base_url`

## Notes for review

- **No code change needed.** `Crawl4AiClient` already sends `Authorization: Bearer <token>` whenever `token` is set (`crawl4ai_client.py`), and `tools.py` already reads `token` from the tool config — the client was forward-compatible; only the example was stale.
- **`config_version` intentionally not bumped**: every changed line is a comment, so there is no schema change and no reason to make users re-run `make config-upgrade`.
- Existing deployments that already pass a token are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)