### PR TITLE
feat(extensions): add an extension system for cross-cutting concerns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,9 +45,11 @@ deer-flow/
 ├── extensions_config.example.json  # Template → copy to extensions_config.json (gitignored): MCP servers + skills
 ├── backend/                        # Python backend — see backend/AGENTS.md
 │   ├── Makefile                    # Per-module backend commands (dev, gateway, test, lint, migrate-rev)
+│   ├── packages/extension-api/     # deerflow-extension-api package (import: deerflow_extension_api.*) — public extension contract
 │   ├── packages/harness/           # deerflow-harness package (import: deerflow.*) — agent framework
 │   └── app/                        # FastAPI Gateway + IM channels (import: app.*)
 ├── frontend/                       # Next.js frontend (pnpm) — see frontend/AGENTS.md
+├── examples/                       # Standalone example packages, outside every build; see examples/deerflow-extension-example/
 ├── docker/                         # docker-compose files, nginx config, provisioner
 ├── skills/                         # Agent skills: public/ (committed), custom/ (gitignored)
 │                                    # Managed integration skill packs are global at .deer-flow/integrations/skills/{provider}/
@@ -57,6 +59,18 @@ deer-flow/
 ├── tests/                          # Root-level tests (currently tests/skills/ — public skill tests)
 └── docs/                           # Cross-cutting docs, plans, and design notes
 ```
+
+Third-party extensions are loaded from a top-level `plugins:` list in `config.yaml`
+(operator-controlled on purpose — that list causes code to be imported, so it is deliberately
+kept out of the API-writable `extensions_config.json`). See the Extension System section in
+[backend/AGENTS.md](backend/AGENTS.md).
+
+`examples/deerflow-extension-example/` is a runnable reference for that mechanism: an
+independent package (single dependency on `deerflow-extension-api`, not a workspace member,
+unreferenced by the host) exercising all five contribution points. Start there when writing
+an extension, and keep it working when changing the extension host — its own tests need no
+host, so nothing in CI covers the "does an independent package still load" path; the
+walkthrough in its README is what verifies that.
 
 Runtime config lives at the **repo root**: copy `config.example.yaml` → `config.yaml`
 (main app config) and `extensions_config.example.json` → `extensions_config.json` (MCP

--- a/README.md
+++ b/README.md
@@ -396,6 +396,25 @@ For Docker development, service startup follows `config.yaml` sandbox mode. In L
 
 See the [Sandbox Configuration Guide](backend/docs/CONFIGURATION.md#sandbox) to configure your preferred mode.
 
+#### Python Extension Packages
+
+Third-party Python extensions are independently installed packages and are enabled explicitly
+through the startup-only `plugins` list in the repository-root `config.yaml`:
+
+```yaml
+plugins:
+  - use: your_extension_package:install
+    config:
+      enabled: true
+```
+
+Installing a package alone does not activate it; restart the Gateway after adding or changing a
+plugin entry. Extension authors depend on the public `deerflow-extension-api` package rather than
+`deerflow.*` or `app.*`. Contributed FastAPI routers are constructed eagerly during `install()` so
+paths, conflict checks and OpenAPI remain stable. A routed extension obtains app-level runtime
+capabilities later in `ExtensionService.start(ExtensionRuntimeDeps)` and resolves them per request
+through its predeclared FastAPI `Depends()` callables.
+
 #### MCP Server
 
 DeerFlow supports configurable MCP servers and skills to extend its capabilities.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -29,6 +29,7 @@ deer-flow/
 │   ├── Makefile               # Backend-only commands (dev, gateway, lint)
 │   ├── langgraph.json         # LangGraph Studio graph configuration
 │   ├── packages/
+│   │   ├── extension-api/     # deerflow-extension-api package (import: deerflow_extension_api.*) — public contract, must never import deerflow
 │   │   └── harness/           # deerflow-harness package (import: deerflow.*)
 │   │       ├── pyproject.toml
 │   │       └── deerflow/
@@ -53,6 +54,7 @@ deer-flow/
 │   │           ├── skills/            # Skills discovery, loading, parsing
 │   │           ├── config/            # Configuration system (app, model, sandbox, tool, etc.)
 │   │           ├── community/         # Community tools (search/fetch/scrape, image search, AIO sandbox)
+│   │           ├── extensions/        # Extension host: registry, loader, placement anchors, hook plumbing
 │   │           ├── reflection/        # Dynamic module loading (resolve_variable, resolve_class)
 │   │           ├── utils/             # Utilities (network, readability)
 │   │           └── client.py          # Embedded Python client (DeerFlowClient)
@@ -281,6 +283,8 @@ Blocking-IO runtime gate (`tests/blocking_io/`):
 
 Boundary check (harness → app import firewall):
 - `tests/test_harness_boundary.py` — ensures `packages/harness/deerflow/` never imports from `app.*`
+- `tests/test_extension_api_contracts.py` — ensures `packages/extension-api/` never imports `deerflow.*` (an extension must be releasable independently of the harness)
+- `tests/test_deermem_self_contained.py` — ensures `agents/memory/backends/deermem/` keeps exactly **one** `from deerflow` line (the ABC contract). Anything host-owned that the backend needs must arrive through the injected `MemoryCallbacks`, not an import
 
 Memory backend async boundary:
 - `MemoryMiddleware.aafter_agent` calls `MemoryManager.aadd`; network-backed
@@ -973,6 +977,214 @@ Focused regression coverage for the updater lives in `backend/tests/test_memory_
 - `consolidation_max_groups_per_cycle` - Maximum categories the LLM can merge in one cycle (default: 3; range: 1–10; also controls the LLM's prompt instruction)
 - `consolidation_max_sources` - Maximum source facts per merge group; prevents over-merging (default: 8; range: 2–20)
 - `watermark_max_keys` - Soft cap on the in-memory conversation-watermark cache (one entry per distinct thread/user/agent). A bounded LRU: when over capacity the least-recently-used entry is dropped, and a dropped key re-extracts one batch on that thread's next turn (same as a restart). Bounds memory in long-lived gateways handling many threads (default: 4096; 0 = unbounded)
+
+### Extension System (`packages/harness/deerflow/extensions/` + `packages/extension-api/`)
+
+Config-driven, in-process extension mechanism. Its purpose is that a third party can ship an
+extension as an independently released pip package with **no** trace of it in core code.
+
+**Two packages, one dependency direction.** The public contract lives in a separate
+`deerflow-extension-api` package (import: `deerflow_extension_api`) that **must never import
+`deerflow`** — that is the sole criterion for "an extension can be released independently",
+and `tests/test_extension_api_contracts.py` pins it. Harness and extensions each depend on
+the contract package; neither depends on the other.
+
+**Contract rules** (all pinned by tests, all so later versions stay additive): every Protocol
+method has a real default implementation, and every *optional* dataclass field has a default.
+A required identity core (e.g. `TaskInfo`'s ids) is legitimate — do not read the rule as
+"every field must have a default".
+
+**Five contribution points**, registered on `ExtensionRegistry` and frozen into an immutable
+`LoadedExtensions`: middlewares, task lifecycle, system model observers, routers, services.
+Every entry carries a `source` string so diagnostics, provenance and ordering errors can name
+the responsible extension. Four are behavior Protocols; routers are concrete `APIRouter`
+values constructed eagerly during `install()` and registered with `registry.routers(...)`,
+not a delayed contributor callback.
+
+**Two phases.** Extensions only ever see `ExtensionRegistry` (write-only, no host
+capabilities), so an extension structurally cannot cause side effects during registration; the
+host hands real dependencies over later via `ExtensionRuntimeDeps`. The registry surface
+extensions annotate `install()` against is the `ExtensionRegistry` Protocol (plus the
+`ExtensionInstall` alias) exported from the contract package — the host's concrete registry
+subclasses it and keeps its machinery (attribution, rollback, build) out of the contract.
+`AppConfig` is never exposed — extensions get the narrow `HostPolicySnapshot` projection, or
+every extension would be pinned to the harness release cadence.
+
+Eager Router construction fixes paths, OpenAPI operations and FastAPI dependency graphs before
+the Gateway serves, while preserving the registration phase's no-capabilities rule. A routed
+extension registers the same object as an `ExtensionService`, binds `ExtensionRuntimeDeps` in
+`start()`, and exposes a bound-method dependency that route handlers resolve through request-time
+`Depends()`. It must return 503 while those deps are unbound (including a fail-open service-start
+failure) and after `stop()` clears them; authentication dependency failures remain fail-closed.
+Do not add routes or rewrite dependency graphs from the lifespan.
+
+**Placement, not indexes.** Middleware contributions declare a semantic `Placement`
+(`MODEL_LOGICAL` / `MODEL_PHYSICAL` / `TOOL_VISIBLE` / `TOOL_RAW` / `STANDARD`); the mapping
+from placement to a real stack position lives in the host's anchor table
+(`extensions/stack.py::PLACEMENT_ANCHORS`). `compose_with_extensions()` must be called once,
+at the end of the **outermost** builder — calling it inside `build_lead_runtime_middlewares()`
+would place `MODEL_PHYSICAL` contributions above the ~18 lead-specific middlewares appended
+afterwards. `MODEL_PHYSICAL` is resolved against the final shape of each scope: the lead
+uses the last core safety middleware that follows `TerminalResponseMiddleware` (and reports
+when it falls back to the terminal anchor), while the subagent anchors inside the last
+`SystemMessageCoalescingMiddleware`, after both durable-context and coalescing request
+transforms. Last-match anchors prevent a config-declared duplicate of a core middleware from
+capturing the insertion point. Guarantees are per hook chain, not per list index.
+
+`tests/test_extension_placement_guarantees.py` asserts each placement's promise against the
+**real lead and subagent stacks**, because nothing else can: appending a new
+request-transforming middleware inner of an anchor leaves the types, the anchor table and the
+pip constraints all valid while the promise silently stops holding. `TOOL_RAW` carries one
+documented carve-out
+(`ClarificationMiddleware`, which must stay last and only intercepts `ask_clarification`);
+it is a named set in the test plus a test guarding the carve-out itself, never a loosened
+assertion. **If a guarantee test fails, fix the anchor table or the middleware's position —
+do not relax the test.**
+
+**Failure isolation.** Contributed middlewares are wrapped in `IsolatedMiddleware`, one
+wrapper per contribution. `GraphBubbleUp` (LangGraph's interrupt/pause/resume control-flow
+signal) is always re-raised unchanged; swallowing it breaks the graph. Fail-open applies only
+to the extension's own failure, never to the downstream model/tool handler: the wrapper tracks
+the handler's latest attempt. If the extension fails before calling it, the host bypasses the
+extension and invokes the handler once; if post-call observation fails, the host reports the
+extension and returns the already-captured result; if the handler itself fails, the original
+exception and traceback propagate without an extension diagnostic or replay. This preserves
+the host retry policy: LangChain middleware may intentionally invoke a handler more than once,
+but isolation recovery never adds another provider call or tool side effect. Each wrapper also
+receives a deterministic, graph-safe name that is unique across the complete middleware stack;
+raw extension sources are normalized because LangGraph reserves `:` and `|` in node names.
+
+Isolation failures write directly to the process's canonical runtime diagnostic sink; wrappers
+must not retain the `append` method of the injection-time diagnostics list, because
+`compose_with_extensions()` only snapshots that list once during stack construction.
+Construction diagnostics still enter the sink as one batch, while each later isolation failure
+uses the single-record path, so neither is duplicated. Sink mutation and snapshots are guarded
+for lead/subagent calls arriving from different loops or threads. `create_app()` initializes the
+stable sink in place with load diagnostics and stores that exact live list on
+`app.state.extension_diagnostics`; router and service start/stop diagnostics must use the
+canonical recorder rather than replacing the app-state list. `get_runtime_diagnostics()` returns
+a defensive snapshot. Tests may reset the sink only when no run is active.
+
+**Hook sites.** Task lifecycle fires around lead runs (`runtime/runs/worker.py`) and subagent
+runs (`subagents/executor.py`); both classify the outcome **success-keyed** — only an
+explicitly successful run reports `COMPLETED`, so a status the host never set (a
+`BaseException` escaping, leaving the run `running`) degrades to `FAILED` rather than looking
+like a clean completion. Stop fires from `finally`, after every persistence step but **before**
+the finalizing flag is cleared: `wait_for_prior_finalizing` polls that flag, so clearing it
+first lets a replacement run announce its start before this run announces its stop. Both
+notifications are bounded (`_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS`) and fail-open per
+contributor. When a host has registered an extension loop, task notifications execute there
+even when a subagent itself runs on an isolated loop; this lets one extension object safely
+serve as both a loop-bound service and a lifecycle contributor. Same-loop calls and hosts
+without a registered loop continue to execute directly. Awaited system-model observations use
+the same dispatch rule, covering subagent summarization observers that share a loop-bound
+service object.
+
+Task-store allocation is broader than lifecycle dispatch. `LoadedExtensions.needs_task_store`
+is precomputed from middleware, task-lifecycle, and system-model-observer registrations; lead
+and subagent runs allocate and install a store whenever any of those task-scoped consumers
+exists. `has_task_lifecycle` separately controls `TaskInfo` construction and start/stop
+notifications, so middleware-only and observer-only extensions receive a live store without
+receiving lifecycle events. A directly invoked subagent without a parent `run_id` still scopes
+its store to `SubagentResult.task_id`, but cannot emit lifecycle events because it lacks a
+complete parent-task identity. Service-only, router-only, and empty registries allocate no
+task store.
+
+**Out-of-graph system model calls** (`SystemOperationKind`) are observed via
+`observe_system_model_call` at three async sites: `runtime/goal.py`,
+`middlewares/title_middleware.py`, and `summarization_middleware.py::_asummarize_with`. The
+three live async sites explicitly pass the active task's exact `ExtensionData` instance to
+the observer when one exists: title and async summarization obtain it from their middleware
+`Runtime`, while goal evaluation receives it from `run_agent` through the goal-continuation
+call chain. This is the same store passed to task lifecycle hooks and exposed to contributed
+middleware; `RunnableConfig` / `invoke_config` is not the authoritative task-store carrier.
+The DeerMem memory-update call is synchronous and runs on a debounce timer thread with no
+event loop, so it is observed through the host-owned
+`MemoryCallbacks.on_memory_llm_result` seam and dispatched to a registered loop
+(`set_extension_notify_loop`, owned by `langgraph_runtime`'s exit stack) — never
+`asyncio.run`, which would create the second event loop that code exists to avoid (issue
+#2615), and never `get_running_loop()`, since this process has several long-lived loops.
+DeerMem updates are deliberately detached from task scope: the debounced update may run
+after the originating task has stopped, so the queue does not retain its task store and the
+observer receives a detached `ExtensionData`. During Gateway shutdown, only this synchronous
+fire-and-forget path is suspended before the memory drain; the registered loop remains
+available until in-flight subagents drain and extension services stop, then the exit stack
+resets it on normal exit and every startup failure/cancellation path. **Coverage gap, by
+decision:** `_summarize_with` (the sync summarization path) is not observed; it is unreachable
+in the Gateway and in subagents, because the middleware overrides both `before_model` and
+`abefore_model`.
+
+**Gateway wiring** (`app/gateway/app.py`, `app/gateway/deps.py`): extensions load during
+`create_app()` because eager router contribution must precede serving; contributed routers mount
+**last**, after every host router, so an extension can never take a path the Gateway serves —
+`include_contributed_routers` compares Starlette's compiled path matchers (with parameter
+group names neutralized), protocol scope, and overlapping HTTP methods; it also recognizes
+common full-shadow relations between built-in converters (for example a preceding
+`/{value}` over a static child, or `/{rest:path}` over `/{id:int}`), including the implicit
+terminal path matcher of a preceding Starlette `Mount`. It reports the conflict naming both
+sides and refuses to mount. Thus `/items/{item_id}` and `/items/{id}` collide for the same
+method, while disjoint methods and equivalent HTTP/WebSocket paths may coexist. A contributed
+`APIRouter.mount()` is rejected with a diagnostic because FastAPI's `include_router()`
+silently ignores `Mount` entries.
+
+Router runtime capabilities evolve through `ExtensionRuntimeDeps`, not through delayed Router
+construction. FastAPI resolves the extension's already-declared `Depends()` callable per request;
+that callable reads the deps bound by service startup. This keeps conflict detection and OpenAPI
+stable while allowing later contract versions to add narrow host-owned capabilities such as auth
+dependencies or a read-only run view.
+
+Services start/stop in the lifespan (`start_services` / `stop_services`), where the session
+factory exists. The lifespan exit stack claims service cleanup **before** the startup batch
+begins, covering cancellation while a later `start()` is still pending after an earlier
+service acquired resources. The same stack claims engine close before engine initialization
+can await schema bootstrap; LIFO teardown stops services once, before stores/checkpointers and
+the engine close, on normal exit and every startup failure/cancellation. Service stop remains
+reverse-order, bounded per service, and fail-open, because a Gateway that cannot shut down is
+worse than a lost observation. Diagnostics accumulate on
+`app.state.extension_diagnostics`.
+
+**Startup reporting.** Every other log branch in the extension host is failure-only, so two
+success lines exist to keep a clean load distinguishable from a `plugins:` block the host
+never read: `load_extensions()` logs `Extensions loaded: x/y (sources)` at INFO whenever any
+spec was configured (x/y separates "all loaded" from "some skipped"; zero configured plugins
+stays at DEBUG, since that is the default state and an unconditional line would be boot
+noise), and `include_contributed_routers()` logs `Extension routers mounted: source -> path`
+per mounted path — which URLs the Gateway handed to third-party code is operational
+information. A router rejected by conflict detection is absent from that line and reported as
+an error instead. Note that `401` on a contributed route proves nothing about mounting:
+`AuthMiddleware` wraps the app and answers before routing, so an unauthenticated request to a
+nonexistent path also returns `401`, never `404`. `/openapi.json` is public and is the
+route-level check.
+
+Config: a top-level `plugins:` list in `config.yaml` (deliberately **not** nested under the
+pre-existing `extensions:` block, which is merged from the API-writable
+`extensions_config.json` — a list that causes code import must not be API-writable). The older
+`extensions.middlewares` mechanism coexists untouched.
+
+**Reference extension** (`examples/deerflow-extension-example/`, repo root): a runnable
+example of the whole contract — all five contribution points, four placements declared in
+pairs (`MODEL_LOGICAL`/`MODEL_PHYSICAL` and `TOOL_RAW`/`TOOL_VISIBLE`, so the gap between
+each pair's counters *is* the guarantee, observed rather than asserted), both
+`ExtensionData` scopes with the mandatory `on_task_stop` flush, and the eager-router +
+service-bound-deps + 503-while-unbound pattern. It is structurally independent on purpose:
+single dependency on `deerflow-extension-api`, **not** a uv workspace member, not
+referenced from any host module, and its tests run against a fake registry built from the
+contract alone (`ExtensionRegistry` is `runtime_checkable`) with no harness installed.
+
+Consequence to keep in mind when changing the host: **no CI test covers whether an
+independent package still loads.** `backend/tests/test_extension_*.py` exercise the host
+against in-repo fakes; they would keep passing if `load_extensions()`, the anchor table or
+`include_contributed_routers()` broke third-party packaging. The manual walkthrough in that
+example's README (install → `plugins:` entry → `curl /api/extension-example/stats`) is the
+only check on that path — run it after touching the loader, the placement anchors, or the
+Gateway wiring. Cheapest way to close the gap later is one `importorskip`-guarded load test
+in `backend/tests` plus an install step in the backend CI job.
+
+Design docs: [the extension system RFC](../docs/plans/2026-07-30-extension-system-rfc.md)
+for the motivation and the contract surface, and
+`docs/superpowers/specs/2026-07-28-sync-system-model-observation-design.md` for why the
+synchronous DeerMem call site is observed through a host-owned callback seam rather than
+directly.
 
 ### Reflection System (`packages/harness/deerflow/reflection/`)
 

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -407,6 +407,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         manager = None
         try:
+            # Before the memory drain below: that drain runs on a worker thread
+            # and each drained item would otherwise submit an observation onto
+            # a loop that is about to stop. Suspend only those fire-and-forget
+            # observations here. The registered loop must remain available
+            # until langgraph_runtime drains in-flight subagents and stops
+            # loop-bound extension services.
+            from deerflow.extensions.notify import suspend_extension_system_observations
+
+            suspend_extension_system_observations()
+        except Exception:
+            logger.debug("Failed to suspend extension system observations (non-fatal)", exc_info=True)
+
+        try:
             app_cfg = get_app_config()
             if app_cfg.memory.enabled:
                 from deerflow.agents.memory import get_memory_manager
@@ -563,6 +576,40 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
     # configure_logging() at lifespan startup) out of sync with the middleware.
     app.add_middleware(TraceMiddleware, enabled=_resolve_trace_enabled_for_app_construction())
 
+    # Extensions load during app construction because router contribution has
+    # to happen before the app serves; their services start later, in the
+    # lifespan, once the persistence engine exists.
+    #
+    # Contributed routers are mounted AFTER the host's own routers below, so a
+    # host path always wins a collision — see include_contributed_routers,
+    # which reports the conflict rather than shadowing.
+    from deerflow.config import get_app_config
+    from deerflow.extensions import (
+        ExtensionLoadError,
+        initialize_runtime_diagnostics,
+        load_extensions,
+        record_runtime_diagnostics,
+        set_loaded_extensions,
+    )
+
+    try:
+        _extensions, _extension_diagnostics = load_extensions(get_app_config().plugins)
+    except ExtensionLoadError:
+        # A `required: true` extension failed: fail-closed on purpose. Swallowing
+        # this would boot the Gateway with EMPTY_EXTENSIONS — silently dropping
+        # every successfully loaded extension along with the failed one.
+        raise
+    except Exception:
+        # Loading is already fail-open per spec; this guards the config read
+        # itself so a malformed plugins block cannot stop the Gateway booting.
+        logger.exception("Extension loading failed; continuing with no extensions")
+        from deerflow.extensions import EMPTY_EXTENSIONS
+
+        _extensions, _extension_diagnostics = EMPTY_EXTENSIONS, []
+    set_loaded_extensions(_extensions)
+    app.state.extensions = _extensions
+    app.state.extension_diagnostics = initialize_runtime_diagnostics(_extension_diagnostics)
+
     # Include routers
     # Models API is mounted at /api/models
     app.include_router(models.router)
@@ -656,6 +703,12 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
             Service health status information.
         """
         return {"status": "healthy", "service": "deer-flow-gateway"}
+
+    # Last, so every host route is already claimed: an extension cannot take a
+    # path the Gateway serves, it can only be told it collided.
+    from deerflow.extensions.gateway import include_contributed_routers
+
+    record_runtime_diagnostics(include_contributed_routers(app, _extensions))
 
     return app
 

--- a/backend/app/gateway/deps.py
+++ b/backend/app/gateway/deps.py
@@ -385,6 +385,33 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
     _validate_agent_storage(startup_config)
 
     async with AsyncExitStack() as stack:
+        # Extension services may build loop-bound clients in start(), and all
+        # awaited lifecycle/observation hooks must later run on that same loop.
+        # Register reset first so AsyncExitStack executes it last: after run
+        # drain, extension-service stop, persistence teardown, and every
+        # startup-failure/cancellation path.
+        try:
+            from deerflow.extensions.notify import (
+                reset_extension_notify_loop,
+                set_extension_notify_loop,
+            )
+
+            set_extension_notify_loop(asyncio.get_running_loop())
+        except Exception:
+            logger.exception("Failed to register the extension notify loop; sync observations will be dropped")
+        else:
+
+            def reset_notify_loop_safely() -> None:
+                try:
+                    reset_extension_notify_loop()
+                except Exception:
+                    logger.debug(
+                        "Failed to reset the extension notify loop (non-fatal)",
+                        exc_info=True,
+                    )
+
+            stack.callback(reset_notify_loop_safely)
+
         config = startup_config
         app.state.checkpoint_channel_mode = freeze_checkpoint_channel_mode(config.database.checkpoint_channel_mode)
         app.state.checkpoint_snapshot_frequency = freeze_checkpoint_snapshot_frequency(config.database.checkpoint_delta.snapshot_frequency)
@@ -393,6 +420,12 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
 
         # Initialize persistence engine BEFORE checkpointer so that
         # auto-create-database logic runs first (postgres backend).
+        # Own the engine in the same exit stack as every dependency created
+        # after it. Register before init: init_engine assigns its globals before
+        # awaiting schema bootstrap, so bootstrap failure/cancellation can
+        # otherwise leave a live engine behind. close_engine is safe when init
+        # never created one. Later service cleanup still runs first in LIFO.
+        stack.push_async_callback(close_engine)
         await init_engine_from_config(config.database)
 
         app.state.checkpointer = await stack.enter_async_context(make_checkpointer(config))
@@ -411,6 +444,30 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
 
             app.state.run_store = MemoryRunStore()
             app.state.feedback_repo = None
+
+        # Extension services bind here: the session factory and engine exist by
+        # now, and this runs on the serving loop — the same one
+        # set_extension_notify_loop() registers, so anything a service builds in
+        # start() (async clients especially) is bound to the loop that later
+        # awaits it. Fail-open: a failed observability service must not stop the
+        # Gateway from serving.
+        from deerflow.extensions import get_loaded_extensions, record_runtime_diagnostics
+        from deerflow.extensions.gateway import start_services, stop_services
+
+        loaded_extensions = get_loaded_extensions()
+
+        async def stop_extension_services() -> None:
+            _stop_diagnostics = await stop_services(loaded_extensions)
+            record_runtime_diagnostics(_stop_diagnostics)
+
+        # Claim teardown ownership before starting the batch: cancellation can
+        # arrive while a later service is still inside start(), after an
+        # earlier one has already acquired resources. This callback is pushed
+        # after the engine callback, so LIFO teardown always stops services
+        # before closing the engine/session factory they received.
+        stack.push_async_callback(stop_extension_services)
+        _start_diagnostics = await start_services(loaded_extensions, config, sf)
+        record_runtime_diagnostics(_start_diagnostics)
 
         from deerflow.persistence.thread_meta import make_thread_store
 
@@ -514,7 +571,6 @@ async def langgraph_runtime(app: FastAPI, startup_config: AppConfig) -> AsyncGen
                             ),
                         ),
                     )
-            await close_engine()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/extension_test_fixtures/demo_extensions.py
+++ b/backend/extension_test_fixtures/demo_extensions.py
@@ -1,0 +1,75 @@
+"""Install functions used by the extension loader tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from deerflow_extension_api import ExtensionRegistry, extension
+
+INSTALLED: list[str] = []
+
+
+class _Contributor:
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+
+def install_ok(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    INSTALLED.append("ok")
+    registry.middlewares(_Contributor("ok"))
+
+
+@extension(api="0.1", name="stamped")
+def install_stamped(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    INSTALLED.append("stamped")
+    registry.task_lifecycle(_Contributor("stamped"))
+
+
+@extension(api="99.0", name="future")
+def install_future_api(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    INSTALLED.append("future")
+    registry.middlewares(_Contributor("future"))
+
+
+@extension(api="0.2", name="newer-minor")
+def install_newer_minor_api(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    """Written against a newer 0.x minor than the host provides: before 1.0,
+    minors carry no compatibility promise in either direction."""
+    INSTALLED.append("newer-minor")
+    registry.middlewares(_Contributor("newer-minor"))
+
+
+def install_partial_then_raise(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    """Registers two contributors, then fails — exercises rollback."""
+    registry.middlewares(_Contributor("partial"))
+    registry.task_lifecycle(_Contributor("partial"))
+    raise ValueError("boom")
+
+
+def install_reads_config(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    INSTALLED.append(f"config:{config.get('mode')}")
+
+
+def install_disabled(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    """Registers nothing when disabled — the zero-cost path."""
+    if not config.get("enabled", False):
+        return
+    registry.middlewares(_Contributor("enabled"))
+
+
+def install_shared_use(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    """Registers a middleware contributor; raises afterward if configured to.
+
+    Two ExtensionSpecs may legitimately share the same `use` with different
+    config (e.g. the same extension mounted twice with different settings).
+    This exists to exercise that rollback must be positional, not keyed by
+    `use` — a failing instance must not erase an earlier, successful
+    instance's registrations just because they share a source string.
+    """
+    registry.middlewares(_Contributor(f"shared:{config.get('label', '')}"))
+    if config.get("fail"):
+        raise ValueError("boom-shared")
+
+
+NOT_CALLABLE = "i am not a function"

--- a/backend/packages/extension-api/deerflow_extension_api/__init__.py
+++ b/backend/packages/extension-api/deerflow_extension_api/__init__.py
@@ -1,0 +1,67 @@
+"""Public contracts for DeerFlow extensions.
+
+This package MUST NOT import `deerflow`. Everything an extension needs to
+integrate lives here, so an extension depends on this package alone and can
+be released independently of the host.
+"""
+
+from __future__ import annotations
+
+from deerflow_extension_api.contracts import (
+    ExtensionInstall,
+    ExtensionRegistry,
+    ExtensionRuntimeDeps,
+    ExtensionService,
+    HostPolicySnapshot,
+    MiddlewareContributor,
+    SystemModelCallObserver,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+    TaskInfo,
+    TaskLifecycleContributor,
+    TaskOutcome,
+    extension,
+)
+from deerflow_extension_api.placement import (
+    AgentBuildContext,
+    AgentScope,
+    MiddlewarePlacement,
+    Placement,
+)
+from deerflow_extension_api.runtime_bridge import (
+    EXTENSION_TASK_STORE_KEY,
+    task_store_from_runtime,
+)
+from deerflow_extension_api.state import ExtensionData
+
+#: Contract version. Pre-1.0: the contract surface is observational only
+#: (contributors and observers), so minors may break and only patches promise
+#: to be additive. From 1.0 on, bump the major on any breaking change; see the
+#: spec's evolution rules for what counts as additive.
+API_VERSION = "0.1"
+
+__all__ = [
+    "API_VERSION",
+    "EXTENSION_TASK_STORE_KEY",
+    "AgentBuildContext",
+    "AgentScope",
+    "ExtensionData",
+    "ExtensionInstall",
+    "ExtensionRegistry",
+    "ExtensionRuntimeDeps",
+    "ExtensionService",
+    "HostPolicySnapshot",
+    "MiddlewareContributor",
+    "MiddlewarePlacement",
+    "Placement",
+    "SystemModelCallObserver",
+    "SystemModelRequest",
+    "SystemModelResult",
+    "SystemOperationKind",
+    "TaskInfo",
+    "TaskLifecycleContributor",
+    "TaskOutcome",
+    "extension",
+    "task_store_from_runtime",
+]

--- a/backend/packages/extension-api/deerflow_extension_api/contracts.py
+++ b/backend/packages/extension-api/deerflow_extension_api/contracts.py
@@ -1,0 +1,234 @@
+"""The extension contracts and their data types.
+
+Compatibility rules enforced throughout this module:
+  * every Protocol method carries a default implementation, so adding a method
+    later stays additive for already-released extensions;
+  * every dataclass field carries a default, so adding a field stays additive.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, runtime_checkable
+
+from deerflow_extension_api.state import ExtensionData
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from deerflow_extension_api.placement import AgentBuildContext, MiddlewarePlacement
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+# --- Host projections -------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HostPolicySnapshot:
+    """The limits the host actually enforces, projected for extensions.
+
+    A narrow projection instead of the host's AppConfig: exposing AppConfig
+    would pin every extension to the harness release cadence. Every field has
+    a default so widening this stays additive.
+    """
+
+    token_budget_enabled: bool = False
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
+    max_total_tokens: int | None = None
+    budget_warn_fraction: float | None = None
+    budget_hard_fraction: float | None = None
+    max_subagents_per_run: int | None = None
+
+
+# --- Task lifecycle ---------------------------------------------------------
+
+
+class TaskOutcome(StrEnum):
+    COMPLETED = "completed"
+    ABORTED = "aborted"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class TaskInfo:
+    """Identity of one agent execution.
+
+    Lead and subagent executions are structurally the same thing, so they share
+    this type: an extension writes one code path for both. The lead's
+    ``task_id`` derives from ``run_id`` (lead task is 1:1 with a run, including
+    across goal continuations, which reuse the same task).
+    """
+
+    task_id: str
+    run_id: str
+    thread_id: str
+    kind: Literal["lead", "subagent"]
+    parent_task_id: str | None = None
+    agent_name: str | None = None
+    resumed: bool = False
+
+
+class TaskLifecycleContributor(Protocol):
+    async def on_task_start(
+        self,
+        app_store: ExtensionData,
+        task_store: ExtensionData,
+        info: TaskInfo,
+    ) -> None:
+        return None
+
+    async def on_task_stop(
+        self,
+        app_store: ExtensionData,
+        task_store: ExtensionData,
+        info: TaskInfo,
+        outcome: TaskOutcome,
+    ) -> None:
+        return None
+
+
+# --- System model calls (outside the agent graph) ---------------------------
+
+
+class SystemOperationKind(StrEnum):
+    GOAL = "goal"
+    MEMORY = "memory"
+    TITLE = "title"
+    SUMMARIZATION = "summarization"
+
+
+@dataclass(frozen=True)
+class SystemModelRequest:
+    """Read-only snapshot taken before the call. Extensions must not mutate."""
+
+    messages: Sequence[Any] = ()
+    model_name: str | None = None
+    invoke_config: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class SystemModelResult:
+    """Read-only snapshot taken after the call.
+
+    On failure ``response`` is None and ``error`` is set — the host notifies on
+    both paths so extensions do not silently miss failed system calls.
+    """
+
+    response: Any | None = None
+    error: BaseException | None = None
+    duration_ms: float | None = None
+
+
+class SystemModelCallObserver(Protocol):
+    async def on_system_model_call(
+        self,
+        app_store: ExtensionData,
+        task_store: ExtensionData,
+        kind: SystemOperationKind,
+        request: SystemModelRequest,
+        result: SystemModelResult,
+    ) -> None:
+        return None
+
+
+# --- Middleware -------------------------------------------------------------
+
+
+class MiddlewareContributor(Protocol):
+    def contribute_middlewares(
+        self,
+        app_store: ExtensionData,
+        ctx: AgentBuildContext,
+    ) -> Sequence[MiddlewarePlacement]:
+        return ()
+
+
+# --- Extension service ------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExtensionRuntimeDeps:
+    """Host dependencies handed to an extension service at binding time.
+
+    Constructed in the Gateway lifespan, after the persistence engine exists.
+    An extension that eagerly registers routers may bind this object in
+    ``start()`` and expose it through request-time FastAPI dependencies; route
+    construction itself remains a registration-phase, capability-free action.
+    Adding fields stays additive because every field has a default.
+    """
+
+    app_store: ExtensionData | None = None
+    policy: HostPolicySnapshot = field(default_factory=HostPolicySnapshot)
+    session_factory: Any | None = None
+
+
+class ExtensionService(Protocol):
+    async def start(self, deps: ExtensionRuntimeDeps) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+# --- Registration surface ---------------------------------------------------
+
+
+@runtime_checkable
+class ExtensionRegistry(Protocol):
+    """The write-only registration surface handed to ``install()``.
+
+    Structural and minimal on purpose: these five methods are the whole
+    contract. The host's concrete registry additionally carries host-only
+    machinery (attribution, positional rollback, build) that is deliberately
+    absent here so the public annotation never advertises it to extensions.
+    Runtime-checkable so tests and duck-typed hosts can verify conformance.
+    """
+
+    def service(self, service: ExtensionService) -> None:
+        return None
+
+    def middlewares(self, contributor: MiddlewareContributor) -> None:
+        return None
+
+    def task_lifecycle(self, contributor: TaskLifecycleContributor) -> None:
+        return None
+
+    def system_model_observer(self, observer: SystemModelCallObserver) -> None:
+        return None
+
+    def routers(self, routers: Sequence[Any]) -> None:
+        """Register routers that the extension constructed eagerly.
+
+        Paths and dependency graphs must be fixed during ``install()`` so the
+        host can detect conflicts and build stable OpenAPI metadata before it
+        serves. Runtime capabilities belong to ``ExtensionRuntimeDeps``:
+        register the same object as a service, bind the deps in ``start()``,
+        and resolve them from route handlers through FastAPI ``Depends``.
+        """
+        return None
+
+
+#: The install() entry point signature every extension exposes.
+ExtensionInstall = Callable[[ExtensionRegistry, Mapping[str, Any]], None]
+
+
+# --- Declaration decorator --------------------------------------------------
+
+
+def extension(*, api: str, name: str | None = None) -> Callable[[F], F]:
+    """Stamp an install function with the API version it was written against.
+
+    Optional. pip's dependency resolution is the primary compatibility
+    mechanism; this covers `--no-deps` installs and editable monorepo checkouts
+    where versions can skew, and turns a deep AttributeError into an
+    actionable startup diagnostic.
+    """
+
+    def _decorate(func: F) -> F:
+        func.__deerflow_api__ = api  # type: ignore[attr-defined]
+        func.__deerflow_name__ = name  # type: ignore[attr-defined]
+        return func
+
+    return _decorate

--- a/backend/packages/extension-api/deerflow_extension_api/placement.py
+++ b/backend/packages/extension-api/deerflow_extension_api/placement.py
@@ -1,0 +1,70 @@
+"""Where an extension's middleware sits in the host's middleware stack.
+
+Placement is declared as a *semantic guarantee* ("I need to observe the raw
+tool return") rather than as a structural position ("put me in layer 3"). A
+middleware occupies one index in the list, but that index only has meaning on
+the hook chain it actually implements — so "outermost" means different things
+on the model axis and the tool axis. Declaring by axis-and-end removes that
+ambiguity and keeps the host free to restructure its stack.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Flag, StrEnum, auto
+from typing import Any
+
+from deerflow_extension_api.contracts import HostPolicySnapshot
+
+
+class Placement(StrEnum):
+    MODEL_LOGICAL = "model_logical"
+    """Model axis, outer end. Guarantee: outer of retry and error handling.
+    Fires once per logical decision regardless of how many times the host
+    retries underneath."""
+
+    MODEL_PHYSICAL = "model_physical"
+    """Model axis, inner end. Guarantee: inner of every request-transforming
+    middleware. Fires once per physical provider call; retries re-enter it."""
+
+    TOOL_VISIBLE = "tool_visible"
+    """Tool axis, outer end. Guarantee: outer of truncation, sanitization and
+    error wrapping. Observes what the model finally sees."""
+
+    TOOL_RAW = "tool_raw"
+    """Tool axis, inner end. Guarantee: adjacent to the real callable
+    boundary. Observes the tool's raw return before any processing."""
+
+    STANDARD = "standard"
+    """No before/after-processing requirement. Relative order against other
+    STANDARD contributors is not guaranteed."""
+
+
+class AgentScope(Flag):
+    LEAD = auto()
+    SUBAGENT = auto()
+    BOTH = LEAD | SUBAGENT
+
+
+@dataclass(frozen=True)
+class AgentBuildContext:
+    """What an extension may know while deciding what to contribute."""
+
+    scope: AgentScope
+    agent_name: str | None = None
+    model_name: str | None = None
+    policy: HostPolicySnapshot = field(default_factory=HostPolicySnapshot)
+
+
+@dataclass(frozen=True)
+class MiddlewarePlacement:
+    """One middleware plus where it needs to sit.
+
+    ``middleware`` is typed ``Any`` rather than ``AgentMiddleware`` so this
+    module stays import-light; the host validates the type at injection time.
+    """
+
+    middleware: Any
+    placement: Placement
+    scope: AgentScope = AgentScope.BOTH
+    order: int = 0

--- a/backend/packages/extension-api/deerflow_extension_api/runtime_bridge.py
+++ b/backend/packages/extension-api/deerflow_extension_api/runtime_bridge.py
@@ -1,0 +1,25 @@
+"""Bridge between LangGraph's runtime context and the task-scoped store.
+
+Middlewares run inside the agent graph and can only reach host state through
+``request.runtime``. The host installs the task store under a host-owned key;
+extensions read it through this helper and keep their own objects *inside* the
+store, so two extensions cannot collide on a runtime-context key.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from deerflow_extension_api.state import ExtensionData
+
+#: Host-owned key. Extensions must not write to the runtime context directly.
+EXTENSION_TASK_STORE_KEY = "__deerflow_extension_task_store"
+
+
+def task_store_from_runtime(runtime: object) -> ExtensionData | None:
+    """Return the task-scoped store, or None when there is no live task."""
+    context = getattr(runtime, "context", None)
+    if not isinstance(context, Mapping):
+        return None
+    store = context.get(EXTENSION_TASK_STORE_KEY)
+    return store if isinstance(store, ExtensionData) else None

--- a/backend/packages/extension-api/deerflow_extension_api/state.py
+++ b/backend/packages/extension-api/deerflow_extension_api/state.py
@@ -1,0 +1,56 @@
+"""Per-scope typed storage handed to extensions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from threading import Lock
+from typing import Any
+
+
+class ExtensionData:
+    """Extension-private state attached to one host-owned scope.
+
+    Keyed by type rather than by string so independent extensions cannot
+    collide on a key. The host creates one instance per scope (app, task) and
+    drops it when that scope ends, which is why extensions never need a
+    stale-handle check: they are handed the store for the current scope on
+    every callback instead of capturing one.
+    """
+
+    __slots__ = ("_scope_id", "_entries", "_lock")
+
+    def __init__(self, scope_id: str) -> None:
+        self._scope_id = scope_id
+        self._entries: dict[type, Any] = {}
+        self._lock = Lock()
+
+    @property
+    def scope_id(self) -> str:
+        """Host identity of the scope this store is attached to."""
+        return self._scope_id
+
+    def get[T](self, typ: type[T]) -> T | None:
+        with self._lock:
+            return self._entries.get(typ)
+
+    def get_or_init[T](self, typ: type[T], init: Callable[[], T]) -> T:
+        """Return the stored value, creating it from ``init`` when absent.
+
+        ``init`` runs while the store is locked, so keep it cheap; heavyweight
+        lazy work belongs inside the stored value itself.
+        """
+        with self._lock:
+            existing = self._entries.get(typ)
+            if existing is not None:
+                return existing
+            created = init()
+            self._entries[typ] = created
+            return created
+
+    def set[T](self, value: T) -> None:
+        with self._lock:
+            self._entries[type(value)] = value
+
+    def remove[T](self, typ: type[T]) -> T | None:
+        with self._lock:
+            return self._entries.pop(typ, None)

--- a/backend/packages/extension-api/pyproject.toml
+++ b/backend/packages/extension-api/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "deerflow-extension-api"
+version = "0.1.0"
+description = "Public contracts for DeerFlow extensions"
+requires-python = ">=3.12"
+# Narrow, deliberate dependency set. This package MUST NOT depend on
+# `deerflow-harness` — that is what lets extensions ship on their own release
+# cadence. The four entries below are public third-party types that any
+# extension already needs (middleware base class, router, runtime, session
+# factory); they are not DeerFlow internals.
+dependencies = [
+    "langchain>=1.3",
+    "langgraph>=1.2.9,<1.3",
+    "fastapi>=0.115.0",
+    "sqlalchemy>=2.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["deerflow_extension_api"]

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -282,6 +282,7 @@ def build_middlewares(
     mcp_routing_middleware: AgentMiddleware | None = None,
     user_id: str | None = None,
     authorization_provider=None,
+    extensions=None,
 ):
     """Build the lead-agent middleware chain based on runtime configuration.
 
@@ -304,6 +305,8 @@ def build_middlewares(
             to ``SkillActivationMiddleware`` so it can resolve per-user custom skills.
         authorization_provider: Provider already resolved for assembly-time
             filtering. Reused by the execution-time authorization middleware.
+        extensions: Loaded extensions whose middleware contributions are merged
+            into the final stack. Defaults to the process-wide set.
 
     Returns:
         List of middleware instances.
@@ -475,7 +478,27 @@ def build_middlewares(
 
     # ClarificationMiddleware should always be last
     middlewares.append(ClarificationMiddleware())
-    return middlewares
+
+    # Extension contributions are merged only here, once the full stack exists.
+    # Doing it inside build_lead_runtime_middlewares() would place
+    # MODEL_PHYSICAL contributions above the lead-specific middlewares appended
+    # above, changing what "the final request" means for observers.
+    from deerflow_extension_api import AgentBuildContext, AgentScope
+
+    from deerflow.extensions.gateway import project_host_policy
+    from deerflow.extensions.stack import compose_with_extensions
+
+    return compose_with_extensions(
+        middlewares,
+        AgentScope.LEAD,
+        AgentBuildContext(
+            scope=AgentScope.LEAD,
+            agent_name=agent_name,
+            model_name=model_name,
+            policy=project_host_policy(resolved_app_config),
+        ),
+        extensions,
+    )
 
 
 def _available_skill_names(agent_config, is_bootstrap: bool) -> set[str] | None:

--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
@@ -9,6 +9,7 @@ import json
 import logging
 import math
 import re
+import time
 import uuid
 from collections import OrderedDict
 from datetime import UTC, datetime, timedelta
@@ -1375,7 +1376,16 @@ class MemoryUpdater:
                 )
             logger.info("Invoking memory-update LLM (thread=%s trace_id=%s)", thread_id, trace_id)
             attempted = True
-            response = model.invoke(prompt, config=invoke_config)
+            _started = time.monotonic()
+            try:
+                response = model.invoke(prompt, config=invoke_config)
+            except BaseException as exc:
+                # Post-LLM-call observability hook, failure path. A memory
+                # update that failed is exactly what a consumer wants to see,
+                # so this fires before the error is handled below.
+                self._notify_llm_result(invoke_config, prompt=prompt, response=None, error=exc, started=_started, model_name=model_name)
+                raise
+            self._notify_llm_result(invoke_config, prompt=prompt, response=response, error=None, started=_started, model_name=model_name)
             success = self._finalize_update(
                 current_memory=current_memory,
                 response_content=response.content,
@@ -1413,6 +1423,46 @@ class MemoryUpdater:
                     response=response,
                     success=success,
                 )
+
+    def _notify_llm_result(
+        self,
+        invoke_config: dict[str, Any],
+        *,
+        prompt: Any,
+        response: Any,
+        error: BaseException | None,
+        started: float,
+        model_name: str | None,
+    ) -> None:
+        """Fire the host's post-LLM-call hook, swallowing anything it does.
+
+        The hook is host-owned (``MemoryCallbacks``); this package must not
+        reach into host modules itself — it is vendorable and permitted exactly
+        one host import, the ABC contract, pinned by
+        ``tests/test_deermem_self_contained.py``. Observation must never turn a
+        successful memory update into a failed one, so every exception,
+        including a misbehaving host implementation, stops here.
+        """
+        if self._callbacks is None:
+            return
+        # getattr rather than the direct attribute access `on_memory_llm_call`
+        # above uses: `callbacks` is typed Any and this package cannot see
+        # MemoryCallbacks, so a duck-typed object predating this hook is skipped
+        # instead of raising. The asymmetry is deliberate, not an oversight.
+        hook = getattr(self._callbacks, "on_memory_llm_result", None)
+        if hook is None:
+            return
+        try:
+            hook(
+                invoke_config,
+                prompt=prompt,
+                response=response,
+                error=error,
+                duration_ms=(time.monotonic() - started) * 1000,
+                model_name=model_name,
+            )
+        except BaseException:
+            logger.warning("Memory LLM result hook failed (non-fatal)", exc_info=True)
 
     def update_memory(
         self,

--- a/backend/packages/harness/deerflow/agents/memory/manager.py
+++ b/backend/packages/harness/deerflow/agents/memory/manager.py
@@ -21,6 +21,7 @@ import logging
 import os
 import threading
 from abc import abstractmethod
+from collections.abc import Mapping
 from pathlib import Path
 from types import ModuleType
 from typing import Any, ClassVar, Literal
@@ -62,6 +63,30 @@ class MemoryCallbacks:
     ) -> None:
         """Pre-LLM-call: mutate ``invoke_config`` (e.g. merge trace metadata)
         before the backend invokes the model. Default: no-op."""
+
+    def on_memory_llm_result(
+        self,
+        invoke_config: dict[str, Any],
+        *,
+        prompt: Any,
+        response: Any,
+        error: BaseException | None,
+        duration_ms: float,
+        model_name: str | None,
+    ) -> None:
+        """Post-LLM-call: observe the outcome of the memory-update model call.
+
+        The result-side counterpart of ``on_memory_llm_call``, and the reason
+        this hook exists rather than the backend calling host code directly:
+        ``backends/deermem/`` is a vendorable package permitted exactly one
+        ``from deerflow`` import (pinned by
+        ``tests/test_deermem_self_contained.py``), so anything host-owned has
+        to arrive through this injected object.
+
+        Fires on both the success and failure paths — a memory update that
+        failed is precisely what an observability consumer wants to see.
+        Implementations must not raise; the backend treats an exception here as
+        a failed memory update. Default: no-op."""
 
 
 class MemoryManagerError(RuntimeError):
@@ -643,6 +668,49 @@ class LangfuseMemoryCallbacks(MemoryCallbacks):
             environment=os.environ.get("DEER_FLOW_ENV") or os.environ.get("ENVIRONMENT"),
             deerflow_trace_id=trace_id,
         )
+
+    def on_memory_llm_result(
+        self,
+        invoke_config: dict[str, Any],
+        *,
+        prompt: Any,
+        response: Any,
+        error: BaseException | None,
+        duration_ms: float,
+        model_name: str | None,
+    ) -> None:
+        """Forward the memory-update model call to extension observers.
+
+        Runs on DeerMem's debounce timer thread, which has no event loop of its
+        own, so the notification is submitted to the host's registered loop and
+        not awaited (see
+        ``extensions.notify.dispatch_system_model_observation``).
+        Swallows everything: the backend treats an exception here as a failed
+        memory update, and an observability hook must never do that.
+        """
+        try:
+            from deerflow_extension_api import SystemModelRequest, SystemModelResult, SystemOperationKind
+
+            from deerflow.extensions import get_loaded_extensions
+            from deerflow.extensions.notify import dispatch_system_model_observation, notify_system_model_call, task_store_for_system_call
+
+            extensions = get_loaded_extensions()
+            if not extensions.has_system_model_observers:
+                # Short-circuit before building any snapshot: this runs on every
+                # memory update, extensions or not.
+                return
+            dispatch_system_model_observation(
+                notify_system_model_call(
+                    extensions,
+                    task_store_for_system_call(invoke_config),
+                    SystemOperationKind.MEMORY,
+                    SystemModelRequest(messages=prompt, model_name=model_name, invoke_config=invoke_config if isinstance(invoke_config, Mapping) else None),
+                    SystemModelResult(response=response, error=error, duration_ms=duration_ms),
+                ),
+                SystemOperationKind.MEMORY.value,
+            )
+        except BaseException:
+            logger.warning("Extension observation of the memory model call failed (non-fatal)", exc_info=True)
 
 
 def _host_default_should_keep_hidden_message(additional_kwargs: Any) -> bool:

--- a/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/summarization_middleware.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import html
 import logging
 from dataclasses import dataclass
-from typing import Any, Protocol, override, runtime_checkable
+from typing import TYPE_CHECKING, Any, Protocol, override, runtime_checkable
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import SummarizationMiddleware
@@ -18,6 +18,9 @@ from langgraph.runtime import Runtime
 from deerflow.agents.middlewares.dynamic_context_middleware import is_dynamic_context_reminder
 from deerflow.config.app_config import get_app_config
 from deerflow.models import create_chat_model
+
+if TYPE_CHECKING:
+    from deerflow_extension_api import ExtensionData
 
 logger = logging.getLogger(__name__)
 _SUMMARY_TRIGGER_MESSAGE_NAME = "summary"
@@ -270,14 +273,20 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
                 return text
         return None
 
-    async def _asummarize_with(self, messages_to_summarize: list[AnyMessage], previous_summary: str | None = None) -> str | None:
+    async def _asummarize_with(
+        self,
+        messages_to_summarize: list[AnyMessage],
+        previous_summary: str | None = None,
+        *,
+        task_store: ExtensionData | None = None,
+    ) -> str | None:
         """Async counterpart of :meth:`_summarize_with` using the nostream model."""
         prompt = self._prepare_summary_prompt(messages_to_summarize, previous_summary)
         if prompt is None or prompt in _CANNED_SUMMARIES:
             return prompt
         names = self._generation_candidate_names()
         for index, name in enumerate(names):
-            text = await self._ainvoke_summary(self._model_for(name), prompt, last=index == len(names) - 1)
+            text = await self._ainvoke_summary(self._model_for(name), prompt, last=index == len(names) - 1, task_store=task_store)
             if text is not None:
                 return text
         return None
@@ -299,12 +308,35 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
             self._log_summary_error(last)
             return None
 
-    async def _ainvoke_summary(self, model: Any | None, prompt: str, *, last: bool = False) -> str | None:
-        """Async counterpart of :meth:`_invoke_summary`."""
+    async def _ainvoke_summary(self, model: Any | None, prompt: str, *, last: bool = False, task_store: ExtensionData | None = None) -> str | None:
+        """Async counterpart of :meth:`_invoke_summary`.
+
+        This is the observed site for ``SystemOperationKind.SUMMARIZATION``: it is
+        the one place the async provider call happens, so wrapping it here — rather
+        than the candidate loop in :meth:`_asummarize_with` — keeps a failed
+        candidate visible to observers instead of hiding it behind the fallback.
+        ``observe_system_model_call`` re-raises, so the ``except`` below retains
+        ownership of the fail-open fallthrough.
+        """
         if model is None:
             return None
+        from deerflow_extension_api import SystemOperationKind
+
+        from deerflow.extensions.notify import observe_system_model_call
+
+        summary_config = {"metadata": {"lc_source": "summarization"}}
         try:
-            response = await model.ainvoke(prompt, config={"metadata": {"lc_source": "summarization"}})
+            response = await observe_system_model_call(
+                SystemOperationKind.SUMMARIZATION,
+                messages=prompt,
+                model_name=getattr(model, "model_name", None),
+                invoke_config=summary_config,
+                invoke=lambda: model.ainvoke(prompt, config=summary_config),
+                # Passed explicitly rather than recovered from `invoke_config`:
+                # the RunnableConfig here carries only tracing metadata, so the
+                # middleware's Runtime is the sole carrier of the live task scope.
+                task_store=task_store,
+            )
             return self._checked_summary(response, last)
         except Exception:
             self._log_summary_error(last)
@@ -530,7 +562,13 @@ class DeerFlowSummarizationMiddleware(SummarizationMiddleware):
         if prepared is None:
             return None
         messages_to_summarize, preserved_messages, previous_summary, total_tokens = prepared
-        summary = await self._asummarize_with(messages_to_summarize, previous_summary=previous_summary)
+        from deerflow_extension_api import task_store_from_runtime
+
+        summary = await self._asummarize_with(
+            messages_to_summarize,
+            previous_summary=previous_summary,
+            task_store=task_store_from_runtime(runtime),
+        )
         if summary is None:
             if raise_on_failure:
                 raise SummaryGenerationError("summary generation failed")

--- a/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/title_middleware.py
@@ -15,6 +15,8 @@ from deerflow.config.title_config import get_title_config
 from deerflow.models import create_chat_model
 
 if TYPE_CHECKING:
+    from deerflow_extension_api import ExtensionData
+
     from deerflow.config.app_config import AppConfig
     from deerflow.config.title_config import TitleConfig
 
@@ -196,7 +198,12 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
         user_msg = self._get_title_user_message(state)
         return {"title": self._fallback_title(user_msg)}
 
-    async def _agenerate_title_result(self, state: TitleMiddlewareState) -> dict | None:
+    async def _agenerate_title_result(
+        self,
+        state: TitleMiddlewareState,
+        *,
+        task_store: "ExtensionData | None" = None,
+    ) -> dict | None:
         """Generate a configured LLM title asynchronously and fall back locally."""
         if not self._should_generate_title(state):
             return None
@@ -218,7 +225,19 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
             if self._app_config is not None:
                 model_kwargs["app_config"] = self._app_config
             model = create_chat_model(name=config.model_name, **model_kwargs)
-            response = await model.ainvoke(prompt, config=self._get_runnable_config())
+            from deerflow_extension_api import SystemOperationKind
+
+            from deerflow.extensions.notify import observe_system_model_call
+
+            title_config = self._get_runnable_config()
+            response = await observe_system_model_call(
+                SystemOperationKind.TITLE,
+                messages=prompt,
+                model_name=config.model_name,
+                invoke_config=title_config,
+                invoke=lambda: model.ainvoke(prompt, config=title_config),
+                task_store=task_store,
+            )
             title = self._parse_title(response.content)
             if title:
                 return {"title": title}
@@ -232,4 +251,9 @@ class TitleMiddleware(AgentMiddleware[TitleMiddlewareState]):
 
     @override
     async def aafter_model(self, state: TitleMiddlewareState, runtime: Runtime) -> dict | None:
-        return await self._agenerate_title_result(state)
+        from deerflow_extension_api import task_store_from_runtime
+
+        return await self._agenerate_title_result(
+            state,
+            task_store=task_store_from_runtime(runtime),
+        )

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -270,26 +270,19 @@ def _build_runtime_middlewares(
     # on every result before ToolProgressMiddleware reads it in _update_state_from_result.
     # Framework rule: first in list = outermost (types.py: "compose with first in list as outermost layer").
     tool_progress_config = app_config.tool_progress
-    _ToolProgressMiddleware = None
     if tool_progress_config.enabled:
-        from deerflow.agents.middlewares.tool_progress_middleware import ToolProgressMiddleware as _ToolProgressMiddleware
+        from deerflow.agents.middlewares.tool_progress_middleware import ToolProgressMiddleware
 
-        tail.append(_ToolProgressMiddleware.from_config(tool_progress_config))
+        tail.append(ToolProgressMiddleware.from_config(tool_progress_config))
 
     tail.append(ToolErrorHandlingMiddleware(app_config=app_config))
 
     middlewares = [*outer_wrappers, *thread_hooks, *tail]
 
-    # Guard: ToolProgressMiddleware (outer) must appear before ToolErrorHandlingMiddleware (inner)
-    # so that its wrap_tool_call chain encloses the stamping step.  Fail loudly at build time
-    # rather than silently no-oping at runtime if a future insertion reverses the order.
-    # Uses isinstance (not type().__name__) so subclasses and renames are covered.
-    if _ToolProgressMiddleware is not None:
-        _progress_idx = next((i for i, m in enumerate(middlewares) if isinstance(m, _ToolProgressMiddleware)), None)
-        _error_idx = next((i for i, m in enumerate(middlewares) if isinstance(m, ToolErrorHandlingMiddleware)), None)
-        if _progress_idx is not None and _error_idx is not None and _progress_idx > _error_idx:
-            raise RuntimeError(f"ToolProgressMiddleware must be outer (index {_progress_idx}) of ToolErrorHandlingMiddleware (index {_error_idx}) — check middleware append order")
-
+    # Ordering invariants are declared in deerflow.extensions.ordering and
+    # validated once at the end of the composing builder, after extension
+    # contributions are merged in — otherwise a contribution could silently
+    # reverse an invariant this builder had already checked.
     return middlewares
 
 
@@ -322,6 +315,7 @@ def build_subagent_runtime_middlewares(
     available_skills: set[str] | None = None,
     user_id: str | None = None,
     authorization_provider=None,
+    extensions=None,
 ) -> list[AgentMiddleware]:
     """Middlewares shared by subagent runtime before subagent-only middlewares."""
     if app_config is None:
@@ -528,4 +522,19 @@ def build_subagent_runtime_middlewares(
 
     middlewares.append(SystemMessageCoalescingMiddleware())
 
-    return middlewares
+    from deerflow_extension_api import AgentBuildContext, AgentScope
+
+    from deerflow.extensions.gateway import project_host_policy
+    from deerflow.extensions.stack import compose_with_extensions
+
+    return compose_with_extensions(
+        middlewares,
+        AgentScope.SUBAGENT,
+        AgentBuildContext(
+            scope=AgentScope.SUBAGENT,
+            agent_name=agent_name,
+            model_name=model_name,
+            policy=project_host_policy(app_config),
+        ),
+        extensions,
+    )

--- a/backend/packages/harness/deerflow/config/app_config.py
+++ b/backend/packages/harness/deerflow/config/app_config.py
@@ -48,6 +48,7 @@ from deerflow.config.tool_config import ToolConfig, ToolGroupConfig
 from deerflow.config.tool_output_config import ToolOutputConfig
 from deerflow.config.tool_progress_config import ToolProgressConfig
 from deerflow.config.tool_search_config import ToolSearchConfig, load_tool_search_config_from_dict
+from deerflow.extensions.loader import ExtensionSpec
 
 load_dotenv()
 
@@ -203,6 +204,19 @@ class AppConfig(BaseModel):
     )
     token_usage: TokenUsageConfig = Field(default_factory=TokenUsageConfig, description="Token usage tracking configuration")
     token_budget: TokenBudgetConfig = Field(default_factory=TokenBudgetConfig, description="Token Budget tracking and limits configuration.")
+    plugins: list[ExtensionSpec] = Field(
+        default_factory=list,
+        description=format_field_description(
+            "plugins",
+            field_doc=(
+                "Extension packages to load at startup, in order. Each entry names an install "
+                "entry point as 'module.path:install' and carries its own private config block. "
+                "Distinct from the `extensions` field above, which configures MCP servers, skills "
+                "and config-declared middlewares and is backed by the HTTP-writable "
+                "extensions_config.json."
+            ),
+        ),
+    )
     max_recursion_limit: int = Field(
         default=1000,
         ge=1,

--- a/backend/packages/harness/deerflow/config/reload_boundary.py
+++ b/backend/packages/harness/deerflow/config/reload_boundary.py
@@ -43,6 +43,7 @@ STARTUP_ONLY_PREFIX = "startup-only:"
 #: field is restart-required — so an operator changing the value knows
 #: which subsystem to restart.
 STARTUP_ONLY_FIELDS: dict[str, str] = {
+    "plugins": ("load_extensions() runs once during create_app() and extension services start in the Gateway lifespan; adding, removing or reconfiguring a plugin requires a restart."),
     "database": ("init_engine_from_config() runs once during langgraph_runtime() startup; the SQLAlchemy engine holds the connection pool and is not rebuilt on config.yaml edits."),
     "checkpointer": ("make_checkpointer() binds the persistent checkpointer once at startup, including SQLite WAL / busy_timeout settings."),
     "run_events": ("make_run_event_store() picks the memory- vs SQL-backed implementation at startup and is frozen onto app.state.run_events_config to stay paired with the underlying event store."),

--- a/backend/packages/harness/deerflow/extensions/__init__.py
+++ b/backend/packages/harness/deerflow/extensions/__init__.py
@@ -1,0 +1,98 @@
+"""DeerFlow's extension mechanism (host side).
+
+The public contracts live in the separate `deerflow-extension-api` package;
+this module implements loading, registration, middleware injection and the
+hook-site plumbing.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from deerflow.extensions.loader import (
+    Diagnostic,
+    ExtensionLoadError,
+    ExtensionSpec,
+    load_extensions,
+)
+from deerflow.extensions.registry import EMPTY_EXTENSIONS, ExtensionRegistry, LoadedExtensions
+
+_loaded: LoadedExtensions = EMPTY_EXTENSIONS
+
+
+def get_loaded_extensions() -> LoadedExtensions:
+    """Return the process-wide loaded extensions.
+
+    Mirrors the existing `get_app_config()` convention so call sites can take
+    an explicit override parameter and fall back to this.
+    """
+    return _loaded
+
+
+def set_loaded_extensions(loaded: LoadedExtensions) -> None:
+    global _loaded
+    _loaded = loaded
+
+
+def reset_loaded_extensions() -> None:
+    """Reset to a FRESH empty set. Used by tests to prevent singleton leaks.
+
+    Builds a new instance rather than reusing EMPTY_EXTENSIONS: that singleton
+    owns a mutable ExtensionData app_store, so resetting to it would carry any
+    write made while "empty" across every later reset and across the process.
+    """
+    global _loaded
+    _loaded = ExtensionRegistry().build()
+
+
+_runtime_diagnostics: list[Diagnostic] = []
+_runtime_diagnostics_lock = threading.RLock()
+
+
+def initialize_runtime_diagnostics(diagnostics: list[Diagnostic]) -> list[Diagnostic]:
+    """Install and return the live diagnostic list for the current host."""
+    with _runtime_diagnostics_lock:
+        _runtime_diagnostics.clear()
+        _runtime_diagnostics.extend(diagnostics)
+        return _runtime_diagnostics
+
+
+def record_runtime_diagnostic(diagnostic: Diagnostic) -> None:
+    """Collect one diagnostic in the canonical process sink."""
+    with _runtime_diagnostics_lock:
+        _runtime_diagnostics.append(diagnostic)
+
+
+def record_runtime_diagnostics(diagnostics: list[Diagnostic]) -> None:
+    """Collect a diagnostic batch in the canonical process sink."""
+    with _runtime_diagnostics_lock:
+        _runtime_diagnostics.extend(diagnostics)
+
+
+def get_runtime_diagnostics() -> list[Diagnostic]:
+    with _runtime_diagnostics_lock:
+        return list(_runtime_diagnostics)
+
+
+def reset_runtime_diagnostics() -> None:
+    with _runtime_diagnostics_lock:
+        _runtime_diagnostics.clear()
+
+
+__all__ = [
+    "EMPTY_EXTENSIONS",
+    "Diagnostic",
+    "ExtensionLoadError",
+    "ExtensionRegistry",
+    "ExtensionSpec",
+    "LoadedExtensions",
+    "get_loaded_extensions",
+    "get_runtime_diagnostics",
+    "initialize_runtime_diagnostics",
+    "load_extensions",
+    "record_runtime_diagnostic",
+    "record_runtime_diagnostics",
+    "reset_loaded_extensions",
+    "reset_runtime_diagnostics",
+    "set_loaded_extensions",
+]

--- a/backend/packages/harness/deerflow/extensions/anchors.py
+++ b/backend/packages/harness/deerflow/extensions/anchors.py
@@ -1,0 +1,120 @@
+"""Translating semantic placements into concrete stack indices.
+
+This is the only module that knows the shape of DeerFlow's middleware stack.
+Restructuring the stack means updating the anchor table here; extensions,
+which declare only what they need to observe, stay untouched.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+_Side = Literal[
+    "outer",
+    "inner",
+    "outer_last",
+    "inner_last",
+    "inner_last_after",
+    "start",
+    "end",
+]
+
+
+@dataclass(frozen=True)
+class AnchorRule:
+    """One attempt at locating an insertion index.
+
+    ``side`` "outer"/"inner" position relative to the first middleware whose
+    type is in ``types``; "outer_last"/"inner_last" use the last matching
+    middleware; "inner_last_after" additionally requires that match to follow
+    the last middleware in ``after_types``. "start"/"end" are the absolute
+    ends of the stack and ignore ``types``.
+    """
+
+    side: _Side
+    types: tuple[type, ...] = ()
+    after_types: tuple[type, ...] = ()
+
+    def resolve(self, middlewares: Sequence[object]) -> int | None:
+        if self.side == "start":
+            return 0
+        if self.side == "end":
+            return len(middlewares)
+        if self.side in {"outer_last", "inner_last"}:
+            for index in range(len(middlewares) - 1, -1, -1):
+                if isinstance(middlewares[index], self.types):
+                    return index if self.side == "outer_last" else index + 1
+            return None
+        if self.side == "inner_last_after":
+            boundary = next(
+                (index for index in range(len(middlewares) - 1, -1, -1) if isinstance(middlewares[index], self.after_types)),
+                None,
+            )
+            if boundary is None:
+                return None
+            for index in range(len(middlewares) - 1, boundary, -1):
+                if isinstance(middlewares[index], self.types):
+                    return index + 1
+            return None
+        for index, middleware in enumerate(middlewares):
+            if isinstance(middleware, self.types):
+                return index if self.side == "outer" else index + 1
+        return None
+
+
+@dataclass(frozen=True)
+class PlacementAnchor:
+    """An ordered fallback chain of anchor rules."""
+
+    chain: tuple[AnchorRule, ...]
+
+    @classmethod
+    def of(cls, *anchors: PlacementAnchor) -> PlacementAnchor:
+        """Concatenate anchors into one fallback chain."""
+        rules: list[AnchorRule] = []
+        for anchor in anchors:
+            rules.extend(anchor.chain)
+        return cls(tuple(rules))
+
+    def resolve(self, middlewares: Sequence[object]) -> tuple[int, bool]:
+        """Return (index, used_primary_rule).
+
+        ``used_primary_rule`` is False when the first rule did not match, which
+        the caller reports as a diagnostic — a silently degraded placement
+        changes what the extension observes with no signal.
+        """
+        for position, rule in enumerate(self.chain):
+            index = rule.resolve(middlewares)
+            if index is not None:
+                return index, position == 0
+        return len(middlewares), False
+
+
+def outer_of(*types: type) -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("outer", types),))
+
+
+def inner_of(*types: type) -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("inner", types),))
+
+
+def inner_of_last(*types: type) -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("inner_last", types),))
+
+
+def inner_of_last_after(*types: type, after: tuple[type, ...]) -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("inner_last_after", types, after),))
+
+
+def outer_of_last(*types: type) -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("outer_last", types),))
+
+
+def outermost() -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("start"),))
+
+
+def innermost() -> PlacementAnchor:
+    return PlacementAnchor((AnchorRule("end"),))

--- a/backend/packages/harness/deerflow/extensions/gateway.py
+++ b/backend/packages/harness/deerflow/extensions/gateway.py
@@ -1,0 +1,388 @@
+"""Gateway-side extension plumbing: policy projection, routers, services."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from deerflow_extension_api import ExtensionRuntimeDeps, HostPolicySnapshot
+
+from deerflow.extensions.loader import Diagnostic
+from deerflow.extensions.registry import LoadedExtensions
+
+logger = logging.getLogger(__name__)
+
+#: A hung stop() would block Gateway shutdown; a Gateway that cannot shut down
+#: is worse than a lost observation, so stop() is bounded. Per service rather
+#: than shared, so one hung service cannot starve the rest of their stop().
+DEFAULT_STOP_TIMEOUT_SECONDS = 30.0
+
+_PATH_PARAMETER_GROUP = re.compile(r"\(\?P<[^>]+>")
+_PATH_PARAMETER = re.compile(r"{([a-zA-Z_][a-zA-Z0-9_]*)(?::([a-zA-Z_][a-zA-Z0-9_]*))?}")
+_RouteMethods = frozenset[str] | None
+_RouteScopes = frozenset[str]
+
+
+@dataclass(frozen=True)
+class _RouteClaim:
+    path: str
+    matcher: str
+    methods: _RouteMethods
+    scopes: _RouteScopes
+    mount_prefix: str | None = None
+
+
+_RouteOwners = list[tuple[_RouteClaim, str]]
+
+
+def project_host_policy(app_config: Any) -> HostPolicySnapshot:
+    """Project the host's enforced limits into the extension-facing snapshot.
+
+    Deliberately narrow: exposing AppConfig itself would pin every extension to
+    the harness release cadence. Read with ``getattr`` defaults so a host whose
+    config predates a field — or omits the section entirely — degrades to the
+    snapshot's own defaults instead of failing extension startup.
+    """
+    token_budget = getattr(app_config, "token_budget", None)
+    subagents = getattr(app_config, "subagents", None)
+    return HostPolicySnapshot(
+        token_budget_enabled=bool(getattr(token_budget, "enabled", False)),
+        max_input_tokens=getattr(token_budget, "max_input_tokens", None),
+        max_output_tokens=getattr(token_budget, "max_output_tokens", None),
+        max_total_tokens=getattr(token_budget, "max_tokens", None),
+        budget_warn_fraction=getattr(token_budget, "warn_threshold", None),
+        budget_hard_fraction=getattr(token_budget, "hard_stop_threshold", None),
+        max_subagents_per_run=getattr(subagents, "max_total_per_run", None),
+    )
+
+
+def _route_path_matcher(route: Any) -> str | None:
+    path = getattr(route, "path", None)
+    if path is None:
+        return None
+    pattern = getattr(getattr(route, "path_regex", None), "pattern", None)
+    if not pattern:
+        return path
+    return _PATH_PARAMETER_GROUP.sub("(?:", pattern)
+
+
+def _route_methods(route: Any) -> _RouteMethods:
+    methods = getattr(route, "methods", None)
+    return frozenset(methods) if methods else None
+
+
+def _route_scopes(route: Any) -> _RouteScopes:
+    from starlette.routing import Mount, Route, WebSocketRoute
+
+    if isinstance(route, WebSocketRoute):
+        return frozenset({"websocket"})
+    if isinstance(route, Route):
+        return frozenset({"http"})
+    if isinstance(route, Mount):
+        return frozenset({"http", "websocket"})
+    return frozenset({"http", "websocket"})
+
+
+def _route_claim(route: Any) -> _RouteClaim | None:
+    from starlette.routing import Mount
+
+    path = getattr(route, "path", None)
+    matcher = _route_path_matcher(route)
+    if path is None or matcher is None:
+        return None
+    return _RouteClaim(
+        path=path,
+        matcher=matcher,
+        methods=_route_methods(route),
+        scopes=_route_scopes(route),
+        mount_prefix=path.rstrip("/") if isinstance(route, Mount) else None,
+    )
+
+
+def _router_routes(router: Any) -> list[_RouteClaim]:
+    from starlette.routing import Mount
+
+    claims: list[_RouteClaim] = []
+    for route in getattr(router, "routes", []):
+        if isinstance(route, Mount):
+            raise TypeError("contributed router contains a Starlette Mount, which FastAPI.include_router() ignores")
+        claim = _route_claim(route)
+        if claim is not None:
+            claims.append(claim)
+    return claims
+
+
+def _methods_overlap(left: _RouteMethods, right: _RouteMethods) -> bool:
+    return left is None or right is None or not left.isdisjoint(right)
+
+
+def _dispatches_overlap(left: _RouteClaim, right: _RouteClaim) -> bool:
+    shared_scopes = left.scopes & right.scopes
+    if "websocket" in shared_scopes:
+        return True
+    return "http" in shared_scopes and _methods_overlap(left.methods, right.methods)
+
+
+def _path_shape(path: str) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    literals: list[str] = []
+    convertors: list[str] = []
+    cursor = 0
+    for match in _PATH_PARAMETER.finditer(path):
+        literals.append(path[cursor : match.start()])
+        convertors.append(match.group(2) or "str")
+        cursor = match.end()
+    literals.append(path[cursor:])
+    return tuple(literals), tuple(convertors)
+
+
+def _convertor_covers(owner: str, candidate: str) -> bool:
+    if owner == candidate or owner == "path":
+        return True
+    if owner == "str":
+        return candidate in {"str", "int", "float", "uuid"}
+    if owner == "float":
+        return candidate in {"float", "int"}
+    return False
+
+
+def _path_segments(
+    path: str,
+) -> tuple[tuple[str, str], ...] | None:
+    """Parse simple slash-delimited static/parameter segments.
+
+    Parameters embedded inside literal text are retained as opaque compound
+    segments. They fall back to the compiled-matcher and literal-skeleton
+    checks unless they occur after an owner's terminal ``:path`` parameter.
+    Keeping them opaque avoids guessing at custom regex-language inclusion.
+    """
+    if not path.startswith("/"):
+        return None
+    if path == "/":
+        return ()
+
+    segments: list[tuple[str, str]] = []
+    for segment in path[1:].split("/"):
+        match = _PATH_PARAMETER.fullmatch(segment)
+        if match is not None:
+            segments.append(("parameter", match.group(2) or "str"))
+        elif _PATH_PARAMETER.search(segment):
+            segments.append(("compound", segment))
+        else:
+            segments.append(("literal", segment))
+    return tuple(segments)
+
+
+def _static_segment_matches(convertor: str, value: str) -> bool:
+    from starlette.convertors import CONVERTOR_TYPES
+
+    registered = CONVERTOR_TYPES.get(convertor)
+    return registered is not None and re.fullmatch(registered.regex, value) is not None
+
+
+def _segment_covers(
+    owner: tuple[str, str],
+    candidate: tuple[str, str],
+) -> bool:
+    owner_kind, owner_value = owner
+    candidate_kind, candidate_value = candidate
+    if owner_kind == "literal":
+        return candidate_kind == "literal" and owner_value == candidate_value
+    if owner_kind == "compound" or candidate_kind == "compound":
+        return False
+    if candidate_kind == "literal":
+        return _static_segment_matches(owner_value, candidate_value)
+    return _convertor_covers(owner_value, candidate_value)
+
+
+def _segmented_path_covers(owner_path: str, candidate_path: str) -> bool:
+    owner = _path_segments(owner_path)
+    candidate = _path_segments(candidate_path)
+    if owner is None or candidate is None:
+        return False
+
+    # A terminal :path parameter consumes every remaining candidate segment.
+    if owner and owner[-1] == ("parameter", "path"):
+        prefix = owner[:-1]
+        # The slash before ``{rest:path}`` is still literal. A candidate with
+        # exactly the prefix's segment count (for example ``/org/{id}`` versus
+        # ``/org/{tenant}/{rest:path}``) does not contain that slash and remains
+        # reachable.
+        return len(candidate) > len(prefix) and all(
+            _segment_covers(owner_segment, candidate_segment)
+            for owner_segment, candidate_segment in zip(
+                prefix,
+                candidate,
+                strict=False,
+            )
+        )
+
+    return len(owner) == len(candidate) and all(
+        _segment_covers(owner_segment, candidate_segment)
+        for owner_segment, candidate_segment in zip(
+            owner,
+            candidate,
+            strict=True,
+        )
+    )
+
+
+def _matcher_covers(owner: _RouteClaim, candidate: _RouteClaim) -> bool:
+    """Whether every candidate path is consumed by the earlier owner.
+
+    Exact compiled matchers cover renamed parameters. The structural cases
+    below handle Starlette's built-in convertors conservatively: a dynamic
+    segment can cover a later static route, broader convertors cover narrower
+    ones with the same literal skeleton, and a terminal ``path`` convertor
+    covers every route below its fixed prefix. Unknown/custom shapes fall back
+    to non-conflicting rather than guessing at regex-language inclusion.
+    """
+    if owner.matcher == candidate.matcher:
+        return True
+
+    owner_literals, owner_convertors = _path_shape(owner.path)
+    candidate_literals, candidate_convertors = _path_shape(candidate.path)
+
+    # Compiled regex matching is exact for a static candidate and handles
+    # custom/embedded parameters that the structural parser intentionally
+    # treats as opaque.
+    if not candidate_convertors:
+        return re.fullmatch(owner.matcher, candidate.path) is not None
+
+    # Starlette Mount stores its implicit terminal ``{path:path}`` only in the
+    # compiled matcher, not ``route.path``. A root mount is normalized to an
+    # empty path. In both cases every descendant is dispatched to the mounted
+    # app before a later route can be considered; the mount's own exact prefix
+    # remains available to a later route (Starlette's matcher requires "/").
+    if owner.mount_prefix is not None:
+        if owner.mount_prefix == "":
+            return True
+        return _segmented_path_covers(
+            f"{owner.mount_prefix}/{{mount_path:path}}",
+            candidate.path,
+        )
+
+    if _segmented_path_covers(owner.path, candidate.path):
+        return True
+
+    return (
+        owner_literals == candidate_literals
+        and len(owner_convertors) == len(candidate_convertors)
+        and all(
+            _convertor_covers(owner_convertor, candidate_convertor)
+            for owner_convertor, candidate_convertor in zip(
+                owner_convertors,
+                candidate_convertors,
+                strict=True,
+            )
+        )
+    )
+
+
+def _find_route_clash(routes: list[_RouteClaim], owners: _RouteOwners) -> tuple[str, str] | None:
+    for route in routes:
+        for owner, holder in owners:
+            if _dispatches_overlap(route, owner) and _matcher_covers(owner, route):
+                return route.path, holder
+    return None
+
+
+def include_contributed_routers(app: Any, extensions: LoadedExtensions) -> list[Diagnostic]:
+    """Include extension routers without installing unreachable routes.
+
+    First writer wins when its matcher fully covers a later route for an
+    overlapping protocol/method. Silently including the later router would
+    leave its endpoint unreachable and make behavior depend on load order; the
+    conflict is reported instead, naming both the extension that lost and the
+    existing owner. Contributed ``Mount`` entries are rejected explicitly
+    because FastAPI's ``include_router`` silently ignores them.
+
+    Fail-open per router: one malformed contribution must not cost the Gateway
+    every other extension's routes.
+    """
+    diagnostics: list[Diagnostic] = []
+    if not extensions.routers:
+        return diagnostics
+
+    mounted: list[str] = []
+    owners: _RouteOwners = []
+    for route in getattr(app, "routes", []):
+        claim = _route_claim(route)
+        if claim is not None:
+            owners.append((claim, "host"))
+
+    for source, router in extensions.routers:
+        try:
+            routes = _router_routes(router)
+            if not routes:
+                raise TypeError(f"contributed router exposes no routes: {router!r}")
+            clash = _find_route_clash(routes, owners)
+            if clash is not None:
+                path, holder = clash
+                message = f"router path {path} is already served by {holder}; this router was not mounted"
+                diagnostics.append(Diagnostic.error(source, message))
+                logger.error("Extension %s: %s", source, message)
+                continue
+            app.include_router(router)
+            for route in routes:
+                owners.append((route, source))
+                mounted.append(f"{source} -> {route.path}")
+        except Exception as exc:
+            message = f"router could not be mounted; continuing without it: {exc}"
+            diagnostics.append(Diagnostic.error(source, message))
+            logger.exception("Extension %s: %s", source, message)
+
+    # Which URLs the Gateway just handed to third-party code is operational
+    # information, so it is reported rather than left to be discovered by
+    # reading /openapi.json. Attributed per path, like every other diagnostic
+    # in this module.
+    if mounted:
+        logger.info("Extension routers mounted: %s", "; ".join(mounted))
+    return diagnostics
+
+
+async def start_services(
+    extensions: LoadedExtensions,
+    app_config: Any,
+    session_factory: Any | None,
+) -> list[Diagnostic]:
+    """Start every extension service. Fail-open per service."""
+    diagnostics: list[Diagnostic] = []
+    if not extensions.services:
+        return diagnostics
+
+    deps = ExtensionRuntimeDeps(
+        app_store=extensions.app_store,
+        policy=project_host_policy(app_config),
+        session_factory=session_factory,
+    )
+    for source, service in extensions.services:
+        try:
+            await service.start(deps)
+        except Exception as exc:
+            message = f"service start() failed; continuing without it: {exc}"
+            diagnostics.append(Diagnostic.error(source, message))
+            logger.exception("Extension %s: %s", source, message)
+    return diagnostics
+
+
+async def stop_services(
+    extensions: LoadedExtensions,
+    timeout_seconds: float = DEFAULT_STOP_TIMEOUT_SECONDS,
+) -> list[Diagnostic]:
+    """Stop services in reverse start order, bounded and fail-open."""
+    diagnostics: list[Diagnostic] = []
+    for source, service in reversed(extensions.services):
+        try:
+            await asyncio.wait_for(service.stop(), timeout=timeout_seconds)
+        except TimeoutError:
+            message = f"service stop() timed out after {timeout_seconds}s; continuing shutdown"
+            diagnostics.append(Diagnostic.error(source, message))
+            logger.error("Extension %s: %s", source, message)
+        except Exception as exc:
+            message = f"service stop() failed; continuing shutdown: {exc}"
+            diagnostics.append(Diagnostic.error(source, message))
+            logger.exception("Extension %s: %s", source, message)
+    return diagnostics

--- a/backend/packages/harness/deerflow/extensions/injection.py
+++ b/backend/packages/harness/deerflow/extensions/injection.py
@@ -1,0 +1,109 @@
+"""Merging extension-contributed middlewares into the host stack."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Mapping, Sequence
+
+from deerflow_extension_api import AgentBuildContext, AgentScope, MiddlewarePlacement, Placement
+
+from deerflow.extensions.anchors import PlacementAnchor
+from deerflow.extensions.isolation import IsolatedMiddleware, graph_safe_middleware_name
+from deerflow.extensions.loader import Diagnostic
+from deerflow.extensions.registry import LoadedExtensions
+
+logger = logging.getLogger(__name__)
+
+
+def inject_middlewares(
+    middlewares: Sequence[object],
+    anchors: Mapping[Placement, PlacementAnchor],
+    scope: AgentScope,
+    ctx: AgentBuildContext,
+    extensions: LoadedExtensions,
+    *,
+    isolation_diagnostic_sink: Callable[[Diagnostic], None] | None = None,
+) -> tuple[list[object], dict[int, str], list[Diagnostic]]:
+    """Insert contributed middlewares at their semantic positions.
+
+    Returns the merged stack, a provenance map from final index to extension
+    source (core middlewares are absent from it), and construction diagnostics.
+    Later isolation failures go to ``isolation_diagnostic_sink``; when omitted,
+    they append to the returned diagnostic list for standalone callers.
+    """
+    result = list(middlewares)
+    diagnostics: list[Diagnostic] = []
+
+    if not extensions.has_middleware_contributors:
+        return result, {}, diagnostics
+
+    collected: list[tuple[str, MiddlewarePlacement]] = []
+    for source, contributor in extensions.middleware_contributors:
+        try:
+            contributions = contributor.contribute_middlewares(extensions.app_store, ctx)
+        except Exception as exc:
+            message = f"contribute_middlewares() failed: {exc}"
+            diagnostics.append(Diagnostic.error(source, message))
+            logger.exception("Extension %s: contribute_middlewares() failed", source)
+            continue
+        for placement in contributions or ():
+            if not (placement.scope & scope):
+                continue
+            collected.append((source, placement))
+
+    if not collected:
+        return result, {}, diagnostics
+
+    # Sort by declared order, then by registration order, so the outcome is
+    # reproducible regardless of dict iteration details.
+    ordered = sorted(enumerate(collected), key=lambda item: (item[1][1].order, item[0]))
+
+    # Insert inner-most positions first: each insertion shifts the indices of
+    # everything after it, so working from the back keeps earlier anchors valid.
+    #
+    # `priority` records each contribution's position in `ordered` (already
+    # sorted by declared order, then registration order). It breaks ties when
+    # two contributions resolve to the *same* target index: inserting always
+    # pushes the previous occupant of that index outward, so to make the
+    # higher-priority (earlier in `ordered`) contribution end up outermost, it
+    # must be the *last* one inserted at that index. Sorting by (index,
+    # priority) descending achieves that: lower-priority items are processed
+    # — and therefore inserted, and therefore displaced outward — first.
+    resolved: list[tuple[int, int, str, object]] = []
+    for priority, (_, (source, placement)) in enumerate(ordered):
+        anchor = anchors.get(placement.placement)
+        if anchor is None:
+            diagnostics.append(Diagnostic.error(source, f"no anchor configured for placement {placement.placement.name}"))
+            continue
+        index, used_primary = anchor.resolve(result)
+        if not used_primary:
+            message = f"placement {placement.placement.name} fell back to a secondary anchor (primary anchor middleware is absent from this stack); the observation semantics of this placement may differ from its documented guarantee"
+            diagnostics.append(Diagnostic.warning(source, message))
+            logger.warning("Extension %s: %s", source, message)
+        resolved.append((index, priority, source, placement.middleware))
+
+    # LangChain requires names to be unique across the complete stack and uses
+    # them as trace identities and, for before/after hooks, LangGraph node IDs.
+    used_names = {getattr(middleware, "name", type(middleware).__name__) for middleware in result}
+    runtime_diagnostic_sink = isolation_diagnostic_sink if isolation_diagnostic_sink is not None else diagnostics.append
+    for index, priority, source, middleware in sorted(resolved, key=lambda item: (item[0], item[1]), reverse=True):
+        inner_name = getattr(middleware, "name", type(middleware).__name__)
+        base_name = graph_safe_middleware_name(f"extension:{source}:{inner_name}:{priority}")
+        name = base_name
+        suffix = 2
+        while name in used_names:
+            name = f"{base_name}_{suffix}"
+            suffix += 1
+        used_names.add(name)
+        result.insert(
+            index,
+            IsolatedMiddleware(
+                middleware,
+                source,
+                runtime_diagnostic_sink,
+                name=name,
+            ),
+        )
+
+    provenance = {index: middleware.source for index, middleware in enumerate(result) if isinstance(middleware, IsolatedMiddleware)}
+    return result, provenance, diagnostics

--- a/backend/packages/harness/deerflow/extensions/isolation.py
+++ b/backend/packages/harness/deerflow/extensions/isolation.py
@@ -1,0 +1,294 @@
+"""Isolating extension middleware failures from the user's run.
+
+Extension middlewares execute inside LangChain's call chain, so an unhandled
+exception would abort the user's run. Every contributed middleware is wrapped
+so an observation failure degrades to a diagnostic and the call passes through.
+The downstream handler is tracked so isolation recovery never adds another
+model request or tool side effect: pre-handler extension failures invoke it
+once, post-handler failures return its captured result, and handler failures
+remain owned by the graph's error policy.
+
+The wrapper must mirror the inner middleware's full interface, not just the
+four wrap-call hooks: LangChain discovers capabilities by inspecting the
+wrapper — hook participation via class-level identity checks
+(`m.__class__.before_model is not AgentMiddleware.before_model`), tools,
+state_schema and transformers via instance attributes. Mirroring is exact in
+both directions: hooks the inner lacks must not appear on the wrapper either,
+or every wrapped middleware would bolt no-op nodes onto the graph and the base
+class's NotImplementedError defaults would spam spurious diagnostics through
+the isolation handler on every model and tool call.
+
+All first-version contributions are observational, hence fail-open. A future
+intercepting (decision-making) contribution would need to fail closed and must
+opt out of this wrapper explicitly.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+from collections.abc import Awaitable, Callable
+from types import TracebackType
+from typing import Any
+
+from langchain.agents.middleware import AgentMiddleware
+from langgraph.errors import GraphBubbleUp
+
+from deerflow.extensions.loader import Diagnostic
+
+logger = logging.getLogger(__name__)
+
+_UNSAFE_GRAPH_NAME = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def graph_safe_middleware_name(value: str) -> str:
+    """Normalize a middleware identity for LangGraph node names."""
+    return _UNSAFE_GRAPH_NAME.sub("_", value)
+
+
+_WRAP_HOOKS = ("wrap_model_call", "awrap_model_call", "wrap_tool_call", "awrap_tool_call")
+_LIFECYCLE_HOOKS = (
+    "before_agent",
+    "abefore_agent",
+    "before_model",
+    "abefore_model",
+    "after_model",
+    "aafter_model",
+    "after_agent",
+    "aafter_agent",
+)
+
+
+def _implemented_hooks(inner: AgentMiddleware) -> frozenset[str]:
+    """The hooks ``inner`` actually overrides, by LangChain's own class-level
+    identity check — instance-level attributes are invisible to the factory,
+    so they are invisible here too."""
+    return frozenset(hook for hook in (*_WRAP_HOOKS, *_LIFECYCLE_HOOKS) if getattr(type(inner), hook, None) is not getattr(AgentMiddleware, hook, None))
+
+
+def _make_sync_wrap_delegate(hook: str):
+    def delegate(self: IsolatedMiddleware, request: Any, handler: Callable[[Any], Any]) -> Any:
+        return self._invoke_sync(hook, getattr(self._inner, hook), request, handler)
+
+    return delegate
+
+
+def _make_async_wrap_delegate(hook: str):
+    async def delegate(self: IsolatedMiddleware, request: Any, handler: Callable[[Any], Awaitable[Any]]) -> Any:
+        return await self._invoke_async(hook, getattr(self._inner, hook), request, handler)
+
+    return delegate
+
+
+def _make_sync_lifecycle_delegate(hook: str):
+    def delegate(self: IsolatedMiddleware, state: Any, runtime: Any) -> Any:
+        return self._invoke_lifecycle_sync(hook, state, runtime)
+
+    return delegate
+
+
+def _make_async_lifecycle_delegate(hook: str):
+    async def delegate(self: IsolatedMiddleware, state: Any, runtime: Any) -> Any:
+        return await self._invoke_lifecycle_async(hook, state, runtime)
+
+    return delegate
+
+
+# Async variants are named explicitly: startswith("a") would also catch the
+# sync after_model/after_agent.
+_ASYNC_HOOKS = frozenset(hook for hook in (*_WRAP_HOOKS, *_LIFECYCLE_HOOKS) if hook[1:].startswith(("wrap", "before", "after")))
+
+
+def _delegate_for(hook: str):
+    if hook in _WRAP_HOOKS:
+        return _make_async_wrap_delegate(hook) if hook in _ASYNC_HOOKS else _make_sync_wrap_delegate(hook)
+    return _make_async_lifecycle_delegate(hook) if hook in _ASYNC_HOOKS else _make_sync_lifecycle_delegate(hook)
+
+
+_subclass_cache: dict[frozenset[str], type[IsolatedMiddleware]] = {}
+_subclass_cache_lock = threading.Lock()
+
+
+def _wrapper_subclass(hooks: frozenset[str]) -> type[IsolatedMiddleware]:
+    """A cached IsolatedMiddleware subclass defining exactly ``hooks``.
+
+    Per hook set, not per middleware: every inner middleware with the same
+    implemented-hook combination shares one subclass.
+    """
+    with _subclass_cache_lock:
+        subclass = _subclass_cache.get(hooks)
+        if subclass is None:
+            namespace = {hook: _delegate_for(hook) for hook in hooks}
+            subclass = type(IsolatedMiddleware.__name__, (IsolatedMiddleware,), namespace)
+            _subclass_cache[hooks] = subclass
+        return subclass
+
+
+class IsolatedMiddleware(AgentMiddleware):
+    """Wrap one extension middleware so its failures cannot break the run.
+
+    Instantiation returns a cached subclass that defines exactly the hooks the
+    inner middleware implements, so LangChain's class-level capability checks
+    see the same interface on the wrapper as on the inner middleware itself.
+    """
+
+    def __new__(cls, inner: AgentMiddleware, source: str, on_error: Callable[[Diagnostic], None], *, name: str | None = None):
+        if cls is IsolatedMiddleware:
+            cls = _wrapper_subclass(_implemented_hooks(inner))
+        return super().__new__(cls)
+
+    def __init__(
+        self,
+        inner: AgentMiddleware,
+        source: str,
+        on_error: Callable[[Diagnostic], None],
+        *,
+        name: str | None = None,
+    ) -> None:
+        super().__init__()
+        self._inner = inner
+        self._source = source
+        self._on_error = on_error
+        if name is None:
+            inner_name = getattr(inner, "name", type(inner).__name__)
+            name = f"extension:{source}:{inner_name}"
+        self._name = graph_safe_middleware_name(name)
+        # Mirror the declared-contribution attributes LangChain reads off the
+        # middleware instance (factory.py: m.tools, m.state_schema,
+        # m.transformers). state_schema is a class attribute on the base but
+        # must be per-instance here: cached subclasses are shared across
+        # middlewares whose schemas differ.
+        self.tools = getattr(inner, "tools", [])
+        self.transformers = getattr(inner, "transformers", ())
+        self.state_schema = getattr(inner, "state_schema", AgentMiddleware.state_schema)
+
+    @property
+    def name(self) -> str:
+        """Stable graph and trace identity for this isolated contribution."""
+        return self._name
+
+    @property
+    def inner(self) -> AgentMiddleware:
+        """The wrapped middleware. Used by ordering checks and tests."""
+        return self._inner
+
+    @property
+    def source(self) -> str:
+        """Extension this middleware came from. Read by the provenance map."""
+        return self._source
+
+    def _report(self, hook: str, exc: Exception) -> None:
+        message = f"{type(self._inner).__name__}.{hook} failed and was skipped: {exc}"
+        logger.exception("Extension %s: %s", self._source, message)
+        try:
+            self._on_error(Diagnostic.error(self._source, message))
+        except Exception:  # pragma: no cover - reporting must never raise
+            logger.exception("Extension %s: diagnostic reporting failed", self._source)
+
+    def _invoke_sync(
+        self,
+        hook: str,
+        inner_hook: Callable[[Any, Callable[[Any], Any]], Any],
+        request: Any,
+        handler: Callable[[Any], Any],
+    ) -> Any:
+        handler_succeeded = False
+        handler_result: Any = None
+        handler_error: BaseException | None = None
+        handler_error_traceback: TracebackType | None = None
+
+        def tracked_handler(inner_request: Any) -> Any:
+            nonlocal handler_error, handler_error_traceback
+            nonlocal handler_result, handler_succeeded
+            handler_error = None
+            handler_error_traceback = None
+            handler_succeeded = False
+            try:
+                handler_result = handler(inner_request)
+            except BaseException as exc:
+                handler_error = exc
+                handler_error_traceback = exc.__traceback__
+                raise
+            else:
+                handler_succeeded = True
+                return handler_result
+
+        try:
+            return inner_hook(request, tracked_handler)
+        except GraphBubbleUp:
+            raise
+        except Exception as exc:
+            if handler_error is not None:
+                if handler_error is exc:
+                    raise
+                raise handler_error.with_traceback(handler_error_traceback) from None
+            self._report(hook, exc)
+            if handler_succeeded:
+                return handler_result
+            return handler(request)
+
+    async def _invoke_async(
+        self,
+        hook: str,
+        inner_hook: Callable[
+            [Any, Callable[[Any], Awaitable[Any]]],
+            Awaitable[Any],
+        ],
+        request: Any,
+        handler: Callable[[Any], Awaitable[Any]],
+    ) -> Any:
+        handler_succeeded = False
+        handler_result: Any = None
+        handler_error: BaseException | None = None
+        handler_error_traceback: TracebackType | None = None
+
+        async def tracked_handler(inner_request: Any) -> Any:
+            nonlocal handler_error, handler_error_traceback
+            nonlocal handler_result, handler_succeeded
+            handler_error = None
+            handler_error_traceback = None
+            handler_succeeded = False
+            try:
+                handler_result = await handler(inner_request)
+            except BaseException as exc:
+                handler_error = exc
+                handler_error_traceback = exc.__traceback__
+                raise
+            else:
+                handler_succeeded = True
+                return handler_result
+
+        try:
+            return await inner_hook(request, tracked_handler)
+        except GraphBubbleUp:
+            raise
+        except Exception as exc:
+            if handler_error is not None:
+                if handler_error is exc:
+                    raise
+                raise handler_error.with_traceback(handler_error_traceback) from None
+            self._report(hook, exc)
+            if handler_succeeded:
+                return handler_result
+            return await handler(request)
+
+    def _invoke_lifecycle_sync(self, hook: str, state: Any, runtime: Any) -> Any:
+        """Lifecycle hooks have no handler to fall through to: the fail-open
+        degradation for a failed observation is applying no state update."""
+        try:
+            return getattr(self._inner, hook)(state, runtime)
+        except GraphBubbleUp:
+            raise
+        except Exception as exc:
+            self._report(hook, exc)
+            return None
+
+    async def _invoke_lifecycle_async(self, hook: str, state: Any, runtime: Any) -> Any:
+        try:
+            return await getattr(self._inner, hook)(state, runtime)
+        except GraphBubbleUp:
+            raise
+        except Exception as exc:
+            self._report(hook, exc)
+            return None

--- a/backend/packages/harness/deerflow/extensions/loader.py
+++ b/backend/packages/harness/deerflow/extensions/loader.py
@@ -1,0 +1,200 @@
+"""Config-driven extension loading.
+
+Entry points are named as `module.path:install`, resolved through the same
+`resolve_variable` helper the guardrails provider already uses. Load order is
+the config list order — explicit and reproducible, which matters because the
+middleware stack is position-sensitive.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from deerflow_extension_api import API_VERSION
+from pydantic import BaseModel, Field
+
+from deerflow.extensions.registry import ExtensionRegistry, LoadedExtensions
+from deerflow.reflection import resolve_variable
+
+logger = logging.getLogger(__name__)
+
+DiagnosticLevel = Literal["debug", "info", "warning", "error"]
+
+
+class ExtensionSpec(BaseModel):
+    """One entry of the `extensions:` list in config.yaml."""
+
+    use: str = Field(description="Entry point path, e.g. 'my_extension:install'")
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Extension-private configuration, passed to install() verbatim",
+    )
+    required: bool = Field(
+        default=False,
+        description="When true, a load failure aborts startup instead of being skipped",
+    )
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A load- or run-time problem attributed to a specific extension.
+
+    The repository has no structured diagnostics channel today; this is a
+    deliberately minimal one whose only job is keeping failures attributable.
+    """
+
+    level: DiagnosticLevel
+    source: str
+    message: str
+
+    @classmethod
+    def error(cls, source: str, message: str) -> Diagnostic:
+        return cls("error", source, message)
+
+    @classmethod
+    def warning(cls, source: str, message: str) -> Diagnostic:
+        return cls("warning", source, message)
+
+    @classmethod
+    def info(cls, source: str, message: str) -> Diagnostic:
+        return cls("info", source, message)
+
+    @classmethod
+    def debug(cls, source: str, message: str) -> Diagnostic:
+        return cls("debug", source, message)
+
+
+class ExtensionLoadError(RuntimeError):
+    """Raised when an extension marked `required: true` fails to load."""
+
+
+def _parse_version(version: str) -> tuple[int, ...] | None:
+    try:
+        return tuple(int(part) for part in version.split("."))
+    except ValueError:
+        return None
+
+
+def _compatible(declared: str, current: str) -> bool:
+    """One-directional, with the semver window for the contract's life stage.
+
+    Pre-1.0 the contract surface is observational only and minors may break,
+    so the window is same major.minor with patches additive: host >= declared.
+    From 1.0 on contracts only grow within a major, so a newer host stays
+    compatible with older extensions while an extension written against a
+    newer minor is refused — it would reach for contract additions the host
+    does not implement. Unparseable versions are refused, not waved through."""
+    declared_parts = _parse_version(declared)
+    current_parts = _parse_version(current)
+    if not declared_parts or not current_parts:
+        return False
+    width = max(len(declared_parts), len(current_parts), 2)
+    declared_padded = declared_parts + (0,) * (width - len(declared_parts))
+    current_padded = current_parts + (0,) * (width - len(current_parts))
+    if declared_padded[0] != current_padded[0]:
+        return False
+    if declared_padded[0] == 0 and declared_padded[1] != current_padded[1]:
+        return False
+    return current_padded >= declared_padded
+
+
+def _range_for(declared: str) -> str:
+    """The pip window matching ``_compatible``'s rules, for the actionable
+    refusal message. Falls back to an exact request when the declared version
+    is unparseable — the message must survive the version that caused it."""
+    parts = _parse_version(declared)
+    if not parts:
+        return f"=={declared}"
+    if parts[0] == 0:
+        minor = parts[1] if len(parts) > 1 else 0
+        return f">={declared},<0.{minor + 1}"
+    return f">={declared},<{parts[0] + 1}.0"
+
+
+def load_extensions(specs: Sequence[ExtensionSpec]) -> tuple[LoadedExtensions, list[Diagnostic]]:
+    """Resolve and install every configured extension.
+
+    Fail-open by default: a broken extension is skipped with a diagnostic so
+    the Gateway still starts. `required: true` flips that to fail-closed for
+    extensions whose absence changes behaviour rather than just observability.
+    """
+    registry = ExtensionRegistry()
+    diagnostics: list[Diagnostic] = []
+    loaded_sources: list[str] = []
+
+    for spec in specs:
+        try:
+            install = resolve_variable(spec.use)
+        except Exception as exc:
+            message = f"could not resolve extension entry point: {exc}"
+            diagnostics.append(Diagnostic.error(spec.use, message))
+            logger.error("Extension %s: %s", spec.use, message)
+            if spec.required:
+                raise ExtensionLoadError(f"required extension {spec.use} failed to load") from exc
+            continue
+
+        if not callable(install):
+            message = f"extension entry point is not callable: {type(install).__name__}"
+            diagnostics.append(Diagnostic.error(spec.use, message))
+            logger.error("Extension %s: %s", spec.use, message)
+            if spec.required:
+                raise ExtensionLoadError(f"required extension {spec.use} is not callable")
+            continue
+
+        declared = getattr(install, "__deerflow_api__", None)
+        if declared is not None and not _compatible(declared, API_VERSION):
+            message = f"extension requires extension-api {declared}, host provides {API_VERSION}. Install a matching version: pip install 'deerflow-extension-api{_range_for(declared)}'"
+            diagnostics.append(Diagnostic.error(spec.use, message))
+            logger.error("Extension %s: %s", spec.use, message)
+            if spec.required:
+                raise ExtensionLoadError(f"required extension {spec.use} declares incompatible api {declared}")
+            continue
+
+        # Positional rollback, not registry.discard(spec.use): two specs may
+        # legitimately share the same `use` with different config, and
+        # discard-by-source would also erase an earlier, successfully
+        # installed instance that happens to share this spec's `use`.
+        mark = registry.mark()
+        try:
+            with registry.attributed_to(spec.use):
+                install(registry, _frozen_config(spec.config))
+        except Exception as exc:
+            registry.rollback_to(mark)
+            message = f"install() failed: {exc}"
+            diagnostics.append(Diagnostic.error(spec.use, message))
+            logger.exception("Extension %s: install() failed", spec.use)
+            if spec.required:
+                raise ExtensionLoadError(f"required extension {spec.use} failed to install") from exc
+            continue
+
+        loaded_sources.append(spec.use)
+
+    # Loading third-party code is exactly the event an operator needs positive
+    # confirmation of, and every other branch here is failure-only — so without
+    # this line a fully successful load is indistinguishable from a `plugins:`
+    # block the host never read. The x/y count names the difference between
+    # "all loaded" and "some were skipped" without repeating the per-failure
+    # errors already logged above.
+    if specs:
+        logger.info("Extensions loaded: %d/%d (%s)", len(loaded_sources), len(specs), ", ".join(loaded_sources) or "none")
+    else:
+        # Debug, not info: no configured plugins is the default state for almost
+        # every deployment, and an unconditional line would be pure boot noise.
+        logger.debug("No extensions configured")
+
+    return registry.build(), diagnostics
+
+
+def _frozen_config(config: dict[str, Any]) -> Mapping[str, Any]:
+    """Hand extensions a shallow copy of their config block.
+
+    This is a shallow copy: it stops an extension from reassigning
+    top-level keys on another extension's (or the caller's) config dict, but
+    nested structures (lists, dicts) are still shared by reference and can be
+    mutated in place. Use plain, top-level config values if this guarantee
+    matters to you.
+    """
+    return dict(config)

--- a/backend/packages/harness/deerflow/extensions/notify.py
+++ b/backend/packages/harness/deerflow/extensions/notify.py
@@ -1,0 +1,417 @@
+"""Notification helpers for the host-side hook points.
+
+Every helper is fail-open: an observation failure is logged and the next
+observer still runs. Callers short-circuit on the precomputed `has_*` flags
+before constructing any payload, so the zero-extension path allocates nothing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable, Coroutine, Mapping
+from typing import Any
+
+from deerflow_extension_api import (
+    ExtensionData,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+    TaskInfo,
+    TaskOutcome,
+)
+
+from deerflow.extensions.registry import LoadedExtensions
+
+logger = logging.getLogger(__name__)
+
+
+def lead_task_id(run_id: str) -> str:
+    """Task identity for a lead agent execution.
+
+    A lead execution is 1:1 with a run — goal continuations re-enter the same
+    run and reuse the same task — so the run id *is* the task id. Lead and
+    subagent then share one task abstraction and extensions write one code path.
+    """
+    return run_id
+
+
+def lead_task_outcome(*, aborted: bool, succeeded: bool) -> TaskOutcome:
+    """Classify how a lead execution ended.
+
+    Takes plain booleans rather than a ``RunRecord`` so the extension layer
+    stays free of runtime schema imports and the classification is unit
+    testable on its own.
+
+    Deliberately keyed on *success*, not on an error probe: only an explicitly
+    successful run reports COMPLETED, so a status the host never anticipated —
+    a run still marked running because a ``BaseException`` escaped, a future
+    ``timeout`` status — degrades to FAILED rather than being reported as a
+    clean completion. Abort wins over both: a cancelled run commonly also
+    unwinds through an exception, and the caller asked for the stop, so that is
+    the more specific explanation.
+    """
+    if aborted:
+        return TaskOutcome.ABORTED
+    if succeeded:
+        return TaskOutcome.COMPLETED
+    return TaskOutcome.FAILED
+
+
+def subagent_task_outcome(*, cancelled: bool, succeeded: bool) -> TaskOutcome:
+    """Classify how a subagent execution ended.
+
+    The sibling of :func:`lead_task_outcome`, and keyed the same way and for the
+    same reason: only an explicitly successful execution reports COMPLETED, so a
+    status the host never set — the result still marked RUNNING because a
+    ``BaseException`` escaped the executor's ``except Exception`` — degrades to
+    FAILED instead of being reported as a clean success.
+
+    Takes booleans rather than a ``SubagentStatus`` so this module keeps no
+    import of ``deerflow.subagents``, which imports this one.
+    """
+    if cancelled:
+        return TaskOutcome.ABORTED
+    if succeeded:
+        return TaskOutcome.COMPLETED
+    return TaskOutcome.FAILED
+
+
+async def _notify_each(
+    contributors: tuple[tuple[str, Any], ...],
+    hook: str,
+    invoke: Callable[[Any], Any],
+    task_id: str,
+    timeout: float | None,
+) -> None:
+    """Call ``hook`` on every contributor, fail-open, within a shared budget.
+
+    ``timeout`` bounds the whole notification, not each contributor: it is a
+    shared budget consumed in order, so a contributor that takes 1s of a 3s
+    budget leaves 2s for the rest, instead of each getting a fresh full timeout
+    (which would make the total unbounded in the number of extensions). A
+    contributor that exhausts the budget is logged as skipped rather than
+    silently dropped — the host cannot wait forever, but it also must not let
+    one hung extension look like success.
+
+    Everything, including *producing* the awaitable, happens inside the try:
+    contributors are arbitrary objects with no runtime validation, so a plain
+    ``def`` or a stale signature raises at call time rather than at await time.
+    """
+    deadline = None if timeout is None else asyncio.get_running_loop().time() + timeout
+    for source, contributor in contributors:
+        try:
+            call = invoke(contributor)
+            if deadline is None:
+                await call
+                continue
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                close = getattr(call, "close", None)
+                if close is not None:
+                    close()
+                logger.warning(
+                    "Extension %s: %s skipped for task %s, the %.1fs budget was already spent",
+                    source,
+                    hook,
+                    task_id,
+                    timeout,
+                )
+                continue
+            await asyncio.wait_for(call, remaining)
+        except Exception:
+            logger.exception("Extension %s: %s failed for task %s", source, hook, task_id)
+
+
+async def notify_task_start(
+    extensions: LoadedExtensions,
+    task_store: ExtensionData,
+    info: TaskInfo,
+    *,
+    timeout: float | None = None,
+) -> None:
+    await _notify_each_on_extension_loop(
+        extensions.task_lifecycle,
+        "on_task_start",
+        lambda contributor: contributor.on_task_start(extensions.app_store, task_store, info),
+        info.task_id,
+        timeout,
+    )
+
+
+async def notify_task_stop(
+    extensions: LoadedExtensions,
+    task_store: ExtensionData,
+    info: TaskInfo,
+    outcome: TaskOutcome,
+    *,
+    timeout: float | None = None,
+) -> None:
+    await _notify_each_on_extension_loop(
+        extensions.task_lifecycle,
+        "on_task_stop",
+        lambda contributor: contributor.on_task_stop(extensions.app_store, task_store, info, outcome),
+        info.task_id,
+        timeout,
+    )
+
+
+async def notify_system_model_call(
+    extensions: LoadedExtensions,
+    task_store: ExtensionData | None,
+    kind: SystemOperationKind,
+    request: SystemModelRequest,
+    result: SystemModelResult,
+    *,
+    timeout: float | None = None,
+) -> None:
+    if not extensions.system_model_observers:
+        # Checked before the fallback store is built: callers are expected to
+        # short-circuit on has_system_model_observers, but this keeps the
+        # module's own "zero-extension path allocates nothing" promise true
+        # even for a call site that forgets to.
+        return
+    store = task_store if task_store is not None else ExtensionData("detached")
+    await _notify_each_on_extension_loop(
+        extensions.system_model_observers,
+        "on_system_model_call",
+        lambda observer: observer.on_system_model_call(extensions.app_store, store, kind, request, result),
+        kind.value,
+        timeout,
+    )
+
+
+def task_store_for_system_call(invoke_config: object) -> ExtensionData | None:
+    """Best-effort compatibility lookup for an out-of-graph call's task store.
+
+    Live call sites pass the store explicitly because LangGraph can normalize
+    ``RunnableConfig`` into shapes this helper cannot safely recover from.
+    This fallback preserves older/direct callers that still put the store in a
+    top-level ``context``. Returns None when no task is live, which is a
+    legitimate state, not an error.
+    """
+    from deerflow_extension_api import EXTENSION_TASK_STORE_KEY
+
+    if not isinstance(invoke_config, Mapping):
+        return None
+    context = invoke_config.get("context")
+    if not isinstance(context, Mapping):
+        return None
+    store = context.get(EXTENSION_TASK_STORE_KEY)
+    return store if isinstance(store, ExtensionData) else None
+
+
+#: Loop on which extension services bind resources and notification hooks run.
+#: An observer holding an async client built on one loop breaks when awaited on
+#: another (issue #2615's failure mode, reproduced inside extension code).
+_notify_loop: asyncio.AbstractEventLoop | None = None
+
+#: Strong references to in-flight fire-and-forget dispatches. Without these
+#: CPython may collect a pending task and log "Task was destroyed but it is
+#: pending" instead of running the observer.
+_pending_dispatches: set[asyncio.Future[Any]] = set()
+
+_warned_no_loop = False
+_system_observations_enabled = True
+
+
+def set_extension_notify_loop(loop: asyncio.AbstractEventLoop | None) -> None:
+    """Register the loop extension notification hooks are dispatched onto.
+
+    Must be the serving loop on which ``ExtensionService.start()`` binds
+    extension resources. Hosts that never register one (the embedded client,
+    the TUI, plain scripts) execute awaited hooks on their current loop; only
+    synchronous fire-and-forget system-model observations are dropped.
+    """
+    global _notify_loop, _system_observations_enabled, _warned_no_loop
+    _notify_loop = loop
+    _system_observations_enabled = True
+    _warned_no_loop = False
+
+
+def reset_extension_notify_loop() -> None:
+    global _notify_loop, _system_observations_enabled, _warned_no_loop
+    _notify_loop = None
+    _system_observations_enabled = True
+    _warned_no_loop = False
+    _pending_dispatches.clear()
+
+
+def suspend_extension_system_observations() -> None:
+    """Drop new synchronous system observations without detaching task hooks.
+
+    Gateway shutdown uses this before flushing the memory debounce thread: new
+    fire-and-forget observations must not target a loop that is about to stop,
+    while in-flight subagents still need that same registered loop for their
+    awaited task-stop lifecycle hook.
+    """
+    global _system_observations_enabled
+    if _notify_loop is not None:
+        _system_observations_enabled = False
+
+
+async def _notify_each_on_extension_loop(
+    contributors: tuple[tuple[str, Any], ...],
+    hook: str,
+    invoke: Callable[[Any], Any],
+    task_id: str,
+    timeout: float | None,
+) -> None:
+    """Run awaited hooks where extension services bind their async resources."""
+    loop = _notify_loop
+    current_loop = asyncio.get_running_loop()
+    if loop is None or loop is current_loop:
+        await _notify_each(contributors, hook, invoke, task_id, timeout)
+        return
+    if not loop.is_running():
+        logger.warning(
+            "No running loop registered for awaited extension hook; %s for %s was dropped",
+            hook,
+            task_id,
+        )
+        return
+
+    notification = _notify_each(contributors, hook, invoke, task_id, timeout)
+    try:
+        future = asyncio.run_coroutine_threadsafe(notification, loop)
+    except Exception:
+        notification.close()
+        logger.exception("Could not dispatch extension %s for task %s to the registered loop", hook, task_id)
+        return
+
+    try:
+        wrapped = asyncio.wrap_future(future)
+        if timeout is None:
+            await wrapped
+        else:
+            await asyncio.wait_for(wrapped, timeout)
+    except TimeoutError:
+        future.cancel()
+        logger.warning(
+            "Extension %s dispatch timed out for task %s after %.1fs",
+            hook,
+            task_id,
+            timeout,
+        )
+    except asyncio.CancelledError:
+        future.cancel()
+        raise
+    except Exception:
+        logger.exception("Extension %s dispatch failed for task %s", hook, task_id)
+
+
+def dispatch_system_model_observation(coro: Coroutine[Any, Any, None], what: str) -> bool:
+    """Submit an observation to the registered loop without waiting for it.
+
+    The entry point for *synchronous* call sites. Observers are ``async def`` by
+    contract, and the call sites that need this run on threads with no event
+    loop of their own (DeerMem's debounce timer), so the coroutine is handed to
+    the serving loop where extension services bound their resources rather
+    than run here.
+
+    Two deliberate non-choices:
+
+    - **Never blocks.** ``run_coroutine_threadsafe(...).result()`` hangs forever
+      when the target loop has been stopped but not closed: the submission is
+      accepted and the future is never resolved. On the memory path that would
+      wedge the debounce queue's ``_processing`` flag for the rest of the
+      process lifetime.
+    - **Never dispatches to ``get_running_loop()``.** Handing the coroutine to
+      whichever of this process's loops happens to be current (Gateway, the
+      isolated subagent loop, BoxLite's) is the cross-loop bug this whole
+      mechanism exists to avoid.
+
+    Returns whether the observation was submitted, for tests and diagnostics.
+    """
+    global _warned_no_loop
+
+    loop = _notify_loop
+    submitted = False
+    try:
+        if not _system_observations_enabled:
+            return False
+        if loop is None or not loop.is_running():
+            # `is_running()` rather than `is_closed()`: a stopped-but-not-closed
+            # loop reports itself open and silently never runs the coroutine.
+            if not _warned_no_loop:
+                _warned_no_loop = True
+                logger.warning("No running loop registered for extension observations; %s and later ones are dropped", what)
+            return False
+        try:
+            future = asyncio.run_coroutine_threadsafe(coro, loop)
+        except Exception:
+            # The loop can close between the check above and this call.
+            logger.debug("Could not dispatch %s to the extension notify loop", what, exc_info=True)
+            return False
+        # Narrower race, not eliminated: the loop can also stop between the
+        # check and the submit, in which case the future never resolves and is
+        # released only by reset_extension_notify_loop(). Unfixable without
+        # cooperation from the loop; the Gateway resets before stopping.
+        _pending_dispatches.add(future)
+        future.add_done_callback(_pending_dispatches.discard)
+        submitted = True
+        return True
+    finally:
+        if not submitted:
+            # Close on every path that did not hand the coroutine off, or it is
+            # garbage collected with "coroutine was never awaited".
+            coro.close()
+
+
+async def observe_system_model_call(
+    kind: SystemOperationKind,
+    *,
+    messages: Any,
+    model_name: str | None,
+    invoke_config: Any,
+    invoke: Callable[[], Awaitable[Any]],
+    task_store: ExtensionData | None = None,
+    timeout: float | None = None,
+) -> Any:
+    """Run an out-of-graph model call and notify observers on both paths.
+
+    One helper rather than the same try/except/notify block repeated at every
+    call site: the sites are spread across four modules, and a duplicated guard
+    is exactly how the task-lifecycle hooks drifted apart earlier in this work.
+
+    Failures are notified and then re-raised — the call's own error handling is
+    unchanged, observation is purely additive. A system call that raised is the
+    event an observability extension most needs, so notifying only on success
+    would hide it.
+
+    ``task_store`` is the authoritative carrier for a live task. The config
+    lookup remains only as a compatibility fallback for direct callers.
+    """
+    from deerflow.extensions import get_loaded_extensions
+
+    extensions = get_loaded_extensions()
+    if not extensions.has_system_model_observers:
+        # Zero-extension path: no snapshot objects, no clock reads, no store
+        # lookup — just the original call.
+        return await invoke()
+
+    store = task_store if task_store is not None else task_store_for_system_call(invoke_config)
+    request = SystemModelRequest(messages=messages, model_name=model_name, invoke_config=invoke_config if isinstance(invoke_config, Mapping) else None)
+    started = time.monotonic()
+    try:
+        response = await invoke()
+    except Exception as exc:
+        await notify_system_model_call(
+            extensions,
+            store,
+            kind,
+            request,
+            SystemModelResult(error=exc, duration_ms=(time.monotonic() - started) * 1000),
+            timeout=timeout,
+        )
+        raise
+    await notify_system_model_call(
+        extensions,
+        store,
+        kind,
+        request,
+        SystemModelResult(response=response, duration_ms=(time.monotonic() - started) * 1000),
+        timeout=timeout,
+    )
+    return response

--- a/backend/packages/harness/deerflow/extensions/ordering.py
+++ b/backend/packages/harness/deerflow/extensions/ordering.py
@@ -1,0 +1,80 @@
+"""Declarative ordering invariants for the middleware stack.
+
+Replaces hand-written index comparisons. Extension-contributed middlewares are
+merged before validation runs, so a contribution cannot slip past an invariant,
+and the failure names the extension responsible.
+
+A broken invariant is the one hard failure in this system: unlike a missing
+observation, it produces wrong behaviour without an error.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from deerflow.extensions.isolation import IsolatedMiddleware
+
+
+@dataclass(frozen=True)
+class OrderingConstraint:
+    outer: type
+    inner: type
+    reason: str
+
+
+def _index_of(middlewares: Sequence[object], target: type) -> int | None:
+    for index, middleware in enumerate(middlewares):
+        candidate = middleware.inner if isinstance(middleware, IsolatedMiddleware) else middleware
+        if isinstance(candidate, target):
+            return index
+    return None
+
+
+def assert_ordering(
+    middlewares: Sequence[object],
+    provenance: Mapping[int, str],
+    constraints: Sequence[OrderingConstraint] | None = None,
+) -> None:
+    """Raise when a constraint is violated. No-op when both sides are absent."""
+    for constraint in constraints if constraints is not None else CORE_ORDERING_CONSTRAINTS:
+        outer_index = _index_of(middlewares, constraint.outer)
+        inner_index = _index_of(middlewares, constraint.inner)
+        if outer_index is None or inner_index is None:
+            continue
+        if outer_index < inner_index:
+            continue
+        culprits = sorted({source for index in (outer_index, inner_index) if (source := provenance.get(index)) is not None})
+        blame = ", ".join(culprits) if culprits else "core middleware order"
+        raise RuntimeError(
+            f"Middleware ordering constraint violated: {constraint.outer.__name__} must be outer "
+            f"(lower index) of {constraint.inner.__name__}, but found at index {outer_index} vs "
+            f"{inner_index}. Reason: {constraint.reason}. Contributed by: {blame}."
+        )
+
+
+def _core_constraints() -> tuple[OrderingConstraint, ...]:
+    from deerflow.agents.middlewares.tool_error_handling_middleware import ToolErrorHandlingMiddleware
+    from deerflow.agents.middlewares.tool_progress_middleware import ToolProgressMiddleware
+
+    return (
+        OrderingConstraint(
+            outer=ToolProgressMiddleware,
+            inner=ToolErrorHandlingMiddleware,
+            reason=("ToolProgressMiddleware reads deerflow_tool_meta in _update_state_from_result, so its wrap_tool_call chain must enclose the ToolErrorHandlingMiddleware step that stamps it"),
+        ),
+    )
+
+
+class _LazyConstraints(tuple):
+    """Defer the middleware imports until first use to avoid an import cycle."""
+
+    _resolved: tuple[OrderingConstraint, ...] | None = None
+
+    def __iter__(self):
+        if _LazyConstraints._resolved is None:
+            _LazyConstraints._resolved = _core_constraints()
+        return iter(_LazyConstraints._resolved)
+
+
+CORE_ORDERING_CONSTRAINTS = _LazyConstraints()

--- a/backend/packages/harness/deerflow/extensions/registry.py
+++ b/backend/packages/harness/deerflow/extensions/registry.py
@@ -1,0 +1,175 @@
+"""Registration-phase registry and its immutable runtime product.
+
+Two-phase separation: extensions only ever see ``ExtensionRegistry`` (write
+only, no host capabilities), and the host hands real dependencies over later
+via ``ExtensionRuntimeDeps``. Because those are different objects, an
+extension structurally cannot cause side effects during registration — no
+throwing stubs needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from deerflow_extension_api import (
+    ExtensionData,
+    ExtensionService,
+    MiddlewareContributor,
+    SystemModelCallObserver,
+    TaskLifecycleContributor,
+)
+from deerflow_extension_api import ExtensionRegistry as ExtensionRegistryContract
+
+_Entry = tuple[str, Any]
+
+
+@dataclass(frozen=True)
+class LoadedExtensions:
+    """Immutable view consumed at runtime.
+
+    Every entry carries its source string so diagnostics, provenance and
+    ordering errors can name the extension responsible.
+    """
+
+    app_store: ExtensionData
+    services: tuple[tuple[str, ExtensionService], ...] = ()
+    middleware_contributors: tuple[tuple[str, MiddlewareContributor], ...] = ()
+    task_lifecycle: tuple[tuple[str, TaskLifecycleContributor], ...] = ()
+    system_model_observers: tuple[tuple[str, SystemModelCallObserver], ...] = ()
+    routers: tuple[tuple[str, Any], ...] = ()
+
+    # Precomputed attributes, not methods: hook sites read one attribute to
+    # short-circuit, so the zero-extension path constructs nothing.
+    has_middleware_contributors: bool = False
+    has_task_lifecycle: bool = False
+    has_system_model_observers: bool = False
+    needs_task_store: bool = False
+
+
+class ExtensionRegistry(ExtensionRegistryContract):
+    """Mutable, registration-phase only.
+
+    Subclasses the public contract Protocol so the host implementation is
+    type-checked against what extensions annotate; the host-only machinery
+    below (attribution, discard, mark/rollback_to, build) stays out of the
+    contract on purpose.
+    """
+
+    def __init__(self) -> None:
+        self._services: list[_Entry] = []
+        self._middlewares: list[_Entry] = []
+        self._task_lifecycle: list[_Entry] = []
+        self._system_model_observers: list[_Entry] = []
+        self._routers: list[_Entry] = []
+        self._current_source: str | None = None
+
+    @contextmanager
+    def attributed_to(self, source: str) -> Iterator[None]:
+        """Attribute everything registered inside the block to ``source``."""
+        previous = self._current_source
+        self._current_source = source
+        try:
+            yield
+        finally:
+            self._current_source = previous
+
+    def _source(self) -> str:
+        if self._current_source is None:
+            raise RuntimeError("registration must happen inside ExtensionRegistry.attributed_to(...)")
+        return self._current_source
+
+    def service(self, service: ExtensionService) -> None:
+        self._services.append((self._source(), service))
+
+    def middlewares(self, contributor: MiddlewareContributor) -> None:
+        self._middlewares.append((self._source(), contributor))
+
+    def task_lifecycle(self, contributor: TaskLifecycleContributor) -> None:
+        self._task_lifecycle.append((self._source(), contributor))
+
+    def system_model_observer(self, observer: SystemModelCallObserver) -> None:
+        self._system_model_observers.append((self._source(), observer))
+
+    def routers(self, routers: Sequence[Any]) -> None:
+        """Register already-constructed routers in deterministic load order.
+
+        Runtime dependencies are bound later through ExtensionService.start();
+        keeping router construction eager lets the Gateway validate every path
+        and freeze its OpenAPI surface before serving.
+        """
+        source = self._source()
+        for router in routers:
+            self._routers.append((source, router))
+
+    def discard(self, source: str) -> None:
+        """Remove every entry registered by ``source``.
+
+        Called when install() raises partway through. A half-registered
+        extension is more dangerous than an absent one because the data it
+        produces looks complete.
+
+        Note: this matches by source string, so it is unsafe when two specs
+        share the same ``use`` with different config — it would remove a
+        different, successfully-installed instance's entries too. Callers
+        that process one install() at a time should prefer
+        ``mark()``/``rollback_to()`` instead.
+        """
+        for bucket in (
+            self._services,
+            self._middlewares,
+            self._task_lifecycle,
+            self._system_model_observers,
+            self._routers,
+        ):
+            bucket[:] = [entry for entry in bucket if entry[0] != source]
+
+    def mark(self) -> tuple[int, int, int, int, int]:
+        """Snapshot bucket lengths so one install() can be undone positionally."""
+        return (
+            len(self._services),
+            len(self._middlewares),
+            len(self._task_lifecycle),
+            len(self._system_model_observers),
+            len(self._routers),
+        )
+
+    def rollback_to(self, mark: tuple[int, int, int, int, int]) -> None:
+        """Undo every registration made since ``mark``.
+
+        Positional rather than source-keyed: two specs may legitimately share
+        a ``use`` string with different config, and deleting by source would
+        take the other instance's successful registrations with it.
+        """
+        for bucket, size in zip(
+            (
+                self._services,
+                self._middlewares,
+                self._task_lifecycle,
+                self._system_model_observers,
+                self._routers,
+            ),
+            mark,
+            strict=True,
+        ):
+            del bucket[size:]
+
+    def build(self) -> LoadedExtensions:
+        return LoadedExtensions(
+            app_store=ExtensionData("app"),
+            services=tuple(self._services),
+            middleware_contributors=tuple(self._middlewares),
+            task_lifecycle=tuple(self._task_lifecycle),
+            system_model_observers=tuple(self._system_model_observers),
+            routers=tuple(self._routers),
+            has_middleware_contributors=bool(self._middlewares),
+            has_task_lifecycle=bool(self._task_lifecycle),
+            has_system_model_observers=bool(self._system_model_observers),
+            needs_task_store=bool(self._middlewares or self._task_lifecycle or self._system_model_observers),
+        )
+
+
+#: Shared empty instance for hosts that load no extensions.
+EMPTY_EXTENSIONS = ExtensionRegistry().build()

--- a/backend/packages/harness/deerflow/extensions/stack.py
+++ b/backend/packages/harness/deerflow/extensions/stack.py
@@ -1,0 +1,187 @@
+"""The anchor table and the single composition entry point.
+
+This is where DeerFlow's stack shape is encoded. Two structural facts drive it:
+
+* The stack is built at two nested points — `build_lead_runtime_middlewares()`
+  produces the base, then `build_middlewares()` appends ~18 lead-specific
+  middlewares that are all *inner* of it. MODEL_PHYSICAL lands in the second
+  group, so extension injection must happen after the final list is assembled,
+  never inside the base builder.
+* First item in the list is the outermost wrapper (LangChain composition rule).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from deerflow_extension_api import AgentBuildContext, AgentScope, Placement
+
+from deerflow.extensions.anchors import (
+    PlacementAnchor,
+    inner_of_last,
+    inner_of_last_after,
+    innermost,
+    outer_of,
+    outer_of_last,
+    outermost,
+)
+from deerflow.extensions.injection import inject_middlewares
+from deerflow.extensions.ordering import assert_ordering
+from deerflow.extensions.registry import LoadedExtensions
+
+
+def _anchors() -> dict[Placement, PlacementAnchor]:
+    from deerflow.agents.middlewares.clarification_middleware import ClarificationMiddleware
+    from deerflow.agents.middlewares.llm_error_handling_middleware import LLMErrorHandlingMiddleware
+    from deerflow.agents.middlewares.safety_finish_reason_middleware import SafetyFinishReasonMiddleware
+    from deerflow.agents.middlewares.terminal_response_middleware import TerminalResponseMiddleware
+
+    return {
+        # Outer of the retry loop, so one logical decision stays one event even
+        # when LLMErrorHandlingMiddleware retries underneath.
+        Placement.MODEL_LOGICAL: outer_of(LLMErrorHandlingMiddleware),
+        # Inner of every lead-agent request transform. Deliberately NOT
+        # innermost(): ClarificationMiddleware sits inner of this point today,
+        # and moving the anchor past it would change what "the final request"
+        # means.
+        Placement.MODEL_PHYSICAL: PlacementAnchor.of(
+            inner_of_last_after(
+                SafetyFinishReasonMiddleware,
+                after=(TerminalResponseMiddleware,),
+            ),
+            inner_of_last(TerminalResponseMiddleware),
+            outer_of_last(ClarificationMiddleware),
+            innermost(),
+        ),
+        Placement.TOOL_VISIBLE: outermost(),
+        # As close to the tool callable as the chain allows. Deliberately NOT
+        # inner_of(ToolErrorHandlingMiddleware): SkillToolPolicyMiddleware and
+        # ClarificationMiddleware are appended later and also wrap tool calls,
+        # so anchoring there left two wrappers inner of "raw" and the placement
+        # silently stopped meaning what it says.
+        #
+        # ClarificationMiddleware remains the one carve-out, the same shape as
+        # MODEL_PHYSICAL's above: it must stay last (it short-circuits the tool
+        # loop with Command(goto=END)), and it only ever intercepts
+        # ask_clarification — it does not transform the result of any tool that
+        # actually executes, so TOOL_RAW still sees raw results.
+        Placement.TOOL_RAW: PlacementAnchor.of(
+            outer_of_last(ClarificationMiddleware),
+            innermost(),
+        ),
+        Placement.STANDARD: PlacementAnchor.of(
+            outer_of(LLMErrorHandlingMiddleware),
+            innermost(),
+        ),
+    }
+
+
+class _AnchorTable(dict):
+    """Resolve the table lazily so importing this module stays cheap and
+    free of middleware import cycles."""
+
+    _loaded = False
+
+    def _ensure(self) -> None:
+        if not _AnchorTable._loaded:
+            self.update(_anchors())
+            _AnchorTable._loaded = True
+
+    def __getitem__(self, key):
+        self._ensure()
+        return dict.__getitem__(self, key)
+
+    def get(self, key, default=None):
+        self._ensure()
+        return dict.get(self, key, default)
+
+    def __iter__(self):
+        self._ensure()
+        return dict.__iter__(self)
+
+    def __len__(self):
+        self._ensure()
+        return dict.__len__(self)
+
+    def snapshot(self) -> dict[Placement, PlacementAnchor]:
+        """Return a populated plain-dict copy.
+
+        CPython's ``dict(subclass)`` fast path can copy the underlying storage
+        without calling this class's lazy ``__iter__`` or ``__len__`` hooks.
+        Callers that need a copy must therefore force resolution explicitly.
+        """
+        self._ensure()
+        return dict(self)
+
+
+PLACEMENT_ANCHORS = _AnchorTable()
+
+
+def _placement_anchors_for_scope(scope: AgentScope) -> dict[Placement, PlacementAnchor]:
+    if scope != AgentScope.SUBAGENT:
+        return PLACEMENT_ANCHORS
+
+    from deerflow.agents.middlewares.system_message_coalescing_middleware import SystemMessageCoalescingMiddleware
+
+    anchors = PLACEMENT_ANCHORS.snapshot()
+    anchors[Placement.MODEL_PHYSICAL] = PlacementAnchor.of(
+        inner_of_last(SystemMessageCoalescingMiddleware),
+        PLACEMENT_ANCHORS[Placement.MODEL_PHYSICAL],
+    )
+    return anchors
+
+
+def compose_with_extensions(
+    middlewares: Sequence[object],
+    scope: AgentScope,
+    ctx: AgentBuildContext,
+    extensions: LoadedExtensions | None = None,
+) -> list[object]:
+    """Merge extension contributions into a fully-assembled stack and validate.
+
+    Call this once, at the end of the outermost builder. Calling it inside the
+    base builder would place MODEL_PHYSICAL contributions above the ~18
+    lead-specific middlewares appended afterwards.
+    """
+    from deerflow.extensions import get_loaded_extensions, record_runtime_diagnostic
+
+    resolved = extensions if extensions is not None else get_loaded_extensions()
+    result = list(middlewares)
+
+    if not resolved.has_middleware_contributors:
+        assert_ordering(result, {})
+        return result
+
+    result, provenance, diagnostics = inject_middlewares(
+        result,
+        _placement_anchors_for_scope(scope),
+        scope,
+        ctx,
+        resolved,
+        isolation_diagnostic_sink=record_runtime_diagnostic,
+    )
+    _record_diagnostics(diagnostics)
+    assert_ordering(result, provenance)
+    return result
+
+
+def _record_diagnostics(diagnostics) -> None:
+    """Diagnostics raised while building a stack are logged by their producers;
+    this hook exists so the Gateway can also surface them on app.state."""
+    from deerflow.extensions import record_runtime_diagnostics
+
+    record_runtime_diagnostics(diagnostics)
+
+
+def middleware_implements(middleware: object, hook_name: str) -> bool:
+    """Whether ``middleware`` actually overrides ``hook_name``.
+
+    Placement guarantees are per hook chain, not per list index: a middleware's
+    position only means something on the chains it participates in. This is how
+    the guarantee tests tell participation from mere presence.
+    """
+    from langchain.agents.middleware import AgentMiddleware
+
+    own = getattr(type(middleware), hook_name, None)
+    base = getattr(AgentMiddleware, hook_name, None)
+    return own is not None and own is not base

--- a/backend/packages/harness/deerflow/runtime/goal.py
+++ b/backend/packages/harness/deerflow/runtime/goal.py
@@ -18,7 +18,7 @@ import threading
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langgraph.checkpoint.base import empty_checkpoint, uuid6
@@ -29,6 +29,9 @@ from deerflow.models import create_chat_model
 from deerflow.tracing import inject_langfuse_metadata
 from deerflow.utils.messages import message_to_text
 from deerflow.utils.time import now_iso
+
+if TYPE_CHECKING:
+    from deerflow_extension_api import ExtensionData
 
 logger = logging.getLogger(__name__)
 
@@ -277,6 +280,7 @@ async def evaluate_goal_completion(
     thread_id: str | None = None,
     user_id: str | None = None,
     deerflow_trace_id: str | None = None,
+    task_store: ExtensionData | None = None,
 ) -> GoalEvaluation:
     """Ask a small non-thinking model whether the active goal is satisfied.
 
@@ -320,9 +324,18 @@ async def evaluate_goal_completion(
         environment=_resolve_environment(),
         deerflow_trace_id=deerflow_trace_id,
     )
-    response = await model.ainvoke(
-        [SystemMessage(content=system_instruction), HumanMessage(content=user_content)],
-        config=invoke_config,
+    from deerflow_extension_api import SystemOperationKind
+
+    from deerflow.extensions.notify import observe_system_model_call
+
+    evaluator_messages = [SystemMessage(content=system_instruction), HumanMessage(content=user_content)]
+    response = await observe_system_model_call(
+        SystemOperationKind.GOAL,
+        messages=evaluator_messages,
+        model_name=model_name,
+        invoke_config=invoke_config,
+        invoke=lambda: model.ainvoke(evaluator_messages, config=invoke_config),
+        task_store=task_store,
     )
     return parse_goal_evaluation_response(_extract_response_text(response.content))
 

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -28,7 +28,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import lru_cache
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from langgraph.checkpoint.base import empty_checkpoint
 from langgraph.types import Overwrite
@@ -84,6 +84,9 @@ from deerflow.workspace_changes.types import WorkspaceSnapshot
 from .manager import RunManager, RunRecord, RunStartOutcome
 from .naming import resolve_root_run_name
 from .schemas import RunStatus
+
+if TYPE_CHECKING:
+    from deerflow_extension_api import ExtensionData
 
 logger = logging.getLogger(__name__)
 
@@ -226,6 +229,17 @@ async def _produced_output_paths(
 _LARGE_FILE_TOOL_NAMES = frozenset({"str_replace", "write_file"})
 _LARGE_FILE_TOOL_BATCH_SIZE = 32
 
+# Shared ceiling on each extension task-lifecycle notification in run_agent —
+# one budget for the whole start notification, one for the whole stop.
+# Extension code is arbitrary; without a bound, one hung contributor keeps the
+# run's task alive indefinitely and blocks RunManager.shutdown's drain.
+#
+# This does NOT guarantee a shutdown cannot miss the run: that drain spends one
+# 5s deadline across stop_heartbeat and every other step of run_agent's finally,
+# so a stall here can still consume whatever is left of it. The bound only
+# converts "hangs forever" into "costs at most this much".
+_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS = 3.0
+
 
 @dataclass
 class _LargeFileToolChunkBatcher:
@@ -349,6 +363,7 @@ def _build_runtime_context(
     run_id: str,
     caller_context: Any | None,
     app_config: AppConfig | None = None,
+    task_store: Any | None = None,
 ) -> dict[str, Any]:
     """Build the dict that becomes ``ToolRuntime.context`` for the run.
 
@@ -370,6 +385,13 @@ def _build_runtime_context(
             runtime_ctx.setdefault(key, value)
     if app_config is not None:
         runtime_ctx["app_config"] = app_config
+    if task_store is not None:
+        from deerflow_extension_api import EXTENSION_TASK_STORE_KEY
+
+        # Host-owned key. Extensions read this through
+        # task_store_from_runtime() and keep their objects inside the store,
+        # so two extensions cannot collide on a runtime-context key.
+        runtime_ctx[EXTENSION_TASK_STORE_KEY] = task_store
     return runtime_ctx
 
 
@@ -519,6 +541,19 @@ async def run_agent(
 
     run_id = record.run_id
     thread_id = record.thread_id
+
+    from deerflow_extension_api import ExtensionData, TaskInfo
+
+    from deerflow.extensions import get_loaded_extensions
+    from deerflow.extensions.notify import lead_task_id, lead_task_outcome, notify_task_start, notify_task_stop
+
+    _extensions = get_loaded_extensions()
+    _task_store: ExtensionData | None = None
+    _task_info: TaskInfo | None = None
+    # Set only if a cancellation lands inside the task-stop notification; the
+    # finally re-raises it once the remaining cleanup has run.
+    deferred_stop_interrupt: BaseException | None = None
+
     pre_run_checkpoint_id: str | None = None
     pre_run_workspace_snapshot: WorkspaceSnapshot | None = None
     workspace_changes_user_id: str | None = None
@@ -631,6 +666,30 @@ async def run_agent(
             return
         started = True
 
+        task_id = lead_task_id(run_id)
+        if _extensions.needs_task_store:
+            _task_store = ExtensionData(task_id)
+
+        if _extensions.has_task_lifecycle:
+            # After the startup barrier, so "start" means the agent really is
+            # going to run: the gateway deliberately enters run_agent for
+            # already-aborted runs, and those return above. Also after
+            # wait_for_prior_finalizing, so an interrupt-strategy replacement
+            # cannot announce its start before the run it replaced announces
+            # its stop. Still before _build_runtime_context(), which is what
+            # installs the store into the runtime context.
+            _task_info = TaskInfo(
+                task_id=task_id,
+                run_id=run_id,
+                thread_id=thread_id,
+                kind="lead",
+                agent_name=record.assistant_id,
+            )
+            assert _task_store is not None
+            # Bounded for the same reason the stop side is: a contributor that
+            # hangs here would hang the run before it streams a single token.
+            await notify_task_start(_extensions, _task_store, _task_info, timeout=_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS)
+
         if not record.ownership_lost and thread_store is not None:
             try:
                 await thread_store.update_status(thread_id, "running")
@@ -698,7 +757,7 @@ async def run_agent(
         # access thread-level data. langgraph-cli does this automatically; we must do it
         # manually here because we drive the graph through ``agent.astream(config=...)``
         # without passing the official ``context=`` parameter.
-        runtime_ctx = _build_runtime_context(thread_id, run_id, config.get("context"), ctx.app_config)
+        runtime_ctx = _build_runtime_context(thread_id, run_id, config.get("context"), ctx.app_config, _task_store)
         incoming_metadata = config.get("metadata") if isinstance(config.get("metadata"), dict) else {}
         deerflow_trace_id = resolve_deerflow_trace_id(incoming_metadata.get(DEERFLOW_TRACE_METADATA_KEY))
         if deerflow_trace_id:
@@ -926,6 +985,7 @@ async def run_agent(
                 abort_event=record.abort_event,
                 user_id=resolve_runtime_user_id(runtime),
                 deerflow_trace_id=deerflow_trace_id,
+                task_store=_task_store,
             )
             if continuation_input is None or record.abort_event.is_set():
                 break
@@ -1173,11 +1233,60 @@ async def run_agent(
                 await ctx.on_run_completed(record)
             except Exception:
                 logger.warning("Run completion hook failed for %s (non-fatal)", run_id, exc_info=True)
+        if _task_info is not None and _task_store is not None:
+            # Placement is pinned on both sides.
+            #
+            # After every persistence step above: extension code is arbitrary
+            # and slow, so running it earlier would eat RunManager.shutdown's
+            # drain budget ahead of the checkpoint and journal flushes, and a
+            # cancellation raised at this await would skip them entirely. It
+            # also means an extension reading run state sees final values
+            # rather than a still-running snapshot.
+            #
+            # Before `set_finalizing(False)`: wait_for_prior_finalizing polls
+            # exactly that flag, so clearing it first would let an
+            # interrupt-strategy replacement run pass the barrier and fire its
+            # on_task_start while this run's on_task_stop is still pending —
+            # an extension keying state by thread_id would see two overlapping
+            # tasks. `publish_end` is an await, so it is enough for the clear
+            # to merely precede this notification for that race to open.
+            #
+            # The cost of sitting here rather than dead last: a slow
+            # contributor delays both the SSE end frame and the finalizing
+            # clear — i.e. a same-thread replacement run's barrier — by up to
+            # the timeout below. That is the accepted trade: a bounded delay
+            # beats an ordering violation extensions cannot defend against.
+            try:
+                await notify_task_stop(
+                    _extensions,
+                    _task_store,
+                    _task_info,
+                    lead_task_outcome(aborted=record.abort_event.is_set() or record.status == RunStatus.interrupted, succeeded=record.status == RunStatus.success),
+                    timeout=_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                # notify_task_stop is fail-open internally; this is the outer
+                # belt for anything it cannot anticipate, because the steps
+                # below must run.
+                logger.warning("Extension task-stop notification failed for run %s (non-fatal)", run_id, exc_info=True)
+            except BaseException as exc:
+                # A cancellation delivered at that await must not strand the
+                # steps below. Leaving record.finalizing set wedges every later
+                # run on this thread in wait_for_prior_finalizing, which has no
+                # overall bound; skipping publish_end leaves SSE consumers
+                # waiting for an end frame that never comes. Re-raised after
+                # cleanup so the task still ends up cancelled.
+                deferred_stop_interrupt = exc
+                logger.warning("Extension task-stop notification interrupted for run %s; completing cleanup first", run_id)
+
         if record.finalizing:
             await run_manager.set_finalizing(run_id, False)
 
         await bridge.publish_end(run_id)
         asyncio.create_task(bridge.cleanup(run_id, delay=60))
+
+        if deferred_stop_interrupt is not None:
+            raise deferred_stop_interrupt
 
 
 # ---------------------------------------------------------------------------
@@ -1343,6 +1452,7 @@ async def _prepare_goal_continuation_input(
     abort_event: asyncio.Event | None = None,
     user_id: str | None = None,
     deerflow_trace_id: str | None = None,
+    task_store: ExtensionData | None = None,
 ) -> dict[str, Any] | None:
     """Evaluate the active goal and return a hidden continuation input if needed.
 
@@ -1423,6 +1533,7 @@ async def _prepare_goal_continuation_input(
             thread_id=thread_id,
             user_id=user_id,
             deerflow_trace_id=deerflow_trace_id,
+            task_store=task_store,
         )
         if abort_event is not None and abort_event.is_set():
             return None

--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -46,6 +46,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Shared ceiling on each extension task-lifecycle notification, mirroring the
+# lead site's constant in runtime/runs/worker.py. It matters more here: every
+# subagent execution in the process shares one isolated event loop, so a
+# contributor that blocks stalls sibling executions, not just its own.
+_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS = 3.0
+
 
 _previous_shutdown_isolated_subagent_loop = globals().get("_shutdown_isolated_subagent_loop")
 if callable(_previous_shutdown_isolated_subagent_loop):
@@ -788,6 +794,41 @@ class SubagentExecutor:
                 status=SubagentStatus.RUNNING,
                 started_at=datetime.now(),
             )
+        from deerflow_extension_api import ExtensionData, TaskInfo
+
+        from deerflow.extensions import get_loaded_extensions
+        from deerflow.extensions.notify import lead_task_id, notify_task_start, notify_task_stop, subagent_task_outcome
+
+        _extensions = get_loaded_extensions()
+        _task_store: ExtensionData | None = None
+        _task_info: TaskInfo | None = None
+        if _extensions.needs_task_store:
+            # The store belongs to this subagent task, whose identity exists
+            # even for direct invocations without a parent run.
+            _task_store = ExtensionData(result.task_id)
+
+        if _extensions.has_task_lifecycle and self.run_id:
+            # task_id lives on the result, not on self: it is either supplied by
+            # the caller's result_holder or generated in the else branch above.
+            _task_info = TaskInfo(
+                task_id=result.task_id,
+                run_id=self.run_id,
+                thread_id=self.thread_id or "",
+                kind="subagent",
+                parent_task_id=lead_task_id(self.run_id),
+                agent_name=self.config.name,
+            )
+            assert _task_store is not None
+        elif _extensions.has_task_lifecycle:
+            # A direct subagent still receives its task store, but no run_id
+            # means there is not enough identity to emit a valid lifecycle
+            # event or connect it to a parent lead task.
+            logger.debug(
+                "[trace=%s] Subagent %s has no run_id; skipping extension task lifecycle",
+                self.trace_id,
+                self.config.name,
+            )
+
         ai_messages = result.ai_messages
         if ai_messages is None:
             ai_messages = []
@@ -804,6 +845,13 @@ class SubagentExecutor:
 
         collector: SubagentTokenCollector | None = None
         try:
+            if _task_info is not None and _task_store is not None:
+                # Inside the try so the finally's stop is guaranteed to pair with
+                # it: a BaseException raised by a contributor here would
+                # otherwise escape _aexecute with a start already announced and
+                # no stop to close it.
+                await notify_task_start(_extensions, _task_store, _task_info, timeout=_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS)
+
             state, final_tools, deferred_setup = await self._build_initial_state(task)
             agent = self._create_agent(final_tools, deferred_setup=deferred_setup)
 
@@ -866,6 +914,10 @@ class SubagentExecutor:
             context["oauth_provider"] = self.oauth_provider
             context["oauth_id"] = self.oauth_id
             context["run_id"] = self.run_id
+            if _task_store is not None:
+                from deerflow_extension_api import EXTENSION_TASK_STORE_KEY
+
+                context[EXTENSION_TASK_STORE_KEY] = _task_store
             if self.channel_user_id:
                 context["channel_user_id"] = self.channel_user_id
             # Authorization identity: is_internal written unconditionally
@@ -1014,6 +1066,39 @@ class SubagentExecutor:
                 error=str(e),
                 token_usage_records=collector.snapshot_records() if collector is not None else None,
             )
+
+        finally:
+            if _task_info is not None and _task_store is not None:
+                # In `finally` so the exception path and the pre-stream cancel
+                # check's early `return` are both covered. The outcome is read
+                # off the terminal status rather than tracked in a flag, so
+                # every branch that sets a status is classified by construction
+                # — and success-keyed, so the branches that set NO status (a
+                # BaseException escaping `except Exception`, leaving the result
+                # RUNNING) degrade to FAILED instead of reporting a clean
+                # completion. Same rule as the lead side, so an extension reads
+                # one classification for both.
+                try:
+                    await notify_task_stop(
+                        _extensions,
+                        _task_store,
+                        _task_info,
+                        subagent_task_outcome(
+                            cancelled=result.status is SubagentStatus.CANCELLED,
+                            succeeded=result.status is SubagentStatus.COMPLETED,
+                        ),
+                        timeout=_EXTENSION_TASK_NOTIFY_TIMEOUT_SECONDS,
+                    )
+                except Exception:
+                    # Bounded and guarded for the same reasons as the lead site:
+                    # every subagent in the process shares one event loop, so an
+                    # unbounded contributor stalls sibling executions too.
+                    logger.warning(
+                        "[trace=%s] Extension task-stop notification failed for subagent %s (non-fatal)",
+                        self.trace_id,
+                        self.config.name,
+                        exc_info=True,
+                    )
 
         return result
 

--- a/backend/packages/harness/pyproject.toml
+++ b/backend/packages/harness/pyproject.toml
@@ -7,6 +7,11 @@ dependencies = [
     "agent-client-protocol>=0.4.0",
     "agent-sandbox>=0.0.30",
     "croniter>=6.0.0",
+    # Exact pin by design (extension-system version contract): the host pins
+    # the contract version it implements, extensions declare ranges. A range
+    # here would let pip resolve a newer contract package than this harness
+    # implements, making newer extensions look supported at runtime.
+    "deerflow-extension-api==0.1.0",
     "dotenv>=0.9.9",
     "exa-py>=1.0.0",
     "httpx>=0.28.0",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,7 +77,8 @@ index-url = "https://pypi.org/simple"
 override-dependencies = ["websockets==16.0"]
 
 [tool.uv.workspace]
-members = ["packages/harness"]
+members = ["packages/harness", "packages/extension-api"]
 
 [tool.uv.sources]
 deerflow-harness = { workspace = true }
+deerflow-extension-api = { workspace = true }

--- a/backend/tests/test_extension_api_contracts.py
+++ b/backend/tests/test_extension_api_contracts.py
@@ -1,0 +1,248 @@
+"""Tests for the extension contract surface.
+
+The contracts carry two compatibility promises that are easy to break by
+accident and impossible to catch at runtime later: every Protocol method has a
+default implementation, and every dataclass field has a default. Both are
+asserted here.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+
+import pytest
+from deerflow_extension_api import (
+    AgentBuildContext,
+    AgentScope,
+    ExtensionData,
+    ExtensionInstall,
+    ExtensionRegistry,
+    ExtensionRuntimeDeps,
+    ExtensionService,
+    HostPolicySnapshot,
+    MiddlewareContributor,
+    MiddlewarePlacement,
+    Placement,
+    SystemModelCallObserver,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+    TaskInfo,
+    TaskLifecycleContributor,
+    TaskOutcome,
+    extension,
+)
+from deerflow_extension_api.runtime_bridge import (
+    EXTENSION_TASK_STORE_KEY,
+    task_store_from_runtime,
+)
+
+
+def test_placement_members_cover_both_axes():
+    assert Placement.MODEL_LOGICAL.value == "model_logical"
+    assert Placement.MODEL_PHYSICAL.value == "model_physical"
+    assert Placement.TOOL_VISIBLE.value == "tool_visible"
+    assert Placement.TOOL_RAW.value == "tool_raw"
+    assert Placement.STANDARD.value == "standard"
+
+
+def test_agent_scope_both_is_union():
+    assert AgentScope.BOTH == AgentScope.LEAD | AgentScope.SUBAGENT
+    assert AgentScope.LEAD in AgentScope.BOTH
+
+
+def test_middleware_placement_defaults():
+    p = MiddlewarePlacement(middleware=object(), placement=Placement.STANDARD)
+    assert p.scope is AgentScope.BOTH
+    assert p.order == 0
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        HostPolicySnapshot,
+        AgentBuildContext,
+        TaskInfo,
+        SystemModelRequest,
+        SystemModelResult,
+        ExtensionRuntimeDeps,
+        MiddlewarePlacement,
+    ],
+)
+def test_every_dataclass_is_frozen(cls):
+    assert dataclasses.is_dataclass(cls)
+    assert cls.__dataclass_params__.frozen, f"{cls.__name__} must be frozen"
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [HostPolicySnapshot, TaskInfo, SystemModelRequest, SystemModelResult],
+)
+def test_additive_dataclasses_are_constructible_with_required_fields_only(cls):
+    """Fields added later must carry defaults, or old extensions break on upgrade.
+
+    HostPolicySnapshot and the two snapshots are host-constructed and fully
+    optional; TaskInfo has a required identity core and optional remainder.
+    ExtensionRuntimeDeps and AgentBuildContext get their own dedicated tests
+    below instead of joining this parametrization, because "constructible with
+    no arguments" does not by itself prove any field's *value* still defaults
+    correctly — see test_extension_runtime_deps_optional_fields_keep_their_defaults
+    and test_agent_build_context_optional_fields_keep_their_defaults.
+    """
+    if cls is HostPolicySnapshot:
+        assert cls() is not None
+    elif cls is TaskInfo:
+        info = cls(task_id="t", run_id="r", thread_id="th", kind="lead")
+        assert info.parent_task_id is None
+        assert info.agent_name is None
+        assert info.resumed is False
+    else:
+        assert cls() is not None
+
+
+def test_extension_runtime_deps_optional_fields_keep_their_defaults():
+    """ExtensionRuntimeDeps is fully optional; every field must default.
+
+    Unlike the parametrized test above, which only proves the constructor
+    takes no required arguments, this asserts each field's actual default
+    value — removing any one of the three defaults must make this fail.
+    """
+    deps = ExtensionRuntimeDeps()
+    assert deps.app_store is None
+    assert isinstance(deps.policy, HostPolicySnapshot)
+    assert deps.session_factory is None
+
+
+def test_agent_build_context_optional_fields_keep_their_defaults():
+    """AgentBuildContext has one required field (scope); the rest must default.
+
+    Unlike the fully-optional dataclasses above, scope is legitimately
+    required, so this is not folded into the parametrized test above — it
+    would misrepresent the required/optional split this suite is meant to
+    document.
+    """
+    ctx = AgentBuildContext(scope=AgentScope.LEAD)
+    assert ctx.agent_name is None
+    assert ctx.model_name is None
+    assert isinstance(ctx.policy, HostPolicySnapshot)
+
+
+@pytest.mark.parametrize(
+    "protocol",
+    [
+        ExtensionRegistry,
+        ExtensionService,
+        MiddlewareContributor,
+        TaskLifecycleContributor,
+        SystemModelCallObserver,
+    ],
+)
+def test_every_protocol_method_has_a_default_implementation(protocol):
+    """Adding a method to a Protocol is only additive when it has a default.
+
+    Without this, shipping a new contract method breaks every already-released
+    extension that does not implement it.
+    """
+    checked = 0
+    for name, member in vars(protocol).items():
+        if name.startswith("_") or not inspect.isfunction(member):
+            continue
+        checked += 1
+        body = inspect.getsource(member).split("\n", 1)[1]
+        assert "return" in body, f"{protocol.__name__}.{name} has no default implementation. Adding a contract method is only additive when it returns a default; otherwise every already-released extension breaks on upgrade."
+    assert checked > 0, f"{protocol.__name__} declared no methods to check"
+
+
+def test_contributor_defaults_return_empty():
+    class _Bare:
+        pass
+
+    bare = _Bare()
+    assert MiddlewareContributor.contribute_middlewares(bare, ExtensionData("app"), AgentBuildContext(scope=AgentScope.LEAD)) == ()
+
+
+def test_router_registration_is_eager_not_a_lazy_contributor_contract():
+    """Routes are concrete registration-time values.
+
+    Runtime capabilities arrive later through ExtensionRuntimeDeps and route
+    handlers resolve them per request with FastAPI dependencies. Advertising a
+    contribute_routers(app_store) callback would encode the opposite lifecycle.
+    """
+    import deerflow_extension_api
+
+    assert "RouterContributor" not in deerflow_extension_api.__all__
+    assert not hasattr(deerflow_extension_api, "RouterContributor")
+
+
+def test_task_store_from_runtime_reads_the_host_key():
+    class _Runtime:
+        def __init__(self, context):
+            self.context = context
+
+    store = ExtensionData("task-1")
+    assert task_store_from_runtime(_Runtime({EXTENSION_TASK_STORE_KEY: store})) is store
+
+
+def test_task_store_from_runtime_returns_none_on_missing_or_wrong_shape():
+    class _Runtime:
+        def __init__(self, context):
+            self.context = context
+
+    assert task_store_from_runtime(None) is None
+    assert task_store_from_runtime(_Runtime({})) is None
+    assert task_store_from_runtime(_Runtime("not-a-mapping")) is None
+    assert task_store_from_runtime(_Runtime({EXTENSION_TASK_STORE_KEY: "wrong type"})) is None
+
+
+def test_extension_decorator_stamps_api_requirement():
+    @extension(api="0.1", name="demo")
+    def install(registry, config):
+        return None
+
+    assert install.__deerflow_api__ == "0.1"
+    assert install.__deerflow_name__ == "demo"
+
+
+def test_task_outcome_members():
+    assert {o.value for o in TaskOutcome} == {"completed", "aborted", "failed"}
+
+
+def test_system_operation_kind_members():
+    assert {k.value for k in SystemOperationKind} == {"goal", "memory", "title", "summarization"}
+
+
+def test_registry_and_install_alias_are_part_of_the_public_surface():
+    """Independent extensions annotate install(registry, config) against the
+    contract package alone — importing the host's concrete registry would pin
+    them to the harness release cadence and advertise host-only machinery."""
+    import typing
+
+    import deerflow_extension_api
+
+    assert "ExtensionRegistry" in deerflow_extension_api.__all__
+    assert "ExtensionInstall" in deerflow_extension_api.__all__
+    parameters, return_type = typing.get_args(ExtensionInstall)
+    assert parameters[0] is ExtensionRegistry, "install()'s first argument must be the public registry contract"
+
+
+def test_harness_pins_the_contract_package_exactly():
+    """The version contract (extension-system design): the host pins the
+    contract package exactly, extensions use ranges. A range here would let an
+    older harness resolve a newer 1.x contract package — API_VERSION would
+    then come from the upgraded package and newer extensions would look
+    supported against a host whose registry/placements/hook pipeline still
+    implements the older contract. The pin makes pip reject that skew at
+    install time."""
+    import tomllib
+    from importlib.metadata import version
+    from pathlib import Path
+
+    from packaging.requirements import Requirement
+
+    pyproject = Path(__file__).parent.parent / "packages" / "harness" / "pyproject.toml"
+    dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+    requirement = next(Requirement(dep) for dep in dependencies if Requirement(dep).name == "deerflow-extension-api")
+
+    expected = f"=={version('deerflow-extension-api')}"
+    assert str(requirement.specifier) == expected, f"the host must pin deerflow-extension-api exactly ({expected}); a range lets pip resolve a contract newer than the host implements"

--- a/backend/tests/test_extension_api_state.py
+++ b/backend/tests/test_extension_api_state.py
@@ -1,0 +1,91 @@
+"""Tests for ExtensionData, the per-scope typed store handed to extensions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from deerflow_extension_api import ExtensionData
+
+
+@dataclass
+class _Counter:
+    value: int = 0
+
+
+@dataclass
+class _Other:
+    name: str = ""
+
+
+def test_get_returns_none_when_absent():
+    store = ExtensionData("task-1")
+    assert store.get(_Counter) is None
+
+
+def test_set_then_get_roundtrips():
+    store = ExtensionData("task-1")
+    store.set(_Counter(value=7))
+    got = store.get(_Counter)
+    assert got is not None
+    assert got.value == 7
+
+
+def test_get_or_init_creates_once():
+    store = ExtensionData("task-1")
+    calls = []
+
+    def _init() -> _Counter:
+        calls.append(1)
+        return _Counter(value=1)
+
+    first = store.get_or_init(_Counter, _init)
+    second = store.get_or_init(_Counter, _init)
+    assert first is second
+    assert calls == [1]
+
+
+def test_types_are_isolated():
+    store = ExtensionData("task-1")
+    store.set(_Counter(value=1))
+    store.set(_Other(name="x"))
+    assert store.get(_Counter).value == 1
+    assert store.get(_Other).name == "x"
+
+
+def test_remove_returns_and_clears():
+    store = ExtensionData("task-1")
+    store.set(_Counter(value=3))
+    removed = store.remove(_Counter)
+    assert removed.value == 3
+    assert store.get(_Counter) is None
+
+
+def test_scope_id_is_exposed():
+    store = ExtensionData("run-42")
+    assert store.scope_id == "run-42"
+
+
+def test_stores_are_independent():
+    a = ExtensionData("task-a")
+    b = ExtensionData("task-b")
+    a.set(_Counter(value=1))
+    assert b.get(_Counter) is None
+
+
+def test_api_package_does_not_import_deerflow():
+    """The API package must stay independent of the host so extensions can
+    depend on it alone. A `deerflow` import here would silently couple every
+    extension to the harness release cadence."""
+    import pathlib
+
+    import deerflow_extension_api
+
+    root = pathlib.Path(deerflow_extension_api.__file__).parent
+    offenders = []
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if stripped.startswith(("import deerflow", "from deerflow")) and not stripped.startswith(("import deerflow_extension_api", "from deerflow_extension_api")):
+                offenders.append(f"{path.name}:{lineno}: {stripped}")
+    assert offenders == [], "deerflow-extension-api must not import deerflow: " + "; ".join(offenders)

--- a/backend/tests/test_extension_config.py
+++ b/backend/tests/test_extension_config.py
@@ -1,0 +1,110 @@
+"""Tests for extension configuration and the process-wide singleton."""
+
+from __future__ import annotations
+
+import pytest
+
+from deerflow.config.app_config import AppConfig
+from deerflow.config.reload_boundary import STARTUP_ONLY_FIELDS
+from deerflow.extensions import (
+    EMPTY_EXTENSIONS,
+    ExtensionRegistry,
+    get_loaded_extensions,
+    reset_loaded_extensions,
+    set_loaded_extensions,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    reset_loaded_extensions()
+    yield
+    reset_loaded_extensions()
+
+
+class _Marker:
+    """Sentinel written into an app_store to detect state leaking across resets."""
+
+    def __init__(self, tag: str = "") -> None:
+        self.tag = tag
+
+
+# AppConfig.sandbox has no default (see app_config.py's
+# `_drop_null_config_sections`: "Required sections without a default
+# (sandbox) intentionally still error when null"), so every AppConfig
+# construction below supplies it, matching the pattern already used in
+# test_app_config_reload.py.
+_SANDBOX = {"sandbox": {"use": "deerflow.sandbox.local:LocalSandboxProvider"}}
+
+
+def test_app_config_defaults_to_no_plugins():
+    assert AppConfig.model_validate(_SANDBOX).plugins == []
+
+
+def test_app_config_parses_plugin_entries():
+    config = AppConfig.model_validate(
+        {
+            **_SANDBOX,
+            "plugins": [
+                {"use": "acme_observability:install", "config": {"enabled": True}},
+                {"use": "acme_policy:install", "required": True},
+            ],
+        }
+    )
+    assert [e.use for e in config.plugins] == ["acme_observability:install", "acme_policy:install"]
+    assert config.plugins[0].config == {"enabled": True}
+    assert config.plugins[0].required is False
+    assert config.plugins[1].required is True
+
+
+def test_new_field_does_not_disturb_the_existing_extensions_field():
+    """AppConfig.extensions is a pre-existing, unrelated field (MCP servers,
+    skills, config-declared middlewares) backed by extensions_config.json.
+    The plugin list is deliberately a separate top-level key: that file is
+    writable through an HTTP endpoint, and a code-loading list must not be."""
+    config = AppConfig.model_validate({**_SANDBOX, "plugins": [{"use": "a:install"}]})
+    assert config.plugins[0].use == "a:install"
+    assert hasattr(config.extensions, "mcp_servers")
+    assert hasattr(config.extensions, "middlewares")
+
+
+def test_plugins_is_registered_as_startup_only():
+    """Plugins load once in create_app(); a config.yaml edit needs a restart.
+    Registering here is what surfaces that to operators."""
+    assert "plugins" in STARTUP_ONLY_FIELDS
+    assert "restart" in STARTUP_ONLY_FIELDS["plugins"].lower()
+
+
+def test_singleton_defaults_to_empty():
+    loaded = get_loaded_extensions()
+    assert loaded.has_middleware_contributors is False
+    assert loaded.has_task_lifecycle is False
+    assert loaded.has_system_model_observers is False
+    assert loaded.services == ()
+    assert loaded.routers == ()
+
+
+def test_singleton_roundtrips():
+    loaded = ExtensionRegistry().build()
+    set_loaded_extensions(loaded)
+    assert get_loaded_extensions() is loaded
+
+
+def test_reset_gives_a_fresh_instance():
+    """Reset must not hand back a shared object. EMPTY_EXTENSIONS owns a
+    mutable app_store, so resetting to it would carry writes forward."""
+    populated = ExtensionRegistry().build()
+    set_loaded_extensions(populated)
+    reset_loaded_extensions()
+    after = get_loaded_extensions()
+    assert after is not populated
+    assert after is not EMPTY_EXTENSIONS
+    assert after.has_task_lifecycle is False
+
+
+def test_reset_does_not_leak_app_store_writes():
+    """The regression the fresh-build reset exists to prevent."""
+    reset_loaded_extensions()
+    get_loaded_extensions().app_store.set(_Marker("dirty"))
+    reset_loaded_extensions()
+    assert get_loaded_extensions().app_store.get(_Marker) is None

--- a/backend/tests/test_extension_gateway_wiring.py
+++ b/backend/tests/test_extension_gateway_wiring.py
@@ -1,0 +1,936 @@
+"""Tests for Gateway-side extension wiring: routers, services, policy."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from deerflow_extension_api import ExtensionRuntimeDeps, HostPolicySnapshot
+from fastapi import WebSocket
+
+from deerflow.config.app_config import AppConfig
+from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.extensions.gateway import include_contributed_routers, project_host_policy, start_services, stop_services
+from deerflow.extensions.registry import ExtensionRegistry
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_diagnostics():
+    from deerflow.extensions import reset_runtime_diagnostics
+
+    reset_runtime_diagnostics()
+    yield
+    reset_runtime_diagnostics()
+
+
+def _app_config() -> AppConfig:
+    # AppConfig.sandbox has no default (`use` is required), so a bare
+    # AppConfig() always fails pydantic validation in this repo — the same
+    # deviation Tasks 5 and 9 hit.
+    return AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"))
+
+
+class _Service:
+    def __init__(self, *, fail_start: bool = False, fail_stop: bool = False) -> None:
+        self.started = False
+        self.stopped = False
+        self.deps: ExtensionRuntimeDeps | None = None
+        self._fail_start = fail_start
+        self._fail_stop = fail_stop
+
+    async def start(self, deps):
+        if self._fail_start:
+            raise ValueError("start exploded")
+        self.started = True
+        self.deps = deps
+
+    async def stop(self):
+        if self._fail_stop:
+            raise ValueError("stop exploded")
+        self.stopped = True
+
+
+def _extensions(*services):
+    registry = ExtensionRegistry()
+    for index, service in enumerate(services):
+        with registry.attributed_to(f"ext{index}:install"):
+            registry.service(service)
+    return registry.build()
+
+
+def test_policy_projection_reads_only_the_declared_fields():
+    """AppConfig must not leak into the extension API — extensions see a narrow,
+    additive projection instead."""
+    policy = project_host_policy(_app_config())
+    assert isinstance(policy, HostPolicySnapshot)
+    assert policy.token_budget_enabled in (True, False)
+
+
+def test_policy_projection_survives_a_config_without_the_sections():
+    """The projection is read with getattr defaults on purpose: a host that has
+    not configured token_budget/subagents must not crash extension startup."""
+    policy = project_host_policy(object())
+    assert policy.token_budget_enabled is False
+    assert policy.max_total_tokens is None
+
+
+def test_services_start_with_deps():
+    service = _Service()
+    extensions = _extensions(service)
+    asyncio.run(start_services(extensions, _app_config(), session_factory=None))
+    assert service.started is True
+    assert service.deps.app_store is extensions.app_store
+
+
+def test_start_failure_is_fail_open():
+    """A failed observability service must not stop the Gateway from starting."""
+    bad, good = _Service(fail_start=True), _Service()
+    extensions = _extensions(bad, good)
+    diagnostics = asyncio.run(start_services(extensions, _app_config(), session_factory=None))
+    assert good.started is True
+    assert any(d.level == "error" for d in diagnostics)
+
+
+def test_services_stop_in_reverse_order():
+    order: list[str] = []
+
+    class _Ordered(_Service):
+        def __init__(self, tag: str) -> None:
+            super().__init__()
+            self.tag = tag
+
+        async def stop(self):
+            order.append(self.tag)
+
+    extensions = _extensions(_Ordered("first"), _Ordered("second"))
+    asyncio.run(stop_services(extensions))
+    assert order == ["second", "first"]
+
+
+def test_stop_failure_does_not_block_shutdown():
+    """A Gateway that cannot shut down is worse than a lost observation."""
+    bad, good = _Service(fail_stop=True), _Service()
+    extensions = _extensions(bad, good)
+    diagnostics = asyncio.run(stop_services(extensions))
+    assert good.stopped is True
+    assert any(d.level == "error" for d in diagnostics)
+
+
+def test_stop_timeout_is_bounded():
+    class _Hangs(_Service):
+        async def stop(self):
+            await asyncio.sleep(60)
+
+    extensions = _extensions(_Hangs())
+    diagnostics = asyncio.run(stop_services(extensions, timeout_seconds=0.05))
+    assert any("timed out" in d.message for d in diagnostics)
+
+
+def test_stop_timeout_does_not_starve_later_services():
+    """The budget is per service, not shared: one hung service must not stop the
+    rest from getting their stop() called."""
+    hung_calls: list[str] = []
+
+    class _Hangs(_Service):
+        async def stop(self):
+            hung_calls.append("hung")
+            await asyncio.sleep(60)
+
+    good = _Service()
+    extensions = _extensions(good, _Hangs())
+    diagnostics = asyncio.run(stop_services(extensions, timeout_seconds=0.05))
+
+    assert hung_calls == ["hung"], "premise: the hung service really was reached first"
+    assert good.stopped is True, "a service after a hung one must still be stopped"
+    assert any("timed out" in d.message for d in diagnostics)
+
+
+def test_zero_services_is_a_no_op():
+    extensions = ExtensionRegistry().build()
+    assert asyncio.run(start_services(extensions, _app_config(), session_factory=None)) == []
+    assert asyncio.run(stop_services(extensions)) == []
+
+
+# --- router contribution ----------------------------------------------------
+
+
+def _router(prefix: str):
+    from fastapi import APIRouter
+
+    router = APIRouter(prefix=prefix)
+
+    @router.get("/ping")
+    def _ping():
+        return {"ok": True}
+
+    return router
+
+
+def _with_routers(*pairs):
+    registry = ExtensionRegistry()
+    for source, routers in pairs:
+        with registry.attributed_to(source):
+            registry.routers(routers)
+    return registry.build()
+
+
+def test_contributed_routers_are_mounted():
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    extensions = _with_routers(("ext0:install", [_router("/ext0")]))
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert diagnostics == []
+    assert TestClient(app).get("/ext0/ping").json() == {"ok": True}
+
+
+def test_mounted_router_paths_are_reported_with_attribution(caplog):
+    """Which URLs the Gateway just handed to third-party code is operational
+    information, not something an operator should have to read /openapi.json for."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    extensions = _with_routers(("ext0:install", [_router("/ext0")]), ("ext1:install", [_router("/ext1")]))
+
+    with caplog.at_level("INFO", logger="deerflow.extensions.gateway"):
+        assert include_contributed_routers(app, extensions) == []
+
+    assert "ext0:install -> /ext0/ping" in caplog.text
+    assert "ext1:install -> /ext1/ping" in caplog.text
+
+
+def test_a_rejected_router_is_not_reported_as_mounted(caplog):
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    # Same path twice: the second router loses conflict detection.
+    extensions = _with_routers(("ext0:install", [_router("/ext0")]), ("ext1:install", [_router("/ext0")]))
+
+    with caplog.at_level("INFO", logger="deerflow.extensions.gateway"):
+        diagnostics = include_contributed_routers(app, extensions)
+
+    assert [diagnostic.source for diagnostic in diagnostics] == ["ext1:install"]
+    assert "ext0:install -> /ext0/ping" in caplog.text
+    assert "ext1:install ->" not in caplog.text
+
+
+def test_zero_contributed_routers_stays_off_the_info_log(caplog):
+    from fastapi import FastAPI
+
+    with caplog.at_level("INFO", logger="deerflow.extensions.gateway"):
+        assert include_contributed_routers(FastAPI(), _with_routers()) == []
+
+    assert "Extension routers mounted" not in caplog.text
+
+
+def test_eager_router_resolves_runtime_deps_per_request():
+    """Routes exist before binding; request-time Depends reads live deps.
+
+    The extension owns the fail-closed readiness check because service startup
+    is intentionally fail-open. No route or dependency graph is rebuilt in the
+    Gateway lifespan.
+    """
+    from fastapi import APIRouter, Depends, FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    session_factory = object()
+
+    class _RoutedService(_Service):
+        def __init__(self) -> None:
+            super().__init__()
+            self.router = APIRouter(prefix="/runtime-bound")
+
+            @self.router.get("/status")
+            def _status(
+                deps: ExtensionRuntimeDeps = Depends(self.require_runtime),
+            ):
+                return {
+                    "scope_id": deps.app_store.scope_id,
+                    "same_deps": deps is self.deps,
+                    "same_session_factory": deps.session_factory is session_factory,
+                }
+
+        def require_runtime(self) -> ExtensionRuntimeDeps:
+            if self.deps is None:
+                raise HTTPException(status_code=503, detail="extension is not ready")
+            return self.deps
+
+        async def stop(self) -> None:
+            self.stopped = True
+            self.deps = None
+
+    service = _RoutedService()
+    registry = ExtensionRegistry()
+    with registry.attributed_to("routed:install"):
+        registry.service(service)
+        registry.routers([service.router])
+    extensions = registry.build()
+
+    app = FastAPI()
+    assert include_contributed_routers(app, extensions) == []
+    assert any(getattr(route, "path", None) == "/runtime-bound/status" for route in app.routes)
+
+    client = TestClient(app)
+    assert client.get("/runtime-bound/status").status_code == 503
+
+    assert asyncio.run(start_services(extensions, _app_config(), session_factory)) == []
+    assert client.get("/runtime-bound/status").json() == {
+        "scope_id": "app",
+        "same_deps": True,
+        "same_session_factory": True,
+    }
+
+    assert asyncio.run(stop_services(extensions)) == []
+    assert client.get("/runtime-bound/status").status_code == 503
+
+
+def test_a_prefix_conflict_names_the_responsible_extension():
+    """Router source attribution exists precisely so this diagnostic can name
+    who collided; without it an operator sees a duplicate path and no owner."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    extensions = _with_routers(
+        ("first:install", [_router("/shared")]),
+        ("second:install", [_router("/shared")]),
+    )
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "second:install"
+    assert "first:install" in diagnostics[0].message, "the diagnostic must name both sides"
+    assert "/shared/ping" in diagnostics[0].message
+
+
+def test_dynamic_routes_with_different_parameter_names_conflict_for_the_same_method():
+    """Starlette matches parameter values, not parameter names, so the earlier
+    route would shadow the later route for every request."""
+    from fastapi import APIRouter, FastAPI
+
+    first = APIRouter()
+    second = APIRouter()
+
+    @first.get("/items/{item_id}")
+    def _first(item_id: str):
+        return {"source": "first", "item_id": item_id}
+
+    @second.get("/items/{id}")
+    def _second(id: str):
+        return {"source": "second", "item_id": id}
+
+    app = FastAPI()
+    extensions = _with_routers(
+        ("first:install", [first]),
+        ("second:install", [second]),
+    )
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "second:install"
+    assert "first:install" in diagnostics[0].message
+    assert "/items/{id}" in diagnostics[0].message
+
+
+def test_contributed_dynamic_route_conflicts_with_equivalent_host_route():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/items/{item_id}")
+    def _host(item_id: str):
+        return {"item_id": item_id}
+
+    contributed = APIRouter()
+
+    @contributed.get("/items/{id}")
+    def _extension(id: str):
+        return {"item_id": id}
+
+    extensions = _with_routers(("extension:install", [contributed]))
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/items/{id}" in diagnostics[0].message
+
+
+def test_contributed_dynamic_route_conflicts_with_equivalent_host_converter_route():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/records/{record_id:int}")
+    def _host(record_id: int):
+        return {"record_id": record_id}
+
+    contributed = APIRouter()
+
+    @contributed.get("/records/{id:int}")
+    def _extension(id: int):
+        return {"record_id": id}
+
+    extensions = _with_routers(("extension:install", [contributed]))
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/records/{id:int}" in diagnostics[0].message
+
+
+def test_host_dynamic_route_conflicts_with_shadowed_contributed_static_route():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/items/{item_id}")
+    def _host(item_id: str):
+        return {"source": "host", "item_id": item_id}
+
+    contributed = APIRouter()
+
+    @contributed.get("/items/new")
+    def _extension():
+        return {"source": "extension"}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/items/new" in diagnostics[0].message
+
+
+def test_host_path_route_conflicts_with_shadowed_contributed_converter_route():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/records/{rest:path}")
+    def _host(rest: str):
+        return {"source": "host", "rest": rest}
+
+    contributed = APIRouter()
+
+    @contributed.get("/records/{id:int}")
+    def _extension(id: int):
+        return {"source": "extension", "id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/records/{id:int}" in diagnostics[0].message
+
+
+def test_host_mount_conflicts_with_a_route_below_its_prefix():
+    """A preceding Mount consumes every descendant before later routes."""
+    from fastapi import APIRouter, FastAPI
+    from starlette.applications import Starlette
+
+    app = FastAPI()
+    app.mount("/assets", Starlette())
+
+    contributed = APIRouter()
+
+    @contributed.get("/assets/{name}")
+    def _extension(name: str):
+        return {"name": name}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/assets/{name}" in diagnostics[0].message
+
+
+def test_host_root_mount_conflicts_with_every_contributed_route():
+    """Starlette normalizes Mount('/') to an empty route.path."""
+    from fastapi import APIRouter, FastAPI
+    from starlette.applications import Starlette
+
+    app = FastAPI()
+    app.mount("/", Starlette())
+
+    contributed = APIRouter()
+
+    @contributed.get("/extension")
+    def _extension():
+        return {"source": "extension"}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/extension" in diagnostics[0].message
+
+
+def test_host_dynamic_mount_conflicts_with_a_narrower_descendant_route():
+    from fastapi import APIRouter, FastAPI
+    from starlette.applications import Starlette
+
+    app = FastAPI()
+    app.mount("/users/{tenant}", Starlette())
+
+    contributed = APIRouter()
+
+    @contributed.get("/users/fixed/{id:int}")
+    def _extension(id: int):
+        return {"id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/users/fixed/{id:int}" in diagnostics[0].message
+
+
+def test_host_embedded_parameter_mount_conflicts_with_static_descendant():
+    from fastapi import APIRouter, FastAPI
+    from starlette.applications import Starlette
+
+    app = FastAPI()
+    app.mount("/pre{tenant}", Starlette())
+
+    contributed = APIRouter()
+
+    @contributed.get("/prefoo/bar")
+    def _extension():
+        return {"source": "extension"}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/prefoo/bar" in diagnostics[0].message
+
+
+def test_terminal_path_route_with_dynamic_prefix_shadows_narrower_route():
+    """A terminal :path converter consumes the candidate's remaining segments."""
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/{tenant}/{rest:path}")
+    def _host(tenant: str, rest: str):
+        return {"tenant": tenant, "rest": rest}
+
+    contributed = APIRouter()
+
+    @contributed.get("/fixed/{id:int}")
+    def _extension(id: int):
+        return {"id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/fixed/{id:int}" in diagnostics[0].message
+
+
+def test_terminal_path_route_does_not_shadow_a_candidate_without_a_remainder():
+    """The slash before Starlette's terminal :path parameter is required."""
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.get("/org/{tenant}/{rest:path}")
+    def _host(tenant: str, rest: str):
+        return {"source": "host", "tenant": tenant, "rest": rest}
+
+    contributed = APIRouter()
+
+    @contributed.get("/org/{id:int}")
+    def _extension(id: int):
+        return {"source": "extension", "id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert diagnostics == []
+    assert TestClient(app).get("/org/123").json() == {
+        "source": "extension",
+        "id": 123,
+    }
+
+
+def test_terminal_path_route_shadows_an_embedded_parameter_remainder():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/{tenant}/{rest:path}")
+    def _host(tenant: str, rest: str):
+        return {"tenant": tenant, "rest": rest}
+
+    contributed = APIRouter()
+
+    @contributed.get("/fixed/pre{id:int}")
+    def _extension(id: int):
+        return {"id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/fixed/pre{id:int}" in diagnostics[0].message
+
+
+def test_broad_dynamic_segments_shadow_static_and_narrower_segments():
+    from fastapi import APIRouter, FastAPI
+
+    app = FastAPI()
+
+    @app.get("/{first}/{second}")
+    def _host(first: str, second: str):
+        return {"first": first, "second": second}
+
+    contributed = APIRouter()
+
+    @contributed.get("/fixed/{id:int}")
+    def _extension(id: int):
+        return {"id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "extension:install"
+    assert "host" in diagnostics[0].message
+    assert "/fixed/{id:int}" in diagnostics[0].message
+
+
+def test_contributed_router_mount_is_rejected_instead_of_silently_ignored():
+    """FastAPI.include_router() does not copy Starlette Mount entries."""
+    from fastapi import APIRouter, FastAPI
+    from starlette.applications import Starlette
+
+    mounted = APIRouter()
+    mounted.mount("/assets", Starlette())
+
+    ordinary = APIRouter()
+
+    @ordinary.get("/assets/{name}")
+    def _ordinary(name: str):
+        return {"name": name}
+
+    app = FastAPI()
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(
+            ("mounted:install", [mounted]),
+            ("ordinary:install", [ordinary]),
+        ),
+    )
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "mounted:install"
+    assert "Mount" in diagnostics[0].message
+    assert any(getattr(route, "path", "") == "/assets/{name}" for route in app.routes), "a rejected Mount must not claim a route FastAPI never installed"
+
+
+def test_dynamic_routes_with_different_methods_do_not_conflict():
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    reads = APIRouter()
+    writes = APIRouter()
+
+    @reads.get("/items/{item_id}")
+    def _read(item_id: str):
+        return {"method": "GET", "item_id": item_id}
+
+    @writes.post("/items/{id}")
+    def _write(id: str):
+        return {"method": "POST", "item_id": id}
+
+    app = FastAPI()
+    extensions = _with_routers(
+        ("reads:install", [reads]),
+        ("writes:install", [writes]),
+    )
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert diagnostics == []
+    client = TestClient(app)
+    assert client.get("/items/42").json()["method"] == "GET"
+    assert client.post("/items/42").json()["method"] == "POST"
+
+
+def test_equivalent_websocket_and_http_routes_do_not_conflict():
+    from fastapi import APIRouter, FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+
+    @app.websocket("/live/{item_id}")
+    async def _live(websocket: WebSocket, item_id: str):
+        await websocket.accept()
+        await websocket.send_text(item_id)
+        await websocket.close()
+
+    contributed = APIRouter()
+
+    @contributed.get("/live/{id}")
+    def _read(id: str):
+        return {"item_id": id}
+
+    diagnostics = include_contributed_routers(
+        app,
+        _with_routers(("extension:install", [contributed])),
+    )
+
+    assert diagnostics == []
+    client = TestClient(app)
+    assert client.get("/live/http").json() == {"item_id": "http"}
+    with client.websocket_connect("/live/socket") as websocket:
+        assert websocket.receive_text() == "socket"
+
+
+def test_a_conflicting_router_is_not_mounted():
+    """First writer wins: silently shadowing an already-mounted path would make
+    which extension answers depend on load order."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    winner = _router("/shared")
+
+    loser = _router("/shared")
+    for route in loser.routes:
+        route.endpoint = lambda: {"ok": False}
+
+    extensions = _with_routers(("first:install", [winner]), ("second:install", [loser]))
+    include_contributed_routers(app, extensions)
+
+    assert TestClient(app).get("/shared/ping").json() == {"ok": True}
+
+
+def test_a_router_that_fails_to_mount_is_fail_open():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    extensions = _with_routers(("bad:install", ["not-a-router"]), ("good:install", [_router("/good")]))
+    diagnostics = include_contributed_routers(app, extensions)
+
+    assert any(d.source == "bad:install" and d.level == "error" for d in diagnostics)
+    assert any(getattr(r, "path", "") == "/good/ping" for r in app.routes), "a later router still mounts"
+
+
+def test_zero_routers_is_a_no_op():
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    before = len(app.routes)
+    assert include_contributed_routers(app, ExtensionRegistry().build()) == []
+    assert len(app.routes) == before
+
+
+@pytest.mark.parametrize("bad", [None, object()])
+def test_router_mounting_tolerates_junk(bad):
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    extensions = _with_routers(("bad:install", [bad]))
+    diagnostics = include_contributed_routers(app, extensions)
+    assert len(diagnostics) == 1
+    assert diagnostics[0].level == "error"
+
+
+# --- the real create_app wiring ---------------------------------------------
+#
+# Everything above tests the helpers in isolation, which passes even if
+# create_app never calls them. These drive the real app builder.
+
+
+def test_create_app_mounts_contributed_routers_and_records_diagnostics(monkeypatch):
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import reset_loaded_extensions
+
+    built = _with_routers(("ext0:install", [_router("/ext-e2e")]))
+    monkeypatch.setattr(extensions_module, "load_extensions", lambda plugins: (built, []))
+
+    reset_loaded_extensions()
+    try:
+        from fastapi.testclient import TestClient
+
+        from app.gateway.app import create_app
+
+        app = create_app()
+
+        assert app.state.extensions is built
+        assert app.state.extension_diagnostics == []
+        assert any(getattr(r, "path", "") == "/ext-e2e/ping" for r in app.routes), "the contributed route was not mounted"
+        # Not a 200: contributed routers sit behind the Gateway's auth
+        # middleware like every other route, which is the intended posture.
+        assert TestClient(app).get("/ext-e2e/ping").status_code != 404
+        assert extensions_module.get_loaded_extensions() is built, "the process-wide singleton must be set too"
+    finally:
+        reset_loaded_extensions()
+
+
+def test_create_app_exposes_runtime_diagnostics_through_its_live_state(monkeypatch):
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import (
+        Diagnostic,
+        record_runtime_diagnostic,
+        reset_loaded_extensions,
+    )
+
+    built = ExtensionRegistry().build()
+    monkeypatch.setattr(extensions_module, "load_extensions", lambda plugins: (built, []))
+
+    reset_loaded_extensions()
+    try:
+        from app.gateway.app import create_app
+
+        app = create_app()
+        diagnostic = Diagnostic.error("runtime:install", "middleware failed")
+
+        record_runtime_diagnostic(diagnostic)
+
+        assert app.state.extension_diagnostics == [diagnostic]
+    finally:
+        reset_loaded_extensions()
+
+
+def test_recreating_the_app_keeps_one_canonical_diagnostic_list(monkeypatch):
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import (
+        Diagnostic,
+        record_runtime_diagnostic,
+        reset_loaded_extensions,
+    )
+
+    built = ExtensionRegistry().build()
+    monkeypatch.setattr(extensions_module, "load_extensions", lambda plugins: (built, []))
+
+    reset_loaded_extensions()
+    try:
+        from app.gateway.app import create_app
+
+        first_app = create_app()
+        second_app = create_app()
+        diagnostic = Diagnostic.error("runtime:install", "middleware failed")
+
+        record_runtime_diagnostic(diagnostic)
+
+        assert first_app.state.extension_diagnostics is second_app.state.extension_diagnostics
+        assert first_app.state.extension_diagnostics == [diagnostic]
+    finally:
+        reset_loaded_extensions()
+
+
+def test_create_app_refuses_to_let_an_extension_shadow_a_host_route(monkeypatch):
+    """Contributed routers mount last, so a host path is always already claimed
+    and the extension is told it collided instead of silently winning."""
+    from fastapi import APIRouter
+
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import reset_loaded_extensions
+
+    hijack = APIRouter()
+
+    @hijack.get("/health")
+    def _hijacked():
+        return {"status": "hijacked"}
+
+    built = _with_routers(("evil:install", [hijack]))
+    monkeypatch.setattr(extensions_module, "load_extensions", lambda plugins: (built, []))
+
+    reset_loaded_extensions()
+    try:
+        from fastapi.testclient import TestClient
+
+        from app.gateway.app import create_app
+
+        app = create_app()
+
+        assert TestClient(app).get("/health").json()["service"] == "deer-flow-gateway"
+        assert any(d.source == "evil:install" and "/health" in d.message for d in app.state.extension_diagnostics)
+    finally:
+        reset_loaded_extensions()
+
+
+def test_create_app_survives_a_loader_that_raises(monkeypatch):
+    """A malformed plugins block must not stop the Gateway from booting."""
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import reset_loaded_extensions
+
+    def _boom(plugins):
+        raise RuntimeError("bad plugins config")
+
+    monkeypatch.setattr(extensions_module, "load_extensions", _boom)
+
+    reset_loaded_extensions()
+    try:
+        from app.gateway.app import create_app
+
+        app = create_app()
+        assert app.state.extensions is not None
+        assert app.state.extension_diagnostics == []
+    finally:
+        reset_loaded_extensions()
+
+
+def test_create_app_aborts_when_a_required_extension_fails(monkeypatch):
+    """`required: true` is fail-closed: the loader signals it with
+    ExtensionLoadError, and create_app must let that abort startup instead of
+    booting with zero extensions — silently dropping every other successfully
+    loaded extension along with the failed one would be worse than fail-open.
+    """
+    import deerflow.extensions as extensions_module
+    from deerflow.extensions import ExtensionLoadError, reset_loaded_extensions
+
+    def _required_boom(plugins):
+        raise ExtensionLoadError("required extension acme_policy:install failed to install")
+
+    monkeypatch.setattr(extensions_module, "load_extensions", _required_boom)
+
+    reset_loaded_extensions()
+    try:
+        from app.gateway.app import create_app
+
+        with pytest.raises(ExtensionLoadError):
+            create_app()
+    finally:
+        reset_loaded_extensions()

--- a/backend/tests/test_extension_injection.py
+++ b/backend/tests/test_extension_injection.py
@@ -1,0 +1,329 @@
+"""Tests for resolving semantic placements into real stack positions."""
+
+from __future__ import annotations
+
+from deerflow_extension_api import (
+    AgentBuildContext,
+    AgentScope,
+    MiddlewarePlacement,
+    Placement,
+)
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+
+from deerflow.extensions.anchors import PlacementAnchor, inner_of, innermost, outer_of, outermost
+from deerflow.extensions.injection import inject_middlewares
+from deerflow.extensions.registry import ExtensionRegistry
+
+
+class _Core:
+    """Stand-in for a core middleware; only its type matters for anchoring."""
+
+
+class _Retry(_Core):
+    pass
+
+
+class _Transform(_Core):
+    pass
+
+
+class _ToolError(_Core):
+    pass
+
+
+class _Last(_Core):
+    pass
+
+
+class _Probe(AgentMiddleware):
+    def __init__(self, tag: str) -> None:
+        super().__init__()
+        self.tag = tag
+
+
+class _NamedCoreMiddleware(AgentMiddleware):
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+
+class _FakeModel(FakeMessagesListChatModel):
+    def bind_tools(self, tools, **kwargs):  # type: ignore[override]
+        return self
+
+
+_ANCHORS = {
+    Placement.MODEL_LOGICAL: outer_of(_Retry),
+    Placement.MODEL_PHYSICAL: inner_of(_Transform),
+    Placement.TOOL_VISIBLE: outermost(),
+    Placement.TOOL_RAW: inner_of(_ToolError),
+    Placement.STANDARD: outer_of(_Last),
+}
+
+
+def _stack() -> list[object]:
+    return [_Retry(), _Transform(), _ToolError(), _Last()]
+
+
+def _contributor(*placements: MiddlewarePlacement):
+    class _C:
+        def contribute_middlewares(self, app_store, ctx):
+            return placements
+
+    return _C()
+
+
+def _extensions(*placements: MiddlewarePlacement):
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.middlewares(_contributor(*placements))
+    return registry.build()
+
+
+def _ctx() -> AgentBuildContext:
+    return AgentBuildContext(scope=AgentScope.LEAD)
+
+
+def _tags(stack: list[object]) -> list[str]:
+    from deerflow.extensions.isolation import IsolatedMiddleware
+
+    out = []
+    for m in stack:
+        target = m.inner if isinstance(m, IsolatedMiddleware) else m
+        out.append(target.tag if isinstance(target, _Probe) else type(target).__name__)
+    return out
+
+
+def test_outermost_lands_at_index_zero():
+    probe = _Probe("visible")
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(probe, Placement.TOOL_VISIBLE)),
+    )
+    assert _tags(result)[0] == "visible"
+
+
+def test_outer_of_lands_immediately_before_the_anchor():
+    probe = _Probe("decision")
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(probe, Placement.MODEL_LOGICAL)),
+    )
+    assert _tags(result) == ["decision", "_Retry", "_Transform", "_ToolError", "_Last"]
+
+
+def test_inner_of_lands_immediately_after_the_anchor():
+    probe = _Probe("attempt")
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(probe, Placement.MODEL_PHYSICAL)),
+    )
+    assert _tags(result) == ["_Retry", "_Transform", "attempt", "_ToolError", "_Last"]
+
+
+def test_all_four_placements_nest_correctly():
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(
+            MiddlewarePlacement(_Probe("visible"), Placement.TOOL_VISIBLE),
+            MiddlewarePlacement(_Probe("decision"), Placement.MODEL_LOGICAL),
+            MiddlewarePlacement(_Probe("attempt"), Placement.MODEL_PHYSICAL),
+            MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW),
+        ),
+    )
+    assert _tags(result) == [
+        "visible",
+        "decision",
+        "_Retry",
+        "_Transform",
+        "attempt",
+        "_ToolError",
+        "raw",
+        "_Last",
+    ]
+
+
+def test_multiple_extension_middlewares_can_compile_into_one_agent():
+    result, _, _ = inject_middlewares(
+        [],
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(
+            MiddlewarePlacement(_Probe("first"), Placement.TOOL_VISIBLE),
+            MiddlewarePlacement(_Probe("second"), Placement.TOOL_VISIBLE),
+        ),
+    )
+
+    agent = create_agent(
+        _FakeModel(responses=[AIMessage(content="ok")]),
+        middleware=result,
+    )
+
+    assert agent is not None
+
+
+def test_extension_middleware_names_avoid_langgraph_reserved_characters():
+    result, _, _ = inject_middlewares(
+        [],
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(_Probe("probe"), Placement.TOOL_VISIBLE)),
+    )
+
+    names = [middleware.name for middleware in result]
+    assert all(":" not in name and "|" not in name for name in names)
+
+
+def test_extension_middleware_names_are_stable_across_equivalent_builds():
+    def build_names() -> list[str]:
+        result, _, _ = inject_middlewares(
+            [],
+            _ANCHORS,
+            AgentScope.LEAD,
+            _ctx(),
+            _extensions(
+                MiddlewarePlacement(_Probe("first"), Placement.TOOL_VISIBLE),
+                MiddlewarePlacement(_Probe("second"), Placement.TOOL_VISIBLE),
+            ),
+        )
+        return [middleware.name for middleware in result]
+
+    assert build_names() == build_names()
+
+
+def test_extension_middleware_name_does_not_collide_with_the_core_stack():
+    placement = MiddlewarePlacement(_Probe("probe"), Placement.TOOL_VISIBLE)
+    first_result, _, _ = inject_middlewares(
+        [],
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(placement),
+    )
+    core = _NamedCoreMiddleware(first_result[0].name)
+
+    result, _, _ = inject_middlewares(
+        [core],
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(placement),
+    )
+
+    agent = create_agent(
+        _FakeModel(responses=[AIMessage(content="ok")]),
+        middleware=result,
+    )
+    assert agent is not None
+
+
+def test_scope_filters_out_non_matching_contributions():
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.SUBAGENT,
+        _ctx(),
+        _extensions(MiddlewarePlacement(_Probe("lead-only"), Placement.STANDARD, scope=AgentScope.LEAD)),
+    )
+    assert "lead-only" not in _tags(result)
+
+
+def test_scope_both_applies_everywhere():
+    for scope in (AgentScope.LEAD, AgentScope.SUBAGENT):
+        result, _, _ = inject_middlewares(
+            _stack(),
+            _ANCHORS,
+            scope,
+            _ctx(),
+            _extensions(MiddlewarePlacement(_Probe("everywhere"), Placement.STANDARD)),
+        )
+        assert "everywhere" in _tags(result)
+
+
+def test_order_field_breaks_ties_within_a_placement():
+    result, _, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(
+            MiddlewarePlacement(_Probe("second"), Placement.TOOL_VISIBLE, order=10),
+            MiddlewarePlacement(_Probe("first"), Placement.TOOL_VISIBLE, order=1),
+        ),
+    )
+    assert _tags(result)[:2] == ["first", "second"]
+
+
+def test_provenance_maps_index_to_source():
+    probe = _Probe("visible")
+    result, provenance, _ = inject_middlewares(
+        _stack(),
+        _ANCHORS,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(probe, Placement.TOOL_VISIBLE)),
+    )
+    assert provenance[0] == "demo:install"
+    assert 1 not in provenance, "core middlewares carry no extension provenance"
+
+
+def test_missing_anchor_falls_back_and_warns():
+    """A conditionally-built stack may lack the anchor. Degrading silently
+    would change what the extension observes with no signal."""
+    anchors = {Placement.MODEL_PHYSICAL: PlacementAnchor.of(inner_of(_Transform), innermost())}
+    stack = [_Retry(), _ToolError()]  # no _Transform
+    result, _, diagnostics = inject_middlewares(
+        stack,
+        anchors,
+        AgentScope.LEAD,
+        _ctx(),
+        _extensions(MiddlewarePlacement(_Probe("attempt"), Placement.MODEL_PHYSICAL)),
+    )
+    assert _tags(result)[-1] == "attempt"
+    assert [d.level for d in diagnostics] == ["warning"]
+    assert "MODEL_PHYSICAL" in diagnostics[0].message
+
+
+def test_no_contributors_returns_the_stack_untouched():
+    stack = _stack()
+    result, provenance, diagnostics = inject_middlewares(stack, _ANCHORS, AgentScope.LEAD, _ctx(), ExtensionRegistry().build())
+    assert result == stack
+    assert provenance == {}
+    assert diagnostics == []
+
+
+def test_contributor_failure_is_isolated_to_that_extension():
+    class _Boom:
+        def contribute_middlewares(self, app_store, ctx):
+            raise ValueError("contributor exploded")
+
+    registry = ExtensionRegistry()
+    with registry.attributed_to("bad:install"):
+        registry.middlewares(_Boom())
+    with registry.attributed_to("good:install"):
+        registry.middlewares(_contributor(MiddlewarePlacement(_Probe("ok"), Placement.TOOL_VISIBLE)))
+
+    result, _, diagnostics = inject_middlewares(_stack(), _ANCHORS, AgentScope.LEAD, _ctx(), registry.build())
+    assert "ok" in _tags(result)
+    assert any(d.level == "error" and d.source == "bad:install" for d in diagnostics)

--- a/backend/tests/test_extension_isolation.py
+++ b/backend/tests/test_extension_isolation.py
@@ -1,0 +1,545 @@
+"""Tests for isolating extension middleware failures from the user's run."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from langchain.agents.middleware import AgentMiddleware
+from langgraph.errors import GraphBubbleUp
+
+from deerflow.extensions.isolation import IsolatedMiddleware
+
+
+class _Boom(AgentMiddleware):
+    def wrap_model_call(self, request, handler):
+        raise ValueError("observation exploded")
+
+    async def awrap_model_call(self, request, handler):
+        raise ValueError("observation exploded")
+
+    def wrap_tool_call(self, request, handler):
+        raise ValueError("observation exploded")
+
+    async def awrap_tool_call(self, request, handler):
+        raise ValueError("observation exploded")
+
+
+class _Bubble(AgentMiddleware):
+    def wrap_tool_call(self, request, handler):
+        raise GraphBubbleUp()
+
+    async def awrap_tool_call(self, request, handler):
+        raise GraphBubbleUp()
+
+
+class _Passthrough(AgentMiddleware):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen = 0
+
+    def wrap_tool_call(self, request, handler):
+        self.seen += 1
+        return handler(request)
+
+
+def _handler(request):
+    return "core-result"
+
+
+async def _ahandler(request):
+    return "core-result"
+
+
+def test_failing_middleware_falls_through_to_the_handler():
+    errors = []
+    wrapped = IsolatedMiddleware(_Boom(), "bad:install", errors.append)
+    assert wrapped.wrap_tool_call("req", _handler) == "core-result"
+    assert wrapped.wrap_model_call("req", _handler) == "core-result"
+    assert len(errors) == 2
+    assert errors[0].source == "bad:install"
+    assert errors[0].level == "error"
+
+
+def test_failing_async_middleware_falls_through():
+    errors = []
+    wrapped = IsolatedMiddleware(_Boom(), "bad:install", errors.append)
+    assert asyncio.run(wrapped.awrap_tool_call("req", _ahandler)) == "core-result"
+    assert asyncio.run(wrapped.awrap_model_call("req", _ahandler)) == "core-result"
+    assert len(errors) == 2
+
+
+def test_graph_bubble_up_propagates_unchanged():
+    """GraphBubbleUp carries LangGraph's interrupt/pause/resume control flow.
+    Swallowing it would break the graph, not just the observation."""
+    wrapped = IsolatedMiddleware(_Bubble(), "ext:install", lambda d: None)
+    with pytest.raises(GraphBubbleUp):
+        wrapped.wrap_tool_call("req", _handler)
+    with pytest.raises(GraphBubbleUp):
+        asyncio.run(wrapped.awrap_tool_call("req", _ahandler))
+
+
+def test_working_middleware_is_not_disturbed():
+    inner = _Passthrough()
+    wrapped = IsolatedMiddleware(inner, "ok:install", lambda d: None)
+    assert wrapped.wrap_tool_call("req", _handler) == "core-result"
+    assert inner.seen == 1
+
+
+def test_post_handler_failure_does_not_replay_tool_handler():
+    """A post-call observer failure must not repeat a tool's side effects."""
+
+    class _FailsAfterHandler(AgentMiddleware):
+        def wrap_tool_call(self, request, handler):
+            handler(request)
+            raise ValueError("post-call observation exploded")
+
+    calls: list[str] = []
+
+    def side_effecting_handler(request):
+        calls.append(request)
+        return "core-result"
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _FailsAfterHandler(),
+        "bad:install",
+        errors.append,
+    )
+
+    assert wrapped.wrap_tool_call("req", side_effecting_handler) == "core-result"
+    assert calls == ["req"]
+    assert len(errors) == 1
+
+
+def test_tool_handler_failure_propagates_without_replay_or_diagnostic():
+    """A real tool failure belongs to the graph, not extension isolation."""
+    failure = RuntimeError("tool exploded")
+    calls: list[str] = []
+
+    def failing_handler(request):
+        calls.append(request)
+        raise failure
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _Passthrough(),
+        "observer:install",
+        errors.append,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        wrapped.wrap_tool_call("req", failing_handler)
+
+    assert exc_info.value is failure
+    assert calls == ["req"]
+    assert errors == []
+
+
+def test_post_handler_failure_does_not_replay_model_handler():
+    """A post-call observer failure must not duplicate provider cost."""
+
+    class _FailsAfterHandler(AgentMiddleware):
+        def wrap_model_call(self, request, handler):
+            handler(request)
+            raise ValueError("post-call observation exploded")
+
+    calls: list[str] = []
+
+    def counted_handler(request):
+        calls.append(request)
+        return "model-result"
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _FailsAfterHandler(),
+        "bad:install",
+        errors.append,
+    )
+
+    assert wrapped.wrap_model_call("req", counted_handler) == "model-result"
+    assert calls == ["req"]
+    assert len(errors) == 1
+
+
+def test_async_post_handler_failure_does_not_replay_tool_handler():
+    """Isolation must not add another async tool side effect."""
+
+    class _FailsAfterHandler(AgentMiddleware):
+        async def awrap_tool_call(self, request, handler):
+            await handler(request)
+            raise ValueError("post-call observation exploded")
+
+    calls: list[str] = []
+
+    async def side_effecting_handler(request):
+        calls.append(request)
+        return "core-result"
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _FailsAfterHandler(),
+        "bad:install",
+        errors.append,
+    )
+
+    result = asyncio.run(wrapped.awrap_tool_call("req", side_effecting_handler))
+
+    assert result == "core-result"
+    assert calls == ["req"]
+    assert len(errors) == 1
+
+
+def test_async_tool_handler_failure_propagates_without_replay_or_diagnostic():
+    """Async graph failures remain owned by the graph's error policy."""
+
+    class _AsyncPassthrough(AgentMiddleware):
+        async def awrap_tool_call(self, request, handler):
+            return await handler(request)
+
+    failure = RuntimeError("tool exploded")
+    calls: list[str] = []
+
+    async def failing_handler(request):
+        calls.append(request)
+        raise failure
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _AsyncPassthrough(),
+        "observer:install",
+        errors.append,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        asyncio.run(wrapped.awrap_tool_call("req", failing_handler))
+
+    assert exc_info.value is failure
+    assert calls == ["req"]
+    assert errors == []
+
+
+def test_async_handler_cancellation_propagates_without_replay_or_diagnostic():
+    """Cancellation is control flow and must never enter fail-open recovery."""
+
+    class _AsyncPassthrough(AgentMiddleware):
+        async def awrap_tool_call(self, request, handler):
+            return await handler(request)
+
+    calls: list[str] = []
+
+    async def cancelled_handler(request):
+        calls.append(request)
+        raise asyncio.CancelledError
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _AsyncPassthrough(),
+        "observer:install",
+        errors.append,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(wrapped.awrap_tool_call("req", cancelled_handler))
+
+    assert calls == ["req"]
+    assert errors == []
+
+
+def test_async_post_handler_failure_does_not_replay_model_handler():
+    """Async provider calls also retain their first successful result."""
+
+    class _FailsAfterHandler(AgentMiddleware):
+        async def awrap_model_call(self, request, handler):
+            await handler(request)
+            raise ValueError("post-call observation exploded")
+
+    calls: list[str] = []
+
+    async def counted_handler(request):
+        calls.append(request)
+        return "model-result"
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _FailsAfterHandler(),
+        "bad:install",
+        errors.append,
+    )
+
+    result = asyncio.run(wrapped.awrap_model_call("req", counted_handler))
+
+    assert result == "model-result"
+    assert calls == ["req"]
+    assert len(errors) == 1
+
+
+def test_middleware_cannot_replace_a_handler_failure_with_its_own_error():
+    """The graph keeps ownership even if an observer masks its exception."""
+
+    class _MasksHandlerFailure(AgentMiddleware):
+        def wrap_tool_call(self, request, handler):
+            try:
+                return handler(request)
+            except RuntimeError:
+                raise ValueError("observer cleanup exploded") from None
+
+    failure = RuntimeError("tool exploded")
+    calls: list[str] = []
+
+    def failing_handler(request):
+        calls.append(request)
+        raise failure
+
+    errors = []
+    wrapped = IsolatedMiddleware(
+        _MasksHandlerFailure(),
+        "observer:install",
+        errors.append,
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        wrapped.wrap_tool_call("req", failing_handler)
+
+    assert exc_info.value is failure
+    assert calls == ["req"]
+    assert errors == []
+
+
+def test_error_message_identifies_the_hook():
+    errors = []
+    wrapped = IsolatedMiddleware(_Boom(), "bad:install", errors.append)
+    wrapped.wrap_tool_call("req", _handler)
+    assert "wrap_tool_call" in errors[0].message
+
+
+# --- interface preservation -------------------------------------------------
+#
+# LangChain discovers middleware capabilities by inspecting the *wrapper*: hook
+# participation is a class-level identity check (`m.__class__.before_model is
+# not AgentMiddleware.before_model`, see langchain/agents/factory.py), and
+# tools/state_schema/transformers are read off the middleware instance. The
+# wrapper must mirror the inner middleware's full interface, not just the four
+# wrap-call hooks — otherwise lifecycle hooks silently never enter the graph
+# and contributed tools/state never register.
+
+_LIFECYCLE_HOOKS = (
+    "before_agent",
+    "abefore_agent",
+    "before_model",
+    "abefore_model",
+    "after_model",
+    "aafter_model",
+    "after_agent",
+    "aafter_agent",
+)
+
+
+def _langchain_detects(middleware: AgentMiddleware, hook_name: str) -> bool:
+    """The exact check langchain.agents.factory uses to decide whether a hook
+    node is added to the graph."""
+    return getattr(type(middleware), hook_name) is not getattr(AgentMiddleware, hook_name)
+
+
+class _LifecycleObserver(AgentMiddleware):
+    """Implements every lifecycle hook, sync and async, none of the wrap-calls."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[str] = []
+
+    def before_agent(self, state, runtime):
+        self.calls.append("before_agent")
+        return {"seen": "before_agent"}
+
+    async def abefore_agent(self, state, runtime):
+        self.calls.append("abefore_agent")
+        return {"seen": "abefore_agent"}
+
+    def before_model(self, state, runtime):
+        self.calls.append("before_model")
+        return {"seen": "before_model"}
+
+    async def abefore_model(self, state, runtime):
+        self.calls.append("abefore_model")
+        return {"seen": "abefore_model"}
+
+    def after_model(self, state, runtime):
+        self.calls.append("after_model")
+        return {"seen": "after_model"}
+
+    async def aafter_model(self, state, runtime):
+        self.calls.append("aafter_model")
+        return {"seen": "aafter_model"}
+
+    def after_agent(self, state, runtime):
+        self.calls.append("after_agent")
+        return {"seen": "after_agent"}
+
+    async def aafter_agent(self, state, runtime):
+        self.calls.append("aafter_agent")
+        return {"seen": "aafter_agent"}
+
+
+def test_wrapper_advertises_the_lifecycle_hooks_the_inner_implements():
+    """A wrapped lifecycle observer must be *seen* by LangChain: without a
+    class-level override the factory never adds the hook node to the graph and
+    the inner hook silently never runs."""
+    wrapped = IsolatedMiddleware(_LifecycleObserver(), "obs:install", lambda d: None)
+    missing = [hook for hook in _LIFECYCLE_HOOKS if not _langchain_detects(wrapped, hook)]
+    assert missing == [], f"LangChain cannot see these wrapped hooks: {missing}"
+
+
+def test_wrapper_does_not_fabricate_hooks_the_inner_lacks():
+    """The mirror must be exact: fabricating hooks would bolt no-op nodes onto
+    every graph and corrupt middleware_implements-based placement checks."""
+    wrapped = IsolatedMiddleware(_Passthrough(), "ok:install", lambda d: None)
+    fabricated = [hook for hook in _LIFECYCLE_HOOKS if _langchain_detects(wrapped, hook)]
+    assert fabricated == [], f"the wrapper invented hooks the inner lacks: {fabricated}"
+
+
+def test_wrapper_mirrors_sync_and_async_hooks_independently():
+    """LangChain wires sync and async variants separately; an async-only inner
+    must not cause a sync no-op node (and vice versa)."""
+
+    class _AsyncOnly(AgentMiddleware):
+        async def abefore_model(self, state, runtime):
+            return None
+
+    wrapped = IsolatedMiddleware(_AsyncOnly(), "obs:install", lambda d: None)
+    assert _langchain_detects(wrapped, "abefore_model")
+    assert not _langchain_detects(wrapped, "before_model")
+    for hook in _LIFECYCLE_HOOKS:
+        if hook != "abefore_model":
+            assert not _langchain_detects(wrapped, hook), hook
+
+
+def test_wrapper_preserves_tools_state_schema_and_transformers():
+    """factory.py reads m.tools / m.state_schema / m.transformers off the
+    wrapper — dropping them unregisters the middleware's contributions."""
+    from langchain_core.tools import tool
+
+    @tool
+    def ext_echo(text: str) -> str:
+        """Echo the text back."""
+        return f"echo:{text}"
+
+    import typing
+
+    class _State(typing.TypedDict, total=False):
+        seen: str
+
+    def _transformer(scope):
+        return None
+
+    class _Contributing(AgentMiddleware):
+        state_schema = _State
+        transformers = (_transformer,)
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.tools = [ext_echo]
+
+    inner = _Contributing()
+    wrapped = IsolatedMiddleware(inner, "contrib:install", lambda d: None)
+    assert list(wrapped.tools) == [ext_echo]
+    assert wrapped.state_schema is _State
+    assert tuple(wrapped.transformers) == (_transformer,)
+
+
+def test_lifecycle_hooks_delegate_to_the_inner():
+    inner = _LifecycleObserver()
+    wrapped = IsolatedMiddleware(inner, "obs:install", lambda d: None)
+    assert wrapped.before_model("state", "runtime") == {"seen": "before_model"}
+    assert wrapped.after_agent("state", "runtime") == {"seen": "after_agent"}
+    assert asyncio.run(wrapped.abefore_agent("state", "runtime")) == {"seen": "abefore_agent"}
+    assert asyncio.run(wrapped.aafter_model("state", "runtime")) == {"seen": "aafter_model"}
+    assert inner.calls == ["before_model", "after_agent", "abefore_agent", "aafter_model"]
+
+
+def test_failing_lifecycle_hook_degrades_to_none_with_a_diagnostic():
+    """Lifecycle hooks have no handler to fall through to; the fail-open
+    degradation is returning no state update."""
+
+    class _FailingObserver(AgentMiddleware):
+        def before_model(self, state, runtime):
+            raise ValueError("observation exploded")
+
+        async def aafter_model(self, state, runtime):
+            raise ValueError("observation exploded")
+
+    errors = []
+    wrapped = IsolatedMiddleware(_FailingObserver(), "bad:install", errors.append)
+    assert wrapped.before_model("state", "runtime") is None
+    assert asyncio.run(wrapped.aafter_model("state", "runtime")) is None
+    assert [d.level for d in errors] == ["error", "error"]
+    assert "before_model" in errors[0].message
+    assert "aafter_model" in errors[1].message
+
+
+def test_graph_bubble_up_propagates_from_lifecycle_hooks():
+    """Interrupts ride on lifecycle hooks too (human-in-the-loop pauses from
+    after_model); isolation must not swallow graph control flow."""
+
+    class _Interrupting(AgentMiddleware):
+        def after_model(self, state, runtime):
+            raise GraphBubbleUp()
+
+        async def abefore_model(self, state, runtime):
+            raise GraphBubbleUp()
+
+    wrapped = IsolatedMiddleware(_Interrupting(), "hitl:install", lambda d: None)
+    with pytest.raises(GraphBubbleUp):
+        wrapped.after_model("state", "runtime")
+    with pytest.raises(GraphBubbleUp):
+        asyncio.run(wrapped.abefore_model("state", "runtime"))
+
+
+def test_middleware_implements_agrees_with_the_wrapper():
+    """Placement-guarantee checks reason about hook participation through
+    middleware_implements(); the wrapper must not distort it."""
+    from deerflow.extensions.stack import middleware_implements
+
+    wrapped = IsolatedMiddleware(_LifecycleObserver(), "obs:install", lambda d: None)
+    for hook in _LIFECYCLE_HOOKS:
+        assert middleware_implements(wrapped, hook), hook
+    assert not middleware_implements(wrapped, "wrap_model_call")
+
+
+def test_create_agent_runs_the_wrapped_hooks_and_registers_the_wrapped_tools():
+    """End to end through a real langchain.agents.create_agent graph: the
+    wrapped middleware's before_model must actually execute and its tools must
+    actually be callable."""
+    from _agent_e2e_helpers import build_single_tool_call_model
+    from langchain.agents import create_agent
+    from langchain_core.messages import HumanMessage
+    from langchain_core.tools import tool
+
+    tool_calls: list[str] = []
+
+    @tool
+    def ext_echo(text: str) -> str:
+        """Echo the text back."""
+        tool_calls.append(text)
+        return f"echo:{text}"
+
+    class _Contributing(AgentMiddleware):
+        def __init__(self) -> None:
+            super().__init__()
+            self.tools = [ext_echo]
+            self.before_model_calls = 0
+
+        def before_model(self, state, runtime):
+            self.before_model_calls += 1
+            return None
+
+    inner = _Contributing()
+    wrapped = IsolatedMiddleware(inner, "contrib:install", lambda d: None)
+
+    model = build_single_tool_call_model(tool_name="ext_echo", tool_args={"text": "hello"})
+    agent = create_agent(model=model, tools=[], middleware=[wrapped])
+    result = agent.invoke({"messages": [HumanMessage(content="say hello")]})
+
+    assert inner.before_model_calls > 0, "the wrapped before_model hook never entered the graph"
+    assert tool_calls == ["hello"], "the wrapped middleware's tool was never registered"
+    assert any(getattr(m, "content", "") == "echo:hello" for m in result["messages"])

--- a/backend/tests/test_extension_loader.py
+++ b/backend/tests/test_extension_loader.py
@@ -1,0 +1,239 @@
+"""Tests for config-driven extension loading."""
+
+from __future__ import annotations
+
+import pytest
+
+from deerflow.extensions.loader import (
+    Diagnostic,
+    ExtensionLoadError,
+    ExtensionSpec,
+    load_extensions,
+)
+from extension_test_fixtures import demo_extensions
+
+_FIXTURE = "extension_test_fixtures.demo_extensions"
+
+
+@pytest.fixture(autouse=True)
+def _reset_fixture_state():
+    demo_extensions.INSTALLED.clear()
+    yield
+    demo_extensions.INSTALLED.clear()
+
+
+def test_no_specs_yields_empty_result():
+    loaded, diagnostics = load_extensions([])
+    assert diagnostics == []
+    assert loaded.has_middleware_contributors is False
+
+
+def test_successful_install_registers_and_attributes():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_ok")
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics == []
+    assert demo_extensions.INSTALLED == ["ok"]
+    assert loaded.middleware_contributors[0][0] == f"{_FIXTURE}:install_ok"
+
+
+def test_config_block_is_passed_through_verbatim():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_reads_config", config={"mode": "fast"})
+    load_extensions([spec])
+    assert demo_extensions.INSTALLED == ["config:fast"]
+
+
+def test_disabled_extension_registers_nothing():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_disabled", config={"enabled": False})
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics == []
+    assert loaded.has_middleware_contributors is False
+
+
+def test_load_order_follows_config_order():
+    specs = [
+        ExtensionSpec(use=f"{_FIXTURE}:install_ok"),
+        ExtensionSpec(use=f"{_FIXTURE}:install_stamped"),
+    ]
+    load_extensions(specs)
+    assert demo_extensions.INSTALLED == ["ok", "stamped"]
+
+
+def test_unresolvable_entry_point_is_skipped_with_an_error_diagnostic():
+    specs = [
+        ExtensionSpec(use="extension_test_fixtures.demo_extensions:does_not_exist"),
+        ExtensionSpec(use=f"{_FIXTURE}:install_ok"),
+    ]
+    loaded, diagnostics = load_extensions(specs)
+    assert [d.level for d in diagnostics] == ["error"]
+    assert "does_not_exist" in diagnostics[0].source
+    assert demo_extensions.INSTALLED == ["ok"], "a broken extension must not stop the rest"
+
+
+def test_non_callable_entry_point_is_rejected():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:NOT_CALLABLE")
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics[0].level == "error"
+    assert "callable" in diagnostics[0].message
+
+
+def test_install_failure_rolls_back_partial_registration():
+    specs = [
+        ExtensionSpec(use=f"{_FIXTURE}:install_partial_then_raise"),
+        ExtensionSpec(use=f"{_FIXTURE}:install_ok"),
+    ]
+    loaded, diagnostics = load_extensions(specs)
+    assert diagnostics[0].level == "error"
+    assert "boom" in diagnostics[0].message
+    sources = {source for source, _ in loaded.middleware_contributors}
+    assert sources == {f"{_FIXTURE}:install_ok"}
+    assert loaded.task_lifecycle == (), "rollback must clear every bucket, not just the first"
+
+
+def test_rollback_does_not_remove_a_different_specs_registrations_sharing_the_same_use():
+    """Two specs may legitimately share `use` with different config (e.g. the
+    same extension mounted twice with different settings). Rollback on the
+    second's install failure must be positional, not keyed by `use` — it must
+    not erase the first instance's already-successful registrations just
+    because they share a source string."""
+    specs = [
+        ExtensionSpec(use=f"{_FIXTURE}:install_shared_use", config={"label": "first"}),
+        ExtensionSpec(use=f"{_FIXTURE}:install_shared_use", config={"label": "second", "fail": True}),
+    ]
+    loaded, diagnostics = load_extensions(specs)
+    assert [d.level for d in diagnostics] == ["error"]
+    assert "boom-shared" in diagnostics[0].message
+    assert len(loaded.middleware_contributors) == 1
+    source, contributor = loaded.middleware_contributors[0]
+    assert source == f"{_FIXTURE}:install_shared_use"
+    assert contributor.tag == "shared:first"
+
+
+def test_required_extension_failure_aborts_startup():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_partial_then_raise", required=True)
+    with pytest.raises(ExtensionLoadError):
+        load_extensions([spec])
+
+
+def test_required_unresolvable_extension_aborts_startup():
+    spec = ExtensionSpec(use="nope.nothing:here", required=True)
+    with pytest.raises(ExtensionLoadError):
+        load_extensions([spec])
+
+
+def test_incompatible_declared_api_is_refused_with_actionable_message():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_future_api")
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics[0].level == "error"
+    assert "99.0" in diagnostics[0].message
+    assert "pip install" in diagnostics[0].message
+    assert demo_extensions.INSTALLED == [], "an incompatible extension must not run"
+
+
+def test_newer_minor_declared_api_is_refused():
+    """Before 1.0, minors carry no compatibility promise: an extension written
+    against 0.2 may use contracts a 0.1 host does not implement, and the host
+    must refuse it with an actionable message."""
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_newer_minor_api")
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics[0].level == "error"
+    assert "0.2" in diagnostics[0].message
+    assert "pip install" in diagnostics[0].message
+    assert demo_extensions.INSTALLED == [], "a newer-minor extension must not run on an older host"
+
+
+def test_newer_minor_required_extension_aborts_startup():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_newer_minor_api", required=True)
+    with pytest.raises(ExtensionLoadError):
+        load_extensions([spec])
+
+
+def test_compatible_declared_api_loads():
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_stamped")
+    loaded, diagnostics = load_extensions([spec])
+    assert diagnostics == []
+    assert demo_extensions.INSTALLED == ["stamped"]
+
+
+def test_compatible_follows_semver_windows():
+    """0.x: minors may break — the window is same major.minor with patches
+    additive (host >= declared). From 1.0 on: contracts only grow within a
+    major. Comparisons are numeric (1.10 > 1.9), not lexicographic."""
+    from deerflow.extensions.loader import _compatible
+
+    # 0.x window: same major.minor, patch-level growth only.
+    assert _compatible("0.1", "0.1")
+    assert _compatible("0.1", "0.1.1"), "patch growth stays compatible"
+    assert not _compatible("0.1.1", "0.1"), "a newer patch declaration exceeds what the host provides"
+    assert not _compatible("0.2", "0.1"), "0.x minors may break: a 0.1 host must refuse 0.2 extensions"
+    assert not _compatible("0.1", "0.2"), "0.x minors promise nothing in the other direction either"
+
+    # 1.x+ window: same major, contracts only grow.
+    assert _compatible("1.0", "1.0")
+    assert _compatible("1.0", "1.1"), "a newer host still provides everything a 1.0 extension declared"
+    assert _compatible("1.9", "1.10"), "minor comparison is numeric, not lexicographic"
+    assert not _compatible("1.1", "1.0"), "the 1.0 host lacks the 1.1 contract additions"
+    assert not _compatible("1.10", "1.9")
+    assert not _compatible("1.0.1", "1.0"), "even a newer patch declaration exceeds what the host provides"
+    assert not _compatible("2.0", "1.5"), "major mismatch"
+    assert not _compatible("1.0", "2.0"), "major mismatch"
+    assert not _compatible("not-a-version", "1.0"), "unparseable versions are refused, not waved through"
+
+
+def test_undeclared_api_is_allowed():
+    """The decorator is optional; pip constraints remain the primary gate."""
+    spec = ExtensionSpec(use=f"{_FIXTURE}:install_ok")
+    _, diagnostics = load_extensions([spec])
+    assert diagnostics == []
+
+
+def test_a_successful_load_is_reported(caplog):
+    """Every other branch is failure-only, so without this line an operator has
+    no way to tell a clean load from a `plugins:` block the host never read."""
+    with caplog.at_level("INFO", logger="deerflow.extensions.loader"):
+        load_extensions([ExtensionSpec(use=f"{_FIXTURE}:install_ok")])
+
+    assert f"Extensions loaded: 1/1 ({_FIXTURE}:install_ok)" in caplog.text
+
+
+def test_the_report_counts_skipped_extensions_apart_from_loaded_ones(caplog):
+    specs = [
+        ExtensionSpec(use=f"{_FIXTURE}:install_ok"),
+        ExtensionSpec(use="does.not.exist:install"),
+    ]
+    with caplog.at_level("INFO", logger="deerflow.extensions.loader"):
+        load_extensions(specs)
+
+    assert f"Extensions loaded: 1/2 ({_FIXTURE}:install_ok)" in caplog.text
+
+
+def test_an_all_failed_load_reports_none_rather_than_an_empty_list(caplog):
+    with caplog.at_level("INFO", logger="deerflow.extensions.loader"):
+        load_extensions([ExtensionSpec(use="does.not.exist:install")])
+
+    assert "Extensions loaded: 0/1 (none)" in caplog.text
+
+
+def test_no_configured_plugins_stays_off_the_info_log(caplog):
+    """The default state for nearly every deployment; a line here is boot noise."""
+    with caplog.at_level("INFO", logger="deerflow.extensions.loader"):
+        load_extensions([])
+
+    assert "Extensions loaded" not in caplog.text
+
+
+def test_diagnostic_helpers_set_level():
+    assert Diagnostic.error("s", "m").level == "error"
+    assert Diagnostic.warning("s", "m").level == "warning"
+    assert Diagnostic.info("s", "m").level == "info"
+    assert Diagnostic.debug("s", "m").level == "debug"
+
+
+def test_host_registry_satisfies_the_public_contract():
+    """Extensions annotate install(registry: ExtensionRegistry, ...) against
+    the contract package alone; the host's concrete registry must satisfy that
+    Protocol, or every correctly-annotated extension is lying about its types."""
+    from deerflow_extension_api import ExtensionRegistry as ContractRegistry
+
+    from deerflow.extensions.registry import ExtensionRegistry as HostRegistry
+
+    assert isinstance(HostRegistry(), ContractRegistry)

--- a/backend/tests/test_extension_ordering.py
+++ b/backend/tests/test_extension_ordering.py
@@ -1,0 +1,89 @@
+"""Tests for declarative middleware ordering constraints."""
+
+from __future__ import annotations
+
+import pytest
+
+from deerflow.extensions.isolation import IsolatedMiddleware
+from deerflow.extensions.ordering import OrderingConstraint, assert_ordering
+
+
+class _Outer:
+    pass
+
+
+class _Inner:
+    pass
+
+
+class _Unrelated:
+    pass
+
+
+_CONSTRAINTS = (OrderingConstraint(outer=_Outer, inner=_Inner, reason="outer must wrap inner"),)
+
+
+def test_correct_order_passes():
+    assert_ordering([_Outer(), _Inner()], {}, _CONSTRAINTS)
+
+
+def test_reversed_order_raises():
+    with pytest.raises(RuntimeError, match="outer must wrap inner"):
+        assert_ordering([_Inner(), _Outer()], {}, _CONSTRAINTS)
+
+
+def test_missing_participant_is_not_a_violation():
+    """The stack is conditionally built; an absent middleware means the
+    constraint simply does not apply."""
+    assert_ordering([_Outer(), _Unrelated()], {}, _CONSTRAINTS)
+    assert_ordering([_Unrelated()], {}, _CONSTRAINTS)
+
+
+def test_violation_message_names_the_responsible_extension():
+    """Without attribution, an operator cannot tell which extension to remove."""
+    stack = [_Inner(), _Outer()]
+    provenance = {0: "bad_ext:install"}
+    with pytest.raises(RuntimeError) as excinfo:
+        assert_ordering(stack, provenance, _CONSTRAINTS)
+    assert "bad_ext:install" in str(excinfo.value)
+
+
+def test_violation_without_extensions_says_core():
+    stack = [_Inner(), _Outer()]
+    with pytest.raises(RuntimeError) as excinfo:
+        assert_ordering(stack, {}, _CONSTRAINTS)
+    assert "core" in str(excinfo.value).lower()
+
+
+def test_violation_does_not_blame_an_uninvolved_extension():
+    """Only the two positions in the violating pair can be responsible. A
+    provenance entry for some other index — an extension that contributed
+    elsewhere in the stack but is not part of this constraint — must not be
+    named, even though it is the only entry in `provenance`."""
+    stack = [_Inner(), _Outer(), _Unrelated()]
+    provenance = {2: "innocent_ext:install"}
+    with pytest.raises(RuntimeError) as excinfo:
+        assert_ordering(stack, provenance, _CONSTRAINTS)
+    message = str(excinfo.value)
+    assert "innocent_ext:install" not in message
+    assert "core" in message.lower()
+
+
+def test_reversed_order_raises_when_a_participant_is_wrapped():
+    """Extension-contributed middlewares are wrapped in IsolatedMiddleware before
+    they reach the merged stack. If _index_of matched only the wrapper's own
+    type, a wrapped participant would read as absent and the constraint would
+    silently stop being enforced instead of raising — the worst possible failure
+    mode for a safety check."""
+    stack = [IsolatedMiddleware(_Inner(), "bad_ext:install", lambda d: None), _Outer()]
+    with pytest.raises(RuntimeError, match="outer must wrap inner"):
+        assert_ordering(stack, {}, _CONSTRAINTS)
+
+
+def test_core_constraints_are_declared():
+    from deerflow.agents.middlewares.tool_error_handling_middleware import ToolErrorHandlingMiddleware
+    from deerflow.agents.middlewares.tool_progress_middleware import ToolProgressMiddleware
+    from deerflow.extensions.ordering import CORE_ORDERING_CONSTRAINTS
+
+    pairs = {(c.outer, c.inner) for c in CORE_ORDERING_CONSTRAINTS}
+    assert (ToolProgressMiddleware, ToolErrorHandlingMiddleware) in pairs

--- a/backend/tests/test_extension_placement_guarantees.py
+++ b/backend/tests/test_extension_placement_guarantees.py
@@ -1,0 +1,262 @@
+"""The guarantee each Placement makes must be met by the real stack.
+
+Neither the type system nor the version number can catch a broken guarantee:
+if a new request-transforming middleware is appended inner of the
+MODEL_PHYSICAL anchor, the anchor table, the types and the pip constraints all
+stay valid while the promise silently stops holding. These tests are the only
+thing standing between that change and a released extension observing the wrong
+data.
+"""
+
+from __future__ import annotations
+
+from deerflow_extension_api import AgentScope, MiddlewarePlacement, Placement
+from langchain.agents.middleware import AgentMiddleware
+
+from deerflow.agents.lead_agent.agent import build_middlewares
+from deerflow.agents.middlewares.tool_error_handling_middleware import (
+    build_subagent_runtime_middlewares,
+)
+from deerflow.config.app_config import AppConfig
+from deerflow.config.extensions_config import ExtensionsConfig
+from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.extensions.isolation import IsolatedMiddleware
+from deerflow.extensions.registry import ExtensionRegistry
+from deerflow.extensions.stack import middleware_implements
+
+
+class _Probe(AgentMiddleware):
+    def __init__(self, tag: str) -> None:
+        super().__init__()
+        self.tag = tag
+
+
+def _extensions(*placements: MiddlewarePlacement):
+    class _C:
+        def contribute_middlewares(self, app_store, ctx):
+            return placements
+
+    registry = ExtensionRegistry()
+    with registry.attributed_to("probe:install"):
+        registry.middlewares(_C())
+    return registry.build()
+
+
+def _stack_with(*placements: MiddlewarePlacement):
+    return build_middlewares(
+        config={"configurable": {}},
+        model_name="gpt-4o",
+        app_config=AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider")),
+        extensions=_extensions(*placements),
+    )
+
+
+def _subagent_stack_with(*placements: MiddlewarePlacement):
+    return build_subagent_runtime_middlewares(
+        app_config=AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider")),
+        model_name="gpt-4o",
+        extensions=_extensions(*placements),
+    )
+
+
+def _index_of_probe(stack, tag: str) -> int:
+    for index, middleware in enumerate(stack):
+        target = middleware.inner if isinstance(middleware, IsolatedMiddleware) else middleware
+        if isinstance(target, _Probe) and target.tag == tag:
+            return index
+    raise AssertionError(f"probe {tag!r} not found in stack")
+
+
+def _unwrap(middleware):
+    return middleware.inner if isinstance(middleware, IsolatedMiddleware) else middleware
+
+
+def test_model_physical_sees_the_final_request():
+    """Nothing inner of MODEL_PHYSICAL may transform the model request."""
+    stack = _stack_with(MiddlewarePlacement(_Probe("physical"), Placement.MODEL_PHYSICAL))
+    index = _index_of_probe(stack, "physical")
+    offenders = [type(_unwrap(m)).__name__ for m in stack[index + 1 :] if middleware_implements(_unwrap(m), "wrap_model_call")]
+    assert offenders == [], (
+        f"these middlewares sit inner of the MODEL_PHYSICAL anchor and wrap model calls, breaking its documented guarantee: {offenders}. Either move them outer of the anchor or update the anchor table in deerflow/extensions/stack.py."
+    )
+
+
+def test_lead_model_physical_uses_the_innermost_tail_anchor():
+    """A configured duplicate must not capture the lead's type-based anchor."""
+    app_config = AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"))
+    app_config.extensions = ExtensionsConfig(middlewares=["deerflow.agents.middlewares.safety_finish_reason_middleware:SafetyFinishReasonMiddleware"])
+    stack = build_middlewares(
+        config={"configurable": {}},
+        model_name="gpt-4o",
+        app_config=app_config,
+        extensions=_extensions(
+            MiddlewarePlacement(
+                _Probe("physical"),
+                Placement.MODEL_PHYSICAL,
+                scope=AgentScope.LEAD,
+            )
+        ),
+    )
+
+    index = _index_of_probe(stack, "physical")
+    offenders = [type(_unwrap(m)).__name__ for m in stack[index + 1 :] if middleware_implements(_unwrap(m), "wrap_model_call")]
+    assert offenders == []
+
+
+def test_lead_model_physical_reports_when_the_safety_anchor_is_disabled():
+    from deerflow.extensions import get_runtime_diagnostics, reset_runtime_diagnostics
+
+    app_config = AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"))
+    app_config.safety_finish_reason.enabled = False
+    reset_runtime_diagnostics()
+    try:
+        build_middlewares(
+            config={"configurable": {}},
+            model_name="gpt-4o",
+            app_config=app_config,
+            extensions=_extensions(
+                MiddlewarePlacement(
+                    _Probe("physical"),
+                    Placement.MODEL_PHYSICAL,
+                    scope=AgentScope.LEAD,
+                )
+            ),
+        )
+        diagnostics = get_runtime_diagnostics()
+    finally:
+        reset_runtime_diagnostics()
+
+    assert any("MODEL_PHYSICAL fell back to a secondary anchor" in diagnostic.message for diagnostic in diagnostics)
+
+
+def test_subagent_model_physical_sees_the_final_request():
+    """Subagents provide the same final-request guarantee as the lead agent."""
+    stack = _subagent_stack_with(
+        MiddlewarePlacement(
+            _Probe("physical"),
+            Placement.MODEL_PHYSICAL,
+            scope=AgentScope.SUBAGENT,
+        )
+    )
+    index = _index_of_probe(stack, "physical")
+    offenders = [type(_unwrap(m)).__name__ for m in stack[index + 1 :] if middleware_implements(_unwrap(m), "wrap_model_call")]
+    assert offenders == [], f"these subagent middlewares sit inner of the MODEL_PHYSICAL anchor and wrap model calls, breaking its documented guarantee: {offenders}"
+
+
+def test_subagent_model_physical_uses_the_innermost_core_coalescer():
+    """A configured duplicate must not capture the type-based primary anchor."""
+    app_config = AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"))
+    app_config.extensions = ExtensionsConfig(middlewares=["deerflow.agents.middlewares.system_message_coalescing_middleware:SystemMessageCoalescingMiddleware"])
+    stack = build_subagent_runtime_middlewares(
+        app_config=app_config,
+        model_name="gpt-4o",
+        extensions=_extensions(
+            MiddlewarePlacement(
+                _Probe("physical"),
+                Placement.MODEL_PHYSICAL,
+                scope=AgentScope.SUBAGENT,
+            )
+        ),
+    )
+
+    index = _index_of_probe(stack, "physical")
+    offenders = [type(_unwrap(m)).__name__ for m in stack[index + 1 :] if middleware_implements(_unwrap(m), "wrap_model_call")]
+    assert offenders == []
+
+
+#: The single documented middleware allowed inner of TOOL_RAW.
+#:
+#: ClarificationMiddleware must stay last — it short-circuits the tool loop with
+#: Command(goto=END) — and it only intercepts ask_clarification, never
+#: transforming the result of a tool that actually executes. So TOOL_RAW still
+#: sees raw results. This carve-out is named explicitly rather than the
+#: assertion being loosened: any OTHER middleware appearing here is a real
+#: regression, and adding to this set must be a deliberate, argued change.
+_TOOL_RAW_CARVE_OUT = {"ClarificationMiddleware"}
+
+
+def test_tool_raw_is_adjacent_to_the_callable_boundary():
+    """Nothing inner of TOOL_RAW may wrap tool calls, bar one documented case."""
+    stack = _stack_with(MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW))
+    index = _index_of_probe(stack, "raw")
+    offenders = [name for m in stack[index + 1 :] if middleware_implements(_unwrap(m), "wrap_tool_call") and (name := type(_unwrap(m)).__name__) not in _TOOL_RAW_CARVE_OUT]
+    assert offenders == [], (
+        f"these middlewares sit inner of TOOL_RAW and wrap tool calls: {offenders}. "
+        "Either move them outer of the anchor or update the anchor table in "
+        "deerflow/extensions/stack.py — do not add them to the carve-out without "
+        "an argument for why TOOL_RAW still sees raw results."
+    )
+
+
+def test_the_tool_raw_carve_out_is_actually_needed():
+    """Guards the carve-out itself: if ClarificationMiddleware ever stops
+    sitting inner of TOOL_RAW, the exemption is dead and must be deleted rather
+    than quietly hiding a future regression."""
+    stack = _stack_with(MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW))
+    index = _index_of_probe(stack, "raw")
+    inner = {type(_unwrap(m)).__name__ for m in stack[index + 1 :]}
+    assert _TOOL_RAW_CARVE_OUT <= inner, f"the carve-out lists middlewares that are no longer inner of TOOL_RAW: {_TOOL_RAW_CARVE_OUT - inner}"
+
+
+def test_tool_visible_sees_the_final_result():
+    """Nothing outer of TOOL_VISIBLE may wrap tool calls."""
+    stack = _stack_with(MiddlewarePlacement(_Probe("visible"), Placement.TOOL_VISIBLE))
+    index = _index_of_probe(stack, "visible")
+    offenders = [type(_unwrap(m)).__name__ for m in stack[:index] if middleware_implements(_unwrap(m), "wrap_tool_call")]
+    assert offenders == [], f"these middlewares sit outer of TOOL_VISIBLE and wrap tool calls: {offenders}"
+
+
+def test_model_logical_is_outer_of_the_retry_loop():
+    """One logical decision must stay one event across provider retries."""
+    from deerflow.agents.middlewares.llm_error_handling_middleware import LLMErrorHandlingMiddleware
+
+    stack = _stack_with(MiddlewarePlacement(_Probe("logical"), Placement.MODEL_LOGICAL))
+    logical = _index_of_probe(stack, "logical")
+    retry = next(index for index, m in enumerate(stack) if isinstance(_unwrap(m), LLMErrorHandlingMiddleware))
+    assert logical < retry, "MODEL_LOGICAL must be outer of the retry middleware"
+
+
+def test_logical_and_physical_nest_in_the_right_order():
+    """Step:Attempt is 1:N — the logical probe must enclose the physical one."""
+    stack = _stack_with(
+        MiddlewarePlacement(_Probe("logical"), Placement.MODEL_LOGICAL),
+        MiddlewarePlacement(_Probe("physical"), Placement.MODEL_PHYSICAL),
+    )
+    assert _index_of_probe(stack, "logical") < _index_of_probe(stack, "physical")
+
+
+def test_visible_and_raw_bracket_the_tool_chain():
+    """Visible/raw form a pair around truncation and sanitization; that gap is
+    what lets an extension see how much a tool result was altered."""
+    stack = _stack_with(
+        MiddlewarePlacement(_Probe("visible"), Placement.TOOL_VISIBLE),
+        MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW),
+    )
+    visible = _index_of_probe(stack, "visible")
+    raw = _index_of_probe(stack, "raw")
+    assert visible < raw
+    between = [type(_unwrap(m)).__name__ for m in stack[visible + 1 : raw] if middleware_implements(_unwrap(m), "wrap_tool_call")]
+    assert between, "the tool-processing chain must sit between the two probes"
+
+
+def test_all_four_probes_coexist_without_violating_ordering():
+    stack = _stack_with(
+        MiddlewarePlacement(_Probe("visible"), Placement.TOOL_VISIBLE),
+        MiddlewarePlacement(_Probe("logical"), Placement.MODEL_LOGICAL),
+        MiddlewarePlacement(_Probe("physical"), Placement.MODEL_PHYSICAL),
+        MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW),
+    )
+    indices = [_index_of_probe(stack, tag) for tag in ("visible", "logical", "physical", "raw")]
+    assert len(set(indices)) == 4
+
+
+def test_middleware_implements_detects_overrides():
+    class _Wraps(AgentMiddleware):
+        def wrap_tool_call(self, request, handler):
+            return handler(request)
+
+    class _Plain(AgentMiddleware):
+        pass
+
+    assert middleware_implements(_Wraps(), "wrap_tool_call") is True
+    assert middleware_implements(_Plain(), "wrap_tool_call") is False

--- a/backend/tests/test_extension_registry.py
+++ b/backend/tests/test_extension_registry.py
@@ -1,0 +1,134 @@
+"""Tests for the extension registry and its immutable build product."""
+
+from __future__ import annotations
+
+import pytest
+
+from deerflow.extensions.registry import EMPTY_EXTENSIONS, ExtensionRegistry
+
+
+class _Contributor:
+    def __init__(self, tag: str = "") -> None:
+        self.tag = tag
+
+
+def test_empty_registry_builds_with_all_flags_false():
+    loaded = ExtensionRegistry().build()
+    assert loaded.has_middleware_contributors is False
+    assert loaded.has_task_lifecycle is False
+    assert loaded.has_system_model_observers is False
+    assert loaded.needs_task_store is False
+    assert loaded.services == ()
+    assert loaded.routers == ()
+
+
+def test_empty_singleton_matches_an_empty_build():
+    assert EMPTY_EXTENSIONS.has_middleware_contributors is False
+    assert EMPTY_EXTENSIONS.has_task_lifecycle is False
+    assert EMPTY_EXTENSIONS.has_system_model_observers is False
+    assert EMPTY_EXTENSIONS.needs_task_store is False
+
+
+@pytest.mark.parametrize(
+    "register",
+    [
+        lambda registry, contributor: registry.middlewares(contributor),
+        lambda registry, contributor: registry.task_lifecycle(contributor),
+        lambda registry, contributor: registry.system_model_observer(contributor),
+    ],
+    ids=["middleware", "task-lifecycle", "system-model-observer"],
+)
+def test_task_scoped_contributions_require_a_task_store(register):
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        register(registry, _Contributor())
+
+    assert registry.build().needs_task_store is True
+
+
+def test_app_scoped_contributions_do_not_require_a_task_store():
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.service(_Contributor())
+        registry.routers([object()])
+
+    assert registry.build().needs_task_store is False
+
+
+def test_entries_carry_their_source():
+    registry = ExtensionRegistry()
+    contributor = _Contributor("mw")
+    with registry.attributed_to("demo_ext:install"):
+        registry.middlewares(contributor)
+    loaded = registry.build()
+    assert loaded.middleware_contributors == (("demo_ext:install", contributor),)
+    assert loaded.has_middleware_contributors is True
+
+
+def test_registration_order_is_preserved():
+    registry = ExtensionRegistry()
+    first, second = _Contributor("a"), _Contributor("b")
+    with registry.attributed_to("a_ext:install"):
+        registry.task_lifecycle(first)
+    with registry.attributed_to("b_ext:install"):
+        registry.task_lifecycle(second)
+    loaded = registry.build()
+    assert [source for source, _ in loaded.task_lifecycle] == ["a_ext:install", "b_ext:install"]
+
+
+def test_discard_removes_every_entry_of_one_source():
+    """A partially-registered extension is worse than an absent one: the data
+    it produces looks complete but is not."""
+    registry = ExtensionRegistry()
+    keep, drop = _Contributor("keep"), _Contributor("drop")
+    with registry.attributed_to("good:install"):
+        registry.middlewares(keep)
+        registry.task_lifecycle(keep)
+    with registry.attributed_to("bad:install"):
+        registry.middlewares(drop)
+        registry.system_model_observer(drop)
+        registry.routers([object()])
+    registry.discard("bad:install")
+    loaded = registry.build()
+    assert loaded.middleware_contributors == (("good:install", keep),)
+    assert loaded.task_lifecycle == (("good:install", keep),)
+    assert loaded.system_model_observers == ()
+    assert loaded.routers == ()
+
+
+def test_registering_outside_attributed_to_raises():
+    registry = ExtensionRegistry()
+    with pytest.raises(RuntimeError, match="attributed_to"):
+        registry.middlewares(_Contributor())
+
+
+def test_build_result_is_frozen():
+    loaded = ExtensionRegistry().build()
+    with pytest.raises(Exception):
+        loaded.services = ()  # type: ignore[misc]
+
+
+def test_app_store_is_created_at_build_time():
+    """The app store must exist before binding so the registration phase and
+    the binding phase see the same object."""
+    loaded = ExtensionRegistry().build()
+    assert loaded.app_store is not None
+    assert loaded.app_store.scope_id == "app"
+
+
+def test_routers_keep_their_source_in_order():
+    """Routers carry (source, router) like every other bucket.
+
+    Router prefix conflicts must produce a diagnostic naming the responsible
+    extension; attribution dropped at build() cannot be recovered later."""
+    registry = ExtensionRegistry()
+    r1, r2, r3 = object(), object(), object()
+    with registry.attributed_to("a:install"):
+        registry.routers([r1, r2])
+    with registry.attributed_to("b:install"):
+        registry.routers([r3])
+    assert registry.build().routers == (
+        ("a:install", r1),
+        ("a:install", r2),
+        ("b:install", r3),
+    )

--- a/backend/tests/test_extension_stack_wiring.py
+++ b/backend/tests/test_extension_stack_wiring.py
@@ -1,0 +1,323 @@
+"""Tests for wiring extension contributions into the real middleware builders."""
+
+from __future__ import annotations
+
+import pytest
+from deerflow_extension_api import AgentScope, MiddlewarePlacement, Placement
+from langchain.agents.middleware import AgentMiddleware
+
+from deerflow.agents.lead_agent.agent import build_middlewares
+from deerflow.config.app_config import AppConfig
+from deerflow.config.sandbox_config import SandboxConfig
+from deerflow.extensions.isolation import IsolatedMiddleware
+from deerflow.extensions.registry import ExtensionRegistry
+from deerflow.extensions.stack import PLACEMENT_ANCHORS
+
+
+def _app_config() -> AppConfig:
+    # AppConfig.sandbox has no default (`use` is a required field), so a bare
+    # AppConfig() always fails pydantic validation in this repo. The brief's
+    # verbatim test code assumed a default-constructible AppConfig; every
+    # other builder test in this suite (e.g. test_lead_agent_model_resolution.py)
+    # supplies this same minimal sandbox stanza for the same reason.
+    return AppConfig(sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"))
+
+
+class _Probe(AgentMiddleware):
+    def __init__(self, tag: str) -> None:
+        super().__init__()
+        self.tag = tag
+
+
+def _extensions(*placements: MiddlewarePlacement):
+    class _C:
+        def contribute_middlewares(self, app_store, ctx):
+            return placements
+
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.middlewares(_C())
+    return registry.build()
+
+
+def _tags(stack):
+    out = []
+    for m in stack:
+        target = m.inner if isinstance(m, IsolatedMiddleware) else m
+        out.append(target.tag if isinstance(target, _Probe) else type(target).__name__)
+    return out
+
+
+def _lead_stack(extensions=None, app_config=None):
+    return build_middlewares(
+        config={"configurable": {}},
+        model_name="gpt-4o",
+        app_config=app_config or _app_config(),
+        extensions=extensions,
+    )
+
+
+def test_anchor_table_covers_every_placement():
+    assert set(PLACEMENT_ANCHORS) == set(Placement)
+
+
+def test_zero_extensions_leaves_the_stack_unchanged():
+    baseline = _tags(_lead_stack())
+    with_empty = _tags(_lead_stack(ExtensionRegistry().build()))
+    assert baseline == with_empty
+    assert not any(isinstance(m, IsolatedMiddleware) for m in _lead_stack())
+
+
+def test_tool_visible_lands_at_the_outermost_position():
+    stack = _lead_stack(_extensions(MiddlewarePlacement(_Probe("visible"), Placement.TOOL_VISIBLE)))
+    assert _tags(stack)[0] == "visible"
+
+
+def test_model_logical_lands_outside_the_retry_middleware():
+    stack = _lead_stack(_extensions(MiddlewarePlacement(_Probe("decision"), Placement.MODEL_LOGICAL)))
+    tags = _tags(stack)
+    assert tags.index("decision") < tags.index("LLMErrorHandlingMiddleware")
+
+
+def test_tool_raw_lands_inside_tool_error_handling():
+    stack = _lead_stack(_extensions(MiddlewarePlacement(_Probe("raw"), Placement.TOOL_RAW)))
+    tags = _tags(stack)
+    assert tags.index("raw") > tags.index("ToolErrorHandlingMiddleware")
+
+
+def test_runtime_isolation_failure_is_recorded_after_stack_composition():
+    from deerflow.extensions import get_runtime_diagnostics, reset_runtime_diagnostics
+
+    class _FailingObserver(AgentMiddleware):
+        def wrap_tool_call(self, request, handler):
+            raise ValueError("observation exploded")
+
+    reset_runtime_diagnostics()
+    try:
+        stack = _lead_stack(
+            _extensions(
+                MiddlewarePlacement(
+                    _FailingObserver(),
+                    Placement.TOOL_VISIBLE,
+                )
+            )
+        )
+        isolated = next(middleware for middleware in stack if isinstance(middleware, IsolatedMiddleware))
+        handler_calls = 0
+
+        def handler(request):
+            nonlocal handler_calls
+            handler_calls += 1
+            return "core-result"
+
+        assert isolated.wrap_tool_call("request", handler) == "core-result"
+        diagnostics = get_runtime_diagnostics()
+    finally:
+        reset_runtime_diagnostics()
+
+    assert handler_calls == 1
+    assert len(diagnostics) == 1
+    assert diagnostics[0].source == "demo:install"
+    assert diagnostics[0].level == "error"
+    assert "wrap_tool_call" in diagnostics[0].message
+
+
+def test_build_and_runtime_diagnostics_are_each_recorded_once():
+    from deerflow.extensions import get_runtime_diagnostics, reset_runtime_diagnostics
+
+    class _FailingObserver(AgentMiddleware):
+        def wrap_model_call(self, request, handler):
+            raise ValueError("observation exploded")
+
+    app_config = _app_config()
+    app_config.safety_finish_reason.enabled = False
+    reset_runtime_diagnostics()
+    try:
+        stack = _lead_stack(
+            _extensions(
+                MiddlewarePlacement(
+                    _FailingObserver(),
+                    Placement.MODEL_PHYSICAL,
+                )
+            ),
+            app_config=app_config,
+        )
+        isolated = next(middleware for middleware in stack if isinstance(middleware, IsolatedMiddleware))
+
+        assert isolated.wrap_model_call("request", lambda request: "core-result") == "core-result"
+        diagnostics = get_runtime_diagnostics()
+    finally:
+        reset_runtime_diagnostics()
+
+    assert [diagnostic.level for diagnostic in diagnostics] == ["warning", "error"]
+    assert sum("fell back to a secondary anchor" in diagnostic.message for diagnostic in diagnostics) == 1
+    assert sum("wrap_model_call" in diagnostic.message for diagnostic in diagnostics) == 1
+
+
+def test_lead_only_contribution_is_absent_from_subagent_stack():
+    from deerflow.agents.middlewares.tool_error_handling_middleware import (
+        build_subagent_runtime_middlewares,
+    )
+
+    extensions = _extensions(MiddlewarePlacement(_Probe("lead-only"), Placement.STANDARD, scope=AgentScope.LEAD))
+    stack = build_subagent_runtime_middlewares(app_config=_app_config(), extensions=extensions)
+    assert "lead-only" not in _tags(stack)
+
+
+def test_first_subagent_build_resolves_every_lazy_anchor(monkeypatch):
+    """A lazy anchor table must be populated before its subagent copy is made.
+
+    ``dict(dict_subclass)`` bypasses the subclass's ``__iter__``/``__len__``
+    hooks in CPython.  Building a subagent first therefore used to copy an
+    empty table, then populate only MODEL_PHYSICAL as it installed the
+    subagent-specific override.
+    """
+    from deerflow.agents.middlewares.tool_error_handling_middleware import (
+        build_subagent_runtime_middlewares,
+    )
+    from deerflow.extensions import stack as stack_module
+
+    fresh_table = stack_module._AnchorTable()
+    monkeypatch.setattr(stack_module._AnchorTable, "_loaded", False)
+    monkeypatch.setattr(stack_module, "PLACEMENT_ANCHORS", fresh_table)
+
+    extensions = _extensions(
+        MiddlewarePlacement(
+            _Probe("subagent-standard"),
+            Placement.STANDARD,
+            scope=AgentScope.SUBAGENT,
+        )
+    )
+    stack = build_subagent_runtime_middlewares(
+        app_config=_app_config(),
+        extensions=extensions,
+    )
+
+    assert "subagent-standard" in _tags(stack)
+
+
+def test_core_ordering_table_is_enforced_against_a_real_stack(monkeypatch):
+    """The default constraint table must be consulted on the REAL built stack.
+
+    Task 7 deleted the in-builder guard and the test that forced a real
+    misordering. Exercising assert_ordering with synthetic classes proves the
+    function works; it does not prove the composing builder calls it with
+    CORE_ORDERING_CONSTRAINTS against the stack it actually produces. This test
+    is the only thing that does.
+
+    It patches the default table rather than reordering real middlewares: the
+    builder imports its middlewares inside the function body, so reordering
+    them would require stubbing sys.modules entries, which tests the stubbing
+    more than the wiring. Patching the table asserts exactly the claim at issue.
+    """
+    from deerflow.agents.middlewares.input_sanitization_middleware import InputSanitizationMiddleware
+    from deerflow.agents.middlewares.tool_error_handling_middleware import ToolErrorHandlingMiddleware
+    from deerflow.extensions import ordering as ordering_mod
+
+    # InputSanitization is the outermost wrapper and ToolErrorHandling sits deep
+    # in the tail, so demanding the reverse is a constraint the real stack breaks.
+    impossible = (
+        ordering_mod.OrderingConstraint(
+            outer=ToolErrorHandlingMiddleware,
+            inner=InputSanitizationMiddleware,
+            reason="deliberately inverted for this test",
+        ),
+    )
+    monkeypatch.setattr(ordering_mod, "CORE_ORDERING_CONSTRAINTS", impossible)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _lead_stack()
+    message = str(excinfo.value)
+    assert "ToolErrorHandlingMiddleware" in message
+    assert "InputSanitizationMiddleware" in message
+    assert "core middleware order" in message, "with no extension at either participating index the blame must fall on core order"
+
+
+def test_core_ordering_table_passes_on_the_unmodified_stack():
+    """The real stack must satisfy the real constraints — otherwise the test
+    above would pass for the wrong reason."""
+    _lead_stack()  # must not raise
+
+
+def test_ordering_violation_raises_and_names_the_extension():
+    """A contribution that inverts a core invariant must fail loudly at build
+    time — the resulting behaviour would otherwise be wrong without an error."""
+    from deerflow.agents.middlewares.tool_error_handling_middleware import ToolErrorHandlingMiddleware
+    from deerflow.extensions.ordering import OrderingConstraint, assert_ordering
+
+    stack = [ToolErrorHandlingMiddleware(app_config=_app_config()), _Probe("x")]
+    constraints = (OrderingConstraint(outer=_Probe, inner=ToolErrorHandlingMiddleware, reason="test"),)
+    with pytest.raises(RuntimeError, match="demo:install"):
+        assert_ordering(stack, {1: "demo:install"}, constraints)
+
+
+# --- AgentBuildContext.policy -----------------------------------------------
+#
+# Extensions read ctx.policy to adapt metering/behaviour to the limits the
+# host actually enforces. Both builders must fill it from the resolved
+# AppConfig — the field defaults to an all-disabled snapshot, so an omission
+# is silent and hands extensions wrong values.
+
+
+class _CtxCapture:
+    def __init__(self) -> None:
+        self.ctx = None
+
+    def contribute_middlewares(self, app_store, ctx):
+        self.ctx = ctx
+        return ()
+
+
+def _extensions_with_contributor(contributor):
+    registry = ExtensionRegistry()
+    with registry.attributed_to("capture:install"):
+        registry.middlewares(contributor)
+    return registry.build()
+
+
+def _policy_config() -> AppConfig:
+    from deerflow.config.subagents_config import SubagentsAppConfig
+    from deerflow.config.token_budget_config import TokenBudgetConfig
+
+    return AppConfig(
+        sandbox=SandboxConfig(use="deerflow.sandbox.local:LocalSandboxProvider"),
+        token_budget=TokenBudgetConfig(
+            enabled=True,
+            max_tokens=12345,
+            max_input_tokens=1000,
+            max_output_tokens=2000,
+            warn_threshold=0.7,
+            hard_stop_threshold=0.95,
+        ),
+        subagents=SubagentsAppConfig(max_total_per_run=7),
+    )
+
+
+def _assert_projected_policy(policy) -> None:
+    assert policy.token_budget_enabled is True
+    assert policy.max_input_tokens == 1000
+    assert policy.max_output_tokens == 2000
+    assert policy.max_total_tokens == 12345
+    assert policy.budget_warn_fraction == 0.7
+    assert policy.budget_hard_fraction == 0.95
+    assert policy.max_subagents_per_run == 7
+
+
+def test_lead_build_context_carries_the_projected_host_policy():
+    capture = _CtxCapture()
+    _lead_stack(extensions=_extensions_with_contributor(capture), app_config=_policy_config())
+    assert capture.ctx is not None, "the contributor was never consulted"
+    _assert_projected_policy(capture.ctx.policy)
+
+
+def test_subagent_build_context_carries_the_projected_host_policy():
+    from deerflow.agents.middlewares.tool_error_handling_middleware import build_subagent_runtime_middlewares
+
+    capture = _CtxCapture()
+    build_subagent_runtime_middlewares(
+        app_config=_policy_config(),
+        model_name="gpt-4o",
+        extensions=_extensions_with_contributor(capture),
+    )
+    assert capture.ctx is not None, "the contributor was never consulted"
+    _assert_projected_policy(capture.ctx.policy)

--- a/backend/tests/test_extension_subagent_lifecycle.py
+++ b/backend/tests/test_extension_subagent_lifecycle.py
@@ -1,0 +1,471 @@
+"""Subagent executions must produce the same task events as lead executions.
+
+These tests drive the real `_aexecute` path. Testing `notify_task_*` directly
+would pass without any executor change, so it would not gate this task's work.
+
+Three deviations from the plan's verbatim test code, all forced by how the repo
+and `_aexecute` actually behave (see the task report):
+
+1. `conftest.py` installs a MagicMock for `deerflow.subagents.executor` to break
+   a production circular import, so a module-level import of `SubagentExecutor`
+   yields a mock. Real classes are imported inside a fixture, following
+   `tests/test_subagent_executor.py`, which solves the same problem.
+2. `_aexecute` catches every exception and converts it into a FAILED
+   `SubagentResult`; it does not propagate. So the driver asserts on the
+   returned result plus the recorder rather than wrapping the call in
+   `pytest.raises`, which would always fail with DID NOT RAISE.
+3. The runtime context reaches the graph as `agent.astream(..., context=...)`,
+   a sibling kwarg of `config=` — not as `config["context"]`. The fake agent
+   captures the `context` kwarg accordingly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from deerflow_extension_api import EXTENSION_TASK_STORE_KEY, TaskInfo, TaskOutcome
+from langchain_core.messages import AIMessage
+
+from deerflow.extensions import reset_loaded_extensions, set_loaded_extensions
+from deerflow.extensions.notify import (
+    reset_extension_notify_loop,
+    set_extension_notify_loop,
+    suspend_extension_system_observations,
+)
+from deerflow.extensions.registry import ExtensionRegistry
+
+# Same set test_subagent_executor.py mocks to import the real executor module.
+_MOCKED_MODULE_NAMES = [
+    "deerflow.agents",
+    "deerflow.agents.thread_state",
+    "deerflow.agents.middlewares",
+    "deerflow.agents.middlewares.thread_data_middleware",
+    "deerflow.sandbox",
+    "deerflow.sandbox.middleware",
+    "deerflow.sandbox.security",
+    "deerflow.models",
+    "deerflow.skills.storage",
+]
+
+
+class _Sentinel(RuntimeError):
+    """Stops execution right after the wiring under test has run."""
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.starts: list[TaskInfo] = []
+        self.stops: list[tuple[TaskInfo, TaskOutcome]] = []
+
+    async def on_task_start(self, app_store, task_store, info):
+        self.starts.append(info)
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        self.stops.append((info, outcome))
+
+
+class _TaskStoreConsumer:
+    def __init__(self) -> None:
+        self.lifecycle_events: list[str] = []
+
+    def contribute_middlewares(self, app_store, ctx):
+        return ()
+
+    async def on_system_model_call(self, app_store, task_store, kind, request, result):
+        return None
+
+    async def on_task_start(self, app_store, task_store, info):
+        self.lifecycle_events.append("start")
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        self.lifecycle_events.append("stop")
+
+
+@pytest.fixture(autouse=True)
+def env():
+    """Import the real executor classes and isolate the extensions singleton."""
+    reset_loaded_extensions()
+    reset_extension_notify_loop()
+
+    original_modules = {name: sys.modules.get(name) for name in _MOCKED_MODULE_NAMES}
+    original_executor = sys.modules.get("deerflow.subagents.executor")
+
+    if "deerflow.subagents.executor" in sys.modules:
+        del sys.modules["deerflow.subagents.executor"]
+    subagents_pkg = sys.modules.get("deerflow.subagents")
+    if subagents_pkg is not None and hasattr(subagents_pkg, "executor"):
+        delattr(subagents_pkg, "executor")
+
+    try:
+        for name in _MOCKED_MODULE_NAMES:
+            sys.modules[name] = MagicMock()
+        storage_module = ModuleType("deerflow.skills.storage")
+        storage_module.get_or_new_skill_storage = lambda **kwargs: SimpleNamespace(load_skills=lambda *, enabled_only: [])
+        storage_module.get_or_new_user_skill_storage = lambda user_id, **kwargs: SimpleNamespace(load_skills=lambda *, enabled_only: [])
+        sys.modules["deerflow.skills.storage"] = storage_module
+
+        from deerflow.subagents.config import SubagentConfig
+        from deerflow.subagents.executor import SubagentExecutor, SubagentResult, SubagentStatus
+
+        # CI checkouts have no config.yaml; these tests never reach real config.
+        sys.modules["deerflow.subagents.executor"].get_app_config = lambda: SimpleNamespace(
+            tool_search=SimpleNamespace(enabled=False),
+            authorization=SimpleNamespace(enabled=False),
+        )
+
+        yield SimpleNamespace(
+            SubagentConfig=SubagentConfig,
+            SubagentExecutor=SubagentExecutor,
+            SubagentResult=SubagentResult,
+            SubagentStatus=SubagentStatus,
+        )
+    finally:
+        # try/finally, unlike the pattern in test_subagent_executor.py this is
+        # copied from: if the real-class import above ever raises, the mocked
+        # modules must not leak into every later test in the process.
+        for name in _MOCKED_MODULE_NAMES:
+            if original_modules[name] is not None:
+                sys.modules[name] = original_modules[name]
+            elif name in sys.modules:
+                del sys.modules[name]
+        if original_executor is not None:
+            sys.modules["deerflow.subagents.executor"] = original_executor
+        subagents_pkg = sys.modules.get("deerflow.subagents")
+        if subagents_pkg is not None and hasattr(subagents_pkg, "executor"):
+            # Cleared at teardown too, not only at setup: otherwise
+            # `from deerflow.subagents import executor` and sys.modules[...]
+            # disagree for the rest of the session.
+            delattr(subagents_pkg, "executor")
+        reset_extension_notify_loop()
+        reset_loaded_extensions()
+
+
+def _install(recorder) -> None:
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.task_lifecycle(recorder)
+    set_loaded_extensions(registry.build())
+
+
+def _install_task_store_consumer(kind: str) -> _TaskStoreConsumer:
+    registry = ExtensionRegistry()
+    consumer = _TaskStoreConsumer()
+    with registry.attributed_to("demo:install"):
+        if kind == "middleware":
+            registry.middlewares(consumer)
+        else:
+            registry.system_model_observer(consumer)
+    set_loaded_extensions(registry.build())
+    return consumer
+
+
+def _executor(env, **overrides):
+    # SubagentConfig's prompt field is `system_prompt`, not `prompt` (see
+    # subagents/config.py); the plan's `_executor()` anticipated this drift.
+    config = env.SubagentConfig(name="researcher", description="d", system_prompt="p", tools=[])
+    kwargs = {"run_id": "run-1", "thread_id": "thread-1"}
+    kwargs.update(overrides)
+    return env.SubagentExecutor(config=config, tools=[], **kwargs)
+
+
+def _raise_sentinel(self, task):
+    raise _Sentinel()
+
+
+def _run(executor):
+    return asyncio.run(executor._aexecute("do the thing"))
+
+
+class _RunningLoop:
+    """A real serving loop running on another thread, like the Gateway's."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        assert self._ready.wait(5), "loop thread did not start"
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.call_soon(self._ready.set)
+        self.loop.run_forever()
+
+    def close(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(5)
+        self.loop.close()
+
+
+class _LoopBoundLifecycleService:
+    """Binds in service startup, then rejects hooks run on another loop."""
+
+    def __init__(self) -> None:
+        self.bound_loop: asyncio.AbstractEventLoop | None = None
+        self.events: list[str] = []
+        self.event_loops: list[asyncio.AbstractEventLoop] = []
+
+    async def start(self, deps) -> None:
+        self.bound_loop = asyncio.get_running_loop()
+
+    async def stop(self) -> None:
+        return None
+
+    async def on_task_start(self, app_store, task_store, info) -> None:
+        loop = asyncio.get_running_loop()
+        if loop is not self.bound_loop:
+            raise RuntimeError("loop-bound service used from the subagent loop")
+        self.events.append("start")
+        self.event_loops.append(loop)
+
+    async def on_task_stop(self, app_store, task_store, info, outcome) -> None:
+        loop = asyncio.get_running_loop()
+        if loop is not self.bound_loop:
+            raise RuntimeError("loop-bound service used from the subagent loop")
+        self.events.append("stop")
+        self.event_loops.append(loop)
+
+
+class _FakeAgent:
+    """Captures what the executor hands the graph, then stops the run."""
+
+    def __init__(self, seen: dict) -> None:
+        self._seen = seen
+
+    def astream(self, *args, **kwargs):
+        self._seen["context"] = kwargs.get("context")
+        raise _Sentinel()
+
+
+def _stub_agent(monkeypatch, env, seen: dict) -> None:
+    async def _fake_build_initial_state(self, task):
+        return ({}, [], None)
+
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _fake_build_initial_state)
+    monkeypatch.setattr(env.SubagentExecutor, "_create_agent", lambda self, tools, **kw: _FakeAgent(seen))
+
+
+def test_task_start_fires_with_subagent_shaped_info(monkeypatch, env):
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _raise_sentinel)
+    _run(executor)
+
+    assert len(recorder.starts) == 1
+    info = recorder.starts[0]
+    assert info.kind == "subagent"
+    assert info.run_id == "run-1", "subagent shares the parent run"
+    assert info.parent_task_id == "run-1", "subagent must point at the lead task"
+    assert info.thread_id == "thread-1"
+    assert info.agent_name == "researcher"
+    assert info.task_id, "task_id comes from result.task_id, not self.task_id"
+
+
+def test_lifecycle_hooks_run_on_the_registered_extension_loop(monkeypatch, env):
+    extension = _LoopBoundLifecycleService()
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.service(extension)
+        registry.task_lifecycle(extension)
+    set_loaded_extensions(registry.build())
+
+    host = _RunningLoop()
+    try:
+        asyncio.run_coroutine_threadsafe(extension.start(None), host.loop).result(5)
+        set_extension_notify_loop(host.loop)
+        # Gateway suspends fire-and-forget memory observations before draining
+        # runs; task lifecycle must retain the registered loop until that drain
+        # and service teardown have completed.
+        suspend_extension_system_observations()
+
+        executor = _executor(env)
+        monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _raise_sentinel)
+        result = _run(executor)
+    finally:
+        reset_extension_notify_loop()
+        host.close()
+
+    assert result.status is env.SubagentStatus.FAILED
+    assert extension.events == ["start", "stop"]
+    assert extension.event_loops == [host.loop, host.loop]
+
+
+def test_failure_reports_failed_outcome_from_finally(monkeypatch, env):
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _raise_sentinel)
+    result = _run(executor)
+
+    assert result.status is env.SubagentStatus.FAILED, "guards the premise of the outcome assertion"
+    assert len(recorder.stops) == 1, "stop must fire on the exception path too"
+    assert recorder.stops[0][1] is TaskOutcome.FAILED
+    assert recorder.stops[0][0].task_id == recorder.starts[0].task_id
+
+
+def test_cancelled_run_reports_aborted(monkeypatch, env):
+    """A user cancellation is an abort, not a failure — the same distinction the
+    lead path draws, so one extension code path reads both.
+
+    This also covers the `return` that the pre-stream cancel check makes from
+    *inside* the try: stop must still fire, which only holds if the notification
+    lives in `finally` rather than after the try.
+    """
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+
+    holder = env.SubagentResult(task_id="cancelme", trace_id="trace-1", status=env.SubagentStatus.RUNNING)
+    holder.cancel_event.set()
+    result = asyncio.run(executor._aexecute("do the thing", holder))
+
+    assert result.status is env.SubagentStatus.CANCELLED
+    assert len(recorder.stops) == 1, "early return inside the try must still notify stop"
+    assert recorder.stops[0][1] is TaskOutcome.ABORTED
+    assert recorder.stops[0][0].task_id == "cancelme", "task id comes from the caller's result holder"
+
+
+def test_task_store_reaches_the_runtime_context(monkeypatch, env):
+    """Contributed middlewares can only read the store through the runtime
+    context, so the executor must install it there for subagents too."""
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+    _run(executor)
+
+    context = seen.get("context") or {}
+    assert EXTENSION_TASK_STORE_KEY in context
+    assert context[EXTENSION_TASK_STORE_KEY].scope_id == recorder.starts[0].task_id
+
+
+def test_task_store_reaches_middleware_without_lifecycle_or_parent_run(monkeypatch, env):
+    consumer = _install_task_store_consumer("middleware")
+    executor = _executor(env, run_id=None)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+
+    result = _run(executor)
+
+    context = seen.get("context") or {}
+    assert EXTENSION_TASK_STORE_KEY in context
+    assert context[EXTENSION_TASK_STORE_KEY].scope_id == result.task_id
+    assert consumer.lifecycle_events == []
+
+
+def test_task_store_reaches_system_observer_without_lifecycle(monkeypatch, env):
+    consumer = _install_task_store_consumer("observer")
+    executor = _executor(env)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+
+    result = _run(executor)
+
+    context = seen.get("context") or {}
+    assert EXTENSION_TASK_STORE_KEY in context
+    assert context[EXTENSION_TASK_STORE_KEY].scope_id == result.task_id
+    assert consumer.lifecycle_events == []
+
+
+def test_zero_contributors_skips_the_wiring_entirely(monkeypatch, env):
+    """The zero-extension path must not install a store in the runtime context.
+
+    Deliberately narrower than "must not construct a store": this asserts the
+    observable half. Registry tests verify the `needs_task_store` construction
+    guard separately.
+    """
+    executor = _executor(env)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+    _run(executor)  # no contributors installed
+
+    context = seen.get("context") or {}
+    assert EXTENSION_TASK_STORE_KEY not in context, "no contributors means no store allocated"
+
+
+def test_missing_run_id_does_not_break_execution(monkeypatch, env):
+    """Subagents can run without a parent run id (e.g. direct invocation)."""
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env, run_id=None)
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _raise_sentinel)
+    _run(executor)
+    assert recorder.starts == [], "no parent run means no subagent task event"
+    assert recorder.stops == [], "and no orphan stop either"
+
+
+class _CompletingAgent:
+    """Streams one chunk with a usable answer, so the run terminates COMPLETED."""
+
+    async def astream(self, *args, **kwargs):
+        yield {"messages": [AIMessage(content="the answer")]}
+
+
+def test_successful_run_reports_completed(monkeypatch, env):
+    """The outcome that fires on virtually every real subagent run.
+
+    Left uncovered, the `else` fallback that produced it also silently reported
+    COMPLETED for a status the host never set — which is exactly the defect this
+    task's fix round closes.
+    """
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+
+    async def _fake_build_initial_state(self, task):
+        return ({}, [], None)
+
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _fake_build_initial_state)
+    monkeypatch.setattr(env.SubagentExecutor, "_create_agent", lambda self, tools, **kw: _CompletingAgent())
+    result = _run(executor)
+
+    assert result.status is env.SubagentStatus.COMPLETED, "premise for the outcome assertion"
+    assert len(recorder.stops) == 1
+    assert recorder.stops[0][1] is TaskOutcome.COMPLETED
+
+
+def test_a_status_the_host_never_set_reports_failed_not_completed(monkeypatch, env):
+    """A BaseException escapes `except Exception`, so the result is still
+    RUNNING when the finally classifies it. Success-keyed classification reports
+    FAILED; the previous `else: COMPLETED` fallback called it a clean success.
+    """
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+
+    def _hard_stop(self, task):
+        raise KeyboardInterrupt("host going down")
+
+    monkeypatch.setattr(env.SubagentExecutor, "_build_initial_state", _hard_stop)
+
+    with pytest.raises(KeyboardInterrupt):
+        _run(executor)
+
+    assert len(recorder.stops) == 1, "the finally must still notify"
+    assert recorder.stops[0][1] is TaskOutcome.FAILED
+
+
+def test_timed_out_reports_failed(monkeypatch, env):
+    """execute_async stamps TIMED_OUT on the holder before cancelling; that is
+    a failure to an extension, not a completion."""
+    recorder = _Recorder()
+    _install(recorder)
+    executor = _executor(env)
+    seen: dict = {}
+    _stub_agent(monkeypatch, env, seen)
+
+    holder = env.SubagentResult(task_id="slowpoke", trace_id="trace-1", status=env.SubagentStatus.RUNNING)
+    holder.try_set_terminal(env.SubagentStatus.TIMED_OUT, error="too slow")
+    result = asyncio.run(executor._aexecute("do the thing", holder))
+
+    assert result.status is env.SubagentStatus.TIMED_OUT
+    assert recorder.stops[0][1] is TaskOutcome.FAILED

--- a/backend/tests/test_extension_system_model_calls.py
+++ b/backend/tests/test_extension_system_model_calls.py
@@ -1,0 +1,758 @@
+"""Tests for observing model calls made outside the agent graph.
+
+Coverage boundary (deviation from the plan — see the task report). The plan
+named five call sites. Four are covered:
+
+- async: ``runtime/goal.py``, ``title_middleware.py``,
+  ``summarization_middleware.py::_asummarize_with``
+- sync:  the DeerMem memory update, via the host-owned ``MemoryCallbacks`` seam
+
+The fifth, ``DeerFlowSummarizationMiddleware._summarize_with``, is deliberately
+NOT wired. It is unreachable in the Gateway and in subagents — the middleware
+overrides both ``before_model`` and ``abefore_model``, so the async graph always
+takes the async path — and its only live host is ``DeerFlowClient.stream()``,
+which registers no loop to dispatch on. Wiring it would buy nothing.
+
+The DeerMem site cannot use the async helper: it runs on a debounce timer thread
+with no event loop, and its sync-ness is deliberate (its own docstring says the
+sync path exists so "no second event loop is created", the fix for issue #2615's
+cross-loop reuse of the shared async httpx pool). So the observation is handed
+to the host's registered loop instead — see
+``extensions.notify.dispatch_system_model_observation``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from deerflow_extension_api import (
+    EXTENSION_TASK_STORE_KEY,
+    ExtensionData,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.runtime import Runtime
+
+from deerflow.extensions import reset_loaded_extensions, set_loaded_extensions
+from deerflow.extensions.notify import notify_system_model_call, observe_system_model_call, task_store_for_system_call
+from deerflow.extensions.registry import ExtensionRegistry
+
+# evaluate_goal_completion short-circuits to `missing_evidence` before it ever
+# builds a model when there is no visible assistant evidence, so the plan's
+# `messages=[]` never reached the call site under test.
+_EVIDENCE = [HumanMessage(content="ship it"), AIMessage(content="I shipped it.")]
+
+
+class _Observer:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bool]] = []
+        self.results: list[SystemModelResult] = []
+        self.requests: list[SystemModelRequest] = []
+        self.stores: list[ExtensionData] = []
+
+    async def on_system_model_call(self, app_store, task_store, kind, request, result):
+        self.calls.append((kind.value, result.error is None))
+        self.results.append(result)
+        self.requests.append(request)
+        self.stores.append(task_store)
+
+
+class _Boom:
+    async def on_system_model_call(self, app_store, task_store, kind, request, result):
+        raise ValueError("observer exploded")
+
+
+def _extensions(*observers):
+    registry = ExtensionRegistry()
+    for index, observer in enumerate(observers):
+        with registry.attributed_to(f"ext{index}:install"):
+            registry.system_model_observer(observer)
+    return registry.build()
+
+
+@pytest.fixture
+def _singleton():
+    reset_loaded_extensions()
+    yield
+    reset_loaded_extensions()
+
+
+def _install(observer) -> None:
+    set_loaded_extensions(_extensions(observer))
+
+
+def test_all_four_kinds_are_representable():
+    assert {k.value for k in SystemOperationKind} == {"goal", "memory", "title", "summarization"}
+
+
+def test_success_is_reported():
+    observer = _Observer()
+    asyncio.run(
+        notify_system_model_call(
+            _extensions(observer),
+            ExtensionData("t"),
+            SystemOperationKind.GOAL,
+            SystemModelRequest(),
+            SystemModelResult(response="ok"),
+        )
+    )
+    assert observer.calls == [("goal", True)]
+
+
+def test_failure_is_reported_too():
+    """A system call that raised is exactly the event an observability
+    extension most needs; notifying only on success would hide it."""
+    observer = _Observer()
+    asyncio.run(
+        notify_system_model_call(
+            _extensions(observer),
+            ExtensionData("t"),
+            SystemOperationKind.MEMORY,
+            SystemModelRequest(),
+            SystemModelResult(error=ValueError("nope")),
+        )
+    )
+    assert observer.calls == [("memory", False)]
+
+
+def test_missing_task_store_is_tolerated():
+    """Some system calls run with no live task (e.g. title generation on a
+    detached path); the observer still gets called with an empty store."""
+    observer = _Observer()
+    asyncio.run(
+        notify_system_model_call(
+            _extensions(observer),
+            None,
+            SystemOperationKind.TITLE,
+            SystemModelRequest(),
+            SystemModelResult(response="ok"),
+        )
+    )
+    assert observer.calls == [("title", True)]
+    assert observer.stores[0].scope_id == "detached"
+
+
+def test_one_failing_observer_does_not_stop_the_others():
+    observer = _Observer()
+    asyncio.run(
+        notify_system_model_call(
+            _extensions(_Boom(), observer),
+            ExtensionData("t"),
+            SystemOperationKind.SUMMARIZATION,
+            SystemModelRequest(),
+            SystemModelResult(response="ok"),
+        )
+    )
+    assert observer.calls == [("summarization", True)]
+
+
+def test_zero_observers_is_a_no_op():
+    asyncio.run(
+        notify_system_model_call(
+            ExtensionRegistry().build(),
+            ExtensionData("t"),
+            SystemOperationKind.GOAL,
+            SystemModelRequest(),
+            SystemModelResult(response="ok"),
+        )
+    )
+
+
+def test_task_store_is_recovered_from_the_invoke_config():
+    """Direct/legacy callers retain the top-level RunnableConfig fallback."""
+    store = ExtensionData("task-1")
+    config = {"context": {EXTENSION_TASK_STORE_KEY: store}}
+    assert task_store_for_system_call(config) is store
+
+
+@pytest.mark.parametrize("config", [None, {}, {"context": None}, {"context": {}}, "not-a-config"])
+def test_task_store_lookup_tolerates_every_shape(config):
+    assert task_store_for_system_call(config) is None
+
+
+# --- observe_system_model_call ---------------------------------------------
+
+
+def test_observe_returns_the_response_and_reports_success(_singleton):
+    observer = _Observer()
+    _install(observer)
+
+    async def _call():
+        return "the answer"
+
+    got = asyncio.run(
+        observe_system_model_call(
+            SystemOperationKind.TITLE,
+            messages=["m"],
+            model_name="gpt-4o",
+            invoke_config={"run_name": "title"},
+            invoke=_call,
+        )
+    )
+    assert got == "the answer"
+    assert observer.calls == [("title", True)]
+    assert observer.results[0].response == "the answer"
+    assert observer.requests[0].model_name == "gpt-4o"
+    assert observer.results[0].duration_ms is not None
+
+
+def test_observe_uses_the_explicit_live_task_store(_singleton):
+    """The host's live task store wins over any stale config-derived value."""
+    observer = _Observer()
+    _install(observer)
+    live_store = ExtensionData("live-task")
+    config_store = ExtensionData("config-task")
+
+    async def _call():
+        return "ok"
+
+    asyncio.run(
+        observe_system_model_call(
+            SystemOperationKind.TITLE,
+            messages=[],
+            model_name=None,
+            invoke_config={"context": {EXTENSION_TASK_STORE_KEY: config_store}},
+            invoke=_call,
+            task_store=live_store,
+        )
+    )
+
+    assert observer.stores == [live_store]
+
+
+def test_observe_reports_failure_and_re_raises(_singleton):
+    """Observation is additive: the call's own error handling must be
+    unchanged, so the exception still propagates after the notification."""
+    observer = _Observer()
+    _install(observer)
+
+    async def _call():
+        raise ValueError("provider down")
+
+    with pytest.raises(ValueError, match="provider down"):
+        asyncio.run(
+            observe_system_model_call(
+                SystemOperationKind.MEMORY,
+                messages=[],
+                model_name=None,
+                invoke_config=None,
+                invoke=_call,
+            )
+        )
+    assert observer.calls == [("memory", False)]
+    assert isinstance(observer.results[0].error, ValueError)
+
+
+def test_observe_does_nothing_measurable_without_observers(_singleton):
+    """Zero-extension path: the original call runs and nothing else does."""
+    calls: list[int] = []
+
+    async def _call():
+        calls.append(1)
+        return "ok"
+
+    got = asyncio.run(
+        observe_system_model_call(
+            SystemOperationKind.GOAL,
+            messages=[],
+            model_name=None,
+            invoke_config=None,
+            invoke=_call,
+        )
+    )
+    assert got == "ok"
+    assert calls == [1]
+
+
+# --- real call sites --------------------------------------------------------
+
+
+class _FakeModel:
+    def __init__(self, *, error: Exception | None = None) -> None:
+        self._error = error
+        self.calls = 0
+
+    async def ainvoke(self, messages, config=None):
+        self.calls += 1
+        if self._error is not None:
+            raise self._error
+
+        class _Response:
+            content = '{"satisfied": true, "blocker": "none", "reason": "done", "evidence_summary": "x"}'
+
+        return _Response()
+
+
+def test_goal_call_site_notifies_on_success(_singleton):
+    """Drives the real evaluate_goal_completion path: a refactor that drops the
+    notification fails here rather than silently losing observations."""
+    from deerflow.runtime.goal import evaluate_goal_completion
+
+    observer = _Observer()
+    _install(observer)
+    store = ExtensionData("goal-task")
+    asyncio.run(
+        evaluate_goal_completion(
+            {"objective": "ship it"},
+            _EVIDENCE,
+            model=_FakeModel(),
+            model_name="gpt-4o",
+            thread_id="t",
+            user_id="u",
+            task_store=store,
+        )
+    )
+    assert observer.calls == [("goal", True)]
+    assert observer.stores == [store]
+
+
+def test_goal_call_site_notifies_on_failure(_singleton):
+    """The failing system call is exactly the event an observability extension
+    most needs; notifying only on success would hide it."""
+    from deerflow.runtime.goal import evaluate_goal_completion
+
+    observer = _Observer()
+    _install(observer)
+    with pytest.raises(ValueError):
+        asyncio.run(
+            evaluate_goal_completion(
+                {"objective": "ship it"},
+                _EVIDENCE,
+                model=_FakeModel(error=ValueError("provider down")),
+                model_name="gpt-4o",
+                thread_id="t",
+                user_id="u",
+            )
+        )
+    assert observer.calls == [("goal", False)]
+
+
+def test_summarization_call_site_notifies(_singleton):
+    """The async summarization path is wired; its sync sibling is not (see the
+    module docstring)."""
+    from deerflow.agents.middlewares.summarization_middleware import DeerFlowSummarizationMiddleware
+
+    observer = _Observer()
+    _install(observer)
+
+    class _SummaryModel:
+        async def ainvoke(self, prompt, config=None):
+            class _R:
+                text = "  a summary  "
+
+            return _R()
+
+    # Stubbed at the boundaries the observed call sits between: prompt
+    # preparation and candidate-model resolution. The observation lives in
+    # `_ainvoke_summary`, the single place the async provider call happens, so a
+    # candidate that fails is still reported rather than hidden by the fallback.
+    middleware = DeerFlowSummarizationMiddleware.__new__(DeerFlowSummarizationMiddleware)
+    middleware._prepare_summary_prompt = lambda messages, previous_summary=None: "prompt"
+    middleware._generation_candidate_names = lambda: [None]
+    middleware._model_for = lambda name: _SummaryModel()
+
+    got = asyncio.run(middleware._asummarize_with(["m"]))
+    assert got == "a summary"
+    assert observer.calls == [("summarization", True)]
+
+
+def test_summarization_reports_a_failed_candidate_before_falling_back(_singleton):
+    """A candidate that raises is a system model call an observer must still see;
+    the fallback to the next candidate must not swallow it."""
+    from deerflow.agents.middlewares.summarization_middleware import DeerFlowSummarizationMiddleware
+
+    observer = _Observer()
+    _install(observer)
+
+    class _Failing:
+        model_name = "first"
+
+        async def ainvoke(self, prompt, config=None):
+            raise RuntimeError("provider is down")
+
+    class _Working:
+        model_name = "second"
+
+        async def ainvoke(self, prompt, config=None):
+            class _R:
+                text = "  a summary  "
+
+            return _R()
+
+    models = {"first": _Failing(), "second": _Working()}
+    middleware = DeerFlowSummarizationMiddleware.__new__(DeerFlowSummarizationMiddleware)
+    middleware._prepare_summary_prompt = lambda messages, previous_summary=None: "prompt"
+    middleware._generation_candidate_names = lambda: ["first", "second"]
+    middleware._model_for = lambda name: models[name]
+
+    got = asyncio.run(middleware._asummarize_with(["m"]))
+
+    assert got == "a summary"
+    assert observer.calls == [("summarization", False), ("summarization", True)]
+
+
+def test_summarization_public_hook_propagates_the_live_task_store(_singleton):
+    """Async compaction observes with the task store from its live Runtime."""
+    from deerflow.agents.middlewares.summarization_middleware import DeerFlowSummarizationMiddleware
+
+    observer = _Observer()
+    _install(observer)
+    store = ExtensionData("summary-task")
+    model = MagicMock()
+    model.with_config.return_value = model
+    model.ainvoke = AsyncMock(return_value=SimpleNamespace(text="compressed"))
+    middleware = DeerFlowSummarizationMiddleware(
+        model=model,
+        trigger=("messages", 4),
+        keep=("messages", 2),
+        token_counter=len,
+    )
+    state = {
+        "messages": [
+            HumanMessage(content="user-1"),
+            AIMessage(content="assistant-1"),
+            HumanMessage(content="user-2"),
+            AIMessage(content="assistant-2"),
+        ]
+    }
+    runtime = Runtime(context={EXTENSION_TASK_STORE_KEY: store})
+
+    result = asyncio.run(middleware.abefore_model(state, runtime))
+
+    assert result is not None
+    assert observer.stores == [store]
+
+
+def test_title_public_hook_propagates_the_live_task_store(_singleton, monkeypatch):
+    """The title observation uses the task store from its live Runtime."""
+    from deerflow.agents.middlewares import title_middleware as title_module
+    from deerflow.config.title_config import TitleConfig
+
+    observer = _Observer()
+    _install(observer)
+    store = ExtensionData("title-task")
+
+    class _TitleModel:
+        async def ainvoke(self, prompt, config=None):
+            return AIMessage(content="A Good Title")
+
+    monkeypatch.setattr(title_module, "create_chat_model", lambda **kwargs: _TitleModel())
+
+    middleware = title_module.TitleMiddleware(
+        title_config=TitleConfig(model_name="gpt-4o"),
+    )
+    state = {
+        "messages": [
+            HumanMessage(content="Question"),
+            AIMessage(content="Answer"),
+        ]
+    }
+
+    result = asyncio.run(
+        middleware.aafter_model(
+            state,
+            Runtime(context={EXTENSION_TASK_STORE_KEY: store}),
+        )
+    )
+
+    assert result == {"title": "A Good Title"}
+    assert observer.calls == [("title", True)]
+    assert observer.stores == [store]
+
+
+async def _noop_observation() -> None:
+    """A stand-in for a real notification coroutine, for dispatcher tests."""
+    return None
+
+
+# --- the synchronous (DeerMem) path -----------------------------------------
+#
+# These target the production wiring: MemoryUpdater -> MemoryCallbacks
+# .on_memory_llm_result -> dispatch_system_model_observation -> the registered
+# loop. The dispatcher is exercised directly for the loop-state failure modes,
+# which are the ones that would hang or silently drop.
+
+import threading  # noqa: E402
+
+from deerflow.agents.memory.manager import LangfuseMemoryCallbacks, MemoryCallbacks  # noqa: E402
+from deerflow.extensions.notify import (  # noqa: E402
+    dispatch_system_model_observation,
+    reset_extension_notify_loop,
+    set_extension_notify_loop,
+    suspend_extension_system_observations,
+)
+
+
+@pytest.fixture
+def _loop_registry():
+    reset_loaded_extensions()
+    reset_extension_notify_loop()
+    yield
+    reset_extension_notify_loop()
+    reset_loaded_extensions()
+
+
+class _RunningLoop:
+    """A real event loop running on its own thread, like the Gateway's."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._ready = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        assert self._ready.wait(5), "loop thread did not start"
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.call_soon(self._ready.set)
+        self.loop.run_forever()
+
+    def stop(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(5)
+
+    def close(self) -> None:
+        self.stop()
+        self.loop.close()
+
+
+def test_awaited_system_observer_runs_on_the_registered_extension_loop(_loop_registry):
+    host = _RunningLoop()
+    observed_loops: list[asyncio.AbstractEventLoop] = []
+
+    class _LoopBoundObserver:
+        async def on_system_model_call(self, app_store, task_store, kind, request, result):
+            loop = asyncio.get_running_loop()
+            if loop is not host.loop:
+                raise RuntimeError("loop-bound observer used from an isolated loop")
+            observed_loops.append(loop)
+
+    set_extension_notify_loop(host.loop)
+    try:
+        asyncio.run(
+            notify_system_model_call(
+                _extensions(_LoopBoundObserver()),
+                ExtensionData("task"),
+                SystemOperationKind.SUMMARIZATION,
+                SystemModelRequest(),
+                SystemModelResult(response="summary"),
+            )
+        )
+    finally:
+        host.close()
+
+    assert observed_loops == [host.loop]
+
+
+def _await_calls(observer, *, expected: int = 1, timeout: float = 5.0) -> bool:
+    """Wait for a fire-and-forget dispatch to land, without a fixed sleep."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if len(observer.calls) >= expected:
+            return True
+        threading.Event().wait(0.005)
+    return False
+
+
+def _memory_result(callbacks, *, response="ok", error=None) -> None:
+    callbacks.on_memory_llm_result(
+        {"run_name": "memory_agent"},
+        prompt="the prompt",
+        response=response,
+        error=error,
+        duration_ms=1.5,
+        model_name="memory-model",
+    )
+
+
+def test_memory_callback_reaches_an_observer_on_the_registered_loop(_loop_registry):
+    observer = _Observer()
+    _install(observer)
+    host = _RunningLoop()
+    set_extension_notify_loop(host.loop)
+    try:
+        _memory_result(LangfuseMemoryCallbacks())
+        assert _await_calls(observer), "observation never arrived"
+    finally:
+        host.close()
+
+    assert observer.calls == [("memory", True)]
+    assert observer.requests[0].model_name == "memory-model"
+    assert observer.results[0].duration_ms == 1.5
+
+
+def test_memory_callback_reports_the_failure_path(_loop_registry):
+    observer = _Observer()
+    _install(observer)
+    host = _RunningLoop()
+    set_extension_notify_loop(host.loop)
+    try:
+        _memory_result(LangfuseMemoryCallbacks(), response=None, error=ValueError("provider down"))
+        assert _await_calls(observer)
+    finally:
+        host.close()
+
+    assert observer.calls == [("memory", False)]
+    assert isinstance(observer.results[0].error, ValueError)
+
+
+def test_memory_callback_is_inert_without_observers(_loop_registry):
+    """Short-circuits before touching the loop: this runs on every memory
+    update whether or not any extension is installed."""
+    touched: list[str] = []
+
+    class _RecordingLoop:
+        def is_running(self):
+            touched.append("is_running")
+            return False
+
+    set_extension_notify_loop(_RecordingLoop())
+    _memory_result(LangfuseMemoryCallbacks())
+    assert touched == [], "the zero-observer path must not consult the loop at all"
+
+
+def test_updater_fires_the_result_hook_on_both_paths(_loop_registry):
+    """End-to-end through the real MemoryUpdater, so the two call sites in
+    updater.py are gated by a test rather than by inspection."""
+    from deerflow.agents.memory.backends.deermem.deermem.config import DeerMemConfig
+    from deerflow.agents.memory.backends.deermem.deermem.core.updater import MemoryUpdater
+
+    class _RecordingCallbacks(MemoryCallbacks):
+        def __init__(self) -> None:
+            self.results: list[tuple[bool, str | None, object]] = []
+
+        def on_memory_llm_result(self, invoke_config, *, prompt, response, error, duration_ms, model_name):
+            self.results.append((error is None, model_name, prompt))
+
+    class _Model:
+        def __init__(self, *, error=None):
+            self._error = error
+
+        def invoke(self, prompt, config=None):
+            if self._error:
+                raise self._error
+
+            class _R:
+                content = "{}"
+
+            return _R()
+
+    config = DeerMemConfig(model={"provider": "openai", "model": "gpt-x", "api_key": "k", "base_url": "u"})
+
+    for error, expected_ok in ((None, True), (ValueError("provider down"), False)):
+        callbacks = _RecordingCallbacks()
+        updater = MemoryUpdater(config, storage=SimpleNamespace(), llm=_Model(error=error), callbacks=callbacks)
+        updater._prepare_update_prompt = lambda **kw: ({}, "the prompt")
+        updater._finalize_update = lambda **kw: True
+
+        # A non-empty feed is required, not incidental: the updater short-circuits
+        # on `not feed_messages` before it ever builds a model, so an empty list
+        # would make this test pass without reaching the call site it guards.
+        updater._do_update_memory_sync(
+            messages=[HumanMessage(content="remember this")],
+            thread_id="t",
+            agent_name=None,
+            signals=frozenset(),
+            user_id="u",
+            trace_id="tr",
+        )
+
+        assert len(callbacks.results) == 1, f"hook did not fire for error={error!r}"
+        ok, model_name, prompt = callbacks.results[0]
+        assert ok is expected_ok
+        assert model_name == "gpt-x"
+        assert prompt == "the prompt"
+
+
+def test_dispatch_drops_when_the_loop_is_stopped_but_not_closed(_loop_registry):
+    """The mode that would hang. `is_closed()` reports False for a stopped loop
+    and `run_coroutine_threadsafe` accepts the submission but never resolves it,
+    so a blocking wait would wedge the memory queue for the process lifetime."""
+    observer = _Observer()
+    _install(observer)
+    host = _RunningLoop()
+    set_extension_notify_loop(host.loop)
+    host.stop()
+    assert not host.loop.is_closed(), "premise: stopped, not closed"
+    try:
+        submitted = dispatch_system_model_observation(_noop_observation(), "memory")
+    finally:
+        host.loop.close()
+    assert submitted is False
+    assert observer.calls == []
+
+
+def test_dispatch_survives_a_closed_loop(_loop_registry):
+    host = _RunningLoop()
+    set_extension_notify_loop(host.loop)
+    host.close()
+    assert dispatch_system_model_observation(_noop_observation(), "memory") is False
+
+
+def test_dispatch_without_a_registered_loop_is_a_no_op(_loop_registry):
+    assert dispatch_system_model_observation(_noop_observation(), "memory") is False
+
+
+def test_suspended_system_observations_are_dropped_with_a_registered_loop(_loop_registry):
+    host = _RunningLoop()
+    set_extension_notify_loop(host.loop)
+    suspend_extension_system_observations()
+    try:
+        assert dispatch_system_model_observation(_noop_observation(), "memory") is False
+    finally:
+        host.close()
+
+
+def test_suspend_without_a_registered_loop_is_a_no_op(_loop_registry):
+    """No runtime owns reset when tests/embedded hosts replace it with a noop."""
+    from deerflow.extensions import notify as notify_module
+
+    suspend_extension_system_observations()
+
+    assert notify_module._system_observations_enabled is True
+
+
+def test_dispatch_never_uses_the_callers_running_loop(_loop_registry):
+    """This process has several long-lived loops (Gateway, the isolated subagent
+    loop, BoxLite's). Dispatching to whichever is current on the calling thread
+    is the cross-loop bug this mechanism exists to avoid.
+
+    The call is made from *inside* the other loop's thread via
+    call_soon_threadsafe, so `get_running_loop()` there really does return the
+    wrong loop — an executor thread would merely raise RuntimeError and the test
+    would pass for the wrong reason.
+    """
+    ran_on: list[object] = []
+
+    class _LoopCapturingObserver:
+        async def on_system_model_call(self, app_store, task_store, kind, request, result):
+            ran_on.append(asyncio.get_running_loop())
+
+    set_loaded_extensions(_extensions(_LoopCapturingObserver()))
+    registered = _RunningLoop()
+    other = _RunningLoop()
+    set_extension_notify_loop(registered.loop)
+    done = threading.Event()
+
+    def _from_inside_the_other_loop():
+        assert asyncio.get_running_loop() is other.loop, "premise: a real, wrong, running loop"
+        _memory_result(LangfuseMemoryCallbacks())
+        done.set()
+
+    try:
+        other.loop.call_soon_threadsafe(_from_inside_the_other_loop)
+        assert done.wait(5)
+        deadline = time.monotonic() + 5
+        while not ran_on and time.monotonic() < deadline:
+            threading.Event().wait(0.005)
+    finally:
+        other.close()
+        registered.close()
+
+    assert ran_on == [registered.loop], "the observation must run on the registered loop, not the caller's"

--- a/backend/tests/test_extension_task_lifecycle.py
+++ b/backend/tests/test_extension_task_lifecycle.py
@@ -1,0 +1,597 @@
+"""Tests for task lifecycle notification and the runtime-context bridge."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from deerflow_extension_api import (
+    EXTENSION_TASK_STORE_KEY,
+    ExtensionData,
+    TaskInfo,
+    TaskOutcome,
+    task_store_from_runtime,
+)
+from langgraph.checkpoint.memory import InMemorySaver
+
+from deerflow.extensions import reset_loaded_extensions, set_loaded_extensions
+from deerflow.extensions.notify import (
+    lead_task_id,
+    lead_task_outcome,
+    notify_task_start,
+    notify_task_stop,
+)
+from deerflow.extensions.registry import ExtensionRegistry
+from deerflow.runtime.runs.manager import RunManager
+from deerflow.runtime.runs.schemas import RunStatus
+from deerflow.runtime.runs.worker import RunContext, _build_runtime_context, run_agent
+
+
+class _Recorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, str, str]] = []
+
+    async def on_task_start(self, app_store, task_store, info):
+        task_store.set(_Marker(info.task_id))
+        self.events.append(("start", info.task_id, info.kind))
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        self.events.append(("stop", info.task_id, outcome.value))
+
+
+class _Marker:
+    def __init__(self, task_id: str) -> None:
+        self.task_id = task_id
+
+
+class _TaskStoreConsumer:
+    def __init__(self) -> None:
+        self.lifecycle_events: list[str] = []
+
+    def contribute_middlewares(self, app_store, ctx):
+        return ()
+
+    async def on_system_model_call(self, app_store, task_store, kind, request, result):
+        return None
+
+    async def on_task_start(self, app_store, task_store, info):
+        self.lifecycle_events.append("start")
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        self.lifecycle_events.append("stop")
+
+
+class _Boom:
+    async def on_task_start(self, app_store, task_store, info):
+        raise ValueError("observer exploded")
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        raise ValueError("observer exploded")
+
+
+def _extensions(*contributors):
+    registry = ExtensionRegistry()
+    for index, contributor in enumerate(contributors):
+        with registry.attributed_to(f"ext{index}:install"):
+            registry.task_lifecycle(contributor)
+    return registry.build()
+
+
+def _info(task_id: str = "task-1", kind: str = "lead") -> TaskInfo:
+    return TaskInfo(task_id=task_id, run_id="run-1", thread_id="thread-1", kind=kind)
+
+
+def test_lead_task_id_derives_from_run_id():
+    """Lead task is 1:1 with a run — including across goal continuations, which
+    reuse the same task — so no new identifier is minted."""
+    assert lead_task_id("run-abc") == "run-abc"
+
+
+def test_start_and_stop_reach_the_contributor():
+    recorder = _Recorder()
+    extensions = _extensions(recorder)
+    store = ExtensionData("task-1")
+    asyncio.run(notify_task_start(extensions, store, _info()))
+    asyncio.run(notify_task_stop(extensions, store, _info(), TaskOutcome.COMPLETED))
+    assert recorder.events == [("start", "task-1", "lead"), ("stop", "task-1", "completed")]
+
+
+def test_contributor_can_store_state_in_the_task_store():
+    recorder = _Recorder()
+    store = ExtensionData("task-1")
+    asyncio.run(notify_task_start(_extensions(recorder), store, _info()))
+    assert store.get(_Marker).task_id == "task-1"
+
+
+def test_one_failing_observer_does_not_stop_the_others():
+    recorder = _Recorder()
+    extensions = _extensions(_Boom(), recorder)
+    store = ExtensionData("task-1")
+    asyncio.run(notify_task_start(extensions, store, _info()))
+    assert recorder.events == [("start", "task-1", "lead")]
+
+
+def test_zero_contributors_is_a_no_op():
+    extensions = ExtensionRegistry().build()
+    store = ExtensionData("task-1")
+    asyncio.run(notify_task_start(extensions, store, _info()))
+    asyncio.run(notify_task_stop(extensions, store, _info(), TaskOutcome.FAILED))
+
+
+def test_runtime_context_bridge_roundtrips():
+    store = ExtensionData("task-1")
+    context = {EXTENSION_TASK_STORE_KEY: store}
+
+    class _Runtime:
+        pass
+
+    runtime = _Runtime()
+    runtime.context = context
+    assert task_store_from_runtime(runtime) is store
+
+
+def test_build_runtime_context_installs_the_store_under_the_host_key():
+    """The bridge above only proves the reader works. This proves the writer
+    does: `_build_runtime_context` is the sole production code that puts the
+    store where `task_store_from_runtime` looks for it."""
+    store = ExtensionData("task-1")
+    ctx = _build_runtime_context("thread-1", "run-1", None, None, store)
+    assert ctx[EXTENSION_TASK_STORE_KEY] is store
+
+
+def test_build_runtime_context_adds_no_key_without_a_store():
+    """Zero-extension path: no store means no key, not a None placeholder."""
+    ctx = _build_runtime_context("thread-1", "run-1", None, None, None)
+    assert EXTENSION_TASK_STORE_KEY not in ctx
+
+
+def test_subagent_info_carries_parent():
+    info = TaskInfo(
+        task_id="call-9",
+        run_id="run-1",
+        thread_id="thread-1",
+        kind="subagent",
+        parent_task_id="run-1",
+    )
+    assert info.parent_task_id == "run-1"
+    assert info.kind == "subagent"
+
+
+def test_lead_outcome_reports_failed_when_the_run_did_not_succeed():
+    """A crashed lead run must not look like a completed one.
+
+    The subagent side (Task 11) maps its failed status to FAILED; without the
+    same mapping here an extension reconciling task state would treat a run
+    that raised as a clean completion.
+    """
+    assert lead_task_outcome(aborted=False, succeeded=False) is TaskOutcome.FAILED
+
+
+def test_lead_outcome_prefers_aborted_over_failure():
+    """Cancellation is the more specific explanation: an aborted run commonly
+    also unwinds through an exception, and the caller asked for the stop."""
+    assert lead_task_outcome(aborted=True, succeeded=False) is TaskOutcome.ABORTED
+    assert lead_task_outcome(aborted=True, succeeded=True) is TaskOutcome.ABORTED
+
+
+def test_lead_outcome_is_completed_only_on_explicit_success():
+    """Keyed on success rather than on an error probe, so a status the host
+    never anticipated degrades to FAILED instead of reporting a clean run."""
+    assert lead_task_outcome(aborted=False, succeeded=True) is TaskOutcome.COMPLETED
+
+
+# --- run_agent-level wiring -------------------------------------------------
+#
+# Everything above tests notify.py in isolation, which passes with both
+# worker.py hunks reverted. These drive the real run_agent so the wiring itself
+# is gated: start/stop firing around a run, the store reaching the runtime
+# context, and the outcome classification reading real run state.
+
+
+class _RunRecorder:
+    def __init__(self) -> None:
+        self.starts: list[TaskInfo] = []
+        self.start_stores: list[ExtensionData] = []
+        self.stops: list[tuple[TaskInfo, TaskOutcome]] = []
+
+    async def on_task_start(self, app_store, task_store, info):
+        self.starts.append(info)
+        self.start_stores.append(task_store)
+
+    async def on_task_stop(self, app_store, task_store, info, outcome):
+        self.stops.append((info, outcome))
+
+
+@pytest.fixture
+def _singleton():
+    reset_loaded_extensions()
+    yield
+    reset_loaded_extensions()
+
+
+def _install(recorder) -> None:
+    registry = ExtensionRegistry()
+    with registry.attributed_to("demo:install"):
+        registry.task_lifecycle(recorder)
+    set_loaded_extensions(registry.build())
+
+
+def _install_task_store_consumer(kind: str) -> _TaskStoreConsumer:
+    registry = ExtensionRegistry()
+    consumer = _TaskStoreConsumer()
+    with registry.attributed_to("demo:install"):
+        if kind == "middleware":
+            registry.middlewares(consumer)
+        else:
+            registry.system_model_observer(consumer)
+    set_loaded_extensions(registry.build())
+    return consumer
+
+
+def _bridge():
+    return SimpleNamespace(publish=AsyncMock(), publish_end=AsyncMock(), cleanup=AsyncMock())
+
+
+async def _drive(record, agent, run_manager) -> None:
+    await run_agent(
+        _bridge(),
+        run_manager,
+        record,
+        ctx=RunContext(checkpointer=InMemorySaver()),
+        agent_factory=lambda *, config: agent,
+        graph_input={},
+        config={},
+    )
+
+
+class _OkAgent:
+    """Captures the runtime context the worker hands the graph."""
+
+    def __init__(self) -> None:
+        self.context = None
+
+    async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+        self.context = (config or {}).get("context")
+        yield {"messages": []}
+
+
+class _TaskStoreReadingAgent:
+    """Reads the task store exactly as contributed middleware does."""
+
+    def __init__(self) -> None:
+        self.task_store = None
+
+    async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+        runtime = (config or {})["configurable"]["__pregel_runtime"]
+        self.task_store = task_store_from_runtime(runtime)
+        yield {"messages": []}
+
+
+class _BoomAgent:
+    async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+        raise ValueError("agent exploded")
+        yield  # pragma: no cover - makes this an async generator
+
+
+@pytest.mark.anyio
+async def test_run_agent_fires_start_and_stop_around_a_real_run(_singleton):
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-1")
+    await _drive(record, _OkAgent(), run_manager)
+
+    assert len(recorder.starts) == 1
+    assert len(recorder.stops) == 1
+    info = recorder.starts[0]
+    assert info.kind == "lead"
+    assert info.task_id == record.run_id, "lead task is 1:1 with the run"
+    assert info.thread_id == "thread-ext-1"
+    assert recorder.stops[0][0].task_id == info.task_id
+    assert recorder.stops[0][1] is TaskOutcome.COMPLETED
+
+
+@pytest.mark.anyio
+async def test_run_agent_puts_the_store_in_the_runtime_context(_singleton):
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-2")
+    agent = _OkAgent()
+    await _drive(record, agent, run_manager)
+
+    assert agent.context is not None
+    store = agent.context[EXTENSION_TASK_STORE_KEY]
+    assert store.scope_id == recorder.starts[0].task_id
+
+
+@pytest.mark.anyio
+async def test_run_agent_allocates_a_store_for_middleware_without_lifecycle(_singleton):
+    consumer = _install_task_store_consumer("middleware")
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-middleware")
+    agent = _TaskStoreReadingAgent()
+
+    await _drive(record, agent, run_manager)
+
+    assert agent.task_store is not None
+    assert agent.task_store.scope_id == record.run_id
+    assert consumer.lifecycle_events == []
+
+
+@pytest.mark.anyio
+async def test_run_agent_allocates_the_live_store_for_system_observers(_singleton, monkeypatch):
+    from deerflow.runtime.runs import worker as worker_module
+
+    consumer = _install_task_store_consumer("observer")
+    captured: list[ExtensionData | None] = []
+
+    async def _capture_goal_store(**kwargs):
+        captured.append(kwargs.get("task_store"))
+        return None
+
+    monkeypatch.setattr(worker_module, "_prepare_goal_continuation_input", _capture_goal_store)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-observer")
+    agent = _TaskStoreReadingAgent()
+
+    await _drive(record, agent, run_manager)
+
+    assert agent.task_store is not None
+    assert agent.task_store.scope_id == record.run_id
+    assert captured == [agent.task_store]
+    assert consumer.lifecycle_events == []
+
+
+@pytest.mark.anyio
+async def test_run_agent_reuses_the_lifecycle_store_for_goal_evaluation(_singleton, monkeypatch):
+    """Goal evaluation receives the exact store installed in the run Runtime."""
+    from deerflow.runtime.runs import worker as worker_module
+
+    recorder = _RunRecorder()
+    _install(recorder)
+    captured: list[ExtensionData | None] = []
+
+    async def _capture_goal_store(**kwargs):
+        captured.append(kwargs.get("task_store"))
+        return None
+
+    monkeypatch.setattr(worker_module, "_prepare_goal_continuation_input", _capture_goal_store)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-goal")
+    agent = _OkAgent()
+
+    await _drive(record, agent, run_manager)
+
+    runtime_store = agent.context[EXTENSION_TASK_STORE_KEY]
+    assert runtime_store is recorder.start_stores[0]
+    assert captured == [runtime_store]
+
+
+@pytest.mark.anyio
+async def test_run_agent_reports_failed_when_the_agent_raises(_singleton):
+    """The regression guard for the outcome classification: before it was keyed
+    on success, a raising run reported COMPLETED."""
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-3")
+    await _drive(record, _BoomAgent(), run_manager)
+
+    assert record.status is RunStatus.error, "guards the premise of the assertion below"
+    assert recorder.stops[0][1] is TaskOutcome.FAILED
+
+
+@pytest.mark.anyio
+async def test_run_agent_adds_nothing_to_the_context_without_extensions(_singleton):
+    """Zero-extension path, end to end."""
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-4")
+    agent = _OkAgent()
+    await _drive(record, agent, run_manager)
+
+    assert EXTENSION_TASK_STORE_KEY not in (agent.context or {})
+
+
+class _HardStopAgent:
+    """Raises a BaseException, which neither `except` clause in run_agent catches."""
+
+    async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+        raise KeyboardInterrupt("host going down")
+        yield  # pragma: no cover - makes this an async generator
+
+
+@pytest.mark.anyio
+async def test_run_agent_does_not_report_completed_when_a_base_exception_escapes(_singleton):
+    """The precise regression guard for the outcome classification.
+
+    A BaseException passes through both `except` clauses, so the run's status
+    is still `running` when the finally reads it and abort_event is unset. An
+    error-probe classification (`status == error`) called that COMPLETED; keying
+    on success reports FAILED instead.
+    """
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-5")
+
+    with pytest.raises(KeyboardInterrupt):
+        await _drive(record, _HardStopAgent(), run_manager)
+
+    assert record.status is RunStatus.running, "premise: no except clause ran, status untouched"
+    assert not record.abort_event.is_set(), "premise: nothing marked this an abort"
+    assert len(recorder.stops) == 1, "stop must still fire from the finally"
+    assert recorder.stops[0][1] is TaskOutcome.FAILED
+
+
+@pytest.mark.anyio
+async def test_run_agent_notifies_stop_before_clearing_finalizing_and_ending_the_stream(_singleton):
+    """Ordering guard for the interrupt multitask strategy.
+
+    `wait_for_prior_finalizing` polls `record.finalizing`, so if this run cleared
+    it before notifying stop, a replacement run could pass the barrier and fire
+    its `on_task_start` while this run's `on_task_stop` was still pending — an
+    extension keying state by thread_id would see two overlapping tasks.
+    `publish_end` is an await, so merely preceding the notification is enough to
+    open that window.
+    """
+    order: list[str] = []
+
+    class _OrderRecorder(_RunRecorder):
+        async def on_task_stop(self, app_store, task_store, info, outcome):
+            order.append("stop")
+            await super().on_task_stop(app_store, task_store, info, outcome)
+
+    finalizing_at_stop: list[bool] = []
+    recorder = _OrderRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-6")
+
+    class _StopWatcher(_OrderRecorder):
+        async def on_task_stop(self, app_store, task_store, info, outcome):
+            # The real invariant, not a proxy: the barrier flag must still be
+            # set while this notification runs.
+            finalizing_at_stop.append(record.finalizing)
+            await super().on_task_stop(app_store, task_store, info, outcome)
+
+    recorder = _StopWatcher()
+    _install(recorder)
+
+    async def _note_publish_end(run_id):
+        order.append("publish_end")
+
+    # A cancelled run is the path that actually sets finalizing (the
+    # `except asyncio.CancelledError` handler in run_agent), so this is the
+    # only shape that can observe the clear happening too early.
+    class _CancelledAgent:
+        async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+            raise asyncio.CancelledError()
+            yield  # pragma: no cover - makes this an async generator
+
+    bridge = SimpleNamespace(publish=AsyncMock(), publish_end=_note_publish_end, cleanup=AsyncMock())
+    await run_agent(
+        bridge,
+        run_manager,
+        record,
+        ctx=RunContext(checkpointer=InMemorySaver()),
+        agent_factory=lambda *, config: _CancelledAgent(),
+        graph_input={},
+        config={},
+    )
+
+    assert "stop" in order
+    assert order.index("stop") < order.index("publish_end"), f"stop must precede publish_end, got {order}"
+    assert finalizing_at_stop == [True], "the finalizing barrier must still be held when on_task_stop runs"
+    assert record.finalizing is False, "and must be cleared afterwards"
+
+
+@pytest.mark.anyio
+async def test_run_agent_skips_the_lifecycle_entirely_when_the_run_never_starts(_singleton):
+    """The gateway deliberately enters run_agent for already-aborted runs; those
+    return at the startup barrier and must produce neither a start nor a stop."""
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-7")
+    await run_manager.cancel(record.run_id)
+
+    await _drive(record, _OkAgent(), run_manager)
+
+    assert recorder.starts == [], "a run that never started must not announce one"
+    assert recorder.stops == [], "and must not announce a stop either"
+
+
+@pytest.mark.anyio
+async def test_run_agent_propagates_the_assistant_id_as_agent_name(_singleton):
+    recorder = _RunRecorder()
+    _install(recorder)
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-8", assistant_id="custom-agent")
+    await _drive(record, _OkAgent(), run_manager)
+
+    assert recorder.starts[0].agent_name == "custom-agent"
+
+
+@pytest.mark.anyio
+async def test_task_stop_budget_is_shared_and_skips_starved_contributors():
+    """A hung contributor must not make the host wait forever, and must not
+    silently look like it succeeded. Its successors are skipped once the shared
+    budget is spent — the budget is per-notification, not per-contributor, so
+    the total stays bounded however many extensions are installed."""
+    reached: list[str] = []
+
+    class _Hang:
+        async def on_task_stop(self, app_store, task_store, info, outcome):
+            reached.append("hang")
+            await asyncio.sleep(10)
+
+    class _Fast:
+        async def on_task_stop(self, app_store, task_store, info, outcome):
+            reached.append("fast")
+
+    extensions = _extensions(_Hang(), _Fast())
+    store = ExtensionData("task-1")
+    loop = asyncio.get_running_loop()
+    began = loop.time()
+    await notify_task_stop(extensions, store, _info(), TaskOutcome.COMPLETED, timeout=0.05)
+    elapsed = loop.time() - began
+
+    assert reached == ["hang"], "the starved successor is skipped, not silently awaited"
+    assert elapsed < 5, f"the hung contributor must not be awaited to completion (took {elapsed}s)"
+
+
+@pytest.mark.anyio
+async def test_a_malformed_contributor_cannot_abort_the_run_cleanup(_singleton):
+    """Contributors are arbitrary objects — the registry does no runtime
+    validation — so a plain `def` or a stale signature raises at CALL time, not
+    at await time. If that escaped, run_agent's finally would skip the
+    finalizing clear (wedging every later run on the thread in
+    wait_for_prior_finalizing, which has no overall bound) and skip publish_end,
+    leaving SSE consumers waiting for an end frame that never comes.
+    """
+
+    class _SyncContributor:
+        async def on_task_start(self, app_store, task_store, info):
+            return None
+
+        def on_task_stop(self, app_store, task_store, info, outcome):  # not a coroutine
+            raise RuntimeError("sync boom")
+
+    class _WrongSignature:
+        async def on_task_start(self, app_store, task_store, info):
+            return None
+
+        async def on_task_stop(self, app_store):  # stale signature
+            return None
+
+    survivor = _RunRecorder()
+    registry = ExtensionRegistry()
+    for index, contributor in enumerate([_SyncContributor(), _WrongSignature(), survivor]):
+        with registry.attributed_to(f"ext{index}:install"):
+            registry.task_lifecycle(contributor)
+    set_loaded_extensions(registry.build())
+
+    ended: list[str] = []
+
+    async def _note_publish_end(run_id):
+        ended.append(run_id)
+
+    run_manager = RunManager()
+    record = await run_manager.create("thread-ext-9")
+    bridge = SimpleNamespace(publish=AsyncMock(), publish_end=_note_publish_end, cleanup=AsyncMock())
+    await run_agent(
+        bridge,
+        run_manager,
+        record,
+        ctx=RunContext(checkpointer=InMemorySaver()),
+        agent_factory=lambda *, config: _OkAgent(),
+        graph_input={},
+        config={},
+    )
+
+    assert ended == [record.run_id], "publish_end must still run after a malformed contributor"
+    assert record.finalizing is False, "the finalizing barrier must not be stranded"
+    assert len(survivor.stops) == 1, "a later well-formed contributor still gets its stop"

--- a/backend/tests/test_gateway_extension_service_lifecycle.py
+++ b/backend/tests/test_gateway_extension_service_lifecycle.py
@@ -1,0 +1,363 @@
+"""Regression tests for extension services owned by the Gateway runtime."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+
+from deerflow.extensions import (
+    get_runtime_diagnostics,
+    initialize_runtime_diagnostics,
+    reset_runtime_diagnostics,
+)
+from deerflow.extensions.registry import ExtensionRegistry
+
+
+def _fake_database_config() -> SimpleNamespace:
+    """Minimal stand-in for AppConfig.database.
+
+    Mirrors the real field set rather than the subset today's code happens to
+    read: langgraph_runtime gained `checkpoint_delta.snapshot_frequency`
+    upstream, and a fake that omits a field fails with an AttributeError far
+    from the behaviour under test. The frequency comes from the real default so
+    this does not pin a magic number.
+    """
+    from deerflow.config.database_config import DEFAULT_CHECKPOINT_SNAPSHOT_FREQUENCY
+
+    return SimpleNamespace(
+        backend="memory",
+        checkpoint_channel_mode="full",
+        checkpoint_delta=SimpleNamespace(snapshot_frequency=DEFAULT_CHECKPOINT_SNAPSHOT_FREQUENCY),
+    )
+
+
+class _RecordingService:
+    def __init__(self, events: list[str] | None = None) -> None:
+        self.started = False
+        self.stopped = False
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._events = events
+
+    async def start(self, _deps) -> None:
+        self.start_calls += 1
+        self.started = True
+        if self._events is not None:
+            self._events.append("service_start")
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        self.stopped = True
+        if self._events is not None:
+            self._events.append("service_stop")
+
+
+@asynccontextmanager
+async def _context(value):
+    yield value
+
+
+@pytest.fixture(autouse=True)
+def _isolate_runtime_diagnostics():
+    reset_runtime_diagnostics()
+    yield
+    reset_runtime_diagnostics()
+
+
+@pytest.mark.asyncio
+async def test_runtime_stops_started_extension_services_when_later_startup_fails(monkeypatch) -> None:
+    """A failure after service startup must not leak the started service."""
+    import deerflow.extensions as extensions_module
+    import deerflow.extensions.notify as notify_module
+    import deerflow.persistence.engine as engine_module
+    import deerflow.persistence.thread_meta as thread_meta_module
+    import deerflow.runtime as runtime_module
+    import deerflow.runtime.checkpointer.async_provider as checkpointer_module
+    from app.gateway.deps import langgraph_runtime
+
+    events: list[str] = []
+
+    class _FailingStartService(_RecordingService):
+        async def start(self, _deps) -> None:
+            self.start_calls += 1
+            events.append("failing_start")
+            raise ValueError("start exploded")
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.stopped = True
+            events.append("failed_start_stop")
+
+    class _FailingStopService(_RecordingService):
+        async def start(self, _deps) -> None:
+            self.start_calls += 1
+            self.started = True
+            events.append("failing_stop_start")
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.stopped = True
+            events.append("failing_stop")
+            raise ValueError("stop exploded")
+
+    failing_start = _FailingStartService(events)
+    service = _RecordingService(events)
+    failing_stop = _FailingStopService(events)
+    registry = ExtensionRegistry()
+    with registry.attributed_to("failing-start:install"):
+        registry.service(failing_start)
+    with registry.attributed_to("recording:install"):
+        registry.service(service)
+    with registry.attributed_to("failing-stop:install"):
+        registry.service(failing_stop)
+    extensions = registry.build()
+
+    async def init_engine(_database) -> None:
+        return None
+
+    async def close_engine() -> None:
+        events.append("engine_close")
+
+    def fail_thread_store(_session_factory, _store):
+        raise RuntimeError("thread store startup failed")
+
+    monkeypatch.setattr(extensions_module, "get_loaded_extensions", lambda: extensions)
+    monkeypatch.setattr(runtime_module, "make_stream_bridge", lambda _config: _context(object()))
+    monkeypatch.setattr(runtime_module, "make_store", lambda _config: _context(object()))
+    monkeypatch.setattr(checkpointer_module, "make_checkpointer", lambda _config: _context(object()))
+    monkeypatch.setattr(engine_module, "init_engine_from_config", init_engine)
+    monkeypatch.setattr(engine_module, "close_engine", close_engine)
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: None)
+    monkeypatch.setattr(thread_meta_module, "make_thread_store", fail_thread_store)
+    monkeypatch.setattr(
+        notify_module,
+        "set_extension_notify_loop",
+        lambda _loop: events.append("notify_set"),
+    )
+    monkeypatch.setattr(
+        notify_module,
+        "reset_extension_notify_loop",
+        lambda: events.append("notify_reset"),
+    )
+
+    app = FastAPI()
+    live_diagnostics = initialize_runtime_diagnostics([])
+    app.state.extension_diagnostics = live_diagnostics
+    startup_config = SimpleNamespace(
+        database=_fake_database_config(),
+        agent_storage=SimpleNamespace(backend="file"),
+    )
+
+    with pytest.raises(RuntimeError, match="thread store startup failed"):
+        async with langgraph_runtime(app, startup_config):
+            pytest.fail("runtime must not yield after startup failure")
+
+    assert service.started is True
+    assert service.stopped is True
+    assert service.stop_calls == 1
+    assert failing_start.start_calls == 1
+    assert failing_stop.stop_calls == 1
+    assert app.state.extension_diagnostics is live_diagnostics
+    assert get_runtime_diagnostics() == app.state.extension_diagnostics
+    assert any(diagnostic.source == "failing-start:install" and "start() failed" in diagnostic.message for diagnostic in app.state.extension_diagnostics)
+    assert any(diagnostic.source == "failing-stop:install" and "stop() failed" in diagnostic.message for diagnostic in app.state.extension_diagnostics)
+    assert events == [
+        "notify_set",
+        "failing_start",
+        "service_start",
+        "failing_stop_start",
+        "failing_stop",
+        "service_stop",
+        "failed_start_stop",
+        "engine_close",
+        "notify_reset",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_closes_engine_when_engine_initialization_fails(monkeypatch) -> None:
+    """Cleanup ownership must exist before schema bootstrap can fail."""
+    import deerflow.persistence.engine as engine_module
+    import deerflow.runtime as runtime_module
+    from app.gateway.deps import langgraph_runtime
+
+    events: list[str] = []
+
+    async def fail_engine_init(_database) -> None:
+        events.append("engine_init")
+        raise RuntimeError("schema bootstrap failed")
+
+    async def close_engine() -> None:
+        events.append("engine_close")
+
+    monkeypatch.setattr(
+        runtime_module,
+        "make_stream_bridge",
+        lambda _config: _context(object()),
+    )
+    monkeypatch.setattr(
+        engine_module,
+        "init_engine_from_config",
+        fail_engine_init,
+    )
+    monkeypatch.setattr(engine_module, "close_engine", close_engine)
+
+    app = FastAPI()
+    startup_config = SimpleNamespace(
+        database=_fake_database_config(),
+        agent_storage=SimpleNamespace(backend="file"),
+    )
+
+    with pytest.raises(RuntimeError, match="schema bootstrap failed"):
+        async with langgraph_runtime(app, startup_config):
+            pytest.fail("runtime must not yield after engine startup failure")
+
+    assert events == ["engine_init", "engine_close"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_stops_services_when_cancelled_during_service_start(monkeypatch) -> None:
+    """Cleanup ownership must exist before the service batch can be cancelled."""
+    import deerflow.extensions as extensions_module
+    import deerflow.persistence.engine as engine_module
+    import deerflow.runtime as runtime_module
+    import deerflow.runtime.checkpointer.async_provider as checkpointer_module
+    from app.gateway.deps import langgraph_runtime
+
+    events: list[str] = []
+    first = _RecordingService(events)
+    blocking_start_entered = asyncio.Event()
+
+    class _BlockingStartService(_RecordingService):
+        async def start(self, _deps) -> None:
+            self.start_calls += 1
+            self.started = True
+            events.append("blocking_start")
+            blocking_start_entered.set()
+            await asyncio.Event().wait()
+
+        async def stop(self) -> None:
+            self.stop_calls += 1
+            self.stopped = True
+            events.append("blocking_stop")
+
+    blocking = _BlockingStartService()
+    registry = ExtensionRegistry()
+    with registry.attributed_to("first:install"):
+        registry.service(first)
+    with registry.attributed_to("blocking:install"):
+        registry.service(blocking)
+    extensions = registry.build()
+
+    async def init_engine(_database) -> None:
+        return None
+
+    async def close_engine() -> None:
+        events.append("engine_close")
+
+    monkeypatch.setattr(extensions_module, "get_loaded_extensions", lambda: extensions)
+    monkeypatch.setattr(runtime_module, "make_stream_bridge", lambda _config: _context(object()))
+    monkeypatch.setattr(runtime_module, "make_store", lambda _config: _context(object()))
+    monkeypatch.setattr(checkpointer_module, "make_checkpointer", lambda _config: _context(object()))
+    monkeypatch.setattr(engine_module, "init_engine_from_config", init_engine)
+    monkeypatch.setattr(engine_module, "close_engine", close_engine)
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: None)
+
+    app = FastAPI()
+    startup_config = SimpleNamespace(
+        database=_fake_database_config(),
+        agent_storage=SimpleNamespace(backend="file"),
+    )
+
+    async def start_runtime() -> None:
+        async with langgraph_runtime(app, startup_config):
+            pytest.fail("runtime must not yield while service startup is blocked")
+
+    startup_task = asyncio.create_task(start_runtime())
+    await asyncio.wait_for(blocking_start_entered.wait(), timeout=1.0)
+    startup_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await startup_task
+
+    assert first.stop_calls == 1
+    assert blocking.stop_calls == 1
+    assert events == [
+        "service_start",
+        "blocking_start",
+        "blocking_stop",
+        "service_stop",
+        "engine_close",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_stops_started_extension_services_when_later_startup_is_cancelled(monkeypatch) -> None:
+    """Cancellation during later bootstrap must unwind the service lifecycle."""
+    import app.gateway.deps as gateway_deps
+    import deerflow.extensions as extensions_module
+    import deerflow.persistence.engine as engine_module
+    import deerflow.persistence.thread_meta as thread_meta_module
+    import deerflow.runtime as runtime_module
+    import deerflow.runtime.checkpointer.async_provider as checkpointer_module
+    import deerflow.runtime.events.store as event_store_module
+
+    events: list[str] = []
+    service = _RecordingService(events)
+    registry = ExtensionRegistry()
+    with registry.attributed_to("recording:install"):
+        registry.service(service)
+    extensions = registry.build()
+    reconciliation_started = asyncio.Event()
+
+    class BlockingRunManager:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def reconcile_orphaned_inflight_runs(self, **_kwargs):
+            reconciliation_started.set()
+            await asyncio.Event().wait()
+
+    async def init_engine(_database) -> None:
+        return None
+
+    async def close_engine() -> None:
+        events.append("engine_close")
+
+    monkeypatch.setattr(extensions_module, "get_loaded_extensions", lambda: extensions)
+    monkeypatch.setattr(runtime_module, "make_stream_bridge", lambda _config: _context(object()))
+    monkeypatch.setattr(runtime_module, "make_store", lambda _config: _context(object()))
+    monkeypatch.setattr(checkpointer_module, "make_checkpointer", lambda _config: _context(object()))
+    monkeypatch.setattr(engine_module, "init_engine_from_config", init_engine)
+    monkeypatch.setattr(engine_module, "close_engine", close_engine)
+    monkeypatch.setattr(engine_module, "get_session_factory", lambda: None)
+    monkeypatch.setattr(thread_meta_module, "make_thread_store", lambda _session_factory, _store: object())
+    monkeypatch.setattr(event_store_module, "make_run_event_store", lambda _config: object())
+    monkeypatch.setattr(gateway_deps, "RunManager", BlockingRunManager)
+
+    app = FastAPI()
+    startup_config = SimpleNamespace(
+        database=_fake_database_config(),
+        agent_storage=SimpleNamespace(backend="file"),
+        run_events=None,
+        stream_bridge=None,
+    )
+
+    async def start_runtime() -> None:
+        async with gateway_deps.langgraph_runtime(app, startup_config):
+            pytest.fail("runtime must not yield while reconciliation is blocked")
+
+    startup_task = asyncio.create_task(start_runtime())
+    await asyncio.wait_for(reconciliation_started.wait(), timeout=1.0)
+    assert service.started is True
+
+    startup_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await startup_task
+
+    assert service.stopped is True
+    assert service.stop_calls == 1
+    assert events == ["service_start", "service_stop", "engine_close"]

--- a/backend/tests/test_goal_worker.py
+++ b/backend/tests/test_goal_worker.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 
 import pytest
+from deerflow_extension_api import ExtensionData
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.checkpoint.base import empty_checkpoint, uuid6
 from langgraph.checkpoint.memory import InMemorySaver
@@ -150,10 +151,12 @@ async def test_goal_worker_returns_hidden_continuation_when_goal_is_unmet(monkey
     thread_id = "goal-thread"
     await _seed_goal_thread(checkpointer, thread_id=thread_id, goal_text="Finish all tests")
     bridge = _CollectingBridge()
+    task_store = ExtensionData("run-1")
 
-    async def fake_evaluate_goal_completion(goal, messages, **_kwargs):
+    async def fake_evaluate_goal_completion(goal, messages, **kwargs):
         assert goal["objective"] == "Finish all tests"
         assert [message.content for message in messages][-1] == "I made a start, but I am not done."
+        assert kwargs["task_store"] is task_store
         return GoalEvaluation(
             satisfied=False,
             blocker="goal_not_met_yet",
@@ -171,6 +174,7 @@ async def test_goal_worker_returns_hidden_continuation_when_goal_is_unmet(monkey
         run_id="run-1",
         model_name="test-model",
         app_config=None,
+        task_store=task_store,
     )
 
     assert continuation is not None

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -223,13 +223,17 @@ def test_tool_progress_middleware_is_outer_relative_to_error_handling(monkeypatc
     assert progress_idx < error_idx, f"ToolProgressMiddleware (index {progress_idx}) must be outer (lower index) than ToolErrorHandlingMiddleware (index {error_idx}); order: {[type(m).__name__ for m in middlewares]}"
 
 
-def test_middleware_ordering_guard_raises_when_progress_is_inner(monkeypatch: pytest.MonkeyPatch):
-    """_build_runtime_middlewares must raise RuntimeError when ToolProgressMiddleware ends up
-    at a higher index than ToolErrorHandlingMiddleware.
+def test_middleware_ordering_guard_moved_to_declarative_constraints(monkeypatch: pytest.MonkeyPatch):
+    """_build_runtime_middlewares no longer hand-validates ordering; the invariant is now
+    declared in deerflow.extensions.ordering (CORE_ORDERING_CONSTRAINTS / assert_ordering) and
+    is checked once the composing builder merges extension contributions in (Task 9).
 
-    We trigger the wrong-order condition by patching SandboxAuditMiddleware to be an actual
-    ToolErrorHandlingMiddleware instance, which appears BEFORE ToolProgressMiddleware in the
-    list. The guard's isinstance() check finds it first, making error_idx < progress_idx.
+    This test previously monkeypatched SandboxAuditMiddleware to a ToolErrorHandlingMiddleware
+    instance to force the wrong-order condition and asserted that the builder itself raised.
+    That in-builder guard was deleted on purpose: validating here would check a stack that
+    hasn't received extension contributions yet. Building under the same wrong-order condition
+    must no longer raise inside this builder; deerflow.extensions.ordering has the equivalent
+    coverage (see test_extension_ordering.py and test_core_constraints_are_declared).
     """
     from deerflow.agents.middlewares.tool_error_handling_middleware import (
         ToolErrorHandlingMiddleware,
@@ -240,7 +244,7 @@ def test_middleware_ordering_guard_raises_when_progress_is_inner(monkeypatch: py
     _stub_runtime_middleware_imports(monkeypatch)
     # Override the SandboxAuditMiddleware stub with a real ToolErrorHandlingMiddleware so it
     # becomes the FIRST ToolErrorHandlingMiddleware in the list, appearing before
-    # ToolProgressMiddleware and triggering the ordering guard.
+    # ToolProgressMiddleware — the same wrong-order condition the deleted guard used to catch.
     monkeypatch.setitem(
         sys.modules,
         "deerflow.agents.middlewares.sandbox_audit_middleware",
@@ -253,8 +257,9 @@ def test_middleware_ordering_guard_raises_when_progress_is_inner(monkeypatch: py
     app_config = _make_app_config()
     app_config = app_config.model_copy(update={"tool_progress": ToolProgressConfig(enabled=True)})
 
-    with pytest.raises(RuntimeError, match="ToolProgressMiddleware must be outer"):
-        build_lead_runtime_middlewares(app_config=app_config, lazy_init=False)
+    # No raise here: the invariant is enforced by assert_ordering at the composing builder,
+    # not inside _build_runtime_middlewares.
+    build_lead_runtime_middlewares(app_config=app_config, lazy_init=False)
 
 
 def test_lead_runtime_middlewares_thread_app_config_to_tool_error_handling(monkeypatch: pytest.MonkeyPatch):

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -13,6 +13,7 @@ resolution-markers = [
 [manifest]
 members = [
     "deer-flow",
+    "deerflow-extension-api",
     "deerflow-harness",
 ]
 overrides = [{ name = "websockets", specifier = "==16.0" }]
@@ -873,6 +874,25 @@ dev = [
 ]
 
 [[package]]
+name = "deerflow-extension-api"
+version = "0.1.0"
+source = { editable = "packages/extension-api" }
+dependencies = [
+    { name = "fastapi" },
+    { name = "langchain" },
+    { name = "langgraph" },
+    { name = "sqlalchemy" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "langchain", specifier = ">=1.3" },
+    { name = "langgraph", specifier = ">=1.2.9,<1.3" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
+]
+
+[[package]]
 name = "deerflow-harness"
 version = "2.1.0"
 source = { editable = "packages/harness" }
@@ -884,6 +904,7 @@ dependencies = [
     { name = "croniter" },
     { name = "cryptography" },
     { name = "ddgs" },
+    { name = "deerflow-extension-api" },
     { name = "dotenv" },
     { name = "duckdb" },
     { name = "e2b-code-interpreter" },
@@ -960,6 +981,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "ddgs", specifier = ">=9.10.0" },
+    { name = "deerflow-extension-api", editable = "packages/extension-api" },
     { name = "dotenv", specifier = ">=0.9.9" },
     { name = "duckdb", specifier = ">=1.4.4" },
     { name = "e2b-code-interpreter", specifier = ">=2.8.0" },

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2396,3 +2396,35 @@ authorization:
 #         # Security features (enabled by default):
 #         pkce_enabled: true               # PKCE (S256) for authorization code flow
 #         nonce_enabled: true              # Nonce validation in ID tokens
+
+# --- Plugins ----------------------------------------------------------------
+# Extension packages, loaded once at startup in the order listed here. Each
+# entry names an install entry point as "module.path:install"; the `config`
+# block is handed to that package verbatim and validated by the package itself.
+#
+# Loading is explicit on purpose: an installed package does nothing until it is
+# listed here, and the list order is what fixes middleware ordering.
+#
+# This is deliberately separate from the `extensions:` block above (MCP servers,
+# skills, config-declared middlewares). That one is backed by
+# extensions_config.json, which the Gateway can rewrite through an HTTP
+# endpoint; a list that causes code to be imported must stay in this
+# operator-controlled file only.
+#
+# For a runnable reference — an independent package using all five contribution
+# points, plus a walkthrough for loading it — see
+# examples/deerflow-extension-example/README.md:
+#
+# plugins:
+#   - use: deerflow_extension_example:install
+#     config:
+#       enabled: true
+#       recent_task_limit: 20
+#   - use: acme_observability:install
+#     config:
+#       enabled: true
+#       queue_capacity: 10000
+#   # `required: true` turns a load failure into a startup failure. Use it for
+#   # packages whose absence changes behaviour rather than just observability.
+#   - use: acme_policy:install
+#     required: true

--- a/docs/plans/2026-07-30-extension-system-rfc.md
+++ b/docs/plans/2026-07-30-extension-system-rfc.md
@@ -1,0 +1,284 @@
+<!-- Authored by @ggnnggez, opened for feedback as
+     https://github.com/bytedance/deer-flow/issues/4573. -->
+
+# RFC: An Extension System for Cross-Cutting Concerns
+
+**Status:** Draft for feedback ([#4573](https://github.com/bytedance/deer-flow/issues/4573)).
+**Affects:** `backend/packages/extension-api/` (new package), `backend/packages/harness/deerflow/extensions/` (new), plus small hook-site additions in the lead/subagent builders, the run worker, the subagent executor, and the Gateway app/lifespan. `config.example.yaml` gains one top-level key.
+
+## TL;DR
+
+DeerFlow's middleware chain is where every cross-cutting concern lands. A default
+local lead-agent build assembles **24 middlewares** today, and the documented chain
+enumerates **35 positions** once optional ones are counted. Every new concern — token
+accounting, audit, progress guards, policy hooks — is one more entry in a chain that
+every user pays for, and whose ordering everyone must reason about together.
+
+Meanwhile, a downstream user who wants to add their *own* cross-cutting behaviour has
+no seam to add it at. They fork, and they edit the files DeerFlow changes most often.
+
+This RFC proposes an **extension system**: a small public contract package that a
+third party depends on, a `plugins:` list that loads their package at startup, and a
+fixed set of contribution points they can attach to — without touching core code, and
+without appearing anywhere in this repository.
+
+The goal is not to add features. It is to **stop the chain from growing** for concerns
+that only some users want, and to make community secondary development a supported
+path rather than a fork.
+
+## 1. Why now: two problems that share one cause
+
+### 1.1 The middleware chain absorbs everything
+
+Read the chain in [backend/AGENTS.md](../../backend/AGENTS.md#middleware-chain). It is a
+carefully ordered list, and the care is real — several entries carry comments explaining
+that they must sit immediately before or after a specific sibling, and the ordering is
+pinned by tests.
+
+That design is correct for the concerns that belong to DeerFlow itself. The problem is
+that it is also the only available answer for concerns that *don't*:
+
+- Ordering is global. Adding one entry means re-reasoning about a 24-to-35 item chain.
+- Cost is global. A middleware that only one deployment needs is still constructed and
+  still runs a hook for everyone.
+- The list is a shared review surface. Every optional concern competes for space in the
+  same file, and every reviewer has to hold the whole ordering in their head.
+
+There is a real, healthy pressure to say "no" to niche middleware. But saying no leaves
+the requester with only one option, which is the second problem.
+
+### 1.2 Secondary development means forking the hottest files
+
+Today, wiring a cross-cutting concern into DeerFlow touches the agent builders, the run
+worker, the subagent executor, and the Gateway lifespan. Those are precisely the files
+with the highest upstream change rate.
+
+The consequence is not "some merge conflicts". It is that a downstream fork's
+maintenance cost is **proportional to upstream's velocity**, in exactly the areas where
+upstream is most active. Every rebase re-litigates the same insertion points. In
+practice this pushes serious downstream users toward stale forks — which is bad for
+them, and bad for us, because their fixes and their field experience never come back.
+
+### 1.3 What exists already, and why it is not enough
+
+`extensions.middlewares` in `extensions_config.json` / `config.yaml` already loads
+middleware classes by path. It is genuine prior art and this RFC does not remove it.
+Its documented limits are the shape of the gap:
+
+- Zero-argument `AgentMiddleware` classes only — no configuration reaches them.
+- One fixed insertion point, near the end of the chain. A concern that must observe the
+  *final* model request, or the *raw* tool return, cannot express that.
+- No lead-only vs subagent-only distinction.
+- Middleware only. Nothing for run lifecycle, out-of-graph model calls, HTTP routes, or
+  anything needing startup and shutdown.
+
+So the mechanism covers "I have a simple middleware and I don't mind where it goes". The
+requests that keep arriving are mostly the other kind.
+
+## 2. What this proposes
+
+Four ideas, none of them large on their own.
+
+**A separate contract package.** `deerflow-extension-api` (import:
+`deerflow_extension_api`) holds everything an extension needs, and **must never import
+`deerflow`**. That single rule is what lets an extension be released independently on
+its own cadence: it depends on the contract, not on the harness. A test enforces the
+rule in CI.
+
+**Explicit loading, operator-owned.** A top-level `plugins:` list in `config.yaml` names
+entry points as `module.path:install`. An installed package does nothing until it is
+listed. The list lives in `config.yaml` rather than the API-writable
+`extensions_config.json` on purpose: a list that causes code to be imported must not be
+reachable from an HTTP endpoint.
+
+**Contribution points instead of edits.** A fixed, reviewed set of places an extension
+may attach — §3. Adding a contribution point is a deliberate act with a review; using
+one is not.
+
+**Semantic placement instead of indexes.** A middleware declares *what it needs to
+observe*, not *where to sit* — §4. This is what keeps the chain free to be
+restructured without breaking released extensions.
+
+### 2.1 Two phases, so registration cannot have side effects
+
+Loading is split in two:
+
+1. **Registration.** The host calls `install(registry, config)`. The `registry` is
+   write-only — it hands out no host capabilities at all. An extension therefore
+   *structurally* cannot touch the runtime during registration; there is nothing to
+   touch.
+2. **Runtime.** Later, the host hands real dependencies to whatever registered as a
+   service, through a narrow `ExtensionRuntimeDeps` object.
+
+The reason for the split is reviewability: "what can an extension do at import time?"
+has a one-word answer — nothing — instead of an audit.
+
+Notably, extensions never see `AppConfig`. They get a narrow projection of the limits
+the host actually enforces. Exposing `AppConfig` would pin every extension to the
+harness release cadence, which would defeat the point of the separate package.
+
+### 2.2 Failure isolation
+
+Contributed middlewares are wrapped so that an extension's own failure degrades to a
+diagnostic and the call proceeds. The wrapper never masks a failure of the underlying
+model or tool call, and never replays one — a third-party observer must not be able to
+cause a second provider call or a duplicated tool side effect. LangGraph's
+interrupt/resume control-flow signal is always re-raised unchanged.
+
+Diagnostics are attributed: every registration carries the entry-point string that
+produced it, so a conflict or a failure names the responsible package.
+
+## 3. The contribution points
+
+Five, grouped by what they are for. Three are behaviour protocols; two are values the
+host takes ownership of.
+
+### Contributors — participate in the agent
+
+| Point | Protocol | What it can do |
+| --- | --- | --- |
+| Middlewares | `MiddlewareContributor` | Return middlewares plus their placement, per agent build |
+| Task lifecycle | `TaskLifecycleContributor` | Observe an agent execution starting and stopping |
+
+`TaskLifecycleContributor` deserves a note: **lead runs and subagent runs are the same
+type of event.** They share one `TaskInfo`, distinguished by a `kind` field, so an
+extension writes one code path for both. The outcome is keyed on *success* — only an
+explicitly successful run reports completed, so an unanticipated terminal state degrades
+to failed rather than being reported as a clean finish.
+
+### Observers — see what middleware cannot
+
+| Point | Protocol | What it can do |
+| --- | --- | --- |
+| System model calls | `SystemModelCallObserver` | Observe model calls made *outside* the agent graph |
+
+This one exists because a meaningful share of DeerFlow's model traffic never passes
+through the middleware chain. Title generation, memory extraction, goal evaluation, and
+summarization all call a model outside the graph. An observability extension that only
+saw the chain would silently miss them.
+
+The observer is notified on **both** the success and the failure path. A system call
+that failed is precisely the event worth seeing, so notifying only on success would
+hide the interesting half.
+
+### Host-owned values
+
+| Point | Type | What it can do |
+| --- | --- | --- |
+| Routers | `APIRouter` values | Contribute HTTP endpoints |
+| Services | `ExtensionService` | Own resources across the Gateway's lifetime |
+
+Routers are constructed **eagerly**, during registration, so the Gateway can detect path
+conflicts and freeze its OpenAPI surface before it serves. Contributed routers mount
+after every host router and cannot take a path the Gateway already serves; a conflict is
+reported and the router is refused rather than silently shadowed.
+
+Since registration has no capabilities, a routed extension registers the same object as
+a service, binds its dependencies when the service starts, and resolves them per request
+through FastAPI's `Depends`. Until they are bound — and after shutdown clears them — its
+routes report unavailable rather than answering with half-built state.
+
+Services start and stop in the Gateway lifespan. Stop is reverse-order, bounded, and
+fail-open: a Gateway that cannot shut down is worse than a lost observation.
+
+## 4. Placement: declare the guarantee, not the index
+
+A middleware occupies one index in a list, but that index only means something on the
+hook chain it actually implements — so "outermost" means different things on the model
+axis and the tool axis. Asking extensions for an index would leak the chain's current
+shape into every released extension.
+
+Instead a contribution declares one of five placements:
+
+| Placement | The guarantee it asks for |
+| --- | --- |
+| `MODEL_LOGICAL` | Outer of retry and error handling — fires once per logical decision |
+| `MODEL_PHYSICAL` | Inner of every request transform — fires once per real provider call |
+| `TOOL_VISIBLE` | Outer of truncation and sanitization — sees what the model finally reads |
+| `TOOL_RAW` | Adjacent to the callable boundary — sees the tool's own return |
+| `STANDARD` | No before/after requirement |
+
+The mapping from placement to a real position lives in a host-owned anchor table, so
+restructuring the chain is a change to one table rather than a break for every extension.
+
+Because a guarantee is a claim about behaviour, it is tested as one: the placement tests
+assert each promise against the **real** lead and subagent chains. Nothing else can catch
+the failure mode — appending a new request-transforming middleware inner of an anchor
+leaves the types, the anchor table, and the version constraints all valid while the
+promise silently stops holding.
+
+## 5. Core flow, end to end
+
+```
+config.yaml: plugins: [ {use: "pkg:install", config: {...}} ]
+        │
+        ▼
+  load_extensions()            once, at startup, in config order
+        │                      resolve entry point → call install(registry, config)
+        ▼
+  install(registry, config)    registration phase: write-only, no capabilities
+        │                      registry.middlewares/task_lifecycle/
+        │                      system_model_observer/routers/service
+        ▼
+  LoadedExtensions             immutable; every entry carries its source string
+        │
+        ├──► agent build ──► placement resolved against the real chain,
+        │                    each contribution wrapped for isolation
+        ├──► run / subagent ──► task start … task stop
+        ├──► out-of-graph model calls ──► observers notified (success and failure)
+        └──► Gateway ──► routers mounted after host routes;
+                         services start in lifespan, stop in reverse
+```
+
+Load order is the config list order — explicit and reproducible, which matters because
+placement ties can only be broken deterministically if load order is.
+
+Failure policy is **fail-open by default**: a broken extension is skipped with a
+diagnostic and the Gateway still starts. An operator can set `required: true` per entry
+to make a load failure a startup failure instead — for packages whose absence changes
+behaviour rather than only observability.
+
+## 6. What this is not
+
+- **Not a plugin marketplace.** No discovery, no auto-loading, no sandboxing. An
+  extension is trusted operator-installed code, exactly like a configured middleware
+  class today.
+- **Not a replacement for `extensions.middlewares`.** That mechanism keeps working,
+  untouched.
+- **Not a stable 1.0 contract yet.** The current surface is deliberately
+  observational — contributors and observers. The version is `0.1` and the compatibility
+  window says so: pre-1.0, minors may break.
+- **Not a place for decision-making hooks, yet.** Everything here observes. A
+  contribution that could *deny* or *alter* a decision needs a fail-**closed** policy
+  and its own review; the isolation wrapper's fail-open behaviour is correct only for
+  observation. Authorization and guardrails already own that space through their own
+  provider protocols.
+
+## 7. Cost to this repository
+
+Worth stating plainly, since the motivation is partly "stop paying for optional things":
+
+- One new package (contract only, no logic) and one new module directory (the host side).
+- Small additions at the hook sites: a task-lifecycle notification around lead and
+  subagent runs, an observation wrapper at four out-of-graph model call sites, and the
+  extension load plus router/service wiring in the Gateway.
+- Zero-extension cost is a design constraint, not an aspiration: every hook site
+  short-circuits on a precomputed flag before constructing any payload, so a deployment
+  with no `plugins:` allocates nothing and the chain is unchanged.
+
+In exchange, the next "can we add a middleware for X?" has a second possible answer.
+
+## 8. Open questions for reviewers
+
+1. **Are five contribution points the right five?** They cover the requests we have
+   seen. The obvious candidates for a sixth are frontend surface and persistence —
+   both deliberately out of scope here.
+2. **Is fail-open the right default?** It favours availability over completeness of
+   observation. `required: true` exists as the per-entry escape hatch, but the default
+   is a judgment call worth challenging.
+3. **How stable should `0.1` feel?** The contract is designed so that growth is additive
+   (every protocol method has a default, every optional field has a default). The
+   question is when to commit to `1.0`.
+4. **Should placement be extensible?** Today the anchor table is host-owned and the five
+   placements are fixed. That is deliberate — a placement is a promise the host has to
+   keep — but it does mean a genuinely new observation point requires an upstream change.

--- a/docs/superpowers/specs/2026-07-28-sync-system-model-observation-design.md
+++ b/docs/superpowers/specs/2026-07-28-sync-system-model-observation-design.md
@@ -1,0 +1,87 @@
+# 设计 v2：同步调用点的系统模型观察
+
+> 补充[扩展系统 RFC](../../plans/2026-07-30-extension-system-rfc.md)。
+> 起因：扩展系统 Task 12 只接线了三个异步调用点，两个同步调用点悬空。
+>
+> **v1 已被设计评审否决（do-not-build as written）。本文是按评审结论重写的版本。**
+> v1 的错误保留在文末「v1 错在哪里」一节，因为其中两条是事实性错误，值得留档。
+
+## 评审后的事实基线
+
+| 事实 | 出处 | 对设计的影响 |
+|---|---|---|
+| `DeerFlowSummarizationMiddleware` **同时**覆盖 `before_model`（:277）与 `abefore_model`（:280） | `summarization_middleware.py` | 异步图走 `abefore_model` → `_asummarize_with`，**已经接线**。同步的 `_summarize_with` 在 Gateway 与 subagent 路径上是死代码 |
+| 唯一走同步图的宿主是 `DeerFlowClient.stream()`（`client.py:930`） | 嵌入式 / TUI | 而该宿主恰恰是「不会注册 loop」的那一类 |
+| `deermem/` 包**只允许一行** `from deerflow`，由测试钉死 | `tests/test_deermem_self_contained.py:262` | 在 `deermem/` 内部直接 import 宿主扩展模块会让既有测试变红 |
+| `MemoryCallbacks` 已是宿主侧可观测缝隙，且其 docstring 明说「More hooks — post-extract / search / inject / error — can be added when callers need them」 | `agents/memory/manager.py:46-63` | 这就是本来就为此准备的扩展点 |
+| `run_coroutine_threadsafe` 投给「已 stop 但未 close」的 loop：提交成功，future **永不 resolve** | 评审实测 | `.result(None)` 会永久阻塞 |
+| `run_coroutine_threadsafe` 投给已 close 的 loop：**同步抛** `RuntimeError` | 评审实测 | 派发本身必须包 try/except |
+
+**结论：两个同步调用点里，`_summarize_with` 一处收益为零** —— Gateway 到不了，TUI 到得了但按 v1 设计会被丢弃。
+真正剩下的缺口只有一条：**DeerMem 记忆更新的 LLM 调用，且仅在 Gateway 宿主内**。
+
+## 两个可选方案
+
+### 方案 X：按缩减范围实现（评审的 minimum change）
+
+1. **放弃 `_summarize_with`**，在扩展契约中写明其不可观测。
+2. **DeerMem 经 `MemoryCallbacks` 接线**，不在 `deermem/` 内 import `deerflow.extensions`：
+   给 `MemoryCallbacks` 增加带 no-op 默认实现的结果侧钩子（`on_memory_llm_result`），
+   在 `_do_update_memory_sync_impl` 的 `model.invoke` 之后与其 `except` 分支各调一次，
+   宿主侧实现放在 `LangfuseMemoryCallbacks` 旁边。可移植性契约与既有测试都不受影响。
+3. **派发策略改为「只投递、不等待」**：
+   ```
+   若无 observer            -> 直接返回（零扩展路径不查 loop）
+   若未注册 loop            -> 丢弃 + 一次性 warning
+   若注册的 loop 未在运行    -> 丢弃（涵盖「已 stop 未 close」这个会挂死的状态）
+   否则                     -> run_coroutine_threadsafe(注册的 loop)，保存强引用，不 .result()
+   整段派发包 try/except BaseException，失败只记日志
+   ```
+   **永远只投给注册的那个 loop，绝不投给 `get_running_loop()`。**
+
+   放弃阻塞等待，就同时消灭了 v1 的三个挂死/泄漏模式（F2 无界阻塞、F6 关闭竞态、F7 超时不取消），
+   代价是失去「观察与调用的时序关系」—— 而评审已证明该性质的论证建立在一个不存在的线程模型上（见 F4），
+   且唯一需要它的调用点是死代码。
+4. **注册点**：`langgraph_runtime` 的 exit stack 首先注册 loop reset（因此 LIFO
+   最后执行），随后才启动 extension service；memory drain 前只暂停新的同步
+   fire-and-forget system observation，因此停机排空期间这类观察会被丢弃。注册 loop
+   本身必须保留到 in-flight subagent drain 与 extension service stop 完成，供 awaited
+   task/system hook 继续使用，随后才重置；同一个 exit stack 也保证任何启动失败/取消
+   都会复位。提前清空会把 loop-bound lifecycle hook 错派回 subagent 隔离 loop。
+5. **`set_extension_notify_loop` 必须与扩展被构造时所在的 loop 一致**，写进 docstring 并在 Task 13
+   的加载点上断言。
+
+**收益**：DeerMem 记忆更新 LLM 调用在 Gateway 内可被观察。
+**成本**：一个宿主侧 loop 注册表 + `MemoryCallbacks` 新钩子 + 约 9 项新测试（含「已 stop 未 close」
+的 loop、并发关闭、进程内第二个 loop 的归属断言）。
+
+### 方案 Y：不建造，把缺口写进契约
+
+在扩展契约中写明：`on_system_model_call` 只覆盖图外的**异步**系统模型调用；
+DeerMem 的记忆更新与同步图路径的摘要调用不产生该事件。
+
+**收益**：零运行时风险，零新增机制。
+**成本**：DeerMem 记忆更新调用永久不可观察。
+
+评审对方案 Y 的论证：契约本就容忍部分覆盖（`task_store` 可为 `None`、`detached` store、
+预算耗尽时跳过 contributor），一条写明的边界与之一致；而方案 X 是在「fail-open 观测」这个目标下，
+为一个条目引入三种停机期故障模式的机器。
+
+## 我的建议
+
+**倾向方案 X，但把它当成 DeerMem 专项而不是「同步调用点通用机制」。** 理由：记忆更新是唯一一个
+真正跑 LLM、又完全在图外、且对可观测性有实际价值的路径；而经 `MemoryCallbacks` 接线不引入新的
+公共扩展 API，日后若判断不值得，删除成本很低。若判断收益不抵成本，方案 Y 也是诚实的答案 —— 前提是
+契约里写清楚，而不是留白。
+
+## v1 错在哪里（留档）
+
+1. **事实错误**：v1 称同步中间件 hook 跑在 executor 线程上、主循环 `await` 时空闲可调度。
+   实际上 LangChain 用 `RunnableCallable`，只有同步实现时**直接在事件循环线程上内联执行**
+   （`langgraph/_internal/_runnable.py:434-435`）。「阻塞是安全的」这一整段论证因此失效。
+2. **事实错误**：v1 把 `aupdate_memory`（`asyncio.to_thread` 路径）列为 memory 的活跃调用路径。
+   它**没有任何生产调用方**。
+3. **自相矛盾**：v1 的分支 1 用 `loop.create_task` 投给「当前线程正在跑的那个 loop」——
+   进程内有三个长生命周期 loop（Gateway、subagent 隔离循环、BoxLite 私有循环），这恰好就是
+   本设计声称要避免的跨循环问题。
+4. **未评估的选项**：v1 的备选表里根本没有「不建造、写进契约」这一行。

--- a/examples/deerflow-extension-example/README.md
+++ b/examples/deerflow-extension-example/README.md
@@ -1,0 +1,154 @@
+# deerflow-extension-example
+
+A worked example of a DeerFlow extension. It is an **independent package**: its only
+dependency is `deerflow-extension-api`, it lives outside `backend/`, it is not a
+workspace member, and nothing in the host mentions it. You install it and list it under
+`plugins:` — exactly as a third-party extension would be adopted.
+
+What it does is deliberately trivial: it counts model calls, tool calls, tasks and the
+host's own system model calls, and serves the counts on one route. The point is the
+**shape** — where each contribution attaches, which scope owns which data, and when host
+capabilities exist.
+
+## What it demonstrates
+
+| Contract surface | Where | Note |
+| --- | --- | --- |
+| `@extension(api=...)` | `__init__.py` | Version stamp; turns a skew into a startup diagnostic |
+| `ExtensionInstall` | `__init__.py` | Entry-point signature, checked by the type checker |
+| `ExtensionRegistry` — all five methods | `__init__.py` | `middlewares` / `task_lifecycle` / `system_model_observer` / `service` / `routers` |
+| `MiddlewareContributor`, `AgentBuildContext` | `probes.py` | Reads `ctx.scope`, `ctx.model_name`, `ctx.policy` |
+| `Placement` ×4, `AgentScope` | `probes.py` | Declared in pairs — see below |
+| `task_store_from_runtime` | `probes.py` | The only way middleware reaches task scope |
+| `TaskLifecycleContributor`, `TaskInfo`, `TaskOutcome` | `lifecycle.py` | One code path for lead and subagent |
+| `SystemModelCallObserver` + request/result/kind | `lifecycle.py` | Counts the failure path too |
+| `ExtensionService`, `ExtensionRuntimeDeps`, `HostPolicySnapshot` | `service.py` | Bind on `start()`, clear on `stop()` |
+| `ExtensionData` — `get` / `set` / `get_or_init` / `remove` | everywhere | Two scopes, one flush |
+
+Deliberately **not** used: `Placement.STANDARD` (reach for it only when you have no
+before/after-processing requirement at all) and `deps.session_factory` for real storage
+(extension persistence — a shared declarative `Base` and its migration chain — is a
+separate concern from the observation contract; the route only reports whether it was
+bound).
+
+### Why the placements come in pairs
+
+The pairs are what make the placement contract *visible in the output*:
+
+- `MODEL_LOGICAL` vs `MODEL_PHYSICAL` — one logical decision may cost several physical
+  provider calls. The gap in `/stats` is the host's retry behaviour, observed.
+- `TOOL_RAW` vs `TOOL_VISIBLE` — the host truncates and sanitizes tool output before the
+  model sees it. The gap in characters is that processing, measured from both ends of the
+  same call.
+
+That is also the shape of the tests: `test_probes.py` retries one decision and asserts
+`logical == 1, physical == 2`. Misdeclare either placement and that assertion is what
+fails.
+
+**A trap worth knowing before you write your own tool probe.** The contract types a tool
+result as `ToolMessage | Command`, and *which one you get depends on your placement*. The
+host's `SandboxMiddleware` sits in the middle of the tool chain and rewraps a
+`ToolMessage` into `Command(update={"sandbox": ..., "messages": [msg]})` so the sandbox id
+reaches state — so anything outer of it, `TOOL_VISIBLE` included, receives a `Command`
+carrying the real result inside. Treat that as "no content" and your outer probe reports
+zero while the inner one reports the true size, which reads exactly like "the host
+truncated everything". `_result_chars` unwraps it; `test_probes.py` pins the behaviour
+with the production shape.
+
+### Why the task record is flushed on stop
+
+The host creates a task-scoped `ExtensionData` per agent execution and **drops it when
+that execution returns**. So `on_task_stop` is the last moment anything a probe
+accumulated can be saved, and it uses `remove()` rather than `get()`: the record is being
+handed over, not shared.
+
+## Run its tests
+
+The tests need no DeerFlow host at all. `tests/conftest.py` builds a fake registry and
+asserts `isinstance(fake, ExtensionRegistry)` — the contract Protocol is
+`runtime_checkable`, which is what lets a third party prove conformance offline.
+
+```bash
+cd examples/deerflow-extension-example
+uv venv --python 3.12
+# `deerflow-extension-api` is not published to PyPI yet, so install it from this
+# repo. Once it is published, this line becomes unnecessary.
+uv pip install -e ../../backend/packages/extension-api
+uv pip install -e ".[dev]"
+uv run --no-project pytest
+```
+
+## Load it into a running DeerFlow
+
+There is no CI test covering this path — the host side is exercised by
+`backend/tests/test_extension_*.py`, and this walkthrough is what verifies that an
+*independent* package still loads. Run it after changing the extension host.
+
+**1. Install it into the backend environment**
+
+```bash
+cd backend
+uv pip install -e ../examples/deerflow-extension-example
+```
+
+**2. List it in `config.yaml`** (repo root). `plugins:` is a top-level key, deliberately
+separate from the `extensions:` block — this list causes code to be imported, so it stays
+in the operator-controlled file and is never API-writable.
+
+```yaml
+plugins:
+  - use: deerflow_extension_example:install
+    config:
+      enabled: true
+      recent_task_limit: 20
+```
+
+**3. Start the stack and read the counters**
+
+```bash
+make dev
+curl -s localhost:2026/api/extension-example/stats | python -m json.tool
+```
+
+Expect zeros, plus `host_policy` populated from the host's projection. Now send a message
+in the UI and read it again: `model_calls`, `tool_calls`, `tasks` and `recent_tasks` move,
+and `system_model_calls.title` appears after the first exchange is titled.
+
+**Did it load at all?** The loader is silent on success — it logs only failures — so an
+empty `gateway.log` is the *good* outcome, not evidence of a problem. For positive
+confirmation, ask the OpenAPI schema, which is a public path and needs no session:
+
+```bash
+curl -s localhost:8001/openapi.json | python -c "import json,sys; print([p for p in json.load(sys.stdin)['paths'] if 'extension-example' in p])"
+```
+
+A non-empty result proves both that `install()` ran and that the router survived conflict
+detection. Do **not** read `401` on the route itself as "not mounted": `AuthMiddleware`
+runs before routing, so an unauthenticated request to a path that does not exist also
+answers `401`, never `404`.
+
+The route goes through nginx's `/api/*` passthrough, so no nginx change is needed. It is
+also behind the Gateway's ordinary auth gate, like any other non-public `/api/*` path: a
+bare `curl` answers `401 not_authenticated` whenever authentication is enabled. Easiest
+fix is to open the URL in the browser tab where you are already signed in; plain `curl`
+works only in auth-disabled mode. A contributed router gets no exemption from this, and
+should not want one.
+
+**4. Check the negative paths too**
+
+- Set `config.enabled: false` → the package is still installed but registers nothing, and
+  the path disappears from `/openapi.json` (the router was never contributed). Check it
+  there rather than on the route, for the `401`-before-routing reason above.
+- Set `recent_task_limit: "twenty"` → startup logs a diagnostic naming this extension and
+  skips it. Add `required: true` to turn that into a startup failure instead.
+
+## Files
+
+```
+deerflow_extension_example/
+├── __init__.py     install() — the only entry point
+├── stats.py        RunStats / TaskRecord — what gets counted; owns its own locks
+├── probes.py       four middlewares + the build-time contributor
+├── lifecycle.py    task lifecycle + system model call observer
+└── service.py      ExtensionService + the eagerly built router
+```

--- a/examples/deerflow-extension-example/deerflow_extension_example/__init__.py
+++ b/examples/deerflow-extension-example/deerflow_extension_example/__init__.py
@@ -1,0 +1,76 @@
+"""A worked example of a DeerFlow extension.
+
+One package, one entry point, all five contribution points. What it does is
+deliberately trivial -- it counts things and serves the counts on one route --
+because the point is the *shape*, not the feature: where each contribution
+attaches, which scope owns which data, and when host capabilities exist.
+
+Install it and list it under ``plugins:`` in ``config.yaml``; see README.md.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from deerflow_extension_api import ExtensionInstall, ExtensionRegistry, extension
+
+from deerflow_extension_example.lifecycle import SystemCallRecorder, TaskRecorder
+from deerflow_extension_example.probes import ProbeContributor
+from deerflow_extension_example.service import ExampleService, build_router
+from deerflow_extension_example.stats import DEFAULT_RECENT_TASKS, StatsAccess
+
+__all__ = ["install"]
+
+
+def _recent_limit(config: Mapping[str, Any]) -> int:
+    """Read one setting, tolerantly.
+
+    The host hands ``install()`` this extension's own config block verbatim and
+    does not validate it -- validating it is this package's job, and doing it
+    here means a typo in ``config.yaml`` surfaces as a startup diagnostic naming
+    this extension rather than as a confusing failure later.
+    """
+    raw = config.get("recent_task_limit", DEFAULT_RECENT_TASKS)
+    try:
+        return int(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"recent_task_limit must be an integer, got {raw!r}") from exc
+
+
+@extension(api="0.1", name="example")
+def install(registry: ExtensionRegistry, config: Mapping[str, Any]) -> None:
+    """Register everything this extension contributes.
+
+    The decorator stamps the contract version this code was written against.
+    pip's resolver is the primary compatibility mechanism; the stamp covers
+    ``--no-deps`` installs and editable monorepo checkouts, where a host/contract
+    version skew would otherwise surface as a deep ``AttributeError`` instead of
+    an actionable startup diagnostic.
+
+    Registration is capability-free by construction: ``registry`` is write-only,
+    so nothing here can reach the host's runtime even by accident. Real
+    dependencies arrive later, in ``ExampleService.start()``.
+    """
+    if not config.get("enabled", True):
+        # An installed package that registers nothing is the correct way to be
+        # switched off. Raising here would be a load failure, which is a
+        # different -- and louder -- thing than being disabled on purpose.
+        return
+
+    access = StatsAccess(recent_limit=_recent_limit(config))
+    service = ExampleService(access)
+
+    registry.middlewares(ProbeContributor(access))
+    registry.task_lifecycle(TaskRecorder(access))
+    registry.system_model_observer(SystemCallRecorder(access))
+    registry.service(service)
+    # Same object as the service above: that is what lets an eagerly built route
+    # resolve runtime dependencies the registration phase cannot have yet.
+    registry.routers([build_router(service, access)])
+
+
+#: Conformance to the published entry-point signature, checked by the type
+#: checker rather than trusted. A host that changes the signature breaks here,
+#: at the boundary, instead of at call time.
+_entry_point: ExtensionInstall = install

--- a/examples/deerflow-extension-example/deerflow_extension_example/lifecycle.py
+++ b/examples/deerflow-extension-example/deerflow_extension_example/lifecycle.py
@@ -1,0 +1,84 @@
+"""Task lifecycle and out-of-graph system model calls.
+
+These two contributors are where the scope discipline lives. The host creates a
+task-scoped store when the task starts and drops it when the task returns, so
+``on_task_stop`` is the last moment anything accumulated during the run can be
+saved. ``remove()`` rather than ``get()``: the record is being handed over, and
+leaving a copy behind in a store that is about to be discarded reads as if it
+still mattered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from deerflow_extension_api import (
+    ExtensionData,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+    TaskInfo,
+    TaskOutcome,
+)
+
+from deerflow_extension_example.stats import StatsAccess, TaskRecord
+
+
+@dataclass(frozen=True)
+class TaskRecorder:
+    """Implements ``TaskLifecycleContributor`` structurally -- no base class.
+
+    The contract is a Protocol, so conformance is a matter of shape. That is
+    also what lets the tests in this package verify it against a fake host.
+    """
+
+    access: StatsAccess
+
+    async def on_task_start(self, app_store: ExtensionData, task_store: ExtensionData, info: TaskInfo) -> None:
+        # Lead and subagent executions are the same type here on purpose: one
+        # code path serves both, and `info.kind` is the only thing that differs.
+        task_store.set(
+            TaskRecord(
+                task_id=info.task_id,
+                kind=info.kind,
+                thread_id=info.thread_id,
+                resumed=info.resumed,
+                agent_name=info.agent_name,
+            )
+        )
+        self.access.of(app_store).note_task_start(info.kind)
+
+    async def on_task_stop(self, app_store: ExtensionData, task_store: ExtensionData, info: TaskInfo, outcome: TaskOutcome) -> None:
+        record = task_store.remove(TaskRecord)
+        # A run that failed before its first model call has no record. The
+        # outcome is still folded in: dropping the task would hide the failure.
+        self.access.of(app_store).absorb(record, outcome.value)
+
+
+@dataclass(frozen=True)
+class SystemCallRecorder:
+    """Implements ``SystemModelCallObserver`` structurally.
+
+    These are the host's own model calls -- title generation, memory extraction,
+    goal evaluation, summarization -- which happen outside the agent graph and
+    are therefore invisible to middleware.
+    """
+
+    access: StatsAccess
+
+    async def on_system_model_call(
+        self,
+        app_store: ExtensionData,
+        task_store: ExtensionData,
+        kind: SystemOperationKind,
+        request: SystemModelRequest,
+        result: SystemModelResult,
+    ) -> None:
+        # The host notifies on both the success and the failure path, so an
+        # observer that only looked at `result.response` would silently miss
+        # every failed system call. Key off `result.error` instead.
+        self.access.of(app_store).note_system_call(
+            kind.value,
+            seconds=(result.duration_ms / 1000.0) if result.duration_ms is not None else None,
+            failed=result.error is not None,
+        )

--- a/examples/deerflow-extension-example/deerflow_extension_example/probes.py
+++ b/examples/deerflow-extension-example/deerflow_extension_example/probes.py
@@ -1,0 +1,182 @@
+"""Four middlewares, declared at four placements.
+
+They are paired on purpose, because the pairs are what make the placement
+contract visible in the output:
+
+* ``MODEL_LOGICAL`` vs ``MODEL_PHYSICAL`` -- one logical decision may cost
+  several physical provider calls. The difference in ``/stats`` *is* the host's
+  retry behaviour, observed rather than assumed.
+* ``TOOL_RAW`` vs ``TOOL_VISIBLE`` -- the host truncates and sanitizes tool
+  output before the model sees it. The difference in characters is that
+  processing, measured from both ends of the same call.
+
+``Placement.STANDARD`` is deliberately unused here. Reach for it only when your
+middleware has no before/after-processing requirement at all; declaring a real
+placement you do not need over-constrains the host for nothing.
+
+Every probe degrades to a plain pass-through when there is no task store: a
+subagent invoked directly has no complete parent-task identity, so the host
+gives it no task scope. That is a documented state, not an error.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any
+
+from deerflow_extension_api import (
+    AgentBuildContext,
+    AgentScope,
+    ExtensionData,
+    MiddlewarePlacement,
+    Placement,
+    task_store_from_runtime,
+)
+from langchain.agents.middleware import AgentMiddleware
+from langchain.agents.middleware.types import ModelCallResult, ModelRequest, ModelResponse
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.types import Command
+
+from deerflow_extension_example.stats import StatsAccess, TaskRecord
+
+#: Only the async hooks are implemented. Both the Gateway runtime and the
+#: subagent executor drive the graph asynchronously, and the host's isolation
+#: wrapper mirrors exactly the hooks a middleware overrides -- adding unused
+#: sync variants would bolt no-op nodes onto the graph for nothing.
+
+
+def _record(request: Any) -> TaskRecord | None:
+    """The current task's record, or None when there is no live task scope."""
+    task_store = task_store_from_runtime(getattr(request, "runtime", None))
+    if task_store is None:
+        return None
+    return task_store.get(TaskRecord)
+
+
+def _tool_name(request: ToolCallRequest) -> str:
+    tool_call = getattr(request, "tool_call", None) or {}
+    name = tool_call.get("name") if isinstance(tool_call, dict) else None
+    return name or "<unknown>"
+
+
+def _content_chars(message: Any) -> int:
+    """Length of one message's text content, whatever shape the content takes."""
+    content = getattr(message, "content", None)
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        return sum(len(part) if isinstance(part, str) else len(str(part.get("text", ""))) if isinstance(part, dict) else 0 for part in content)
+    return 0
+
+
+def _result_chars(result: ToolMessage | Command) -> int:
+    """Length of a tool result's text content.
+
+    **A tool result is not always a ToolMessage by the time you see it.** The
+    contract types this return as ``ToolMessage | Command``, and which one you
+    actually get depends on your placement: the host's ``SandboxMiddleware``
+    sits in the middle of the tool chain and rewraps a ``ToolMessage`` into
+    ``Command(update={"sandbox": ..., "messages": [msg]})`` so the sandbox id
+    reaches state. Anything placed *outer* of it — including ``TOOL_VISIBLE`` —
+    therefore observes a ``Command`` carrying the real result inside, while
+    ``TOOL_RAW`` still sees the bare ``ToolMessage``.
+
+    So the wrapper has to be unwrapped, or the two ends of the tool axis
+    silently measure different things and the pair stops being comparable. A
+    ``Command`` with no messages really is pure control flow and measures zero.
+    """
+    content = getattr(result, "content", None)
+    if isinstance(content, str | list):
+        return _content_chars(result)
+    update = getattr(result, "update", None)
+    if isinstance(update, dict):
+        messages = update.get("messages")
+        if isinstance(messages, list):
+            return sum(_content_chars(message) for message in messages)
+    return 0
+
+
+class LogicalModelProbe(AgentMiddleware):
+    """Counts model *decisions*, outer of the host's retry and error handling."""
+
+    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelCallResult:
+        record = _record(request)
+        if record is not None:
+            # Counted before the call: a decision the provider ultimately failed
+            # to serve is still a decision the agent made.
+            record.note_logical_model_call()
+        return await handler(request)
+
+
+class PhysicalModelProbe(AgentMiddleware):
+    """Counts and times *provider calls*, inner of every request transform."""
+
+    async def awrap_model_call(self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]) -> ModelCallResult:
+        record = _record(request)
+        started = perf_counter()
+        try:
+            return await handler(request)
+        finally:
+            # `finally`, so a failed attempt still counts as an attempt -- and so
+            # the exception keeps propagating untouched. Observation must never
+            # change the run's outcome.
+            if record is not None:
+                record.note_physical_model_call(perf_counter() - started)
+
+
+class VisibleToolProbe(AgentMiddleware):
+    """Observes what the model finally sees, outer of truncation/sanitization."""
+
+    async def awrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]]) -> ToolMessage | Command:
+        result = await handler(request)
+        record = _record(request)
+        if record is not None:
+            record.note_visible_tool_result(_tool_name(request), _result_chars(result))
+        return result
+
+
+class RawToolProbe(AgentMiddleware):
+    """Observes the tool's own return, adjacent to the callable boundary."""
+
+    async def awrap_tool_call(self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]]) -> ToolMessage | Command:
+        result = await handler(request)
+        record = _record(request)
+        if record is not None:
+            record.note_raw_tool_result(_result_chars(result))
+        return result
+
+
+def _scope_label(scope: AgentScope) -> str:
+    return scope.name.lower() if scope.name else str(scope)
+
+
+@dataclass(frozen=True)
+class ProbeContributor:
+    """Decides what to contribute to one agent build.
+
+    Note what this does *not* do: it never checks ``ctx.scope`` to decide
+    whether to return the tool probes. Scope is declared on the contribution
+    and the host filters -- hand-filtering here would duplicate the host's rule
+    and drift from it.
+    """
+
+    access: StatsAccess
+
+    def contribute_middlewares(self, app_store: ExtensionData, ctx: AgentBuildContext) -> Sequence[MiddlewarePlacement]:
+        self.access.of(app_store).note_agent_build(
+            _scope_label(ctx.scope),
+            ctx.model_name,
+            ctx.policy.max_subagents_per_run,
+        )
+        return (
+            MiddlewarePlacement(LogicalModelProbe(), Placement.MODEL_LOGICAL, AgentScope.BOTH),
+            MiddlewarePlacement(PhysicalModelProbe(), Placement.MODEL_PHYSICAL, AgentScope.BOTH),
+            # Tool observation is scoped to the lead agent: subagents run their
+            # own tool loops, and folding those into the same totals would make
+            # "what the model saw" ambiguous about *which* model.
+            MiddlewarePlacement(VisibleToolProbe(), Placement.TOOL_VISIBLE, AgentScope.LEAD),
+            MiddlewarePlacement(RawToolProbe(), Placement.TOOL_RAW, AgentScope.LEAD),
+        )

--- a/examples/deerflow-extension-example/deerflow_extension_example/service.py
+++ b/examples/deerflow-extension-example/deerflow_extension_example/service.py
@@ -1,0 +1,83 @@
+"""The service and its router -- one object, two roles.
+
+Routers must be constructed eagerly, during ``install()``, so the host can
+detect path conflicts and freeze its OpenAPI surface before it serves. But
+``install()`` is capability-free by design: there is nothing to talk to yet.
+
+The resolution is the pattern below. The same object registers as an
+``ExtensionService`` and provides the router's FastAPI dependency: paths and the
+dependency graph are fixed at import time, while the actual host capabilities
+arrive later in ``start()`` and are resolved per request through ``Depends()``.
+
+That makes the 503 window explicit rather than accidental. Before ``start()``,
+after ``stop()``, and when ``start()`` failed and the host fail-opened past it,
+the route reports unavailable instead of serving a half-built answer.
+"""
+
+# NOTE: no `from __future__ import annotations` in this module, on purpose.
+# PEP 563 turns every annotation into a string, and FastAPI resolves those
+# strings against *module* globals -- so a marker like
+# `Annotated[..., Depends(service.require_deps)]`, whose `service` is local to
+# `build_router()`, fails to resolve. FastAPI's resolution is lenient: it keeps
+# the raw string instead of raising, the `Depends` is silently lost, and the
+# parameter degrades into a required query parameter answering 422 where you
+# expected 503. Either drop the future import here (this file) or use the
+# `deps: X = Depends(...)` default-value form, which is evaluated eagerly.
+
+from dataclasses import asdict
+from typing import Annotated, Any
+
+from deerflow_extension_api import ExtensionRuntimeDeps
+from fastapi import APIRouter, Depends, HTTPException
+
+from deerflow_extension_example.stats import RunStats, StatsAccess
+
+ROUTE_PREFIX = "/api/extension-example"
+
+
+class ExampleService:
+    """Binds host runtime dependencies for the lifetime of the Gateway."""
+
+    def __init__(self, access: StatsAccess) -> None:
+        self._access = access
+        self._deps: ExtensionRuntimeDeps | None = None
+
+    async def start(self, deps: ExtensionRuntimeDeps) -> None:
+        self._deps = deps
+        if deps.app_store is not None:
+            # The host's enforced limits, projected. Recorded rather than acted
+            # on here because this example only observes; a real extension would
+            # size its buffers or skip work the host already caps.
+            self._access.of(deps.app_store).note_host_policy(asdict(deps.policy))
+
+    async def stop(self) -> None:
+        # Unbinding is the point: the router stays mounted for the rest of the
+        # shutdown sequence, and it must stop answering with stale capabilities.
+        self._deps = None
+
+    def require_deps(self) -> ExtensionRuntimeDeps:
+        """FastAPI dependency. Resolved per request, never captured at import."""
+        deps = self._deps
+        if deps is None or deps.app_store is None:
+            raise HTTPException(status_code=503, detail="extension-example is not started yet")
+        return deps
+
+
+def build_router(service: ExampleService, access: StatsAccess) -> APIRouter:
+    """Construct the router eagerly. No host capabilities are touched here."""
+    router = APIRouter(prefix=ROUTE_PREFIX, tags=["extension-example"])
+
+    @router.get("/stats")
+    async def read_stats(deps: Annotated[ExtensionRuntimeDeps, Depends(service.require_deps)]) -> dict[str, Any]:
+        assert deps.app_store is not None  # require_deps() already refused None
+        stats: RunStats = access.of(deps.app_store)
+        return {
+            "scope_id": deps.app_store.scope_id,
+            # Reported, not used: this example stores nothing. Persistence for
+            # extensions (a shared declarative Base and its migration chain) is
+            # a separate concern from the observation contract.
+            "session_factory_available": deps.session_factory is not None,
+            **stats.snapshot(),
+        }
+
+    return router

--- a/examples/deerflow-extension-example/deerflow_extension_example/stats.py
+++ b/examples/deerflow-extension-example/deerflow_extension_example/stats.py
@@ -1,0 +1,225 @@
+"""What this extension actually records.
+
+Two scopes, one flush. The host creates a task-scoped ``ExtensionData`` per
+agent execution and drops it when that execution returns, so anything a probe
+accumulates during a run has to be moved into the app-scoped store before the
+task ends -- which is what ``on_task_stop`` is for. Nothing here reaches back
+into the host: these are plain objects the extension owns.
+
+``ExtensionData`` locks its own storage, but the values you put *inside* it are
+yours to protect. Each counter object therefore carries its own lock: probes on
+the model axis and the tool axis can be re-entered while another await is in
+flight, and a real extension should not have to reason about which of its
+increments happen to be atomic.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import Any
+
+from deerflow_extension_api import ExtensionData
+
+#: Keeps ``/stats`` bounded regardless of what an operator configures.
+MAX_RECENT_TASKS = 500
+DEFAULT_RECENT_TASKS = 20
+
+
+@dataclass
+class TaskRecord:
+    """Counters for one agent execution. Lives in the task-scoped store.
+
+    Type-keyed storage is why this class exists at all: ``ExtensionData`` is
+    keyed by type, not by string, so no other extension can collide with it.
+    """
+
+    task_id: str
+    kind: str
+    thread_id: str
+    resumed: bool = False
+    agent_name: str | None = None
+
+    logical_model_calls: int = 0
+    physical_model_calls: int = 0
+    model_seconds: float = 0.0
+
+    tool_calls: int = 0
+    raw_result_chars: int = 0
+    visible_result_chars: int = 0
+    tools_used: dict[str, int] = field(default_factory=dict)
+
+    _lock: Lock = field(default_factory=Lock, repr=False, compare=False)
+
+    def note_logical_model_call(self) -> None:
+        with self._lock:
+            self.logical_model_calls += 1
+
+    def note_physical_model_call(self, seconds: float) -> None:
+        with self._lock:
+            self.physical_model_calls += 1
+            self.model_seconds += seconds
+
+    def note_visible_tool_result(self, tool_name: str, chars: int) -> None:
+        with self._lock:
+            self.tool_calls += 1
+            self.visible_result_chars += chars
+            self.tools_used[tool_name] = self.tools_used.get(tool_name, 0) + 1
+
+    def note_raw_tool_result(self, chars: int) -> None:
+        with self._lock:
+            self.raw_result_chars += chars
+
+    def summary(self, outcome: str) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "task_id": self.task_id,
+                "kind": self.kind,
+                "thread_id": self.thread_id,
+                "agent_name": self.agent_name,
+                "resumed": self.resumed,
+                "outcome": outcome,
+                "logical_model_calls": self.logical_model_calls,
+                "physical_model_calls": self.physical_model_calls,
+                "model_seconds": round(self.model_seconds, 3),
+                "tool_calls": self.tool_calls,
+                "raw_result_chars": self.raw_result_chars,
+                "visible_result_chars": self.visible_result_chars,
+                "tools_used": dict(self.tools_used),
+            }
+
+
+@dataclass
+class RunStats:
+    """Process-wide totals. Lives in the app-scoped store.
+
+    The app store outlives every run, so this is where per-task records go to
+    be aggregated. ``recent_tasks`` is a bounded deque on purpose: an extension
+    that grows without limit inside the host's process is a leak, not a feature.
+    """
+
+    recent_limit: int = DEFAULT_RECENT_TASKS
+
+    builds_by_scope: dict[str, int] = field(default_factory=dict)
+    models_seen: dict[str, int] = field(default_factory=dict)
+    policy_max_subagents_per_run: int | None = None
+    host_policy: dict[str, Any] | None = None
+
+    tasks_started: int = 0
+    tasks_by_outcome: dict[str, int] = field(default_factory=dict)
+    tasks_by_kind: dict[str, int] = field(default_factory=dict)
+
+    logical_model_calls: int = 0
+    physical_model_calls: int = 0
+    model_seconds: float = 0.0
+    tool_calls: int = 0
+    raw_result_chars: int = 0
+    visible_result_chars: int = 0
+
+    system_calls: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    recent_tasks: deque[dict[str, Any]] = field(default_factory=deque)
+    _lock: Lock = field(default_factory=Lock, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        self.recent_limit = max(1, min(int(self.recent_limit), MAX_RECENT_TASKS))
+        self.recent_tasks = deque(self.recent_tasks, maxlen=self.recent_limit)
+
+    def note_agent_build(self, scope: str, model_name: str | None, max_subagents_per_run: int | None) -> None:
+        """Record that the host asked us what to contribute to one agent build."""
+        with self._lock:
+            self.builds_by_scope[scope] = self.builds_by_scope.get(scope, 0) + 1
+            if model_name:
+                self.models_seen[model_name] = self.models_seen.get(model_name, 0) + 1
+            # Proof that the narrow host-policy projection reaches the builder,
+            # not just service startup. A real extension would use it to make a
+            # decision (size a buffer, skip work the host already caps).
+            if max_subagents_per_run is not None:
+                self.policy_max_subagents_per_run = max_subagents_per_run
+
+    def note_host_policy(self, policy: dict[str, Any]) -> None:
+        with self._lock:
+            self.host_policy = policy
+
+    def note_task_start(self, kind: str) -> None:
+        with self._lock:
+            self.tasks_started += 1
+            self.tasks_by_kind[kind] = self.tasks_by_kind.get(kind, 0) + 1
+
+    def absorb(self, record: TaskRecord | None, outcome: str) -> None:
+        """Fold one finished task into the totals.
+
+        ``record`` is None when the task produced no observations at all (a run
+        that failed before its first model call). The outcome is still counted:
+        losing the task entirely would make failures invisible.
+        """
+        summary = record.summary(outcome) if record is not None else None
+        with self._lock:
+            self.tasks_by_outcome[outcome] = self.tasks_by_outcome.get(outcome, 0) + 1
+            if summary is None:
+                return
+            self.logical_model_calls += summary["logical_model_calls"]
+            self.physical_model_calls += summary["physical_model_calls"]
+            self.model_seconds += summary["model_seconds"]
+            self.tool_calls += summary["tool_calls"]
+            self.raw_result_chars += summary["raw_result_chars"]
+            self.visible_result_chars += summary["visible_result_chars"]
+            self.recent_tasks.append(summary)
+
+    def note_system_call(self, kind: str, seconds: float | None, failed: bool) -> None:
+        with self._lock:
+            entry = self.system_calls.setdefault(kind, {"calls": 0, "errors": 0, "seconds": 0.0})
+            entry["calls"] += 1
+            if failed:
+                entry["errors"] += 1
+            if seconds is not None:
+                entry["seconds"] = round(entry["seconds"] + seconds, 3)
+
+    def snapshot(self) -> dict[str, Any]:
+        """A JSON-safe copy. Callers never get the live objects."""
+        with self._lock:
+            return {
+                "agent_builds": {
+                    "by_scope": dict(self.builds_by_scope),
+                    "models_seen": dict(self.models_seen),
+                    "policy_max_subagents_per_run": self.policy_max_subagents_per_run,
+                },
+                "host_policy": dict(self.host_policy) if self.host_policy else None,
+                "tasks": {
+                    "started": self.tasks_started,
+                    "by_outcome": dict(self.tasks_by_outcome),
+                    "by_kind": dict(self.tasks_by_kind),
+                },
+                "model_calls": {
+                    # The gap between these two is the host's retry behaviour --
+                    # the guarantee MODEL_LOGICAL and MODEL_PHYSICAL encode.
+                    "logical": self.logical_model_calls,
+                    "physical": self.physical_model_calls,
+                    "seconds": round(self.model_seconds, 3),
+                },
+                "tool_calls": {
+                    "count": self.tool_calls,
+                    # The gap here is truncation and sanitization: TOOL_RAW sees
+                    # the tool's own return, TOOL_VISIBLE sees what survived.
+                    "raw_chars": self.raw_result_chars,
+                    "visible_chars": self.visible_result_chars,
+                },
+                "system_model_calls": {kind: dict(entry) for kind, entry in self.system_calls.items()},
+                "recent_tasks": list(self.recent_tasks),
+            }
+
+
+@dataclass(frozen=True)
+class StatsAccess:
+    """The one seam every component uses to reach the app-scoped stats.
+
+    ``get_or_init`` rather than ``set``: the host hands the same app store to
+    the builder, the lifecycle hooks, the observer and the service, and any of
+    them can be the first to run. Whoever gets there first creates it.
+    """
+
+    recent_limit: int = DEFAULT_RECENT_TASKS
+
+    def of(self, app_store: ExtensionData) -> RunStats:
+        return app_store.get_or_init(RunStats, lambda: RunStats(recent_limit=self.recent_limit))

--- a/examples/deerflow-extension-example/pyproject.toml
+++ b/examples/deerflow-extension-example/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "deerflow-extension-example"
+version = "0.1.0"
+description = "A worked example of a DeerFlow extension: one package, all five contribution points"
+readme = "README.md"
+requires-python = ">=3.12"
+# One dependency, deliberately. This is what "an extension can be released
+# independently of the host" means in practice: nothing here depends on
+# `deerflow-harness` or on the Gateway app. langchain/fastapi/langgraph arrive
+# transitively through the contract package, which declares them because every
+# extension needs the middleware base class and the router type.
+dependencies = ["deerflow-extension-api>=0.1,<0.2"]
+
+[project.optional-dependencies]
+dev = ["pytest>=9.0.3", "pytest-asyncio>=1.3.0", "httpx>=0.28.0"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["deerflow_extension_example"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/examples/deerflow-extension-example/ruff.toml
+++ b/examples/deerflow-extension-example/ruff.toml
@@ -1,0 +1,15 @@
+# Mirrors the host repo's style so the example reads like the code around it.
+# An independent package carries its own tooling config: `cd backend && make lint`
+# does not reach outside `backend/`.
+line-length = 240
+target-version = "py312"
+
+[lint]
+select = ["E", "F", "I", "UP"]
+
+[lint.isort]
+known-first-party = ["deerflow_extension_example"]
+
+[format]
+quote-style = "double"
+indent-style = "space"

--- a/examples/deerflow-extension-example/tests/conftest.py
+++ b/examples/deerflow-extension-example/tests/conftest.py
@@ -1,0 +1,75 @@
+"""A fake host, built from the contract alone.
+
+This is the part worth copying. ``ExtensionRegistry`` is a runtime-checkable
+Protocol and every contract type is importable without the harness, so a
+third-party extension can prove it registers correctly, that its probes count
+correctly, and that its route reports 503 before startup -- with no DeerFlow
+host installed anywhere.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from deerflow_extension_api import (
+    EXTENSION_TASK_STORE_KEY,
+    ExtensionData,
+    ExtensionService,
+    MiddlewareContributor,
+    SystemModelCallObserver,
+    TaskLifecycleContributor,
+)
+
+
+class FakeRegistry:
+    """Records what an extension registers. Mirrors the contract's five methods."""
+
+    # Collections are named apart from the contract's method names on purpose:
+    # ``task_lifecycle`` and ``routers`` are both methods, so an attribute of the
+    # same name would shadow them on the instance and break registration.
+    def __init__(self) -> None:
+        self.registered_services: list[ExtensionService] = []
+        self.registered_middlewares: list[MiddlewareContributor] = []
+        self.registered_lifecycle: list[TaskLifecycleContributor] = []
+        self.registered_observers: list[SystemModelCallObserver] = []
+        self.registered_routers: list[Any] = []
+
+    def service(self, service: ExtensionService) -> None:
+        self.registered_services.append(service)
+
+    def middlewares(self, contributor: MiddlewareContributor) -> None:
+        self.registered_middlewares.append(contributor)
+
+    def task_lifecycle(self, contributor: TaskLifecycleContributor) -> None:
+        self.registered_lifecycle.append(contributor)
+
+    def system_model_observer(self, observer: SystemModelCallObserver) -> None:
+        self.registered_observers.append(observer)
+
+    def routers(self, routers: Any) -> None:
+        self.registered_routers.extend(routers)
+
+
+@dataclass
+class FakeRuntime:
+    """Stands in for LangGraph's Runtime: middlewares only read ``context``."""
+
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FakeModelRequest:
+    runtime: FakeRuntime | None = None
+
+
+@dataclass
+class FakeToolRequest:
+    tool_call: dict[str, Any] = field(default_factory=dict)
+    runtime: FakeRuntime | None = None
+
+
+def task_scope() -> tuple[ExtensionData, FakeRuntime]:
+    """A task-scoped store, installed the way the host installs it."""
+    task_store = ExtensionData("task-1")
+    return task_store, FakeRuntime(context={EXTENSION_TASK_STORE_KEY: task_store})

--- a/examples/deerflow-extension-example/tests/test_install.py
+++ b/examples/deerflow-extension-example/tests/test_install.py
@@ -1,0 +1,124 @@
+"""What install() registers, and what it refuses to."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import FakeRegistry
+from deerflow_extension_api import (
+    AgentBuildContext,
+    AgentScope,
+    ExtensionData,
+    ExtensionRegistry,
+    Placement,
+)
+
+from deerflow_extension_example import install
+from deerflow_extension_example.lifecycle import SystemCallRecorder, TaskRecorder
+from deerflow_extension_example.probes import ProbeContributor
+from deerflow_extension_example.service import ROUTE_PREFIX, ExampleService
+from deerflow_extension_example.stats import MAX_RECENT_TASKS, RunStats
+
+
+def test_fake_registry_satisfies_the_published_contract() -> None:
+    # The contract Protocol is runtime-checkable, which is what lets a third
+    # party verify conformance without the host.
+    assert isinstance(FakeRegistry(), ExtensionRegistry)
+
+
+def test_registers_all_five_contribution_points() -> None:
+    registry = FakeRegistry()
+
+    install(registry, {})
+
+    assert len(registry.registered_middlewares) == 1
+    assert isinstance(registry.registered_middlewares[0], ProbeContributor)
+    assert len(registry.registered_lifecycle) == 1
+    assert isinstance(registry.registered_lifecycle[0], TaskRecorder)
+    assert len(registry.registered_observers) == 1
+    assert isinstance(registry.registered_observers[0], SystemCallRecorder)
+    assert len(registry.registered_services) == 1
+    assert isinstance(registry.registered_services[0], ExampleService)
+    assert len(registry.registered_routers) == 1
+
+
+def test_router_is_built_eagerly_at_the_declared_prefix() -> None:
+    registry = FakeRegistry()
+
+    install(registry, {})
+
+    paths = [route.path for route in registry.registered_routers[0].routes]
+    assert paths == [f"{ROUTE_PREFIX}/stats"]
+
+
+def test_install_declares_the_api_version_it_was_written_against() -> None:
+    assert install.__deerflow_api__ == "0.1"
+    assert install.__deerflow_name__ == "example"
+
+
+def test_disabled_registers_nothing_and_does_not_fail() -> None:
+    registry = FakeRegistry()
+
+    install(registry, {"enabled": False})
+
+    assert registry.registered_middlewares == []
+    assert registry.registered_lifecycle == []
+    assert registry.registered_observers == []
+    assert registry.registered_services == []
+    assert registry.registered_routers == []
+
+
+def test_malformed_config_fails_loudly_during_install() -> None:
+    # The host turns this into a diagnostic naming this extension, and skips it
+    # unless the operator marked it `required: true`.
+    with pytest.raises(ValueError, match="recent_task_limit"):
+        install(FakeRegistry(), {"recent_task_limit": "twenty"})
+
+
+def test_recent_task_limit_is_clamped() -> None:
+    registry = FakeRegistry()
+    install(registry, {"recent_task_limit": 10_000})
+
+    app_store = ExtensionData("app")
+    registry.registered_middlewares[0].contribute_middlewares(app_store, _lead_ctx())
+
+    assert app_store.get(RunStats).recent_limit == MAX_RECENT_TASKS
+
+
+def test_contributions_declare_paired_placements_and_scopes() -> None:
+    registry = FakeRegistry()
+    install(registry, {})
+
+    contributions = registry.registered_middlewares[0].contribute_middlewares(ExtensionData("app"), _lead_ctx())
+
+    declared = [(item.placement, item.scope) for item in contributions]
+    assert declared == [
+        (Placement.MODEL_LOGICAL, AgentScope.BOTH),
+        (Placement.MODEL_PHYSICAL, AgentScope.BOTH),
+        (Placement.TOOL_VISIBLE, AgentScope.LEAD),
+        (Placement.TOOL_RAW, AgentScope.LEAD),
+    ]
+
+
+def test_the_builder_records_what_the_host_told_it() -> None:
+    registry = FakeRegistry()
+    install(registry, {})
+    app_store = ExtensionData("app")
+
+    registry.registered_middlewares[0].contribute_middlewares(app_store, _lead_ctx())
+    registry.registered_middlewares[0].contribute_middlewares(app_store, AgentBuildContext(scope=AgentScope.SUBAGENT, model_name="fast-model"))
+
+    snapshot = app_store.get(RunStats).snapshot()
+    assert snapshot["agent_builds"]["by_scope"] == {"lead": 1, "subagent": 1}
+    assert snapshot["agent_builds"]["models_seen"] == {"main-model": 1, "fast-model": 1}
+    assert snapshot["agent_builds"]["policy_max_subagents_per_run"] == 6
+
+
+def _lead_ctx() -> AgentBuildContext:
+    from deerflow_extension_api import HostPolicySnapshot
+
+    return AgentBuildContext(
+        scope=AgentScope.LEAD,
+        agent_name="lead-agent",
+        model_name="main-model",
+        policy=HostPolicySnapshot(max_subagents_per_run=6),
+    )

--- a/examples/deerflow-extension-example/tests/test_lifecycle.py
+++ b/examples/deerflow-extension-example/tests/test_lifecycle.py
@@ -1,0 +1,140 @@
+"""Task scope hand-off, and the system-model observer's two paths."""
+
+from __future__ import annotations
+
+from deerflow_extension_api import (
+    ExtensionData,
+    SystemModelRequest,
+    SystemModelResult,
+    SystemOperationKind,
+    TaskInfo,
+    TaskOutcome,
+)
+
+from deerflow_extension_example.lifecycle import SystemCallRecorder, TaskRecorder
+from deerflow_extension_example.stats import RunStats, StatsAccess, TaskRecord
+
+ACCESS = StatsAccess(recent_limit=3)
+
+
+def _info(kind: str = "lead", **overrides: object) -> TaskInfo:
+    fields: dict[str, object] = {
+        "task_id": "task-1",
+        "run_id": "run-1",
+        "thread_id": "thread-1",
+        "kind": kind,
+    }
+    fields.update(overrides)
+    return TaskInfo(**fields)  # type: ignore[arg-type]
+
+
+async def test_start_opens_a_task_record_and_stop_hands_it_over() -> None:
+    recorder = TaskRecorder(ACCESS)
+    app_store, task_store = ExtensionData("app"), ExtensionData("task-1")
+    info = _info(agent_name="lead-agent")
+
+    await recorder.on_task_start(app_store, task_store, info)
+    task_store.get(TaskRecord).note_physical_model_call(0.5)
+    await recorder.on_task_stop(app_store, task_store, info, TaskOutcome.COMPLETED)
+
+    # Taken out, not copied: the store is about to be discarded by the host.
+    assert task_store.get(TaskRecord) is None
+    snapshot = app_store.get(RunStats).snapshot()
+    assert snapshot["tasks"] == {"started": 1, "by_outcome": {"completed": 1}, "by_kind": {"lead": 1}}
+    assert snapshot["model_calls"]["physical"] == 1
+    assert snapshot["recent_tasks"][0]["agent_name"] == "lead-agent"
+    assert snapshot["recent_tasks"][0]["outcome"] == "completed"
+
+
+async def test_lead_and_subagent_share_one_code_path() -> None:
+    recorder = TaskRecorder(ACCESS)
+    app_store = ExtensionData("app")
+
+    for kind, task_id in (("lead", "task-1"), ("subagent", "task-2")):
+        task_store = ExtensionData(task_id)
+        info = _info(kind, task_id=task_id, parent_task_id="task-1" if kind == "subagent" else None)
+        await recorder.on_task_start(app_store, task_store, info)
+        await recorder.on_task_stop(app_store, task_store, info, TaskOutcome.COMPLETED)
+
+    assert app_store.get(RunStats).snapshot()["tasks"]["by_kind"] == {"lead": 1, "subagent": 1}
+
+
+async def test_a_stop_without_observations_still_counts_the_outcome() -> None:
+    """A run that failed before its first model call must not vanish."""
+    recorder = TaskRecorder(ACCESS)
+    app_store, task_store = ExtensionData("app"), ExtensionData("task-1")
+
+    await recorder.on_task_stop(app_store, task_store, _info(), TaskOutcome.FAILED)
+
+    snapshot = app_store.get(RunStats).snapshot()
+    assert snapshot["tasks"]["by_outcome"] == {"failed": 1}
+    assert snapshot["recent_tasks"] == []
+
+
+async def test_every_outcome_is_recorded_under_its_own_name() -> None:
+    recorder = TaskRecorder(ACCESS)
+    app_store = ExtensionData("app")
+
+    for outcome in (TaskOutcome.COMPLETED, TaskOutcome.ABORTED, TaskOutcome.FAILED):
+        await recorder.on_task_stop(app_store, ExtensionData("task"), _info(), outcome)
+
+    assert app_store.get(RunStats).snapshot()["tasks"]["by_outcome"] == {
+        "completed": 1,
+        "aborted": 1,
+        "failed": 1,
+    }
+
+
+async def test_recent_tasks_stays_bounded_by_the_configured_limit() -> None:
+    recorder = TaskRecorder(ACCESS)  # recent_limit=3
+    app_store = ExtensionData("app")
+
+    for index in range(5):
+        task_store = ExtensionData(f"task-{index}")
+        info = _info(task_id=f"task-{index}")
+        await recorder.on_task_start(app_store, task_store, info)
+        await recorder.on_task_stop(app_store, task_store, info, TaskOutcome.COMPLETED)
+
+    recent = app_store.get(RunStats).snapshot()["recent_tasks"]
+    assert [entry["task_id"] for entry in recent] == ["task-2", "task-3", "task-4"]
+
+
+async def test_system_model_calls_are_counted_per_kind() -> None:
+    observer = SystemCallRecorder(ACCESS)
+    app_store, task_store = ExtensionData("app"), ExtensionData("task-1")
+
+    await observer.on_system_model_call(
+        app_store,
+        task_store,
+        SystemOperationKind.TITLE,
+        SystemModelRequest(model_name="fast-model"),
+        SystemModelResult(response="A title", duration_ms=250.0),
+    )
+    await observer.on_system_model_call(
+        app_store,
+        task_store,
+        SystemOperationKind.MEMORY,
+        SystemModelRequest(),
+        SystemModelResult(response="ok", duration_ms=1000.0),
+    )
+
+    assert app_store.get(RunStats).snapshot()["system_model_calls"] == {
+        "title": {"calls": 1, "errors": 0, "seconds": 0.25},
+        "memory": {"calls": 1, "errors": 0, "seconds": 1.0},
+    }
+
+
+async def test_a_failed_system_call_is_not_silently_missed() -> None:
+    """The host notifies on both paths; keying off `response` would lose this."""
+    observer = SystemCallRecorder(ACCESS)
+    app_store = ExtensionData("app")
+
+    await observer.on_system_model_call(
+        app_store,
+        ExtensionData("task-1"),
+        SystemOperationKind.SUMMARIZATION,
+        SystemModelRequest(),
+        SystemModelResult(response=None, error=RuntimeError("rate limited"), duration_ms=None),
+    )
+
+    assert app_store.get(RunStats).snapshot()["system_model_calls"] == {"summarization": {"calls": 1, "errors": 1, "seconds": 0.0}}

--- a/examples/deerflow-extension-example/tests/test_probes.py
+++ b/examples/deerflow-extension-example/tests/test_probes.py
@@ -1,0 +1,186 @@
+"""The probes, driven directly -- including the case the placement exists for."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import FakeModelRequest, FakeToolRequest, task_scope
+from langchain_core.messages import ToolMessage
+from langgraph.types import Command
+
+from deerflow_extension_example.probes import (
+    LogicalModelProbe,
+    PhysicalModelProbe,
+    RawToolProbe,
+    VisibleToolProbe,
+)
+from deerflow_extension_example.stats import TaskRecord
+
+
+def _record(task_store) -> TaskRecord:
+    record = TaskRecord(task_id="task-1", kind="lead", thread_id="thread-1")
+    task_store.set(record)
+    return record
+
+
+async def test_one_logical_decision_can_cost_several_physical_calls() -> None:
+    """The guarantee the model-axis pair encodes, observed end to end.
+
+    The physical probe sits inner of retry; the logical probe sits outer of it.
+    So a retried decision must count once logically and twice physically -- this
+    is the assertion that would fail if either placement were misdeclared.
+    """
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+    logical = LogicalModelProbe()
+    physical = PhysicalModelProbe()
+    request = FakeModelRequest(runtime=runtime)
+
+    async def provider(_request: FakeModelRequest) -> str:
+        return "response"
+
+    async def retrying_handler(inner: FakeModelRequest) -> str:
+        await physical.awrap_model_call(inner, provider)
+        return await physical.awrap_model_call(inner, provider)
+
+    result = await logical.awrap_model_call(request, retrying_handler)
+
+    assert result == "response"
+    assert record.logical_model_calls == 1
+    assert record.physical_model_calls == 2
+    assert record.model_seconds >= 0.0
+
+
+async def test_a_failed_attempt_still_counts_and_still_raises() -> None:
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+
+    async def failing(_request: FakeModelRequest) -> str:
+        raise RuntimeError("provider is down")
+
+    with pytest.raises(RuntimeError, match="provider is down"):
+        await PhysicalModelProbe().awrap_model_call(FakeModelRequest(runtime=runtime), failing)
+
+    assert record.physical_model_calls == 1
+
+
+async def test_tool_probes_measure_both_ends_of_the_same_call() -> None:
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+    request = FakeToolRequest(tool_call={"name": "web_fetch"}, runtime=runtime)
+    raw = RawToolProbe()
+    visible = VisibleToolProbe()
+
+    async def tool(_request: FakeToolRequest) -> ToolMessage:
+        return ToolMessage(content="x" * 100, tool_call_id="call-1")
+
+    async def truncating_handler(inner: FakeToolRequest) -> ToolMessage:
+        # Stands in for the host's output budget: the raw probe is inner of it,
+        # the visible probe is outer of it.
+        result = await raw.awrap_tool_call(inner, tool)
+        return ToolMessage(content=result.content[:10], tool_call_id="call-1")
+
+    result = await visible.awrap_tool_call(request, truncating_handler)
+
+    assert len(result.content) == 10
+    assert record.raw_result_chars == 100
+    assert record.visible_result_chars == 10
+    assert record.tool_calls == 1
+    assert record.tools_used == {"web_fetch": 1}
+
+
+async def test_a_command_wrapped_result_is_unwrapped_not_counted_as_zero() -> None:
+    """The production shape: the host's SandboxMiddleware sits between the two
+    probes and rewraps the ToolMessage into a Command so the sandbox id reaches
+    state. The outer probe therefore sees a Command, and counting that as zero
+    would make the raw/visible pair measure different things — which reads as
+    "the host truncated everything" instead of "I failed to unwrap"."""
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+    request = FakeToolRequest(tool_call={"name": "bash"}, runtime=runtime)
+    raw = RawToolProbe()
+    visible = VisibleToolProbe()
+
+    async def tool(_request: FakeToolRequest) -> ToolMessage:
+        return ToolMessage(content="200000\n", tool_call_id="call-1")
+
+    async def sandbox_wrapping_handler(inner: FakeToolRequest) -> Command:
+        result = await raw.awrap_tool_call(inner, tool)
+        return Command(update={"sandbox": {"sandbox_id": "local:t1"}, "messages": [result]})
+
+    await visible.awrap_tool_call(request, sandbox_wrapping_handler)
+
+    assert record.raw_result_chars == 7
+    assert record.visible_result_chars == 7, "the outer probe must see through the Command wrapper"
+    assert record.tool_calls == 1
+
+
+async def test_a_pure_control_flow_command_measures_as_zero() -> None:
+    """A Command with no messages carries no content — zero is correct there."""
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+
+    async def tool(_request: FakeToolRequest) -> Command:
+        return Command(goto="__end__")
+
+    await VisibleToolProbe().awrap_tool_call(FakeToolRequest(tool_call={"name": "ask_clarification"}, runtime=runtime), tool)
+
+    assert record.tool_calls == 1
+    assert record.visible_result_chars == 0
+
+
+async def test_a_result_with_neither_content_nor_update_measures_as_zero() -> None:
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+
+    async def tool(_request: FakeToolRequest) -> object:
+        return object()
+
+    await VisibleToolProbe().awrap_tool_call(FakeToolRequest(tool_call={"name": "task"}, runtime=runtime), tool)
+
+    assert record.tool_calls == 1
+    assert record.visible_result_chars == 0
+
+
+async def test_unnamed_tool_calls_do_not_break_the_breakdown() -> None:
+    task_store, runtime = task_scope()
+    record = _record(task_store)
+
+    async def tool(_request: FakeToolRequest) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="call-1")
+
+    await VisibleToolProbe().awrap_tool_call(FakeToolRequest(tool_call={}, runtime=runtime), tool)
+
+    assert record.tools_used == {"<unknown>": 1}
+
+
+@pytest.mark.parametrize("runtime", [None, "no-context"])
+async def test_probes_pass_through_when_there_is_no_task_scope(runtime: object) -> None:
+    """A directly invoked subagent has no parent task, so it gets no task store.
+
+    Every probe must degrade to a plain pass-through there. This is the test
+    that catches an extension assuming the store is always present.
+    """
+
+    async def provider(_request: object) -> str:
+        return "response"
+
+    async def tool(_request: object) -> ToolMessage:
+        return ToolMessage(content="ok", tool_call_id="call-1")
+
+    model_request = FakeModelRequest(runtime=None if runtime is None else runtime)
+    tool_request = FakeToolRequest(tool_call={"name": "bash"}, runtime=None if runtime is None else runtime)
+
+    assert await LogicalModelProbe().awrap_model_call(model_request, provider) == "response"
+    assert await PhysicalModelProbe().awrap_model_call(model_request, provider) == "response"
+    assert (await VisibleToolProbe().awrap_tool_call(tool_request, tool)).content == "ok"
+    assert (await RawToolProbe().awrap_tool_call(tool_request, tool)).content == "ok"
+
+
+async def test_probes_pass_through_when_the_task_store_holds_no_record() -> None:
+    task_store, runtime = task_scope()  # store exists, on_task_start never ran
+
+    async def provider(_request: FakeModelRequest) -> str:
+        return "response"
+
+    assert await LogicalModelProbe().awrap_model_call(FakeModelRequest(runtime=runtime), provider) == "response"
+    assert task_store.get(TaskRecord) is None

--- a/examples/deerflow-extension-example/tests/test_service_route.py
+++ b/examples/deerflow-extension-example/tests/test_service_route.py
@@ -1,0 +1,76 @@
+"""The eager router and its 503 window, tested without a host.
+
+Only this extension's router is mounted -- no Gateway, no auth middleware, no
+harness. That is the whole point of building routers eagerly and resolving host
+capabilities through ``Depends()``: the dependency graph is testable in isolation.
+"""
+
+from __future__ import annotations
+
+from deerflow_extension_api import ExtensionData, ExtensionRuntimeDeps, HostPolicySnapshot
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from deerflow_extension_example.service import ROUTE_PREFIX, ExampleService, build_router
+from deerflow_extension_example.stats import StatsAccess
+
+STATS_URL = f"{ROUTE_PREFIX}/stats"
+
+
+def _client() -> tuple[TestClient, ExampleService]:
+    access = StatsAccess()
+    service = ExampleService(access)
+    app = FastAPI()
+    app.include_router(build_router(service, access))
+    return TestClient(app), service
+
+
+def _deps() -> ExtensionRuntimeDeps:
+    return ExtensionRuntimeDeps(
+        app_store=ExtensionData("app"),
+        policy=HostPolicySnapshot(token_budget_enabled=True, max_total_tokens=1_000_000, max_subagents_per_run=6),
+        session_factory=object(),
+    )
+
+
+def test_unavailable_before_the_service_starts() -> None:
+    client, _service = _client()
+
+    assert client.get(STATS_URL).status_code == 503
+
+
+async def test_available_once_the_host_binds_runtime_dependencies() -> None:
+    client, service = _client()
+
+    await service.start(_deps())
+    response = client.get(STATS_URL)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["scope_id"] == "app"
+    assert body["session_factory_available"] is True
+    # The narrow projection the host hands over, echoed back verbatim.
+    assert body["host_policy"]["max_total_tokens"] == 1_000_000
+    assert body["host_policy"]["max_subagents_per_run"] == 6
+    assert body["tasks"] == {"started": 0, "by_outcome": {}, "by_kind": {}}
+
+
+async def test_unavailable_again_after_stop() -> None:
+    """The router stays mounted through shutdown; it must stop answering."""
+    client, service = _client()
+    await service.start(_deps())
+    assert client.get(STATS_URL).status_code == 200
+
+    await service.stop()
+
+    assert client.get(STATS_URL).status_code == 503
+
+
+async def test_unavailable_when_the_host_bound_no_app_store() -> None:
+    # ExtensionRuntimeDeps fields all default, so a host that fail-opened past a
+    # partial startup can hand over a deps object with nothing in it.
+    client, service = _client()
+
+    await service.start(ExtensionRuntimeDeps())
+
+    assert client.get(STATS_URL).status_code == 503


### PR DESCRIPTION
Design discussion: #4573 — please read that first; this PR is the implementation
behind it. Opened as a **draft** so the design can be settled before anyone
reviews the diff line by line.

## Why

Cross-cutting concerns in DeerFlow have exactly one home: the lead-agent
middleware chain. A default local build assembles **24 middlewares**, and the
documented chain enumerates **35 positions** once optional ones are counted.
Every new concern — token accounting, audit, progress guards, policy hooks — is
one more entry in a list that every user pays for and whose ordering everyone
has to reason about together. There is a healthy pressure to say "no" to niche
middleware.

But saying no leaves the requester one option. Wiring a cross-cutting concern in
today means editing the agent builders, the run worker, the subagent executor,
and the Gateway lifespan — the files with the highest upstream change rate. A
downstream fork's maintenance cost therefore scales with upstream's velocity, in
exactly the areas where upstream is most active. That pushes serious downstream
users toward stale forks, which is bad for them and bad for us, because their
fixes never come back.

`extensions.middlewares` already loads middleware classes by path and is genuine
prior art, kept untouched here. Its documented limits are the shape of the gap:
zero-argument classes only, one fixed insertion point near the end of the chain,
no lead-vs-subagent distinction, and nothing for run lifecycle, out-of-graph
model calls, HTTP routes, or anything needing startup and shutdown.

The goal of this PR is not to add features. It is to stop the chain from growing
for concerns only some users want, and to make secondary development a supported
path rather than a fork.

## What changed

Nothing changes for a deployment that does not configure an extension. The
middleware chain is unchanged, every hook site short-circuits on a precomputed
flag before constructing any payload, and `extensions.middlewares` still works
exactly as before.

For someone who wants to add a cross-cutting concern:

- **A new `plugins:` list in `config.yaml`** names entry points as
  `module.path:install`. An installed package does nothing until it is listed.
  The list deliberately lives in `config.yaml` rather than the API-writable
  `extensions_config.json`, because a list that causes code to be imported must
  not be reachable from an HTTP endpoint. `required: true` per entry turns a
  load failure into a startup failure; the default is fail-open with a
  diagnostic.
- **A new package, `deerflow-extension-api`**, holds the whole contract and
  **must never import `deerflow`** — a test pins that. This is what lets an
  extension be released on its own cadence instead of the harness's.
- **Five contribution points:** middlewares, task lifecycle, system model call
  observers, routers, services. Task lifecycle treats a lead run and a subagent
  run as the same event type, so an extension writes one code path for both.
  System model observers exist because title, memory, goal evaluation and
  summarization call models *outside* the graph, where middleware cannot see
  them — an observability extension that only saw the chain would silently miss
  them.
- **Placement is declared semantically**, not as a list index:
  `MODEL_LOGICAL` / `MODEL_PHYSICAL` / `TOOL_VISIBLE` / `TOOL_RAW` / `STANDARD`.
  The mapping to a real position lives in a host-owned anchor table, so the
  chain stays free to be restructured without breaking released extensions.
- **Two phases.** Registration receives a write-only registry with no host
  capabilities, so an extension structurally cannot reach the runtime at import
  time. Real dependencies arrive later, through a narrow projection of the
  limits the host enforces — deliberately *not* `AppConfig`, which would pin
  every extension to the harness release cadence.
- **Failure isolation.** A contributed middleware's own failure degrades to an
  attributed diagnostic and the call proceeds. The wrapper never masks or
  replays a failure of the underlying model or tool call, so a third-party
  observer cannot cause a second provider call or a duplicated tool side effect.

`examples/deerflow-extension-example/` is a runnable reference exercising all
five points. It depends only on the contract package, is not a uv workspace
member, and no host module references it — that independence is the point. Its
own tests run against a fake registry built from the contract alone, with no
harness installed.

Docs: the RFC lands in `docs/plans/`, and `backend/AGENTS.md` gains a section on
the extension host, the placement guarantees, and the isolation rules.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [x] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

On **Backend API**: no existing endpoint changes shape. The Gateway gains the
ability to mount routers contributed by an extension, always *after* every host
router, and refuses one whose path is already served rather than shadowing it.

On **Dependencies**: no third-party dependency is added. `backend/pyproject.toml`
gains `packages/extension-api` as a second uv workspace member. The new package
itself depends only on `langchain`, `langgraph`, `fastapi` and `sqlalchemy` —
public types an extension already needs (middleware base class, router, runtime,
session factory), never DeerFlow internals.

## Validation

Backend, on this branch:

- `ruff check .` and `ruff format --check .` — clean (1056 files).
- Full `pytest tests/` — 10474 passed, 63 skipped, 14 failed.

The 14 failures are pre-existing and environment-dependent, not caused by this
change. Verified by stashing this branch's changes and re-running the same
tests at the merge base: identical failure set, same names. They are local
artifacts — a persisted JWT secret file, a local `config.yaml` that configures a
checkpointer, this checkout being a git worktree, plus one upstream benchmark
test that is order-dependent in a full-suite run and passes in isolation. Worth
confirming against CI.

Extension-specific tests: `pytest -k extension` — 306 passed, 3 skipped.

`examples/deerflow-extension-example/`: 30 passed, using its own environment
with only the contract package installed (no harness), which is the point of
that suite.

Frontend was not touched, so frontend checks were not run.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Design was iterated in conversation first and written up as
the RFC in #4573; the implementation was then written against that design, with
the placement guarantees, isolation semantics and hook-site placement decided in
review rather than generated in one pass. Test-first for the contract-level
behaviour (the placement guarantee tests assert against the real lead and
subagent chains, so they fail if the chain is restructured underneath them).

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
