### PR TITLE
fix(tests): isolate custom agent API tests from the local config.yaml

### DIFF
--- a/backend/tests/test_custom_agent.py
+++ b/backend/tests/test_custom_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -513,6 +514,20 @@ class TestMemoryFilePath:
 # ===========================================================================
 
 
+# Model names the agents API tests may send in a create/update payload. The
+# router validates `model` against the app config, so the fixture pins a stub
+# config exposing exactly these instead of leaving the assertion at the mercy
+# of whatever `config.yaml` happens to sit in the repo root: CI has none (the
+# validation is skipped and the request passes), a real dev checkout does (an
+# unlisted model name yields 422 and the test fails).
+_KNOWN_TEST_MODELS = frozenset({"deepseek-v3"})
+
+
+def _stub_app_config():
+    """App config that knows only ``_KNOWN_TEST_MODELS``."""
+    return SimpleNamespace(get_model_config=lambda name: SimpleNamespace(name=name) if name in _KNOWN_TEST_MODELS else None)
+
+
 def _make_test_app(tmp_path: Path):
     """Create a FastAPI app with the agents router, patching paths to tmp_path."""
     from fastapi import FastAPI
@@ -532,7 +547,11 @@ def agent_client(tmp_path):
     paths_instance = _make_paths(tmp_path)
     previous_config = AgentsApiConfig(**get_agents_api_config().model_dump())
 
-    with patch("deerflow.config.agents_config.get_paths", return_value=paths_instance), patch.object(agents_router, "get_paths", return_value=paths_instance):
+    with (
+        patch("deerflow.config.agents_config.get_paths", return_value=paths_instance),
+        patch.object(agents_router, "get_paths", return_value=paths_instance),
+        patch.object(agents_router, "get_app_config", _stub_app_config),
+    ):
         set_agents_api_config(AgentsApiConfig(enabled=True))
         try:
             app = _make_test_app(tmp_path)


### PR DESCRIPTION
## Why

`backend/tests/test_custom_agent.py::TestAgentsAPI::test_create_agent_with_model_and_tool_groups`
passes in CI but fails on any developer machine that has a real `config.yaml` in
the repo root — i.e. on any checkout actually set up to run DeerFlow. It surfaced
while running `make test` on a normal dev setup right after `cp
config.example.yaml config.yaml`.

The test POSTs an agent with `"model": "deepseek-v3"`. The gateway validates the
model against the app config (`_validate_model_exists`,
`backend/app/gateway/routers/agents.py`), and that check is deliberately
best-effort: it is skipped when the app config *cannot be loaded at all*.

- CI: no `config.yaml` on disk → `get_app_config()` raises → validation skipped →
  201, test green.
- Dev machine: `config.yaml` loads fine, but `deepseek-v3` is not among its
  `models:` entries → 422, test red.

So the assertion silently depends on the absence of a config file. That makes
`make test` unreliable for contributors and hides the failure from CI, which is
the classic way a test stops meaning anything.

Production behavior is not the bug here and is left untouched: skipping model
validation when no config can be loaded is documented and intentional. The bug
is that the test never pinned the config it validates against.

## What changed

Tests only — no runtime behavior change.

The `agent_client` fixture in `backend/tests/test_custom_agent.py` now also
patches `get_app_config` in the agents router with a small stub that knows
exactly the model names the API tests use (`_KNOWN_TEST_MODELS = {"deepseek-v3"}`),
alongside the `get_paths` patching it already does for `tmp_path` isolation.

Result: the agents API tests exercise the *same* code path in both environments —
model validation actually runs, against a config the test owns — instead of
being skipped in CI and hitting the machine's real config elsewhere.

This follows the fixture's existing style (`patch.object(agents_router, ...)`)
and the pattern already used in `tests/test_update_agent_e2e_user_isolation.py`,
which stubs `get_app_config` with a `get_model_config` that only knows its own
fake model. The alternative repo pattern —
`monkeypatch.setenv("DEER_FLOW_CONFIG_PATH", tmp_config)` + `reset_app_config()`
(`tests/test_agent_storage_backend.py`, `tests/test_app_config_reload.py`) — is
the right tool when a test is *about* on-disk config resolution; here the config
is incidental to the endpoint under test, so the lighter in-module stub keeps
the fixture honest without loading a full `AppConfig` (and without perturbing the
`title_config` singleton that `tests/conftest.py` has to reset for exactly that
reason).

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path that reproduces the bug:
  `backend/tests/test_custom_agent.py::TestAgentsAPI::test_create_agent_with_model_and_tool_groups`
- Did it go red on `main` and green on this branch? **yes** — with the caveat
  that the red condition is environmental, not a new test: the failure needs a
  `config.yaml` present in the repo root (CI has none, so it is green there by
  accident). On `main`, with `config.yaml` present:

  ```
  E       assert 422 == 201
  E        +  where 422 = <Response [422 Unprocessable Entity]>.status_code
  tests/test_custom_agent.py:765: AssertionError
  1 failed, 65 passed, 1 warning in 1.48s
  ```

  Same command on `main` with the config made unresolvable
  (`DEER_FLOW_CONFIG_PATH=/nonexistent/nope.yaml`) passes — that is the proof
  the assertion was riding on the skip branch.

  On this branch it is green in **both** environments (see Validation).
- A brand-new failing test wasn't the right instrument: the existing test is
  already the reproduction; it just needed a deterministic config. Adding a
  second test would have duplicated it without pinning anything extra.

## Validation

`cd backend && make format && make lint` — clean:

```
uv run ruff check . --fix && uv run ruff format .
All checks passed!
1045 files left unchanged
```

Full backend suite, **with** a real `config.yaml` in the repo root (the case that
was red on `main`):

```
10750 passed, 69 skipped, 14 warnings in 197.02s (0:03:17)
```

Full backend suite, **without** `config.yaml` (CI-equivalent — the workflows
never create one):

```
10750 passed, 69 skipped, 14 warnings in 195.24s (0:03:15)
```

Targeted file, both environments: `66 passed` each.

Frontend untouched, so frontend checks were not run.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** The failure surfaced while setting up a dev environment for
DeerFlow with Claude Code; under my direction it traced the cause (the
`except -> skip` branch in `_validate_model_exists`), surveyed how the rest of
the suite isolates app config (`DEER_FLOW_CONFIG_PATH` + `reset_app_config` vs.
patching `get_app_config`), and wrote the fixture change. Both environment
scenarios were run and verified before submission. I take responsibility for
the change as submitted.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
