### PR TITLE
fix(runtime): recursively serialize nested payloads

### DIFF
--- a/backend/packages/harness/deerflow/runtime/serialization.py
+++ b/backend/packages/harness/deerflow/runtime/serialization.py
@@ -26,13 +26,13 @@ def serialize_lc_object(obj: Any) -> Any:
     # Pydantic v2
     if hasattr(obj, "model_dump"):
         try:
-            return obj.model_dump()
+            return serialize_lc_object(obj.model_dump())
         except Exception:
             pass
     # Pydantic v1 / older objects
     if hasattr(obj, "dict"):
         try:
-            return obj.dict()
+            return serialize_lc_object(obj.dict())
         except Exception:
             pass
     # Interrupt is a __slots__ class — no model_dump/dict/__dict__, so it
@@ -125,7 +125,7 @@ def serialize_messages_tuple(obj: Any) -> Any:
     """Serialize a messages-mode tuple ``(chunk, metadata)``."""
     if isinstance(obj, tuple) and len(obj) == 2:
         chunk, metadata = obj
-        return [serialize_lc_object(chunk), metadata if isinstance(metadata, dict) else {}]
+        return [serialize_lc_object(chunk), serialize_lc_object(metadata) if isinstance(metadata, dict) else {}]
     return serialize_lc_object(obj)
 
 

--- a/backend/tests/test_serialization.py
+++ b/backend/tests/test_serialization.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 
 class _FakePydanticV2:
     """Object with model_dump (Pydantic v2)."""
@@ -15,6 +17,16 @@ class _FakePydanticV1:
 
     def dict(self):
         return {"key": "v1"}
+
+
+class _FakeNestedPydanticV2:
+    def model_dump(self):
+        return {"nested": [_FakePydanticV1()]}
+
+
+class _FakeNestedPydanticV1:
+    def dict(self):
+        return {"nested": [_FakePydanticV2()]}
 
 
 class _Unprintable:
@@ -76,6 +88,18 @@ def test_serialize_pydantic_v1():
     assert serialize_lc_object(_FakePydanticV1()) == {"key": "v1"}
 
 
+def test_serialize_pydantic_exports_recursively():
+    from deerflow.runtime.serialization import serialize_lc_object
+
+    for value, expected in [
+        (_FakeNestedPydanticV2(), {"nested": [{"key": "v1"}]}),
+        (_FakeNestedPydanticV1(), {"nested": [{"key": "v2"}]}),
+    ]:
+        result = serialize_lc_object(value)
+        assert result == expected
+        assert json.loads(json.dumps(result)) == expected
+
+
 def test_serialize_fallback_str():
     from deerflow.runtime.serialization import serialize_lc_object
 
@@ -124,6 +148,26 @@ def test_serialize_messages_tuple():
     metadata = {"langgraph_node": "agent"}
     result = serialize_messages_tuple((chunk, metadata))
     assert result == [{"key": "v2"}, {"langgraph_node": "agent"}]
+
+
+def test_serialize_messages_tuple_metadata_recursively():
+    from deerflow.runtime.serialization import serialize_messages_tuple
+
+    result = serialize_messages_tuple(
+        (
+            _FakePydanticV2(),
+            {"langgraph_node": "agent", "nested": _FakeNestedPydanticV2()},
+        )
+    )
+
+    assert result == [
+        {"key": "v2"},
+        {
+            "langgraph_node": "agent",
+            "nested": {"nested": [{"key": "v1"}]},
+        },
+    ]
+    assert json.loads(json.dumps(result)) == result
 
 
 def test_serialize_messages_tuple_non_dict_metadata():


### PR DESCRIPTION
## Why

`deerflow.runtime.serialization` describes its output as recursively JSON-serializable, but two branches stopped one level too early:

- `model_dump()` / legacy `.dict()` results were returned without recursively serializing values nested inside the exported mapping.
- `messages-tuple` metadata dictionaries were passed through unchanged.

Objects such as nested LangChain/Pydantic values could therefore survive the canonical serializer and make the final JSON encoder raise `TypeError`. This affects SSE publishing and Gateway response paths that rely on this module as their serialization boundary.

## What changed

- Feed Pydantic v2 `model_dump()` and v1 `.dict()` results back through `serialize_lc_object()`.
- Apply the same recursive serialization to messages-mode metadata.
- Add regression tests that verify nested exported models and nested metadata both survive a real `json.dumps()` round trip.

The fallback ordering and wire shape are unchanged: messages mode still emits `[chunk, metadata]`, and non-dict metadata still becomes `{}`.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

Runtime code changes are limited to the internal canonical serializer; no API schema, event framing, or persisted format changes.

## Screenshots / Recording

Not applicable; this is an internal serialization fix.

## Bug fix verification

- Test path: `backend/tests/test_serialization.py`
- Before the fix, nested `model_dump()` values and messages metadata made `json.dumps()` raise `TypeError: Object of type ... is not JSON serializable`.
- After the fix, both payloads round-trip through `json.dumps()` and retain the existing plain-dict/list wire shape.

## Validation

- `cd backend && uv run pytest -q tests/test_serialization.py tests/test_interrupt_serialization.py tests/test_serialize_message_content.py`
  - 43 passed
- Expanded serializer consumers:
  - 274 passed across serialization, worker streaming/rollback, threads, runs, and paginated run-message tests
- `cd backend && uv run ruff check .`
- `cd backend && uv run ruff format --check .`
  - 1057 files already formatted
- Rechecked immediately before submission:
  - `backend/.venv/bin/pytest tests/test_serialization.py -q`: 28 passed
  - focused Ruff check and format check: passed

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited the canonical serialization boundary, reproduced the final JSON encoding failure, implemented the recursive conversion, and added/ran focused and consumer-level regression tests.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.