### PR TITLE
refactor(frontend): extract SHOWCASE_ROUTE_PREFIX constant

### DIFF
--- a/frontend/src/components/workspace/chats/use-thread-chat.ts
+++ b/frontend/src/components/workspace/chats/use-thread-chat.ts
@@ -3,6 +3,7 @@
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { SHOWCASE_ROUTE_PREFIX } from "@/core/threads/static-demo";
 import { uuid } from "@/core/utils/uuid";
 
 export const THREAD_CHAT_RESET_EVENT = "deer-flow:thread-chat-reset";
@@ -120,7 +121,7 @@ export function useThreadChat() {
   }, []);
 
   const isMock =
-    actualPathname.startsWith("/showcase/") ||
+    actualPathname.startsWith(`${SHOWCASE_ROUTE_PREFIX}/`) ||
     searchParams.get("mock") === "true";
   return {
     threadId: isNewPath ? (newThreadIdRef.current ?? threadId) : threadId,

--- a/frontend/src/core/threads/static-demo.ts
+++ b/frontend/src/core/threads/static-demo.ts
@@ -131,8 +131,11 @@ export function isDemoThreadId(threadId: string): boolean {
   return DEMO_THREAD_ID_SET.has(threadId);
 }
 
+/** Route prefix for the public, read-only showcase demo thread pages. */
+export const SHOWCASE_ROUTE_PREFIX = "/showcase";
+
 export function pathOfPublicDemoThread(threadId: string): string {
-  return `/showcase/${encodeURIComponent(threadId)}`;
+  return `${SHOWCASE_ROUTE_PREFIX}/${encodeURIComponent(threadId)}`;
 }
 
 export type ThreadSearchParams = NonNullable<


### PR DESCRIPTION
References #4635

## Why

#4635 added the public showcase routes for case studies, and the `/showcase` route prefix ended up written as a bare string literal in two independent places:

- `core/threads/static-demo.ts` builds showcase paths with `` `/showcase/${...}` ``
- `components/workspace/chats/use-thread-chat.ts` separately decides "is this a mock/read-only view?" with `actualPathname.startsWith("/showcase/")`

Two copies of one route fact means changing or namespacing the prefix later requires finding both. Missing the second one is the quiet failure: path generation would move to the new prefix while the mock-mode detection kept matching the old one, so showcase pages would silently stop being treated as read-only demos — a wrong-behavior bug rather than a build error, since both halves still typecheck fine on their own.

## What changed

No user-visible or behavioral change. `SHOWCASE_ROUTE_PREFIX` is now exported from `core/threads/static-demo.ts` (which already owns the demo-thread domain) and consumed by both the path builder and the mock-mode check, so the prefix is defined once.

The rendered strings are byte-identical before and after: `pathOfPublicDemoThread` still produces `/showcase/<id>`, and the mock check still tests `startsWith("/showcase/")`.

## Surface area

- [x] **Frontend UI** — touches `frontend/src/components/workspace/chats/use-thread-chat.ts`, though only the source of a string constant, not any rendering or interaction

(No screenshots: nothing rendered changes. The two files produce the same strings as before — this is a pure single-source-of-truth refactor.)

## Validation

Run from `frontend/`:

- `pnpm format` — "All matched files use Prettier code style!"
- `pnpm lint` — clean
- `pnpm typecheck` — clean
- `make test` — no failures

I did not run `pnpm build` or the E2E suites: this change alters no rendered output, no route, and no data shape, so those add cost without covering anything the type checker and unit tests don't already. Happy to run them if you'd rather see them green before merging.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted. It found both copies of the literal, made the extraction, and drafted this description. I reviewed and finalized every line.

Human verification performed for this change:

- Read the full diff — two files, 6 insertions, 2 deletions.
- Confirmed both call sites produce byte-identical strings after the change, so the refactor is genuinely behavior-preserving rather than merely plausible.
- Checked the constant is declared in the module that already owns demo-thread logic, so the dependency direction is component → core, not the reverse.
- Ran the frontend format, lint, typecheck, and unit-test commands quoted above myself and read their output.
- Grepped the whole frontend for the literal: `src/` now contains it exactly once, at the constant's declaration. The three remaining occurrences are in tests (`tests/unit/core/threads/static-demo.test.ts`, `tests/e2e/thread-history.spec.ts`) and are deliberately left as literals — a test that pins a public URL should assert the concrete string rather than re-derive it from the constant under test, or it can never fail.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
