### PR TITLE
fix(skills): use managed integrations root for slash activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ deer-flow/
 ├── frontend/                       # Next.js frontend (pnpm) — see frontend/AGENTS.md
 ├── docker/                         # docker-compose files, nginx config, provisioner
 ├── skills/                         # Agent skills: public/ (committed), custom/ (gitignored)
-│                                    # Managed integration skill packs are installed per user under .deer-flow/users/{user_id}/skills/integrations/
+│                                    # Managed integration skill packs are global at .deer-flow/integrations/skills/{provider}/
+│                                    # Integration credentials and enabled state remain per-user
 ├── contracts/                      # Cross-component JSON contracts (e.g. subagent status, skill review)
 ├── scripts/                        # Root orchestration scripts invoked by the Makefile (check, configure, doctor, support_bundle, serve, nginx, docker, deploy, setup_wizard)
 ├── tests/                          # Root-level tests (currently tests/skills/ — public skill tests)

--- a/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
+++ b/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
@@ -6,12 +6,12 @@ read from the global ``{base_dir}/skills/public/`` (read-only).
 
 Layout::
 
-    <host_root>/public/<name>/SKILL.md            ← global, read-only
-    <user_custom_root>/<name>/SKILL.md             ← per-user, read-write
-    <user_integrations_root>/<provider>/<name>/SKILL.md  ← per-user, read-only
-    <user_custom_root>/.history/<name>.jsonl       ← per-user history
-    <user_skills_root>/_skill_states.json          ← per-user enabled state
-    <global_custom_root>/<name>/SKILL.md           ← legacy fallback, read-only
+    <host_root>/public/<name>/SKILL.md                   ← global, read-only
+    <user_custom_root>/<name>/SKILL.md                   ← per-user, read-write
+    <integrations_root>/<provider>/<name>/SKILL.md       ← global, read-only
+    <user_custom_root>/.history/<name>.jsonl             ← per-user history
+    <user_skills_root>/_skill_states.json                ← per-user enabled state
+    <global_custom_root>/<name>/SKILL.md                 ← legacy fallback, read-only
 
 Fallback: when a user has no custom skills yet, global ``skills/custom/``
 skills are yielded as ``SkillCategory.LEGACY`` (read-only) so they are
@@ -386,25 +386,34 @@ class UserScopedSkillStorage(LocalSkillStorage):
         return self._user_custom_root
 
     def get_user_integrations_root(self) -> Path:
-        """Host path to this user's managed integration skills root directory."""
-        return self._user_integrations_root
+        """Host path to the global managed integration skills root directory."""
+        return self._integrations_root
 
     # ------------------------------------------------------------------
-    # Path validation — accept per-user custom root as well as global root
+    # Path validation — accept public, per-user custom, and integration roots
     # ------------------------------------------------------------------
 
     def validate_skill_file_path(self, skill_file: Path) -> Path:
-        """Accept files under *either* the global root or the per-user custom root.
+        """Accept files under the public, per-user custom, or integration root.
 
-        Custom skills live in ``_user_custom_root`` which is not a sub-path
-        of ``_host_root``, so the default implementation's single-root check
-        would reject them.  This override allows both roots.
+        Custom and managed integration skills live outside ``_host_root``, so
+        the default implementation's single-root check would reject them.
         """
         resolved_file = skill_file.resolve()
-        for allowed_root in (self._host_root.resolve(), self._user_custom_root.resolve(), self._user_integrations_root.resolve()):
+        allowed_roots = (
+            self._host_root.resolve(),
+            self._user_custom_root.resolve(),
+            self._integrations_root.resolve(),
+        )
+        for allowed_root in allowed_roots:
             try:
                 resolved_file.relative_to(allowed_root)
                 return resolved_file
             except ValueError:
                 continue
-        raise ValueError(f"Resolved skill file {resolved_file} must stay within either the global skills root ({self._host_root.resolve()}) or the per-user custom root ({self._user_custom_root.resolve()}).")
+        raise ValueError(
+            f"Resolved skill file {resolved_file} must stay within the global skills root "
+            f"({self._host_root.resolve()}), the per-user custom root "
+            f"({self._user_custom_root.resolve()}), or the managed integration skills root "
+            f"({self._integrations_root.resolve()})."
+        )

--- a/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
+++ b/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
@@ -385,9 +385,13 @@ class UserScopedSkillStorage(LocalSkillStorage):
         """Host path to this user's custom skills root directory."""
         return self._user_custom_root
 
-    def get_user_integrations_root(self) -> Path:
+    def get_integrations_root(self) -> Path:
         """Host path to the global managed integration skills root directory."""
         return self._integrations_root
+
+    def get_user_integrations_root(self) -> Path:
+        """Compatibility alias for :meth:`get_integrations_root`."""
+        return self.get_integrations_root()
 
     # ------------------------------------------------------------------
     # Path validation — accept public, per-user custom, and integration roots

--- a/backend/tests/test_slash_skills.py
+++ b/backend/tests/test_slash_skills.py
@@ -9,7 +9,10 @@ from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from app.channels.commands import KNOWN_CHANNEL_COMMANDS
 from deerflow.agents.middlewares import skill_activation_middleware as middleware_module
 from deerflow.agents.middlewares.skill_activation_middleware import SkillActivationMiddleware, is_slash_skill_activation_reminder
+from deerflow.config.extensions_config import ExtensionsConfig
+from deerflow.config.paths import Paths
 from deerflow.skills.slash import RESERVED_SLASH_SKILL_NAMES, parse_slash_skill_reference, resolve_slash_skill
+from deerflow.skills.storage.user_scoped_skill_storage import UserScopedSkillStorage
 from deerflow.skills.types import Skill, SkillCategory
 from deerflow.utils.messages import ORIGINAL_USER_CONTENT_KEY
 
@@ -139,6 +142,49 @@ def test_skill_activation_middleware_injects_hidden_human_context_for_model_call
     assert "<user_request>\nanalyze uploads/foo.csv\n</user_request>" in activation_msg.content
     assert user_msg.content == original.content
     assert request.state["messages"] == [original]
+
+
+def test_skill_activation_middleware_reads_public_skill_from_real_user_scoped_storage(monkeypatch, tmp_path):
+    skills_root = tmp_path / "skills"
+    skill_dir = skills_root / "public" / "ppt-generation"
+    skill_dir.mkdir(parents=True)
+    skill_content = "---\nname: ppt-generation\ndescription: Create presentations\n---\n\n# Presentation workflow\n"
+    (skill_dir / "SKILL.md").write_text(skill_content, encoding="utf-8")
+
+    app_config = SimpleNamespace(
+        skills=SimpleNamespace(
+            get_skills_path=lambda: skills_root,
+            container_path="/mnt/skills",
+            use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage",
+        ),
+    )
+    extensions_config = ExtensionsConfig()
+    monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: Paths(base_dir=tmp_path))
+    monkeypatch.setattr(ExtensionsConfig, "from_file", classmethod(lambda cls, config_path=None: extensions_config))
+    monkeypatch.setattr("deerflow.config.extensions_config.get_extensions_config", lambda: extensions_config)
+    storage = UserScopedSkillStorage("test-user", host_path=str(skills_root), app_config=app_config)
+    monkeypatch.setattr(middleware_module, "get_or_new_user_skill_storage", lambda user_id, **kwargs: storage)
+
+    middleware = SkillActivationMiddleware(
+        app_config=app_config,
+        user_id="test-user",
+        slash_source_owner_token=_SLASH_SOURCE_OWNER_TOKEN,
+    )
+    original = HumanMessage(content="/ppt-generation Create a simple deck", id="msg-real-storage")
+    request = _make_model_request([original])
+    captured = {}
+
+    def handler(model_request: ModelRequest):
+        captured["messages"] = model_request.messages
+        return AIMessage(content="ok")
+
+    result = middleware.wrap_model_call(request, handler)
+
+    assert isinstance(result, AIMessage)
+    activation_msg, user_msg = captured["messages"]
+    assert is_slash_skill_activation_reminder(activation_msg)
+    assert "Presentation workflow" in activation_msg.content
+    assert user_msg is original
 
 
 def test_skill_activation_middleware_does_not_duplicate_existing_activation(monkeypatch, tmp_path):

--- a/backend/tests/test_user_scoped_skill_storage.py
+++ b/backend/tests/test_user_scoped_skill_storage.py
@@ -89,7 +89,10 @@ class TestPathRedirection:
         assert user_storage.get_skills_root_path() == skills_root
 
     def test_managed_integration_skill_paths_use_global_root(self, user_storage: UserScopedSkillStorage, base_dir: Path):
-        assert user_storage.get_user_integrations_root() == base_dir / "integrations" / "skills"
+        assert user_storage.get_integrations_root() == base_dir / "integrations" / "skills"
+
+    def test_user_integrations_root_is_compatibility_alias(self, user_storage: UserScopedSkillStorage):
+        assert user_storage.get_user_integrations_root() == user_storage.get_integrations_root()
 
     def test_user_id_property(self, user_storage: UserScopedSkillStorage):
         assert user_storage.user_id == "test-user"

--- a/backend/tests/test_user_scoped_skill_storage.py
+++ b/backend/tests/test_user_scoped_skill_storage.py
@@ -88,6 +88,9 @@ class TestPathRedirection:
     def test_public_skill_paths_still_use_global_root(self, user_storage: UserScopedSkillStorage, skills_root: Path):
         assert user_storage.get_skills_root_path() == skills_root
 
+    def test_managed_integration_skill_paths_use_global_root(self, user_storage: UserScopedSkillStorage, base_dir: Path):
+        assert user_storage.get_user_integrations_root() == base_dir / "integrations" / "skills"
+
     def test_user_id_property(self, user_storage: UserScopedSkillStorage):
         assert user_storage.user_id == "test-user"
 
@@ -281,6 +284,26 @@ class TestHistoryIsolation:
 
 class TestPathSafety:
     """UserScopedSkillStorage inherits path-traversal guards from LocalSkillStorage."""
+
+    def test_accepts_skill_files_from_all_allowed_roots(self, user_storage: UserScopedSkillStorage, skills_root: Path, base_dir: Path):
+        skill_files = [
+            skills_root / "public" / "public-skill" / "SKILL.md",
+            base_dir / "users" / "test-user" / "skills" / "custom" / "custom-skill" / "SKILL.md",
+            base_dir / "integrations" / "skills" / "lark-cli" / "lark-doc" / "SKILL.md",
+        ]
+        for skill_file in skill_files:
+            skill_file.parent.mkdir(parents=True, exist_ok=True)
+            skill_file.write_text(_skill_content(skill_file.parent.name), encoding="utf-8")
+
+        assert [user_storage.validate_skill_file_path(skill_file) for skill_file in skill_files] == [skill_file.resolve() for skill_file in skill_files]
+
+    def test_rejects_skill_file_outside_allowed_roots(self, user_storage: UserScopedSkillStorage, base_dir: Path):
+        skill_file = base_dir / "untrusted" / "escaped-skill" / "SKILL.md"
+        skill_file.parent.mkdir(parents=True)
+        skill_file.write_text(_skill_content("escaped-skill"), encoding="utf-8")
+
+        with pytest.raises(ValueError, match="must stay within"):
+            user_storage.validate_skill_file_path(skill_file)
 
     def test_rejects_invalid_skill_name(self, user_storage: UserScopedSkillStorage):
         with pytest.raises(ValueError, match="hyphen-case"):


### PR DESCRIPTION
Fixes  #4568

## Why

Activating a slash skill with `UserScopedSkillStorage` failed before the first
model call with:

`AttributeError: 'UserScopedSkillStorage' object has no attribute '_user_integrations_root'`

The storage constructor initializes the global managed integration skill
directory as `_integrations_root`, but the compatibility getter and skill-file
path validation referenced the nonexistent `_user_integrations_root`.

Because all allowed roots were evaluated before validation began, this also
broke public slash skills such as `/ppt-generation`, even though their files
were located under the valid public skills root.

## What changed

- Kept `get_user_integrations_root()` for compatibility, but made it return the
  initialized global `_integrations_root`.
- Updated skill-file validation to allow:
  - global public skills;
  - per-user custom skills;
  - global managed integration skills.
- Kept rejection of files outside all three trusted roots.
- Updated validation errors and storage documentation to describe the three
  allowed roots accurately.
- Corrected the repository documentation:
  - managed integration skill packs are globally installed under
    `{DEER_FLOW_HOME}/integrations/skills/{provider}/`;
  - integration credentials and enabled state remain per-user.
- Added regression coverage for the storage roots and a real
  `UserScopedSkillStorage` slash-activation path.
- Did not widen middleware exception handling or suppress `AttributeError`.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [x] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Manual Docker verification passed with `/ppt-generation`: the run entered normal
model processing and completed without the `_user_integrations_root` exception.

<img width="2390" height="768" alt="image" src="https://github.com/user-attachments/assets/0007220c-43b1-4770-ad28-002bd6fece78" />

## Bug fix verification

- Test paths that reproduce the bug:
  - `backend/tests/test_user_scoped_skill_storage.py`
  - `backend/tests/test_slash_skills.py`
- Did they go red on `main` and green on this branch? **Yes**
- Before the fix, all four new regression cases failed with the same
  `_user_integrations_root` `AttributeError`.
- After the fix, all four cases pass, including public slash-skill activation
  through a real `UserScopedSkillStorage` and a stub model handler.

## Validation

- `uv run pytest -q tests/test_user_scoped_skill_storage.py tests/test_slash_skills.py`
  - `70 passed`
- `cd backend && make format`
  - passed
- `cd backend && make lint`
  - passed
- `cd backend && make test`
  - `10202 passed, 61 skipped, 1 failed`
  - The single local failure was unrelated:
    `TestAgentsAPI.test_create_agent_with_model_and_tool_groups` expected the
    locally unconfigured `deepseek-v3` model.
  - Re-running that test without the local `config.yaml` override passed.
- Manual Docker verification:
  - `/ppt-generation` completed successfully;
  - no `_user_integrations_root` exception occurred.
- Frontend E2E was not run because no frontend files changed.

