### PR TITLE
fix(frontend): guard malformed thread titles

### DIFF
--- a/frontend/src/components/workspace/thread-title.tsx
+++ b/frontend/src/components/workspace/thread-title.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 
 import { useI18n } from "@/core/i18n/hooks";
 import type { AgentThreadState } from "@/core/threads";
+import { titleOfThread } from "@/core/threads/utils";
 
 import { useThreadChat } from "./chats";
 import { FlipDisplay } from "./flip-display";
@@ -17,11 +18,12 @@ export function ThreadTitle({
 }) {
   const { t } = useI18n();
   const { isNewThread } = useThreadChat();
+  const title = titleOfThread(thread, "");
   useEffect(() => {
     let _title = t.pages.untitled;
 
-    if (thread.values?.title) {
-      _title = thread.values.title;
+    if (title) {
+      _title = title;
     } else if (isNewThread) {
       _title = t.pages.newChat;
     }
@@ -36,15 +38,11 @@ export function ThreadTitle({
     t.pages.untitled,
     t.pages.appName,
     thread.isThreadLoading,
-    thread.values,
+    title,
   ]);
 
-  if (!thread.values?.title) {
+  if (!title) {
     return null;
   }
-  return (
-    <FlipDisplay uniqueKey={threadId}>
-      {thread.values.title ?? "Untitled"}
-    </FlipDisplay>
-  );
+  return <FlipDisplay uniqueKey={threadId}>{title}</FlipDisplay>;
 }

--- a/frontend/src/core/threads/utils.ts
+++ b/frontend/src/core/threads/utils.ts
@@ -62,8 +62,12 @@ export function textOfMessage(message: Message) {
   return null;
 }
 
-export function titleOfThread(thread: AgentThread) {
-  return thread.values?.title ?? "Untitled";
+export function titleOfThread(
+  thread: { values?: { title?: unknown } | null },
+  fallback = "Untitled",
+): string {
+  const title = thread.values?.title;
+  return typeof title === "string" ? title : fallback;
 }
 
 export function isThreadPinned(thread: Pick<AgentThread, "metadata">) {

--- a/frontend/tests/unit/core/threads/utils.test.ts
+++ b/frontend/tests/unit/core/threads/utils.test.ts
@@ -9,6 +9,7 @@ import {
   sortPinnedThreads,
   textOfMessage,
   THREAD_PINNED_METADATA_KEY,
+  titleOfThread,
 } from "@/core/threads/utils";
 
 function makeThread(
@@ -182,4 +183,23 @@ test("textOfMessage returns null when array content has no text", () => {
   } as unknown as Message;
 
   expect(textOfMessage(message)).toBeNull();
+});
+
+test("titleOfThread returns string titles", () => {
+  expect(titleOfThread(makeThread("Conversation title"))).toBe(
+    "Conversation title",
+  );
+});
+
+test("titleOfThread falls back for missing or malformed titles", () => {
+  for (const title of [undefined, null, 42, { unexpected: true }, ["title"]]) {
+    const thread = {
+      values: title === undefined ? {} : { title },
+    };
+    expect(titleOfThread(thread)).toBe("Untitled");
+  }
+});
+
+test("titleOfThread supports a caller-provided fallback", () => {
+  expect(titleOfThread({ values: { title: false } }, "")).toBe("");
 });


### PR DESCRIPTION
## Why

Thread titles come from persisted runtime state, but the frontend currently trusts the TypeScript declaration and returns `thread.values.title` without a runtime check. A malformed or legacy payload such as an object then reaches several string-only consumers:

- the chats search page calls `.toLowerCase()`;
- Markdown/JSON export sanitizes the title with `.replace()`;
- the thread header renders the value as a React child.

Those paths respectively throw at search/export time or fail the page render. One malformed thread can therefore make the history page unusable even though the rest of the thread record is valid.

## What changed

- Treat the title at the shared `titleOfThread()` boundary as runtime `unknown`.
- Preserve valid string titles exactly, including the existing empty-string behavior.
- Fall back to a guaranteed string for missing or non-string values.
- Reuse the guarded helper in `ThreadTitle` so document-title and React-child rendering follow the same rule as lists, search, rename, share, and export.
- Add regression coverage for missing, null, numeric, object, array, and boolean title payloads.

The patch does not coerce objects with `String(...)`: doing so would expose `[object Object]` in the UI and filenames. It also does not change title generation or persisted thread state; this is a narrow consumer-side compatibility guard.

## Surface area

- [x] **Frontend UI** — thread list/search/header/export consumers
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

Valid thread titles are unchanged. Only malformed non-string runtime values now degrade to the existing untitled behavior instead of crashing a consumer.

## Screenshots / Recording

Not applicable. The regression is a runtime type boundary: valid titles render unchanged, while malformed values are intentionally replaced by the existing fallback.

## Bug fix verification

- Before: `titleOfThread()` can return `{ unexpected: true }`; chats search throws `title.toLowerCase is not a function`, export throws `name.replace is not a function`, and React rejects the object child.
- After: the same payload produces `"Untitled"` (or the caller-provided localized/empty fallback), and all string-only consumers remain valid.

## Validation

- Focused thread utility and export tests:
  - `pnpm exec rstest run tests/unit/core/threads/utils.test.ts tests/unit/core/threads/export.test.ts`
  - 2 files, 36 tests passed
- Full frontend unit suite:
  - `pnpm test run`
  - 125 files, 979 tests passed
- `pnpm exec eslint src/core/threads/utils.ts src/components/workspace/thread-title.tsx tests/unit/core/threads/utils.test.ts`
- `pnpm exec tsc --noEmit`
- Focused Prettier check and `git diff --check`

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited title consumers, reproduced the runtime type failures on the default branch, checked open PRs for overlapping work, implemented the shared guard, and ran the focused and full frontend validation suites.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.