### PR TITLE
test(tool-output): stop expressing "unwritable path" as a magic absolute path

### DIFF
--- a/backend/tests/test_tool_output_budget_middleware.py
+++ b/backend/tests/test_tool_output_budget_middleware.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import pathlib
 import tempfile
 from types import SimpleNamespace
 
@@ -83,9 +84,8 @@ def _unwritable_outputs_path():
     relative path that ``os.makedirs`` happily creates at the drive root.
     """
     with tempfile.TemporaryDirectory() as tmpdir:
-        blocker = os.path.join(tmpdir, "not-a-directory")
-        with open(blocker, "w", encoding="utf-8") as f:
-            f.write("placeholder")
+        blocker = pathlib.Path(tmpdir) / "not-a-directory"
+        blocker.touch()
         yield os.path.join(blocker, "outputs")
 
 

--- a/backend/tests/test_tool_output_budget_middleware.py
+++ b/backend/tests/test_tool_output_budget_middleware.py
@@ -8,6 +8,7 @@ sync/async code paths.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -64,6 +65,28 @@ def _make_request(tool_name: str = "remote_executor", tool_call_id: str = "tc-1"
         tool_call={"name": tool_name, "id": tool_call_id},
         runtime=runtime,
     )
+
+
+@contextlib.contextmanager
+def _unwritable_outputs_path():
+    """Yield an ``outputs_path`` that ``os.makedirs`` cannot create, on any platform.
+
+    The parent component is a regular file, so creating a directory below it
+    fails with an ``OSError`` subclass everywhere (``NotADirectoryError`` on
+    POSIX, ``FileNotFoundError`` on Windows) and nothing is written outside the
+    temporary directory.
+
+    This deliberately avoids expressing "unwritable" as a magic absolute path.
+    ``/nonexistent/...`` was creatable by root in the CI container, and its
+    replacement ``/dev/null/...`` relies on ``/dev/null`` being a character
+    device, which is only true on POSIX -- on Windows it is an ordinary
+    relative path that ``os.makedirs`` happily creates at the drive root.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        blocker = os.path.join(tmpdir, "not-a-directory")
+        with open(blocker, "w", encoding="utf-8") as f:
+            f.write("placeholder")
+        yield os.path.join(blocker, "outputs")
 
 
 def _tm(content: str = "ok", name: str = "tool", tool_call_id: str = "tc-1") -> ToolMessage:
@@ -160,20 +183,15 @@ class TestExternalize:
                 assert f.read() == "full content here"
 
     def test_returns_none_on_invalid_path(self):
-        # ``/dev/null`` is a character device on both Linux and macOS, so
-        # ``os.makedirs`` cannot create any subdirectory under it for any
-        # user (including root). The previously-used ``/nonexistent/...``
-        # path was silently created by ``mkdir -p`` when the test process
-        # ran as root inside the CI container, which made this test fail
-        # in CI independently of the externalization logic under test.
-        path = _externalize(
-            "data",
-            tool_name="test",
-            tool_call_id="tc-1",
-            outputs_path="/dev/null/cannot-mkdir-here",
-            storage_subdir=".tool-results",
-        )
-        assert path is None
+        with _unwritable_outputs_path() as outputs_path:
+            path = _externalize(
+                "data",
+                tool_name="test",
+                tool_call_id="tc-1",
+                outputs_path=outputs_path,
+                storage_subdir=".tool-results",
+            )
+            assert path is None
 
     def test_txt_extension_for_unknown_tool(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -710,9 +728,10 @@ class TestWrapToolCallFallback:
         mw = ToolOutputBudgetMiddleware(config=config)
         content = "x" * 500
         msg = _tm(content, name="tool")
-        req = _make_request(outputs_path="/dev/null/cannot-mkdir-here")
 
-        result = mw.wrap_tool_call(req, lambda _: msg)
+        with _unwritable_outputs_path() as outputs_path:
+            req = _make_request(outputs_path=outputs_path)
+            result = mw.wrap_tool_call(req, lambda _: msg)
 
         assert isinstance(result, ToolMessage)
         assert "omitted from tool output" in result.content


### PR DESCRIPTION
## Why

Two tests use `/dev/null/cannot-mkdir-here` to force `os.makedirs` to fail. That relies on `/dev/null` being a POSIX character device. On Windows it is treated as a relative path, so the tests create files outside their temporary directory and fail instead of exercising the intended fallback.

The earlier `/nonexistent/...` spelling had the same underlying problem: it could be created by a privileged Linux process. The test should construct the failure condition itself rather than depend on the host filesystem.

## What changed

Both tests now create a regular file inside a `TemporaryDirectory` and use a child of that file as `outputs_path`. Creating a directory below a file raises `OSError` on both POSIX and Windows, and all test artifacts remain inside the temporary directory.

No production code or documented behavior changes.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [x] **Docs / tests / CI only**

## Bug fix verification

- Tests: `TestExternalize::test_returns_none_on_invalid_path` and `TestWrapToolCallFallback::test_fallback_when_disk_write_fails`
- The old tests fail on Windows and write under `C:\dev\null\...`; the new tests pass without changing the external file count.
- Removing the production `except OSError: return None` guard makes both tests fail, confirming that they still cover the intended branch.

## Validation

Linux, Python 3.12:

- `make lint`
- `make test`: 11065 passed, 73 skipped
- `make test-blocking-io`: 70 passed

Windows 11:

- `ruff check .`
- `pytest tests/test_tool_output_budget_middleware.py`: 124 passed

This is a portability and test-isolation fix, not a proposal to support the full backend on Windows.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Investigation, implementation, and local validation assistance.

- [ ] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.