### PR TITLE
feat(channels): add clickable HTML artifact links to IM replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ channels:
   langgraph_url: http://localhost:8001/api
   # Gateway API URL (default: http://localhost:8001)
   gateway_url: http://localhost:8001
+  # Optional public DeerFlow URL used for clickable HTML artifact links in IM replies
+  public_base_url: https://deer.example.com
 
   # Optional: global session defaults for all mobile channels
   session:
@@ -528,6 +530,7 @@ Notes:
 - `assistant_id: lead_agent` calls the default LangGraph assistant directly.
 - If `assistant_id` is set to a custom agent name, DeerFlow still routes through `lead_agent` and injects that value as `agent_name`, so the custom agent's SOUL/config takes effect for IM channels.
 - IM channel workers call Gateway's LangGraph-compatible API internally and automatically attach process-local internal auth plus the CSRF cookie/header pair required for thread and run creation.
+- When `public_base_url` is configured, resolved `.html`, `.htm`, and `.xhtml` artifacts are listed as Markdown links in IM replies. The normal file attachment is still sent as a fallback. Links use the existing authenticated artifact API, so auth-enabled deployments require the recipient to have a DeerFlow browser session; active HTML remains a download to avoid executing generated scripts on the DeerFlow origin.
 - Feishu/Lark now queues rapid follow-up messages per mapped DeerFlow `thread_id` instead of immediately surfacing the generic busy reply, and topic replies keep a per-message card with a compact source-message preview across queued/running/final patches.
 
 Set the corresponding API keys in your `.env` file:
@@ -602,7 +605,7 @@ DINGTALK_CLIENT_SECRET=your_client_secret
 4. *(Optional)* To enable streaming AI Card replies (typewriter effect), create an **AI Card** template on the [DingTalk Card Platform](https://open.dingtalk.com/document/dingstart/typewriter-effect-streaming-ai-card), then set `card_template_id` in `config.yaml` to the template ID. You also need to apply for the `Card.Streaming.Write` and `Card.Instance.Write` permissions.
 
 
-When DeerFlow runs in Docker Compose, IM channels execute inside the `gateway` container. In that case, do not point `channels.langgraph_url` or `channels.gateway_url` at `localhost`; use container service names such as `http://gateway:8001/api` and `http://gateway:8001`, or set `DEER_FLOW_CHANNELS_LANGGRAPH_URL` and `DEER_FLOW_CHANNELS_GATEWAY_URL`.
+When DeerFlow runs in Docker Compose, IM channels execute inside the `gateway` container. In that case, do not point `channels.langgraph_url` or `channels.gateway_url` at `localhost`; use container service names such as `http://gateway:8001/api` and `http://gateway:8001`, or set `DEER_FLOW_CHANNELS_LANGGRAPH_URL` and `DEER_FLOW_CHANNELS_GATEWAY_URL`. `channels.public_base_url` is different: set it to the browser-facing deployment URL, or use `DEER_FLOW_CHANNELS_PUBLIC_BASE_URL`.
 
 **Commands**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -317,6 +317,8 @@ channels:
   langgraph_url: http://localhost:8001/api
   # Gateway API URL（默认：http://localhost:8001）
   gateway_url: http://localhost:8001
+  # 可选：浏览器可访问的 DeerFlow 地址，用于在 IM 回复中生成 HTML 文件超链接
+  public_base_url: https://deer.example.com
 
   # 可选：所有移动端渠道共用的全局 session 默认值
   session:
@@ -385,6 +387,8 @@ channels:
     allowed_users: []                          # 留空表示允许所有人
     card_template_id: ""                       # 可选：AI 卡片模板 ID，用于流式打字机效果
 ```
+
+配置 `public_base_url` 后，已成功解析的 `.html`、`.htm` 和 `.xhtml` 文件会在 IM 回复中显示为 Markdown 超链接，同时仍会正常发送文件附件作为回退。链接继续使用现有的 artifact 鉴权：启用鉴权时，接收者需要已有 DeerFlow 浏览器会话；为避免生成的脚本在 DeerFlow 域名下执行，HTML 仍会以下载方式打开。也可以通过 `DEER_FLOW_CHANNELS_PUBLIC_BASE_URL` 设置该地址。
 
 说明：
 - `assistant_id: lead_agent` 会直接调用默认的 LangGraph assistant。

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -958,7 +958,8 @@ The cached value is reused for both the blocking (`runs.wait`) and streaming (`_
 **Configuration** (`config.yaml` -> `channels`):
 - `langgraph_url` - LangGraph-compatible Gateway API base URL (default: `http://localhost:8001/api`)
 - `gateway_url` - Gateway API URL for auxiliary commands (default: `http://localhost:8001`)
-- In Docker Compose, IM channels run inside the `gateway` container, so `localhost` points back to that container. Use `http://gateway:8001/api` for `langgraph_url` and `http://gateway:8001` for `gateway_url`, or set `DEER_FLOW_CHANNELS_LANGGRAPH_URL` / `DEER_FLOW_CHANNELS_GATEWAY_URL`.
+- `public_base_url` - Optional browser-facing DeerFlow URL used to add authenticated HTML artifact links to IM replies; attachment delivery remains the fallback
+- In Docker Compose, IM channels run inside the `gateway` container, so `localhost` points back to that container. Use `http://gateway:8001/api` for `langgraph_url` and `http://gateway:8001` for `gateway_url`, or set `DEER_FLOW_CHANNELS_LANGGRAPH_URL` / `DEER_FLOW_CHANNELS_GATEWAY_URL`. Set `public_base_url` to the external deployment URL or use `DEER_FLOW_CHANNELS_PUBLIC_BASE_URL`.
 - Per-channel configs: `feishu` (app_id, app_secret), `slack` (bot_token, app_token), `telegram` (bot_token, optional `rich_messages` for final Markdown Rich Messages), `dingtalk` (client_id, client_secret, optional `card_template_id` for AI Card streaming), `github` (operator kill-switch `enabled`, plus `default_mention_login` for mention-required GitHub triggers), `buzz` (relay_url, private_key)
 
 **User-owned channel connections** (`config.yaml` -> `channel_connections`):

--- a/backend/app/channels/manager.py
+++ b/backend/app/channels/manager.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from html import escape
 from pathlib import Path
 from typing import Any
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit, urlunsplit
 
 import httpx
 from langgraph_sdk.errors import ConflictError
@@ -55,6 +55,7 @@ DEFAULT_LANGGRAPH_URL = "http://localhost:8001/api"
 DEFAULT_GATEWAY_URL = "http://localhost:8001"
 DEFAULT_ASSISTANT_ID = "lead_agent"
 CUSTOM_AGENT_NAME_PATTERN = re.compile(r"^[A-Za-z0-9-]+$")
+HTML_ARTIFACT_SUFFIXES = frozenset({".htm", ".html", ".xhtml"})
 
 # Lead-agent recursion budget (LangGraph super-steps for the lead graph only).
 # This is independent of subagent depth: a `task()` dispatch runs the whole
@@ -676,17 +677,74 @@ def _is_hidden_human_control_message(msg: Mapping[str, Any]) -> bool:
     return additional_kwargs.get("hide_from_ui") is True
 
 
-def _format_artifact_text(artifacts: list[str]) -> str:
-    """Format artifact paths into a human-readable text block listing filenames."""
+_OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
+
+
+def _normalize_public_base_url(value: str | None) -> str | None:
+    """Return a safe external HTTP(S) base URL without a trailing slash."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+
+    raw_value = value.strip()
+    if any(character.isspace() for character in raw_value):
+        return None
+
+    try:
+        parsed = urlsplit(raw_value)
+        # Accessing ``port`` validates malformed values such as ``:not-a-port``.
+        parsed.port
+    except ValueError:
+        return None
+
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        return None
+    if parsed.query or parsed.fragment:
+        return None
+
+    # Encode Markdown-significant punctuation in an optional reverse-proxy path.
+    normalized_path = quote(parsed.path.rstrip("/"), safe="/-._~!$&'*,;=:@")
+    return urlunsplit((parsed.scheme.lower(), parsed.netloc, normalized_path, "", ""))
+
+
+def _artifact_browser_url(virtual_path: str, *, thread_id: str | None, public_base_url: str | None) -> str | None:
+    """Build an externally reachable URL for an HTML artifact."""
     import posixpath
 
-    filenames = [posixpath.basename(p) for p in artifacts]
-    if len(filenames) == 1:
-        return f"Created File: 📎 {filenames[0]}"
-    return "Created Files: 📎 " + "、".join(filenames)
+    base_url = _normalize_public_base_url(public_base_url)
+    if not base_url or not thread_id or not virtual_path.startswith(_OUTPUTS_VIRTUAL_PREFIX):
+        return None
+    if posixpath.splitext(virtual_path)[1].lower() not in HTML_ARTIFACT_SUFFIXES:
+        return None
+
+    encoded_thread_id = quote(thread_id, safe="")
+    encoded_artifact_path = "/".join(quote(segment, safe="") for segment in virtual_path.lstrip("/").split("/"))
+    return f"{base_url}/api/threads/{encoded_thread_id}/artifacts/{encoded_artifact_path}"
 
 
-_OUTPUTS_VIRTUAL_PREFIX = "/mnt/user-data/outputs/"
+def _escape_markdown_link_label(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def _format_artifact_text(
+    artifacts: list[str],
+    *,
+    thread_id: str | None = None,
+    public_base_url: str | None = None,
+) -> str:
+    """Format artifact filenames, linking HTML when an external base URL is set."""
+    import posixpath
+
+    formatted_artifacts: list[str] = []
+    for artifact in artifacts:
+        filename = posixpath.basename(artifact)
+        browser_url = _artifact_browser_url(artifact, thread_id=thread_id, public_base_url=public_base_url)
+        if browser_url:
+            filename = f"[{_escape_markdown_link_label(filename)}]({browser_url})"
+        formatted_artifacts.append(filename)
+
+    if len(formatted_artifacts) == 1:
+        return f"Created File: 📎 {formatted_artifacts[0]}"
+    return "Created Files: 📎 " + "、".join(formatted_artifacts)
 
 
 def _unknown_command_reply(command: str | None = None) -> str:
@@ -855,6 +913,7 @@ def _prepare_artifact_delivery(
     artifacts: list[str],
     *,
     user_id: str | None = None,
+    public_base_url: str | None = None,
 ) -> tuple[str, list[ResolvedAttachment]]:
     """Resolve attachments and append filename fallbacks to the text response."""
     attachments: list[ResolvedAttachment] = []
@@ -872,7 +931,11 @@ def _prepare_artifact_delivery(
     # Always include resolved attachment filenames as a text fallback so files
     # remain discoverable even when the upload is skipped or fails.
     if attachments:
-        resolved_text = _format_artifact_text([attachment.virtual_path for attachment in attachments])
+        resolved_text = _format_artifact_text(
+            [attachment.virtual_path for attachment in attachments],
+            thread_id=thread_id,
+            public_base_url=public_base_url,
+        )
         response_text = (response_text + "\n\n" + resolved_text) if response_text else resolved_text
 
     return response_text, attachments
@@ -987,6 +1050,7 @@ class ChannelManager:
         max_concurrency: int = 5,
         langgraph_url: str = DEFAULT_LANGGRAPH_URL,
         gateway_url: str = DEFAULT_GATEWAY_URL,
+        public_base_url: str | None = None,
         assistant_id: str = DEFAULT_ASSISTANT_ID,
         default_session: dict[str, Any] | None = None,
         channel_sessions: dict[str, Any] | None = None,
@@ -1000,6 +1064,9 @@ class ChannelManager:
         self._max_concurrency = max_concurrency
         self._langgraph_url = langgraph_url
         self._gateway_url = gateway_url
+        self._public_base_url = _normalize_public_base_url(public_base_url)
+        if public_base_url and not self._public_base_url:
+            logger.warning("[Manager] ignoring invalid channels.public_base_url; expected an HTTP(S) URL without query or fragment")
         self._assistant_id = assistant_id
         self._default_session = _as_dict(default_session)
         self._channel_sessions = dict(channel_sessions or {})
@@ -2169,11 +2236,21 @@ class ChannelManager:
         # Reuse the storage owner cached at the top of _handle_chat so uploads and
         # artifact delivery always resolve to the same bucket, even if a future
         # channel.receive_file returns a rewritten InboundMessage.
-        response_text, attachments = _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
+        response_text, attachments = _prepare_artifact_delivery(
+            thread_id,
+            response_text,
+            artifacts,
+            user_id=storage_user_id,
+            public_base_url=self._public_base_url,
+        )
 
         if not response_text:
             if attachments:
-                response_text = _format_artifact_text([a.virtual_path for a in attachments])
+                response_text = _format_artifact_text(
+                    [a.virtual_path for a in attachments],
+                    thread_id=thread_id,
+                    public_base_url=self._public_base_url,
+                )
             else:
                 response_text = "(No response from agent)"
 
@@ -2286,11 +2363,21 @@ class ChannelManager:
             # Reuse the storage owner resolved by _handle_chat so artifact delivery
             # matches the upload bucket and we avoid re-running _safe_user_id_for_run
             # (and its possible filesystem touch) on the streaming-error path.
-            response_text, attachments = _prepare_artifact_delivery(thread_id, response_text, artifacts, user_id=storage_user_id)
+            response_text, attachments = _prepare_artifact_delivery(
+                thread_id,
+                response_text,
+                artifacts,
+                user_id=storage_user_id,
+                public_base_url=self._public_base_url,
+            )
 
             if not response_text:
                 if attachments:
-                    response_text = _format_artifact_text([attachment.virtual_path for attachment in attachments])
+                    response_text = _format_artifact_text(
+                        [attachment.virtual_path for attachment in attachments],
+                        thread_id=thread_id,
+                        public_base_url=self._public_base_url,
+                    )
                 elif stream_error:
                     if _is_thread_busy_error(stream_error):
                         response_text = THREAD_BUSY_MESSAGE

--- a/backend/app/channels/service.py
+++ b/backend/app/channels/service.py
@@ -48,6 +48,7 @@ _CHANNEL_CREDENTIAL_KEYS: dict[str, list[str]] = {
 
 _CHANNELS_LANGGRAPH_URL_ENV = "DEER_FLOW_CHANNELS_LANGGRAPH_URL"
 _CHANNELS_GATEWAY_URL_ENV = "DEER_FLOW_CHANNELS_GATEWAY_URL"
+_CHANNELS_PUBLIC_BASE_URL_ENV = "DEER_FLOW_CHANNELS_PUBLIC_BASE_URL"
 
 
 def _channel_has_credentials(name: str, channel_config: dict[str, Any]) -> bool:
@@ -111,6 +112,7 @@ class ChannelService:
         config = dict(channels_config or {})
         langgraph_url = _resolve_service_url(config, "langgraph_url", _CHANNELS_LANGGRAPH_URL_ENV, DEFAULT_LANGGRAPH_URL)
         gateway_url = _resolve_service_url(config, "gateway_url", _CHANNELS_GATEWAY_URL_ENV, DEFAULT_GATEWAY_URL)
+        public_base_url = _resolve_service_url(config, "public_base_url", _CHANNELS_PUBLIC_BASE_URL_ENV, "")
         default_session = config.pop("session", None)
         channel_sessions = {name: channel_config.get("session") for name, channel_config in config.items() if isinstance(channel_config, dict)}
         from app.channels.dedupe_store import make_inbound_dedupe_store
@@ -120,6 +122,7 @@ class ChannelService:
             store=self.store,
             langgraph_url=langgraph_url,
             gateway_url=gateway_url,
+            public_base_url=public_base_url,
             default_session=default_session if isinstance(default_session, dict) else None,
             channel_sessions=channel_sessions,
             connection_repo=connection_repo,

--- a/backend/docs/IM_CHANNEL_CONNECTIONS.md
+++ b/backend/docs/IM_CHANNEL_CONNECTIONS.md
@@ -262,6 +262,10 @@ Configure the actual IM bots under the existing `channels` block:
 
 ```yaml
 channels:
+  # Optional browser-facing DeerFlow URL for clickable HTML artifact links.
+  # The regular IM file upload remains as a fallback.
+  public_base_url: https://deer.example.com
+
   telegram:
     enabled: true
     bot_token: $TELEGRAM_BOT_TOKEN
@@ -299,6 +303,8 @@ channels:
     relay_url: wss://buzz.example.com
     private_key: $BUZZ_PRIVATE_KEY   # hex or nsec1…
 ```
+
+`public_base_url` can also be supplied through `DEER_FLOW_CHANNELS_PUBLIC_BASE_URL`. It must be an HTTP(S) URL that exposes DeerFlow's `/api` routes. Artifact authorization is unchanged: auth-enabled deployments require a matching DeerFlow browser session, and active HTML is downloaded instead of executed on the application origin.
 
 Then enable user bindings in `channel_connections`:
 

--- a/backend/tests/test_channel_file_attachments.py
+++ b/backend/tests/test_channel_file_attachments.py
@@ -589,3 +589,60 @@ class TestManagerArtifactResolution:
         result = _format_artifact_text(["/mnt/user-data/outputs/a.txt", "/mnt/user-data/outputs/b.txt"])
         assert "a.txt" in result
         assert "b.txt" in result
+
+    def test_format_artifact_text_links_html_when_public_base_url_is_configured(self):
+        from app.channels.manager import _format_artifact_text
+
+        result = _format_artifact_text(
+            ["/mnt/user-data/outputs/report [final].html"],
+            thread_id="thread / 1",
+            public_base_url="https://deer.example.com/deer-flow/",
+        )
+
+        assert result == ("Created File: 📎 [report \\[final\\].html](https://deer.example.com/deer-flow/api/threads/thread%20%2F%201/artifacts/mnt/user-data/outputs/report%20%5Bfinal%5D.html)")
+
+    def test_format_artifact_text_does_not_link_non_html_artifacts(self):
+        from app.channels.manager import _format_artifact_text
+
+        result = _format_artifact_text(
+            ["/mnt/user-data/outputs/report.pdf"],
+            thread_id="thread-1",
+            public_base_url="https://deer.example.com",
+        )
+
+        assert result == "Created File: 📎 report.pdf"
+
+    def test_format_artifact_text_ignores_unsafe_public_base_url(self):
+        from app.channels.manager import _format_artifact_text
+
+        result = _format_artifact_text(
+            ["/mnt/user-data/outputs/report.html"],
+            thread_id="thread-1",
+            public_base_url="javascript:alert(1)",
+        )
+
+        assert result == "Created File: 📎 report.html"
+
+    def test_prepare_artifact_delivery_links_resolved_html_and_keeps_attachment(self, tmp_path):
+        from app.channels.manager import _prepare_artifact_delivery
+
+        thread_id = "thread-1"
+        outputs_dir = tmp_path / "outputs"
+        outputs_dir.mkdir()
+        html_file = outputs_dir / "report.html"
+        html_file.write_text("<h1>Report</h1>", encoding="utf-8")
+
+        mock_paths = MagicMock()
+        mock_paths.resolve_virtual_path.return_value = html_file
+        mock_paths.sandbox_outputs_dir.return_value = outputs_dir
+
+        with patch("deerflow.config.paths.get_paths", return_value=mock_paths):
+            text, attachments = _prepare_artifact_delivery(
+                thread_id,
+                "Done.",
+                ["/mnt/user-data/outputs/report.html"],
+                public_base_url="https://deer.example.com",
+            )
+
+        assert text == ("Done.\n\nCreated File: 📎 [report.html](https://deer.example.com/api/threads/thread-1/artifacts/mnt/user-data/outputs/report.html)")
+        assert [attachment.actual_path for attachment in attachments] == [html_file]

--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6839,6 +6839,28 @@ class TestChannelService:
         assert service.manager._langgraph_url == "http://custom-gateway:8001/api"
         assert service.manager._gateway_url == "http://custom-gateway:8001"
 
+    def test_public_base_url_is_forwarded_to_manager(self, monkeypatch):
+        from app.channels.service import ChannelService
+
+        monkeypatch.setenv("DEER_FLOW_CHANNELS_PUBLIC_BASE_URL", "https://env.example.com")
+
+        service = ChannelService(
+            channels_config={
+                "public_base_url": "https://deer.example.com/deer-flow/",
+            }
+        )
+
+        assert service.manager._public_base_url == "https://deer.example.com/deer-flow"
+
+    def test_public_base_url_falls_back_to_env(self, monkeypatch):
+        from app.channels.service import ChannelService
+
+        monkeypatch.setenv("DEER_FLOW_CHANNELS_PUBLIC_BASE_URL", "https://deer.example.com/")
+
+        service = ChannelService(channels_config={})
+
+        assert service.manager._public_base_url == "https://deer.example.com"
+
     def test_from_app_config_uses_explicit_config(self):
         from app.channels.service import ChannelService
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2203,13 +2203,18 @@ run_ownership:
 #   langgraph_url: http://localhost:8001/api
 #   # Gateway API URL for auxiliary queries like /models, /memory (default: http://localhost:8001)
 #   gateway_url: http://localhost:8001
+#   # Optional browser-facing DeerFlow URL. When set, resolved HTML artifacts in
+#   # IM replies are rendered as clickable links while file attachments remain as a fallback.
+#   # The URL must expose DeerFlow's /api routes and must not include a query or fragment.
+#   public_base_url: https://deer.example.com
 #   #
 #   # Docker Compose note:
 #   # If channels run inside the gateway container, use container DNS names instead
 #   # of localhost, for example:
 #   # langgraph_url: http://gateway:8001/api
 #   # gateway_url: http://gateway:8001
-#   # You can also set DEER_FLOW_CHANNELS_LANGGRAPH_URL / DEER_FLOW_CHANNELS_GATEWAY_URL.
+#   # You can also set DEER_FLOW_CHANNELS_LANGGRAPH_URL / DEER_FLOW_CHANNELS_GATEWAY_URL /
+#   # DEER_FLOW_CHANNELS_PUBLIC_BASE_URL.
 #
 #   # Optional: default mobile/session settings for all IM channels
 #   session:


### PR DESCRIPTION
Fixes #4173

## Why

Generated HTML artifacts sent through IM channels are currently surfaced as sandbox paths or file attachments. In DingTalk, recipients cannot click the response to reach DeerFlow's existing artifact endpoint, which makes generated web reports harder to access from the conversation.

## What changed

- Add an opt-in `channels.public_base_url` setting, with `DEER_FLOW_CHANNELS_PUBLIC_BASE_URL` as its environment fallback.
- Render resolved `.html`, `.htm`, and `.xhtml` output artifacts as encoded Markdown links to the existing authenticated artifact API.
- Preserve the existing attachment delivery and plain-filename fallback for unsupported clients, missing files, non-HTML artifacts, and invalid configuration.
- Apply the behavior to both blocking and streaming channel responses.
- Validate HTTP(S) base URLs, encode thread/artifact path segments, and escape Markdown link labels.
- Document the configuration, authentication requirement, and active-content download policy in the example config and English/Chinese channel documentation.

## Surface area

- [ ] **Frontend UI** - page / component / setting / interaction under `frontend/`
- [x] **Backend API** - endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** - agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** - `docker/` or sandboxed execution
- [ ] **Skills** - change under `skills/`
- [ ] **Dependencies** - new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** - changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** - no runtime behavior change

## Screenshots / Recording

Not applicable: this change has no frontend UI. DingTalk's existing `sampleMarkdown` renderer preserves standard Markdown links, and attachment delivery remains unchanged.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/test_channel_file_attachments.py tests/test_channels.py tests/test_dingtalk_channel.py -q -k "not symlink"` - 494 passed, 3 deselected
- `uv run pytest tests/test_artifacts_router.py tests/blocking_io/test_artifacts_router.py -q -k "not symlink"` - 28 passed

A broader Windows run reached 10,920 passing tests and 84 skips; its remaining failures require POSIX permissions/tooling or optional local services (for example `chmod`, bash, Lark CLI, and Browserless) and did not include the changed channel or artifact-link tests.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Assisted with implementation, regression tests, documentation, and local validation.

- [x] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.