### PR TITLE
fix(frontend): stop channel polls at expiry

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -83,6 +83,9 @@ The frontend is a stateful chat application. Users create **threads** (conversat
    mutation, disables switches until that mutation's success refetch completes,
    displays the backend error `detail` through a toast, and invalidates
    `["mcpConfig"]` only after success.
+   IM channel connection polling treats `expires_in` as a hard bind deadline:
+   a timer that wakes at or after that deadline must stop without issuing one
+   final connections request.
 6. Components subscribe to thread state and render updates
 
 The chat header's context-window control is intentionally persistent: while `context_usage` is unavailable, `ContextUsageBadge` renders a gauge placeholder rather than unmounting; once data arrives, the same position shows the percentage. `useThreadTokenUsage` retains placeholder data only when the response `thread_id` still matches the active route, so same-thread refetches do not flicker and cross-thread navigation never displays the previous chat's usage.

--- a/frontend/src/core/channels/connect-poll.ts
+++ b/frontend/src/core/channels/connect-poll.ts
@@ -61,7 +61,7 @@ export function startConnectionPoll(
   const schedule = () => {
     timer = setTimeout(() => {
       timer = undefined;
-      if (cancelled) {
+      if (cancelled || now() >= deadline) {
         return;
       }
       void fetchConnections()

--- a/frontend/tests/unit/core/channels/connect-poll.test.ts
+++ b/frontend/tests/unit/core/channels/connect-poll.test.ts
@@ -78,6 +78,28 @@ describe("startConnectionPoll", () => {
     expect(fetchConnections).toHaveBeenCalledTimes(1);
   });
 
+  test("does not fetch after the bind window expires before the next tick", async () => {
+    const fetchConnections = rs.fn(async () => [
+      connection("telegram", "connected"),
+    ]);
+    const onConnected = rs.fn();
+    let nowValue = 0;
+    startConnectionPoll({
+      provider: "telegram",
+      expiresInSeconds: 1,
+      fetchConnections,
+      onConnected,
+      intervalMs: 2000,
+      now: () => nowValue,
+    });
+
+    nowValue = 2000;
+    await rs.advanceTimersByTimeAsync(2000);
+
+    expect(fetchConnections).not.toHaveBeenCalled();
+    expect(onConnected).not.toHaveBeenCalled();
+  });
+
   test("a non-finite expires_in falls back to a finite deadline and terminates", async () => {
     const fetchConnections = rs.fn(async () => [
       connection("telegram", "pending"),
@@ -100,9 +122,9 @@ describe("startConnectionPoll", () => {
     // running forever (Date.now() >= NaN would otherwise never be true).
     nowValue = 10_000_000;
     await rs.advanceTimersByTimeAsync(1000);
-    expect(fetchConnections).toHaveBeenCalledTimes(2);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
 
     await rs.advanceTimersByTimeAsync(10000);
-    expect(fetchConnections).toHaveBeenCalledTimes(2);
+    expect(fetchConnections).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Why

Channel connection polling treats the provider's `expires_in` value as the
binding window, but the deadline was checked only after a connections request
finished. If the next timer fired after that window had already closed, the
client still issued one expired request and could report a late connection.

## What changed

- Check the hard bind deadline before invoking `fetchConnections`.
- Stop an expired timer tick without sending a final request or calling
  `onConnected`.
- Update the existing malformed-`expires_in` regression to assert that it also
  stops before an expired request.
- Document the polling deadline contract in the frontend guide.

The retry interval, cancellation API, connection matching, and finite fallback
for malformed `expires_in` values are unchanged.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable. This is a timer-boundary fix in the existing channel
connection flow and does not change its rendered UI.

## Bug fix verification

- Test path: `frontend/tests/unit/core/channels/connect-poll.test.ts`
- Red on `main`: yes. Advancing a 2-second poll timer past a 1-second bind
  window still called `fetchConnections` once.
- Green on this branch: yes. The expired tick performs no fetch and cannot
  report a connection.

## Validation

- [x] `pnpm exec rstest run --include 'tests/unit/core/channels/connect-poll.test.ts'` — 4 cases passed in each configured Rstest project
- [x] `pnpm test` — 125 files, 977 tests passed
- [x] `pnpm check` — ESLint and TypeScript passed
- [x] `pnpm exec prettier --check AGENTS.md src/core/channels/connect-poll.ts tests/unit/core/channels/connect-poll.test.ts`
- [x] `NEXT_TELEMETRY_DISABLED=1 SKIP_ENV_VALIDATION=1 pnpm build` — production build and 87/87 static pages passed
- [x] `git diff --check`

Playwright E2E was not run; the deadline behavior is deterministic and covered
at the polling boundary with fake time.

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited the timer boundary, added the red regression,
implemented the one-condition fix, and ran the repository validation commands.
I reviewed the final diff and test expectations.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
