### PR TITLE
fix(artifacts): scope full previews to their thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,7 @@ This section accumulates work toward the **2.1.0** milestone
 
 ### Fixed
 
+- **artifacts:** Keep explicit full-file loading scoped to the source thread, so a same-path artifact in another conversation keeps its 1 MiB preview.
 - **sandbox:** `SandboxAuditMiddleware` no longer blocks ordinary command
   substitution that only captures output. The rule now judges *position* instead
   of matching any `$(`: `x=$(curl url)`, `echo $(curl url)`, an argument, and a

--- a/frontend/src/core/artifacts/hooks.ts
+++ b/frontend/src/core/artifacts/hooks.ts
@@ -18,8 +18,13 @@ export function useArtifactContent({
     return filepath.startsWith("write-file:");
   }, [filepath]);
   const { thread, isMock } = useThread();
-  const [fullFilepath, setFullFilepath] = useState<string | null>(null);
-  const fullContentRequested = fullFilepath === filepath;
+  const [fullContentSelection, setFullContentSelection] = useState<{
+    filepath: string;
+    threadId: string;
+  } | null>(null);
+  const fullContentRequested =
+    fullContentSelection?.filepath === filepath &&
+    fullContentSelection.threadId === threadId;
   const content = useMemo(() => {
     if (isWriteFile) {
       return loadArtifactContentFromToolCall({ url: filepath, thread });
@@ -54,8 +59,8 @@ export function useArtifactContent({
   }, [enabled, isWriteFile, refetch, thread.isLoading]);
 
   const loadFullContent = useCallback(() => {
-    setFullFilepath(filepath);
-  }, [filepath]);
+    setFullContentSelection({ filepath, threadId });
+  }, [filepath, threadId]);
 
   return {
     content: isWriteFile ? content : data?.content,

--- a/frontend/tests/unit/core/artifacts/hooks.dom.test.tsx
+++ b/frontend/tests/unit/core/artifacts/hooks.dom.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, rs } from "@rstest/core";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+
+rs.mock("@/components/workspace/messages/context", () => ({
+  useThread: rs.fn(),
+}));
+
+rs.mock("@/core/artifacts/loader", () => ({
+  loadArtifactContent: rs.fn(),
+  loadArtifactContentFromToolCall: rs.fn(),
+}));
+
+import { useThread } from "@/components/workspace/messages/context";
+import { useArtifactContent } from "@/core/artifacts/hooks";
+import { loadArtifactContent } from "@/core/artifacts/loader";
+
+const mockedUseThread = rs.mocked(useThread);
+const mockedLoadArtifactContent = rs.mocked(loadArtifactContent);
+const filepath = "/mnt/user-data/outputs/report.md";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function QueryWrapper({ children }: PropsWithChildren) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useArtifactContent", () => {
+  beforeEach(() => {
+    mockedUseThread.mockReturnValue({
+      thread: { isLoading: false, messages: [] },
+      isMock: false,
+    } as never);
+    mockedLoadArtifactContent.mockImplementation(async ({ full }) => ({
+      content: full ? "complete report" : "preview",
+      url: filepath,
+      sha256: undefined,
+      truncated: !full,
+      previewBytes: full ? 15 : 7,
+      totalBytes: 15,
+    }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    mockedUseThread.mockReset();
+    mockedLoadArtifactContent.mockReset();
+  });
+
+  it("keeps a full-content request scoped to its thread", async () => {
+    const { result, rerender } = renderHook(
+      ({ threadId }: { threadId: string }) =>
+        useArtifactContent({ filepath, threadId, enabled: true }),
+      {
+        initialProps: { threadId: "thread-a" },
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockedLoadArtifactContent).toHaveBeenLastCalledWith({
+        filepath,
+        threadId: "thread-a",
+        isMock: false,
+        full: false,
+      });
+    });
+
+    act(() => {
+      result.current.loadFullContent();
+    });
+
+    await waitFor(() => {
+      expect(mockedLoadArtifactContent).toHaveBeenLastCalledWith({
+        filepath,
+        threadId: "thread-a",
+        isMock: false,
+        full: true,
+      });
+    });
+
+    rerender({ threadId: "thread-b" });
+
+    await waitFor(() => {
+      expect(mockedLoadArtifactContent).toHaveBeenLastCalledWith({
+        filepath,
+        threadId: "thread-b",
+        isMock: false,
+        full: false,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why

Selecting "load full file" for an artifact was remembered by filepath alone. If a user then switched to another conversation with an artifact at the same path, the second conversation requested the full file instead of the bounded preview.

## What changed

Full-file selection now includes the source thread. A same-path artifact in another conversation starts with the normal 1 MiB preview until its user explicitly asks to load the entire file.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable: this changes an artifact request's range behavior without changing rendered UI.

## Bug fix verification

- Test path that reproduces the bug: `frontend/tests/unit/core/artifacts/hooks.dom.test.tsx`
- Did it go red on `main` and green on this branch? yes

## Validation

- `pnpm exec prettier --check src/core/artifacts/hooks.ts tests/unit/core/artifacts/hooks.dom.test.tsx`
- `pnpm check`
- `pnpm test` (970 passed)
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build`
- `pnpm test:e2e` (passed after installing the repository's required Playwright Chromium browser)

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Traced the artifact loader and hook lifecycle, wrote the focused regression test and fix, then ran the listed validation.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
