### PR TITLE
fix(middleware): skip raw tool-call fallback when invalid view carries the same call

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dangling_tool_call_middleware.py
@@ -195,7 +195,13 @@ class DanglingToolCallMiddleware(AgentMiddleware[AgentState]):
             normalized.append(normalized_call)
 
         raw_tool_calls = (getattr(msg, "additional_kwargs", None) or {}).get("tool_calls") or []
-        if not tool_calls:
+        # The raw payload is a fallback serialization of the same calls: the
+        # OpenAI serializer reaches for it only once BOTH structured views are
+        # empty (mirrors the gating in _normalize_tool_call_ids).  Collecting
+        # it while invalid_tool_calls is non-empty would count the same call
+        # twice and emit two ToolMessages for one id — the exact duplicate-id
+        # shape strict providers reject.
+        if not tool_calls and not getattr(msg, "invalid_tool_calls", None):
             for raw_tc in raw_tool_calls:
                 if not isinstance(raw_tc, dict):
                     continue

--- a/backend/tests/test_dangling_tool_call_middleware.py
+++ b/backend/tests/test_dangling_tool_call_middleware.py
@@ -229,6 +229,33 @@ class TestBuildPatchedMessagesPatching:
         assert patched[1].name == "unknown_tool"
         assert patched[1].status == "error"
 
+    def test_raw_fallback_is_skipped_when_invalid_view_carries_the_same_call(self):
+        # The raw additional_kwargs payload is a fallback serialization of the
+        # same calls; the provider reaches for it only when BOTH structured
+        # views are empty (see _normalize_tool_call_ids). Collecting it while
+        # invalid_tool_calls is non-empty counts the call twice and emits two
+        # ToolMessages for one id — the duplicate-id shape strict providers
+        # reject with HTTP 400.
+        mw = DanglingToolCallMiddleware()
+        msgs = [
+            AIMessage.model_construct(
+                content="",
+                type="ai",
+                tool_calls=[],
+                invalid_tool_calls=[{"id": "call_x", "name": "read_file", "args": None, "error": "parse"}],
+                additional_kwargs={"tool_calls": [{"id": "call_x", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}]},
+                response_metadata={},
+            )
+        ]
+
+        patched = mw._build_patched_messages(msgs)
+
+        assert patched is not None
+        tool_messages = [m for m in patched if isinstance(m, ToolMessage)]
+        assert len(tool_messages) == 1
+        assert tool_messages[0].tool_call_id == "call_x"
+        assert tool_messages[0].status == "error"
+
     def test_existing_tool_result_still_sanitizes_empty_structured_tool_call_name(self):
         mw = DanglingToolCallMiddleware()
         msgs = [


### PR DESCRIPTION
## Why

`DanglingToolCallMiddleware._message_tool_calls` collected the raw `additional_kwargs["tool_calls"]` payload whenever the structured `tool_calls` list was empty — even when `invalid_tool_calls` was non-empty and carried an entry with the **same id**. The raw payload is a fallback serialization of the *same* calls: the OpenAI serializer reaches for it only once both structured views are empty, which is exactly the gating `_normalize_tool_call_ids` documents and implements. Collecting it alongside the invalid entry counted the call twice, and `_build_patched_messages` then emitted **two placeholder ToolMessages for one `tool_call_id`** — the duplicate-id shape strict OpenAI-compatible providers reject with HTTP 400, which is the failure this middleware exists to prevent.

(Defensive consistency fix: the internal gating between `_message_tool_calls` and `_normalize_tool_call_ids` disagreed; standard `langchain_openai` never produces this shape, but patched OpenAI-compatible providers do write raw `tool_calls` into `additional_kwargs`, so the duplicate-placeholder path is reachable in principle.)

## What changed

- The raw payload is now collected only when **both** structured views (`tool_calls` and `invalid_tool_calls`) are empty, matching the documented serializer behavior and the gating in `_normalize_tool_call_ids`. The raw-only fallback case is unchanged.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [x] **Agents / LangGraph** — `DanglingToolCallMiddleware` tool-call collection
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `backend/tests/test_dangling_tool_call_middleware.py::TestBuildPatchedMessagesPatching::test_raw_fallback_is_skipped_when_invalid_view_carries_the_same_call`
- Red on `main`, green on this branch: **yes** (fails on main with 2 placeholders for `call_x`; passes here with exactly 1)

## Validation

```
cd backend
PYTHONPATH=. uv run pytest tests/test_dangling_tool_call_middleware.py  # 64/64 pass
uv run ruff check / ruff format --check                                  # clean
```

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI located the inconsistency during a codebase audit, wrote the fix and test; I reviewed the change and verified the red/green test run locally.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
