### PR TITLE
fix(frontend): restore user message above same-run steps after mid-run reload

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -646,6 +646,97 @@ export function restoreLocalTurnMessageOrder(
 }
 
 /**
+ * Reconnect/reload counterpart of {@link restoreLocalTurnMessageOrder}.
+ *
+ * After a mid-run page reload the local-turn baseline is empty, so the local
+ * restore never runs — yet the same ordering race still applies: replayed
+ * `messages-tuple` steps can reach the merged list before the turn's human
+ * message (the retained replay buffer may even have dropped it), and the
+ * live-only human is then woven in before the next shared history anchor,
+ * leaving steps of the SAME run above the user message they belong to.
+ *
+ * Canonical history is seq-sorted, so a visible AI/tool step sitting above
+ * the last visible human while another message of the same run sits below it
+ * (a "same-run sandwich") is provably misplaced. Run_id-less steps are
+ * live-only (history rows always carry run_id) and are attributable to the
+ * reconnected run only when a run_id-less step also follows the human —
+ * otherwise they may be orphans from an older turn (#4399) or a stray
+ * transient and must keep their position. A resent turn after an interrupted
+ * run fails both checks and is left untouched.
+ */
+export function restoreReconnectedTurnMessageOrder(
+  messages: Message[],
+): Message[] {
+  let humanIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.type === "human" && !isHiddenFromUIMessage(message)) {
+      humanIndex = index;
+      break;
+    }
+  }
+  if (humanIndex <= 0) {
+    return messages;
+  }
+
+  // Only the segment since the previous visible human can belong to the
+  // active turn; older turns are anchored by their own human message.
+  let segmentStart = 0;
+  for (let index = humanIndex - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.type === "human" && !isHiddenFromUIMessage(message)) {
+      segmentStart = index + 1;
+      break;
+    }
+  }
+  if (segmentStart >= humanIndex) {
+    return messages;
+  }
+
+  const runIdsAfter = new Set<string>();
+  let hasLiveOnlyStepAfter = false;
+  for (const message of messages.slice(humanIndex + 1)) {
+    const runId = getMessageRunId(message);
+    if (runId) {
+      runIdsAfter.add(runId);
+    } else if (
+      (message.type === "ai" || message.type === "tool") &&
+      !isHiddenFromUIMessage(message)
+    ) {
+      hasLiveOnlyStepAfter = true;
+    }
+  }
+
+  const misplacedSteps: Message[] = [];
+  const stablePrefix = messages.slice(0, segmentStart);
+  for (const message of messages.slice(segmentStart, humanIndex)) {
+    const isVisibleStep =
+      (message.type === "ai" || message.type === "tool") &&
+      !isHiddenFromUIMessage(message);
+    const runId = getMessageRunId(message);
+    if (
+      isVisibleStep &&
+      ((runId !== undefined && runIdsAfter.has(runId)) ||
+        (runId === undefined && hasLiveOnlyStepAfter))
+    ) {
+      misplacedSteps.push(message);
+    } else {
+      stablePrefix.push(message);
+    }
+  }
+  if (misplacedSteps.length === 0) {
+    return messages;
+  }
+
+  return [
+    ...stablePrefix,
+    messages[humanIndex]!,
+    ...misplacedSteps,
+    ...messages.slice(humanIndex + 1),
+  ];
+}
+
+/**
  * Keep a run-scoped ledger of every visible message that reached a committed
  * UI frame. Live checkpoint windows can roll forward between two
  * summarization events; replacing this ledger with only the newest window
@@ -2419,7 +2510,7 @@ export function useThreadStream({
     );
     const localTurnOrderBaseline = localTurnOrderBaselineIdentitiesRef.current;
     return localTurnOrderBaseline === null
-      ? merged
+      ? restoreReconnectedTurnMessageOrder(merged)
       : restoreLocalTurnMessageOrder(merged, localTurnOrderBaseline);
   }, [
     previouslyRenderedOrder,

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -19,7 +19,11 @@ import { fetch } from "../api/fetcher";
 import { getBackendBaseURL } from "../config";
 import { useI18n } from "../i18n/hooks";
 import { getMessageRunId } from "../messages/run-duration";
-import { isHiddenFromUIMessage } from "../messages/utils";
+import {
+  hasContent,
+  hasToolCalls,
+  isHiddenFromUIMessage,
+} from "../messages/utils";
 import type { FileInMessage } from "../messages/utils";
 import type { LocalSettings } from "../settings";
 import { isSidecarThread, SIDECAR_METADATA_KEY } from "../sidecar/thread";
@@ -659,10 +663,19 @@ export function restoreLocalTurnMessageOrder(
  * the last visible human while another message of the same run sits below it
  * (a "same-run sandwich") is provably misplaced. Run_id-less steps are
  * live-only (history rows always carry run_id) and are attributable to the
- * reconnected run only when a run_id-less step also follows the human —
- * otherwise they may be orphans from an older turn (#4399) or a stray
- * transient and must keep their position. A resent turn after an interrupted
- * run fails both checks and is left untouched.
+ * reconnected run only when a run_id-less step also follows the human.
+ *
+ * Only steps after the last terminal assistant answer (visible content, no
+ * tool calls) in the segment are candidates: such an answer completes the
+ * turn that owns it, so everything up to it belongs to a finished turn and
+ * must keep its position even when run_ids are absent or uniform across
+ * turns (branch-seeded history, mocked feeds). A still-streaming text step
+ * can look like a terminal answer before its tool call arrives (#4304); it
+ * then stays above the human until canonical history heals the order — an
+ * accepted transient, far safer than pulling a completed turn's answer
+ * below the next user message. A resent turn after an interrupted run and
+ * pagination orphans from older turns (#4399) fail the checks as well and
+ * are left untouched.
  */
 export function restoreReconnectedTurnMessageOrder(
   messages: Message[],
@@ -693,6 +706,21 @@ export function restoreReconnectedTurnMessageOrder(
     return messages;
   }
 
+  // A terminal assistant answer completes the turn that owns it. Only steps
+  // after the last such boundary can belong to the active turn.
+  let candidateStart = segmentStart;
+  for (let index = segmentStart; index < humanIndex; index++) {
+    const message = messages[index]!;
+    if (
+      message.type === "ai" &&
+      !isHiddenFromUIMessage(message) &&
+      hasContent(message) &&
+      !hasToolCalls(message)
+    ) {
+      candidateStart = index + 1;
+    }
+  }
+
   const runIdsAfter = new Set<string>();
   let hasLiveOnlyStepAfter = false;
   for (const message of messages.slice(humanIndex + 1)) {
@@ -708,8 +736,8 @@ export function restoreReconnectedTurnMessageOrder(
   }
 
   const misplacedSteps: Message[] = [];
-  const stablePrefix = messages.slice(0, segmentStart);
-  for (const message of messages.slice(segmentStart, humanIndex)) {
+  const stablePrefix = messages.slice(0, candidateStart);
+  for (const message of messages.slice(candidateStart, humanIndex)) {
     const isVisibleStep =
       (message.type === "ai" || message.type === "tool") &&
       !isHiddenFromUIMessage(message);

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -1633,8 +1633,9 @@ test("reconnected turn order moves same-run steps back behind the user message",
     id: "step-a1",
     type: "ai",
     content: "Searching the web",
+    tool_calls: [{ id: "tc-a1", name: "web_search", args: {} }],
     run_id: "run-r",
-  } as Message;
+  } as unknown as Message;
   const stepA2 = {
     id: "step-a2",
     type: "tool",
@@ -1705,8 +1706,9 @@ test("reconnected turn order only moves steps of the sandwiched run in multi-tur
     id: "step-misplaced",
     type: "ai",
     content: "Second run step above the human",
+    tool_calls: [{ id: "tc-misplaced", name: "read_file", args: {} }],
     run_id: "run-2",
-  } as Message;
+  } as unknown as Message;
   const human2 = {
     id: "human-2",
     type: "human",
@@ -1740,7 +1742,8 @@ test("reconnected turn order moves live-only steps before any history loads", ()
     id: "live-early",
     type: "ai",
     content: "Replayed step",
-  } as Message;
+    tool_calls: [{ id: "tc-early", name: "web_search", args: {} }],
+  } as unknown as Message;
   const human = {
     id: "live-human",
     type: "human",
@@ -1803,8 +1806,9 @@ test("reconnected turn order keeps hidden control messages and older-run orphans
     id: "orphan",
     type: "ai",
     content: "Pagination orphan from an older run",
+    tool_calls: [{ id: "tc-orphan", name: "web_search", args: {} }],
     run_id: "run-0",
-  } as Message;
+  } as unknown as Message;
   const hiddenControl = {
     id: "control",
     type: "human",
@@ -1815,8 +1819,9 @@ test("reconnected turn order keeps hidden control messages and older-run orphans
     id: "misplaced",
     type: "ai",
     content: "Same-run step",
+    tool_calls: [{ id: "tc-misplaced", name: "read_file", args: {} }],
     run_id: "run-r",
-  } as Message;
+  } as unknown as Message;
   const human = {
     id: "human-r",
     type: "human",
@@ -1859,6 +1864,118 @@ test("reconnected turn order is a no-op when the human message already leads its
   ]);
   expect(restoreReconnectedTurnMessageOrder([step])).toEqual([step]);
   expect(restoreReconnectedTurnMessageOrder([])).toEqual([]);
+});
+
+test("reconnected turn order keeps a completed turn's answer above the next human message", () => {
+  // Regression for the branch-thread e2e shape: history feeds where every
+  // message shares one run_id (branch-seeded threads, mocked feeds). A
+  // terminal answer completes its turn and must never be pulled below the
+  // next human message even though the naive same-run check would match.
+  const human1 = {
+    id: "human-1",
+    type: "human",
+    content: "First question",
+    run_id: "run-x",
+  } as Message;
+  const answer1 = {
+    id: "ai-1",
+    type: "ai",
+    content: "First answer",
+    run_id: "run-x",
+  } as Message;
+  const human2 = {
+    id: "human-2",
+    type: "human",
+    content: "Second question",
+    run_id: "run-x",
+  } as Message;
+  const intermediate = {
+    id: "ai-2",
+    type: "ai",
+    content: "Intermediate answer",
+    run_id: "run-x",
+  } as Message;
+  const toolCalling = {
+    id: "ai-3",
+    type: "ai",
+    content: "",
+    tool_calls: [{ id: "tc-1", name: "write_todos", args: {} }],
+    run_id: "run-x",
+  } as unknown as Message;
+  const toolResult = {
+    id: "tool-1",
+    type: "tool",
+    tool_call_id: "tc-1",
+    content: "Todos updated",
+    run_id: "run-x",
+  } as Message;
+  const final = {
+    id: "ai-4",
+    type: "ai",
+    content: "Final answer",
+    run_id: "run-x",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      human1,
+      answer1,
+      human2,
+      intermediate,
+      toolCalling,
+      toolResult,
+      final,
+    ]),
+  ).toEqual([
+    human1,
+    answer1,
+    human2,
+    intermediate,
+    toolCalling,
+    toolResult,
+    final,
+  ]);
+});
+
+test("reconnected turn order treats a content-only streaming text as a boundary", () => {
+  // Accepted transient (#4304): a still-streaming text step looks like a
+  // terminal answer until its tool call arrives, so it stays above the human
+  // until canonical history heals the order. Tool-calling steps after the
+  // last such boundary are still restored.
+  const streamingText = {
+    id: "streaming-text",
+    type: "ai",
+    content: "Let me analyze this",
+    run_id: "run-r",
+  } as Message;
+  const toolStep = {
+    id: "tool-step",
+    type: "ai",
+    content: "",
+    tool_calls: [{ id: "tc-1", name: "read_file", args: {} }],
+    run_id: "run-r",
+  } as unknown as Message;
+  const human = {
+    id: "human-r",
+    type: "human",
+    content: "Question",
+  } as Message;
+  const laterStep = {
+    id: "later",
+    type: "ai",
+    content: "",
+    tool_calls: [{ id: "tc-2", name: "write_file", args: {} }],
+    run_id: "run-r",
+  } as unknown as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      streamingText,
+      toolStep,
+      human,
+      laterStep,
+    ]),
+  ).toEqual([streamingText, human, toolStep, laterStep]);
 });
 
 test("rendered message ledger does not retain explicitly superseded messages", () => {

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -23,6 +23,7 @@ import {
   resolveThreadTransientHistoryBridge,
   resolveTransientHistoryBridge,
   restoreLocalTurnMessageOrder,
+  restoreReconnectedTurnMessageOrder,
   type ThreadMessagesPageResponse,
 } from "@/core/threads/hooks";
 import type { RunMessage } from "@/core/threads/types";
@@ -1621,6 +1622,243 @@ test("local turn order keeps early streamed steps behind the user message", () =
     earlyAssistantStep,
     laterAssistantStep,
   ]);
+});
+
+test("reconnected turn order moves same-run steps back behind the user message", () => {
+  // Reload mid-run: replayed `messages-tuple` steps reach the merged list
+  // before the turn's human message (the retained replay buffer may have
+  // dropped it). The live-only human is woven before the next shared anchor,
+  // leaving same-run steps above the user message they belong to.
+  const stepA1 = {
+    id: "step-a1",
+    type: "ai",
+    content: "Searching the web",
+    run_id: "run-r",
+  } as Message;
+  const stepA2 = {
+    id: "step-a2",
+    type: "tool",
+    content: "search results",
+    tool_call_id: "tc-a2",
+    run_id: "run-r",
+  } as Message;
+  const human = {
+    id: "human-r",
+    type: "human",
+    content: "Analyze deerflow",
+  } as Message;
+  const stepB1 = {
+    id: "step-b1",
+    type: "ai",
+    content: "Reading the source",
+    run_id: "run-r",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([stepA1, stepA2, human, stepB1]),
+  ).toEqual([human, stepA1, stepA2, stepB1]);
+});
+
+test("reconnected turn order leaves a resent turn after an interrupted run untouched", () => {
+  // Legit layout: an interrupted earlier run left steps without a final
+  // answer, then the user sent a new message. The earlier run's steps must
+  // NOT be pulled below the new human message.
+  const interruptedStep = {
+    id: "step-old",
+    type: "ai",
+    content: "Interrupted run step",
+    run_id: "run-1",
+  } as Message;
+  const human = {
+    id: "human-2",
+    type: "human",
+    content: "Same question again",
+    run_id: "run-2",
+  } as Message;
+  const newStep = {
+    id: "step-new",
+    type: "ai",
+    content: "New run step",
+    run_id: "run-2",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([interruptedStep, human, newStep]),
+  ).toEqual([interruptedStep, human, newStep]);
+});
+
+test("reconnected turn order only moves steps of the sandwiched run in multi-turn history", () => {
+  const human1 = { id: "human-1", type: "human", content: "First" } as Message;
+  const step1 = {
+    id: "step-1",
+    type: "ai",
+    content: "First run step",
+    run_id: "run-1",
+  } as Message;
+  const answer1 = {
+    id: "answer-1",
+    type: "ai",
+    content: "First answer",
+    run_id: "run-1",
+  } as Message;
+  const misplacedStep = {
+    id: "step-misplaced",
+    type: "ai",
+    content: "Second run step above the human",
+    run_id: "run-2",
+  } as Message;
+  const human2 = {
+    id: "human-2",
+    type: "human",
+    content: "Second",
+  } as Message;
+  const step2 = {
+    id: "step-2",
+    type: "ai",
+    content: "Second run step below the human",
+    run_id: "run-2",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      human1,
+      step1,
+      answer1,
+      misplacedStep,
+      human2,
+      step2,
+    ]),
+  ).toEqual([human1, step1, answer1, human2, misplacedStep, step2]);
+});
+
+test("reconnected turn order moves live-only steps before any history loads", () => {
+  // Right after reconnect no history page has landed yet: every live message
+  // lacks run_id. A run_id-less step below the human proves the live stream
+  // is past turn start, so run_id-less steps above the human belong to the
+  // same reconnected run.
+  const earlyStep = {
+    id: "live-early",
+    type: "ai",
+    content: "Replayed step",
+  } as Message;
+  const human = {
+    id: "live-human",
+    type: "human",
+    content: "Question",
+  } as Message;
+  const laterStep = {
+    id: "live-later",
+    type: "ai",
+    content: "Fresh step",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([earlyStep, human, laterStep]),
+  ).toEqual([human, earlyStep, laterStep]);
+});
+
+test("reconnected turn order keeps run_id-less steps when no run_id-less step follows the human", () => {
+  // A run_id-less step above the human is only attributable to the current
+  // run when the run_id-less live stream continues below the human. With
+  // every message below the human carrying a (different) run_id, the stray
+  // step may belong to an older turn and must stay put.
+  const human1 = { id: "human-1", type: "human", content: "First" } as Message;
+  const step1 = {
+    id: "step-1",
+    type: "ai",
+    content: "First run step",
+    run_id: "run-1",
+  } as Message;
+  const strayStep = {
+    id: "stray",
+    type: "ai",
+    content: "Ambiguous step",
+  } as Message;
+  const human2 = {
+    id: "human-2",
+    type: "human",
+    content: "Second",
+    run_id: "run-2",
+  } as Message;
+  const step2 = {
+    id: "step-2",
+    type: "ai",
+    content: "Second run step",
+    run_id: "run-2",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      human1,
+      step1,
+      strayStep,
+      human2,
+      step2,
+    ]),
+  ).toEqual([human1, step1, strayStep, human2, step2]);
+});
+
+test("reconnected turn order keeps hidden control messages and older-run orphans in place", () => {
+  const orphanStep = {
+    id: "orphan",
+    type: "ai",
+    content: "Pagination orphan from an older run",
+    run_id: "run-0",
+  } as Message;
+  const hiddenControl = {
+    id: "control",
+    type: "human",
+    content: "<memory>context</memory>",
+    additional_kwargs: { hide_from_ui: true },
+  } as Message;
+  const misplacedStep = {
+    id: "misplaced",
+    type: "ai",
+    content: "Same-run step",
+    run_id: "run-r",
+  } as Message;
+  const human = {
+    id: "human-r",
+    type: "human",
+    content: "Question",
+  } as Message;
+  const laterStep = {
+    id: "later",
+    type: "ai",
+    content: "Later same-run step",
+    run_id: "run-r",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      orphanStep,
+      hiddenControl,
+      misplacedStep,
+      human,
+      laterStep,
+    ]),
+  ).toEqual([orphanStep, hiddenControl, human, misplacedStep, laterStep]);
+});
+
+test("reconnected turn order is a no-op when the human message already leads its turn", () => {
+  const human = {
+    id: "human-r",
+    type: "human",
+    content: "Question",
+  } as Message;
+  const step = {
+    id: "step",
+    type: "ai",
+    content: "Step",
+    run_id: "run-r",
+  } as Message;
+
+  expect(restoreReconnectedTurnMessageOrder([human, step])).toEqual([
+    human,
+    step,
+  ]);
+  expect(restoreReconnectedTurnMessageOrder([step])).toEqual([step]);
+  expect(restoreReconnectedTurnMessageOrder([])).toEqual([]);
 });
 
 test("rendered message ledger does not retain explicitly superseded messages", () => {


### PR DESCRIPTION
## Why                                                                                            
                                                                                                     
   - **Trigger:** during a long run we reloaded the chat page mid-stream. After the reload, the      
     conversation rendered as: steps panel (16 steps) → token-usage row → **the user's own           
     message** → another steps panel (15 steps) → a second token-usage row.                          
   - **Pain:** the turn's steps panel appeared *above* the user message it belongs to, and the       
     per-turn token row was split in two, making one run look like two separate turns. The           
     backend data was verified correct (single run, single human message, seq-ordered event          
     store) — this is purely a frontend merge-order bug.                                             
                                                                                                     
   Root cause: after a mid-run page reload, the replay buffer may already have dropped early         
   events (`subscriber fell behind retained buffer`), so replayed `messages-tuple` steps reach       
   the merged list before the turn's human message. The live-only human is then woven in before      
   the next shared history anchor in `mergeMessages`, landing *between* steps of its own run.        
   The existing `restoreLocalTurnMessageOrder` guard only covers the turn submitted by the           
   mounted client (its baseline ref is empty after a reload), so the reconnected path had no         
   protection.                                                                                       
                                                                                                     
   ## What changed                                                                                   
                                                                                                     
   - Chat message ordering is now self-healing after a mid-run page reload / stream reconnect:       
     steps of a run can no longer render above the user message that started the run. No             
     setting, API, or data-shape change; users just stop seeing the split-turn layout.               
   - New `restoreReconnectedTurnMessageOrder` applied in the `mergedMessages` memo when there        
     is no local-submit baseline. A visible AI/tool step above the last visible human message is     
     moved back below it only when it is provably misplaced:                                         
     - **same-run sandwich** — the step's `run_id` also appears on a message below the human         
       (canonical history is seq-sorted, so this is provably wrong), or                              
     - **live-only** — the step has no `run_id` (history rows always carry one) and a                
       `run_id`-less step also follows the human, attributing both to the reconnected run.           
   - Layouts that must not change are preserved: pagination orphans from older turns (#4399),        
     a resent turn after an interrupted run (older run's steps correctly stay above the new          
     human message), and ambiguous `run_id`-less steps when no live-only step follows the human.     
                                                                                                     
   ## Surface area                                                                                   
                                                                                                     
   - [x] **Frontend UI** — page / component / setting / interaction under `frontend/`                
   - [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`         
   - [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change       
   - [ ] **Sandbox** — `docker/` or sandboxed execution                                              
   - [ ] **Skills** — change under `skills/`                                                         
   - [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or                        
 `frontend/package.json` (say what it buys us)                                                       
   - [ ] **Default behavior change** — changes existing behavior without the user opting in (default 
 model, default setting, data shape)                                                                 
   - [ ] **Docs / tests / CI only** — no runtime behavior change                                     
                                                                                                     
   (Only `frontend/src/core/threads/hooks.ts` message-merge logic + its unit tests; the change       
   is a pure client-side ordering correction with no opt-in needed, but it only ever activates       
   on provably misordered frames.)                                                                   
                                                                                                     
   ## Screenshots / Recording                                                                        
                                                                                                                                            
                                                                                                                                        
<img width="1733" height="1338" alt="image" src="https://github.com/user-attachments/assets/57c7e7f3-d99d-48b9-bcf8-dea8cc80a039" />
                                                                                             
   ## Bug fix verification                                                                           
                                                                                                     
   - Test path that reproduces the bug:                                                              
     `frontend/tests/unit/core/threads/message-merge.test.ts` —                                      
     `reconnected turn order moves same-run steps back behind the user message`                      
     (plus 6 companion cases: interrupted-run resend, multi-turn sandwich, live-only steps,          
     ambiguous run_id-less steps, hidden control messages + pagination orphans, no-op cases)         
   - Did it go red on `main` and green on this branch? **yes** — all 7 new tests fail on main        
     (`restoreReconnectedTurnMessageOrder` does not exist) and pass with the fix.                    
                                                                                                     
   ## Validation                                                                                     
                                                                                                     
   - `cd frontend && pnpm exec rstest run` — full unit suite: **983 passed, 0 failed**               
   - `cd frontend && pnpm typecheck` — pass                                                          
   - `pnpm exec eslint src/core/threads/hooks.ts tests/unit/core/threads/message-merge.test.ts` —    
 pass                                                                                                
   - pre-commit hooks: eslint (pass), prettier (auto-formatted, included in the commit)              
   - Not run: `pnpm build`, `make test-e2e` (change is confined to the message-merge seam            
     covered by the unit suite; happy to run if reviewers want)                                      
                                                                                                     
   ## AI assistance                                                                                  
                                                                                                     
   **Tool(s) used:** Kimi Code (AI coding agent)                                                     
                                                                                                     
   **How you used it:** AI investigated the bug end-to-end (read backend SQLite store, gateway       
   logs, checkpoint state to prove backend ordering was correct; traced the frontend                 
   merge/reconnect path), proposed the fix, wrote the failing tests first (TDD) and the              
   implementation. I reviewed the analysis and the diff.                                             
                                                                                                     
   - [x] I've read and understand every line of this change and take responsibility for it — it's    
 not unreviewed AI output.