### PR TITLE
docs(lark): drop dead link to uncommitted sandbox init spec

### DIFF
--- a/docker/lark-cli-init/README.md
+++ b/docker/lark-cli-init/README.md
@@ -5,9 +5,6 @@ sandbox Pod via an **init container + shared `emptyDir`**, instead of the Gatewa
 downloading Linux binaries from GitHub at install time and mounting them via
 hostPath/PVC.
 
-See the design at
-[`docs/superpowers/specs/2026-07-21-lark-sandbox-init-container-design.md`](../../docs/superpowers/specs/2026-07-21-lark-sandbox-init-container-design.md).
-
 ## What it does
 
 - **Build time** (network available): downloads and SHA-256-verifies the official


### PR DESCRIPTION
Fixes # <!-- no issue — docs-only dead-link fix -->

## Why

I'm getting started with DeerFlow — reading through the codebase to learn
how it fits together and looking for a small, concrete way to contribute.
While exploring, I got curious about the state of the docs and checked the
internal links across the .md files. That surfaced a dead one:
`docker/lark-cli-init/README.md` points to
`docs/superpowers/specs/2026-07-21-lark-sandbox-init-container-design.md`, a
design spec that was never committed (absent across the full git history —
dead on arrival in #3971). For the next person digging into the lark sandbox
init design, that's a 404 dead end. It's a tiny fix, but it felt like a good
first contribution: self-contained, and it leaves the docs a little better
than I found them.

## What changed

Removed the dangling "See the design at ..." reference from the
lark-cli-init README. The README's body (What it does / Build / Wiring it
into the provisioner) already documents the init-container behavior on its
own, so no information is lost.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

Docs-only change to `docker/lark-cli-init/README.md`. No backend Python or
frontend js/ts touched, so the `ruff` / `eslint` / `prettier` hooks do not
apply. Verified the target spec path is absent across the full git history
(`git log --all -- <path>` → empty) and absent in the working tree.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI 辅助 Coding — 用脚本扫描仓库 .md 文档的坏相对链接，定位到这一处并生成删除改动；改动由人类逐行审阅定稿。

**人类验证环节：**

- 逐行确认改动内容（仅删除指向不存在文件的链接句，共 3 行）
- 核实目标 spec 在 `git log --all` 全历史中从未存在、工作树中也不存在
- 确认该坏链接由 #3971 引入、已断开约 11 天
- 确认 README 主体自包含，删除该引用不丢失实质信息
- 对本次提交负全部责任

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
