### PR TITLE
fix:修复 #4675 中 ContextVar 缺失时误用 default 用户桶的问题。+ 增加回归、边界、兼容性验证，防止该路径解…

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
@@ -7,7 +7,7 @@ from langgraph.config import get_config
 from langgraph.types import Command
 
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX, get_paths
-from deerflow.runtime.user_context import get_effective_user_id
+from deerflow.runtime.user_context import resolve_runtime_user_id
 from deerflow.tools.types import Runtime
 
 OUTPUTS_VIRTUAL_PREFIX = f"{VIRTUAL_PATH_PREFIX}/outputs"
@@ -28,6 +28,11 @@ def _get_thread_id(runtime: Runtime) -> str | None:
         return get_config().get("configurable", {}).get("thread_id")
     except RuntimeError:
         return None
+
+
+def _resolve_present_files_user_id(runtime: Runtime) -> str:
+    """Resolve the user bucket used when translating present_files paths."""
+    return resolve_runtime_user_id(runtime)
 
 
 def _normalize_presented_filepath(
@@ -66,7 +71,7 @@ def _normalize_presented_filepath(
 
     if stripped == virtual_prefix or stripped.startswith(virtual_prefix + "/"):
         try:
-            actual_path = get_paths().resolve_virtual_path(thread_id, filepath, user_id=get_effective_user_id())
+            actual_path = get_paths().resolve_virtual_path(thread_id, filepath, user_id=_resolve_present_files_user_id(runtime))
         except TypeError:
             actual_path = get_paths().resolve_virtual_path(thread_id, filepath)
     else:

--- a/backend/tests/test_present_file_tool_core_logic.py
+++ b/backend/tests/test_present_file_tool_core_logic.py
@@ -51,6 +51,46 @@ def test_present_files_keeps_virtual_outputs_path(tmp_path, monkeypatch):
     assert result.update["artifacts"] == ["/mnt/user-data/outputs/summary.json"]
 
 
+def test_present_files_uses_runtime_context_user_for_virtual_outputs_path(tmp_path, monkeypatch):
+    outputs_dir = tmp_path / "users" / "runtime-user" / "threads" / "thread-1" / "user-data" / "outputs"
+    outputs_dir.mkdir(parents=True)
+    artifact_path = outputs_dir / "report_status.json"
+    artifact_path.write_text("{}")
+    seen = {}
+
+    def resolve_virtual_path(thread_id, path, *, user_id=None):
+        seen["thread_id"] = thread_id
+        seen["path"] = path
+        seen["user_id"] = user_id
+        return artifact_path.resolve()
+
+    monkeypatch.setattr(
+        present_file_tool_module,
+        "get_paths",
+        lambda: SimpleNamespace(resolve_virtual_path=resolve_virtual_path),
+    )
+
+    runtime = SimpleNamespace(
+        state={"thread_data": {"outputs_path": str(outputs_dir)}},
+        context={"thread_id": "thread-1", "user_id": "runtime-user"},
+        config={},
+    )
+
+    result = present_file_tool_module.present_file_tool.func(
+        runtime=runtime,
+        filepaths=["/mnt/user-data/outputs/report_status.json"],
+        tool_call_id="tc-user",
+    )
+
+    assert seen == {
+        "thread_id": "thread-1",
+        "path": "/mnt/user-data/outputs/report_status.json",
+        "user_id": "runtime-user",
+    }
+    assert result.update["artifacts"] == ["/mnt/user-data/outputs/report_status.json"]
+    assert result.update["messages"][0].content == "Successfully presented files"
+
+
 def test_present_files_uses_config_thread_id_when_context_missing(tmp_path, monkeypatch):
     outputs_dir = tmp_path / "threads" / "thread-from-config" / "user-data" / "outputs"
     outputs_dir.mkdir(parents=True)
@@ -76,6 +116,20 @@ def test_present_files_uses_config_thread_id_when_context_missing(tmp_path, monk
     )
 
     assert result.update["artifacts"] == ["/mnt/user-data/outputs/summary.json"]
+    assert result.update["messages"][0].content == "Successfully presented files"
+
+
+def test_present_files_allows_empty_file_list(tmp_path):
+    outputs_dir = tmp_path / "threads" / "thread-1" / "user-data" / "outputs"
+    outputs_dir.mkdir(parents=True)
+
+    result = present_file_tool_module.present_file_tool.func(
+        runtime=_make_runtime(str(outputs_dir)),
+        filepaths=[],
+        tool_call_id="tc-empty",
+    )
+
+    assert result.update["artifacts"] == []
     assert result.update["messages"][0].content == "Successfully presented files"
 
 


### PR DESCRIPTION
…析问题复发。

<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Fixes #

## Why

<!-- Why are you opening this PR? Cover two things:
       - The trigger — what made you write this? A bug you hit, a feature you need,
         tech debt, or a prod issue?
       - The pain being addressed — user-facing problem, or what it unblocks.
     For non-trivial features, please open an issue/discussion first to align on
     scope before writing code. -->


## What changed

<!-- Describe the change from a user's / caller's perspective, not as a code diff. e.g.:
       - "Settings now has a 'Custom endpoint' field, off by default"
       - "Backend /api/chat gains a `stream` flag, defaults to false"
       - "Default model changed from X to Y — existing users notice on first run" -->


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

<!-- If you checked "Frontend UI", attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

<!-- Skip (delete) this section if this PR is not a bug fix.

     Bugs should be encoded as a failing test that goes red before the fix.
     Confirm:
       - Test path that reproduces the bug:
       - Did it go red on `main` and green on this branch? (yes / no)
       - If a red test wasn't cheap to write, explain why and what you did instead. -->


## Validation

<!-- What you actually ran. Run at least the checks for the area you changed:
       Backend:   cd backend  && make lint && make test
       Frontend:  cd frontend && pnpm format && pnpm lint && pnpm typecheck && BETTER_AUTH_SECRET=local-dev-secret pnpm build && make test
       Frontend E2E (if you touched frontend/): cd frontend && make test-e2e -->


## AI assistance

<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
     welcome. Disclosing it just helps reviewers calibrate how closely to read the
     diff. Please fill all three; don't delete the section. -->

**Tool(s) used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, or "none" -->

**How you used it:** <!-- e.g. "generated the module from a spec", "autocomplete only",
     "AI wrote tests, I wrote the impl". A prompt or conversation link is great too. -->

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

