### PR TITLE
fix(security): sanitize tool error messages to prevent information leakage

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -69,9 +69,19 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
     def _build_error_message(self, request: ToolCallRequest, exc: Exception) -> ToolMessage:
         tool_name = str(request.tool_call.get("name") or "unknown_tool")
         tool_call_id = str(request.tool_call.get("id") or _MISSING_TOOL_CALL_ID)
-        detail = str(exc).strip() or exc.__class__.__name__
-        if len(detail) > 500:
-            detail = detail[:497] + "..."
+        
+        # Sanitize exception message to prevent information leakage.
+        # Only expose safe exception types; for others, use a generic message
+        # to avoid leaking file paths, internal state, or other sensitive info.
+        safe_exception_types = (ValueError, TypeError, KeyError, AttributeError)
+        if isinstance(exc, safe_exception_types):
+            detail = str(exc).strip() or exc.__class__.__name__
+            if len(detail) > 500:
+                detail = detail[:497] + "..."
+        else:
+            # For potentially sensitive exceptions, use a generic message.
+            # The full exception is logged server-side via logger.exception().
+            detail = "An internal error occurred. Check server logs for details."
 
         content = f"Error: Tool '{tool_name}' failed with {exc.__class__.__name__}: {detail}. {_RECOVERY_HINT}"
         message = ToolMessage(

--- a/backend/tests/test_tool_error_handling_middleware.py
+++ b/backend/tests/test_tool_error_handling_middleware.py
@@ -419,7 +419,7 @@ def test_wrap_tool_call_returns_error_tool_message_on_exception():
     req = _request(name="web_search", tool_call_id="tc-42")
 
     def _boom(_req):
-        raise RuntimeError("network down")
+        raise ValueError("invalid query syntax")
 
     result = middleware.wrap_tool_call(req, _boom)
 
@@ -428,7 +428,7 @@ def test_wrap_tool_call_returns_error_tool_message_on_exception():
     assert result.name == "web_search"
     assert result.status == "error"
     assert "Tool 'web_search' failed" in result.text
-    assert "network down" in result.text
+    assert "invalid query syntax" in result.text
 
 
 def test_wrap_tool_call_stamps_tool_meta_on_exception():
@@ -436,7 +436,7 @@ def test_wrap_tool_call_stamps_tool_meta_on_exception():
     req = _request(name="web_search", tool_call_id="tc-42")
 
     def _boom(_req):
-        raise ConnectionError("connection refused")
+        raise ValueError("invalid parameter")
 
     result = middleware.wrap_tool_call(req, _boom)
 
@@ -453,7 +453,7 @@ def test_task_exception_wrapper_uses_subagent_result_formatter():
     req = _request(name="task", tool_call_id="tc-task")
 
     def _boom(_req):
-        raise RuntimeError("network down")
+        raise ValueError("invalid task configuration")
 
     result = middleware.wrap_tool_call(req, _boom)
 
@@ -461,9 +461,9 @@ def test_task_exception_wrapper_uses_subagent_result_formatter():
     assert result.tool_call_id == "tc-task"
     assert result.name == "task"
     assert result.status == "error"
-    assert result.content == "Task failed. Error: RuntimeError: network down. Continue with available context, or choose an alternative tool."
+    assert result.content == "Task failed. Error: ValueError: invalid task configuration. Continue with available context, or choose an alternative tool."
     assert result.additional_kwargs[SUBAGENT_STATUS_KEY] == "failed"
-    assert result.additional_kwargs[SUBAGENT_ERROR_KEY] == "RuntimeError: network down"
+    assert result.additional_kwargs[SUBAGENT_ERROR_KEY] == "ValueError: invalid task configuration"
 
 
 def test_wrap_tool_call_uses_fallback_tool_call_id_when_missing():
@@ -498,7 +498,7 @@ async def test_awrap_tool_call_returns_error_tool_message_on_exception():
     req = _request(name="mcp_tool", tool_call_id="tc-async")
 
     async def _boom(_req):
-        raise TimeoutError("request timed out")
+        raise ValueError("invalid async request")
 
     result = await middleware.awrap_tool_call(req, _boom)
 
@@ -506,7 +506,47 @@ async def test_awrap_tool_call_returns_error_tool_message_on_exception():
     assert result.tool_call_id == "tc-async"
     assert result.name == "mcp_tool"
     assert result.status == "error"
-    assert "request timed out" in result.text
+    assert "invalid async request" in result.text
+
+
+def test_wrap_tool_call_sanitizes_unsafe_exception_messages():
+    """Unsafe exception types (RuntimeError, OSError, etc.) must have their
+    messages sanitized to prevent information leakage. Only the exception class
+    name should be exposed, not the full message which may contain file paths
+    or internal state."""
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="web_search", tool_call_id="tc-unsafe")
+
+    def _boom(_req):
+        raise RuntimeError("/etc/passwd: permission denied for user root")
+
+    result = middleware.wrap_tool_call(req, _boom)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "RuntimeError" in result.text
+    # The sensitive message content must NOT be exposed
+    assert "/etc/passwd" not in result.text
+    assert "permission denied" not in result.text
+    assert "internal error" in result.text.lower()
+
+
+def test_wrap_tool_call_preserves_safe_exception_messages():
+    """Safe exception types (ValueError, TypeError, KeyError, AttributeError)
+    should have their full messages preserved for debugging purposes."""
+    middleware = ToolErrorHandlingMiddleware()
+    req = _request(name="web_search", tool_call_id="tc-safe")
+
+    def _boom(_req):
+        raise ValueError("invalid parameter 'foo': must be positive")
+
+    result = middleware.wrap_tool_call(req, _boom)
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "ValueError" in result.text
+    # Safe exceptions should expose their full message
+    assert "invalid parameter 'foo': must be positive" in result.text
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Fix information leakage in tool error messages.

## Problem
Tool error messages exposed full exception details (file paths, internal state) which could leak sensitive data.

## Solution
- Only expose full messages for safe exception types (ValueError, TypeError, KeyError, AttributeError)
- Replace other exceptions with generic 'internal error' message
- Exception class names still exposed for debugging
- Full exceptions logged server-side via logger.exception()

## Testing
Added tests for both safe and unsafe exception sanitization.