### PR TITLE
fix(mcp): ignore oversized path-like text

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -117,9 +117,9 @@ def _local_uri_to_virtual_path(
 
     try:
         real = src.resolve()
+        if not real.is_file():
+            return None
     except OSError:
-        return None
-    if not real.is_file():
         return None
 
     try:

--- a/backend/tests/test_mcp_file_migration.py
+++ b/backend/tests/test_mcp_file_migration.py
@@ -203,6 +203,20 @@ class TestRewriteLocalPathsInText:
 
         assert result == text
 
+    def test_oversized_path_like_text_is_left_untouched(self, paths: Paths):
+        workspace = paths.sandbox_work_dir("t1", user_id="u1")
+        text = f"手术室/重症监护室（OR/ICU）整体解决方案{'说明' * 200}"
+
+        with _patch_paths(paths):
+            result = mcp_tools._rewrite_local_paths_in_text(
+                text,
+                thread_id="t1",
+                user_id="u1",
+                source_base_dir=workspace,
+            )
+
+        assert result == text
+
     def test_playwright_markdown_path_is_rewritten_twice_without_copy(self, paths: Paths):
         workspace = paths.sandbox_work_dir("t1", user_id="u1")
         _workspace_file(paths, ".playwright-mcp/page.png", content=b"png")


### PR DESCRIPTION
## Why

MCP tool results can contain slash-separated natural language. The free-text path matcher may interpret a long text fragment as a local path candidate. Filesystem probing of that candidate can raise `OSError: File name too long`, causing an otherwise valid MCP text result to fail.

This follows the best-effort behavior established in #4456. That fix covers malformed URI parsing; this change covers errors raised while probing filesystem candidates.

## What changed

- Treat filesystem errors while checking path-like candidates as unresolved local paths.
- Leave the original MCP text unchanged.
- Add regression coverage for oversized slash-separated natural language.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [x] **Agents / LangGraph** - MCP tool result normalization
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

N/A. This is a backend MCP result-normalization fix.

## Bug fix verification

- Regression test: `backend/tests/test_mcp_file_migration.py::TestRewriteLocalPathsInText::test_oversized_path_like_text_is_left_untouched`
- Before the fix, the reproduction raises `OSError: File name too long`. After the fix, the original text is returned unchanged.

## Validation

- `uv run --project backend pytest backend/tests/test_mcp_file_migration.py` - passed (60 tests)
- `uv run --project backend ruff check backend/packages/harness/deerflow/mcp/tools.py backend/tests/test_mcp_file_migration.py` - passed
- `uv run --project backend ruff format --check backend/packages/harness/deerflow/mcp/tools.py backend/tests/test_mcp_file_migration.py` - passed
- `git diff --check` - passed

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Claude Code helped inspect the MCP result-conversion path, reproduce the failure, implement the focused fix and regression test, and run validation. I reviewed the final diff and validation output.

- [x] I have read and understand every line of this change and take responsibility for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)