### PR TITLE
fix(channels): reject malformed Buzz key padding

### DIFF
--- a/backend/app/channels/buzz_nostr.py
+++ b/backend/app/channels/buzz_nostr.py
@@ -63,6 +63,8 @@ def _bech32_decode(expected_hrp: str, value: str) -> bytes:
         if bits >= 8:
             bits -= 8
             out.append((acc >> bits) & 0xFF)
+    if bits and acc & ((1 << bits) - 1):
+        raise ValueError(f"nonzero bech32 padding in {value!r}")
     if len(out) != 32:
         raise ValueError(f"expected 32-byte payload in {value!r}")
     return bytes(out)

--- a/backend/tests/test_buzz_nostr.py
+++ b/backend/tests/test_buzz_nostr.py
@@ -36,6 +36,25 @@ def test_parse_pubkey_accepts_hex_and_npub():
     assert buzz_nostr.parse_pubkey(PK3_NPUB) == PK3_HEX
 
 
+@pytest.mark.parametrize(
+    ("parser", "malformed"),
+    [
+        (
+            buzz_nostr.parse_private_key,
+            "nsec1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp3fuyy7t",
+        ),
+        (
+            buzz_nostr.parse_pubkey,
+            "npub1lycg5qvjtrp3qjf5f7zl382j9x6nrjz9sdhenvyxq8c3808qxmu3875l8g",
+        ),
+    ],
+)
+def test_bech32_keys_reject_nonzero_padding(parser, malformed):
+    """A valid checksum must not make non-canonical payload padding valid."""
+    with pytest.raises(ValueError, match="padding"):
+        parser(malformed)
+
+
 def test_event_id_matches_nip01_reference_vector():
     eid = buzz_nostr.event_id(PK3_HEX, 1700000000, 9, [["h", CHANNEL]], "hello buzz")
     assert eid == "6aa2ef0a72e39e52ac7c3680e6a76ed75c90340e684148da6221086b443d2089"


### PR DESCRIPTION
## Why

NIP-19 encodes a 32-byte key as 52 five-bit bech32 words. The last word has
four padding bits that must be zero, but the Buzz decoder discarded those bits
without validating them. A checksum-valid `npub` or `nsec` with nonzero padding
was therefore accepted as an alias of a canonical key.

For example, the malformed but checksum-valid
`npub1lycg5qvjtrp3qjf5f7zl382j9x6nrjz9sdhenvyxq8c3808qxmu3875l8g`
was accepted as
`f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9`.

## What changed

- Reject a bech32 key when discarded payload bits are nonzero.
- Add fixed checksum-valid malformed vectors for both `npub` and `nsec`.

Canonical hex, `npub`, and `nsec` inputs are unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [ ] **Backend API** - endpoint / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded dependency
- [ ] **Default behavior change** - only malformed Buzz key strings are rejected
- [ ] **Docs / tests / CI only** - includes a runtime parser correction

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Red on `main`: both checksum-valid malformed vectors were accepted
  (`34 passed, 2 failed`).
- Green after the fix: Buzz suites pass (`141 passed`).

## Validation

- `cd backend && PYTHONPATH=. uv run --extra buzz pytest
  tests/test_buzz_nostr.py tests/test_buzz_channel.py -q` - 141 passed
- `cd backend && make test` with the Buzz extra installed -
  11204 passed, 72 skipped
- Focused Ruff lint and format checks passed
- `git diff --check` passed

## Duplicate check

Searched all open PR titles and bodies for `bech32`, `padding`, `npub`,
`nsec`, `Buzz`, and `Nostr`; no active implementation was found.

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited the newly merged Buzz parser, generated fixed
checksum-valid malformed vectors, wrote the failing regression first, applied
the minimal decoder check, and ran focused plus full validation. I reviewed the
final diff and can explain each changed line.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
