### PR TITLE
fix(gateway): bind local dev gateway to 127.0.0.1 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,8 @@ DeerFlow has key high-privilege capabilities including **system command executio
 - **Unauthorized illegal invocation**: Agent functionality could be discovered by unauthorized third parties or malicious internet scanners, triggering bulk unauthorized requests that execute high-risk operations such as system commands and file read/write, potentially causing serious security consequences.
 - **Compliance and legal risks**: If the agent is illegally invoked to conduct cyberattacks, data theft, or other illegal activities, it may result in legal liability and compliance risks.
 
+> **Note on default bind addresses**: Local development (`scripts/serve.sh`), the gateway config default, and the plain `uvicorn` invocation all bind to `127.0.0.1` by default. **Docker deployments (`docker-compose.yaml`, `backend/Dockerfile`) bind the gateway to `0.0.0.0` inside the container** because the nginx reverse proxy and other containers must reach it over the container network. When you publish container ports (`ports:` in docker-compose) or deploy on a host with a public/LAN interface, the gateway becomes reachable beyond loopback — apply the security measures below.
+
 ### Security Recommendations
 
 **Note: We strongly recommend deploying DeerFlow in a local trusted network environment.** If you need cross-device or cross-network deployment, you must implement strict security measures, such as:

--- a/backend/app/gateway/config.py
+++ b/backend/app/gateway/config.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 class GatewayConfig(BaseModel):
     """Configuration for the API Gateway."""
 
-    host: str = Field(default="0.0.0.0", description="Host to bind the gateway server")
+    host: str = Field(default="127.0.0.1", description="Host to bind the gateway server")
     port: int = Field(default=8001, description="Port to bind the gateway server")
     enable_docs: bool = Field(default=True, description="Enable Swagger/ReDoc/OpenAPI endpoints")
 
@@ -19,7 +19,7 @@ def get_gateway_config() -> GatewayConfig:
     global _gateway_config
     if _gateway_config is None:
         _gateway_config = GatewayConfig(
-            host=os.getenv("GATEWAY_HOST", "0.0.0.0"),
+            host=os.getenv("GATEWAY_HOST", "127.0.0.1"),
             port=int(os.getenv("GATEWAY_PORT", "8001")),
             enable_docs=os.getenv("GATEWAY_ENABLE_DOCS", "true").lower() == "true",
         )

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -253,8 +253,11 @@ mkdir -p logs
 mkdir -p temp/client_body_temp temp/proxy_temp temp/fastcgi_temp temp/uwsgi_temp temp/scgi_temp
 
 # 1. Gateway API
+# Local development binds to 127.0.0.1 only (nginx reverse-proxies on the same
+# host). Set GATEWAY_BIND_HOST=0.0.0.0 to expose beyond loopback intentionally.
+GATEWAY_BIND_HOST="${GATEWAY_BIND_HOST:-127.0.0.1}"
 run_service "Gateway" \
-    "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host 0.0.0.0 --port 8001 $GATEWAY_EXTRA_FLAGS > ../logs/gateway.log 2>&1" \
+    "cd backend && PYTHONPATH=. uv run uvicorn app.gateway.app:app --host $GATEWAY_BIND_HOST --port 8001 $GATEWAY_EXTRA_FLAGS > ../logs/gateway.log 2>&1" \
     8001 30
 
 # 2. Frontend


### PR DESCRIPTION
## Summary

The README security section states DeerFlow is designed to run in a **local trusted environment (loopback only)**, but two default paths bind the gateway to `0.0.0.0`:

- `scripts/serve.sh` — local development entrypoint
- `backend/app/gateway/config.py` — `GatewayConfig.host` default and `GATEWAY_HOST` fallback

This silently exposes the agent API (including open registration and agent runs) to the LAN or beyond, contradicting the documented trust model.

## Changes

1. **`scripts/serve.sh`**: bind uvicorn to `127.0.0.1` by default. The local nginx reverse-proxy runs on the same host, so functionality is unchanged. New opt-in env var `GATEWAY_BIND_HOST=0.0.0.0` for intentional exposure.
2. **`backend/app/gateway/config.py`**: `GatewayConfig.host` default and `GATEWAY_HOST` fallback changed to `127.0.0.1` to match the documented trust model.
3. **`README.md`**: document the actual bind behaviour — local dev/plain uvicorn bind loopback by default, Docker deployments still bind `0.0.0.0` inside the container (nginx/sibling containers need it), and port publishing or public-interface deployment exposes the gateway.

## Why Docker is unchanged

`docker-compose.yaml` and `backend/Dockerfile` pass `--host 0.0.0.0` explicitly because the nginx reverse proxy and sibling containers reach the gateway over the container network. Inside a container this is not a direct host exposure; the risk materializes only when ports are published or the host has a public interface — which the updated README note now calls out.

## Testing

- `bash -n scripts/serve.sh` passes
- No tests assert the gateway bind default (verified via grep of `backend/tests/`)

## Related

Fixes the documentation/implementation mismatch described in #4698 (see accompanying issue).