### PR TITLE
ci(lark): publish lark-cli-init/broker images

### DIFF
--- a/.github/workflows/lark-cli-images.yaml
+++ b/.github/workflows/lark-cli-images.yaml
@@ -1,0 +1,98 @@
+name: Publish lark-cli Images
+
+# Publishes the two Lark sandbox runtime images (Pattern A init container and
+# Pattern B broker sidecar). These track the upstream `larksuite/cli` release,
+# not the DeerFlow `v*` release, so they publish on their own trigger and are
+# tagged by the lark-cli version rather than being wired into container.yaml.
+on:
+  workflow_dispatch:
+    inputs:
+      lark_cli_version:
+        description: "larksuite/cli release to build (e.g. v1.0.65)"
+        required: true
+        default: v1.0.65
+  push:
+    tags:
+      - "lark-cli-v*"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-images:
+    # Only publish from the upstream repo; a fork dispatch/tag skips the job.
+    if: github.repository == 'bytedance/deer-flow'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Pattern A init image: relative `COPY build-runtime.sh entrypoint.sh`,
+          # so the build context is its own dir.
+          - component: lark-cli-init
+            context: docker/lark-cli-init
+            file: docker/lark-cli-init/Dockerfile
+          # Pattern B broker image: copies the shared build-runtime.sh and the
+          # harness module, so the build context is the repo root.
+          - component: lark-cli-broker
+            context: .
+            file: docker/lark-cli-broker/Dockerfile
+    env:
+      IMAGE_NAME: ${{ github.repository }}-${{ matrix.component }}
+    steps:
+      - name: Resolve lark-cli version
+        id: version
+        # workflow_dispatch supplies it as an input; a `lark-cli-v*` tag encodes
+        # it after the prefix (lark-cli-v1.0.65 -> v1.0.65).
+        run: |
+          if [ -n "${{ inputs.lark_cli_version }}" ]; then
+            version="${{ inputs.lark_cli_version }}"
+          else
+            version="${GITHUB_REF_NAME#lark-cli-}"
+          fi
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 #v6.0.3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 #v3.11.1
+      - name: Log in to the Container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Tag by the lark-cli version (not the DeerFlow release). No `latest`.
+          tags: |
+            type=raw,value=${{ steps.version.outputs.value }}
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 #v6.18.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          # The sidecar/init stage a real arch-dispatched lark-cli binary, so
+          # publish both arches the sandbox may run on.
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            LARK_CLI_VERSION=${{ steps.version.outputs.value }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be #v2.4.0
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/lark-cli-images.yaml
+++ b/.github/workflows/lark-cli-images.yaml
@@ -48,10 +48,14 @@ jobs:
       - name: Resolve lark-cli version
         id: version
         # workflow_dispatch supplies it as an input; a `lark-cli-v*` tag encodes
-        # it after the prefix (lark-cli-v1.0.65 -> v1.0.65).
+        # it after the prefix (lark-cli-v1.0.65 -> v1.0.65). The input is passed
+        # via env (not interpolated into the script) to avoid shell expression
+        # injection if the repo gate on dispatch ever widens.
+        env:
+          LARK_CLI_VERSION_INPUT: ${{ inputs.lark_cli_version }}
         run: |
-          if [ -n "${{ inputs.lark_cli_version }}" ]; then
-            version="${{ inputs.lark_cli_version }}"
+          if [ -n "$LARK_CLI_VERSION_INPUT" ]; then
+            version="$LARK_CLI_VERSION_INPUT"
           else
             version="${GITHUB_REF_NAME#lark-cli-}"
           fi
@@ -83,8 +87,8 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           push: true
-          # The sidecar/init stage a real arch-dispatched lark-cli binary, so
-          # publish both arches the sandbox may run on.
+          # The sidecar/init image ships a real arch-dispatched lark-cli binary,
+          # so publish both arches the sandbox may run on.
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,6 +111,24 @@ Artifacts (under the running repo's owner, where `<date>` is `YYYYMMDD`):
 The chart version is patched in-workflow only - `Chart.yaml` and `values.yaml`
 in the repo are never modified.
 
+## lark-cli sandbox images
+
+The two optional Lark sandbox runtime images — `lark-cli-init` (Pattern A) and
+`lark-cli-broker` (Pattern B) — are **not** part of the `v*` release. They track
+the upstream `larksuite/cli` version, so they publish independently via
+`.github/workflows/lark-cli-images.yaml`:
+
+- Trigger with `workflow_dispatch` (a `lark_cli_version` input, e.g. `v1.0.65`)
+  or by pushing a `lark-cli-v*` tag (the version is read from after the prefix).
+- Builds multi-arch (`linux/amd64,linux/arm64`) and pushes
+  `ghcr.io/<owner>/deer-flow-{lark-cli-init,lark-cli-broker}:<lark-cli-version>`.
+- Gated on `github.repository == 'bytedance/deer-flow'`; not tied to the
+  `verify-versions` gate (its version is the lark-cli release, not the DeerFlow
+  release), and it never touches `latest`.
+
+Both features stay opt-in: the provisioner ignores them until
+`LARK_CLI_INIT_IMAGE` / `LARK_CLI_BROKER_IMAGE` point at a published tag.
+
 ## Version gate
 
 Both publishing workflows call `.github/workflows/verify-versions.yml` as their

--- a/docker/lark-cli-broker/Dockerfile.dockerignore
+++ b/docker/lark-cli-broker/Dockerfile.dockerignore
@@ -1,0 +1,28 @@
+# Dedicated ignore-file for the lark-cli-broker image.
+#
+# BuildKit uses this instead of the repo-root .dockerignore for builds that pass
+# `-f docker/lark-cli-broker/Dockerfile` (docker/build-push-action, `docker build`).
+# The root .dockerignore excludes the whole `docker/` tree, but this image builds
+# from a repo-root context and must COPY:
+#   - docker/lark-cli-init/build-runtime.sh
+#   - docker/lark-cli-broker/entrypoint.sh
+#   - backend/packages/harness/deerflow/integrations/lark_broker.py
+# so `docker/` and `backend/` must NOT be excluded here. Patterns are relative to
+# the build context root (the repo root).
+
+.git
+*.log
+
+# Python noise (keep backend sources; only drop build artifacts)
+**/__pycache__/
+*.py[cod]
+.venv/
+backend/.venv/
+backend/htmlcov/
+backend/.coverage
+
+# Components this image never needs
+frontend/
+docs/
+skills/
+**/node_modules/

--- a/docker/lark-cli-broker/README.md
+++ b/docker/lark-cli-broker/README.md
@@ -50,6 +50,12 @@ docker build -t deer-flow/lark-cli-broker:v1.0.65 \
 The tag should encode the lark-cli version so it can be bumped independently of
 the upstream `all-in-one-sandbox` image.
 
+CI publishes multi-arch (`linux/amd64,linux/arm64`) images to
+`ghcr.io/<owner>/deer-flow-lark-cli-broker:<lark-cli-version>` via
+`.github/workflows/lark-cli-images.yaml` (run it with a `lark_cli_version` input,
+or push a `lark-cli-v*` tag). This is decoupled from the DeerFlow `v*` release
+because the image tracks the upstream `larksuite/cli` version.
+
 ## Wiring it into the provisioner
 
 Broker mode is **opt-in** and off by default. Enable it by publishing this image
@@ -71,9 +77,9 @@ and pointing the provisioner at it:
   Lark integration sandbox-runtime readiness signal in
   `/api/integrations/lark/status` (`sandbox_runtime_mode: "broker"`).
 
-> Publishing note: this repository currently ships only backend/frontend images.
-> Publishing a `lark-cli-broker` tag is a fast-follow; until then the feature
-> stays behind the empty-default `LARK_CLI_BROKER_IMAGE`.
+> Opt-in note: broker mode stays off until `LARK_CLI_BROKER_IMAGE` is set on the
+> provisioner, so an unpublished or unconfigured image is a no-op (Pattern A /
+> legacy path, no behavior change).
 
 ## Broker HTTP contract (loopback)
 

--- a/docker/lark-cli-init/README.md
+++ b/docker/lark-cli-init/README.md
@@ -41,6 +41,12 @@ docker build -t deer-flow/lark-cli-init:v1.0.65 \
 The tag should encode the lark-cli version so it can be bumped independently of
 the upstream `all-in-one-sandbox` sandbox image.
 
+CI publishes multi-arch (`linux/amd64,linux/arm64`) images to
+`ghcr.io/<owner>/deer-flow-lark-cli-init:<lark-cli-version>` via
+`.github/workflows/lark-cli-images.yaml` (run it with a `lark_cli_version` input,
+or push a `lark-cli-v*` tag). This is decoupled from the DeerFlow `v*` release
+because the image tracks the upstream `larksuite/cli` version.
+
 ## Wiring it into the provisioner
 
 The init-container runtime path is **opt-in** and off by default. Enable it by
@@ -58,6 +64,6 @@ publishing this image and pointing the provisioner at it:
   (`{"lark_cli_init_image": true|false}`), which the Gateway surfaces as the
   Lark integration sandbox-runtime readiness signal in `/api/integrations/lark/status`.
 
-> Publishing note: this repository currently ships only backend/frontend images.
-> Publishing a `lark-cli-init` tag is a fast-follow; until then the feature stays
-> behind the empty-default `LARK_CLI_INIT_IMAGE`.
+> Opt-in note: the init-container path stays off until `LARK_CLI_INIT_IMAGE` is
+> set on the provisioner, so an unpublished or unconfigured image is a no-op
+> (legacy hostPath / Gateway download path, no behavior change).


### PR DESCRIPTION
## Why

Follow-up to #4501 (Pattern B broker) and #3971 (Pattern A init container), closing #4532.

Both Lark sandbox runtime images (`docker/lark-cli-init/`, `docker/lark-cli-broker/`) shipped only their build definitions — neither was published by CI. They are opt-in and referenced through the empty-default `LARK_CLI_INIT_IMAGE` / `LARK_CLI_BROKER_IMAGE`, so operators had to build and push them by hand. @zhfeng asked on #4501 whether we can provide the `lark-cli-broker` image officially.

## What

New `.github/workflows/lark-cli-images.yaml` that builds and pushes both images to GHCR. It tracks the upstream `larksuite/cli` version rather than the DeerFlow `v*` release, so it's intentionally **decoupled** from `container.yaml` and the `verify-versions` gate:

- **Trigger:** `workflow_dispatch` with a `lark_cli_version` input (e.g. `v1.0.65`), or a `lark-cli-v*` tag (version read from after the prefix).
- **Multi-arch:** `linux/amd64,linux/arm64` via QEMU + Buildx — the images stage a real arch-dispatched `lark-cli` binary.
- **Per-component build context:** `lark-cli-init` builds from its own dir (relative `COPY`); `lark-cli-broker` builds from the repo root (it copies the shared `build-runtime.sh` and the harness `lark_broker.py`).
- **Tags:** by lark-cli version, no `latest`, gated on `github.repository == 'bytedance/deer-flow'`. Pinned action SHAs match the rest of the repo; new QEMU/Buildx SHAs verified against their tags.

Published names: `ghcr.io/<owner>/deer-flow-lark-cli-init` and `-lark-cli-broker`, tagged `:<lark-cli-version>`.

### Docs
- `RELEASING.md`: new "lark-cli sandbox images" section documenting the independent publishing.
- `docker/lark-cli-init/README.md` + `docker/lark-cli-broker/README.md`: document the CI publish path; replaced the "publishing is a fast-follow" notes with opt-in notes.

## Rollout / compatibility

- No behavior change: both features stay opt-in behind the empty-default env vars until an operator points them at a published tag.
- No change to the images themselves, the provisioner, or the runtime — this only adds a publish path + docs.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses.
- [x] New action SHAs (`setup-qemu-action@v3.6.0`, `setup-buildx-action@v3.11.1`) verified against their tags.
- [ ] Maintainer dispatches the workflow (or pushes a `lark-cli-v*` tag) to confirm the multi-arch push to GHCR.

Closes #4532