### PR TITLE
fix: normalize invalid reasoning_effort "minimal" to "low" (#4514)

### DIFF
--- a/backend/packages/harness/deerflow/models/factory.py
+++ b/backend/packages/harness/deerflow/models/factory.py
@@ -258,7 +258,7 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
                 model_settings_from_config.get("extra_body"),
                 {"thinking": {"type": "disabled"}},
             )
-            model_settings_from_config["reasoning_effort"] = "minimal"
+            model_settings_from_config["reasoning_effort"] = "low"
         elif has_thinking_settings and (disable_chat_template_kwargs := _vllm_disable_chat_template_kwargs(effective_wte.get("extra_body", {}).get("chat_template_kwargs") or {})):
             # vLLM uses chat template kwargs to switch thinking on/off.
             model_settings_from_config["extra_body"] = _deep_merge_dicts(
@@ -271,6 +271,19 @@ def create_chat_model(name: str | None = None, thinking_enabled: bool = False, *
     if not model_config.supports_reasoning_effort:
         kwargs.pop("reasoning_effort", None)
         model_settings_from_config.pop("reasoning_effort", None)
+
+    # Normalize known-but-invalid reasoning_effort values to their closest valid
+    # equivalent. "minimal" is sent by the frontend for flash ("闪速") mode and was
+    # previously also hardcoded in the thinking-disabled path above, but it is not a
+    # valid OpenAI-compatible value (the API expects one of low/medium/high/xhigh/max)
+    # and reaches the constructor via the kwargs path, which bypasses AgentConfig's
+    # Literal["low", "medium", "high"] type check. Map it to "low" for both the runtime
+    # kwargs and the config-derived settings so it never reaches the LLM client (#4514).
+    _REASONING_EFFORT_NORMALIZE: dict[str, str] = {"minimal": "low"}
+    if (re := kwargs.get("reasoning_effort")) and re in _REASONING_EFFORT_NORMALIZE:
+        kwargs["reasoning_effort"] = _REASONING_EFFORT_NORMALIZE[re]
+    if (re := model_settings_from_config.get("reasoning_effort")) and re in _REASONING_EFFORT_NORMALIZE:
+        model_settings_from_config["reasoning_effort"] = _REASONING_EFFORT_NORMALIZE[re]
 
     # Normalize the api_base -> base_url alias FIRST, so the downstream OpenAI-compatible
     # heuristics (stream_usage default below / stream_chunk_timeout) see the canonical endpoint key.

--- a/backend/tests/test_model_factory.py
+++ b/backend/tests/test_model_factory.py
@@ -211,7 +211,7 @@ def test_thinking_enabled_merges_when_thinking_enabled_settings(monkeypatch):
 
 def test_thinking_disabled_openai_gateway_format(monkeypatch):
     """When thinking is configured via extra_body (OpenAI-compatible gateway),
-    disabling must inject extra_body.thinking.type=disabled and reasoning_effort=minimal."""
+    disabling must inject extra_body.thinking.type=disabled and reasoning_effort=low."""
     wte = {"extra_body": {"thinking": {"type": "enabled", "budget_tokens": 10000}}}
     cfg = _make_app_config(
         [
@@ -237,8 +237,69 @@ def test_thinking_disabled_openai_gateway_format(monkeypatch):
     factory_module.create_chat_model(name="openai-gw", thinking_enabled=False)
 
     assert captured.get("extra_body") == {"thinking": {"type": "disabled"}}
-    assert captured.get("reasoning_effort") == "minimal"
+    assert captured.get("reasoning_effort") == "low"
     assert "thinking" not in captured  # must NOT set the direct thinking param
+
+
+def test_thinking_disabled_openai_gateway_never_emits_minimal(monkeypatch):
+    """Regression for #4514: the OpenAI-compatible gateway thinking-disabled path
+    must never emit reasoning_effort="minimal". "minimal" is not a valid
+    OpenAI-compatible value (the API expects one of low/medium/high/xhigh/max) and
+    returns 400. The disable path used to hardcode "minimal"; it now emits "low"."""
+    wte = {"extra_body": {"thinking": {"type": "enabled", "budget_tokens": 10000}}}
+    cfg = _make_app_config(
+        [
+            _make_model(
+                "openai-gw",
+                supports_thinking=True,
+                supports_reasoning_effort=True,
+                when_thinking_enabled=wte,
+            )
+        ]
+    )
+    _patch_factory(monkeypatch, cfg)
+
+    captured: dict = {}
+
+    class CapturingModel(FakeChatModel):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            BaseChatModel.__init__(self, **kwargs)
+
+    monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
+
+    factory_module.create_chat_model(name="openai-gw", thinking_enabled=False)
+
+    assert captured.get("reasoning_effort") != "minimal"
+
+
+def test_runtime_reasoning_effort_minimal_kwarg_normalized_to_low(monkeypatch):
+    """Regression for #4514: a runtime reasoning_effort="minimal" kwarg (sent by the
+    frontend for flash / "闪速" mode) reaches the constructor via the **kwargs path,
+    which bypasses AgentConfig's Literal["low", "medium", "high"] check. The factory
+    must normalize it to "low" so the invalid value never reaches the LLM client."""
+    cfg = _make_app_config(
+        [
+            _make_model(
+                "flash-model",
+                supports_reasoning_effort=True,
+            )
+        ]
+    )
+    _patch_factory(monkeypatch, cfg)
+
+    captured: dict = {}
+
+    class CapturingModel(FakeChatModel):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            BaseChatModel.__init__(self, **kwargs)
+
+    monkeypatch.setattr(factory_module, "resolve_class", lambda path, base: CapturingModel)
+
+    factory_module.create_chat_model(name="flash-model", reasoning_effort="minimal")
+
+    assert captured.get("reasoning_effort") == "low"
 
 
 def test_thinking_disabled_langchain_anthropic_format(monkeypatch):
@@ -332,7 +393,8 @@ def test_when_thinking_disabled_takes_precedence_over_hardcoded_disable(monkeypa
     factory_module.create_chat_model(name="custom-disable", thinking_enabled=False)
 
     assert captured.get("extra_body") == {"thinking": {"type": "disabled"}}
-    # User overrode the hardcoded "minimal" with "low"
+    # when_thinking_disabled explicitly sets reasoning_effort="low", overriding
+    # the hardcoded disable-path default (also "low" since #4514)
     assert captured.get("reasoning_effort") == "low"
 
 
@@ -476,8 +538,8 @@ def test_reasoning_effort_preserved_when_supported(monkeypatch):
     factory_module.create_chat_model(name="effort-model", thinking_enabled=False)
 
     # When supports_reasoning_effort=True, it should NOT be cleared to None
-    # The disable path sets it to "minimal"; supports_reasoning_effort=True keeps it
-    assert captured.get("reasoning_effort") == "minimal"
+    # The disable path sets it to "low"; supports_reasoning_effort=True keeps it
+    assert captured.get("reasoning_effort") == "low"
 
 
 # ---------------------------------------------------------------------------
@@ -1078,7 +1140,7 @@ def test_create_chat_model_resolves_patched_mimo_provider(model_id):
 
 def test_no_duplicate_kwarg_when_reasoning_effort_in_config_and_thinking_disabled(monkeypatch):
     """When reasoning_effort is set in config.yaml (extra field) AND the thinking-disabled
-    path also injects reasoning_effort=minimal into kwargs, the factory must not raise
+    path also injects reasoning_effort=low into kwargs, the factory must not raise
     TypeError: got multiple values for keyword argument 'reasoning_effort'."""
     wte = {"extra_body": {"thinking": {"type": "enabled", "budget_tokens": 5000}}}
     # ModelConfig.extra="allow" means extra fields from config.yaml land in model_dump()
@@ -1108,8 +1170,8 @@ def test_no_duplicate_kwarg_when_reasoning_effort_in_config_and_thinking_disable
     # Must not raise TypeError
     factory_module.create_chat_model(name="doubao-model", thinking_enabled=False)
 
-    # kwargs (runtime) takes precedence: thinking-disabled path sets reasoning_effort=minimal
-    assert captured.get("reasoning_effort") == "minimal"
+    # kwargs (runtime) takes precedence: thinking-disabled path sets reasoning_effort=low (#4514)
+    assert captured.get("reasoning_effort") == "low"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #4514

## Why

Flash（闪速）mode sends `reasoning_effort="minimal"` from the frontend, and the thinking-disabled OpenAI-gateway branch in `models/factory.py` also hardcoded `"minimal"`. But `"minimal"` is not a valid OpenAI-compatible value — the API expects one of `low/medium/high/xhigh/max`. It bypasses `AgentConfig`'s `Literal["low","medium","high"]` type check because it reaches the constructor via the runtime `kwargs` path rather than the config path, so it lands at the LLM client unvalidated and the gateway rejects the request with a 400. Users hitting flash mode against an OpenAI-compatible gateway can't get a response.

## What changed

- `create_chat_model()` now normalizes a known-but-invalid `reasoning_effort="minimal"` to `"low"` (the value @Void615 suggested as the default) for **both** the runtime `kwargs` and the config-derived model settings, so it never reaches the LLM client.
- The thinking-disabled OpenAI-gateway branch that previously hardcoded `reasoning_effort="minimal"` now sets `"low"` directly.
- No user-facing config or behavior change beyond flash mode now working instead of 400-ing; models that never sent `"minimal"` are unaffected.

## Surface area

- [x] **Agents / LangGraph** — model factory (`create_chat_model`) reasoning_effort handling
- [x] **Docs / tests / CI only** — adds regression tests

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_model_factory.py::test_thinking_disabled_openai_gateway_never_emits_minimal` and `::test_runtime_reasoning_effort_minimal_kwarg_normalized_to_low`
- Did it go red on `main` and green on this branch? **yes** — on `main` the thinking-disabled path emits `"minimal"` and the runtime kwarg passes through unchanged, so both asserts fail; with the fix both pass.

## Validation

```
cd backend && make format   # ruff format --check: already formatted
cd backend && make lint     # All checks passed!
cd backend && PYTHONPATH=. uv run pytest tests/test_model_factory.py -q   # 84 passed
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI traced the root cause from the issue's stack trace through `models/factory.py`, drafted the normalization fix and the two regression tests, and I reviewed the diff, confirmed the invalid-vs-valid `reasoning_effort` value set against the gateway contract, and ran the format/lint/test gates locally before pushing.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.