### PR TITLE
test(llm-error): rename a stand-in, not the shared FakeError

### DIFF
--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -39,6 +39,21 @@ def _reset_process_limiter() -> Iterator[None]:
     mod._CAP_RESOLVED = False
 
 
+@pytest.fixture(autouse=True)
+def _guard_shared_exception_name() -> Iterator[None]:
+    """Fail the test that renames the shared ``FakeError`` class.
+
+    Several tests below drive classification by name (``type(exc).__name__``),
+    so they set ``exc.__class__.__name__``. That mutates the *class*, not the
+    instance: doing it to ``FakeError`` renames it for the rest of the session
+    and every later test asserting ``error_type == "FakeError"`` fails. Use a
+    dedicated stand-in (``_ReadError`` and friends) instead. Without this guard
+    the damage only surfaces in whichever test happens to run next.
+    """
+    yield
+    assert FakeError.__name__ == "FakeError", "this test renamed the shared FakeError class; rename a dedicated stand-in such as _ReadError instead of exc.__class__ on FakeError"
+
+
 def _make_app_config() -> AppConfig:
     """Minimal AppConfig for middleware tests; circuit_breaker uses defaults."""
     return AppConfig(sandbox=SandboxConfig(use="test"))
@@ -810,8 +825,7 @@ def test_user_message_for_read_error_uses_generic_transient_copy() -> None:
     Regression guard for the #3195 CR feedback.
     """
     middleware = _build_middleware()
-    exc = FakeError("connection dropped mid-stream")
-    exc.__class__.__name__ = "ReadError"
+    exc = _ReadError("connection dropped mid-stream")
 
     message = middleware._build_user_message(exc, reason="transient")
 

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -53,10 +53,7 @@ def _guard_shared_exception_name() -> Iterator[None]:
     original_name = FakeError.__name__
     yield
     try:
-        assert FakeError.__name__ == "FakeError", (
-            "this test renamed the shared FakeError class; rename a dedicated stand-in "
-            "such as _ReadError instead of exc.__class__ on FakeError"
-        )
+        assert FakeError.__name__ == "FakeError", "this test renamed the shared FakeError class; rename a dedicated stand-in such as _ReadError instead of exc.__class__ on FakeError"
     finally:
         FakeError.__name__ = original_name
 

--- a/backend/tests/test_llm_error_handling_middleware.py
+++ b/backend/tests/test_llm_error_handling_middleware.py
@@ -50,8 +50,15 @@ def _guard_shared_exception_name() -> Iterator[None]:
     dedicated stand-in (``_ReadError`` and friends) instead. Without this guard
     the damage only surfaces in whichever test happens to run next.
     """
+    original_name = FakeError.__name__
     yield
-    assert FakeError.__name__ == "FakeError", "this test renamed the shared FakeError class; rename a dedicated stand-in such as _ReadError instead of exc.__class__ on FakeError"
+    try:
+        assert FakeError.__name__ == "FakeError", (
+            "this test renamed the shared FakeError class; rename a dedicated stand-in "
+            "such as _ReadError instead of exc.__class__ on FakeError"
+        )
+    finally:
+        FakeError.__name__ = original_name
 
 
 def _make_app_config() -> AppConfig:


### PR DESCRIPTION
## Why

`test_user_message_for_read_error_uses_generic_transient_copy` renames the shared `FakeError` class through `exc.__class__.__name__`. The mutation survives the test and makes later tests observe `ReadError` instead of `FakeError`.

Declaration order currently hides the leak. Running the renaming test before a later `FakeError` assertion reproduces it deterministically.

## What changed

- Use the existing `_ReadError` stand-in instead of renaming `FakeError`.
- Add an autouse fixture that verifies `FakeError.__name__` after each test, so a future class-level mutation fails at its source.

Production behavior is unchanged.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [x] **Docs / tests / CI only**

## Bug fix verification

Running the affected test before `test_async_model_call_returns_user_message_for_quota_errors` fails on `main`; reversing the order passes. Reverting the stand-in change makes the new invariant fixture fail during teardown of the offending test.

## Validation

Linux, Python 3.12:

- `pytest tests/test_llm_error_handling_middleware.py`: 75 passed
- `make test`: 11096 passed, 73 skipped
- Ruff check and format check pass
- Random-order seed 424242: 11096 passed

Seed 987654 leaves one unrelated order-dependent failure in `test_skills_custom_router.py`; it is intentionally outside this focused change.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Investigation, implementation, and local validation assistance.

- [ ] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.