### PR TITLE
fix(uploads): offload conversion metadata IO

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -261,6 +261,8 @@ Blocking-IO runtime gate (`tests/blocking_io/`):
   `test_integrations_router.py` (locks Lark integration install and auth
   completion route handlers offloading archive filesystem work and `lark-cli`
   subprocesses);
+  `test_file_conversion.py` (locks source metadata reads and generated
+  Markdown writes off the event loop);
   `test_uploads_middleware.py` (locks `UploadsMiddleware.abefore_agent`
   offloading the uploads-directory scan off the event loop);
   `test_uploads_router.py` (locks Gateway upload/list/delete endpoints

--- a/backend/packages/harness/deerflow/utils/file_conversion.py
+++ b/backend/packages/harness/deerflow/utils/file_conversion.py
@@ -10,6 +10,7 @@ PDF conversion strategy (auto mode):
 
 Large files (> ASYNC_THRESHOLD_BYTES) are converted in a thread pool via
 asyncio.to_thread() to avoid blocking the event loop (fixes #1569).
+Source metadata reads and generated Markdown writes are always offloaded.
 
 No FastAPI or HTTP dependencies — pure utility functions.
 """
@@ -159,7 +160,7 @@ async def convert_file_to_markdown(file_path: Path, output_path: Path | None = N
     """
     try:
         pdf_converter = _get_pdf_converter()
-        file_size = file_path.stat().st_size
+        file_size = (await asyncio.to_thread(file_path.stat)).st_size
 
         if file_size > _ASYNC_THRESHOLD_BYTES:
             text = await asyncio.to_thread(_do_convert, file_path, pdf_converter)
@@ -167,7 +168,7 @@ async def convert_file_to_markdown(file_path: Path, output_path: Path | None = N
             text = _do_convert(file_path, pdf_converter)
 
         md_path = output_path if output_path is not None else file_path.with_suffix(".md")
-        md_path.write_text(text, encoding="utf-8")
+        await asyncio.to_thread(md_path.write_text, text, encoding="utf-8")
 
         logger.info("Converted %s to markdown: %s (%d chars)", file_path.name, md_path.name, len(text))
         return md_path

--- a/backend/tests/blocking_io/test_file_conversion.py
+++ b/backend/tests/blocking_io/test_file_conversion.py
@@ -1,0 +1,34 @@
+"""Regression coverage for file-conversion metadata IO on the event loop."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from deerflow.utils.file_conversion import convert_file_to_markdown
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_file_conversion_metadata_io_does_not_block_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "report.pdf"
+    await asyncio.to_thread(source.write_bytes, b"%PDF-1.4 test")
+
+    monkeypatch.setattr(
+        "deerflow.utils.file_conversion._get_pdf_converter",
+        lambda: "auto",
+    )
+    monkeypatch.setattr(
+        "deerflow.utils.file_conversion._do_convert",
+        lambda _path, _converter: "# Report\n",
+    )
+
+    result = await convert_file_to_markdown(source)
+
+    assert result == source.with_suffix(".md")
+    assert await asyncio.to_thread(result.read_text, encoding="utf-8") == "# Report\n"

--- a/backend/tests/test_file_conversion.py
+++ b/backend/tests/test_file_conversion.py
@@ -239,10 +239,13 @@ class TestGetPdfConverter:
 
 
 class TestConvertFileToMarkdown:
-    def test_small_file_runs_synchronously(self, tmp_path):
-        """Small files (< 1 MB) are converted in the event loop thread."""
+    def test_small_file_conversion_runs_synchronously(self, tmp_path):
+        """Small-file conversion stays inline while metadata IO is offloaded."""
         pdf = tmp_path / "small.pdf"
         pdf.write_bytes(b"%PDF-1.4 " + b"x" * 100)  # well under 1 MB
+
+        async def fake_to_thread(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
 
         with (
             patch("deerflow.utils.file_conversion._get_pdf_converter", return_value="auto"),
@@ -250,13 +253,14 @@ class TestConvertFileToMarkdown:
                 "deerflow.utils.file_conversion._do_convert",
                 return_value="# Small PDF",
             ) as mock_convert,
-            patch("asyncio.to_thread") as mock_thread,
+            patch("asyncio.to_thread", side_effect=fake_to_thread) as mock_thread,
         ):
             md_path = _run(convert_file_to_markdown(pdf))
 
-        # asyncio.to_thread must NOT have been called
-        mock_thread.assert_not_called()
         mock_convert.assert_called_once()
+        threaded_functions = [call.args[0] for call in mock_thread.call_args_list]
+        assert mock_convert not in threaded_functions
+        assert len(threaded_functions) == 2  # source stat + Markdown write
         assert md_path == pdf.with_suffix(".md")
         assert md_path.read_text() == "# Small PDF"
 
@@ -279,7 +283,7 @@ class TestConvertFileToMarkdown:
         ):
             md_path = _run(convert_file_to_markdown(pdf))
 
-        mock_thread.assert_called_once()
+        assert mock_thread.call_count == 3  # source stat + conversion + Markdown write
         assert md_path == pdf.with_suffix(".md")
         assert md_path.read_text() == "# Large PDF"
 


### PR DESCRIPTION
## Why

`convert_file_to_markdown()` is an async API, but it reads source metadata with
`Path.stat()` and writes generated Markdown with `Path.write_text()` directly
on the event loop. Slow or network-backed upload storage can therefore stall
unrelated Gateway requests, and the strict Blockbuster gate turns the source
stat into a caught conversion failure that returns `None`.

## What changed

- Offload the source `stat()` call through `asyncio.to_thread`.
- Offload the generated Markdown write through `asyncio.to_thread`.
- Keep the existing size policy unchanged: small-file conversion remains
  inline, while conversion above 1 MiB remains worker-threaded.
- Add strict Blockbuster coverage and update the size-policy tests to
  distinguish conversion work from metadata IO.

Converter selection, fallback behavior, output paths, and error handling are
unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [ ] **Backend API** - endpoint / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded dependency
- [ ] **Default behavior change** - conversion policy and output stay unchanged
- [ ] **Docs / tests / CI only** - runtime IO ownership changes

## Screenshots / Recording

Not applicable. This changes event-loop ownership without changing output.

## Bug fix verification

- Test path: `backend/tests/blocking_io/test_file_conversion.py`
- Red on `main`: yes; `BlockingError: os.stat` is caught and conversion returns
  `None`
- Green on this branch: yes

## Validation

- Focused conversion/upload suite - 73 passed
- `cd backend && make test` - 11064 passed, 74 skipped
- `cd backend && make detect-blocking-io` - findings reduced from 22 to 20;
  both `file_conversion.py` findings removed
- Focused Ruff lint and format checks passed
- `git diff --check` passed

## Duplicate check

Reviewed 586 open issues and 360 open PRs. PR #2065 also changes
`file_conversion.py`, but it implements a LibreOffice fallback for legacy
`.doc` files. This PR does not modify converter routing or fallback behavior;
it only moves source metadata and destination writes off the event loop.

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Used the repository's static detector to identify the
candidate, wrote a strict runtime regression before implementation, audited all
open PR changed files, implemented the two IO offloads, and updated tests to
prove the existing small/large conversion policy is preserved. I reviewed the
final diff and ran focused plus full validation.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
