### PR TITLE
fix(frontend): sort chats page by pinned state

### DIFF
--- a/frontend/src/core/threads/thread-list-model.ts
+++ b/frontend/src/core/threads/thread-list-model.ts
@@ -34,7 +34,7 @@ export function buildThreadListModel(
     .slice(0, MAX_VISIBLE_THREADS);
   const model: ThreadListModel = {
     byId,
-    threads,
+    threads: sortedThreads,
     displayedThreads: [...pinnedThreads, ...recentThreads],
     canLoadMore: recentThreads.length < MAX_VISIBLE_THREADS,
   };

--- a/frontend/tests/unit/core/threads/thread-list-model.test.ts
+++ b/frontend/tests/unit/core/threads/thread-list-model.test.ts
@@ -22,6 +22,16 @@ function pinnedThread(id: string, updatedAt: string): AgentThread {
 }
 
 describe("thread list model", () => {
+  it("sorts the full thread list with pinned threads first", () => {
+    const unpinned = thread("unpinned", "2026-01-02T00:00:00.000Z");
+    const pinned = pinnedThread("pinned", "2026-01-01T00:00:00.000Z");
+
+    const model = buildThreadListModel([[unpinned, pinned]]);
+
+    expect(model.threads).toEqual([pinned, unpinned]);
+    expect(model.displayedThreads).toEqual([pinned, unpinned]);
+  });
+
   it("deduplicates once while only bounding recent sidebar rows", () => {
     const pages = Array.from({ length: 5 }, (_, page) =>
       Array.from({ length: 50 }, (_, index) => {


### PR DESCRIPTION
## Why
The chats page model could keep `threads` in the original paged order while `displayedThreads` already used pinned-first ordering. Consumers of the full list could therefore render pinned chats below unpinned chats.

## How
Use the pinned-aware sorted list as the canonical `threads` value, while keeping the existing bounded `displayedThreads` behavior. Add unit coverage for both outputs.

## Verification
- `source ~/.nvm/nvm.sh && nvm use 22.21.1 >/dev/null && python3 ../scripts/pnpm.py test -- tests/unit/core/threads/thread-list-model.test.ts`
- `source ~/.nvm/nvm.sh && nvm use 22.21.1 >/dev/null && python3 ../scripts/pnpm.py check`
