### PR TITLE
Add deerflow governance extension

### DIFF
--- a/extensions/deerflow-governance/.gitignore
+++ b/extensions/deerflow-governance/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.py[cod]
+.venv/
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.ruff_cache/
+
+# 运行时产物：审批库与审计账本
+governance.yaml
+data/

--- a/extensions/deerflow-governance/Makefile
+++ b/extensions/deerflow-governance/Makefile
@@ -1,0 +1,37 @@
+PY ?= python3
+export PYTHONPATH := src
+export DEERFLOW_GOVERNANCE_CONFIG ?= governance.yaml
+
+.PHONY: help install test demo validate simulate audit pending gate clean
+
+help:
+	@echo "make test      47 个核心层用例（不需要 DeerFlow / langchain / API key）"
+	@echo "make demo      端到端演示：三态审批 + 指纹复用 + 授权隔离 + 预算熔断"
+	@echo "make validate  校验 governance.yaml（可进 CI）"
+	@echo "make gate      test + validate + demo，一条命令跑完全部离线验收"
+	@echo "make pending   查看待审批队列"
+
+install:
+	$(PY) -m pip install -e .
+
+test:
+	$(PY) -m unittest discover -s tests -v
+
+demo:
+	$(PY) scripts/demo_flow.py
+
+validate:
+	$(PY) -m deerflow_governance.cli validate
+
+pending:
+	$(PY) -m deerflow_governance.cli pending
+
+audit:
+	$(PY) -m deerflow_governance.cli audit -n 40
+
+gate: test validate demo
+	@echo "\n离线验收全部通过"
+
+clean:
+	rm -rf data/*.db data/*.jsonl
+	find . -name __pycache__ -type d -exec rm -rf {} +

--- a/extensions/deerflow-governance/README.md
+++ b/extensions/deerflow-governance/README.md
@@ -1,0 +1,89 @@
+# deerflow-governance · DeerFlow 生产治理插件
+
+给 [DeerFlow 2.0](https://github.com/bytedance/deer-flow) 补上三件生产环境跑不掉、但框架本身没做的事：
+
+| 能力 | DeerFlow 现状 | 本插件补什么 |
+|---|---|---|
+| **人工审批** | `GuardrailProvider` 只有 allow / deny 两态 | 补第三态 **ask**：挂起、开审批单、人批完再放行 |
+| **合规审计** | 有 `SandboxAuditMiddleware` 和 LangSmith/Langfuse 链路追踪 | 补**面向合规的决策账本**：策略判定 → 开单 → 裁决人 → 结论，append-only 可导出 |
+| **成本治理** | `TokenBudgetMiddleware` 管单 run 的 token；`SubagentLimitMiddleware` 管并发数 ≤ 3 | 补 **run/thread/day 三层 × 五维度**（token、金额、工具调用、委派次数、墙钟）+ 预警/熔断两级阈值 |
+
+**零侵入**：不改 DeerFlow 一行代码。审批走官方的 `guardrails.provider.use` 反射加载点，
+预算走 `build_middlewares(custom_middlewares=[...])` 官方注入点。
+
+## 30 秒看懂它做什么
+
+```
+[放行] 主Agent → bash: pytest tests/ -q                    规则 bash-default
+[拦截] 主Agent → bash: rm -rf /data/prod                   规则 bash-destructive（critical，直接拒绝，不给审批机会）
+[挂起] 主Agent → bash: git push origin main                规则 bash-credentials-or-push → 开单 APR-2CB10E4AC1
+
+  $ governance approve APR-2CB10E4AC1 --by 张三 --note "已确认目标分支"
+
+[放行] 主Agent → bash: git push origin main                已由 张三 批准
+[拦截] 主Agent → bash: git push origin --force main        exact 授权不外溢，--force 是另一次操作
+
+[放行] 主Agent  → bash: ls -al                             常规 shell
+[挂起] 子Agent → bash: ls -al                              同一条命令，子 Agent 更严（用户看不到它的中间过程）
+```
+
+预算：
+
+```
+第 3 轮  tokens=162000  调用=66  委派=6  成本=¥0.4320  →  WARN
+         [预算预警] 本次运行的子 Agent 委派次数已用 6 / 8（75%）。请收敛策略：优先完成主线…
+第 4 轮  tokens=216000  调用=88  委派=8  成本=¥0.5760  →  STOP
+         [预算熔断] 本次运行的子 Agent 委派次数已达上限（8 / 8），本轮停止继续调用工具…
+```
+
+## 快速开始
+
+```bash
+pip install -e .                       # 或直接 PYTHONPATH=src
+cp governance.example.yaml governance.yaml
+export DEERFLOW_GOVERNANCE_CONFIG=$PWD/governance.yaml
+
+make test                              # 47 个用例，不需要 DeerFlow / API key
+make demo                              # 端到端演示全部场景
+governance validate                    # 校验策略配置（可进 CI）
+governance simulate --tool bash --arg command="rm -rf build" --explain   # 干跑，上线新规则前必做
+```
+
+接进 DeerFlow：见 [docs/INTEGRATION.md](docs/INTEGRATION.md)（两处配置，不改源码）。
+设计取舍与源码依据：见 [docs/DESIGN.md](docs/DESIGN.md)。
+
+## 架构
+
+```
+交付面     cli.py（审批/审计/预算/干跑）
+                    │
+适配层     provider.py            middleware.py          ← 唯一 import DeerFlow / langchain 的两个文件
+           GuardrailProvider      AgentMiddleware
+                    │                    │
+核心层     engine.py（审批状态机）  budget.py（分层账本+熔断）
+           policy.py（规则引擎）    pricing.py（金额口径）
+           fingerprint.py（指纹）   store.py（SQLite 单据+审计）
+                    └──────── contracts.py（唯一语义真源） ────────┘
+```
+
+**核心层零三方依赖**（只用 stdlib + PyYAML 读配置），所以 47 个用例和端到端演示
+能在**没装 DeerFlow、没装 langchain、没有 API key** 的机器上完整跑完。
+适配层刻意写得很薄：字段搬运 + 结果翻译，不含任何判断。
+
+## 审批模式
+
+| 模式 | 机制 | 适用 | 状态 |
+|---|---|---|---|
+| `ticket`（默认） | 开单 → 本次拒绝并告知单号 → 人批 → 重试放行 | 主 Agent 与**子 Agent 都可用** | 已离线验证 |
+| `interrupt` | 调 LangGraph `interrupt()` 真正挂起 | 只能用于主 Agent | **未实测**，见 INTEGRATION.md |
+
+选 `ticket` 作默认的理由：DeerFlow 的子 agent 图是 `checkpointer=False` 编译的
+（AGENTS.md 原文："subagents are one-shot and never resume"），
+子 agent 里 `interrupt()` 不成立；而恰恰是子 agent 最需要审批 —— 它的中间过程用户看不见。
+
+## 已知边界
+
+- 预算账本默认在**内存**里，进程重启清零。跨进程的日配额需要注入 `CounterBackend`（接口已留，未提供 SQLite 实现）。
+- 价目表是**可覆盖的默认值不是事实**，上线前必须核对各家官方价目页；未知模型成本记 `unknown` 而非 0。
+- 策略是**规则匹配**不是语义理解，`bash: python -c "import os;os.system('rm -rf /')"` 这类嵌套绕过拦不住 —— 真正的隔离边界是沙箱，本插件是沙箱之上的审批层，不是替代品。
+- 引用 DeerFlow 内部符号（`GuardrailRequest` 字段、`build_middlewares` 签名）会随上游演进，锁定的版本见 INTEGRATION.md。

--- a/extensions/deerflow-governance/docs/DESIGN.md
+++ b/extensions/deerflow-governance/docs/DESIGN.md
@@ -1,0 +1,196 @@
+# 设计说明：问题 → 方案 → 取舍
+
+写给两类人：接手改这个插件的人，和面试时问「你为什么这么设计」的人。
+每一节都是先说**踩到的具体问题**，再说方案，最后说**这个方案牺牲了什么**。
+
+---
+
+## 问题 1：Agent 有了沙箱，为什么还需要审批？
+
+沙箱解决的是「炸不炸得到宿主机」，审批解决的是「该不该做这件事」。这是两个正交的问题。
+
+`git push origin main` 在沙箱里执行得干干净净，不会污染任何本地文件——
+但它把代码推上了远端。`rm -rf /data/prod` 在容器里也跑得很成功，
+如果那个目录是 volume 挂进来的。沙箱是**隔离边界**，不是**授权边界**。
+
+DeerFlow 两边都想到了：有 `Sandbox`（三种 provider）也有 `GuardrailProvider`。
+但 guardrail 只有 allow / deny 两态——**要么放行要么拒绝，没有「等人看一眼」**。
+
+而现实里绝大多数高风险操作既不该无脑放行，也不该一律拒绝，它们需要一个人看两秒钟。
+这就是本插件补的第三态。
+
+**取舍**：三态让链路变长了（拒绝 → 人批 → 重试），任务不再是一气呵成。
+换来的是高风险操作有了人的确认点。如果你的场景里没有真正危险的操作，
+不要引入这套东西，纯负担。
+
+---
+
+## 问题 2：为什么审批要落 SQLite 而不是弹个窗？
+
+因为**审批的人和跑 agent 的进程通常不是同一个**，甚至不在同一台机器。
+
+DeerFlow 的运行形态是 Gateway 服务 + 前端 + 六个 IM 渠道（飞书/钉钉/Slack…）。
+一个跑在服务器上的 run 想弹窗给谁看？放内存的审批只是个弹窗，不是审批系统。
+
+落库带来三个必需的能力：跨进程、跨时间、可追溯。
+`governance approve APR-XXXX --by 张三 --note "..."` 可以在任何一台能访问这个库的机器上执行。
+
+**取舍**：多了一个 SQLite 文件要运维，多了一个「谁来批」的流程问题。
+以及热路径上多了一次 DB 查询——但这发生在工具调用前，相对工具本身的耗时可以忽略。
+
+---
+
+## 问题 3：为什么用「审批单」而不是 LangGraph 的 `interrupt()`？
+
+`interrupt()` 才是"正统"做法，我最初也是奔着它去的。读源码之后改了主意。
+
+三条证据：
+
+1. **DeerFlow 自己没用 `interrupt()` 做中断**。它的澄清机制
+   （`ClarificationMiddleware`）用的是 `Command(goto=END)`——结束本轮，
+   靠用户的下一条消息续上。这说明上游的 run/thread 模型更适应「结束-重开」而不是「挂起-恢复」。
+
+2. **子 agent 根本没法 resume**。AGENTS.md:343 原文：
+   > Subagent graphs are compiled with `checkpointer=False` to avoid inheriting
+   > the parent run's checkpointer, since subagents are one-shot and never resume.
+
+   而子 agent 恰恰是最需要审批的地方——它在隔离上下文里跑，用户看不到中间过程，
+   出事最难复盘。一个在子 agent 里用不了的审批机制，等于没做。
+
+3. **Gateway 的 resume 通路我没实测**。没实测的东西不能当默认。
+
+所以默认走「开单 + 拒绝 + 告知单号 + 重试放行」。这条路径不依赖 checkpointer、
+不依赖 resume 语义、主子 agent 通吃，而且能在**完全没有 DeerFlow 的环境里被单测覆盖**。
+
+`interrupt` 模式仍然保留在配置里（依据是 `GuardrailMiddleware` 显式
+`except GraphBubbleUp: raise`，注释写着 "Preserve LangGraph control-flow signals"，
+说明 provider 层就是官方给 HITL 留的口子），但标注为实验、未实测。
+
+**取舍**：ticket 模式的用户体验不如真正的挂起——模型会先收到一次拒绝。
+用「不要重试、不要绕过、可以先做别的」的明确指令把这个体验损失补回来一部分。
+
+---
+
+## 问题 4：审批系统最常见的失效模式是什么？
+
+**不是被绕过，是被无脑放行。**
+
+每次执行 `pytest -q` 都弹一次审批，人第三次就开始闭眼点「同意」，
+第十次就把整个模式切成 YOLO。**审批疲劳会让审批系统在两天内退化成零。**
+
+所以指纹机制不是优化，是必需品：
+
+```python
+compute(tool_name=..., tool_input=..., rule_id=..., scope=..., thread_id=...)
+```
+
+三档授权范围，由规则自己声明：
+
+| scope | 含义 | 用在哪 |
+|---|---|---|
+| `exact` | 参数完全一致才算同一次操作 | 高危单次操作（`git push`、写 `.env`） |
+| `tool` | 同工具任意参数 | 批量低危操作（子 agent 的只读 shell，批一次管 30 分钟） |
+| `rule` | 命中同一条规则即可 | 大类放行 |
+
+配合 `ttl_seconds` 做时效，配合 `thread_bound_grants` 做会话隔离
+（在 A 会话批准的 `rm -rf build/` 不该自动放行 B 会话的同一条命令）。
+
+指纹计算必须**可复现**：排序 key、剔除易变字段（`tool_call_id` / `run_id` / `sandbox_id`）、
+压缩空白、截断超长值。否则一个空格就会让「批过的操作」永远命中不了，
+用户会觉得「明明批过了还问」，然后又回到无脑放行。
+
+**取舍**：`tool` 和 `rule` 范围会放大授权面。这是效率和严格性的显式交易，
+所以把它做成**每条规则自己声明**，而不是全局开关——高危规则用 `exact`，低危用 `tool`。
+
+---
+
+## 问题 5：为什么策略要匹配参数，不能只看工具名？
+
+`bash: pytest -q` 和 `bash: rm -rf /` 是同一个工具，风险差两个数量级。
+
+只按工具名做策略只有两种结果：把 `bash` 全放（等于没做），或者把 `bash` 全拦
+（agent 直接废掉）。两种都会让治理形同虚设。
+
+所以规则引擎支持参数级条件（`equals` / `contains` / `regex` / `path_prefix` / `absent`），
+`when` 是 AND、`when_any` 是 OR（后者专门给「危险命令黑名单」用）。
+
+同时支持 `scope: subagent` 维度——同一条 `ls -al`，主 agent 放行、子 agent 要批。
+理由同问题 3：子 agent 的中间过程用户看不见。
+
+**求值语义刻意选了「有序 + 首条命中即返回」**，和防火墙、IAM、Nginx location 一致。
+运维不需要学一套新的求值模型就能读懂 `governance.yaml`，规则冲突时的行为也是确定的。
+
+**取舍**：正则匹配拦不住语义等价的绕过——
+`python -c "import os;os.system('rm -rf /')"` 命中不了 `rm\s+-rf` 这条规则。
+**这是本插件的硬边界，写在 README 里没藏着**：真正的隔离靠沙箱，
+本插件是沙箱之上的授权层，不是替代品。要收紧就把 `default_effect` 改成 `ask`，
+用白名单代替黑名单——代价是审批量暴增，回到问题 4。
+
+---
+
+## 问题 6：为什么预算要分三层五维？
+
+DeerFlow 已经有 `TokenBudgetMiddleware`（单 run 的 token 上限），我不重复造。
+补的是它没覆盖的两个失控形态：
+
+**形态一：单 run 都不超标，但一个会话开了二十个 run。**
+所以要 thread 层；再往上还有 day 层管当日总配额。三层独立计数，取最严的一条。
+
+**形态二：失控的不是 token，是时间。**
+长任务真正卡死的样子通常是「某个子 agent 在一个网页上重试了 40 分钟」——
+token 消耗其实不大，但任务已经废了。所以除了 token 还要有
+`tool_calls` / `delegations` / `wall_ms` / `cost_cents` 四个维度。
+
+**两级阈值**：先 WARN（把剩余预算作为 `<system-reminder>` 注入，让模型自己收敛），
+再 STOP（清空 tool_calls，让它基于已有信息收尾）。
+只有硬停没有预警，任务会毫无征兆断在半路；对长任务来说，
+「半成品 + 明确说明还差什么」远比一个异常堆栈有用——这一点跟 DeerFlow 自带
+`TokenBudgetMiddleware` 的硬停做法保持一致，不另起一套。
+
+**未知模型的成本记 `unknown` 而不是 0。** 把未知当零，会让整套预算体系在换模型的
+那一天静默失效，而且没有任何报警——这是可观测性里最典型的伪健康状态。
+`strict_pricing: true` 时直接启动报错，宁可跑不起来也不要跑了一个月才发现成本一直记成 0。
+
+**取舍**：账本默认在内存里，进程重启清零。理由是熔断判断在热路径上，
+每次读 SQLite 会把延迟带进主循环。跨进程的日配额留了 `CounterBackend` 接口，
+但**没有提供 SQLite 实现**——不写没验证过的东西。
+
+---
+
+## 问题 7：为什么核心层要零三方依赖？
+
+这条约束来自一个很实际的处境：**我改这个插件的机器上装不了 langgraph**
+（PyPI 不可达），而 DeerFlow 完整跑起来需要 API key、Gateway、前端、沙箱。
+
+如果把判断逻辑写进 `GuardrailProvider` 的方法体里，那我每改一次规则引擎，
+唯一的验证方式就是「起整个 DeerFlow 点几下看看」。这不是验证，这是碰运气。
+
+所以分层：
+
+- `policy` / `fingerprint` / `budget` / `pricing` / `store` / `engine` → 只用 stdlib
+- `provider` / `middleware` → 只做字段搬运和结果翻译，不含判断
+
+结果是 45 个用例 + 端到端演示能在无网、无 key、无 DeerFlow 的环境里跑完，
+而且**真的抓到了 bug**：预算判定里 `worst` 初始为 `OK`，
+比较逻辑写成 `verdict_level is not STOP`，导致 WARN 永远压不过 OK、预警一次都没触发过。
+这种 off-by-one 靠人肉点界面是发现不了的。
+
+**取舍**：适配层的代码没有测试覆盖，只能靠「它很薄」来保证。
+所以 INTEGRATION.md 里明确列了「锁定的上游事实」表——
+上游一改字段，先看那张表。
+
+---
+
+## 与 DeerFlow 官方能力的边界（不重复造轮子）
+
+| 官方已有 | 本插件的关系 |
+|---|---|
+| `GuardrailMiddleware` + `GuardrailProvider` | **复用**：本插件是一个 provider 实现，不新写中间件 |
+| `SandboxAuditMiddleware` | **不重叠**：那是沙箱操作的安全日志，本插件是授权决策账本 |
+| `TokenBudgetMiddleware` | **不重叠**：那是单 run token，本插件是三层五维 |
+| `SubagentLimitMiddleware` | **不重叠**：那是并发数 ≤ 3，本插件是委派总次数与成本 |
+| `LoopDetectionMiddleware` | **不重叠**：那是重复工具调用检测，本插件是预算 |
+| LangSmith / Langfuse tracing | **不重叠**：那是可观测性，本插件是合规审计（append-only、有裁决人） |
+| `Skill` 的 `security_scanner` | **不重叠**：那是 skill 内容的 LLM 安全分类，本插件是运行时工具调用授权 |
+
+一句话：**能用官方扩展点就不写新中间件，官方已经做了的就不做第二遍。**

--- a/extensions/deerflow-governance/docs/INTEGRATION.md
+++ b/extensions/deerflow-governance/docs/INTEGRATION.md
@@ -1,0 +1,213 @@
+# 接入 DeerFlow
+
+**不改 DeerFlow 一行源码。** 两处配置搞定：审批走反射加载点，预算走中间件注入点。
+
+本文引用的上游符号均已在本机源码中核对过，对应版本见文末「锁定的上游事实」。
+
+---
+
+## 1. 审批：挂 GuardrailProvider
+
+DeerFlow 用 `resolve_variable()` 反射加载 guardrail provider，
+与它加载 models / tools / sandbox 是**同一套机制**——这就是官方留的扩展点。
+
+编辑 `deer-flow/config.yaml`：
+
+```yaml
+guardrails:
+  enabled: true
+  fail_closed: true # provider 抛异常时拦截而不是放行
+  provider:
+    use: "deerflow_governance.provider:ApprovalGuardrailProvider"
+    config:
+      config_path: "/abs/path/to/governance.yaml"
+```
+
+把插件装进 backend 的环境：
+
+```bash
+cd deer-flow/backend
+uv pip install -e ../../deerflow-governance      # 或把 src/ 加进 PYTHONPATH
+```
+
+**验证挂上了没**：
+
+```bash
+cd deer-flow/backend && make dev
+# 另开一个终端，让 agent 跑一个会命中 ask 规则的操作，然后：
+governance pending
+```
+
+如果 `governance pending` 里出现了单子，说明 provider 已经在拦截链路上。
+
+### 为什么 ask 要表达成 allow=False
+
+`GuardrailDecision` 只有一个 `allow: bool`，没有第三态。本插件把 `ask` 编码成
+`allow=False` + reason code `governance.approval_pending`，并在 message 里写清楚：
+
+> 此操作需要人工审批，已提交审批单 APR-XXXX（风险等级：high，命中规则：xxx）。
+> **在审批通过之前请不要重试本操作，也不要尝试用其他工具绕过它。**
+> 你可以：先完成不需要审批的部分，或向用户说明正在等待审批结果。
+
+最后那句是必需的。裸拒绝会让模型立刻换个工具去达成同样的效果——
+`write_file` 被拦就改用 `bash: echo > file`。**审批系统的第一个失效模式不是被绕过，
+而是模型不知道自己被审批了。**
+
+---
+
+## 2. 预算：挂 BudgetBreakerMiddleware
+
+`build_middlewares` 的签名（`packages/harness/deerflow/agents/lead_agent/agent.py:260`）：
+
+```python
+def build_middlewares(
+    config: RunnableConfig,
+    model_name: str | None,
+    agent_name: str | None = None,
+    custom_middlewares: list[AgentMiddleware] | None = None,   # ← 官方注入点
+    *,
+    available_skills: set[str] | None = None,
+    app_config: AppConfig | None = None,
+    deferred_setup=None,
+):
+```
+
+第 379-380 行：
+
+```python
+if custom_middlewares:
+    middlewares.extend(custom_middlewares)
+```
+
+注入位置在 `SafetyFinishReasonMiddleware` / `ClarificationMiddleware` 这条尾巴之前，
+正是 AGENTS.md 第 235 条描述的位置（"Custom middlewares … injected here, before the safety/clarification tail"）。
+
+调用方式：
+
+```python
+from deerflow_governance.middleware import BudgetBreakerMiddleware
+
+middlewares = build_middlewares(
+    config,
+    model_name,
+    custom_middlewares=[BudgetBreakerMiddleware.from_config("/abs/path/to/governance.yaml")],
+)
+```
+
+### 挂在哪个调用点
+
+`build_middlewares` 有两个调用方（AGENTS.md 明确要求这个函数名保持稳定，
+因为它跨模块被 `client.py` import）：
+
+1. `make_lead_agent`（Gateway 服务路径）
+2. `DeerFlowClient`（嵌入式客户端路径）
+
+要全局生效就两处都传。**如果你不想动 DeerFlow 的文件**，可以走 SDK 层：
+`create_deerflow_agent(extra_middleware=[...])` 支持 `@Next` / `@Prev` 锚点定位，
+但那条路径的中间件链是精简子集，不等同于生产链路（`factory.py` 自己的 docstring
+说"matches make_lead_agent (14 middlewares)"，而 AGENTS.md 描述的生产链路有 27 项——
+**上游这三处描述互相不一致**，以 AGENTS.md 为准）。
+
+### 中间件顺序的坑
+
+LangChain 的钩子有两种派发方向，写自定义中间件前必须知道：
+
+- `wrap_model_call` / `wrap_tool_call`：**洋葱模型**，按注册顺序从外向内包裹
+- `after_model`：**反序**触发（DeerFlow 正是靠这一点，把 `SafetyFinishReasonMiddleware`
+  注册在自定义中间件之后，好让它的 `after_model` 先跑）
+
+`BudgetBreakerMiddleware` 同时用了这两类钩子：`after_model` 记账与硬停，
+`wrap_model_call` 把预警作为 `<system-reminder>` 注入下一次请求。放在自定义区即可，
+不需要争抢特定位置。
+
+---
+
+## 3. 审批操作
+
+审批的人通常不是跑 agent 的人，所以给了一个不依赖 DeerFlow 的 CLI：
+
+```bash
+governance pending                                    # 待审批队列
+governance show APR-XXXX                              # 单据详情（含完整命令）
+governance approve APR-XXXX --by 张三 --note "已确认目标分支"
+governance deny    APR-XXXX --by 张三 --note "禁止直推主干"
+governance audit --thread <thread_id> -n 50           # 决策链
+governance stats                                      # 治理概览
+governance expire                                     # 清理过期批准
+```
+
+`--by` 是必填的：没有裁决人的审批记录在审计上没有意义。
+
+---
+
+## 4. 上线前的验证顺序
+
+```bash
+# 1. 策略配置能加载、规则合法（放进 CI）
+governance validate
+
+# 2. 干跑关键场景，确认判定符合预期
+governance simulate --tool bash --arg command="rm -rf build" --explain
+governance simulate --tool bash --arg command="pytest -q"
+governance simulate --tool write_file --arg file_path="backend/.env"
+governance simulate --tool bash --arg command="ls" --subagent
+
+# 3. 核心层回归
+make test
+
+# 4. 端到端演示（不需要 DeerFlow）
+make demo
+
+# 5. 接进 DeerFlow 后做冒烟：跑一个会命中 ask 的任务，确认 governance pending 有单
+```
+
+前四步都不需要 DeerFlow 环境，可以进 CI。
+
+---
+
+## 5. `interrupt` 模式（实验，未实测）
+
+`approval_mode: interrupt` 会让 provider 直接调 LangGraph 的 `interrupt()`。
+
+**依据**（`packages/harness/deerflow/guardrails/middleware.py:75-77`）：
+
+```python
+except GraphBubbleUp:
+    # Preserve LangGraph control-flow signals (interrupt/pause/resume).
+    raise
+```
+
+DeerFlow 显式把 `GraphBubbleUp` 放行，注释直接写了 interrupt/pause/resume——
+说明 provider 层就是官方为 HITL 预留的挂载点。
+
+**但仍然不设为默认**，两个原因：
+
+1. Gateway 侧的 resume 通路（怎么把人工决定回灌进 `Command(resume=...)`）**本人未实测**。
+   DeerFlow 自己的中断做法是 `ClarificationMiddleware` 用 `Command(goto=END)` 结束本轮、
+   靠用户下一条消息续上，而不是 `interrupt()`。
+2. 子 agent 图是 `checkpointer=False` 编译的（AGENTS.md:343 原文
+   "Subagent graphs are compiled with `checkpointer=False` … subagents are one-shot and never resume"），
+   `interrupt()` 在子 agent 里不成立。而子 agent 恰恰最需要审批。
+
+要试可以开，但请自己补上 resume 侧的验证，并把结果回写本节。
+
+---
+
+## 6. 锁定的上游事实
+
+本插件依赖以下 DeerFlow 内部符号。上游变动时，**先核对这张表再改代码**：
+
+| 依赖 | 位置 | 用法 |
+|---|---|---|
+| `GuardrailRequest` 字段 | `deerflow/guardrails/provider.py` | provider 逐字段搬运 |
+| `GuardrailDecision` / `GuardrailReason` | 同上 | 返回值构造 |
+| `GuardrailProvider` 协议（`name` / `evaluate` / `aevaluate`） | 同上 | 鸭子类型实现，无需继承 |
+| `GraphBubbleUp` 放行 | `deerflow/guardrails/middleware.py:75` | interrupt 模式的前提 |
+| `guardrails.provider.use` 反射加载 | `deerflow/config/guardrails_config.py` | 挂载方式 |
+| `build_middlewares(custom_middlewares=...)` | `deerflow/agents/lead_agent/agent.py:264,379` | 中间件注入 |
+| `AgentMiddleware` 钩子集 | `langchain/agents/middleware/types.py` | `after_model` / `wrap_model_call` |
+| `ToolCallRequest.tool_call` / `.runtime.context` | `langgraph.prebuilt.tool_node` | 间接（经 GuardrailRequest） |
+
+核对环境：本机 `deer-flow/backend`，Python 3.12，`.venv` 内的 langchain 已装。
+**本插件的适配层未在真实 DeerFlow 运行时跑过**（我这边缺 API key 与可运行的 Gateway），
+核心层的 47 个用例与端到端演示已全绿。接进去之后请补运行证据并回写本文件。

--- a/extensions/deerflow-governance/governance.example.yaml
+++ b/extensions/deerflow-governance/governance.example.yaml
@@ -1,0 +1,146 @@
+# DeerFlow 治理插件配置
+#
+# 规则**有序，首条命中即返回**（与防火墙 / IAM 同一套语义）。
+# 上线新规则前先跑：governance simulate --tool bash --arg command="..." --explain
+# 进 CI 校验：governance validate
+
+approval_mode: ticket # ticket（默认，推荐）| interrupt（实验，见 docs/INTEGRATION.md）
+fail_closed: true
+strict_pricing: false # true = 未知模型的成本直接报错，而不是记成 unknown
+
+storage:
+  db_path: "data/governance.db"
+  audit_jsonl: "data/audit.jsonl" # 设为 false 关闭 JSONL 落盘
+
+# ---------------------------------------------------------------- 策略
+policy:
+  # 必填。不给隐式默认值：「忘了配」和「故意放行」在审计上不是一回事。
+  default_effect: allow
+  default_reason: "未命中治理规则，按白名单外默认放行处理（如需收紧改为 ask/deny）"
+  thread_bound_grants: true # 在 A 会话批准的操作不自动放行 B 会话
+
+  rules:
+    # ---------- 只读工具：直接放行，不进审批队列 ----------
+    - id: readonly-tools
+      tools: ["read_file", "ls", "glob", "grep", "view_image", "web_fetch", "web_search", "image_search", "tool_search"]
+      effect: allow
+      risk: low
+      reason: "只读工具，不改变任何外部状态"
+
+    # ---------- 破坏性 shell：一律拒绝，不给审批机会 ----------
+    - id: bash-destructive
+      tools: ["bash"]
+      effect: deny
+      risk: critical
+      reason: "命中破坏性命令黑名单。这类操作不应该由 Agent 执行，请人工在终端确认后手动执行"
+      when_any:
+        - { arg: command, regex: "rm\\s+(-[a-zA-Z]*\\s+)*-?[rf]" }
+        - { arg: command, regex: "\\bmkfs\\b|\\bdd\\s+if=|\\bshutdown\\b|\\breboot\\b" }
+        - { arg: command, regex: ":\\(\\)\\s*\\{.*\\};:" } # fork bomb
+        - { arg: command, regex: "\\bchmod\\s+777\\s+/" }
+        - { arg: command, regex: "curl[^|]*\\|\\s*(ba)?sh" } # 管道执行远程脚本
+
+    # ---------- 涉及凭证/推送：必须人批 ----------
+    - id: bash-credentials-or-push
+      tools: ["bash"]
+      effect: ask
+      risk: high
+      reason: "命令涉及凭证、远程推送或包发布，需要人工确认"
+      when_any:
+        - { arg: command, regex: "git\\s+push" }
+        - { arg: command, regex: "\\b(npm|pnpm|yarn)\\s+publish\\b|\\btwine\\s+upload\\b" }
+        - { arg: command, regex: "\\b(AWS_|OPENAI_|ANTHROPIC_)[A-Z_]*=" }
+        - { arg: command, regex: "\\bssh\\b|\\bscp\\b|\\brsync\\b.*::" }
+      grant_scope: exact
+      ttl_seconds: 0 # 只对这一次生效
+
+    # ---------- 子 Agent 的 shell：比主 Agent 更严 ----------
+    # 理由：子 Agent 在隔离上下文里跑，用户看不到它的中间过程，
+    # 出问题时最难复盘，所以给它更小的权限面。
+    - id: subagent-bash-ask
+      tools: ["bash"]
+      scope: subagent
+      effect: ask
+      risk: high
+      reason: "子 Agent 执行 shell，用户看不到中间过程，需要人工确认"
+      grant_scope: tool
+      ttl_seconds: 1800
+
+    # ---------- 常规 shell：放行 ----------
+    - id: bash-default
+      tools: ["bash"]
+      effect: allow
+      risk: medium
+      reason: "常规 shell 命令，已排除破坏性与凭证类"
+
+    # ---------- 写入受保护路径：人批 ----------
+    - id: write-protected-path
+      tools: ["write_file", "str_replace"]
+      effect: ask
+      risk: high
+      reason: "写入受保护路径（配置 / CI / 依赖清单），可能影响构建与部署"
+      when_any:
+        - { arg: file_path, regex: "(^|/)\\.env" }
+        - { arg: file_path, regex: "(^|/)\\.github/" }
+        - { arg: file_path, regex: "(^|/)(Dockerfile|docker-compose\\.ya?ml)$" }
+        - { arg: file_path, regex: "(^|/)(pyproject\\.toml|package\\.json|uv\\.lock|requirements\\.txt)$" }
+        - { arg: file_path, regex: "(^|/)config\\.ya?ml$" }
+      grant_scope: exact
+
+    - id: write-default
+      tools: ["write_file", "str_replace"]
+      effect: allow
+      risk: medium
+      reason: "常规文件写入"
+
+    # ---------- 改 Agent 自身配置：人批（防止自我提权） ----------
+    - id: self-modify-agent
+      tools: ["update_agent", "setup_agent", "skill_manage"]
+      effect: ask
+      risk: critical
+      reason: "修改 Agent 自身配置或技能，属于自我提权路径，必须人工确认"
+      grant_scope: exact
+
+    # ---------- MCP 外部工具：默认人批一次，批后 30 分钟内同工具放行 ----------
+    - id: mcp-tools
+      tools: ["mcp__*"]
+      effect: ask
+      risk: high
+      reason: "MCP 外部工具会把数据发到第三方服务，首次使用需要确认"
+      grant_scope: tool
+      ttl_seconds: 1800
+
+    # ---------- 委派子 Agent：放行但计入预算 ----------
+    - id: task-delegation
+      tools: ["task"]
+      effect: allow
+      risk: medium
+      reason: "委派子 Agent，成本由 BudgetBreakerMiddleware 计入"
+
+# ---------------------------------------------------------------- 预算
+# 维度：total_tokens / cost_cents（分）/ tool_calls / delegations / wall_ms
+# 层级：run（单次运行）/ thread（单个会话）/ day（当日，UTC）
+budget:
+  run:
+    total_tokens: 400000
+    cost_cents: 800 # ¥8
+    tool_calls: 120
+    delegations: 8
+    wall_ms: 1800000 # 30 分钟
+    warn_ratio: 0.75
+  thread:
+    total_tokens: 2000000
+    cost_cents: 3000 # ¥30
+    delegations: 40
+    warn_ratio: 0.8
+  day:
+    cost_cents: 20000 # ¥200
+    warn_ratio: 0.85
+
+# ---------------------------------------------------------------- 价目
+# 单位：分 / 每百万 token。**上线前务必核对各家官方价目页**，这里只是可覆盖的默认值。
+# 未在表中的模型，成本记为 unknown（不是 0），并单独统计其 token 数。
+prices:
+  deepseek-chat: { input_cents_per_mtok: 200, output_cents_per_mtok: 800 }
+  "qwen3-*": { input_cents_per_mtok: 80, output_cents_per_mtok: 200 }
+  "claude-*sonnet*": { input_cents_per_mtok: 2160, output_cents_per_mtok: 10800 }

--- a/extensions/deerflow-governance/pyproject.toml
+++ b/extensions/deerflow-governance/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deerflow-governance"
+version = "0.1.0"
+description = "DeerFlow 生产治理插件：人工审批闸 + 合规审计账本 + 分层成本预算熔断"
+readme = "README.md"
+requires-python = ">=3.12"
+# 核心层只需要 PyYAML 读配置。langchain / langgraph / deerflow 是**运行时宿主提供**的，
+# 刻意不写进 dependencies：本包要能在没有 DeerFlow 的机器上装上并跑完单测。
+dependencies = ["PyYAML>=6.0"]
+
+[project.optional-dependencies]
+# 仅当你要真的接进 DeerFlow 时才需要；平时开发/测试不装
+host = ["langchain>=1.0", "langgraph>=0.6"]
+
+[project.scripts]
+governance = "deerflow_governance.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+
+[tool.ruff]
+# 与 DeerFlow backend 保持一致（AGENTS.md: line length 240），避免两边格式互相打架
+line-length = 240
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/extensions/deerflow-governance/scripts/demo_flow.py
+++ b/extensions/deerflow-governance/scripts/demo_flow.py
@@ -1,0 +1,120 @@
+"""端到端演示：模拟一次 Agent 触发审批 → 人工批准 → 放行的完整链路。
+
+    PYTHONPATH=src python3 scripts/demo_flow.py
+
+用假的 GuardrailRequest 驱动引擎（不需要 DeerFlow / langchain / API key），
+证明三态审批、指纹复用、授权范围隔离、审计链这几件事真的成立。
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from deerflow_governance.budget import BudgetLedger  # noqa: E402
+from deerflow_governance.contracts import CallContext, Usage  # noqa: E402
+from deerflow_governance.engine import ApprovalEngine  # noqa: E402
+from deerflow_governance.policy import PolicyEngine  # noqa: E402
+from deerflow_governance.pricing import PriceBook, format_cents  # noqa: E402
+from deerflow_governance.store import GovernanceStore  # noqa: E402
+
+CFG = ROOT / "governance.example.yaml"
+
+
+def line(title: str) -> None:
+    print("\n" + "=" * 74)
+    print(title)
+    print("=" * 74)
+
+
+def show(engine: ApprovalEngine, ctx: CallContext, label: str) -> object:
+    d = engine.decide(ctx)
+    flag = "放行" if d.allow else "拦截"
+    scope = "子Agent" if ctx.is_subagent else "主Agent"
+    print(f"\n[{flag}] {scope} → {ctx.tool_name}: {list(ctx.tool_input.values())[:1]}")
+    print(f"      规则 {d.verdict.rule_id} / 风险 {d.verdict.risk} / code={d.code}")
+    print(f"      给模型的消息: {d.message.splitlines()[0][:88]}")
+    return d
+
+
+def main() -> int:
+    import yaml
+
+    data = yaml.safe_load(CFG.read_text(encoding="utf-8"))
+    policy = PolicyEngine.from_dict(data["policy"])
+    tmp = tempfile.TemporaryDirectory()
+    store = GovernanceStore(Path(tmp.name) / "g.db", jsonl_path=Path(tmp.name) / "audit.jsonl")
+    engine = ApprovalEngine(policy, store)
+
+    line("场景 1：只读工具直接放行，不打扰任何人")
+    show(engine, CallContext("read_file", {"file_path": "backend/app/main.py"}, thread_id="T1", run_id="R1"), "read")
+
+    line("场景 2：破坏性命令直接拒绝，并明确告诉模型不要重试")
+    show(engine, CallContext("bash", {"command": "rm -rf /data/prod"}, thread_id="T1", run_id="R1"), "rm")
+
+    line("场景 3：git push 需要人批 —— 模型连续重试 3 次也只开一张单")
+    ctx_push = CallContext("bash", {"command": "git push origin main"}, thread_id="T1", run_id="R1")
+    first = show(engine, ctx_push, "push")
+    for _ in range(2):
+        again = engine.decide(ctx_push)
+        assert again.ticket.ticket_id == first.ticket.ticket_id
+    print(f"      重试 3 次后待审批队列长度 = {len(store.list_tickets(status=None))} 张单（未被刷爆）")
+
+    line("场景 4：人工批准后同一操作放行；但换成 --force 就不放行（exact 授权不外溢）")
+    store.decide(first.ticket.ticket_id, approved=True, by="张三", note="已确认目标分支是 feature 分支")
+    show(engine, ctx_push, "push-after")
+    show(engine, CallContext("bash", {"command": "git push origin --force main"}, thread_id="T1", run_id="R1"), "force")
+
+    line("场景 5：子 Agent 的 shell 更严（同一条 ls，主 Agent 放行、子 Agent 要批）")
+    show(engine, CallContext("bash", {"command": "ls -al"}, thread_id="T1", run_id="R1"), "ls-lead")
+    sub = show(engine, CallContext("bash", {"command": "ls -al"}, thread_id="T1", run_id="R1", is_subagent=True), "ls-sub")
+    store.decide(sub.ticket.ticket_id, approved=True, by="张三", note="本次调研任务放开子 Agent 只读 shell")
+    print("      批准后（grant_scope=tool，30 分钟内同工具放行）：")
+    show(engine, CallContext("bash", {"command": "cat README.md"}, thread_id="T1", run_id="R1", is_subagent=True), "cat-sub")
+
+    line("场景 6：跨会话不串权 —— 在 T1 批过的 push，在 T2 依然要重新批")
+    show(engine, CallContext("bash", {"command": "git push origin main"}, thread_id="T2", run_id="R9"), "push-T2")
+
+    line("审计账本（决策链完整可追溯）")
+    print(f"{'时间序':<6}{'类型':<18}{'工具':<12}{'结论':<12}{'规则':<28}裁决人")
+    print("-" * 100)
+    for i, r in enumerate(reversed(store.audit_tail(limit=40)), start=1):
+        who = r["detail"].get("decided_by", "")
+        print(f"{i:<6}{r['kind']:<18}{r['tool_name'][:10]:<12}{r['effect'][:10]:<12}{r['rule_id'][:26]:<28}{who}")
+    print("\n统计:", store.stats())
+
+    line("预算账本：三层五维 + 两级阈值")
+    ledger = BudgetLedger.from_dict(data["budget"])
+    prices = PriceBook.from_dict(data.get("prices") or {})
+    for i in range(1, 7):
+        usage = Usage(
+            input_tokens=48_000, output_tokens=6_000, tool_calls=22, delegations=2, wall_ms=210_000,
+            cost_cents=prices.cost_cents("deepseek-chat", 48_000, 6_000),
+        )
+        ledger.record(usage, run_id="R1", thread_id="T1")
+        v = ledger.check(run_id="R1", thread_id="T1")
+        snap = ledger.snapshot(run_id="R1", thread_id="T1")["run"]
+        cost = format_cents(snap["cost_cents"])
+        print(f"  第 {i} 轮  tokens={snap['total_tokens']:>7}  调用={snap['tool_calls']:>3}  委派={snap['delegations']:>2}  成本={cost:>10}  →  {v.level.value.upper()}")
+        if v.message:
+            print(f"           {v.message[:96]}")
+        if v.level.value == "stop":
+            break
+
+    line("未知模型的成本：记为 unknown，不伪装成 0")
+    led2 = BudgetLedger.from_dict({"run": {"cost_cents": 100}})
+    led2.record(Usage(input_tokens=2_000_000, cost_cents=prices.cost_cents("our-internal-model", 2_000_000, 0)), run_id="X", thread_id=None)
+    c = led2.counter("run", "X")
+    print(f"  cost_cents={format_cents(c.cost_cents)}  cost_unknown_tokens={c.cost_unknown_tokens}  判定={led2.check(run_id='X', thread_id=None).level.value}")
+    print("  （若把未知成本当 0，换模型那天整套预算体系会静默失效）")
+
+    tmp.cleanup()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/deerflow-governance/src/deerflow_governance/__init__.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/__init__.py
@@ -1,0 +1,27 @@
+"""DeerFlow 生产治理插件：人工审批闸 + 合规审计账本 + 分层成本预算熔断。
+
+核心层（policy / fingerprint / budget / pricing / store / engine）零三方依赖，
+可在没有 DeerFlow 与 langchain 的环境里被完整单测。
+适配层（provider / middleware）按需 import，因此不在这里做顶层导出 ——
+`import deerflow_governance` 不应该因为宿主环境缺 langchain 而失败。
+"""
+
+__version__ = "0.1.0"
+
+from .contracts import BudgetLevel, CallContext, Effect, TicketStatus, Usage, Verdict
+from .engine import ApprovalEngine, Decision
+from .policy import PolicyEngine, Rule
+
+__all__ = [
+    "ApprovalEngine",
+    "BudgetLevel",
+    "CallContext",
+    "Decision",
+    "Effect",
+    "PolicyEngine",
+    "Rule",
+    "TicketStatus",
+    "Usage",
+    "Verdict",
+    "__version__",
+]

--- a/extensions/deerflow-governance/src/deerflow_governance/budget.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/budget.py
@@ -1,0 +1,229 @@
+"""分层预算账本与熔断判定（零三方依赖核心）。
+
+DeerFlow 自带 `TokenBudgetMiddleware`（单 run 的 token 上限）和
+`SubagentLimitMiddleware`（并发子 agent ≤ 3），本模块补的是它们没覆盖的三件事：
+
+1. **多维度**：不只 token，还有工具调用次数、委派次数、墙钟时长、金额。
+   长任务失控最常见的形态不是 token 爆炸，而是「一个子 agent 卡在某个网页上重试了 40 分钟」。
+2. **多层级**：run / thread / day 三层独立计数。单 run 不超标不代表一个会话里
+   连着开二十个 run 不超标，更不代表一天不超标。
+3. **两级阈值**：先 warn（把剩余预算作为 system-reminder 注入，让模型自己收敛），
+   再 stop（硬停）。只有硬停没有预警，会让任务在毫无征兆的情况下断在半路。
+
+设计取舍：**账本在内存里，进程重启即清零**（除非注入持久化后端）。
+理由是熔断要在工具调用的热路径上做判断，每次都读 SQLite 会把延迟带进主循环；
+跨进程的日配额通过可选的 `PersistentCounterBackend` 落 SQLite，按需开启。
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from .contracts import BudgetLevel, BudgetVerdict, Usage
+
+DIMENSIONS = ("total_tokens", "cost_cents", "tool_calls", "delegations", "wall_ms")
+LEVELS = ("run", "thread", "day")
+# 严重度排序。写成显式表而不是靠枚举比较：早期版本用 `is not STOP` 做判断，
+# 结果 WARN 永远压不过初始的 OK，预警一次都没触发过 —— 被 test_ok_then_warn_then_stop 抓出来。
+SEVERITY = {BudgetLevel.OK: 0, BudgetLevel.WARN: 1, BudgetLevel.STOP: 2}
+
+
+@dataclass
+class Limits:
+    """某一层级的上限。None 表示该维度不设限。"""
+
+    total_tokens: int | None = None
+    cost_cents: float | None = None
+    tool_calls: int | None = None
+    delegations: int | None = None
+    wall_ms: int | None = None
+    warn_ratio: float = 0.8
+
+    def limit_for(self, dimension: str) -> float | None:
+        value = getattr(self, dimension, None)
+        return float(value) if value is not None else None
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Limits":
+        known = {f for f in DIMENSIONS} | {"warn_ratio"}
+        unknown = set(d or {}) - known
+        if unknown:
+            raise ValueError(f"未知的预算维度: {sorted(unknown)}；支持 {sorted(known)}")
+        return cls(**(d or {}))
+
+
+@dataclass
+class Counter:
+    total_tokens: int = 0
+    cost_cents: float = 0.0
+    tool_calls: int = 0
+    delegations: int = 0
+    wall_ms: int = 0
+    cost_unknown_tokens: int = 0  # 无价目模型消耗的 token，单独计，不混进 cost
+    started_at: float = field(default_factory=time.time)
+
+    def add(self, usage: Usage) -> None:
+        self.total_tokens += usage.total_tokens
+        self.tool_calls += usage.tool_calls
+        self.delegations += usage.delegations
+        self.wall_ms += usage.wall_ms
+        if usage.cost_cents is None:
+            self.cost_unknown_tokens += usage.total_tokens
+        else:
+            self.cost_cents += usage.cost_cents
+
+    def value_of(self, dimension: str) -> float:
+        return float(getattr(self, dimension))
+
+    def snapshot(self) -> dict:
+        return {
+            "total_tokens": self.total_tokens,
+            "cost_cents": round(self.cost_cents, 4),
+            "cost_unknown_tokens": self.cost_unknown_tokens,
+            "tool_calls": self.tool_calls,
+            "delegations": self.delegations,
+            "wall_ms": self.wall_ms,
+        }
+
+
+class CounterBackend(Protocol):
+    """可选的跨进程计数后端（用于日配额）。默认实现是纯内存。"""
+
+    def bump(self, key: str, usage: Usage) -> Counter: ...
+
+    def get(self, key: str) -> Counter: ...
+
+
+class _BoundedCounters(OrderedDict):
+    """限长 LRU。长期运行的服务里 thread/run 的 key 是无界增长的，必须封顶。"""
+
+    def __init__(self, maxsize: int = 2000) -> None:
+        super().__init__()
+        self._maxsize = maxsize
+
+    def __setitem__(self, key, value) -> None:  # type: ignore[no-untyped-def]
+        super().__setitem__(key, value)
+        super().move_to_end(key)
+        while len(self) > self._maxsize:
+            super().popitem(last=False)
+
+
+class BudgetLedger:
+    """线程安全的分层账本。"""
+
+    def __init__(self, limits: dict[str, Limits], *, maxsize: int = 2000, day_backend: CounterBackend | None = None) -> None:
+        unknown = set(limits) - set(LEVELS)
+        if unknown:
+            raise ValueError(f"未知的预算层级: {sorted(unknown)}；支持 {sorted(LEVELS)}")
+        self._limits = limits
+        self._counters: dict[str, _BoundedCounters] = {level: _BoundedCounters(maxsize) for level in LEVELS}
+        self._day_backend = day_backend
+        self._lock = threading.RLock()
+
+    # ---------------- 记账 ----------------
+
+    @staticmethod
+    def _day_key(now: float) -> str:
+        return time.strftime("%Y-%m-%d", time.gmtime(now))
+
+    def record(self, usage: Usage, *, run_id: str | None, thread_id: str | None, now: float | None = None) -> None:
+        now = now if now is not None else time.time()
+        with self._lock:
+            for level, key in (("run", run_id), ("thread", thread_id), ("day", self._day_key(now))):
+                if key is None:
+                    continue
+                if level == "day" and self._day_backend is not None:
+                    self._day_backend.bump(key, usage)
+                    continue
+                bucket = self._counters[level]
+                counter = bucket.get(key)
+                if counter is None:
+                    counter = Counter(started_at=now)
+                    bucket[key] = counter
+                counter.add(usage)
+
+    def counter(self, level: str, key: str | None) -> Counter:
+        if key is None:
+            return Counter()
+        if level == "day" and self._day_backend is not None:
+            return self._day_backend.get(key)
+        with self._lock:
+            return self._counters[level].get(key) or Counter()
+
+    def reset(self, level: str, key: str) -> None:
+        with self._lock:
+            self._counters[level].pop(key, None)
+
+    # ---------------- 判定 ----------------
+
+    def check(self, *, run_id: str | None, thread_id: str | None, now: float | None = None) -> BudgetVerdict:
+        """返回最严重的一条判定。stop 优先于 warn；同级取超出比例最高的维度。"""
+        now = now if now is not None else time.time()
+        worst = BudgetVerdict(level=BudgetLevel.OK)
+        worst_ratio = 0.0
+
+        for level, key in (("run", run_id), ("thread", thread_id), ("day", self._day_key(now))):
+            limits = self._limits.get(level)
+            if limits is None or key is None:
+                continue
+            counter = self.counter(level, key)
+            for dim in DIMENSIONS:
+                limit = limits.limit_for(dim)
+                if not limit:
+                    continue
+                used = counter.value_of(dim)
+                ratio = used / limit
+                if ratio >= 1.0:
+                    verdict_level = BudgetLevel.STOP
+                elif ratio >= limits.warn_ratio:
+                    verdict_level = BudgetLevel.WARN
+                else:
+                    continue
+                # 更严重的等级永远压过较轻的；同级比超出比例
+                more_severe = SEVERITY[verdict_level] > SEVERITY[worst.level]
+                if more_severe or (verdict_level is worst.level and ratio > worst_ratio):
+                    worst_ratio = ratio
+                    worst = BudgetVerdict(
+                        level=verdict_level, dimension=dim, used=used, limit=limit, scope=level,
+                        message=_message(verdict_level, level, dim, used, limit),
+                    )
+        return worst
+
+    def snapshot(self, *, run_id: str | None, thread_id: str | None, now: float | None = None) -> dict:
+        now = now if now is not None else time.time()
+        return {
+            "run": self.counter("run", run_id).snapshot(),
+            "thread": self.counter("thread", thread_id).snapshot(),
+            "day": self.counter("day", self._day_key(now)).snapshot(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict, **kwargs) -> "BudgetLedger":
+        return cls({level: Limits.from_dict(cfg) for level, cfg in (data or {}).items()}, **kwargs)
+
+
+_DIM_LABEL = {
+    "total_tokens": "token 用量", "cost_cents": "成本", "tool_calls": "工具调用次数",
+    "delegations": "子 Agent 委派次数", "wall_ms": "执行时长",
+}
+_LEVEL_LABEL = {"run": "本次运行", "thread": "本会话", "day": "今日"}
+
+
+def _fmt(dim: str, value: float) -> str:
+    if dim == "cost_cents":
+        return f"¥{value / 100:.2f}"
+    if dim == "wall_ms":
+        return f"{value / 1000:.0f}s"
+    return f"{int(value)}"
+
+
+def _message(level: BudgetLevel, scope: str, dim: str, used: float, limit: float) -> str:
+    scope_label = _LEVEL_LABEL.get(scope, scope)
+    dim_label = _DIM_LABEL.get(dim, dim)
+    if level is BudgetLevel.STOP:
+        return f"[预算熔断] {scope_label}的{dim_label}已达上限（{_fmt(dim, used)} / {_fmt(dim, limit)}），本轮停止继续调用工具。请直接给出当前已取得的结论，并说明还差哪些步骤。"
+    return f"[预算预警] {scope_label}的{dim_label}已用 {_fmt(dim, used)} / {_fmt(dim, limit)}（{used / limit:.0%}）。请收敛策略：优先完成主线，避免展开次要分支。"

--- a/extensions/deerflow-governance/src/deerflow_governance/cli.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/cli.py
@@ -1,0 +1,219 @@
+"""审批与审计命令行。零三方依赖（argparse + stdlib），可在没装 DeerFlow 的机器上跑。
+
+审批的人通常不是跑 agent 的人，这个 CLI 就是给他们的：
+
+    governance pending                     # 看待审批队列
+    governance show APR-XXXX               # 看单据详情
+    governance approve APR-XXXX --by 张三 --note "确认过目标目录"
+    governance deny    APR-XXXX --by 张三 --note "禁止直接改生产配置"
+    governance audit --thread <id> -n 50   # 查审计账本
+    governance stats                       # 治理概览（真实数据，没有就显示 N/A）
+    governance simulate --tool bash --arg command="rm -rf build"   # 干跑策略，上线前验证规则
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+from .config import load as load_config
+from .contracts import CallContext, TicketStatus
+from .engine import ApprovalEngine
+from .policy import PolicyEngine
+from .store import GovernanceStore
+
+
+class _ConfigArgumentParser(argparse.ArgumentParser):
+    def parse_args(self, args=None, namespace=None):
+        parsed = super().parse_args(args, namespace)
+        command_config = getattr(parsed, "config", None)
+        global_config = getattr(parsed, "_global_config", None)
+        parsed.config = command_config or global_config
+        if hasattr(parsed, "_global_config"):
+            delattr(parsed, "_global_config")
+        return parsed
+
+
+def _fmt_ts(ts: float | None) -> str:
+    return time.strftime("%m-%d %H:%M", time.localtime(ts)) if ts else "-"
+
+
+def _store(args) -> GovernanceStore:
+    return load_config(args.config).build_store()
+
+
+def cmd_pending(args) -> int:
+    tickets = _store(args).list_tickets(status=TicketStatus.PENDING, limit=args.limit)
+    if not tickets:
+        print("待审批队列为空")
+        return 0
+    print(f"{'单号':<16}{'风险':<10}{'范围':<10}{'创建':<14}摘要")
+    print("-" * 100)
+    for t in tickets:
+        scope = "子Agent" if t.is_subagent else "主Agent"
+        print(f"{t.ticket_id:<16}{t.risk:<10}{scope:<10}{_fmt_ts(t.created_at):<14}{t.tool_input_brief}")
+    return 0
+
+
+def cmd_show(args) -> int:
+    ticket = _store(args).get_ticket(args.ticket_id)
+    if ticket is None:
+        print(f"找不到审批单 {args.ticket_id}", file=sys.stderr)
+        return 1
+    for key, value in ticket.__dict__.items():
+        if key in {"created_at", "decided_at", "expires_at"}:
+            value = _fmt_ts(value)
+        if hasattr(value, "value"):
+            value = value.value
+        print(f"{key:<18}: {value}")
+    return 0
+
+
+def _decide(args, approved: bool) -> int:
+    ticket = _store(args).decide(args.ticket_id, approved=approved, by=args.by, note=args.note)
+    if ticket is None:
+        print(f"{args.ticket_id} 不存在，或已经被裁决过（不允许二次裁决）", file=sys.stderr)
+        return 1
+    verb = "已批准" if approved else "已驳回"
+    expire = f"，有效期至 {_fmt_ts(ticket.expires_at)}" if ticket.expires_at else "（仅本次有效）"
+    print(f"{verb} {ticket.ticket_id}{expire if approved else ''}")
+    print(f"  操作: {ticket.tool_input_brief}")
+    print(f"  裁决人: {args.by}　意见: {args.note or '（无）'}")
+    return 0
+
+
+def cmd_approve(args) -> int:
+    return _decide(args, True)
+
+
+def cmd_deny(args) -> int:
+    return _decide(args, False)
+
+
+def cmd_audit(args) -> int:
+    rows = _store(args).audit_tail(limit=args.limit, thread_id=args.thread)
+    if not rows:
+        print("审计账本为空")
+        return 0
+    if args.json:
+        for r in rows:
+            print(json.dumps(r, ensure_ascii=False, default=str))
+        return 0
+    print(f"{'时间':<14}{'类型':<18}{'工具':<16}{'结论':<22}{'规则':<20}摘要")
+    print("-" * 120)
+    for r in rows:
+        brief = r["detail"].get("brief", "") if isinstance(r.get("detail"), dict) else ""
+        print(f"{_fmt_ts(r['ts']):<14}{r['kind']:<18}{r['tool_name'][:14]:<16}{r['effect'][:20]:<22}{r['rule_id'][:18]:<20}{brief[:50]}")
+    return 0
+
+
+def cmd_stats(args) -> int:
+    stats = _store(args).stats()
+    if stats["decisions"] == 0:
+        print("暂无治理记录（N/A）")
+        return 0
+    for key, value in stats.items():
+        print(f"{key:<18}: {value if value is not None else 'N/A'}")
+    return 0
+
+
+def cmd_expire(args) -> int:
+    print(f"已将 {_store(args).expire_stale()} 张过期批准置为 expired")
+    return 0
+
+
+def cmd_simulate(args) -> int:
+    """干跑：不落库、不开单，只看策略会怎么判。上线新规则前必跑。"""
+    cfg = load_config(args.config)
+    tool_input = {}
+    for pair in args.arg or []:
+        if "=" not in pair:
+            print(f"参数格式应为 key=value，收到: {pair}", file=sys.stderr)
+            return 2
+        key, value = pair.split("=", 1)
+        tool_input[key] = value
+
+    ctx = CallContext(tool_name=args.tool, tool_input=tool_input, thread_id=args.thread, is_subagent=args.subagent, user_role=args.role)
+    verdict = cfg.policy.evaluate(ctx)
+    print(f"判定    : {verdict.effect.value}")
+    print(f"命中规则: {verdict.rule_id}　风险: {verdict.risk}　授权范围: {verdict.grant_scope}　TTL: {verdict.ttl_seconds or '仅本次'}")
+    print(f"原因    : {verdict.reason}")
+    print(f"指纹    : {verdict.fingerprint}")
+    if args.explain:
+        print("\n逐条规则命中情况：")
+        for rule_id, hit in cfg.policy.explain(ctx):
+            print(f"  {'✓' if hit else ' '} {rule_id}")
+    return 0
+
+
+def cmd_validate(args) -> int:
+    """只校验配置能否加载、规则是否合法。适合进 CI。"""
+    try:
+        cfg = load_config(args.config)
+    except Exception as exc:  # noqa: BLE001 —— CLI 边界，转成可读输出而不是堆栈
+        print(f"配置校验失败: {exc}", file=sys.stderr)
+        return 1
+    print(f"规则数    : {len(cfg.policy.rules)}")
+    print(f"默认判定  : {cfg.policy.default_effect.value}")
+    print(f"审批模式  : {cfg.approval_mode}")
+    print(f"预算层级  : {', '.join(cfg.budget._limits) or '（未配置）'}")
+    print(f"账本      : {cfg.db_path}")
+    print("配置校验通过")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    config_help = "governance.yaml 路径（默认读 DEERFLOW_GOVERNANCE_CONFIG 或 ./governance.yaml）"
+    global_config_parent = argparse.ArgumentParser(add_help=False)
+    global_config_parent.add_argument("--config", dest="_global_config", default=None, help=config_help)
+    command_config_parent = argparse.ArgumentParser(add_help=False)
+    command_config_parent.add_argument("--config", dest="config", default=None, help=config_help)
+
+    p = _ConfigArgumentParser(prog="governance", description="DeerFlow 治理插件：审批 / 审计 / 预算", parents=[global_config_parent])
+    sub = p.add_subparsers(dest="command", required=True)
+
+    q = sub.add_parser("pending", help="待审批队列", parents=[command_config_parent])
+    q.add_argument("-n", "--limit", type=int, default=30)
+    q.set_defaults(func=cmd_pending)
+
+    s = sub.add_parser("show", help="审批单详情", parents=[command_config_parent])
+    s.add_argument("ticket_id")
+    s.set_defaults(func=cmd_show)
+
+    for name, fn, help_text in (("approve", cmd_approve, "批准"), ("deny", cmd_deny, "驳回")):
+        d = sub.add_parser(name, help=help_text, parents=[command_config_parent])
+        d.add_argument("ticket_id")
+        d.add_argument("--by", required=True, help="裁决人，会写进审计账本")
+        d.add_argument("--note", default="", help="裁决意见")
+        d.set_defaults(func=fn)
+
+    a = sub.add_parser("audit", help="审计账本", parents=[command_config_parent])
+    a.add_argument("-n", "--limit", type=int, default=40)
+    a.add_argument("--thread", default=None)
+    a.add_argument("--json", action="store_true")
+    a.set_defaults(func=cmd_audit)
+
+    sub.add_parser("stats", help="治理概览", parents=[command_config_parent]).set_defaults(func=cmd_stats)
+    sub.add_parser("expire", help="清理过期批准", parents=[command_config_parent]).set_defaults(func=cmd_expire)
+    sub.add_parser("validate", help="校验配置（可进 CI）", parents=[command_config_parent]).set_defaults(func=cmd_validate)
+
+    m = sub.add_parser("simulate", help="干跑策略，不落库", parents=[command_config_parent])
+    m.add_argument("--tool", required=True)
+    m.add_argument("--arg", action="append", help="key=value，可重复")
+    m.add_argument("--thread", default="sim")
+    m.add_argument("--role", default=None)
+    m.add_argument("--subagent", action="store_true")
+    m.add_argument("--explain", action="store_true", help="打印每条规则是否命中")
+    m.set_defaults(func=cmd_simulate)
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/extensions/deerflow-governance/src/deerflow_governance/config.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/config.py
@@ -1,0 +1,62 @@
+"""governance.yaml 加载。唯一配置入口，业务代码里不出现 os.environ。"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .budget import BudgetLedger
+from .policy import PolicyEngine
+from .pricing import PriceBook
+from .store import GovernanceStore
+
+DEFAULT_CONFIG_ENV = "DEERFLOW_GOVERNANCE_CONFIG"
+
+
+@dataclass
+class GovernanceConfig:
+    policy: PolicyEngine
+    budget: BudgetLedger
+    prices: PriceBook
+    db_path: Path
+    jsonl_path: Path | None
+    approval_mode: str = "ticket"
+    fail_closed: bool = True
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def build_store(self) -> GovernanceStore:
+        return GovernanceStore(self.db_path, jsonl_path=self.jsonl_path)
+
+
+def _resolve(base: Path, value: str | None, default: str) -> Path:
+    p = Path(value or default)
+    return p if p.is_absolute() else (base / p)
+
+
+def load(path: str | Path | None = None) -> GovernanceConfig:
+    """按优先级解析配置文件路径：显式参数 > 环境变量 > ./governance.yaml。"""
+    import yaml
+
+    candidate = path or os.environ.get(DEFAULT_CONFIG_ENV) or "governance.yaml"
+    cfg_path = Path(candidate).expanduser().resolve()
+    if not cfg_path.exists():
+        raise FileNotFoundError(
+            f"找不到治理配置 {cfg_path}。"
+            f"请复制 governance.example.yaml 并通过 {DEFAULT_CONFIG_ENV} 指向它。"
+        )
+    data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    base = cfg_path.parent
+
+    storage = data.get("storage") or {}
+    return GovernanceConfig(
+        policy=PolicyEngine.from_dict(data.get("policy") or {}),
+        budget=BudgetLedger.from_dict(data.get("budget") or {}),
+        prices=PriceBook.from_dict(data.get("prices") or {}, strict=bool(data.get("strict_pricing", False))),
+        db_path=_resolve(base, storage.get("db_path"), "data/governance.db"),
+        jsonl_path=_resolve(base, storage.get("audit_jsonl"), "data/audit.jsonl") if storage.get("audit_jsonl", True) else None,
+        approval_mode=str(data.get("approval_mode", "ticket")),
+        fail_closed=bool(data.get("fail_closed", True)),
+        raw=data,
+    )

--- a/extensions/deerflow-governance/src/deerflow_governance/contracts.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/contracts.py
@@ -1,0 +1,219 @@
+"""跨层唯一语义真源。
+
+刻意只用 dataclass 而不用 pydantic：本包的核心层要能在**不安装 DeerFlow、不安装 langchain**
+的环境里被完整单测（见 tests/），少一个依赖就少一处版本冲突面。
+适配层（provider.py / middleware.py）才允许 import langchain / langgraph。
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class Effect(str, Enum):
+    """策略判定结果。"""
+
+    ALLOW = "allow"
+    ASK = "ask"  # 需要人工审批
+    DENY = "deny"
+
+
+class TicketStatus(str, Enum):
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+    EXPIRED = "expired"
+
+
+class BudgetLevel(str, Enum):
+    OK = "ok"
+    WARN = "warn"
+    STOP = "stop"
+
+
+class Scope(str, Enum):
+    """规则适用范围。DeerFlow 的 GuardrailRequest 自带 is_subagent，这里直接对齐。"""
+
+    ANY = "any"
+    LEAD = "lead"
+    SUBAGENT = "subagent"
+
+
+# --------------------------------------------------------------------------
+# 调用上下文
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class CallContext:
+    """一次工具调用的治理上下文。
+
+    字段刻意与 DeerFlow 的 `deerflow.guardrails.provider.GuardrailRequest` 一一对齐，
+    provider.py 只做字段搬运，不做语义转换 —— 上游改字段时只有一处需要跟。
+    """
+
+    tool_name: str
+    tool_input: dict[str, Any] = field(default_factory=dict)
+    thread_id: str | None = None
+    run_id: str | None = None
+    tool_call_id: str | None = None
+    user_id: str | None = None
+    user_role: str | None = None
+    agent_id: str | None = None
+    is_subagent: bool = False
+    timestamp: str = ""
+
+    @property
+    def scope(self) -> Scope:
+        return Scope.SUBAGENT if self.is_subagent else Scope.LEAD
+
+
+# --------------------------------------------------------------------------
+# 策略判定
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Verdict:
+    """策略引擎的输出。provider 只消费这个结构，不重新判断。"""
+
+    effect: Effect
+    rule_id: str
+    reason: str
+    risk: str = "unknown"  # low / medium / high / critical
+    fingerprint: str = ""
+    grant_scope: str = "exact"  # exact / tool / rule —— 批准一次能覆盖多大范围
+    ttl_seconds: int = 0  # 批准的有效期，0 表示只对本次生效
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["effect"] = self.effect.value
+        return d
+
+
+# --------------------------------------------------------------------------
+# 审批单
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Ticket:
+    """人工审批单。
+
+    这是「挂起等人批」这个流程的物化：DeerFlow 原生 guardrail 只有 allow/deny 两态，
+    没有第三态，本包补的就是这一态。
+    """
+
+    ticket_id: str
+    fingerprint: str
+    status: TicketStatus
+    tool_name: str
+    tool_input_brief: str
+    reason: str
+    rule_id: str
+    risk: str
+    thread_id: str | None
+    run_id: str | None
+    is_subagent: bool
+    created_at: float
+    decided_at: float | None = None
+    decided_by: str | None = None
+    decision_note: str = ""
+    expires_at: float | None = None
+    grant_scope: str = "exact"
+
+    @classmethod
+    def new(cls, ctx: CallContext, verdict: Verdict, *, now: float, brief: str) -> "Ticket":
+        return cls(
+            ticket_id="APR-" + uuid.uuid4().hex[:10].upper(),
+            fingerprint=verdict.fingerprint,
+            status=TicketStatus.PENDING,
+            tool_name=ctx.tool_name,
+            tool_input_brief=brief,
+            reason=verdict.reason,
+            rule_id=verdict.rule_id,
+            risk=verdict.risk,
+            thread_id=ctx.thread_id,
+            run_id=ctx.run_id,
+            is_subagent=ctx.is_subagent,
+            created_at=now,
+            expires_at=(now + verdict.ttl_seconds) if verdict.ttl_seconds else None,
+            grant_scope=verdict.grant_scope,
+        )
+
+    def is_valid_at(self, now: float) -> bool:
+        """已批准且未过期。过期的批准不能继续放行 —— 这是审批制度的基本要求。"""
+        if self.status is not TicketStatus.APPROVED:
+            return False
+        return self.expires_at is None or now < self.expires_at
+
+
+# --------------------------------------------------------------------------
+# 预算
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Usage:
+    """一次增量用量。cost_cents 为 None 表示该模型无价目，禁止当 0 处理。"""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    tool_calls: int = 0
+    delegations: int = 0
+    wall_ms: int = 0
+    cost_cents: float | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+@dataclass
+class BudgetVerdict:
+    level: BudgetLevel
+    dimension: str = ""
+    used: float = 0.0
+    limit: float = 0.0
+    scope: str = ""
+    message: str = ""
+
+    @property
+    def ratio(self) -> float:
+        return (self.used / self.limit) if self.limit else 0.0
+
+
+# --------------------------------------------------------------------------
+# 审计
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class AuditRecord:
+    """审计账本的一行。追加写，永不修改 —— 审计记录被改就没有审计价值了。"""
+
+    record_id: str
+    ts: float
+    kind: str  # policy_decision / ticket_created / ticket_decided / budget_event
+    tool_name: str = ""
+    effect: str = ""
+    rule_id: str = ""
+    risk: str = ""
+    fingerprint: str = ""
+    ticket_id: str = ""
+    thread_id: str | None = None
+    run_id: str | None = None
+    user_id: str | None = None
+    is_subagent: bool = False
+    detail: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def new(cls, kind: str, **kwargs: Any) -> "AuditRecord":
+        return cls(record_id=uuid.uuid4().hex[:16], ts=time.time(), kind=kind, **kwargs)
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/extensions/deerflow-governance/src/deerflow_governance/engine.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/engine.py
@@ -1,0 +1,157 @@
+"""审批引擎 —— 把「策略判定 + 审批单 + 审计」串成一个可离线单测的纯逻辑核心。
+
+provider.py 只是把 DeerFlow 的 GuardrailRequest 搬进来、把结果搬回去；
+所有真正的判断都在这里，因此这一层能在不装 DeerFlow、不装 langchain 的环境里被完整覆盖。
+
+三态语义（这是本包相对 DeerFlow 原生 guardrail 的核心增量）：
+
+    allow → 直接放行
+    deny  → 拒绝，给模型一条可读的原因，让它换路径而不是盲目重试
+    ask   → **挂起等人批**。DeerFlow 原生只有 allow/deny 两态，没有这一态。
+
+`ask` 的落地方式有两种模式：
+
+- `ticket`（默认）：开一张审批单，本次调用先拒绝并把单号告诉模型。人批完之后，
+  模型或用户重试同一个操作即放行。**不依赖 checkpointer、不依赖 resume 语义，
+  子 agent 里也能用**（DeerFlow 的子 agent 图是 `checkpointer=False` 编译的，
+  一次性执行、从不 resume，所以在子 agent 里 interrupt 是不成立的）。
+- `interrupt`（实验）：调用 LangGraph 的 `interrupt()` 真正挂起。
+  依据是 DeerFlow 的 `GuardrailMiddleware` 显式 `except GraphBubbleUp: raise`，
+  注释写着 "Preserve LangGraph control-flow signals (interrupt/pause/resume)" ——
+  说明 provider 层就是官方预留的 HITL 挂载点。但**上游 Gateway 的 resume 通路本人未实测**，
+  故不设为默认，详见 docs/INTEGRATION.md。
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+from .contracts import AuditRecord, CallContext, Effect, Ticket, TicketStatus, Verdict
+from .fingerprint import brief as make_brief
+from .policy import PolicyEngine
+from .store import GovernanceStore
+
+
+@dataclass
+class Decision:
+    """引擎对外的最终结论。provider 直接翻译成 GuardrailDecision，不再做判断。"""
+
+    allow: bool
+    code: str
+    message: str
+    verdict: Verdict
+    ticket: Ticket | None = None
+    needs_interrupt: bool = False  # interrupt 模式下由 provider 负责真正调用 interrupt()
+
+
+_PENDING_TMPL = (
+    "此操作需要人工审批，已提交审批单 {ticket_id}（风险等级：{risk}，命中规则：{rule_id}）。"
+    "原因：{reason}\n"
+    "在审批通过之前请不要重试本操作，也不要尝试用其他工具绕过它。"
+    "你可以：先完成不需要审批的部分，或向用户说明正在等待 {ticket_id} 的审批结果。"
+)
+_DENIED_TMPL = (
+    "此操作被治理策略拒绝（规则 {rule_id}，风险等级：{risk}）。原因：{reason}\n"
+    "请换一种不触发该策略的实现方式，不要重试同一个调用。"
+)
+_TICKET_DENIED_TMPL = "此操作的审批单 {ticket_id} 已被人工驳回。驳回意见：{note}\n请按驳回意见调整方案，不要重试。"
+_EXPIRED_TMPL = "此操作此前的审批已过期（审批单 {ticket_id}），需要重新申请。已提交新的审批单 {new_ticket_id}。"
+
+
+class ApprovalEngine:
+    def __init__(
+        self,
+        policy: PolicyEngine,
+        store: GovernanceStore,
+        *,
+        mode: str = "ticket",
+        auto_expire: bool = True,
+    ) -> None:
+        if mode not in {"ticket", "interrupt"}:
+            raise ValueError(f"未知的审批模式: {mode}（只支持 ticket / interrupt）")
+        self.policy = policy
+        self.store = store
+        self.mode = mode
+        self.auto_expire = auto_expire
+
+    # ------------------------------------------------------------------
+
+    def decide(self, ctx: CallContext, *, now: float | None = None) -> Decision:
+        now = now if now is not None else time.time()
+        verdict = self.policy.evaluate(ctx)
+
+        self.store.append_audit(
+            AuditRecord.new(
+                "policy_decision", tool_name=ctx.tool_name, effect=verdict.effect.value,
+                rule_id=verdict.rule_id, risk=verdict.risk, fingerprint=verdict.fingerprint,
+                thread_id=ctx.thread_id, run_id=ctx.run_id, user_id=ctx.user_id,
+                is_subagent=ctx.is_subagent,
+                detail={"brief": make_brief(ctx.tool_name, ctx.tool_input), "grant_scope": verdict.grant_scope},
+            )
+        )
+
+        if verdict.effect is Effect.ALLOW:
+            return Decision(True, "governance.allowed", verdict.reason, verdict)
+
+        if verdict.effect is Effect.DENY:
+            return Decision(
+                False, "governance.denied",
+                _DENIED_TMPL.format(rule_id=verdict.rule_id, risk=verdict.risk, reason=verdict.reason),
+                verdict,
+            )
+
+        return self._handle_ask(ctx, verdict, now)
+
+    # ------------------------------------------------------------------
+
+    def _handle_ask(self, ctx: CallContext, verdict: Verdict, now: float) -> Decision:
+        existing = self.store.find_by_fingerprint(verdict.fingerprint)
+
+        if existing is not None:
+            if existing.status is TicketStatus.APPROVED:
+                if existing.is_valid_at(now):
+                    return Decision(True, "governance.approved", f"已由 {existing.decided_by} 批准（{existing.ticket_id}）", verdict, ticket=existing)
+                if self.auto_expire:
+                    self.store.expire_stale(now=now)
+                fresh = self._open_ticket(ctx, verdict, now)
+                return Decision(
+                    False, "governance.approval_expired",
+                    _EXPIRED_TMPL.format(ticket_id=existing.ticket_id, new_ticket_id=fresh.ticket_id),
+                    verdict, ticket=fresh, needs_interrupt=self.mode == "interrupt",
+                )
+
+            if existing.status is TicketStatus.DENIED:
+                return Decision(
+                    False, "governance.approval_denied",
+                    _TICKET_DENIED_TMPL.format(ticket_id=existing.ticket_id, note=existing.decision_note or "（无）"),
+                    verdict, ticket=existing,
+                )
+
+            if existing.status is TicketStatus.PENDING:
+                # 已经在等了就不要重复开单，否则模型每重试一次就多一张单，审批队列会被刷爆
+                return Decision(
+                    False, "governance.approval_pending",
+                    _PENDING_TMPL.format(ticket_id=existing.ticket_id, risk=verdict.risk, rule_id=verdict.rule_id, reason=verdict.reason),
+                    verdict, ticket=existing, needs_interrupt=self.mode == "interrupt",
+                )
+
+        ticket = self._open_ticket(ctx, verdict, now)
+        return Decision(
+            False, "governance.approval_pending",
+            _PENDING_TMPL.format(ticket_id=ticket.ticket_id, risk=verdict.risk, rule_id=verdict.rule_id, reason=verdict.reason),
+            verdict, ticket=ticket, needs_interrupt=self.mode == "interrupt",
+        )
+
+    def _open_ticket(self, ctx: CallContext, verdict: Verdict, now: float) -> Ticket:
+        ticket = Ticket.new(ctx, verdict, now=now, brief=make_brief(ctx.tool_name, ctx.tool_input))
+        self.store.create_ticket(ticket)
+        self.store.append_audit(
+            AuditRecord.new(
+                "ticket_created", tool_name=ctx.tool_name, effect="ask", rule_id=verdict.rule_id,
+                risk=verdict.risk, fingerprint=verdict.fingerprint, ticket_id=ticket.ticket_id,
+                thread_id=ctx.thread_id, run_id=ctx.run_id, user_id=ctx.user_id, is_subagent=ctx.is_subagent,
+                detail={"brief": ticket.tool_input_brief, "expires_at": ticket.expires_at},
+            )
+        )
+        return ticket

--- a/extensions/deerflow-governance/src/deerflow_governance/fingerprint.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/fingerprint.py
@@ -1,0 +1,104 @@
+"""工具调用指纹。
+
+要解决的问题：审批不能每次都问。人工批过一次 `bash: pytest tests/ -q` 之后，
+同一个线程里再跑一次同样的命令还要弹审批，审批就会被当成噪音、被无脑放行 ——
+这是所有审批系统失效的第一原因。
+
+所以需要一个「同类调用」的判定：
+- `exact`：参数完全一致才算同一类（最严，默认给 critical 风险用）
+- `rule`：命中同一条策略规则就算同一类（最宽，给低风险批量操作用）
+- `tool`：同一个工具就算同一类（中间档）
+
+指纹必须**可复现**：同样的调用在任何机器上算出同一个值，否则审批记录跨进程失效。
+因此排序 key、剔除易变字段、截断超长值，全部走同一套规范化。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from typing import Any
+
+# 这些字段每次调用都不同，不该进入指纹，否则「批过的操作」永远命中不了
+VOLATILE_KEYS = {
+    "tool_call_id", "run_id", "request_id", "timestamp", "trace_id",
+    "sandbox_id", "session_id", "nonce", "idempotency_key",
+}
+
+_MAX_VALUE_CHARS = 400
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize_value(value: Any, *, depth: int = 0) -> Any:
+    """递归规范化参数值。
+
+    - 字符串压缩空白并截断（超长的 write_file content 不该让指纹随一个空格变化）
+    - dict 按 key 排序
+    - 嵌套深度超过 4 层折叠成类型标记，防止病态输入把指纹计算拖垮
+    """
+    if depth > 4:
+        return f"<depth-capped:{type(value).__name__}>"
+    if isinstance(value, str):
+        s = _WS_RE.sub(" ", value).strip()
+        return s if len(s) <= _MAX_VALUE_CHARS else s[:_MAX_VALUE_CHARS] + f"…<{len(s)}chars>"
+    if isinstance(value, dict):
+        return {k: normalize_value(v, depth=depth + 1) for k, v in sorted(value.items()) if k not in VOLATILE_KEYS}
+    if isinstance(value, (list, tuple)):
+        return [normalize_value(v, depth=depth + 1) for v in value]
+    if isinstance(value, (int, float, bool)) or value is None:
+        return value
+    return f"<{type(value).__name__}>"
+
+
+def canonical_args(tool_input: dict[str, Any]) -> str:
+    normalized = normalize_value(dict(tool_input or {}))
+    return json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def compute(
+    *,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    rule_id: str,
+    scope: str = "exact",
+    thread_id: str | None = None,
+    thread_bound: bool = True,
+) -> str:
+    """计算指纹。
+
+    Args:
+        scope: exact / tool / rule —— 决定指纹里包含多少信息，信息越少覆盖面越大。
+        thread_bound: 批准是否只在本线程有效。默认 True：
+            在 A 会话批准的 `rm -rf build/` 不应该自动放行 B 会话的同一条命令。
+    """
+    parts: list[str] = [f"scope={scope}"]
+    if thread_bound:
+        parts.append(f"thread={thread_id or '-'}")
+
+    if scope == "rule":
+        parts.append(f"rule={rule_id}")
+    elif scope == "tool":
+        parts.append(f"tool={tool_name}")
+    elif scope == "exact":
+        parts.append(f"tool={tool_name}")
+        parts.append(f"args={canonical_args(tool_input)}")
+    else:
+        raise ValueError(f"未知的 grant scope: {scope}（只支持 exact / tool / rule）")
+
+    raw = "|".join(parts)
+    return "fp_" + hashlib.sha256(raw.encode("utf-8")).hexdigest()[:24]
+
+
+def brief(tool_name: str, tool_input: dict[str, Any], *, limit: int = 180) -> str:
+    """给人看的一行摘要，用于审批单列表。不参与指纹计算。"""
+    if not tool_input:
+        return tool_name
+    # bash 类工具最重要的信息就是命令本身，优先展示
+    for key in ("command", "cmd", "file_path", "path", "url", "query", "description"):
+        if key in tool_input and isinstance(tool_input[key], str):
+            text = _WS_RE.sub(" ", tool_input[key]).strip()
+            out = f"{tool_name}: {text}"
+            return out if len(out) <= limit else out[: limit - 1] + "…"
+    out = f"{tool_name}: {canonical_args(tool_input)}"
+    return out if len(out) <= limit else out[: limit - 1] + "…"

--- a/extensions/deerflow-governance/src/deerflow_governance/middleware.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/middleware.py
@@ -1,0 +1,216 @@
+"""BudgetBreakerMiddleware —— 分层成本预算与熔断。
+
+挂载方式（backend/packages/harness/deerflow/agents/lead_agent/agent.py 已经预留了口子）：
+
+    build_middlewares(config, model_name, custom_middlewares=[BudgetBreakerMiddleware.from_config()])
+
+`build_middlewares` 的第 379-380 行是 `if custom_middlewares: middlewares.extend(custom_middlewares)`，
+插入位置在 safety/clarification 尾巴之前，正是自定义中间件的官方注入点。
+
+与 DeerFlow 自带能力的边界（刻意不重复造轮子）：
+
+| 已有 | 本中间件补的 |
+|---|---|
+| `TokenBudgetMiddleware`：单 run 的 token 上限 | thread / day 两层，以及 token 之外的四个维度 |
+| `SubagentLimitMiddleware`：并发子 agent ≤ 3 | 委派**总次数**与子 agent 累计成本 |
+| `TokenUsageMiddleware`：记录 token 指标 | 按价目表折算金额，未知模型记为 unknown 而不是 0 |
+| 无 | 墙钟时长熔断（长任务真正的失控形态往往是卡住而不是 token 爆炸） |
+
+两级阈值的必要性：只有硬停没有预警，任务会毫无征兆地断在半路；
+预警走 `wrap_model_call` 注入 system-reminder，让模型自己收敛策略，
+这比直接砍断保留了更多有效产出。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from langchain.agents import AgentState
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, SystemMessage
+from langgraph.runtime import Runtime
+
+from .budget import BudgetLedger
+from .config import GovernanceConfig, load as load_config
+from .contracts import AuditRecord, BudgetLevel, Usage
+from .pricing import PriceBook
+from .store import GovernanceStore
+
+logger = logging.getLogger(__name__)
+
+
+class BudgetBreakerMiddleware(AgentMiddleware[AgentState]):
+    """按 run / thread / day 三层、五个维度做预算记账与熔断。"""
+
+    def __init__(
+        self,
+        ledger: BudgetLedger,
+        prices: PriceBook,
+        store: GovernanceStore | None = None,
+        *,
+        model_name: str | None = None,
+        hard_stop: bool = True,
+    ) -> None:
+        super().__init__()
+        self._ledger = ledger
+        self._prices = prices
+        self._store = store
+        self._model_name = model_name
+        self._hard_stop = hard_stop
+        self._pending_warnings: dict[str, list[str]] = {}
+        self._turn_started: dict[str, float] = {}
+
+    @classmethod
+    def from_config(cls, config_path: str | None = None, *, config: GovernanceConfig | None = None, **kwargs) -> "BudgetBreakerMiddleware":
+        cfg = config or load_config(config_path)
+        return cls(cfg.budget, cfg.prices, cfg.build_store(), **kwargs)
+
+    # ---------------- 上下文提取 ----------------
+
+    @staticmethod
+    def _ids(runtime: Runtime) -> tuple[str | None, str | None]:
+        context = getattr(runtime, "context", None)
+        context = context if isinstance(context, dict) else {}
+        return context.get("run_id"), context.get("thread_id")
+
+    def _key(self, runtime: Runtime) -> str:
+        run_id, thread_id = self._ids(runtime)
+        return run_id or thread_id or "default"
+
+    # ---------------- 记账 ----------------
+
+    @staticmethod
+    def _last_ai_message(state: AgentState) -> AIMessage | None:
+        for message in reversed(state.get("messages", []) or []):
+            if isinstance(message, AIMessage):
+                return message
+        return None
+
+    def _collect(self, state: AgentState, runtime: Runtime) -> Usage:
+        message = self._last_ai_message(state)
+        if message is None:
+            return Usage()
+
+        raw = getattr(message, "usage_metadata", None) or {}
+        input_tokens = int(raw.get("input_tokens", 0) or 0)
+        output_tokens = int(raw.get("output_tokens", 0) or 0)
+
+        tool_calls = list(getattr(message, "tool_calls", None) or [])
+        delegations = sum(1 for tc in tool_calls if (tc.get("name") if isinstance(tc, dict) else None) == "task")
+
+        # 真实模型名优先取本次响应的 metadata，取不到才回落到构造时的模型名 ——
+        # 子 agent 可能跑在不同模型上，用 lead 的模型名折算成本会系统性算错。
+        metadata = getattr(message, "response_metadata", None) or {}
+        model = metadata.get("model_name") or metadata.get("model") or self._model_name
+
+        key = self._key(runtime)
+        started = self._turn_started.pop(key, None)
+        wall_ms = int((time.perf_counter() - started) * 1000) if started else 0
+
+        return Usage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            tool_calls=len(tool_calls),
+            delegations=delegations,
+            wall_ms=wall_ms,
+            cost_cents=self._prices.cost_cents(model, input_tokens, output_tokens),
+        )
+
+    # ---------------- 钩子 ----------------
+
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        run_id, thread_id = self._ids(runtime)
+        usage = self._collect(state, runtime)
+        if usage.total_tokens or usage.tool_calls or usage.wall_ms:
+            self._ledger.record(usage, run_id=run_id, thread_id=thread_id)
+
+        verdict = self._ledger.check(run_id=run_id, thread_id=thread_id)
+        if verdict.level is BudgetLevel.OK:
+            return None
+
+        self._audit(verdict, run_id=run_id, thread_id=thread_id)
+
+        if verdict.level is BudgetLevel.WARN:
+            # 预警不改状态，只排队等下次 model call 时作为 system-reminder 注入
+            self._pending_warnings.setdefault(self._key(runtime), []).append(verdict.message)
+            return None
+
+        if not self._hard_stop:
+            self._pending_warnings.setdefault(self._key(runtime), []).append(verdict.message)
+            return None
+
+        return self._build_hard_stop(state, verdict.message)
+
+    async def aafter_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self.after_model(state, runtime)
+
+    def wrap_model_call(self, request: Any, handler: Callable[[Any], Any]) -> Any:
+        self._before_call(request)
+        return handler(self._inject_warnings(request))
+
+    async def awrap_model_call(self, request: Any, handler: Callable[[Any], Awaitable[Any]]) -> Any:
+        self._before_call(request)
+        return await handler(self._inject_warnings(request))
+
+    # ---------------- 内部 ----------------
+
+    def _before_call(self, request: Any) -> None:
+        runtime = getattr(request, "runtime", None)
+        if runtime is not None:
+            self._turn_started[self._key(runtime)] = time.perf_counter()
+
+    def _inject_warnings(self, request: Any) -> Any:
+        runtime = getattr(request, "runtime", None)
+        if runtime is None:
+            return request
+        warnings = self._pending_warnings.pop(self._key(runtime), [])
+        if not warnings:
+            return request
+        messages = list(getattr(request, "messages", []) or [])
+        messages.append(SystemMessage(content="\n".join(f"<system-reminder>{w}</system-reminder>" for w in warnings)))
+        try:
+            return request.override(messages=messages)
+        except AttributeError:
+            # 不同 langchain 版本的 ModelRequest 可能没有 override()，降级为原地替换
+            request.messages = messages
+            return request
+
+    @staticmethod
+    def _build_hard_stop(state: AgentState, message: str) -> dict:
+        """硬停：清空未执行的 tool_calls 并把熔断说明附到消息尾部。
+
+        与 DeerFlow 自带 `TokenBudgetMiddleware` 的硬停做法保持一致 ——
+        不抛异常中断整个 run，而是让模型基于已有信息给出一个收尾答案。
+        对长任务来说，「半成品 + 明确说明还差什么」远比「一个异常堆栈」有用。
+        """
+        last = None
+        for m in reversed(state.get("messages", []) or []):
+            if isinstance(m, AIMessage):
+                last = m
+                break
+        if last is None:
+            return {}
+        content = last.content
+        text = content if isinstance(content, str) else str(content)
+        patched = AIMessage(
+            content=f"{text}\n\n{message}".strip(),
+            id=last.id,
+            additional_kwargs=dict(getattr(last, "additional_kwargs", {}) or {}),
+            response_metadata=dict(getattr(last, "response_metadata", {}) or {}),
+            tool_calls=[],
+        )
+        return {"messages": [patched]}
+
+    def _audit(self, verdict, *, run_id: str | None, thread_id: str | None) -> None:
+        if self._store is None:
+            return
+        self._store.append_audit(
+            AuditRecord.new(
+                "budget_event", effect=verdict.level.value, risk=verdict.dimension,
+                thread_id=thread_id, run_id=run_id,
+                detail={"scope": verdict.scope, "dimension": verdict.dimension, "used": verdict.used, "limit": verdict.limit},
+            )
+        )

--- a/extensions/deerflow-governance/src/deerflow_governance/policy.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/policy.py
@@ -1,0 +1,218 @@
+"""策略引擎（零三方依赖核心）。
+
+设计要点：
+
+1. **首条命中即返回**，规则有序。这是防火墙、IAM、审批系统的通用语义，
+   运维人员不需要学一套新的求值模型就能读懂 governance.yaml。
+
+2. **默认拒绝还是默认放行，必须显式写在配置里**。不给隐式默认值，
+   因为「忘了配」和「故意配成放行」在审计上是两件事。
+
+3. **参数级匹配**，而不只是工具名级。`bash: pytest -q` 和 `bash: rm -rf /`
+   是同一个工具，风险差着两个数量级；只按工具名做策略，要么全放要么全拦，
+   两种都会让审批失去意义。
+
+4. **规则可解释**：每条判定都带 rule_id 和人话 reason，直接进审计账本和给模型的错误消息。
+   agent 收到「被拒了」还必须知道「为什么、能不能换个方式」，否则它会盲目重试。
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from .contracts import CallContext, Effect, Scope, Verdict
+from .fingerprint import compute as compute_fingerprint
+
+RISK_ORDER = {"low": 0, "medium": 1, "high": 2, "critical": 3}
+
+
+# --------------------------------------------------------------------------
+# 参数条件
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class ArgCondition:
+    """单个参数上的判定条件。全部条件为 AND 关系。"""
+
+    arg: str
+    equals: Any = None
+    contains: str | None = None
+    regex: str | None = None
+    path_prefix: str | None = None
+    absent: bool = False
+
+    def __post_init__(self) -> None:
+        self._compiled: re.Pattern | None = re.compile(self.regex) if self.regex else None
+
+    def matches(self, tool_input: dict[str, Any]) -> bool:
+        present = self.arg in tool_input
+        if self.absent:
+            return not present
+        if not present:
+            return False
+        value = tool_input[self.arg]
+        text = value if isinstance(value, str) else str(value)
+
+        if self.equals is not None and value != self.equals:
+            return False
+        if self.contains is not None and self.contains not in text:
+            return False
+        if self._compiled is not None and not self._compiled.search(text):
+            return False
+        if self.path_prefix is not None and not text.replace("\\", "/").lstrip("./").startswith(self.path_prefix.lstrip("./")):
+            return False
+        return True
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ArgCondition":
+        known = {"arg", "equals", "contains", "regex", "path_prefix", "absent"}
+        unknown = set(d) - known
+        if unknown:
+            raise ValueError(f"未知的参数条件字段: {sorted(unknown)}；支持 {sorted(known)}")
+        if "arg" not in d:
+            raise ValueError("参数条件必须有 arg 字段")
+        return cls(**d)
+
+
+# --------------------------------------------------------------------------
+# 规则
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Rule:
+    id: str
+    effect: Effect
+    tools: list[str] = field(default_factory=lambda: ["*"])  # 支持 glob，如 mcp__*
+    scope: Scope = Scope.ANY
+    risk: str = "medium"
+    reason: str = ""
+    when: list[ArgCondition] = field(default_factory=list)
+    when_any: list[ArgCondition] = field(default_factory=list)  # OR 关系，用于「危险命令黑名单」
+    grant_scope: str = "exact"
+    ttl_seconds: int = 0
+    roles: list[str] = field(default_factory=list)  # 为空表示不限角色
+
+    def matches(self, ctx: CallContext) -> bool:
+        if not any(fnmatch.fnmatch(ctx.tool_name, pattern) for pattern in self.tools):
+            return False
+        if self.scope is not Scope.ANY and self.scope is not ctx.scope:
+            return False
+        if self.roles and (ctx.user_role or "") not in self.roles:
+            return False
+        if self.when and not all(c.matches(ctx.tool_input) for c in self.when):
+            return False
+        if self.when_any and not any(c.matches(ctx.tool_input) for c in self.when_any):
+            return False
+        return True
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Rule":
+        d = dict(d)
+        if "id" not in d:
+            raise ValueError("规则必须有 id —— 没有 id 的规则无法在审计里追溯")
+        try:
+            effect = Effect(d.pop("effect"))
+        except KeyError as exc:
+            raise ValueError(f"规则 {d.get('id')} 缺少 effect") from exc
+        except ValueError as exc:
+            raise ValueError(f"规则 {d.get('id')} 的 effect 非法，只能是 allow/ask/deny") from exc
+
+        scope = Scope(d.pop("scope", "any"))
+        risk = d.pop("risk", "medium")
+        if risk not in RISK_ORDER:
+            raise ValueError(f"规则 {d['id']} 的 risk 非法：{risk}，只能是 {sorted(RISK_ORDER)}")
+        when = [ArgCondition.from_dict(c) for c in d.pop("when", [])]
+        when_any = [ArgCondition.from_dict(c) for c in d.pop("when_any", [])]
+        grant_scope = d.pop("grant_scope", "exact")
+        if grant_scope not in {"exact", "tool", "rule"}:
+            raise ValueError(f"规则 {d['id']} 的 grant_scope 非法：{grant_scope}")
+
+        rule_id = d.pop("id")
+        tools = d.pop("tools", ["*"])
+        reason = d.pop("reason", "")
+        ttl = int(d.pop("ttl_seconds", 0))
+        roles = d.pop("roles", [])
+        if d:
+            raise ValueError(f"规则 {rule_id} 含未知字段: {sorted(d)}")
+        return cls(
+            id=rule_id, effect=effect, tools=tools, scope=scope, risk=risk, reason=reason,
+            when=when, when_any=when_any, grant_scope=grant_scope, ttl_seconds=ttl, roles=roles,
+        )
+
+
+# --------------------------------------------------------------------------
+# 引擎
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class PolicyEngine:
+    rules: list[Rule]
+    default_effect: Effect
+    default_reason: str = "未命中任何规则，按默认策略处理"
+    thread_bound_grants: bool = True
+
+    def evaluate(self, ctx: CallContext) -> Verdict:
+        for rule in self.rules:
+            if rule.matches(ctx):
+                fp = compute_fingerprint(
+                    tool_name=ctx.tool_name,
+                    tool_input=ctx.tool_input,
+                    rule_id=rule.id,
+                    scope=rule.grant_scope,
+                    thread_id=ctx.thread_id,
+                    thread_bound=self.thread_bound_grants,
+                )
+                return Verdict(
+                    effect=rule.effect,
+                    rule_id=rule.id,
+                    reason=rule.reason or f"命中规则 {rule.id}",
+                    risk=rule.risk,
+                    fingerprint=fp,
+                    grant_scope=rule.grant_scope,
+                    ttl_seconds=rule.ttl_seconds,
+                )
+
+        fp = compute_fingerprint(
+            tool_name=ctx.tool_name, tool_input=ctx.tool_input, rule_id="__default__",
+            scope="exact", thread_id=ctx.thread_id, thread_bound=self.thread_bound_grants,
+        )
+        return Verdict(
+            effect=self.default_effect, rule_id="__default__", reason=self.default_reason,
+            risk="medium", fingerprint=fp, grant_scope="exact",
+        )
+
+    # ---------------- 加载 ----------------
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PolicyEngine":
+        if "default_effect" not in data:
+            raise ValueError("governance 配置必须显式声明 default_effect —— 「忘了配」和「故意放行」在审计上不是一回事")
+        default = Effect(data["default_effect"])
+        rules = [Rule.from_dict(r) for r in data.get("rules", [])]
+        ids = [r.id for r in rules]
+        dupes = {i for i in ids if ids.count(i) > 1}
+        if dupes:
+            raise ValueError(f"规则 id 重复: {sorted(dupes)} —— 重复 id 会让审计无法定位是哪一条生效")
+        return cls(
+            rules=rules,
+            default_effect=default,
+            default_reason=data.get("default_reason", "未命中任何规则，按默认策略处理"),
+            thread_bound_grants=bool(data.get("thread_bound_grants", True)),
+        )
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "PolicyEngine":
+        import yaml  # 只有加载配置时才需要，核心求值不依赖
+
+        with open(path, encoding="utf-8") as f:
+            return cls.from_dict(yaml.safe_load(f) or {})
+
+    def explain(self, ctx: CallContext) -> list[tuple[str, bool]]:
+        """调试用：返回每条规则是否命中。定位「为什么这条被放行了」时非常有用。"""
+        return [(r.id, r.matches(ctx)) for r in self.rules]

--- a/extensions/deerflow-governance/src/deerflow_governance/pricing.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/pricing.py
@@ -1,0 +1,86 @@
+"""模型价目表 → 金额口径（零三方依赖）。
+
+为什么要有金额而不是只算 token：
+「这次任务花了 84 万 token」对业务方没有意义，「这次任务花了 4.7 元」才有。
+预算熔断要能按金额设阈值，成本归因要能按人/按线程/按子 agent 出账。
+
+**不认识的模型返回 None，绝不返回 0。** 把未知成本当成零，会让整个预算体系
+在换模型的那一天静默失效 —— 这是可观测性里最典型的伪健康状态。
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Price:
+    """每百万 token 的价格，单位：分（人民币）。用分而不是元，避免浮点累加误差放大。"""
+
+    input_cents_per_mtok: float
+    output_cents_per_mtok: float
+    currency: str = "CNY"
+
+
+# 默认表只放几个常见模型做示例。真实价格随时会变，**上线前必须核对官方价目页**，
+# 因此这里刻意不写死成「事实」，而是当作可覆盖的默认值。
+DEFAULT_PRICES: dict[str, Price] = {
+    "deepseek-chat": Price(200.0, 800.0),
+    "deepseek-reasoner": Price(400.0, 1600.0),
+    "qwen-max*": Price(2400.0, 9600.0),
+    "qwen-plus*": Price(80.0, 200.0),
+    "qwen3-*": Price(80.0, 200.0),
+    "gpt-4o*": Price(1800.0, 7200.0),
+    "claude-*sonnet*": Price(2160.0, 10800.0),
+    "claude-*haiku*": Price(180.0, 900.0),
+    "gemini-*flash*": Price(54.0, 216.0),
+}
+
+
+class PriceBook:
+    def __init__(self, prices: dict[str, Price] | None = None, *, strict: bool = False) -> None:
+        """strict=True 时，遇到未知模型直接抛错而不是返回 None。
+
+        生产环境建议 strict=True：宁可启动失败，也不要跑了一个月才发现某个模型的成本一直记成 0。
+        """
+        self._prices = dict(prices if prices is not None else DEFAULT_PRICES)
+        self._strict = strict
+
+    def lookup(self, model: str | None) -> Price | None:
+        if not model:
+            return None
+        if model in self._prices:
+            return self._prices[model]
+        # 最长匹配优先，避免 qwen3-* 抢在 qwen3-coder-plus 的精确条目前面
+        candidates = [(pat, p) for pat, p in self._prices.items() if fnmatch.fnmatch(model, pat)]
+        if candidates:
+            return max(candidates, key=lambda kv: len(kv[0]))[1]
+        if self._strict:
+            raise KeyError(f"模型 {model!r} 没有价目，无法计算成本（strict 模式）")
+        return None
+
+    def cost_cents(self, model: str | None, input_tokens: int, output_tokens: int) -> float | None:
+        price = self.lookup(model)
+        if price is None:
+            return None
+        return input_tokens / 1_000_000 * price.input_cents_per_mtok + output_tokens / 1_000_000 * price.output_cents_per_mtok
+
+    @classmethod
+    def from_dict(cls, data: dict, *, strict: bool = False) -> "PriceBook":
+        prices = {
+            name: Price(
+                input_cents_per_mtok=float(v["input_cents_per_mtok"]),
+                output_cents_per_mtok=float(v["output_cents_per_mtok"]),
+                currency=v.get("currency", "CNY"),
+            )
+            for name, v in (data or {}).items()
+        }
+        return cls(prices or None, strict=strict)
+
+
+def format_cents(cents: float | None) -> str:
+    """给人看的金额。None 显示 N/A，不显示 0.00 —— 两者含义完全不同。"""
+    if cents is None:
+        return "N/A"
+    return f"¥{cents / 100:.4f}" if cents < 100 else f"¥{cents / 100:.2f}"

--- a/extensions/deerflow-governance/src/deerflow_governance/provider.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/provider.py
@@ -1,0 +1,119 @@
+"""GuardrailProvider 适配层 —— 唯一接触 DeerFlow 类型的文件之一。
+
+挂载方式（config.yaml）：
+
+    guardrails:
+      enabled: true
+      fail_closed: true
+      provider:
+        use: "deerflow_governance.provider:ApprovalGuardrailProvider"
+        config:
+          config_path: "./governance.yaml"
+
+DeerFlow 用 `resolve_variable()` 反射加载这个类路径，把 `config` 段作为 kwargs 传进构造函数
+（与 models / tools / sandbox 完全同一套机制），因此**接入本包不需要改 DeerFlow 一行代码**。
+
+本文件刻意保持很薄：字段搬运 + 结果翻译，所有判断在 engine.py，
+这样 engine 能在不装 DeerFlow 的环境里被完整单测。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .config import GovernanceConfig, load as load_config
+from .contracts import CallContext
+from .engine import ApprovalEngine
+
+logger = logging.getLogger(__name__)
+
+
+class ApprovalGuardrailProvider:
+    """三态审批 provider：allow / deny / ask（挂起等人批）。
+
+    DeerFlow 原生的 `GuardrailDecision` 只有 allow 布尔位，没有「待审批」这一态。
+    这里把 ask 表达成 `allow=False` + 结构化 reason code `governance.approval_pending`，
+    并在 reason.message 里告诉模型审批单号与「不要绕过」的明确指令 ——
+    否则模型收到一个裸拒绝，会立刻尝试用别的工具达成同样的效果。
+    """
+
+    name = "deerflow-governance-approval"
+
+    def __init__(self, *, config_path: str | None = None, config: GovernanceConfig | None = None) -> None:
+        self._cfg = config or load_config(config_path)
+        self._engine = ApprovalEngine(
+            self._cfg.policy,
+            self._cfg.build_store(),
+            mode=self._cfg.approval_mode,
+        )
+
+    # ---------------- GuardrailProvider 协议 ----------------
+
+    def evaluate(self, request: Any):  # request: deerflow.guardrails.provider.GuardrailRequest
+        from deerflow.guardrails.provider import GuardrailDecision, GuardrailReason
+
+        ctx = self._to_context(request)
+        decision = self._engine.decide(ctx)
+
+        if decision.needs_interrupt and not decision.allow:
+            self._raise_interrupt(decision)
+
+        return GuardrailDecision(
+            allow=decision.allow,
+            reasons=[GuardrailReason(code=decision.code, message=decision.message)],
+            policy_id=decision.verdict.rule_id,
+            metadata={
+                "risk": decision.verdict.risk,
+                "fingerprint": decision.verdict.fingerprint,
+                "ticket_id": decision.ticket.ticket_id if decision.ticket else "",
+                "grant_scope": decision.verdict.grant_scope,
+            },
+        )
+
+    async def aevaluate(self, request: Any):
+        # 判定全是本地计算 + SQLite，没有网络 IO；引入 async 只会多一层线程池而不会更快。
+        # 若未来接入远程策略服务，这里再改成真正的异步实现。
+        return self.evaluate(request)
+
+    # ---------------- 内部 ----------------
+
+    @staticmethod
+    def _to_context(request: Any) -> CallContext:
+        return CallContext(
+            tool_name=getattr(request, "tool_name", "") or "",
+            tool_input=getattr(request, "tool_input", None) or {},
+            thread_id=getattr(request, "thread_id", None),
+            run_id=getattr(request, "run_id", None),
+            tool_call_id=getattr(request, "tool_call_id", None),
+            user_id=getattr(request, "user_id", None),
+            user_role=getattr(request, "user_role", None),
+            agent_id=getattr(request, "agent_id", None),
+            is_subagent=bool(getattr(request, "is_subagent", False)),
+            timestamp=getattr(request, "timestamp", "") or "",
+        )
+
+    def _raise_interrupt(self, decision) -> None:
+        """interrupt 模式：抛 LangGraph 的控制流信号真正挂起。
+
+        DeerFlow 的 GuardrailMiddleware 里有 `except GraphBubbleUp: raise`，
+        注释是 "Preserve LangGraph control-flow signals (interrupt/pause/resume)"，
+        所以这个信号能干净地穿过中间件冒泡上去。
+
+        ⚠️ 上游 Gateway 的 resume 通路本人未实测，且 DeerFlow 的子 agent 图是
+        `checkpointer=False` 编译的（一次性执行、从不 resume），子 agent 里用不了这个模式。
+        默认模式是 ticket，这条路径只在显式配置 approval_mode: interrupt 时才走。
+        """
+        from langgraph.types import interrupt
+
+        interrupt(
+            {
+                "type": "governance_approval_required",
+                "ticket_id": decision.ticket.ticket_id if decision.ticket else "",
+                "tool_name": decision.ticket.tool_name if decision.ticket else "",
+                "brief": decision.ticket.tool_input_brief if decision.ticket else "",
+                "risk": decision.verdict.risk,
+                "rule_id": decision.verdict.rule_id,
+                "reason": decision.verdict.reason,
+            }
+        )

--- a/extensions/deerflow-governance/src/deerflow_governance/store.py
+++ b/extensions/deerflow-governance/src/deerflow_governance/store.py
@@ -1,0 +1,236 @@
+"""审批单与审计账本的持久化（只用 stdlib sqlite3）。
+
+为什么审批单必须落库而不是放内存：
+审批的本质是「跨进程、跨时间的人工介入」——审批的人和跑 agent 的进程不是同一个，
+甚至不在同一台机器。放内存的审批系统只是个弹窗，不是审批。
+
+审计账本是 **append-only**：只有 INSERT，没有 UPDATE/DELETE 的接口。
+能被改的审计记录没有审计价值。审批单本身可以改状态（pending→approved），
+但每一次状态变更都会往审计账本追加一条记录，形成不可篡改的决策链。
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+from .contracts import AuditRecord, Ticket, TicketStatus
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS approval_ticket (
+    ticket_id        TEXT PRIMARY KEY,
+    fingerprint      TEXT NOT NULL,
+    status           TEXT NOT NULL,
+    tool_name        TEXT NOT NULL,
+    tool_input_brief TEXT NOT NULL,
+    reason           TEXT NOT NULL,
+    rule_id          TEXT NOT NULL,
+    risk             TEXT NOT NULL,
+    thread_id        TEXT,
+    run_id           TEXT,
+    is_subagent      INTEGER NOT NULL DEFAULT 0,
+    created_at       REAL NOT NULL,
+    decided_at       REAL,
+    decided_by       TEXT,
+    decision_note    TEXT NOT NULL DEFAULT '',
+    expires_at       REAL,
+    grant_scope      TEXT NOT NULL DEFAULT 'exact'
+);
+CREATE INDEX IF NOT EXISTS idx_ticket_fp ON approval_ticket(fingerprint, status);
+CREATE INDEX IF NOT EXISTS idx_ticket_status ON approval_ticket(status, created_at);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    record_id   TEXT PRIMARY KEY,
+    ts          REAL NOT NULL,
+    kind        TEXT NOT NULL,
+    tool_name   TEXT NOT NULL DEFAULT '',
+    effect      TEXT NOT NULL DEFAULT '',
+    rule_id     TEXT NOT NULL DEFAULT '',
+    risk        TEXT NOT NULL DEFAULT '',
+    fingerprint TEXT NOT NULL DEFAULT '',
+    ticket_id   TEXT NOT NULL DEFAULT '',
+    thread_id   TEXT,
+    run_id      TEXT,
+    user_id     TEXT,
+    is_subagent INTEGER NOT NULL DEFAULT 0,
+    detail      TEXT NOT NULL DEFAULT '{}'
+);
+CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(ts);
+CREATE INDEX IF NOT EXISTS idx_audit_thread ON audit_log(thread_id, ts);
+"""
+
+
+class GovernanceStore:
+    def __init__(self, db_path: str | Path, *, jsonl_path: str | Path | None = None) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        # 审计同时写一份 JSONL：SQLite 便于查询，JSONL 便于外部日志系统采集与离线归档
+        self.jsonl_path = Path(jsonl_path) if jsonl_path else None
+        if self.jsonl_path:
+            self.jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        with self._conn() as conn:
+            conn.executescript(SCHEMA)
+
+    @contextmanager
+    def _conn(self):
+        conn = sqlite3.connect(self.db_path, timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ---------------- 审批单 ----------------
+
+    def create_ticket(self, ticket: Ticket) -> Ticket:
+        with self._lock, self._conn() as conn:
+            conn.execute(
+                """INSERT INTO approval_ticket
+                   (ticket_id, fingerprint, status, tool_name, tool_input_brief, reason, rule_id, risk,
+                    thread_id, run_id, is_subagent, created_at, decided_at, decided_by, decision_note,
+                    expires_at, grant_scope)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    ticket.ticket_id, ticket.fingerprint, ticket.status.value, ticket.tool_name,
+                    ticket.tool_input_brief, ticket.reason, ticket.rule_id, ticket.risk,
+                    ticket.thread_id, ticket.run_id, int(ticket.is_subagent), ticket.created_at,
+                    ticket.decided_at, ticket.decided_by, ticket.decision_note, ticket.expires_at,
+                    ticket.grant_scope,
+                ),
+            )
+        return ticket
+
+    def _row_to_ticket(self, row: sqlite3.Row) -> Ticket:
+        return Ticket(
+            ticket_id=row["ticket_id"], fingerprint=row["fingerprint"], status=TicketStatus(row["status"]),
+            tool_name=row["tool_name"], tool_input_brief=row["tool_input_brief"], reason=row["reason"],
+            rule_id=row["rule_id"], risk=row["risk"], thread_id=row["thread_id"], run_id=row["run_id"],
+            is_subagent=bool(row["is_subagent"]), created_at=row["created_at"], decided_at=row["decided_at"],
+            decided_by=row["decided_by"], decision_note=row["decision_note"], expires_at=row["expires_at"],
+            grant_scope=row["grant_scope"],
+        )
+
+    def get_ticket(self, ticket_id: str) -> Ticket | None:
+        with self._conn() as conn:
+            row = conn.execute("SELECT * FROM approval_ticket WHERE ticket_id=?", (ticket_id,)).fetchone()
+        return self._row_to_ticket(row) if row else None
+
+    def find_by_fingerprint(self, fingerprint: str) -> Ticket | None:
+        """查这个指纹上最新的一张单。
+
+        排序刻意用 created_at DESC：同一指纹可能被批过又被撤销再重申，
+        永远以最新一次人工决定为准，而不是「曾经批过就一直有效」。
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM approval_ticket WHERE fingerprint=? ORDER BY created_at DESC LIMIT 1",
+                (fingerprint,),
+            ).fetchone()
+        return self._row_to_ticket(row) if row else None
+
+    def decide(self, ticket_id: str, *, approved: bool, by: str, note: str = "", now: float | None = None) -> Ticket | None:
+        now = now if now is not None else time.time()
+        status = TicketStatus.APPROVED if approved else TicketStatus.DENIED
+        with self._lock, self._conn() as conn:
+            cur = conn.execute(
+                """UPDATE approval_ticket SET status=?, decided_at=?, decided_by=?, decision_note=?
+                   WHERE ticket_id=? AND status=?""",
+                (status.value, now, by, note, ticket_id, TicketStatus.PENDING.value),
+            )
+            if cur.rowcount == 0:
+                return None  # 不存在，或已经被裁决过 —— 不允许二次裁决
+        ticket = self.get_ticket(ticket_id)
+        if ticket:
+            self.append_audit(
+                AuditRecord.new(
+                    "ticket_decided", tool_name=ticket.tool_name, effect=status.value, rule_id=ticket.rule_id,
+                    risk=ticket.risk, fingerprint=ticket.fingerprint, ticket_id=ticket.ticket_id,
+                    thread_id=ticket.thread_id, run_id=ticket.run_id, is_subagent=ticket.is_subagent,
+                    detail={"decided_by": by, "note": note, "grant_scope": ticket.grant_scope},
+                )
+            )
+        return ticket
+
+    def list_tickets(self, *, status: TicketStatus | None = None, limit: int = 50) -> list[Ticket]:
+        sql = "SELECT * FROM approval_ticket"
+        params: tuple = ()
+        if status is not None:
+            sql += " WHERE status=?"
+            params = (status.value,)
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        with self._conn() as conn:
+            rows = conn.execute(sql, (*params, limit)).fetchall()
+        return [self._row_to_ticket(r) for r in rows]
+
+    def expire_stale(self, *, now: float | None = None) -> int:
+        """把过期的已批准单标记为 expired。由 CLI 或定时任务调用。"""
+        now = now if now is not None else time.time()
+        with self._lock, self._conn() as conn:
+            cur = conn.execute(
+                "UPDATE approval_ticket SET status=? WHERE status=? AND expires_at IS NOT NULL AND expires_at < ?",
+                (TicketStatus.EXPIRED.value, TicketStatus.APPROVED.value, now),
+            )
+            return cur.rowcount
+
+    # ---------------- 审计 ----------------
+
+    def append_audit(self, record: AuditRecord) -> None:
+        """只追加。本类刻意不提供审计记录的 update/delete 接口。"""
+        with self._lock, self._conn() as conn:
+            conn.execute(
+                """INSERT OR IGNORE INTO audit_log
+                   (record_id, ts, kind, tool_name, effect, rule_id, risk, fingerprint, ticket_id,
+                    thread_id, run_id, user_id, is_subagent, detail)
+                   VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    record.record_id, record.ts, record.kind, record.tool_name, record.effect,
+                    record.rule_id, record.risk, record.fingerprint, record.ticket_id, record.thread_id,
+                    record.run_id, record.user_id, int(record.is_subagent),
+                    json.dumps(record.detail, ensure_ascii=False, default=str),
+                ),
+            )
+        if self.jsonl_path:
+            with self.jsonl_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(record.to_dict(), ensure_ascii=False, default=str) + "\n")
+
+    def audit_tail(self, *, limit: int = 50, thread_id: str | None = None) -> list[dict]:
+        sql = "SELECT * FROM audit_log"
+        params: tuple = ()
+        if thread_id:
+            sql += " WHERE thread_id=?"
+            params = (thread_id,)
+        sql += " ORDER BY ts DESC LIMIT ?"
+        with self._conn() as conn:
+            rows = conn.execute(sql, (*params, limit)).fetchall()
+        out = []
+        for r in rows:
+            d = dict(r)
+            d["detail"] = json.loads(d["detail"] or "{}")
+            out.append(d)
+        return out
+
+    def stats(self) -> dict:
+        """真实统计。没有数据就返回 0 / None，不编造。"""
+        with self._conn() as conn:
+            total = conn.execute("SELECT COUNT(*) c FROM audit_log WHERE kind='policy_decision'").fetchone()["c"]
+            if total == 0:
+                return {"decisions": 0, "allow": 0, "ask": 0, "deny": 0, "pending_tickets": 0, "approval_rate": None}
+            by_effect = {r["effect"]: r["c"] for r in conn.execute("SELECT effect, COUNT(*) c FROM audit_log WHERE kind='policy_decision' GROUP BY effect")}
+            pending = conn.execute("SELECT COUNT(*) c FROM approval_ticket WHERE status='pending'").fetchone()["c"]
+            decided = conn.execute("SELECT status, COUNT(*) c FROM approval_ticket WHERE status IN ('approved','denied') GROUP BY status").fetchall()
+            decided_map = {r["status"]: r["c"] for r in decided}
+            total_decided = sum(decided_map.values())
+        return {
+            "decisions": total,
+            "allow": by_effect.get("allow", 0),
+            "ask": by_effect.get("ask", 0),
+            "deny": by_effect.get("deny", 0),
+            "pending_tickets": pending,
+            "approval_rate": round(decided_map.get("approved", 0) / total_decided, 4) if total_decided else None,
+        }

--- a/extensions/deerflow-governance/tests/test_governance.py
+++ b/extensions/deerflow-governance/tests/test_governance.py
@@ -1,0 +1,387 @@
+"""治理插件核心层单测 —— 全部可离线运行，不需要 DeerFlow / langchain / API key。
+
+    python3 -m unittest discover -s tests -v
+    pytest tests -q                              # 装了 pytest 也能跑
+
+覆盖的是本包真正的风险面：策略求值、指纹稳定性、审批状态机、预算熔断、审计不可篡改。
+适配层（provider.py / middleware.py）需要 DeerFlow 环境，验收方式见 docs/INTEGRATION.md。
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from deerflow_governance.budget import BudgetLedger, Limits  # noqa: E402
+from deerflow_governance.cli import build_parser  # noqa: E402
+from deerflow_governance.contracts import BudgetLevel, CallContext, Effect, TicketStatus, Usage  # noqa: E402
+from deerflow_governance.engine import ApprovalEngine  # noqa: E402
+from deerflow_governance.fingerprint import brief, compute  # noqa: E402
+from deerflow_governance.policy import PolicyEngine  # noqa: E402
+from deerflow_governance.pricing import PriceBook, format_cents  # noqa: E402
+from deerflow_governance.store import GovernanceStore  # noqa: E402
+
+POLICY = {
+    "default_effect": "allow",
+    "rules": [
+        {"id": "readonly", "tools": ["read_file", "ls", "grep"], "effect": "allow", "risk": "low", "reason": "只读"},
+        {
+            "id": "bash-destructive", "tools": ["bash"], "effect": "deny", "risk": "critical", "reason": "破坏性命令",
+            "when_any": [{"arg": "command", "regex": r"rm\s+(-[a-zA-Z]*\s+)*-?[rf]"}, {"arg": "command", "regex": r"\bmkfs\b"}],
+        },
+        {
+            "id": "bash-push", "tools": ["bash"], "effect": "ask", "risk": "high", "reason": "涉及远程推送",
+            "when_any": [{"arg": "command", "regex": r"git\s+push"}], "grant_scope": "exact",
+        },
+        {
+            "id": "subagent-bash", "tools": ["bash"], "scope": "subagent", "effect": "ask", "risk": "high",
+            "reason": "子 Agent 执行 shell", "grant_scope": "tool", "ttl_seconds": 60,
+        },
+        {"id": "bash-default", "tools": ["bash"], "effect": "allow", "risk": "medium", "reason": "常规 shell"},
+        {
+            "id": "write-protected", "tools": ["write_file"], "effect": "ask", "risk": "high", "reason": "受保护路径",
+            "when": [{"arg": "file_path", "regex": r"(^|/)\.env"}],
+        },
+        {"id": "mcp", "tools": ["mcp__*"], "effect": "ask", "risk": "high", "reason": "外部服务", "grant_scope": "tool"},
+        {"id": "admin-only", "tools": ["update_agent"], "effect": "allow", "risk": "high", "reason": "管理员放行", "roles": ["admin"]},
+    ],
+}
+
+
+def ctx(tool: str, **args) -> CallContext:
+    sub = args.pop("_subagent", False)
+    thread = args.pop("_thread", "t1")
+    role = args.pop("_role", None)
+    return CallContext(tool_name=tool, tool_input=args, thread_id=thread, run_id="r1", is_subagent=sub, user_role=role)
+
+
+class TestCLI(unittest.TestCase):
+    def test_config_works_before_or_after_subcommand(self):
+        parser = build_parser()
+
+        before = parser.parse_args(["--config", "gov.yaml", "validate"])
+        after = parser.parse_args(["validate", "--config", "gov.yaml"])
+
+        self.assertEqual(before.command, "validate")
+        self.assertEqual(before.config, "gov.yaml")
+        self.assertEqual(after.command, "validate")
+        self.assertEqual(after.config, "gov.yaml")
+
+    def test_config_after_subcommand_with_arguments(self):
+        args = build_parser().parse_args(["simulate", "--config", "gov.yaml", "--tool", "bash", "--arg", "command=git push"])
+
+        self.assertEqual(args.command, "simulate")
+        self.assertEqual(args.config, "gov.yaml")
+        self.assertEqual(args.tool, "bash")
+        self.assertEqual(args.arg, ["command=git push"])
+
+
+class TestPolicy(unittest.TestCase):
+    def setUp(self):
+        self.engine = PolicyEngine.from_dict(POLICY)
+
+    def test_first_match_wins(self):
+        """bash-destructive 排在 bash-default 前面，顺序必须决定结果。"""
+        v = self.engine.evaluate(ctx("bash", command="rm -rf build/"))
+        self.assertIs(v.effect, Effect.DENY)
+        self.assertEqual(v.rule_id, "bash-destructive")
+
+    def test_same_tool_different_risk(self):
+        """同一个工具按参数分流 —— 这是「只按工具名做策略」办不到的。"""
+        self.assertIs(self.engine.evaluate(ctx("bash", command="pytest -q")).effect, Effect.ALLOW)
+        self.assertIs(self.engine.evaluate(ctx("bash", command="git push origin main")).effect, Effect.ASK)
+        self.assertIs(self.engine.evaluate(ctx("bash", command="mkfs.ext4 /dev/sda")).effect, Effect.DENY)
+
+    def test_scope_subagent_is_stricter(self):
+        self.assertIs(self.engine.evaluate(ctx("bash", command="ls -al")).effect, Effect.ALLOW)
+        self.assertIs(self.engine.evaluate(ctx("bash", command="ls -al", _subagent=True)).effect, Effect.ASK)
+
+    def test_glob_tool_match(self):
+        self.assertEqual(self.engine.evaluate(ctx("mcp__github__create_issue")).rule_id, "mcp")
+
+    def test_arg_condition_and_semantics(self):
+        self.assertIs(self.engine.evaluate(ctx("write_file", file_path="app/.env")).effect, Effect.ASK)
+        self.assertIs(self.engine.evaluate(ctx("write_file", file_path="app/main.py")).effect, Effect.ALLOW)
+
+    def test_role_gate(self):
+        self.assertEqual(self.engine.evaluate(ctx("update_agent", _role="admin")).rule_id, "admin-only")
+        self.assertEqual(self.engine.evaluate(ctx("update_agent", _role="viewer")).rule_id, "__default__")
+
+    def test_default_effect_must_be_explicit(self):
+        with self.assertRaises(ValueError):
+            PolicyEngine.from_dict({"rules": []})
+
+    def test_duplicate_rule_id_rejected(self):
+        with self.assertRaises(ValueError):
+            PolicyEngine.from_dict({"default_effect": "allow", "rules": [
+                {"id": "x", "effect": "allow"}, {"id": "x", "effect": "deny"},
+            ]})
+
+    def test_unknown_field_rejected(self):
+        """配置写错字段名必须报错。静默忽略拼错的规则字段 = 策略静默失效。"""
+        with self.assertRaises(ValueError):
+            PolicyEngine.from_dict({"default_effect": "allow", "rules": [{"id": "x", "effect": "ask", "whn": []}]})
+
+    def test_explain(self):
+        hits = dict(self.engine.explain(ctx("bash", command="rm -rf /")))
+        self.assertTrue(hits["bash-destructive"])
+        self.assertFalse(hits["readonly"])
+
+
+class TestFingerprint(unittest.TestCase):
+    def test_stable_across_key_order_and_whitespace(self):
+        a = compute(tool_name="bash", tool_input={"command": "pytest  -q", "cwd": "."}, rule_id="r", thread_id="t")
+        b = compute(tool_name="bash", tool_input={"cwd": ".", "command": "pytest -q"}, rule_id="r", thread_id="t")
+        self.assertEqual(a, b)
+
+    def test_volatile_keys_excluded(self):
+        a = compute(tool_name="bash", tool_input={"command": "ls", "tool_call_id": "1"}, rule_id="r", thread_id="t")
+        b = compute(tool_name="bash", tool_input={"command": "ls", "tool_call_id": "2"}, rule_id="r", thread_id="t")
+        self.assertEqual(a, b)
+
+    def test_scope_widens_coverage(self):
+        kw = dict(tool_name="bash", rule_id="r", thread_id="t")
+        exact_a = compute(tool_input={"command": "ls"}, scope="exact", **kw)
+        exact_b = compute(tool_input={"command": "pwd"}, scope="exact", **kw)
+        tool_a = compute(tool_input={"command": "ls"}, scope="tool", **kw)
+        tool_b = compute(tool_input={"command": "pwd"}, scope="tool", **kw)
+        self.assertNotEqual(exact_a, exact_b)
+        self.assertEqual(tool_a, tool_b)
+
+    def test_thread_bound(self):
+        kw = dict(tool_name="bash", tool_input={"command": "ls"}, rule_id="r")
+        self.assertNotEqual(compute(thread_id="a", **kw), compute(thread_id="b", **kw))
+        self.assertEqual(compute(thread_id="a", thread_bound=False, **kw), compute(thread_id="b", thread_bound=False, **kw))
+
+    def test_brief_prefers_command(self):
+        self.assertIn("git push", brief("bash", {"command": "git push origin main", "cwd": "/x"}))
+
+    def test_invalid_scope(self):
+        with self.assertRaises(ValueError):
+            compute(tool_name="bash", tool_input={}, rule_id="r", scope="whatever")
+
+
+class GovernanceTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.store = GovernanceStore(Path(self.tmp.name) / "g.db", jsonl_path=Path(self.tmp.name) / "audit.jsonl")
+        self.engine = ApprovalEngine(PolicyEngine.from_dict(POLICY), self.store)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+
+class TestApprovalFlow(GovernanceTestBase):
+    def test_allow_passes_through(self):
+        d = self.engine.decide(ctx("read_file", file_path="a.py"))
+        self.assertTrue(d.allow)
+        self.assertIsNone(d.ticket)
+
+    def test_deny_tells_model_not_to_retry(self):
+        d = self.engine.decide(ctx("bash", command="rm -rf /"))
+        self.assertFalse(d.allow)
+        self.assertEqual(d.code, "governance.denied")
+        self.assertIn("不要重试", d.message)
+        self.assertIsNone(d.ticket)
+
+    def test_ask_opens_ticket_and_blocks(self):
+        d = self.engine.decide(ctx("bash", command="git push origin main"))
+        self.assertFalse(d.allow)
+        self.assertEqual(d.code, "governance.approval_pending")
+        self.assertIsNotNone(d.ticket)
+        self.assertIn(d.ticket.ticket_id, d.message)
+        self.assertIn("不要重试", d.message)  # 防止模型换工具绕过
+
+    def test_retry_reuses_pending_ticket(self):
+        """模型重试不能刷爆审批队列 —— 同一指纹只应有一张 pending 单。"""
+        c = ctx("bash", command="git push origin main")
+        first = self.engine.decide(c)
+        for _ in range(4):
+            again = self.engine.decide(c)
+            self.assertEqual(again.ticket.ticket_id, first.ticket.ticket_id)
+        self.assertEqual(len(self.store.list_tickets(status=TicketStatus.PENDING)), 1)
+
+    def test_approved_then_allowed(self):
+        c = ctx("bash", command="git push origin main")
+        pending = self.engine.decide(c)
+        self.store.decide(pending.ticket.ticket_id, approved=True, by="张三", note="确认过分支")
+        after = self.engine.decide(c)
+        self.assertTrue(after.allow)
+        self.assertIn("张三", after.message)
+
+    def test_denied_ticket_keeps_blocking(self):
+        c = ctx("bash", command="git push origin main")
+        pending = self.engine.decide(c)
+        self.store.decide(pending.ticket.ticket_id, approved=False, by="李四", note="禁止直推主干")
+        after = self.engine.decide(c)
+        self.assertFalse(after.allow)
+        self.assertEqual(after.code, "governance.approval_denied")
+        self.assertIn("禁止直推主干", after.message)
+
+    def test_double_decision_rejected(self):
+        pending = self.engine.decide(ctx("bash", command="git push origin main"))
+        self.assertIsNotNone(self.store.decide(pending.ticket.ticket_id, approved=True, by="a"))
+        self.assertIsNone(self.store.decide(pending.ticket.ticket_id, approved=False, by="b"))
+
+    def test_tool_scope_grant_covers_similar_calls(self):
+        """子 Agent 规则用 grant_scope=tool：批一次 bash，同工具其他命令也放行。"""
+        first = self.engine.decide(ctx("bash", command="ls", _subagent=True))
+        self.store.decide(first.ticket.ticket_id, approved=True, by="张三")
+        second = self.engine.decide(ctx("bash", command="cat README.md", _subagent=True))
+        self.assertTrue(second.allow)
+
+    def test_exact_scope_does_not_leak(self):
+        """而 exact 授权不能外溢到别的命令 —— 这是审批粒度的核心保证。"""
+        first = self.engine.decide(ctx("bash", command="git push origin main"))
+        self.store.decide(first.ticket.ticket_id, approved=True, by="张三")
+        other = self.engine.decide(ctx("bash", command="git push origin --force main"))
+        self.assertFalse(other.allow)
+
+    def test_grant_expires(self):
+        c = ctx("bash", command="ls", _subagent=True)  # 该规则 ttl_seconds=60
+        first = self.engine.decide(c, now=1000.0)
+        self.store.decide(first.ticket.ticket_id, approved=True, by="张三", now=1001.0)
+        self.assertTrue(self.engine.decide(c, now=1030.0).allow)
+        expired = self.engine.decide(c, now=2000.0)
+        self.assertFalse(expired.allow)
+        self.assertEqual(expired.code, "governance.approval_expired")
+
+    def test_grant_is_thread_bound(self):
+        approved = self.engine.decide(ctx("bash", command="git push origin main", _thread="A"))
+        self.store.decide(approved.ticket.ticket_id, approved=True, by="张三")
+        self.assertFalse(self.engine.decide(ctx("bash", command="git push origin main", _thread="B")).allow)
+
+    def test_invalid_mode(self):
+        with self.assertRaises(ValueError):
+            ApprovalEngine(PolicyEngine.from_dict(POLICY), self.store, mode="magic")
+
+
+class TestAudit(GovernanceTestBase):
+    def test_every_decision_is_audited(self):
+        self.engine.decide(ctx("read_file", file_path="a.py"))
+        self.engine.decide(ctx("bash", command="rm -rf /"))
+        d = self.engine.decide(ctx("bash", command="git push origin main"))
+        self.store.decide(d.ticket.ticket_id, approved=True, by="张三", note="ok")
+
+        kinds = [r["kind"] for r in self.store.audit_tail(limit=50)]
+        self.assertEqual(kinds.count("policy_decision"), 3)
+        self.assertEqual(kinds.count("ticket_created"), 1)
+        self.assertEqual(kinds.count("ticket_decided"), 1)
+
+    def test_audit_is_append_only(self):
+        """审计表不提供任何 update/delete 接口 —— 能改的审计没有审计价值。"""
+        public = {n for n in dir(self.store) if not n.startswith("_")}
+        self.assertFalse({"update_audit", "delete_audit", "clear_audit"} & public)
+
+    def test_jsonl_mirror(self):
+        self.engine.decide(ctx("read_file", file_path="a.py"))
+        lines = self.store.jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        self.assertGreaterEqual(len(lines), 1)
+
+    def test_stats_return_none_not_zero_when_empty(self):
+        s = self.store.stats()
+        self.assertEqual(s["decisions"], 0)
+        self.assertIsNone(s["approval_rate"])
+
+
+class TestBudget(unittest.TestCase):
+    def ledger(self, **over):
+        cfg = {"run": {"total_tokens": 1000, "tool_calls": 10, "warn_ratio": 0.8}, "thread": {"total_tokens": 3000}}
+        cfg.update(over)
+        return BudgetLedger.from_dict(cfg)
+
+    def test_ok_then_warn_then_stop(self):
+        led = self.ledger()
+        led.record(Usage(input_tokens=400, output_tokens=100), run_id="r", thread_id="t")
+        self.assertIs(led.check(run_id="r", thread_id="t").level, BudgetLevel.OK)
+        led.record(Usage(input_tokens=350), run_id="r", thread_id="t")
+        self.assertIs(led.check(run_id="r", thread_id="t").level, BudgetLevel.WARN)
+        led.record(Usage(input_tokens=300), run_id="r", thread_id="t")
+        v = led.check(run_id="r", thread_id="t")
+        self.assertIs(v.level, BudgetLevel.STOP)
+        self.assertEqual(v.dimension, "total_tokens")
+        self.assertIn("熔断", v.message)
+
+    def test_stop_beats_warn_across_dimensions(self):
+        led = self.ledger()
+        led.record(Usage(input_tokens=850), run_id="r", thread_id="t")  # warn
+        led.record(Usage(tool_calls=10), run_id="r", thread_id="t")  # stop
+        v = led.check(run_id="r", thread_id="t")
+        self.assertIs(v.level, BudgetLevel.STOP)
+        self.assertEqual(v.dimension, "tool_calls")
+
+    def test_thread_layer_catches_what_run_layer_misses(self):
+        """单 run 都不超标，但一个会话里连开多个 run 会超 —— 这正是分层的意义。"""
+        led = self.ledger()
+        for i in range(4):
+            led.record(Usage(input_tokens=900), run_id=f"r{i}", thread_id="t")
+            self.assertIsNot(led.check(run_id=f"r{i}", thread_id="t").level, BudgetLevel.STOP if i < 3 else BudgetLevel.OK)
+        self.assertIs(led.check(run_id="r9", thread_id="t").level, BudgetLevel.STOP)
+
+    def test_unknown_cost_not_counted_as_zero(self):
+        led = BudgetLedger.from_dict({"run": {"cost_cents": 100}})
+        led.record(Usage(input_tokens=999999, cost_cents=None), run_id="r", thread_id=None)
+        counter = led.counter("run", "r")
+        self.assertEqual(counter.cost_cents, 0.0)
+        self.assertEqual(counter.cost_unknown_tokens, 999999)  # 单独统计，不伪装成 0 成本
+        self.assertIs(led.check(run_id="r", thread_id=None).level, BudgetLevel.OK)
+
+    def test_unlimited_dimension_never_triggers(self):
+        led = BudgetLedger.from_dict({"run": {"total_tokens": 100}})
+        led.record(Usage(tool_calls=10_000), run_id="r", thread_id=None)
+        self.assertIs(led.check(run_id="r", thread_id=None).level, BudgetLevel.OK)
+
+    def test_unknown_level_and_dimension_rejected(self):
+        with self.assertRaises(ValueError):
+            BudgetLedger.from_dict({"forever": {"total_tokens": 1}})
+        with self.assertRaises(ValueError):
+            Limits.from_dict({"tokens": 1})
+
+    def test_counter_is_bounded(self):
+        led = BudgetLedger.from_dict({"run": {"total_tokens": 10}}, maxsize=5)
+        for i in range(20):
+            led.record(Usage(input_tokens=1), run_id=f"r{i}", thread_id=None)
+        self.assertLessEqual(len(led._counters["run"]), 5)
+
+    def test_snapshot_shape(self):
+        led = self.ledger()
+        led.record(Usage(input_tokens=10, output_tokens=5, tool_calls=1, delegations=1), run_id="r", thread_id="t")
+        snap = led.snapshot(run_id="r", thread_id="t")
+        self.assertEqual(snap["run"]["total_tokens"], 15)
+        self.assertEqual(snap["run"]["delegations"], 1)
+
+
+class TestPricing(unittest.TestCase):
+    def test_exact_and_glob(self):
+        book = PriceBook()
+        self.assertIsNotNone(book.lookup("deepseek-chat"))
+        self.assertIsNotNone(book.lookup("qwen3-coder-plus"))
+
+    def test_longest_pattern_wins(self):
+        book = PriceBook({"qwen*": None, "qwen3-coder*": None} and {
+            "qwen*": __import__("deerflow_governance.pricing", fromlist=["Price"]).Price(1, 1),
+            "qwen3-coder*": __import__("deerflow_governance.pricing", fromlist=["Price"]).Price(9, 9),
+        })
+        self.assertEqual(book.lookup("qwen3-coder-plus").input_cents_per_mtok, 9)
+
+    def test_unknown_model_is_none_not_zero(self):
+        self.assertIsNone(PriceBook().cost_cents("some-internal-model", 1_000_000, 1_000_000))
+        self.assertEqual(format_cents(None), "N/A")
+
+    def test_strict_mode_raises(self):
+        with self.assertRaises(KeyError):
+            PriceBook(strict=True).lookup("nope-model")
+
+    def test_cost_math(self):
+        cents = PriceBook().cost_cents("deepseek-chat", 1_000_000, 1_000_000)
+        self.assertAlmostEqual(cents, 1000.0, places=4)  # 200 + 800
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/extensions/deerflow-governance/uv.lock
+++ b/extensions/deerflow-governance/uv.lock
@@ -1,0 +1,902 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "deerflow-governance"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+host = [
+    { name = "langchain" },
+    { name = "langgraph" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "langchain", marker = "extra == 'host'", specifier = ">=1.0" },
+    { name = "langgraph", marker = "extra == 'host'", specifier = ">=0.6" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+provides-extras = ["host"]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "langchain"
+version = "1.3.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/68/a6dbad9c22df4087a0f9e79ddd46226c442b30128bfeee538d5889492a73/langchain-1.3.14.tar.gz", hash = "sha256:1b6696c72ba3bbbce54d745e0180742c9f6ece8bbc59ed5a46c3e20b9a435929", size = 645181, upload-time = "2026-07-16T13:28:18.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ec/0f942e78a621f8e3162ff1ed24284f469aaf51fb4607ee5831c626f2b2bc/langchain-1.3.14-py3-none-any.whl", hash = "sha256:4d10dbe91005952cddd56d0dc77aa108964da6bae90ab20063653957e901f782", size = 139560, upload-time = "2026-07-16T13:28:16.498Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langchain-protocol" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/3e/63af6b9d76d9be907c7c524d6ec18a2efed7e0e2d123fea0230d78dbd73f/langchain_core-1.5.3.tar.gz", hash = "sha256:a56457ac444fef41e9404443c187f0ecea708d36e816ea4ba9573c027f7d1a2d", size = 972461, upload-time = "2026-07-30T14:55:55.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/e6/c7c39efe0bc7e1b7c3d8f54f85846e04c901913c3d3e99068b218558c6f1/langchain_core-1.5.3-py3-none-any.whl", hash = "sha256:48b56fa580277209594dd7baf837f5b9a2a3651613f34ff9fb1728b429df015f", size = 561687, upload-time = "2026-07-30T14:55:54.419Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/59/b5959aea96faa9146e2e49a7a22882b3528c62efafe9a6a95beab30c2305/langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6", size = 6150, upload-time = "2026-06-18T17:08:26.959Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/2e/d82db9eec13ad0f72e7aaad5c4bc730ab111934fdc83c85523206eb9b0a0/langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a", size = 7221, upload-time = "2026-06-18T17:08:25.996Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/70/1d/a32f3caf4b3d60651656c0d64976b48d168653e81c71bb7512e9a31541aa/langgraph-1.2.10.tar.gz", hash = "sha256:05a183a746ed570a06c7c1b879920163509a75df9e44e92dd2238218d677fd37", size = 723404, upload-time = "2026-07-28T18:33:51.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/4d/3fc3e2535ee2c731130d71371848ebc6d4a9d2e8ae6060b11987ba134951/langgraph-1.2.10-py3-none-any.whl", hash = "sha256:52c48bd42fa31a1de0e1c0f0ebfe342e11ca2957b8b3563f83dbd60d8e30f921", size = 247753, upload-time = "2026-07-28T18:33:50.028Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "langchain-core" },
+    { name = "langchain-protocol" },
+    { name = "orjson" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/2b/bd8ac26d4e97f6df88ef05ce5b6a38945a3903e1025d926f4752aa88aa97/langgraph_sdk-0.4.2.tar.gz", hash = "sha256:b88f0f5f6328ac0680d6790614a905b2bcfa257f2276dba4e38f0e86db0aa738", size = 348327, upload-time = "2026-06-01T17:51:19.856Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/05/aac507337cceae773c2cc9ab91eb6301963af7aeeb55b4217a00e15aff17/langgraph_sdk-0.4.2-py3-none-any.whl", hash = "sha256:75fa5096c1177ce39c847096a8fe3745ffd480ddb412995f836e9f5f884c43dd", size = 160521, upload-time = "2026-06-01T17:51:18.849Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.10.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+    { name = "websockets" },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b6/c2/804558586a5363af85fc5b03ea327d0ba5d4d83da4c7d53fbed2413ef681/langsmith-0.10.14.tar.gz", hash = "sha256:edd3711ed1a334e5fb87b15eb0777b5abe5ad931dc13bfb79b93fffcbd2c2b4c", size = 4782076, upload-time = "2026-07-30T23:27:22.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/62/178c8c5bb50efd3e88986212993349aa027ff90364ccd4db4e3c596aede6/langsmith-0.10.14-py3-none-any.whl", hash = "sha256:185432f170c1639e9be14aad4116ba59079753a5762c7e1a26c11cf9988f8288", size = 726292, upload-time = "2026-07-30T23:27:20.333Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/91/63938e0e7e7876658e5e40178e7c0735b53527886fe11797a11699c55edd/uuid_utils-0.17.0.tar.gz", hash = "sha256:abb5667a36119019b3fa320c4d10c21ebccfcc87c8a739e6a0056cee7f48dde2", size = 43220, upload-time = "2026-07-09T13:49:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/80/a7e685968e3cec99d6fe2fb25d0f5726310e1bba356da68c13dfd8b7d140/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:9205068badf453d2f0821fd5d340389b4679992d7ff79d4f3e5608996dd1b287", size = 556403, upload-time = "2026-07-09T13:48:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/3102d93bcb7b0bfe6bede63ff8f221a7f91348e10a37f682773be27c56d9/uuid_utils-0.17.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0fcca4e838af9ac9243b3358d7c14afa4dca286a87781124c272d6c4cad9c968", size = 285608, upload-time = "2026-07-09T13:48:28.769Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fb/d59695f0f8db065b93c63316eaafa05a22d75a0486978a33736c52c646d5/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0f3729e839209f3457d0d8b6a35a376fdf65577a5aecaf4cc3587d3305759ba6", size = 319926, upload-time = "2026-07-09T13:48:29.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/03/62fabcd1e990e07a0e220e8d552af45bc16f107fa8e55c2014a706bb1a1e/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3dac0ad0cd9a2818d1775215365a4e8c2f8ada215529dd26f3f8cceeb67a6988", size = 327172, upload-time = "2026-07-09T13:48:31.187Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/a5081391338b459e2f8d8b12581f00f8caa6317fab510e0e85c18c59e938/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e671b2322ef09106ecb1ca0f4c398b134d5e2c1f80d7a4f3336847a3072c0e94", size = 439075, upload-time = "2026-07-09T13:48:32.295Z" },
+    { url = "https://files.pythonhosted.org/packages/59/30/91795bd01e17a13661280d4899fbf38fb05e3f38e873f9aaec106ec30aa0/uuid_utils-0.17.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb3e5caca8d3a6f72ea4cce024583f989f6f2e9186f98800213fff0176e8bcc", size = 320247, upload-time = "2026-07-09T13:48:33.64Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/11/09102b78303e4eb62069d6d88ef9fd661dc523e8f429e1fd67eaa78a6f44/uuid_utils-0.17.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8b72c2002202038666bf647f9a790906214c7c11cd0d6efef77b7d07bef3034a", size = 344738, upload-time = "2026-07-09T13:48:34.786Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f9/be95bad6954b60328878c3800258f01a6accd24fd75112d13f023462d53f/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4e2ac1c0b56f2c91b6f158e29ed96b1503223fe8aa6e79b1be1dc55bd8a5131c", size = 496845, upload-time = "2026-07-09T13:48:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/02/8a19a34e0530d987488a068a71576a236f5c8c746630b870b57f71eb24ef/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:6c142bd0cb4dba31c10babe00d59f7ef6460f0ef55eaa9c1a9da270684af996a", size = 603233, upload-time = "2026-07-09T13:48:37.512Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a8/b1abab36ff73b0248d82179816467f6d39a2e80fd64329a895ca94f3508e/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e252db239eb41c32248e096e0d170bce5896a4fd3405556362bc3dd83d912206", size = 561401, upload-time = "2026-07-09T13:48:38.977Z" },
+    { url = "https://files.pythonhosted.org/packages/61/91/70e7b528b351cc03a9ca43e6116371cdde31bb12bcead7ca2ca1367366cc/uuid_utils-0.17.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:237722b6581bb5b4eb4cefbcbe5c6e2980a440aabe781fbe50ebf1cb71eee4cc", size = 525314, upload-time = "2026-07-09T13:48:40.599Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/9167e90cf9937d6558f92d022ff3024a69d938a514d9c8faa4080f73b001/uuid_utils-0.17.0-cp312-cp312-win32.whl", hash = "sha256:46a73cacdf512f473a81f65dbf84186e08cfe6e9118fa582b6c6b33a8288a30d", size = 166831, upload-time = "2026-07-09T13:48:41.862Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/7d/0b889654d9ee3413f810cf4685e241285f650d98a4103ac9f3c6bcc95f29/uuid_utils-0.17.0-cp312-cp312-win_amd64.whl", hash = "sha256:e59b60a0a4cb7541480e02090d37dc2df3b72df4c2e776fff64ce3a4e3dd4637", size = 172944, upload-time = "2026-07-09T13:48:42.992Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/8c6e1bf65e4d400352885dadc656ad6d0af96e89231e3f04686bc2197128/uuid_utils-0.17.0-cp312-cp312-win_arm64.whl", hash = "sha256:d561a4c5747a1e6c7fa7c49a0292e78b4e8c456332caa084fc7abad8de828652", size = 172459, upload-time = "2026-07-09T13:48:44.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/dd/614fb9912157ac0128e6050859ccf06d9f13df9a944a803e8f80f6157e38/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d11a7bc1e02da8984d32e6de9e0826c6edac00eac17de270f372bf32f9a0af63", size = 557259, upload-time = "2026-07-09T13:48:45.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/11/d072711704de3d21bec08b6c2f36a215200ca1d5e01a390ea1ac434080a0/uuid_utils-0.17.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7a49f47ac26df3e431c56b825c1bae8e6d3d591fdbb7438c227cc9845a7e3d73", size = 286271, upload-time = "2026-07-09T13:48:47.018Z" },
+    { url = "https://files.pythonhosted.org/packages/18/6d/8a63e5eb2d5a6ba69a6c2036e305075bd6f5a022e7ea25fc6ce0eb7c51d2/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:32df1944808877702ceea398c103881c09a679bb672a215e01c2a84231266bf9", size = 320025, upload-time = "2026-07-09T13:48:48.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/bdc2caf9719d9090d7c46043242ae6136cba4f7a7ee384992ab905ad9aa1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98c88d3edd08e7245562e9815996dbc6f0bd4745e1c76462f24af5ae4e187dd1", size = 327931, upload-time = "2026-07-09T13:48:49.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/33/9219d09d51ead282b578b2a4e0a515c2cce3ec52076cada8bfb7e35727d5/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a4370089c8b2e42f1db51d76408c7fa8eaa2934bf854d17983d16179c07c098", size = 438537, upload-time = "2026-07-09T13:48:50.842Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/79/e8e0f8b3955f2081c116157119d87659937893242eb834aa170da04d660b/uuid_utils-0.17.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:09a55b7a5ae764985cb46467496a1787678d0a1400356157a080ad95b1a36869", size = 320656, upload-time = "2026-07-09T13:48:52.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/d1ceddc430ff04b6e21704b2030d4438074a2f478b265dab43da957791c1/uuid_utils-0.17.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:56aa6488b931246fae11924e4bd0e2b32677e63945eecb71c29e3c2ca0dc3131", size = 345310, upload-time = "2026-07-09T13:48:54.076Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/62/89438e12f389a843e626b7e37691319a057b3d6b80914609106891faadda/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:309a35f12d99dde19032bc2259cda6431c85eeac0879134dc777cc3087d7e1cb", size = 496771, upload-time = "2026-07-09T13:48:55.365Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d2/eedcd99f522d60e238ead03844f0d51743ba84d33044959e230b756bf212/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:21c79b61ff750abcf057163dd764ccb6196cde7a26cda1b31b45cd97769e03b3", size = 603631, upload-time = "2026-07-09T13:48:56.746Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a8/bb1b38aaddd7243b6e562c6694f499bf094800918316192fd8cb2cdc2620/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4134353bfe3026ddab8e886002dc52bc5a0ab04611aabb0eaae23c32e6e57f64", size = 562008, upload-time = "2026-07-09T13:48:58.241Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/77/5f7ed930dc105e293845c09e4d5bd84076318a12f45a46783e1af64906d7/uuid_utils-0.17.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7c89359affecebe2e39e6a116d069b363c936511a9572b308402489a26957d89", size = 525527, upload-time = "2026-07-09T13:48:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/25/1b55697adf6811a6f92cff6340e6b03e31fd6bc51066a5c10698c29b3679/uuid_utils-0.17.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:6a019a31bc4db89a0903a3e4f6b218571f3a6ff0ad4b3d3fe1c8f91a05ff6e3e", size = 97965, upload-time = "2026-07-09T13:49:01.217Z" },
+    { url = "https://files.pythonhosted.org/packages/26/bf/cd729343de4684230be8a966bad7bfc2cf10ce3e643b1189a8b5370dbe35/uuid_utils-0.17.0-cp313-cp313-win32.whl", hash = "sha256:b3131a82d0c7611f0aa480a6d36929e001a3f54ba0fc029a8118a5863cce513c", size = 167316, upload-time = "2026-07-09T13:49:02.354Z" },
+    { url = "https://files.pythonhosted.org/packages/76/f0/e602ae0a1b139a7826e5189b93d91902564def06d5006324fd2faf82c8fc/uuid_utils-0.17.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e311f908d2f842fca4c7dcebc4f10306b8089b204ef04cf6704b4332c9ff6ff", size = 173630, upload-time = "2026-07-09T13:49:03.529Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/52/024ebece265b387154115dc4f1d9727174ef82623069f4bec8b7ed7e73f7/uuid_utils-0.17.0-cp313-cp313-win_arm64.whl", hash = "sha256:c351737e2e65497c7200ab4ffb8af97e9f48be6488309abdd265fe08d66ee92f", size = 173214, upload-time = "2026-07-09T13:49:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/56/44/e2fd3fdf356e1b55d2acf1b956b4f3f29ffb215a99c387eba04b1c5fba66/uuid_utils-0.17.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:673d89cc434cc9b97a0b4cf61272f6fca70a81f64eb0afbface2a0d9f77f06cd", size = 562232, upload-time = "2026-07-09T13:49:06.201Z" },
+    { url = "https://files.pythonhosted.org/packages/19/28/65e0980d668a6d44e699f59d1acf43d6b5d4893592c115ce7c680bb4dfa1/uuid_utils-0.17.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:387cf7437c94ddec08651a0f1081381299c7075bc48a6251d8922bf39973378a", size = 287858, upload-time = "2026-07-09T13:49:07.45Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/5e97bcebc90fb6a10f98af3dc1ba552e04183aba59e2edc0b9cf486dd998/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:220b52746d99e11964badac3c0869016e0c24bafb70a7dd5c2c072a6be3da9cc", size = 321587, upload-time = "2026-07-09T13:49:09.489Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d7/88b2a2370cc3d455ba0515fb6f5c8f7ac0c0f55a86801b6e56a432f22c17/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0ab4a66e7a035ad6625cfc1fbdb34f5c2d25a80ae1ef4bfee458ea2036333c6d", size = 328964, upload-time = "2026-07-09T13:49:11.292Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0f/181c5da673953dfc0958cb4fb3a4984a9098673ddb05cac68e994bc8511b/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5641071337eb11d61a001ea08793bf72216f3241f0a433ed2764804b2a3e3cc7", size = 442909, upload-time = "2026-07-09T13:49:12.644Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/38/5c5e665af542884a8fd3c61725c38453239e13940326b5b70f3ef8881a97/uuid_utils-0.17.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9082e709014946b1f6e96ae6ecd93652efca2d2a6a3ab67dbe151c8b4bf193a4", size = 323076, upload-time = "2026-07-09T13:49:13.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/35/7de97de18cbf226c2a4f2104ad15e56ca4491717c81c0b71795c0c585b4e/uuid_utils-0.17.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1fd6f0e8a162dc0e9255b6aebe3cd175e76c33202f1bf39da9e6294b93db0099", size = 347360, upload-time = "2026-07-09T13:49:15.237Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a1/9915d5dd59fdd1957ded5d188c0ea0b9db5a1d84d42c8d8828a7b83b366e/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d63010803d7c368963bbe6f7ec379593e76dd581d7db0f29118d88713c9e0354", size = 499267, upload-time = "2026-07-09T13:49:16.774Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/05/88108405262ec850cea0f95733445d6873e5772af3292baabd9ef8457740/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a46bedc273b6f58f11dee816ff74999625ef8d007890f411b7a4975bf1c89330", size = 604940, upload-time = "2026-07-09T13:49:18.147Z" },
+    { url = "https://files.pythonhosted.org/packages/89/d5/6dbcd300de47cc443cff2656cd5327a385751213dcb2101cfee7388170b2/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:405233a5f625b3d995648f4647fa6befa4567cf3f74e1f6b9837e16f7310f0e0", size = 564172, upload-time = "2026-07-09T13:49:19.593Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/94/e8057f2288a415fba8a978bca4b589f5cb6b91a028a5dc07a1775938b33f/uuid_utils-0.17.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b6c5d2d71e1f17329150ad9427d27f4a3f29a01792e7ecdc64a98ac5368fc4d5", size = 528533, upload-time = "2026-07-09T13:49:21.075Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6b/31713148c77e48e62f51aa042a98a54a8be0396912ea5130f83f52ae722d/uuid_utils-0.17.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:f7e9b8728ba07a3cb2f29d5aa1a266c2664eb8ef0fd43afa34627c92f7fac8f0", size = 99197, upload-time = "2026-07-09T13:49:22.351Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f3/ca6f6ac5428312df8ed632f6dd9f9e6aba23090471fcdeae53eab027e8b3/uuid_utils-0.17.0-cp314-cp314-win32.whl", hash = "sha256:58838921e377791ef22c64cc92141bfae030f43651ff9272f0f28a208a9e6a5a", size = 169540, upload-time = "2026-07-09T13:49:23.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/cd/7ede0db66411fa09817d79b680f7454ea9bee2d374e1922e4efd065760a3/uuid_utils-0.17.0-cp314-cp314-win_amd64.whl", hash = "sha256:42275ebd0e8e74e32cdbfb8bd88fc99576567d51d54a508020611fd8f4f463a0", size = 175984, upload-time = "2026-07-09T13:49:24.703Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/81/533b5f80cd4918c0693f4e1b7b90ceb1caa45f4266ae8b528135d7ecca5d/uuid_utils-0.17.0-cp314-cp314-win_arm64.whl", hash = "sha256:b5d11cccba076a32321ef1380dea956821f0b51794ef59df64e58fb1cd543aae", size = 174749, upload-time = "2026-07-09T13:49:25.886Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/f400ac39d06fd8be5b099c09e41bb975205926722a3e8d53348817cb7ff9/uuid_utils-0.17.0-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:fae8b282f0cb22a5de222999f7723f4e5ec04f6fcdf4aaef879b5b36625ae2b0", size = 562610, upload-time = "2026-07-09T13:49:27.374Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8c/c71c8312304c56f6d0bcba87cd402fa79bec35d18ffc8c41954196ca68e5/uuid_utils-0.17.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:967955620df45e6cffe2e9950cb9903cb455649396f896b26b04363a91a5054b", size = 289473, upload-time = "2026-07-09T13:49:28.989Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cd/522117e2e5184ca1d4f0f85ee833e9e21bd8c6b99eff8a4d1a8e5a194e33/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:375cde148430d60a4a07c03abaa0774c4fddfdd90de99b4ba02f24088bc9d750", size = 321600, upload-time = "2026-07-09T13:49:30.4Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f4/0d81f9bd346fc717bc561c08fa6457e0328966eb76e536b938fe77d56459/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:975c17da26c5b9d46c336b03c52a057ac28378d6f9d98b58d32a038589bb3912", size = 329569, upload-time = "2026-07-09T13:49:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/41/26e1363f36a94c9e8ec2dd21d5f63088d3e7c723adbb12dcc8fdc77be417/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3150d836290c88f1d26eb59c4db280d87417dd3bfaadd2889c77416c8f0ff6fa", size = 442051, upload-time = "2026-07-09T13:49:33.024Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a7/2c1ed1b34d7df7fdcc11c28fd26d94d44843b37d9af2435ff9fd8abdbc08/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9472a8de37faf8bd216c628e0e68c8f6bef730d3ba0a5060f3b0fa460c992ac2", size = 324372, upload-time = "2026-07-09T13:49:34.554Z" },
+    { url = "https://files.pythonhosted.org/packages/78/bf/328d3c6bb22c496944a1b3b732207d71aa6964eb604e5e3b9dcb91ed0a00/uuid_utils-0.17.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d27c531edb8d1f38ca2eddaa1fa24913a460aeb721f2efd4ef42a124ce94e354", size = 348548, upload-time = "2026-07-09T13:49:35.898Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/76/a07de5cb7b90582fdbbc830fd19be129cbbb9897cfe239fef469d7bd2d09/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5670c52a438e21483ce715776144914a4e2a2a5c62d9dee15f8a3e90cf128ae6", size = 498985, upload-time = "2026-07-09T13:49:37.142Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/62/9966e46ae34fcec6b06119631fb3c09705ea78835035ce3a82d3348eb61a/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:6f29689a76fe7a49cbd629a794d0ec1eab48814e323a00a146a741b0195bde68", size = 605183, upload-time = "2026-07-09T13:49:38.648Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/4e/bb962ba0fe31e903b199f22cf4c1a6cba35a8987aef526d287277ab8ca8b/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4441600447d340ae103a353f01dbcd22ff680e5ee1a22988efe8d7b791d8fdb3", size = 565412, upload-time = "2026-07-09T13:49:40.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/9e/122adfeeeae8a84ccfd43bce627b104d12a2180a93bffd2c0e1b54dad7a6/uuid_utils-0.17.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7b04935a79c03c41ad08d0a5f390aac968bfb561f1268897bc5b0f077971efd", size = 529885, upload-time = "2026-07-09T13:49:41.513Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/257304dded339dc35fc9bf35722ac68fd4fdb930f255b8f7bccdf74ebba9/uuid_utils-0.17.0-cp314-cp314t-win32.whl", hash = "sha256:239d8a281fe10bae33205b5d43185834d556b18434e0a113b5dc1dfb2fd97e91", size = 169472, upload-time = "2026-07-09T13:49:42.871Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c8/e78c06db7e9ce317ce7b8759ff2058333eac75caa8c22b75f0059589c9be/uuid_utils-0.17.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e288a06cbbbcd01b44386e767985c9e21d2ad9bf59829aa7058d9a2a494804ab", size = 176271, upload-time = "2026-07-09T13:49:44.105Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/11/bd1c70e1ad3301163cebe66c8d26de26e6814d52f642a849448bd2833626/uuid_utils-0.17.0-cp314-cp314t-win_arm64.whl", hash = "sha256:1776a80d16369999b21627028cc5dbce819be83e1e079fdd7a51b587d2916db9", size = 175004, upload-time = "2026-07-09T13:49:45.591Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/e6/26d09fab466b7ca9c7737474c52be4f76a40301b08362eb2dbc19dcc16c1/websockets-15.0.1.tar.gz", hash = "sha256:82544de02076bafba038ce055ee6412d68da13ab47f0c60cab827346de828dee", size = 177016, upload-time = "2025-03-05T20:03:41.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/6b/4545a0d843594f5d0771e86463606a3988b5a09ca5123136f8a76580dd63/websockets-15.0.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:3e90baa811a5d73f3ca0bcbf32064d663ed81318ab225ee4f427ad4e26e5aff3", size = 175437, upload-time = "2025-03-05T20:02:16.706Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/71/809a0f5f6a06522af902e0f2ea2757f71ead94610010cf570ab5c98e99ed/websockets-15.0.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:592f1a9fe869c778694f0aa806ba0374e97648ab57936f092fd9d87f8bc03665", size = 173096, upload-time = "2025-03-05T20:02:18.832Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/69/1a681dd6f02180916f116894181eab8b2e25b31e484c5d0eae637ec01f7c/websockets-15.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0701bc3cfcb9164d04a14b149fd74be7347a530ad3bbf15ab2c678a2cd3dd9a2", size = 173332, upload-time = "2025-03-05T20:02:20.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/02/0073b3952f5bce97eafbb35757f8d0d54812b6174ed8dd952aa08429bcc3/websockets-15.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8b56bdcdb4505c8078cb6c7157d9811a85790f2f2b3632c7d1462ab5783d215", size = 183152, upload-time = "2025-03-05T20:02:22.286Z" },
+    { url = "https://files.pythonhosted.org/packages/74/45/c205c8480eafd114b428284840da0b1be9ffd0e4f87338dc95dc6ff961a1/websockets-15.0.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0af68c55afbd5f07986df82831c7bff04846928ea8d1fd7f30052638788bc9b5", size = 182096, upload-time = "2025-03-05T20:02:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/14/8f/aa61f528fba38578ec553c145857a181384c72b98156f858ca5c8e82d9d3/websockets-15.0.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64dee438fed052b52e4f98f76c5790513235efaa1ef7f3f2192c392cd7c91b65", size = 182523, upload-time = "2025-03-05T20:02:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/0267396610add5bc0d0d3e77f546d4cd287200804fe02323797de77dbce9/websockets-15.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d5f6b181bb38171a8ad1d6aa58a67a6aa9d4b38d0f8c5f496b9e42561dfc62fe", size = 182790, upload-time = "2025-03-05T20:02:26.99Z" },
+    { url = "https://files.pythonhosted.org/packages/02/05/c68c5adbf679cf610ae2f74a9b871ae84564462955d991178f95a1ddb7dd/websockets-15.0.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5d54b09eba2bada6011aea5375542a157637b91029687eb4fdb2dab11059c1b4", size = 182165, upload-time = "2025-03-05T20:02:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/29/93/bb672df7b2f5faac89761cb5fa34f5cec45a4026c383a4b5761c6cea5c16/websockets-15.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3be571a8b5afed347da347bfcf27ba12b069d9d7f42cb8c7028b5e98bbb12597", size = 182160, upload-time = "2025-03-05T20:02:31.634Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/83/de1f7709376dc3ca9b7eeb4b9a07b4526b14876b6d372a4dc62312bebee0/websockets-15.0.1-cp312-cp312-win32.whl", hash = "sha256:c338ffa0520bdb12fbc527265235639fb76e7bc7faafbb93f6ba80d9c06578a9", size = 176395, upload-time = "2025-03-05T20:02:33.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/71/abf2ebc3bbfa40f391ce1428c7168fb20582d0ff57019b69ea20fa698043/websockets-15.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcd5cf9e305d7b8338754470cf69cf81f420459dbae8a3b40cee57417f4614a7", size = 176841, upload-time = "2025-03-05T20:02:34.498Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9f/51f0cf64471a9d2b4d0fc6c534f323b664e7095640c34562f5182e5a7195/websockets-15.0.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ee443ef070bb3b6ed74514f5efaa37a252af57c90eb33b956d35c8e9c10a1931", size = 175440, upload-time = "2025-03-05T20:02:36.695Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/05/aa116ec9943c718905997412c5989f7ed671bc0188ee2ba89520e8765d7b/websockets-15.0.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5a939de6b7b4e18ca683218320fc67ea886038265fd1ed30173f5ce3f8e85675", size = 173098, upload-time = "2025-03-05T20:02:37.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0b/33cef55ff24f2d92924923c99926dcce78e7bd922d649467f0eda8368923/websockets-15.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:746ee8dba912cd6fc889a8147168991d50ed70447bf18bcda7039f7d2e3d9151", size = 173329, upload-time = "2025-03-05T20:02:39.298Z" },
+    { url = "https://files.pythonhosted.org/packages/31/1d/063b25dcc01faa8fada1469bdf769de3768b7044eac9d41f734fd7b6ad6d/websockets-15.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:595b6c3969023ecf9041b2936ac3827e4623bfa3ccf007575f04c5a6aa318c22", size = 183111, upload-time = "2025-03-05T20:02:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/93/53/9a87ee494a51bf63e4ec9241c1ccc4f7c2f45fff85d5bde2ff74fcb68b9e/websockets-15.0.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3c714d2fc58b5ca3e285461a4cc0c9a66bd0e24c5da9911e30158286c9b5be7f", size = 182054, upload-time = "2025-03-05T20:02:41.926Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b2/83a6ddf56cdcbad4e3d841fcc55d6ba7d19aeb89c50f24dd7e859ec0805f/websockets-15.0.1-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0f3c1e2ab208db911594ae5b4f79addeb3501604a165019dd221c0bdcabe4db8", size = 182496, upload-time = "2025-03-05T20:02:43.304Z" },
+    { url = "https://files.pythonhosted.org/packages/98/41/e7038944ed0abf34c45aa4635ba28136f06052e08fc2168520bb8b25149f/websockets-15.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:229cf1d3ca6c1804400b0a9790dc66528e08a6a1feec0d5040e8b9eb14422375", size = 182829, upload-time = "2025-03-05T20:02:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/17/de15b6158680c7623c6ef0db361da965ab25d813ae54fcfeae2e5b9ef910/websockets-15.0.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:756c56e867a90fb00177d530dca4b097dd753cde348448a1012ed6c5131f8b7d", size = 182217, upload-time = "2025-03-05T20:02:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/33/2b/1f168cb6041853eef0362fb9554c3824367c5560cbdaad89ac40f8c2edfc/websockets-15.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:558d023b3df0bffe50a04e710bc87742de35060580a293c2a984299ed83bc4e4", size = 182195, upload-time = "2025-03-05T20:02:51.561Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/20b6cdf273913d0ad05a6a14aed4b9a85591c18a987a3d47f20fa13dcc47/websockets-15.0.1-cp313-cp313-win32.whl", hash = "sha256:ba9e56e8ceeeedb2e080147ba85ffcd5cd0711b89576b83784d8605a7df455fa", size = 176393, upload-time = "2025-03-05T20:02:53.814Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6c/c65773d6cab416a64d191d6ee8a8b1c68a09970ea6909d16965d26bfed1e/websockets-15.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:e09473f095a819042ecb2ab9465aee615bd9c2028e4ef7d933600a8401c79561", size = 176837, upload-time = "2025-03-05T20:02:55.237Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/63/71aa56b151a1b28770037a61bd4e461c2619cfc8866a4fcaf1548605e325/xxhash-3.8.1.tar.gz", hash = "sha256:b0de4bf3aa66363552d52c6a89003c479911f12098cd48a53d44a0f7a25f7c46", size = 86223, upload-time = "2026-07-06T10:49:58.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/91/f65c34a7aa7b4e7cf4854f8e6ef3f7ee32ceac41d4f008da0780db0612f6/xxhash-3.8.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e6e49370822c1f4d8d90e678b06dbcb08b51a026a7c4b55479e7d467f2e813bc", size = 34680, upload-time = "2026-07-06T10:44:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/57/04/b10a245a4c09a9cfa88f8e9ae755029413ad1ac17047f9a61906e5ae0799/xxhash-3.8.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:220d68130f83f7cc86d6edfdeab176adc73d7200bf3a8ec10c629e8cf605c215", size = 32397, upload-time = "2026-07-06T10:44:42.196Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/75/45ab795b5945b6388583bd75202106af505537935566c15a1577797a0e08/xxhash-3.8.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d365ee1892c1fa803536f8c6ce21d24b29c9718ec75eb856095c07830f8c478", size = 220549, upload-time = "2026-07-06T10:44:43.603Z" },
+    { url = "https://files.pythonhosted.org/packages/13/44/5ba2bd0a14ddf4193fc7d8ec29625f659f22c06d60b28f04bf46305d8330/xxhash-3.8.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:852bfe059720632e2f16a6a4745e41d20937b2bf2a42a401e2412046bb6971cc", size = 241186, upload-time = "2026-07-06T10:44:45.534Z" },
+    { url = "https://files.pythonhosted.org/packages/23/32/c4147def4d1e4538b906f82731e0ba23424377fc50a7cddd03cd284c8f63/xxhash-3.8.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f8c25a7061d952de589bd0ea0eaadee32378ff83dd6a677b267f9cd86f401f8", size = 264852, upload-time = "2026-07-06T10:44:47.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/bd/71ed14f4f0318bb7fd7b2ec51999413487fa8da8d41208e84d50d1ef0f98/xxhash-3.8.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:868a8dcaff1a84ba78038e1cef14fc88ccf84d9b4d12ea604696e0693296aa56", size = 242663, upload-time = "2026-07-06T10:44:48.846Z" },
+    { url = "https://files.pythonhosted.org/packages/91/09/70af22c565a8473b3f2ae73f88e7721af281bc4a575236dbd1970c9f76f6/xxhash-3.8.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6536d8677d2fff7e64cd0b98b976df9de7aee0e69590044c2af5f51b76b7a170", size = 473510, upload-time = "2026-07-06T10:44:50.695Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/34db781c8f0cf99c544ca1f2bc2e5bf55426e1eb4ca6de8ea5da56a9f352/xxhash-3.8.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:82c0cedd280eab2e8291270e6c04894dbc096f8159a39dcf1807429f026ca3cc", size = 220469, upload-time = "2026-07-06T10:44:52.422Z" },
+    { url = "https://files.pythonhosted.org/packages/93/5f/9a184f615fa5a4dce30c01534f62946ce5a11ce40f73785cbd356ccabaa9/xxhash-3.8.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daa86e4b68221d38e669bb236ba112d0335353829fb627c82e5909e4bbe8694c", size = 310290, upload-time = "2026-07-06T10:44:54.142Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dc/9b9a9789011ee153723a5eb9e7dd7fcbae2ba9b3fe7a729249ca7c252056/xxhash-3.8.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2bc7113e6f2b6b3922dd61796ca9f36af09da3773898e7003038dc992fc83b8d", size = 238173, upload-time = "2026-07-06T10:44:55.693Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/4d/71c6005ada9dcb608a4e1902e8475ecadb5f3fbfa04e1e244d276a2d0c43/xxhash-3.8.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5eed32dad81d6ba8e62dc7b9ffa0500199385d7810a8dd9d4eafaceb8c6e20bb", size = 269026, upload-time = "2026-07-06T10:44:57.424Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/87/d6c036ba25dfbd9c8633be5aa86fc9474bbb9e2c68212a841d090abe7344/xxhash-3.8.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:83697b0ea1f10e7f5d8b26a4906fa851393c61546c63839643a2b7fe2d868061", size = 224970, upload-time = "2026-07-06T10:44:59.085Z" },
+    { url = "https://files.pythonhosted.org/packages/48/62/4c1f035a41c5752aa05e195b6c904c07b94fe9061a16de61e72a6e6b135f/xxhash-3.8.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:36fc69160465ae75c6ec4ac9f781bb2aa16ae7ff869e73c26fee85fbb11b9887", size = 240820, upload-time = "2026-07-06T10:45:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/da/14/d39d565069b87e86d21a2af2a31d04db79249d25aa8d5b62959056a89857/xxhash-3.8.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:445e0f5a31f2f3546ae0895d4811e159518cdc9d824c11419898d40cfadb677e", size = 300619, upload-time = "2026-07-06T10:45:02.716Z" },
+    { url = "https://files.pythonhosted.org/packages/13/22/75467acc887edc8cf71c97ab1708feb3df7a88bda589b9f399765c6387d2/xxhash-3.8.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:dfe0580fbfd5e4af87d0cc52d2044f155d55ebd8c8a93568758a2ea7d8e15975", size = 443267, upload-time = "2026-07-06T10:45:04.653Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b6/1da3baa5fa6ef705e3425fddd382be7dfc4dfba2686df90a20f16e9c7b1b/xxhash-3.8.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:095e1323fa108be1292c54c86da3ef3c7a7dc015b105a52133973bc07a6ad11a", size = 217338, upload-time = "2026-07-06T10:45:06.304Z" },
+    { url = "https://files.pythonhosted.org/packages/78/dd/b5295a9f97484e7a1c2b283a742ca45e3104991c55a1ef670dde161829ba/xxhash-3.8.1-cp312-cp312-win32.whl", hash = "sha256:bf28f55e427e0483acb1f666bd0d869b6d5e5a716680c216ad7befe3d4cfba2e", size = 31970, upload-time = "2026-07-06T10:45:07.823Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/31/3fa0b807d7e21515cd975e7fe5c039d52ac3e9401a96d6ad68dae6305215/xxhash-3.8.1-cp312-cp312-win_amd64.whl", hash = "sha256:2256e80e4960ee282f63428adb349cb7f8bd8efe4db770d88eb815f4b9860724", size = 32741, upload-time = "2026-07-06T10:45:09.42Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/05/86feada74e239600e6875aa507afb40482a89b92700aa74a92da83bdcb77/xxhash-3.8.1-cp312-cp312-win_arm64.whl", hash = "sha256:9df56e6df96a60590935e22373041cccc91fd55858763dcffb55bf63b3a2b396", size = 29234, upload-time = "2026-07-06T10:45:10.809Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8c/446bb782cd0d27007a917b5569a08dd73219c3e8d6e459014db104b27bdb/xxhash-3.8.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:3c682fcd96eb4bf64be32a4d95f96107e1588005831bd8a741b324fdda01b913", size = 38562, upload-time = "2026-07-06T10:45:12.425Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ec/c0c45627eaa6be7a5d6117423adf8f7a15b17ee74b4b17072cca5959a225/xxhash-3.8.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:036a024d8b9c01f70782e09ed98d532e76fd23f950ae7154bd950fe94e90ebec", size = 36656, upload-time = "2026-07-06T10:45:13.932Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/94/8324c04cc7597154caaeba6c094e01fbd2e7601d01e7a13eea9f5420e77b/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d6a5c0bce213b23b0166fe0d35bcbbe23ce4b968f257cc7eb6fd57cb8e1e6297", size = 31169, upload-time = "2026-07-06T10:45:15.687Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a4/beb6bb26e1184e126dbe7a5682330214ef54dcfbf882078aa9f4b5428d42/xxhash-3.8.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:5177aa44eddaa97c6ef0cc00c6d540edb64d51781d2f8fb941612ec61a92c9ed", size = 32177, upload-time = "2026-07-06T10:45:17.035Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0f/fc4c92a5a528f839b34b6419b2e53c8597f2a629d5a1f5d721f65bfa1fd6/xxhash-3.8.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7801b7223db017b9c0c9ccf37e44524edb35a1544a1c032add22c061c6af0276", size = 34642, upload-time = "2026-07-06T10:45:18.39Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/58/edbfb141d4000767ac6a9694f8ac0763e2c2e983e65c9e31620ba56e2667/xxhash-3.8.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e80238259655bf69d7bcd08226a970d7f42605f3157786bfa76dd13472d7fa0", size = 34684, upload-time = "2026-07-06T10:45:20.033Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3f/5072f1f0f5714186f0ac2a0b5a4929ce30d4b845e94886b6c01b6ebda0be/xxhash-3.8.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bcab50a389cc04d87f90092af78a6adba2ab3deca63175a3344ca83514045315", size = 32401, upload-time = "2026-07-06T10:45:21.414Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c7/802ea2f9c2ed59219934d6d65c470d502b1788043eae277a52af8658bda6/xxhash-3.8.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a2489d3a776fa380cb8e71f54c7fda268a9baf3de9b1395093fd280f95735907", size = 220617, upload-time = "2026-07-06T10:45:23.234Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a8/e10488efd31fcb13fcd6acbc6e788f10c6f8e3a0cc4ae3eb89dc19c55a12/xxhash-3.8.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:32ab1e5432690276e71192be7401b55f96db2d0eedea5d44eb1f164505669cc0", size = 241295, upload-time = "2026-07-06T10:45:25.364Z" },
+    { url = "https://files.pythonhosted.org/packages/18/cc/14180b17d44892a631f8ae7323c30bfbb1328efc8209e528a480293528ac/xxhash-3.8.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b30e01a0b97a4bc3f519a4d7a82da3dc53251fb0de5eeea8660dcd4ff094c0c2", size = 264688, upload-time = "2026-07-06T10:45:27.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/72/a14019d0c5f6c41ee407a503036ae32787c91325ca218a96a9b5627be651/xxhash-3.8.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1f44275ddb0978b67a58a951501903f04d49335a91f7681c9ce122ecb8ccb329", size = 242740, upload-time = "2026-07-06T10:45:28.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/08/92550e556c6fcfcb96c6a336945eb53a431ed43120ed749636debb16c5cf/xxhash-3.8.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3b87cbd974512c0c5fc7b469c36b2cdc9ee6d76e4ec78bccb2c7184611c49b0", size = 473599, upload-time = "2026-07-06T10:45:30.524Z" },
+    { url = "https://files.pythonhosted.org/packages/29/83/e361d3c1acd1b21e1d489616de6fa4aaf843365d8179f612e3743eac20a9/xxhash-3.8.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98ee81b4b7f3023c9cb04a78cc67610baffcb5812d92f2096cb5a5efc6f19437", size = 220559, upload-time = "2026-07-06T10:45:32.979Z" },
+    { url = "https://files.pythonhosted.org/packages/05/01/006a4243c2c2a6831827f9999f6d1c23feeef100eb023c1f886022a00bf3/xxhash-3.8.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2666f059a1588a99267e33605365ed89cea92f424b3522806a9f4bd8ad2e3d62", size = 310383, upload-time = "2026-07-06T10:45:35.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/20/af388e8bf9f9a0f89eeef7d2a1935d176ee1c20bc6adeda05035879379cf/xxhash-3.8.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:b0093cf7eeb91b84776e8742113afa4bdf47533d36cf719179aaaf1f56f6f8bf", size = 238228, upload-time = "2026-07-06T10:45:38.02Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6b/4666579a87eebd1744663c404297355fa0658617b015cedfa58810ee7036/xxhash-3.8.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3a800912a2e5e975d4128969d645c4a2a80aa886ccd6c9b1c6f44529e327e8cf", size = 269137, upload-time = "2026-07-06T10:45:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d3/e963a8a46f900a137d91b02144d8ea07a8f812971b138204a3b2f8b8e55c/xxhash-3.8.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:0fe37f72a207223d22a4eddc3149d4298993385aa9daef25c039246ca5a309f3", size = 225068, upload-time = "2026-07-06T10:45:41.718Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/80/9d181dbcde4b0fe48375f48833a5832d4b8cd2b349b15110c92ee472d874/xxhash-3.8.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5db43f249b4be9f99ef4b967863f37094fb40e67effafb78ba4f0356b6396104", size = 240874, upload-time = "2026-07-06T10:45:43.414Z" },
+    { url = "https://files.pythonhosted.org/packages/39/15/ce3ab5a1cd27ead25a5196e55a7284220f6ad6e316da494ffd900b2b600f/xxhash-3.8.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c4ed42965c2cd9081f011be22f69d0e65d3b6165fe7734072fd0c232840bbd4e", size = 300702, upload-time = "2026-07-06T10:45:45.135Z" },
+    { url = "https://files.pythonhosted.org/packages/96/c0/2281a8ab5f2a62dbf57a23c58a01ccc1d98abf40f71193c8a81f59e759b5/xxhash-3.8.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3557bec8fcb11738a8920eeb68974bc76b75262f6947998d3147954ce0a4b893", size = 443351, upload-time = "2026-07-06T10:45:47.188Z" },
+    { url = "https://files.pythonhosted.org/packages/81/2e/071a58c1a53a52d4f7a3aa0987be0c396dffd40da8204805fe1b130a81f4/xxhash-3.8.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:00de40f3b42240db23a82a5c682b55d7263d84a26a953240c1aee463409660e3", size = 217396, upload-time = "2026-07-06T10:45:48.925Z" },
+    { url = "https://files.pythonhosted.org/packages/68/44/36ab58134badd9d3433fc7b53c4ca8d113d8e807782885628640f8297a4d/xxhash-3.8.1-cp313-cp313-win32.whl", hash = "sha256:b5196cc2574cfec572a5f3fb7cfa5ade27305ae3d06516a082132441aff4c83a", size = 31974, upload-time = "2026-07-06T10:45:50.591Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/2a0b84798448e766f7b89ceed073cb0cb5a43fc9ebbacbdea74a38de18e3/xxhash-3.8.1-cp313-cp313-win_amd64.whl", hash = "sha256:538f5f865df6cd8c32dd63158a0e5b4f5dd08d732a7da8b7228a5a0776c8ce55", size = 32739, upload-time = "2026-07-06T10:45:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/bb51dbf7c363ff88a7cbd50b7959718219577ef44d7cf255929ffc4a2194/xxhash-3.8.1-cp313-cp313-win_arm64.whl", hash = "sha256:a6617f30641ba0d8baa1635fbefb1dffc5165ec36d26921bd5cee13497cd937a", size = 29239, upload-time = "2026-07-06T10:45:53.714Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d3/827ca123c2ee5443a6aaed3c5dd199237dc2f010e2bebd7ec09ef36f3a5f/xxhash-3.8.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:bfcd82852c62a60e314670a9602de354c4460f8adad916e2e42a20860c7870bc", size = 34964, upload-time = "2026-07-06T10:45:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/05/67/67ae2a3ccdeb8b8ef025d35aee9edd1d26c3abe5051d47da9286232afbf8/xxhash-3.8.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:08ea2081f5e88615fec8622a9f87fbe21b8ea58d88cfc02163ca11026ee62a92", size = 32697, upload-time = "2026-07-06T10:45:57.288Z" },
+    { url = "https://files.pythonhosted.org/packages/38/5a/3d3994346e1f45493679cb5c1ffc2bf454e410e9d1e8a662d253becee91e/xxhash-3.8.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2e32855b6f9e5b18f449e59d45e3d5778bdeb660632ef2693cca267a11246c75", size = 225954, upload-time = "2026-07-06T10:45:58.897Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2c/53169270309b7cd8e05504e07fe123bac053b89d00ac63617faacf0a2ec0/xxhash-3.8.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6e088bd7870775624256a0d84c2a6714afd223b2eeb56b0ca58398e52a32fda", size = 249776, upload-time = "2026-07-06T10:46:00.977Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e0/5c551d8d592f944506f7c5185e210255c15e672a3c6008c156a1bd9b775e/xxhash-3.8.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:72eb5ae575cc7ae2b23f6f8064a8b10f638c7149819ae9cc6d20ebd4d37a1629", size = 274776, upload-time = "2026-07-06T10:46:02.869Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2a/d3a762270cee2d7bcd0e25e28c623e5f3f5c0dc637b66e3e47dd5b0bb3f0/xxhash-3.8.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d0b48cdf690a64cedf7258c3dc9506cc41fc86edd7739c40e3098952265dc068", size = 252056, upload-time = "2026-07-06T10:46:04.688Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/b78e4373b2cb6d1c42af60ea2d7e9146ad0710b239ac7f706d5d31d5bb98/xxhash-3.8.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fb9e256a357dfcede7818c6d34e70db2d6b664394803d1de4b6984d2de76c0f1", size = 482108, upload-time = "2026-07-06T10:46:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/0d/642d923336ea61a15f8ce64fc7e078729e6e06c3a026e517fa79b2c23b7a/xxhash-3.8.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51f71a6e2ad071e70c937e41fcb6c19f82c3f9f49831eba850ed4a106ffbb647", size = 226739, upload-time = "2026-07-06T10:46:08.598Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/0a/a37d6da6427d45a8d23e3ee3a0ca9c9d4a90364849c6637fe2963a755f9b/xxhash-3.8.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e4a6443968c4e8dc69967e12776776a5952c119cc1bd94168ad1c5ad667c2be1", size = 319658, upload-time = "2026-07-06T10:46:10.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/51/ebbd40da8a3f1bc53b4b7a9a87f8e28bd95c5f21bc14b8a57860cf367d1b/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:714503083a1f2065c9ad15340dd49ac8a8e948a505a705ffa1750cb951519113", size = 246059, upload-time = "2026-07-06T10:46:12.634Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4c/d9014030147e1f0bb26e7da47aa240dd9ec61c763c573e558111d869f8e1/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:77f74e45a1e5574bbbf80181c8027b3a4c65c2248fffbd557bd596fff13102f9", size = 275535, upload-time = "2026-07-06T10:46:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/caee2db41fadcd5a25aa4323213f9afec5a8586d4e419241e3d659362bd7/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:4e0e1b0fb0259c1b75d1251ac0bb4d7ab675d36f7a6bf4ba6aa630dae94f9ffa", size = 231292, upload-time = "2026-07-06T10:46:16.452Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/60/f52f08bcdc904c4514ea5c25caa19e9f3214144434a6ff96dc82dc1cbddd/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:10e4393ec33633c2f05ad01869e546ad080b1a18f2650503731f153774608b31", size = 250490, upload-time = "2026-07-06T10:46:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a0/94dc7ae310838f250669c6ad7168e6d6fca17d49dac1053f06dc232c4a56/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:b3ba794c3d885803db6c3116686923f1ec13bc86e621e169a375282b63ea1cc6", size = 309861, upload-time = "2026-07-06T10:46:20.503Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f9/adeead7d0eb28cdfc2832544ea639ffbc6749ccde47a8e228d667459182e/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:57189a69c0891e4818853feaa521c972d22c880a001453addea015f48e3c3398", size = 448739, upload-time = "2026-07-06T10:46:22.79Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a4/22ec0e07db57d901c9298ae98aa3cf2be45bafded6f07c13131e85b89032/xxhash-3.8.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d59e71153fe9ff85648d00e18649b07e9b22c797291abb7e27274fa06df8b838", size = 223657, upload-time = "2026-07-06T10:46:24.831Z" },
+    { url = "https://files.pythonhosted.org/packages/94/32/8a9531f37b59e5a013003db7cb7414baf4ce7e0e1268e0d5947cd3d6a2df/xxhash-3.8.1-cp313-cp313t-win32.whl", hash = "sha256:5b96f0024e9840f449bd91b2d005c921a4b666055a0d1b6492463799f32aae22", size = 32377, upload-time = "2026-07-06T10:46:26.86Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/2ca45fd7f671de5f81fc297ef1c95080b40c86ec6be0cc6034b8f7707ac8/xxhash-3.8.1-cp313-cp313t-win_amd64.whl", hash = "sha256:37d5a56c36dcc0b9a87b814cd992598d33863ff683749de6c86081f278d5e629", size = 33274, upload-time = "2026-07-06T10:46:28.39Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/54/20d7163463ddb6438b73a427d1655a77a502cf9b9b0c3ada3599629d9c0a/xxhash-3.8.1-cp313-cp313t-win_arm64.whl", hash = "sha256:6696c8752aded28ff3b16f33ef28ce28fb5d209b80c206746f943199fcf5fd65", size = 29375, upload-time = "2026-07-06T10:46:29.962Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/df2ba04f22a6cd6b39f96a6577329a8471a55c90ef8d8e2f7c102363613f/xxhash-3.8.1-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:9db455cb649dcfe4504d6d68a6d83a7315a99a3ca59871dc3ff840671f99adba", size = 38430, upload-time = "2026-07-06T10:46:31.496Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/4f/6a059e8ad3ca8deedc91dfe335b211204900895152212c03ebbe721de68b/xxhash-3.8.1-cp314-cp314-android_24_x86_64.whl", hash = "sha256:affb37f152e55b5e4494bb9d0107f7bb08515c6704fbed82d9f61214d74adc17", size = 36558, upload-time = "2026-07-06T10:46:33.078Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/95/40be178205acce092ae418feb20ac737b32a02c7b864926ed0717354c9f8/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:460261045936975193bfd20549a0de1cd52a33b405cbb972f0d80940c42266cd", size = 31181, upload-time = "2026-07-06T10:46:34.793Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/89/2da4dbf051bafa156c0e3f12012db2b0ac3b84ff37ca1f021f6bfffcdfbb/xxhash-3.8.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:38c887aedb696ef8bca19983206d270848558cfae4a91afa6a2fb05dde58ffc5", size = 32192, upload-time = "2026-07-06T10:46:36.393Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/4e/e000bbae3566bc8e0be771a8a0f294aa99075e3f0bc4ef43922ebffdebc8/xxhash-3.8.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:594131ce1aad18db3689781f806db1b065cdaa04f4df36b4c038d2013aefd0bf", size = 34691, upload-time = "2026-07-06T10:46:38.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4a/ea954aacc7d1c8711880ac2b55da94429a9b4296b151c4fc0966549ca1ee/xxhash-3.8.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:78c794b643d214f1522e7a288bcf5a2de120d26cd170516749a4009dc92722c9", size = 34807, upload-time = "2026-07-06T10:46:39.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/29/df598e738ff37558ac627264deb2e560902d9bf7f46d3bd5175c9eee593e/xxhash-3.8.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:af0c9fedc4a2c24e8664953882fe8185f3790b8338c9c700f76f5ad660817711", size = 32410, upload-time = "2026-07-06T10:46:41.359Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/81ab40e7d33ada0b3df5d1bc884894d15dbf4f805cd645b685e4606bb8e0/xxhash-3.8.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:115772daeb71b2f3b9381177017f53e6cf3f3439c840737fdabd21aba6e54920", size = 220564, upload-time = "2026-07-06T10:46:43.463Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6f/62ae6f5c8606320a0e2a41c2dc8c6d91cc5d63d0f84dd9582e9543779dd8/xxhash-3.8.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:000435984a0469b0f822fe76f35bddea0f96a4d6521b3339a60a6428cdee1edc", size = 241462, upload-time = "2026-07-06T10:46:45.509Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a1/9c3a0ec6cb524396f551eddd102a76690a795494eb9784fc67542b0daa37/xxhash-3.8.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2f1c68394818e0595569c2ff3cbc1e6d5a36a434e796f5c526b987b80c8a8c62", size = 264491, upload-time = "2026-07-06T10:46:47.655Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/700a4674e4308eb59d2fdb973977e82eae231bea5044753fee5c9eec0e0c/xxhash-3.8.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:46b39976d008e2a845758650f0ff7136bca004f40da0c8798bd37ac37860154f", size = 242905, upload-time = "2026-07-06T10:46:49.857Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8a/72d9874375c8d4cbc64a8cd1d659d5695a8765c3db82efa82dc5bd9f14d0/xxhash-3.8.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d5006c65ec507a333479e76e00e2c368781f16c24ededa764763956b32a0e93e", size = 473873, upload-time = "2026-07-06T10:46:51.953Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f0/6db07590ed7e0a77f186ef0bcea8d52553bf1ba57833e09467a2411f0f2d/xxhash-3.8.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31a2649bcf1fe97cf11c79848d761df33ac46b3896942d31b640557b486ff6b", size = 220765, upload-time = "2026-07-06T10:46:55.41Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/10/00d12d8b8beabbf49a8bbc626fb9f40445145a8887eb41a6acfb69149ac4/xxhash-3.8.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8f759eed402448c2bdbb492e4fba1f20668ffe29688605ea61f0f67f9e4e386d", size = 310478, upload-time = "2026-07-06T10:46:57.729Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f9/12a82394eefb0f185d15a7f7b9f627c61c475a72dd83718436a5b84b42ac/xxhash-3.8.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7b5f97ecfede10d5b2870383620e2d25c8561e217c7bf9081073802b54248d2b", size = 238393, upload-time = "2026-07-06T10:46:59.87Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f3/53f963e320b9ce678337aa7273f39ce692ded8b99e3d22a866ec722159ab/xxhash-3.8.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1da930bbcac3e8fbe2191850e2abb57977a99348c12c4b385e1058ac1b0a9ecc", size = 268704, upload-time = "2026-07-06T10:47:01.806Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/50/5b5badbd87c82d9f9b5f58ac74a3f29ef08f6fc387b324b8fd482450b862/xxhash-3.8.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:747476436f6891b9773374ce8d48edcc8b12cb5b61b67c6fb6289633747d088f", size = 225015, upload-time = "2026-07-06T10:47:03.784Z" },
+    { url = "https://files.pythonhosted.org/packages/30/93/3ca68265afe7b4e69435e08a7b6a1d9d0f2a071e889da1f8041ed00fe878/xxhash-3.8.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:4ef09bbc2519a93cd0f95f2ceb5f7b85919dffea643278e02362bf40e3c4bed1", size = 240951, upload-time = "2026-07-06T10:47:05.816Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/27e19670c40f46b5e76e11f2f4713d21054804568425d870670e757172ad/xxhash-3.8.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a5eed9d41995a83f3332b4e3396abb7f433cac584222bd7e305b606d8353861e", size = 300751, upload-time = "2026-07-06T10:47:07.95Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/fb/b33e27689959fe7ed2ae0b830af41560d65213943983afa9db3a8d481bce/xxhash-3.8.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:53f3ed9118397074ff63a79b66b7fec1c84c782eecde35c5bc94e420a971c231", size = 443480, upload-time = "2026-07-06T10:47:10Z" },
+    { url = "https://files.pythonhosted.org/packages/26/60/0e0d973be5fe280753ef02fbc89349492ad6e903bf1dcb870b668f94b662/xxhash-3.8.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d247b34bf433c92b41689318fd25d246313cab2275a6a47e2efac178b80d6efe", size = 217657, upload-time = "2026-07-06T10:47:12.196Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/68/c9e3ecef4a9a417d464cb5bd200aa12f73192dee677901b9e08e0ad0d1bb/xxhash-3.8.1-cp314-cp314-win32.whl", hash = "sha256:d58ce8b6cfa9c4d2f230557f69caf7c06369e318015d0b19485095bc2c5963ab", size = 32690, upload-time = "2026-07-06T10:47:14.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/99/e9e44588c0b62837bbec5ba7927816de0afa03406b1a0b6c7a7e1d1a30a0/xxhash-3.8.1-cp314-cp314-win_amd64.whl", hash = "sha256:6cee733fe4ccb1737e0997135283c82341e5cfa9cf214b165f9087fb663aaf4f", size = 33460, upload-time = "2026-07-06T10:47:16.021Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2b/64f36d86380b3657ad9031967ab814f3ef31307174650853f69c18932ebc/xxhash-3.8.1-cp314-cp314-win_arm64.whl", hash = "sha256:58346024d47e84f7d8b3e7f5d6faa1d58acbbe49a8771497872059f58c1d8ea5", size = 30092, upload-time = "2026-07-06T10:47:17.81Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cb/18b64bff88c58a0ca209dc533e63cf02d7ae5aa6b1b9a9fd14e81b5dbd60/xxhash-3.8.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:01cab782f8a0a05ecad2c63d7ef10f7ab475f660e0d6419d069418c14d88de7c", size = 35024, upload-time = "2026-07-06T10:47:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1d/72d8a70520e5dcddb472ea0486d299da3240745a10658290cd7b5690ede2/xxhash-3.8.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:717b12fdc51819833704e85e6926d76981ffa3f780ef92e33ebb8b26d46bb230", size = 32697, upload-time = "2026-07-06T10:47:21.649Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b8/e041f555903c56db3d0a731b3d72a6575d75e0ed868b1bd2e5176111ca44/xxhash-3.8.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ec55d80e9b8a519d742669e0b49e8ce9e6747be42bf3c138158b6543a9c8e489", size = 226044, upload-time = "2026-07-06T10:47:23.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7e/5cdcf06bf6ec4b5d2ac073feb23432ec1d603fd438864cbd2c09c7cb45e1/xxhash-3.8.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98d8ac1129b4dd39098cffed94d1284aceb61c3aa396757ccc736ac392e4cee5", size = 249899, upload-time = "2026-07-06T10:47:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c0/eb7e059cb5e1dba11fd30d2fdf882f56e5a417a3eaa43669d43623767f45/xxhash-3.8.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3bc0fa90830df1e1277f33cc6e55de9990b83c0319fd8c7412866cfde38b025e", size = 274892, upload-time = "2026-07-06T10:47:27.931Z" },
+    { url = "https://files.pythonhosted.org/packages/66/74/a600aaf7cd39957fd1510adeedb1749c1e7eb82bd632a1153d9c664c3135/xxhash-3.8.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c73b6f652f0745425aa6378319c331293b5341756262e9408ed3d45f183375e6", size = 252243, upload-time = "2026-07-06T10:47:30.288Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/04/78d88fa75a6763e5d09bf1b947a392a27988903381b219006f92f3c68fc8/xxhash-3.8.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f6114692261eff4266386cdec0f7d87eee24e317ab397c218b7ae6a76b4c6339", size = 482191, upload-time = "2026-07-06T10:47:32.45Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/06/07a8aea1108d682de8791ce608cdf367d75ff4e7e57cd3c154bdc6f47b23/xxhash-3.8.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df57c0b161ec1b3ed0526a67b0db0914b557e86ee8aae51887aec941b261542", size = 226877, upload-time = "2026-07-06T10:47:34.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b5/86bade5618a524d2c06c4041aa2fe8e5749ce16e88afba60d67c1684a21f/xxhash-3.8.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9043877a917be88ccf230aa5667c1bd059bce80f4c2727e4defa1b29b7f48b08", size = 319794, upload-time = "2026-07-06T10:47:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/23/69/9b1a2b89b1621bb740fbcb7beb512f60f99480c1bdc680c0c90e1f56ff75/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:559e3cabe522231909f9de98ef06929edbd53782046bd21aae0c72db6f2a0775", size = 246202, upload-time = "2026-07-06T10:47:39.676Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ea/662ed6cb49f1d34078b6a3a3e0f3d29ff93fd7b5a03c0bc9ecfd9b2159c3/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:264710bd335016f303763ce1275c6486df30bb57c2245c91b224c983d7ac39b8", size = 275628, upload-time = "2026-07-06T10:47:41.99Z" },
+    { url = "https://files.pythonhosted.org/packages/13/f5/49fc9e4c6728a5a3bd8fe639199d2fa67609b3a84f938aff6e8568dd3e4f/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:e14800b9b10bb39d7a60ad4a310e403164d7b8988a27ae933d4e40618a44088e", size = 231390, upload-time = "2026-07-06T10:47:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/64/9d/3acaf8f599c0e0b30e910a3a11ba32929da53c86dc73c7c55fe6a010b4e9/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:ea6a3e734b0fd41b82784a400be946821900daebe610c050a5e0760838a34f99", size = 250600, upload-time = "2026-07-06T10:47:47.611Z" },
+    { url = "https://files.pythonhosted.org/packages/23/64/8acab4c5ec60dbe664b5b9858fd44c2413b07e535b09556a0a5022e78aa6/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:cf399fac542a1c7a4734a435b93df2c55e858c7d31abf6c1bdf46f9ae67fbfd0", size = 310032, upload-time = "2026-07-06T10:47:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/56/47/a0288d7329b1fe63e2734a32d19d444a96ae2b4810f545bc61e561224917/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:44c89d915a75c11d2547eaee9098fcd80398987c4bff2974a0497a925bf92c07", size = 448882, upload-time = "2026-07-06T10:47:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e7/3071dfd3beb5c38204ce1cf56bf7749fce08de900fa92714b81d1d8ca1f2/xxhash-3.8.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:358650d5bda9c635da699c53adf4e8134af492ecc79c960f917eebf088bb6799", size = 223728, upload-time = "2026-07-06T10:47:55.093Z" },
+    { url = "https://files.pythonhosted.org/packages/12/11/b99949f0ba2b07e9f9ffe83b9c86faa685f9080725dc21a916a607313be5/xxhash-3.8.1-cp314-cp314t-win32.whl", hash = "sha256:c240939e963653054fc7e4a17c382829cda4aa88a7daf0af841715dbded1b497", size = 33150, upload-time = "2026-07-06T10:47:57.274Z" },
+    { url = "https://files.pythonhosted.org/packages/54/1c/09703eb341f8416e74e58d6c6732d4b5c46de59c942363203cb237cc95b0/xxhash-3.8.1-cp314-cp314t-win_amd64.whl", hash = "sha256:7258ee276e8772599bc19e14b36f6260306e21b637190cd7cb489a2449d48684", size = 34005, upload-time = "2026-07-06T10:47:59.434Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f9/6ed7251bb6a8af10ac73b1821c60583d2826e5b2064e45a979c935287c98/xxhash-3.8.1-cp314-cp314t-win_arm64.whl", hash = "sha256:8f454166c2ffed45636c8d501741e649851ba2f346c4eb73a64c07ac00428f20", size = 30239, upload-time = "2026-07-06T10:48:01.874Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
+]


### PR DESCRIPTION
Adds the deerflow-governance plugin with approval guardrails, audit ledger, budget breaker middleware, CLI, docs, and offline tests. Verified with 47 unit tests, governance validate, simulate, and demo_flow.py.