### PR TITLE
docs(tui): note transparent mode assumes a dark terminal

### DIFF
--- a/backend/docs/TUI.md
+++ b/backend/docs/TUI.md
@@ -39,7 +39,9 @@ instead of hanging.
 Transparent rendering is opt-in; the solid DeerFlow palette remains the default.
 The transparent mode uses Textual's `ansi_default` background for the main
 screen, header, transcript, status, palette, composer, and modal surfaces while
-keeping truecolor foregrounds and selection highlights. Combine
+keeping truecolor foregrounds and selection highlights. Those foregrounds are
+calibrated for dark terminal backgrounds, so on a light-background terminal they
+may render with low contrast. Combine
 `--tui-transparent` with `--tui` when the UI also needs to be forced without a
 detected TTY.
 


### PR DESCRIPTION
References #4631

## Why

Suggested in the #4631 review: the transparent TUI mode swaps only the *background* for the terminal's own (`background: ansi_default` in `tui/app.py`), while keeping the truecolor foreground palette from `tui/theme.py`. That palette is calibrated for a dark background, so on a light-background terminal the text can come out barely readable — and nothing in the docs says so before you flip the mode on.

This is measurable rather than a matter of taste. WCAG contrast ratios for the palette's foregrounds against the solid default background (`#1a1b26`) versus a white terminal background:

| Palette color | vs dark `#1a1b26` | vs white `#ffffff` |
|---|---|---|
| `text` `#c0caf5` | 10.59 | **1.61** |
| `primary` `#7dcfff` | 9.96 | **1.72** |
| `accent` `#9ece6a` | 9.35 | **1.83** |
| `warning` `#e0af68` | 8.55 | **2.00** |
| `user` `#7aa2f7` | 6.79 | **2.52** |

WCAG AA wants 4.5:1 for body text (3:1 for large text). The main text color lands at 1.61:1 on white — so this is not a marginal degradation, it is unreadable. (`dim` and `muted` are the exception: being mid-tone, they happen to do better on white than on the dark background.)

## What changed

Documentation only. `backend/docs/TUI.md` now states the dark-background assumption right where `--tui-transparent` / `DEER_FLOW_TUI_TRANSPARENT` is described, so a user reads it before turning the mode on rather than after.

No behavior change: the transparent mode is still opt-in, the solid DeerFlow palette is still the default, and no color values were touched.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

- `backend/docs/TUI.md` is the only changed file; no code path is touched, so no test suite covers it.
- Verified the claim against the source rather than restating the review comment: `tui/app.py:53` sets `background: ansi_default` (background only), and the foreground values are the ones in `tui/theme.py`.
- Computed the WCAG contrast ratios above from those exact hex values to confirm the assumption is real and worth documenting.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted. It located the transparent-mode implementation and the palette definition, computed the contrast table, and drafted the doc sentence and this description. I reviewed and finalized every line.

Human verification performed for this change:

- Read the full diff — one file, 3 insertions, 1 deletion.
- Confirmed in the source that transparent mode overrides only the background and inherits the dark-calibrated foregrounds, instead of taking the #4631 review comment at face value.
- Checked the resulting sentence sits next to the flag it qualifies, so it is discoverable at the point of decision.
- Confirmed no color value, default, or code path changed.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
