### PR TITLE
feat: allow bypassing ask_clarification form by typing in chat input

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -34,11 +34,9 @@ import { useAgent } from "@/core/agents";
 import { useI18n } from "@/core/i18n/hooks";
 import {
   buildHumanInputResponseText,
-  hasOpenHumanInputRequest,
   type HumanInputRequest,
   type HumanInputResponse,
 } from "@/core/messages/human-input";
-import { isHiddenFromUIMessage } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
@@ -224,14 +222,6 @@ export default function AgentChatPage() {
     threadId,
     thread.values.goal,
   );
-  const hasOpenHumanInputCard = useMemo(
-    () =>
-      hasOpenHumanInputRequest(
-        thread.messages,
-        (message) => !isHiddenFromUIMessage(message),
-      ),
-    [thread.messages],
-  );
 
   return (
     <ThreadContext.Provider value={{ thread, isMock }}>
@@ -319,8 +309,7 @@ export default function AgentChatPage() {
                     env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY !== "true" &&
                     !isUploading &&
                     !thread.isLoading &&
-                    !hasGoal &&
-                    !hasOpenHumanInputCard
+                    !hasGoal
                   }
                   onEditAndRegenerateMessage={handleEditAndRegenerate}
                   onSubmitHumanInput={
@@ -401,7 +390,6 @@ export default function AgentChatPage() {
                     disabled={
                       env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
                       isUploading ||
-                      hasOpenHumanInputCard ||
                       (!isNewThread && isHistoryLoading)
                     }
                     onContextChange={(context) =>

--- a/frontend/src/app/workspace/agents/new/page.tsx
+++ b/frontend/src/app/workspace/agents/new/page.tsx
@@ -40,11 +40,9 @@ import {
 import { useI18n } from "@/core/i18n/hooks";
 import {
   buildHumanInputResponseText,
-  hasOpenHumanInputRequest,
   type HumanInputRequest,
   type HumanInputResponse,
 } from "@/core/messages/human-input";
-import { isHiddenFromUIMessage } from "@/core/messages/utils";
 import { safeLocalStorage } from "@/core/settings/local";
 import { hasToolResult, useThreadStream } from "@/core/threads/hooks";
 import { uuid } from "@/core/utils/uuid";
@@ -119,14 +117,6 @@ export default function NewAgentPage() {
       });
     },
   });
-  const hasOpenHumanInputCard = useMemo(
-    () =>
-      hasOpenHumanInputRequest(
-        thread.messages,
-        (message) => !isHiddenFromUIMessage(message),
-      ),
-    [thread.messages],
-  );
 
   useEffect(() => {
     if (typeof window === "undefined" || step !== "chat") {
@@ -225,14 +215,14 @@ export default function NewAgentPage() {
   const handleChatSubmit = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
-      if (!trimmed || thread.isLoading || hasOpenHumanInputCard) return;
+      if (!trimmed || thread.isLoading) return;
       await sendMessage(
         threadId,
         { text: trimmed, files: [] },
         { agent_name: agentName },
       );
     },
-    [agentName, hasOpenHumanInputCard, sendMessage, thread.isLoading, threadId],
+    [agentName, sendMessage, thread.isLoading, threadId],
   );
 
   const handleSubmitHumanInput = useCallback(
@@ -443,17 +433,17 @@ export default function NewAgentPage() {
                   </div>
                 ) : (
                   <PromptInput
-                    disabled={thread.isLoading || hasOpenHumanInputCard}
+                    disabled={thread.isLoading}
                     onSubmit={({ text }) => void handleChatSubmit(text)}
                   >
                     <PromptInputTextarea
                       autoFocus
                       placeholder={t.agents.createPageSubtitle}
-                      disabled={thread.isLoading || hasOpenHumanInputCard}
+                      disabled={thread.isLoading}
                     />
                     <PromptInputFooter className="justify-end">
                       <PromptInputSubmit
-                        disabled={thread.isLoading || hasOpenHumanInputCard}
+                        disabled={thread.isLoading}
                       />
                     </PromptInputFooter>
                   </PromptInput>

--- a/frontend/src/app/workspace/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/chats/[thread_id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { type PromptInputMessage } from "@/components/ai-elements/prompt-input";
@@ -38,11 +38,9 @@ import { useBrowserControlEnabled } from "@/core/features";
 import { useI18n } from "@/core/i18n/hooks";
 import {
   buildHumanInputResponseText,
-  hasOpenHumanInputRequest,
   type HumanInputRequest,
   type HumanInputResponse,
 } from "@/core/messages/human-input";
-import { isHiddenFromUIMessage } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import { useNotification } from "@/core/notification/hooks";
 import { useLocalSettings, useThreadSettings } from "@/core/settings";
@@ -254,14 +252,6 @@ export default function ChatPage() {
     threadId,
     thread.values.goal,
   );
-  const hasOpenHumanInputCard = useMemo(
-    () =>
-      hasOpenHumanInputRequest(
-        thread.messages,
-        (message) => !isHiddenFromUIMessage(message),
-      ),
-    [thread.messages],
-  );
 
   return (
     <ThreadContext.Provider value={{ thread, isMock }}>
@@ -332,8 +322,7 @@ export default function ChatPage() {
                     !isUploading &&
                     !thread.isLoading &&
                     !branchThread.isPending &&
-                    !hasGoal &&
-                    !hasOpenHumanInputCard
+                    !hasGoal
                   }
                   onEditAndRegenerateMessage={handleEditAndRegenerate}
                   onSubmitHumanInput={
@@ -419,7 +408,6 @@ export default function ChatPage() {
                         isMock ||
                         env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true" ||
                         isUploading ||
-                        hasOpenHumanInputCard ||
                         (!isNewThread && isHistoryLoading)
                       }
                       onContextChange={(context) =>

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -73,7 +73,6 @@ import { useAuth } from "@/core/auth/AuthProvider";
 import { getBackendBaseURL } from "@/core/config";
 import { useI18n } from "@/core/i18n/hooks";
 import { polishInputDraft } from "@/core/input-polish/api";
-import { hasOpenHumanInputRequest } from "@/core/messages/human-input";
 import { isHiddenFromUIMessage } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import {
@@ -1301,14 +1300,6 @@ export function InputBox({
     dismissedSkillSuggestionValue !== textInput.value;
   const isComposerDisabled = disabled === true;
   const isMockThread = isMock === true;
-  const hasOpenHumanInputCard = useMemo(
-    () =>
-      hasOpenHumanInputRequest(
-        thread.messages,
-        (message) => !isHiddenFromUIMessage(message),
-      ),
-    [thread.messages],
-  );
   const composerLocked = isComposerDisabled || polishingInput;
   const inputPolishUndoAvailable =
     !polishingInput &&
@@ -1317,7 +1308,6 @@ export function InputBox({
   const inputPolishDisabled =
     isComposerDisabled ||
     isMockThread ||
-    hasOpenHumanInputCard ||
     polishingInput ||
     (!inputPolishUndoAvailable &&
       (status === "streaming" ||

--- a/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
+++ b/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
@@ -51,11 +51,9 @@ import {
 import { useI18n } from "@/core/i18n/hooks";
 import {
   buildHumanInputResponseText,
-  hasOpenHumanInputRequest,
   type HumanInputRequest,
   type HumanInputResponse,
 } from "@/core/messages/human-input";
-import { isHiddenFromUIMessage } from "@/core/messages/utils";
 import { useModels } from "@/core/models/hooks";
 import type { Model } from "@/core/models/types";
 import { useLocalSettings } from "@/core/settings";
@@ -209,14 +207,6 @@ export function SidecarPanel({ className }: { className?: string }) {
 
   const hasPendingReferences = sidecar.activeReferences.length > 0;
   const hasSidecarThread = Boolean(sidecar.sidecarThreadId);
-  const hasOpenHumanInputCard = useMemo(
-    () =>
-      hasOpenHumanInputRequest(
-        thread.messages,
-        (message) => !isHiddenFromUIMessage(message),
-      ),
-    [thread.messages],
-  );
   const tokenUsageInlineMode = tokenUsageEnabled
     ? localSettings.tokenUsage.inlineMode
     : "off";
@@ -226,7 +216,6 @@ export function SidecarPanel({ className }: { className?: string }) {
     creatingThread ||
     Boolean(queuedSubmit) ||
     isUploading ||
-    hasOpenHumanInputCard ||
     (hasSidecarThread && isHistoryLoading) ||
     (sidecar.isMock ?? false) ||
     env.NEXT_PUBLIC_STATIC_WEBSITE_ONLY === "true";


### PR DESCRIPTION
## Summary

This PR resolves #4529 by allowing users to bypass the `ask_clarification` form by typing directly in the chat input.

## Problem

When `ask_clarification` was invoked, the chat input was disabled (`hasOpenHumanInputCard = true`). Users were required to complete all form fields to proceed and could not type a free-form reply instead.

This was restrictive when:
- The user wants to give a different answer than the available options
- The user wants to skip the clarification and let the agent decide
- The form options are malformed or unhelpful

## Solution

Remove the `hasOpenHumanInputCard` disable binding from the chat input across all pages. Users can now:
1. Send free-form messages while a clarification form is open
2. The message is processed as a normal human message
3. The pending clarification is superseded by the new message
4. The agent receives the free-form text and decides how to proceed

This is the lightest-weight approach: no new protocol, no backend cancellation mechanism, just unblocking the input. The agent naturally interprets the free-form reply in context.

## Changes

- **page.tsx (chats/[thread_id])**: Remove `hasOpenHumanInputCard` from `disabled` prop and `canEdit` check
- **agents/new/page.tsx**: Remove `hasOpenHumanInputCard` from send guard and all disabled props
- **agents/[agent_name]/chats/[thread_id]/page.tsx**: Same changes as above
- **input-box.tsx**: Remove `hasOpenHumanInputCard` from `inputPolishDisabled`
- **sidecar-panel.tsx**: Remove `hasOpenHumanInputCard` from disabled check
- Clean up unused variable definitions and imports across all files

## Testing

- [x] Code changes are frontend-only (5 files, -63 lines, +8 lines)
- [x] No backend changes required - existing backend handles free-form messages naturally
- [x] Removed all `hasOpenHumanInputCard` gating from composer entry points
- [x] Cleaned up unused imports (`hasOpenHumanInputRequest`, `isHiddenFromUIMessage`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have verified the changes are syntactically correct
- [x] The change is minimal and focused on the single issue