### PR TITLE
fix(channels): offload artifact path resolution

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -271,6 +271,8 @@ Blocking-IO runtime gate (`tests/blocking_io/`):
   skips redundant sandbox sync when thread data is already mounted);
   `test_channel_outbound_files.py` (locks Feishu, Telegram, and WeCom outbound
   attachment open/read/hash work off the event loop);
+  `test_channel_artifact_resolution.py` (locks IM response artifact path
+  resolution and metadata reads off the event loop);
   `test_openviking_memory_backend.py` (locks the OpenViking backend's async
   add/context/search entrypoints offloading synchronous HTTP and watermark
   filesystem IO); and

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -849,7 +849,7 @@ def _resolve_attachments(thread_id: str, artifacts: list[str], *, user_id: str |
     return attachments
 
 
-def _prepare_artifact_delivery(
+async def _prepare_artifact_delivery(
     thread_id: str,
     response_text: str,
     artifacts: list[str],
@@ -861,7 +861,7 @@ def _prepare_artifact_delivery(
     if not artifacts:
         return response_text, attachments
 
-    attachments = _resolve_attachments(thread_id, artifacts, user_id=user_id)
+    attachments = await asyncio.to_thread(_resolve_attachments, thread_id, artifacts, user_id=user_id)
     resolved_virtuals = {attachment.virtual_path for attachment in attachments}
     unresolved = [path for path in artifacts if path not in resolved_virtuals]
 
@@ -2169,7 +2169,7 @@ class ChannelManager:
         # Reuse the storage owner cached at the top of _handle_chat so uploads and
         # artifact delivery always resolve to the same bucket, even if a future
         # channel.receive_file returns a rewritten InboundMessage.
-        response_text, attachments = _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
+        response_text, attachments = await _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
 
         if not response_text:
             if attachments:
@@ -2286,7 +2286,7 @@ class ChannelManager:
             # Reuse the storage owner resolved by _handle_chat so artifact delivery
             # matches the upload bucket and we avoid re-running _safe_user_id_for_run
             # (and its possible filesystem touch) on the streaming-error path.
-            response_text, attachments = _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
+            response_text, attachments = await _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
 
             if not response_text:
                 if attachments:

--- a/backend/tests/blocking_io/test_channel_artifact_resolution.py
+++ b/backend/tests/blocking_io/test_channel_artifact_resolution.py
@@ -1,0 +1,38 @@
+"""Regression coverage for IM artifact resolution on the event loop."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.channels.manager import _prepare_artifact_delivery
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_channel_artifact_resolution_does_not_block_event_loop(tmp_path: Path) -> None:
+    outputs_dir = tmp_path / "outputs"
+    artifact = outputs_dir / "report.pdf"
+    await asyncio.to_thread(outputs_dir.mkdir)
+    await asyncio.to_thread(artifact.write_bytes, b"%PDF-1.4")
+
+    paths = MagicMock()
+    paths.sandbox_outputs_dir.return_value = outputs_dir
+    paths.resolve_virtual_path.return_value = artifact
+
+    with patch("deerflow.config.paths.get_paths", return_value=paths):
+        text, attachments = await _prepare_artifact_delivery(
+            "thread-1",
+            "Report ready",
+            ["/mnt/user-data/outputs/report.pdf"],
+            user_id="user-1",
+        )
+
+    assert text.startswith("Report ready")
+    assert text.endswith("report.pdf")
+    assert len(attachments) == 1
+    assert attachments[0].actual_path == artifact
+    assert attachments[0].size == len(b"%PDF-1.4")


### PR DESCRIPTION
## Why

IM responses resolve generated artifact paths before publishing attachments.
That resolution performs `Path.resolve()`, `is_file()`, and `stat()` calls from
the async channel dispatch path. Slow or network-backed storage can therefore
stall every channel and Gateway coroutine on the same event loop.

DeerFlow's strict Blockbuster gate reproduces this deterministically on `main`:
the artifact delivery path fails with `BlockingError: os.path.abspath`.

## What changed

- Make the artifact-delivery preparation boundary asynchronous.
- Resolve artifact paths and metadata in `asyncio.to_thread`.
- Await the shared boundary from streaming and non-streaming channel responses.
- Add strict Blockbuster coverage and document the regression anchor.

Response text, attachment metadata, path validation, and delivery behavior are
unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [x] **Backend API** - IM channel response dispatch under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded dependency
- [ ] **Default behavior change** - changes existing behavior without opt-in
- [ ] **Docs / tests / CI only** - no runtime behavior change

## Screenshots / Recording

Not applicable. This changes event-loop ownership without changing output.

## Bug fix verification

- Test path: `backend/tests/blocking_io/test_channel_artifact_resolution.py`
- Red on `main`: yes, `BlockingError: os.path.abspath`
- Green on this branch: yes

## Validation

- `cd backend && make test-blocking-io` - 71 passed
- `cd backend && PYTHONPATH=. uv run pytest tests/test_channel_file_attachments.py tests/test_channels.py -q` - 358 passed
- `cd backend && make test` - 11064 passed, 74 skipped
- `cd backend && make detect-blocking-io` - findings reduced from 22 to 21; `manager.py` finding removed
- Focused Ruff lint and format checks passed
- `git diff --check` passed

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited the repository's blocking-I/O report, reproduced
the event-loop violation with a strict regression test, implemented the worker
offload, checked all open PR files for overlapping work, and ran focused plus
full backend validation. I reviewed the final control flow and diff.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
