### PR TITLE
fix(scheduler): normalize once-schedule next_run_at to UTC

### DIFF
--- a/backend/packages/harness/deerflow/scheduler/schedules.py
+++ b/backend/packages/harness/deerflow/scheduler/schedules.py
@@ -41,6 +41,10 @@ def next_run_at(
             # A naive run_at means "wall-clock time in the task's declared
             # timezone", matching how cron schedules interpret it.
             run_at = run_at.replace(tzinfo=ZoneInfo(timezone_name))
+        # Normalize to UTC like the cron branch: next_run_at is persisted to
+        # timezone-discarding columns (SQLite), where a non-UTC offset shifts
+        # the effective fire time by the whole offset.
+        run_at = run_at.astimezone(UTC)
         return run_at if run_at > now else None
 
     if schedule_type == "cron":

--- a/backend/tests/test_scheduled_task_schedules.py
+++ b/backend/tests/test_scheduled_task_schedules.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -36,6 +36,30 @@ def test_next_run_at_for_once_returns_none_after_fire_time():
         now=now,
     )
     assert result is None
+
+
+def test_next_run_at_for_once_normalizes_naive_run_at_to_utc():
+    now = datetime(2026, 7, 31, 0, 0, tzinfo=UTC)
+    result = next_run_at(
+        "once",
+        {"run_at": "2026-08-01T09:00:00"},
+        "Asia/Shanghai",
+        now=now,
+    )
+    assert result == datetime(2026, 8, 1, 1, 0, tzinfo=UTC)
+    assert result.utcoffset() == timedelta(0)
+
+
+def test_next_run_at_for_once_normalizes_aware_run_at_to_utc():
+    now = datetime(2026, 7, 31, 0, 0, tzinfo=UTC)
+    result = next_run_at(
+        "once",
+        {"run_at": "2026-08-01T09:00:00+08:00"},
+        "UTC",
+        now=now,
+    )
+    assert result == datetime(2026, 8, 1, 1, 0, tzinfo=UTC)
+    assert result.utcoffset() == timedelta(0)
 
 
 def test_next_run_at_for_cron_uses_timezone():


### PR DESCRIPTION
## Why

A `once` scheduled task declared in a non-UTC timezone fires hours off on the default SQLite backend. With `timezone: Asia/Shanghai`, a task scheduled for 09:00 fires ~8 hours late; for negative-offset timezones it fires hours *early*, which also defeats the `min_once_delay_seconds` protection applied at creation time. The `next_run_at` shown by the API is wrong by the same amount.

Root cause: the `once` branch of `next_run_at()` returns the run time with the task's local timezone offset attached, while the `cron` branch normalizes to UTC (`schedules.py`, `next_local.astimezone(UTC)`). The value is persisted into `scheduled_tasks.next_run_at`, and SQLAlchemy's SQLite dialect discards tzinfo on bind — only the wall-clock digits survive, and the claim query compares them against `datetime.now(UTC)`. Postgres `timestamptz` normalizes on write, which is why only SQLite deployments are affected.

## What changed

- `once` schedules now fire at the correct instant regardless of the task's declared timezone and database backend: the `once` branch converts the run time to UTC before returning, matching the `cron` branch.
- `next_run_at` values returned by the scheduled-task API now show the true UTC fire time.

## Surface area

- [ ] **Frontend UI**
- [x] **Backend API** — `next_run_at` values persisted/returned for `once` scheduled tasks
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change** — `once` tasks in non-UTC timezones on SQLite now fire at the declared local time instead of shifted by the UTC offset
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `backend/tests/test_scheduled_task_schedules.py::test_next_run_at_for_once_normalizes_naive_run_at_to_utc` and `::test_next_run_at_for_once_normalizes_aware_run_at_to_utc`
- Red on `main`, green on this branch: **yes** (2 failed on main, 8/8 pass here)

## Validation

```
cd backend
PYTHONPATH=. uv run pytest tests/test_scheduled_task_schedules.py tests/test_scheduled_task_service.py tests/test_scheduled_task_claims.py tests/test_scheduled_task_lifecycle.py tests/test_scheduled_task_router_behavior.py  # all pass
uv run ruff check / ruff format --check  # clean
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI located the bug during a codebase audit, wrote the fix and tests; I reviewed the change and verified the red/green test runs locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
