### PR TITLE
fix(frontend): sync streaming list markers with content

### DIFF
--- a/frontend/src/components/workspace/messages/markdown-content.tsx
+++ b/frontend/src/components/workspace/messages/markdown-content.tsx
@@ -16,8 +16,9 @@ import {
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
 import {
   preprocessStreamdownMarkdown,
+  rehypeStreamingListItems,
   streamdownPluginsWithoutRawHtml,
-  streamdownWordAnimation,
+  streamdownSmoothStreamingAnimation,
 } from "@/core/streamdown";
 import {
   SafeMessageResponse,
@@ -241,8 +242,13 @@ export function MarkdownContent({
   const effectiveRehypePlugins = useMemo(() => {
     const base = streamdownPluginsWithoutRawHtml.rehypePlugins ?? [];
     const extra = rehypePlugins ?? [];
-    return [...base, ...extra] as ClipboardSafeStreamdownProps["rehypePlugins"];
-  }, [rehypePlugins]);
+    const streaming = isStreamingRender ? [rehypeStreamingListItems] : [];
+    return [
+      ...base,
+      ...extra,
+      ...streaming,
+    ] as ClipboardSafeStreamdownProps["rehypePlugins"];
+  }, [isStreamingRender, rehypePlugins]);
   const components = useMemo(() => {
     const baseComponents = {
       a: createMarkdownLinkComponent(),
@@ -267,7 +273,7 @@ export function MarkdownContent({
       rehypePlugins={effectiveRehypePlugins}
       components={toStreamdownComponents(components)}
       parseIncompleteMarkdown={isLoading}
-      animated={streamdownWordAnimation}
+      animated={streamdownSmoothStreamingAnimation}
       isAnimating={isLoading}
     >
       {normalizedContent}

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -53,17 +53,30 @@ export const streamdownSmoothStreamingAnimation = {
  *
  * A trailing `2.` or `-` is parsed as an empty list item while content is
  * streaming. Hide that transient item, then mark it for a matching marker
- * animation as soon as its first child arrives.
+ * animation as soon as its first child arrives. Keep mid-list empty items in
+ * the box tree so ordered-list counters never renumber later items.
  */
 export function rehypeStreamingListItems() {
   return (tree: Root) => {
-    visit(tree, "element", (node) => {
+    visit(tree, "element", (node, index, parent) => {
       if (node.tagName !== "li") {
         return;
       }
 
       if (node.children.length === 0) {
-        node.properties.hidden = true;
+        const isTrailingListItem =
+          index !== undefined &&
+          parent?.type === "element" &&
+          (parent.tagName === "ol" || parent.tagName === "ul") &&
+          !parent.children
+            .slice(index + 1)
+            .some(
+              (sibling) =>
+                sibling.type === "element" && sibling.tagName === "li",
+            );
+        if (isTrailingListItem) {
+          node.properties.hidden = true;
+        }
         return;
       }
 

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -1,10 +1,12 @@
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
+import type { Root } from "hast";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { StreamdownProps } from "streamdown";
+import { visit } from "unist-util-visit";
 
 const katexOptions = {
   output: "html",
@@ -36,6 +38,39 @@ export const streamdownWordAnimation = {
   duration: 200,
   sep: "word",
 } as const satisfies Exclude<StreamdownProps["animated"], boolean | undefined>;
+
+export const streamdownSmoothStreamingAnimation = {
+  ...streamdownWordAnimation,
+  // Streamdown defaults to 40ms per new word. A large chunk can therefore
+  // delay later list-item text by seconds while its native marker is already
+  // visible. Smooth content reveal owns the pacing here, so start every new
+  // word's fade together with its surrounding marker.
+  stagger: 0,
+} as const satisfies Exclude<StreamdownProps["animated"], boolean | undefined>;
+
+/**
+ * Keeps native list markers in step with Streamdown's word reveal.
+ *
+ * A trailing `2.` or `-` is parsed as an empty list item while content is
+ * streaming. Hide that transient item, then mark it for a matching marker
+ * animation as soon as its first child arrives.
+ */
+export function rehypeStreamingListItems() {
+  return (tree: Root) => {
+    visit(tree, "element", (node) => {
+      if (node.tagName !== "li") {
+        return;
+      }
+
+      if (node.children.length === 0) {
+        node.properties.hidden = true;
+        return;
+      }
+
+      node.properties["data-streaming-list-item"] = "true";
+    });
+  };
+}
 
 export const streamdownPluginsWithoutRawHtml = {
   plugins: streamdownPlugins.plugins,

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -72,6 +72,16 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@keyframes streaming-list-marker-fade-in {
+  from {
+    color: transparent;
+  }
+}
+
+[data-streaming-list-item]::marker {
+  animation: streaming-list-marker-fade-in 200ms ease both;
+}
+
 @theme {
   --font-sans:
     ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.dom.test.tsx
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.dom.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "@rstest/core";
+import { cleanup, render, waitFor } from "@testing-library/react";
+
+import { MarkdownContent } from "@/components/workspace/messages/markdown-content";
+
+afterEach(cleanup);
+
+describe("MarkdownContent streaming list transitions (DOM)", () => {
+  it("reveals the same list item with marker animation when content arrives", async () => {
+    const { container, rerender } = render(
+      <MarkdownContent content={"1. First\n\n2."} isLoading={true} />,
+    );
+    const initialItems = container.querySelectorAll<HTMLLIElement>(
+      '[data-streamdown="list-item"]',
+    );
+    const firstItem = initialItems[0]!;
+    const pendingItem = initialItems[1]!;
+
+    expect(pendingItem.hidden).toBe(true);
+    expect(pendingItem.hasAttribute("data-streaming-list-item")).toBe(false);
+
+    rerender(
+      <MarkdownContent content={"1. First\n\n2. Second"} isLoading={true} />,
+    );
+
+    await waitFor(() => {
+      expect(pendingItem.textContent).toContain("Second");
+    });
+    const revealedItems = container.querySelectorAll<HTMLLIElement>(
+      '[data-streamdown="list-item"]',
+    );
+
+    expect(revealedItems[0]).toBe(firstItem);
+    expect(revealedItems[1]).toBe(pendingItem);
+    expect(pendingItem.hidden).toBe(false);
+    expect(pendingItem.getAttribute("data-streaming-list-item")).toBe("true");
+  });
+});

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
@@ -125,6 +125,18 @@ describe("MarkdownContent streaming lists", () => {
     expect(html).not.toContain('data-streaming-list-item="true"');
   });
 
+  it("keeps a mid-list empty item visible so ordered counters stay stable", () => {
+    const html = renderMarkdown(
+      ["1. First", "2.", "3. Third"].join("\n"),
+      true,
+    );
+    const listItems = html.match(/<li[^>]*>/g);
+
+    expect(listItems).toHaveLength(3);
+    expect(listItems?.[1]).not.toContain("hidden");
+    expect(html).not.toContain('hidden=""');
+  });
+
   it("marks nested list items without hiding existing content", () => {
     const html = renderMarkdown(
       ["1. Parent", "   - Nested child"].join("\n"),

--- a/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
+++ b/frontend/tests/unit/components/workspace/messages/markdown-content.test.ts
@@ -98,6 +98,7 @@ describe("MarkdownContent streaming animation", () => {
     expect(html).toContain("data-sd-animate");
     expect(html).toContain("--sd-animation:sd-fadeIn");
     expect(html).toContain("--sd-duration:200ms");
+    expect(html).not.toContain("--sd-delay");
     expect(html).not.toContain("animate-fade-in");
   });
 
@@ -105,6 +106,41 @@ describe("MarkdownContent streaming animation", () => {
     const html = renderMarkdown("Hello completed world", false);
 
     expect(html).not.toContain("data-sd-animate");
+  });
+});
+
+describe("MarkdownContent streaming lists", () => {
+  it("hides a trailing empty ordered-list item until its content arrives", () => {
+    const html = renderMarkdown(["1. First", "", "2."].join("\n"), true);
+
+    expect(html).toContain('data-streaming-list-item="true"');
+    expect(html).toContain('data-streamdown="list-item" hidden=""');
+  });
+
+  it("hides a trailing empty unordered-list item until its content arrives", () => {
+    const html = renderMarkdown("-", true);
+
+    expect(html).toContain('data-streamdown="unordered-list"');
+    expect(html).toContain('data-streamdown="list-item" hidden=""');
+    expect(html).not.toContain('data-streaming-list-item="true"');
+  });
+
+  it("marks nested list items without hiding existing content", () => {
+    const html = renderMarkdown(
+      ["1. Parent", "   - Nested child"].join("\n"),
+      true,
+    );
+
+    expect(html.match(/data-streaming-list-item="true"/g)).toHaveLength(2);
+    expect(html).not.toContain('hidden=""');
+  });
+
+  it("leaves completed list markup outside streaming treatment", () => {
+    const html = renderMarkdown(["1. First", "", "2."].join("\n"), false);
+
+    expect(html).toContain('data-streamdown="ordered-list"');
+    expect(html).not.toContain("data-streaming-list-item");
+    expect(html).not.toContain('hidden=""');
   });
 });
 

--- a/frontend/tests/unit/core/streamdown/plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown/plugins.test.ts
@@ -8,6 +8,7 @@ import {
   reasoningPlugins,
   streamdownPlugins,
   streamdownRenderingPlugins,
+  streamdownSmoothStreamingAnimation,
   streamdownWordAnimation,
 } from "@/core/streamdown/plugins";
 
@@ -22,6 +23,15 @@ test("streaming word animation uses Streamdown's stable incremental animation", 
     animation: "fadeIn",
     duration: 200,
     sep: "word",
+  });
+});
+
+test("smooth message streaming does not add a cumulative word delay", () => {
+  expect(streamdownSmoothStreamingAnimation).toEqual({
+    animation: "fadeIn",
+    duration: 200,
+    sep: "word",
+    stagger: 0,
   });
 });
 


### PR DESCRIPTION
Fixes #4523

## Why

During streamed AI responses, an incomplete Markdown list item such as a trailing `2.` or `-` can be parsed as an empty `<li>`. The browser paints its native list marker immediately, while Streamdown is still revealing the item content.

Streamdown's default per-word stagger can further delay the text, making ordered-list numbers and bullet markers appear noticeably ahead of their content.

## What changed

- Transient empty ordered and unordered list items remain hidden until their content arrives.
- List markers and newly arrived item content now begin the same 200ms fade-in together.
- Cumulative word staggering is disabled only for smoothly streamed chat messages.
- Completed messages, historical Markdown, nested lists, custom renderers, and subtask-card animations retain their existing behavior.
- Added regression coverage for ordered lists, unordered lists, nested lists, completed messages, animation timing, and DOM reuse during streaming.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Before: See the reproduction screenshots in #4523.

After: ✅ 
<img width="2640" height="1526" alt="image" src="https://github.com/user-attachments/assets/0fb586d4-b714-45ba-9ac9-77de737be09d" />


## Bug fix verification

- Test paths:
  - `frontend/tests/unit/components/workspace/messages/markdown-content.test.ts`
  - `frontend/tests/unit/components/workspace/messages/markdown-content.dom.test.tsx`
  - `frontend/tests/unit/core/streamdown/plugins.test.ts`
- Did it go red on `main` and green on this branch?
  - The tests were not rerun against a separate `main` checkout. The regression assertions cover behavior absent on `main`, and all pass on this branch.
  - The issue was also reproduced before the fix and manually verified after the fix in the Docker development environment.

## Validation

- `cd frontend && pnpm format:write`
- `cd frontend && pnpm test`
  - 92 test files
  - 832 tests passed
  - 0 failures
- `cd frontend && pnpm check`
- Manual Docker verification at `http://localhost:2026` using long ordered lists with nested unordered items
- Static audit of all frontend E2E suites for list selectors, streaming animation attributes, DOM snapshots, and visual regression coverage
- E2E was not run locally; it is deferred to the PR pipeline

