### PR TITLE
fix(frontend): keep inline-code <think> pairs in content and restore copy for reasoning-only turns

### DIFF
--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -431,8 +431,13 @@ export function getAssistantTurnCopyData(
       .reverse()
       .filter((message) => message.type === "ai")
       .map((message) => {
+        // extractContentFromMessage never returns null, so fall back to
+        // reasoning on empty text (same rule as getMessageCopyData) —
+        // otherwise a reasoning-only turn loses its copy button entirely.
         const content = extractContentFromMessage(message);
-        return content ?? extractReasoningContentFromMessage(message) ?? "";
+        return content.length > 0
+          ? content
+          : (extractReasoningContentFromMessage(message) ?? "");
       })
       .find((content) => content.length > 0) ?? null
   );
@@ -483,14 +488,23 @@ function splitInlineReasoning(content: string): InlineReasoningSplit {
   const reasoningParts: string[] = [];
 
   // First pass: strip every fully closed `<think>...</think>` pair and
-  // collect its body as reasoning.
-  let cleaned = content.replace(THINK_TAG_RE, (_, reasoning: string) => {
-    const normalized = reasoning.trim();
-    if (normalized) {
-      reasoningParts.push(normalized);
-    }
-    return "";
-  });
+  // collect its body as reasoning. A pair whose opener sits right after a
+  // backtick is the model talking about the tag literally inside markdown
+  // inline code (same guard as the streaming pass below) — leave it in the
+  // rendered content instead of hollowing out the code span.
+  let cleaned = content.replace(
+    THINK_TAG_RE,
+    (match: string, reasoning: string, offset: number) => {
+      if (content[offset - 1] === "`") {
+        return match;
+      }
+      const normalized = reasoning.trim();
+      if (normalized) {
+        reasoningParts.push(normalized);
+      }
+      return "";
+    },
+  );
 
   // Streaming-safe pass: a `<think>` opener whose `</think>` has not arrived
   // yet means the rest of the chunk is reasoning in flight. Route it into the

--- a/frontend/tests/unit/core/messages/utils.test.ts
+++ b/frontend/tests/unit/core/messages/utils.test.ts
@@ -456,6 +456,30 @@ describe("inline <think> tag splitting", () => {
     expect(hasReasoning(message)).toBe(false);
   });
 
+  test("a closed <think> pair inside markdown inline code stays in content", () => {
+    // The model talking about the tag literally, e.g. when explaining prompt
+    // engineering. Hollowing the code span out into the reasoning panel
+    // corrupts the visible answer.
+    const message = aiMessage(
+      "Wrap your reasoning in `<think>your reasoning</think>` before answering.",
+    );
+    expect(extractContentFromMessage(message)).toBe(
+      "Wrap your reasoning in `<think>your reasoning</think>` before answering.",
+    );
+    expect(extractReasoningContentFromMessage(message)).toBeNull();
+    expect(hasReasoning(message)).toBe(false);
+  });
+
+  test("a closed <think> pair outside code is still stripped when another sits in inline code", () => {
+    const message = aiMessage(
+      "<think>real reasoning</think>Use `<think>text</think>` markers.",
+    );
+    expect(extractContentFromMessage(message)).toBe(
+      "Use `<think>text</think>` markers.",
+    );
+    expect(extractReasoningContentFromMessage(message)).toBe("real reasoning");
+  });
+
   test("a backtick-prefixed <think> mid-stream is not split into reasoning", () => {
     // Simulates the moment the model has emitted the opening backtick and
     // `<think>` for a literal documentation reference, before the closing
@@ -686,6 +710,22 @@ test("hides assistant copy data while that turn is streaming", () => {
 
   expect(getAssistantTurnCopyData(messages)).toBe("Partial answer");
   expect(getAssistantTurnCopyData(messages, { isStreaming: true })).toBeNull();
+});
+
+test("falls back to reasoning for a reasoning-only assistant turn's copy data", () => {
+  // A turn can end with reasoning but no answer text (e.g. stopped during
+  // thinking). getMessageCopyData already copies the reasoning in that case;
+  // the turn-level copy button must not disappear instead.
+  const messages = [
+    {
+      id: "ai-1",
+      type: "ai",
+      content: "",
+      additional_kwargs: { reasoning_content: "the actual reasoning" },
+    },
+  ] as Message[];
+
+  expect(getAssistantTurnCopyData(messages)).toBe("the actual reasoning");
 });
 
 test("marks the latest assistant message as streaming", () => {


### PR DESCRIPTION
## Why

Two related defects in the reasoning extraction path of `core/messages/utils.ts`:

1. **Inline-code `<think>` pairs are hollowed out.** `splitInlineReasoning`'s first pass strips every closed `<think>...</think>` pair unconditionally. A message that discusses the tag literally in markdown inline code — e.g. ``Wrap your reasoning in `<think>your reasoning</think>` before answering.`` — renders as ``Wrap your reasoning in `` ` `` `` before answering.`` with the inner text shipped to the Reasoning panel. Any conversation about prompt engineering triggers this. The streaming (unclosed-opener) pass already guards backtick-adjacent openers as "literal tag talk"; the closed-pair pass lacked the same guard.

2. **Reasoning-only turns lose their copy button.** `getAssistantTurnCopyData` falls back to reasoning via `content ?? reasoning`, but `extractContentFromMessage` never returns null/undefined (empty text is `""`), so the fallback is dead code. A turn whose messages carry only reasoning (e.g. stopped mid-thinking) yields no copy data and the turn-level copy button disappears — inconsistent with `getMessageCopyData`, which does copy reasoning for the same message.

## What changed

- A closed `<think>...</think>` pair whose opener sits right after a backtick now stays in the rendered content (same rule the streaming pass already applies); pairs outside code are still stripped into the Reasoning panel.
- The turn-level copy button now falls back to reasoning when a turn has no answer text, matching the per-message copy behavior.

## Surface area

- [x] **Frontend UI** — message content/Reasoning panel rendering, turn copy button
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Pure text-extraction fixes; previously-corrupted code spans now render verbatim and the copy button appears for reasoning-only turns — covered by the unit tests below.

## Bug fix verification

- Test paths: `frontend/tests/unit/core/messages/utils.test.ts` — "a closed <think> pair inside markdown inline code stays in content", "a closed <think> pair outside code is still stripped when another sits in inline code", "falls back to reasoning for a reasoning-only assistant turn's copy data"
- Red on `main`, green on this branch: **yes** (3 failed on main, 55/55 pass here)

## Validation

```
cd frontend
pnpm rstest run              # full unit suite, 884/884 pass
pnpm typecheck               # clean
pnpm exec eslint / prettier --check  # clean on changed files
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI located the bugs during a codebase audit, wrote the fixes and tests; I reviewed the changes and verified the red/green test runs locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
