### PR TITLE
fix(frontend): stop matching <header> as <head> in HTML preview base injection

### DIFF
--- a/frontend/src/core/artifacts/preview.ts
+++ b/frontend/src/core/artifacts/preview.ts
@@ -175,8 +175,14 @@ export function appendHtmlPreviewBaseHref(
 
   const baseHref = htmlBaseHref(url, currentHref);
   const baseElement = `<base href="${escapeHtmlAttribute(baseHref)}">`;
-  if (/<head[^>]*>/i.exec(content)) {
-    return content.replace(/<head([^>]*)>/i, `<head$1>${baseElement}`);
+  // "(?:\s[^>]*)?" keeps the tag-name boundary so `<header>` (a common
+  // leading tag in agent-generated fragments) is not mistaken for `<head>`;
+  // mirrors appendHtmlPreviewScrollRestoration below.
+  if (/<head(?:\s[^>]*)?>/i.test(content)) {
+    return content.replace(
+      /<head(?:\s[^>]*)?>/i,
+      (headTag) => `${headTag}${baseElement}`,
+    );
   }
   return `${baseElement}${content}`;
 }

--- a/frontend/tests/unit/core/artifacts/preview.test.ts
+++ b/frontend/tests/unit/core/artifacts/preview.test.ts
@@ -282,6 +282,39 @@ test("preserves existing head elements when injecting scroll restoration", () =>
   );
 });
 
+test("does not mistake <header> for <head> when injecting the base href", () => {
+  // Agent-generated fragments often have no <head> but open with <header>;
+  // the base must then be prepended so assets before the tag resolve too.
+  const html =
+    '<img src="logo.png"><header class="top">Report</header><main>content</main>';
+
+  const result = appendHtmlPreviewBaseHref(
+    html,
+    "/demo/threads/thread-1/user-data/outputs/report.html",
+    "http://localhost/workspace/chats/thread-1",
+  );
+
+  expect(result).toBe(
+    '<base href="http://localhost/demo/threads/thread-1/user-data/outputs/">' +
+      html,
+  );
+});
+
+test("injects the base href inside an attributed <head> tag", () => {
+  const html =
+    '<!doctype html><html><head lang="en"><meta charset="utf-8"></head><body>x</body></html>';
+
+  const result = appendHtmlPreviewBaseHref(
+    html,
+    "/demo/threads/thread-1/user-data/outputs/report.html",
+    "http://localhost/workspace/chats/thread-1",
+  );
+
+  expect(result).toContain(
+    '<head lang="en"><base href="http://localhost/demo/threads/thread-1/user-data/outputs/">',
+  );
+});
+
 test("does not duplicate HTML scroll restoration script", () => {
   const html = appendHtmlPreviewScrollRestoration(
     "<html><body>x</body></html>",


### PR DESCRIPTION
## Why

`appendHtmlPreviewBaseHref` detects the head tag with `/<head[^>]*>/i`, which also matches `<header ...>`. Agent-generated report fragments often have no `<head>` but open with `<header>`; for those, the `<base>` element is injected after the `<header>` opening tag instead of being prepended to the fragment, so relative assets appearing before that point (e.g. a leading `<img src="logo.png">`) resolve without the base and fail to load in the sandboxed preview iframe.

The sibling injector `appendHtmlPreviewScrollRestoration` already uses the word-boundary-safe pattern `/<head(?:\s[^>]*)?>/i` — this one is the leftover older regex.

## What changed

- HTML artifact previews of fragments that contain `<header>` (or other `head*`-prefixed tags) but no `<head>` now load their relative assets correctly: the base href is prepended instead of being buried after the `<header>` tag.
- Both head-injection helpers now share the same tag-detection pattern.

## Surface area

- [x] **Frontend UI** — HTML artifact preview iframe asset resolution
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

No visual chrome change — previously-broken relative images/stylesheets in affected previews now load; covered by the unit tests below.

## Bug fix verification

- Test path: `frontend/tests/unit/core/artifacts/preview.test.ts` — "does not mistake <header> for <head> when injecting the base href" (plus a companion test pinning attributed `<head lang="en">` injection)
- Red on `main`, green on this branch: **yes**

## Validation

```
cd frontend
pnpm rstest run tests/unit/core/artifacts/preview.test.ts  # 14/14 pass
pnpm exec eslint / prettier --check  # clean on changed files
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI located the bug during a codebase audit, wrote the fix and tests; I reviewed the change and verified the red/green test runs locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
