### PR TITLE
fix(skills): offload user install directory creation

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -261,6 +261,8 @@ Blocking-IO runtime gate (`tests/blocking_io/`):
   `test_integrations_router.py` (locks Lark integration install and auth
   completion route handlers offloading archive filesystem work and `lark-cli`
   subprocesses);
+  `test_skills_install.py` (locks local and user-scoped archive installation
+  filesystem phases off the event loop);
   `test_uploads_middleware.py` (locks `UploadsMiddleware.abefore_agent`
   offloading the uploads-directory scan off the event loop);
   `test_uploads_router.py` (locks Gateway upload/list/delete endpoints

--- a/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
+++ b/backend/packages/harness/deerflow/skills/storage/user_scoped_skill_storage.py
@@ -330,7 +330,7 @@ class UserScopedSkillStorage(LocalSkillStorage):
         custom_dir = self._user_custom_root
 
         # Ensure user custom directory exists
-        custom_dir.mkdir(parents=True, exist_ok=True)
+        await asyncio.to_thread(custom_dir.mkdir, parents=True, exist_ok=True)
 
         # The per-file security scan is an async LLM call and must stay on the
         # event loop; every filesystem phase around it runs in a worker thread.

--- a/backend/tests/blocking_io/test_skills_install.py
+++ b/backend/tests/blocking_io/test_skills_install.py
@@ -23,10 +23,13 @@ import asyncio
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
+from deerflow.config.paths import Paths
 from deerflow.skills.storage.local_skill_storage import LocalSkillStorage
+from deerflow.skills.storage.user_scoped_skill_storage import UserScopedSkillStorage
 
 pytestmark = pytest.mark.asyncio
 
@@ -71,3 +74,35 @@ async def test_install_skill_archive_does_not_block_event_loop(tmp_path: Path, m
     installed_md = tmp_path / "skills" / "custom" / "loop-skill" / "SKILL.md"
     assert await asyncio.to_thread(installed_md.exists)
     assert await asyncio.to_thread((tmp_path / "skills" / "custom" / "loop-skill" / "references" / "usage.md").exists)
+
+
+async def test_user_scoped_install_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    archive = tmp_path / "loop-skill.skill"
+    await asyncio.to_thread(_build_archive, archive)
+
+    async def _allow_scan(content: str, *, executable: bool = False, location: str = "SKILL.md", app_config=None, static_findings=None):
+        return SimpleNamespace(decision="allow", reason="anchor stub")
+
+    monkeypatch.setattr("deerflow.skills.installer.scan_skill_content", _allow_scan)
+
+    skills_root = tmp_path / "skills"
+    config = SimpleNamespace(
+        skills=SimpleNamespace(
+            get_skills_path=lambda: skills_root,
+            container_path="/mnt/skills",
+            use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage",
+        )
+    )
+    paths = await asyncio.to_thread(Paths, base_dir=tmp_path)
+    with patch("deerflow.config.paths.get_paths", return_value=paths):
+        storage = await asyncio.to_thread(
+            UserScopedSkillStorage,
+            "alice",
+            host_path=str(skills_root),
+            app_config=config,
+        )
+        result = await storage.ainstall_skill_from_archive(archive)
+
+    assert result["success"] is True
+    installed_md = tmp_path / "users" / "alice" / "skills" / "custom" / "loop-skill" / "SKILL.md"
+    assert await asyncio.to_thread(installed_md.is_file)


### PR DESCRIPTION
## Why

`UserScopedSkillStorage.ainstall_skill_from_archive()` offloads archive
extraction, validation, commit, and cleanup, but it still creates the user's
custom-skill directory directly on the asyncio event loop. On slow or
network-backed storage, that filesystem write can stall unrelated Gateway
requests.

The strict Blockbuster gate reproduces this on `main` with
`BlockingError: os.mkdir`.

## What changed

- Create the user-scoped custom-skill directory through `asyncio.to_thread`.
- Extend the existing archive-install Blockbuster test to exercise the real
  user-scoped extraction, security-scan, and commit pipeline.
- Document that both local and user-scoped install paths are runtime anchors.

Archive validation, security scanning, commit ordering, user isolation, and
the response contract are unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [ ] **Backend API** - endpoint / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [x] **Skills** - user-scoped archive installation
- [ ] **Dependencies** - new/upgraded dependency
- [ ] **Default behavior change** - changes existing behavior without opt-in
- [ ] **Docs / tests / CI only** - no runtime behavior change

## Screenshots / Recording

Not applicable. This changes event-loop ownership without changing output.

## Bug fix verification

- Test path: `backend/tests/blocking_io/test_skills_install.py`
- Red on `main`: yes, `BlockingError: os.mkdir`
- Green on this branch: yes

## Validation

- `cd backend && make test-blocking-io` - 71 passed
- Focused user storage/projection suite - 71 passed
- `cd backend && make test` - 11064 passed, 74 skipped
- `cd backend && make detect-blocking-io` - findings reduced from 22 to 21;
  `user_scoped_skill_storage.py` finding removed
- Focused Ruff lint and format checks passed
- `git diff --check` passed

## Duplicate check

Reviewed 586 open issues and 360 open PRs. The only open PR changing
`user_scoped_skill_storage.py`, #4164, addresses lead-agent tool filtering and
does not touch archive installation or this event-loop boundary.

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Used DeerFlow's static detector to identify the candidate,
added a strict runtime regression before the implementation, audited every
open PR's changed files for overlap, implemented the one-line offload boundary,
and ran focused plus full validation. I reviewed the final diff and behavior.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
