### PR TITLE
fix: resolve pnpm runner before changing cwd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ cd frontend && pnpm test      # Unit tests
 Rule of thumb: **root `make` = the full application**; **`backend/Makefile` and `frontend/`
 (`pnpm`) = per-module work.**
 
-Host-side pnpm consumers, including the root/frontend Makefiles and local diagnostic scripts, must run through `scripts/pnpm.py`. The runner preserves direct `pnpm`/`pnpm.cmd` priority, falls back to `corepack pnpm`, and is invoked from `frontend/` so Corepack honors the package-manager version pinned by that project.
+Host-side pnpm consumers, including the root/frontend Makefiles and local diagnostic scripts, must run through `scripts/pnpm.py`. The runner preserves direct `pnpm`/`pnpm.cmd` priority, falls back to `corepack pnpm`, resolves its own absolute path before changing directories, and is invoked from `frontend/` so Corepack honors the package-manager version pinned by that project.
 
 ## Where to Go Next
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ On Windows, run the local development flow from Git Bash. Native `cmd.exe` and P
    make check  # Verifies Node.js 22+, pnpm, uv, nginx
    ```
 
-   The local `make check`, `make install`, `make dev`, and `make start` entry points use a direct `pnpm`/`pnpm.cmd` executable when available and otherwise fall back to `corepack pnpm`. Corepack runs from `frontend/`, so it honors the `packageManager` version pinned in `frontend/package.json`; enabling a global pnpm shim is not required.
+   The local `make check`, `make install`, `make dev`, and `make start` entry points use a direct `pnpm`/`pnpm.cmd` executable when available and otherwise fall back to `corepack pnpm`. The shared runner resolves its own absolute path before switching to `frontend/`, so these entry points remain independent of the caller's working directory while Corepack honors the `packageManager` version pinned in `frontend/package.json`; enabling a global pnpm shim is not required.
 
 2. **Install dependencies**:
    ```bash

--- a/backend/tests/test_check_script.py
+++ b/backend/tests/test_check_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import runpy
 import subprocess
 from pathlib import Path
 
@@ -68,10 +69,13 @@ def test_find_pnpm_command_falls_back_to_corepack_cmd(monkeypatch):
     ]
 
 
-def test_check_script_uses_shared_pnpm_runner():
-    check_script = CHECK_SCRIPT_PATH.read_text(encoding="utf-8")
+def test_check_script_resolves_shared_pnpm_runner_from_relative_script_path(monkeypatch):
+    monkeypatch.chdir(REPO_ROOT)
 
-    assert 'Path(__file__).with_name("pnpm.py")' in check_script
+    namespace = runpy.run_path(str(Path("scripts") / "check.py"))
+
+    assert namespace["PNPM_SCRIPT_PATH"] == PNPM_SCRIPT_PATH
+    assert namespace["FRONTEND_DIR"] == REPO_ROOT / "frontend"
 
 
 def test_check_script_preserves_runner_failure_diagnostics(monkeypatch):

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -6,7 +6,9 @@ Run from repo root:
 
 from __future__ import annotations
 
+import runpy
 import sys
+from pathlib import Path
 
 import doctor
 
@@ -28,6 +30,15 @@ class TestCheckPython:
 
 
 class TestCheckPnpm:
+    def test_resolves_shared_runner_from_relative_script_path(self, monkeypatch):
+        repo_root = Path(doctor.__file__).resolve().parents[1]
+        monkeypatch.chdir(repo_root)
+
+        namespace = runpy.run_path(str(Path("scripts") / "doctor.py"))
+
+        assert namespace["PNPM_SCRIPT_PATH"] == repo_root / "scripts" / "pnpm.py"
+        assert namespace["FRONTEND_DIR"] == repo_root / "frontend"
+
     def test_uses_shared_runner_from_frontend(self, monkeypatch):
         captured = {}
 

--- a/backend/tests/test_pnpm_script.py
+++ b/backend/tests/test_pnpm_script.py
@@ -122,7 +122,7 @@ def test_official_entrypoints_route_pnpm_through_shared_runner():
     assert 'DEERFLOW_PNPM_RUNNER="$REPO_ROOT/scripts/pnpm.py"' in serve_script
     assert 'FRONTEND_CMD=\'"$DEERFLOW_PNPM_PYTHON" "$DEERFLOW_PNPM_RUNNER" run dev\'' in serve_script
     assert '"\\$DEERFLOW_PNPM_RUNNER\\" run preview"' in serve_script
-    assert 'Path(__file__).with_name("pnpm.py")' in doctor_script
+    assert 'Path(__file__).resolve().with_name("pnpm.py")' in doctor_script
     assert 'project_root / "scripts" / "pnpm.py"' in support_bundle_script
 
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -8,7 +8,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-PNPM_SCRIPT_PATH = Path(__file__).with_name("pnpm.py")
+PNPM_SCRIPT_PATH = Path(__file__).resolve().with_name("pnpm.py")
 FRONTEND_DIR = PNPM_SCRIPT_PATH.parent.parent / "frontend"
 COREPACK_NOTICE = "Using pnpm via Corepack."
 

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -24,7 +24,7 @@ from typing import Literal
 # ---------------------------------------------------------------------------
 
 Status = Literal["ok", "warn", "fail", "skip"]
-PNPM_SCRIPT_PATH = Path(__file__).with_name("pnpm.py")
+PNPM_SCRIPT_PATH = Path(__file__).resolve().with_name("pnpm.py")
 FRONTEND_DIR = PNPM_SCRIPT_PATH.parent.parent / "frontend"
 
 


### PR DESCRIPTION
Fixes #4733

## Why

`scripts/check.py` and `scripts/doctor.py` run the shared pnpm helper with `cwd=frontend/`. When Python preserves a relative script path such as `scripts/check.py`, the derived helper remains `scripts/pnpm.py`; after the cwd switch, Python looks for `frontend/scripts/pnpm.py` and reports that pnpm is unavailable even when it works normally.

## What changed

- Resolve each entry point's own path before deriving the pnpm helper and frontend directory.
- Add regression tests that load both scripts through a relative `scripts/...` path and verify the derived paths are absolute.
- Keep the existing entry-point contract test and pnpm documentation aligned with that invariant.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — local dependency checks no longer depend on how the script path is represented
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this does not change the UI.

## Bug fix verification

- Test paths that reproduce the bug:
  - `backend/tests/test_check_script.py::test_check_script_resolves_shared_pnpm_runner_from_relative_script_path`
  - `backend/tests/test_doctor.py::TestCheckPnpm::test_resolves_shared_runner_from_relative_script_path`
- Did they go red on `main` and green on this branch? **yes** — both failed with `PosixPath('scripts/pnpm.py')` before the two path-resolution changes, then passed afterward.

## Validation

- `cd backend && uv run pytest tests/test_check_script.py tests/test_pnpm_script.py tests/test_doctor.py tests/test_support_bundle.py tests/test_serve_nginx_stop.py tests/test_uvicorn_reload_exclude.py -q` — **118 passed**.
- `cd backend && uv run ruff check ../scripts/check.py ../scripts/doctor.py tests/test_check_script.py tests/test_doctor.py tests/test_pnpm_script.py` — passed.
- `cd backend && uv run ruff format --check tests/test_check_script.py tests/test_doctor.py tests/test_pnpm_script.py` — passed.
- `python3 -m py_compile scripts/check.py scripts/doctor.py` — passed.
- Relative-path smoke test via `runpy.run_path("scripts/check.py")` resolved the helper to the repository's absolute `scripts/pnpm.py` and returned pnpm `10.26.2` successfully.
- `git diff --check` — passed.

Not run: the full backend suite or frontend checks. The change is limited to the two host-side diagnostic entry points and their focused tests.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex traced the relative-path/cwd interaction from #4733, added the red/green regression tests, made the two-line implementation change, and ran the focused verification above.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
