### PR TITLE
fix(channels): validate Buzz relay host

### DIFF
--- a/backend/app/channels/buzz.py
+++ b/backend/app/channels/buzz.py
@@ -254,14 +254,15 @@ class BuzzChannel(Channel):
     def __init__(self, bus: MessageBus, config: dict[str, Any]) -> None:
         super().__init__(name="buzz", bus=bus, config=config)
         self._relay_url = str(config.get("relay_url", "")).strip()
-        if not self._relay_url.startswith(("ws://", "wss://")):
-            raise ValueError("channels.buzz.relay_url must be a ws:// or wss:// URL")
+        parsed_relay_url = urlparse(self._relay_url)
+        if parsed_relay_url.scheme not in ("ws", "wss") or not parsed_relay_url.hostname:
+            raise ValueError("channels.buzz.relay_url must be a ws:// or wss:// URL with a host")
         # One community per relay URL (see the design's multi-community note), so the
         # relay host is this channel's workspace: it scopes inbound dedupe, the
         # persisted connection row written by `/connect`, and the lookup that resolves
         # that row back on the inbound path. Computed once here so those three uses
         # can never drift apart.
-        self._workspace_id = urlparse(self._relay_url).netloc
+        self._workspace_id = parsed_relay_url.netloc
         self._private_key_raw = str(config.get("private_key", ""))
         self._keys: buzz_nostr.NostrKeys | None = None  # parsed in start() so coincurve stays lazy
         self._allowed_users = {buzz_nostr.parse_pubkey(v) for v in config.get("allowed_users", []) or []}

--- a/backend/tests/test_buzz_channel.py
+++ b/backend/tests/test_buzz_channel.py
@@ -63,9 +63,18 @@ def test_config_parsing_normalizes_allowlist_and_defaults():
     assert ch._relay_url == "wss://buzz.example.com"
 
 
-def test_config_rejects_non_websocket_relay_url():
+@pytest.mark.parametrize(
+    "relay_url",
+    [
+        "https://buzz.example.com",
+        "ws://",
+        "wss://",
+        "ws:///missing-host",
+    ],
+)
+def test_config_rejects_invalid_websocket_relay_url(relay_url):
     with pytest.raises(ValueError):
-        _channel(relay_url="https://buzz.example.com")
+        _channel(relay_url=relay_url)
 
 
 def test_start_and_stop_manage_outbound_subscription():


### PR DESCRIPTION
## Why

`BuzzChannel` previously validated `relay_url` with a string-prefix check.
Values such as `ws://`, `wss://`, and `ws:///missing-host` passed construction
even though they have no hostname.

That leaves `workspace_id` empty and lets `start()` launch a relay task that can
only fail and reconnect forever. Invalid configuration should fail immediately
with the same actionable validation error used for non-WebSocket URLs.

## What changed

- Parse the relay URL once during channel construction.
- Require a `ws` or `wss` scheme and a non-empty hostname.
- Reuse the parsed URL when deriving the workspace identity.
- Extend config validation coverage with three hostless WebSocket forms.

Valid relay paths, query strings, ports, and existing workspace identities are
unchanged.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [ ] **Backend API** - endpoint / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded dependency
- [x] **Default behavior change** - invalid hostless Buzz URLs now fail fast
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Red on `main`: HTTPS was rejected, but all three hostless WebSocket forms
  were accepted (`1 passed, 3 failed`).
- Green after the fix: Buzz suites pass (`142 passed`).

## Validation

- `cd backend && PYTHONPATH=. uv run --extra buzz pytest
  tests/test_buzz_channel.py tests/test_buzz_nostr.py -q` - 142 passed
- `cd backend && make test` with the Buzz extra installed -
  11205 passed, 72 skipped
- Focused Ruff lint and format checks passed
- `git diff --check` passed

## Duplicate check

Searched open issues and PRs for Buzz relay URL, WebSocket host, and invalid URL
validation; no active report or implementation was found.

## AI assistance

**Tool(s) used:** TRAE

**How you used it:** Audited the newly merged Buzz connector, wrote the
parameterized failing configuration test first, implemented the minimal
constructor validation, and ran focused plus full validation. I reviewed the
final diff and can explain each changed line.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
