### PR TITLE
fix(channels): keep empty topic_id distinct from missing topic

### DIFF
--- a/backend/app/channels/store.py
+++ b/backend/app/channels/store.py
@@ -73,7 +73,12 @@ class ChannelStore:
 
     @staticmethod
     def _key(channel_name: str, chat_id: str, topic_id: str | None = None) -> str:
-        if topic_id:
+        # Use ``is not None`` (not truthiness) so an empty ``topic_id`` stays a
+        # distinct key from the topic-less base mapping. ``remove()`` already
+        # treats any non-None topic_id as topic-specific; collapsing ``""`` here
+        # would let a topic write/delete clobber the base ``channel:chat`` entry
+        # (e.g. DingTalk group messages whose ``message_id`` is missing).
+        if topic_id is not None:
             return f"{channel_name}:{chat_id}:{topic_id}"
         return f"{channel_name}:{chat_id}"
 

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -289,6 +289,23 @@ class TestChannelStore:
         store = ChannelStore(path=path)
         assert store.get_thread_id("x", "y") is None
 
+    def test_empty_topic_id_is_distinct_from_none(self, store):
+        """Empty topic_id must not collapse onto the topic-less base key.
+
+        Channels such as DingTalk may pass ``topic_id=""`` when a group
+        message lacks ``message_id``. Truthy keying would overwrite/delete the
+        base conversation mapping instead of a topic-specific entry.
+        """
+        store.set_thread_id("dingtalk", "conv", "base-thread", topic_id=None)
+        store.set_thread_id("dingtalk", "conv", "empty-topic-thread", topic_id="")
+
+        assert store.get_thread_id("dingtalk", "conv") == "base-thread"
+        assert store.get_thread_id("dingtalk", "conv", topic_id="") == "empty-topic-thread"
+
+        assert store.remove("dingtalk", "conv", topic_id="") is True
+        assert store.get_thread_id("dingtalk", "conv", topic_id="") is None
+        assert store.get_thread_id("dingtalk", "conv") == "base-thread"
+
 
 # ---------------------------------------------------------------------------
 # Channel base class tests


### PR DESCRIPTION
﻿ChannelStore._key() treated topic_id="" like missing, so empty topics could overwrite or delete the base conversation mapping. It now matches remove() with is not None and has a regression test.
