### PR TITLE
fix(docker): set DEER_FLOW_ROOT for log commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,8 +106,8 @@ make up / down   # Build/stop the production Docker stack (browser at localhost:
 make docker-start / docker-stop / docker-logs   # Docker development environment
 ```
 
-Docker log commands resolve `DEER_FLOW_ROOT` from the current checkout before
-invoking Compose, matching the start and stop commands.
+Docker log and restart commands resolve `DEER_FLOW_ROOT` from the current
+checkout before invoking Compose, matching the start and stop commands.
 
 Run `make help` for the full list.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ make up / down   # Build/stop the production Docker stack (browser at localhost:
 make docker-start / docker-stop / docker-logs   # Docker development environment
 ```
 
+Docker log commands resolve `DEER_FLOW_ROOT` from the current checkout before
+invoking Compose, matching the start and stop commands.
+
 Run `make help` for the full list.
 
 **Per-module commands drive a single module** (run inside that module):

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Use the table below as a practical starting point when choosing how to run DeerF
 ```bash
 make docker-init    # Pull sandbox image (only once or when image updates)
 make docker-start   # Start services (auto-detects sandbox mode from config.yaml)
-make docker-logs    # View logs (resolves the repository root automatically)
+make docker-logs    # View logs (restart also resolves the repository root automatically)
 ```
 
 `make docker-start` starts `provisioner` only when `config.yaml` uses provisioner mode (`sandbox.use: deerflow.community.aio_sandbox:AioSandboxProvider` with `provisioner_url`).

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Use the table below as a practical starting point when choosing how to run DeerF
 ```bash
 make docker-init    # Pull sandbox image (only once or when image updates)
 make docker-start   # Start services (auto-detects sandbox mode from config.yaml)
-make docker-logs    # View logs (restart also resolves the repository root automatically)
+make docker-logs    # View logs
 ```
 
 `make docker-start` starts `provisioner` only when `config.yaml` uses provisioner mode (`sandbox.use: deerflow.community.aio_sandbox:AioSandboxProvider` with `provisioner_url`).

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Use the table below as a practical starting point when choosing how to run DeerF
 ```bash
 make docker-init    # Pull sandbox image (only once or when image updates)
 make docker-start   # Start services (auto-detects sandbox mode from config.yaml)
+make docker-logs    # View logs (resolves the repository root automatically)
 ```
 
 `make docker-start` starts `provisioner` only when `config.yaml` uses provisioner mode (`sandbox.use: deerflow.community.aio_sandbox:AioSandboxProvider` with `provisioner_url`).

--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -106,8 +106,9 @@ sandbox:
     assert _detect_mode_with_config(config) == "local"
 
 
-def test_logs_sets_deer_flow_root_before_compose():
-    """Log commands should resolve Compose mounts from the repository root."""
+@pytest.mark.parametrize("docker_command", ["logs --gateway", "restart"])
+def test_compose_commands_set_deer_flow_root_before_compose(docker_command):
+    """Log and restart commands should resolve mounts from the repository root."""
     with tempfile.TemporaryDirectory() as tmpdir:
         command = f"""
 source '{SCRIPT_PATH}'
@@ -116,6 +117,6 @@ DOCKER_DIR='{tmpdir}'
 COMPOSE_CMD=capture_compose
 capture_compose() {{ test "${{DEER_FLOW_ROOT:-}}" = "$PROJECT_ROOT"; }}
 unset DEER_FLOW_ROOT
-logs --gateway
+{docker_command}
 """
         subprocess.check_call([BASH_EXECUTABLE, "-lc", command])

--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -104,3 +104,18 @@ sandbox:
 """.strip()
 
     assert _detect_mode_with_config(config) == "local"
+
+
+def test_logs_sets_deer_flow_root_before_compose():
+    """Log commands should resolve Compose mounts from the repository root."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        command = f"""
+source '{SCRIPT_PATH}'
+PROJECT_ROOT='{tmpdir}'
+DOCKER_DIR='{tmpdir}'
+COMPOSE_CMD=capture_compose
+capture_compose() {{ test "${{DEER_FLOW_ROOT:-}}" = "$PROJECT_ROOT"; }}
+unset DEER_FLOW_ROOT
+logs --gateway
+"""
+        subprocess.check_call([BASH_EXECUTABLE, "-lc", command])

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -282,6 +282,12 @@ start() {
 # View Docker development logs
 logs() {
     local service=""
+
+    # DEER_FLOW_ROOT is referenced in docker-compose-dev.yaml; set it before
+    # reading logs so Compose does not resolve mounted paths from an empty root.
+    if [ -z "$DEER_FLOW_ROOT" ]; then
+        export DEER_FLOW_ROOT="$PROJECT_ROOT"
+    fi
     
     case "$1" in
         --frontend)

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -339,6 +339,11 @@ stop() {
 
 # Restart Docker development environment
 restart() {
+    # DEER_FLOW_ROOT is referenced in docker-compose-dev.yaml; set it before
+    # restarting services so Compose resolves mounted paths from this checkout.
+    if [ -z "$DEER_FLOW_ROOT" ]; then
+        export DEER_FLOW_ROOT="$PROJECT_ROOT"
+    fi
     echo "========================================"
     echo "  Restarting DeerFlow Docker Services"
     echo "========================================"


### PR DESCRIPTION
Refs #3336

## Why

`make docker-logs*` and direct `./scripts/docker.sh restart` invoked Compose without `DEER_FLOW_ROOT`, causing an empty-variable warning.

## What changed

- Set `DEER_FLOW_ROOT` before Docker log and restart commands invoke Compose.
- Cover both paths with the existing shell regression test.
- Document the behavior.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable — no UI changes.

## Bug fix verification

- Test path: `backend/tests/test_docker_sandbox_mode_detection.py`
- Red on `main`, green on this branch: yes; both shell paths lack the guard on `main`.

## Validation

- `cd backend && make lint`
- `cd backend && uv run pytest tests/test_docker_sandbox_mode_detection.py -v` — 8 passed
- `cd backend && make test` — 10,811 passed, 72 skipped in a hardened credential-free container with DNS enabled. The offline baseline cannot resolve public placeholder hosts in unchanged browser tests.

## AI assistance

**Tool(s) used:** OpenAI Codex

**How you used it:** Assisted with implementation and tests; `tiammomo` reviewed the diff and results.

- [x] I have read and understand every line of this change and take responsibility for it — it is not unreviewed AI output.
