### PR TITLE
fix(frontend): parse uploaded filenames containing parentheses

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -845,7 +845,11 @@ export function parseUploadedFiles(content: string): FileInMessage[] {
 
   // Parse file list
   // Format: - filename (size)\n  Path: /path/to/file
-  const fileRegex = /- ([^\n(]+)\s*\(([^)]+)\)\s*\n\s*Path:\s*([^\n]+)/g;
+  // The filename itself may contain parentheses (e.g. "photo (1).png"), so
+  // the size group is anchored on the trailing "(<number> <unit>)" pair the
+  // backend emits instead of stopping the filename at the first "(".
+  const fileRegex =
+    /- (.+)\s*\(([\d.]+\s*(?:B|KB|MB|GB|TB))\)\s*\n\s*Path:\s*([^\n]+)/gi;
   const files: FileInMessage[] = [];
   let fileMatch;
 

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -603,6 +603,31 @@ describe("human message internal context stripping", () => {
     ]);
   });
 
+  test("parses uploaded filenames that contain parentheses", () => {
+    // Browsers name duplicate downloads "photo (1).png"; the backend emits the
+    // filename verbatim, so the parser must not stop the name at the first "(".
+    const content =
+      "<current_uploads>\nThe following files were uploaded in this message:\n\n- photo (1).png (12.3 KB)\n  Path: /mnt/user-data/uploads/photo (1).png\n- report (final) (2).docx (1.5 MB)\n  Path: /mnt/user-data/uploads/report (final) (2).docx\n- normal.pdf (3.0 KB)\n  Path: /mnt/user-data/uploads/normal.pdf\n</current_uploads>\n\nSummarize";
+
+    expect(parseUploadedFiles(content)).toEqual([
+      {
+        filename: "photo (1).png",
+        size: Math.round(12.3 * 1024),
+        path: "/mnt/user-data/uploads/photo (1).png",
+      },
+      {
+        filename: "report (final) (2).docx",
+        size: Math.round(1.5 * 1024 * 1024),
+        path: "/mnt/user-data/uploads/report (final) (2).docx",
+      },
+      {
+        filename: "normal.pdf",
+        size: 3 * 1024,
+        path: "/mnt/user-data/uploads/normal.pdf",
+      },
+    ]);
+  });
+
   test("stripInternalMarkers removes current_uploads blocks on export", () => {
     const content =
       "<current_uploads>\n- paper.docx (177.6 KB)\n  Path: /mnt/user-data/uploads/paper.docx\n</current_uploads>\n\nExport me";


### PR DESCRIPTION
## Why

Uploading a file whose name contains parentheses — e.g. `photo (1).png`, the standard browser duplicate-download naming — makes the file chip silently disappear from the message. `parseUploadedFiles` captures the filename with `[^\n(]+`, which stops at the first `(`; the entry then fails to match the `(size)` part and the whole line is dropped, while other files in the same block still parse. This hits the fallback rendering path used when `additional_kwargs.files` is absent (IM-channel threads viewed in the Web UI, older histories).

## What changed

- File chips now render for uploaded filenames containing parentheses. The parser anchors the size group on the trailing `(<number> <unit>)` pair the backend emits (`uploads_middleware` formats sizes as `%.1f KB` / `%.1f MB`) and lets the filename match greedily up to it.

## Surface area

- [x] **Frontend UI** — file chips on messages with uploads (fallback parsing path)
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Pure parsing fix in `core/messages/utils.ts`; no visual chrome changes — previously-missing chips now appear, covered by the unit test below.

## Bug fix verification

- Test path: `frontend/tests/unit/core/messages/utils.test.ts` — "parses uploaded filenames that contain parentheses"
- Red on `main`, green on this branch: **yes**

## Validation

```
cd frontend
pnpm rstest run tests/unit/core/messages/utils.test.ts  # 53/53 pass
pnpm exec eslint / prettier --check  # clean on changed files
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI located the bug during a codebase audit, wrote the fix and tests; I reviewed the change and verified the red/green test runs locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
