### PR TITLE
test: add opt-in model and tool compatibility smoke runner

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,9 @@ make test
 # Requires a valid root config.yaml and API credentials.
 make test-live
 
+# Explicit model/tool compatibility smoke checks (also real APIs)
+make model-smoke ARGS="--model configured-model-name"
+
 # Frontend unit tests
 cd frontend
 make test
@@ -326,6 +329,13 @@ make test-e2e
 local sandboxes, artifacts, and files. It is never run by the default backend
 test command or CI. Direct pytest invocations of `tests/test_client_live.py`
 must also set `DEER_FLOW_RUN_LIVE_TESTS=1`.
+
+`make model-smoke` is a separate manual runner for basic chat, streaming, and
+model-driven sandbox tool compatibility. It also sets
+`DEER_FLOW_RUN_LIVE_TESTS=1`, calls real model APIs, and may incur charges. It
+is not pytest-collected or run by default CI. See
+[`backend/tests/model_compat/README.md`](backend/tests/model_compat/README.md)
+for model selection, result categories, cleanup behavior, and exit codes.
 
 ### PR Regression Checks
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -102,6 +102,7 @@ make dev                # Run Gateway API with reload (port 8001)
 make gateway            # Run Gateway API only (port 8001)
 make test               # Run offline backend tests (excludes live external-API tests)
 make test-live          # Explicitly run live DeerFlowClient tests with real APIs
+make model-smoke ARGS="--model NAME"  # Explicit model/tool compatibility smoke runner
 make test-blocking-io   # Run strict Blockbuster runtime gate on tests/blocking_io/
 make lint               # Lint with ruff
 make format             # Format code with ruff
@@ -1406,6 +1407,19 @@ PYTHONPATH=. uv run pytest tests/test_<feature>.py -v
 Direct pytest collection or execution of `tests/test_client_live.py` remains
 skipped unless `DEER_FLOW_RUN_LIVE_TESTS=1` is set. Do not add that opt-in to
 default CI workflows.
+
+`tests/model_compat/run_smoke.py` is a manual, non-pytest entry point for model
+and sandbox-tool compatibility. Run it only via `make model-smoke ARGS="--model
+NAME"` (or a direct command with `DEER_FLOW_RUN_LIVE_TESTS=1`): it calls real
+model APIs and may incur charges. CI is rejected even when the opt-in is set.
+Its orchestration and event-contract logic is covered offline by
+`tests/test_model_compat_smoke.py`; keep that layer injectable and free of real
+model/network calls. Each live case must retain unique user/thread isolation,
+an in-memory checkpointer, normal sandbox release, and best-effort local thread
+cleanup. Its process-local config copy must keep title generation,
+summarization, memory injection, and memory writes disabled so only the selected
+lead model can consume model quota. Full usage and exit codes are in
+`tests/model_compat/README.md`.
 
 ### Running the Full Application
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -13,6 +13,9 @@ test:
 test-live:
 	DEER_FLOW_RUN_LIVE_TESTS=1 PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest -m live tests/ -v -s
 
+model-smoke:
+	DEER_FLOW_RUN_LIVE_TESTS=1 PYTHONPATH=.:packages/harness:packages/extension-api PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run python tests/model_compat/run_smoke.py $(ARGS)
+
 test-blocking-io:
 	PYTHONPATH=. PYTHONIOENCODING=utf-8 PYTHONUTF8=1 uv run pytest tests/blocking_io -q --tb=short
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -462,6 +462,9 @@ make test
 
 # Explicit real-API DeerFlowClient integration suite
 make test-live
+
+# Explicit model/tool compatibility checks for a configured model
+make model-smoke ARGS="--model configured-model-name"
 ```
 
 The live suite requires a valid root `config.yaml` and API credentials. It may
@@ -469,6 +472,12 @@ incur API costs or create local sandboxes, artifacts, and files, so it is not
 part of default test runs or CI. Direct pytest invocation of
 `tests/test_client_live.py` also requires
 `DEER_FLOW_RUN_LIVE_TESTS=1`.
+
+The model/tool smoke runner is likewise explicit: `make model-smoke` sets
+`DEER_FLOW_RUN_LIVE_TESTS=1`, calls real model APIs, and may incur API charges.
+It is a manual non-pytest entry point and is never part of default tests or CI.
+See [`tests/model_compat/README.md`](tests/model_compat/README.md) for the five
+contracts, model/case parameters, output categories, isolation, and exit codes.
 
 `make detect-blocking-io` statically scans backend business code for blocking
 IO that may run on the backend event loop and is not test-coverage-bound. It

--- a/backend/tests/model_compat/README.md
+++ b/backend/tests/model_compat/README.md
@@ -1,0 +1,75 @@
+# Model/tool compatibility smoke runner
+
+This directory contains a manual live runner for checking whether configured
+models satisfy DeerFlow's core chat, streaming, and sandbox-tool contracts.
+It is not a pytest module, is not collected by the default test suite, and is
+never run by CI.
+
+> **Warning:** the smoke command calls real model APIs, may incur API charges,
+> and may start the configured sandbox. Do not run it unless you intend to use
+> real credentials and quota.
+
+## Requirements
+
+- A valid `config.yaml` at the repository root.
+- Credentials required by the selected provider, supplied through the normal
+  DeerFlow configuration/environment mechanism.
+- Backend dependencies already installed. The runner never changes them.
+
+The runner never reads or prints `.env` itself. Diagnostic text and JSON output
+redact common credential forms, but prompts and model responses should still
+avoid including secrets.
+
+## Run explicitly
+
+From `backend/`, list configured model names without making a model request:
+
+```bash
+make model-smoke ARGS="--list-models"
+```
+
+Run all five checks for one or more explicitly selected models:
+
+```bash
+make model-smoke ARGS="--model model-name"
+make model-smoke ARGS="--model model-a --model model-b"
+```
+
+`make model-smoke` sets the required `DEER_FLOW_RUN_LIVE_TESTS=1`
+acknowledgement. A direct invocation must set it explicitly:
+
+```bash
+DEER_FLOW_RUN_LIVE_TESTS=1 PYTHONPATH=.:packages/harness:packages/extension-api \
+  uv run python tests/model_compat/run_smoke.py --model model-name
+```
+
+Use `--all-models` to select every configured model, or repeat `--case` to run
+only named checks. `--help` lists the accepted case names. Every case is a real
+model turn, so `--all-models` can consume substantially more API quota.
+
+Each model/case pair receives unique smoke-only user and thread identifiers, an
+in-memory checkpointer, and an isolated workspace. Local thread data is removed
+after the case; `--keep-workspaces` is an explicit debugging override. Sandbox
+resources are released through DeerFlow's normal middleware lifecycle. The
+runner also disables title generation, summarization, and memory injection or
+writes in its process-local config copy, preventing hidden auxiliary model
+requests and persistent smoke-user memory without modifying `config.yaml`.
+
+## Output and exit codes
+
+The default output is a tab-separated summary with model, case, status, error
+category, first-content latency (when applicable), and detail. Add
+`--json-output /path/to/results.json` for a redacted JSON report. Failures are
+classified as `configuration_error`, `model_incompatible`, `tool_failure`, or
+`runner_error`.
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Every selected check passed, or `--list-models` succeeded. |
+| `1` | A compatibility or tool check failed. |
+| `2` | Opt-in, CI, argument, model selection, or local configuration error. |
+| `3` | The runner or cleanup failed unexpectedly. |
+
+The runner refuses live execution when `CI` is set. Offline unit tests for its
+parser, selection, event analysis, summaries, cleanup, redaction, and exit code
+logic live in `tests/test_model_compat_smoke.py` and use fakes only.

--- a/backend/tests/model_compat/run_smoke.py
+++ b/backend/tests/model_compat/run_smoke.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Explicit live entry point for DeerFlow model/tool compatibility checks."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from smoke import (
+    CASES,
+    CaseSpec,
+    ConfigurationError,
+    ErrorCategory,
+    SmokeResult,
+    evaluate_case,
+    observe_events,
+    redact_text,
+    run_cli,
+)
+
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+REPO_ROOT = BACKEND_ROOT.parent
+DEFAULT_CONFIG_PATH = REPO_ROOT / "config.yaml"
+
+
+def isolate_client_config(client: Any) -> None:
+    """Install a process-local config copy with auxiliary model work disabled."""
+    config = client._app_config
+    isolated = config.model_copy(
+        deep=True,
+        update={
+            "title": config.title.model_copy(
+                deep=True,
+                update={"enabled": False, "model_name": None},
+            ),
+            "summarization": config.summarization.model_copy(
+                deep=True,
+                update={"enabled": False, "model_name": None},
+            ),
+            "memory": config.memory.model_copy(
+                deep=True,
+                update={"enabled": False, "injection_enabled": False},
+            ),
+        },
+    )
+    client._app_config = isolated
+
+
+def _invocation_error_category(exc: Exception) -> ErrorCategory:
+    """Classify failures that escaped the normal model/tool middleware."""
+    name = type(exc).__name__.lower()
+    if isinstance(exc, (ImportError, ValueError)) or any(
+        marker in name
+        for marker in (
+            "authentication",
+            "credential",
+            "permissiondenied",
+            "configuration",
+            "modelnotfound",
+        )
+    ):
+        return ErrorCategory.CONFIGURATION
+    if "sandbox" in name or "tool" in name:
+        return ErrorCategory.TOOL_FAILURE
+    if any(marker in name for marker in ("badrequest", "invalidrequest", "notimplemented", "unsupported")):
+        return ErrorCategory.MODEL_INCOMPATIBLE
+    return ErrorCategory.RUNNER
+
+
+class DeerFlowRuntime:
+    """Thin, injectable adapter around the embedded DeerFlow client."""
+
+    cases = CASES
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[str | None], Any],
+        set_user: Callable[[Any], Any],
+        reset_user: Callable[[Any], None],
+        delete_thread: Callable[[str, str], None],
+    ) -> None:
+        self._client_factory = client_factory
+        self._set_user = set_user
+        self._reset_user = reset_user
+        self._delete_thread = delete_thread
+
+    def _client(self, model: str | None) -> Any:
+        try:
+            return self._client_factory(model)
+        except Exception as exc:
+            raise ConfigurationError(f"could not initialize DeerFlowClient: {redact_text(exc)}") from exc
+
+    def list_models(self) -> list[str]:
+        try:
+            payload = self._client(None).list_models()
+            models = payload.get("models", []) if isinstance(payload, dict) else []
+            names = [str(model["name"]) for model in models if isinstance(model, dict) and model.get("name")]
+        except ConfigurationError:
+            raise
+        except Exception as exc:
+            raise ConfigurationError(f"could not read configured models: {redact_text(exc)}") from exc
+        if not names:
+            raise ConfigurationError("config.yaml does not define any named models")
+        return names
+
+    def run_case(self, model: str, case: CaseSpec, thread_id: str, user_id: str) -> SmokeResult:
+        token = self._set_user(SimpleNamespace(id=user_id))
+        try:
+            client = self._client(model)
+            try:
+                observation = observe_events(client.stream(case.prompt, thread_id=thread_id, user_id=user_id))
+            except Exception as exc:
+                category = _invocation_error_category(exc)
+                return SmokeResult(
+                    model=model,
+                    case=case.name,
+                    passed=False,
+                    detail=f"model invocation raised {type(exc).__name__}: {redact_text(exc)}",
+                    category=category,
+                )
+
+            artifact = None
+            artifact_error = None
+            if case.artifact_path:
+                try:
+                    artifact, _mime_type = client.get_artifact(thread_id, case.artifact_path)
+                except Exception as exc:
+                    artifact_error = f"{type(exc).__name__}: {redact_text(exc)}"
+            return evaluate_case(
+                model,
+                case.name,
+                observation,
+                artifact=artifact,
+                artifact_error=artifact_error,
+            )
+        finally:
+            self._reset_user(token)
+
+    def cleanup(self, thread_id: str, user_id: str) -> None:
+        self._delete_thread(thread_id, user_id)
+
+
+def _import_deerflow_runtime() -> tuple[Any, ...]:
+    """Import live-only dependencies after the opt-in gate has passed."""
+    from langgraph.checkpoint.memory import InMemorySaver
+
+    from deerflow.client import DeerFlowClient
+    from deerflow.config.paths import get_paths
+    from deerflow.runtime.user_context import reset_current_user, set_current_user
+
+    return DeerFlowClient, InMemorySaver, get_paths, set_current_user, reset_current_user
+
+
+def make_runtime(
+    config_path: Path = DEFAULT_CONFIG_PATH,
+    *,
+    importer: Callable[[], tuple[Any, ...]] = _import_deerflow_runtime,
+) -> DeerFlowRuntime:
+    """Build the live adapter without ever reading or printing `.env` values."""
+    if not config_path.is_file():
+        raise ConfigurationError(f"config.yaml not found at {config_path}")
+
+    DeerFlowClient, InMemorySaver, get_paths, set_current_user, reset_current_user = importer()
+
+    def client_factory(model: str | None) -> Any:
+        client = DeerFlowClient(
+            config_path=str(config_path),
+            checkpointer=InMemorySaver(),
+            model_name=model,
+            thinking_enabled=False,
+            subagent_enabled=False,
+            plan_mode=False,
+            available_skills=set(),
+            environment="model-compat-smoke",
+        )
+        isolate_client_config(client)
+        return client
+
+    def delete_thread(thread_id: str, user_id: str) -> None:
+        get_paths().delete_thread_dir(thread_id, user_id=user_id)
+
+    return DeerFlowRuntime(
+        client_factory=client_factory,
+        set_user=set_current_user,
+        reset_user=reset_current_user,
+        delete_thread=delete_thread,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    return int(run_cli(argv, runtime_factory=make_runtime))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/model_compat/smoke.py
+++ b/backend/tests/model_compat/smoke.py
@@ -1,0 +1,499 @@
+"""Offline-testable core for the opt-in model/tool compatibility smoke runner."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import asdict, dataclass, field
+from enum import IntEnum, StrEnum
+from pathlib import Path
+from typing import Any, Protocol
+
+LIVE_OPT_IN = "DEER_FLOW_RUN_LIVE_TESTS"
+
+
+class CaseName(StrEnum):
+    BASIC_CHAT = "basic_chat"
+    STREAMING = "streaming"
+    WRITE_FILE = "write_file"
+    WRITE_READ = "write_then_read"
+    TOOL_ERROR_RECOVERY = "tool_error_recovery"
+
+
+class ErrorCategory(StrEnum):
+    CONFIGURATION = "configuration_error"
+    MODEL_INCOMPATIBLE = "model_incompatible"
+    TOOL_FAILURE = "tool_failure"
+    RUNNER = "runner_error"
+
+
+class ExitCode(IntEnum):
+    OK = 0
+    CHECK_FAILED = 1
+    CONFIGURATION = 2
+    RUNNER_ERROR = 3
+
+
+class ConfigurationError(RuntimeError):
+    """A safe-to-report invocation or local configuration failure."""
+
+
+@dataclass(frozen=True)
+class CaseSpec:
+    name: CaseName
+    prompt: str
+    artifact_path: str | None = None
+    expected_artifact: bytes | None = None
+
+
+CASES: tuple[CaseSpec, ...] = (
+    CaseSpec(
+        CaseName.BASIC_CHAT,
+        "Reply with exactly DEERFLOW_SMOKE_CHAT_OK and do not call any tools.",
+    ),
+    CaseSpec(
+        CaseName.STREAMING,
+        "Reply with a short sentence beginning with DEERFLOW_SMOKE_STREAM_OK. Do not call tools.",
+    ),
+    CaseSpec(
+        CaseName.WRITE_FILE,
+        "Use write_file to create /mnt/user-data/outputs/model_compat_write.txt containing exactly DEERFLOW_SMOKE_WRITE_OK, then confirm completion.",
+        "/mnt/user-data/outputs/model_compat_write.txt",
+        b"DEERFLOW_SMOKE_WRITE_OK",
+    ),
+    CaseSpec(
+        CaseName.WRITE_READ,
+        "First use write_file to create /mnt/user-data/outputs/model_compat_chain.txt containing exactly DEERFLOW_SMOKE_CHAIN_OK. Then use read_file to read that same file before replying with what you read.",
+        "/mnt/user-data/outputs/model_compat_chain.txt",
+        b"DEERFLOW_SMOKE_CHAIN_OK",
+    ),
+    CaseSpec(
+        CaseName.TOOL_ERROR_RECOVERY,
+        "First use read_file on "
+        "/mnt/user-data/outputs/definitely_missing_model_compat_file.txt and observe the "
+        "expected error. Then recover by using write_file to create "
+        "/mnt/user-data/outputs/model_compat_recovery.txt containing exactly "
+        "DEERFLOW_SMOKE_RECOVERY_OK, and confirm recovery.",
+        "/mnt/user-data/outputs/model_compat_recovery.txt",
+        b"DEERFLOW_SMOKE_RECOVERY_OK",
+    ),
+)
+
+
+@dataclass
+class ToolCall:
+    name: str
+    call_id: str | None
+    args: dict[str, Any]
+    sequence: int
+
+
+@dataclass
+class ToolResult:
+    name: str
+    call_id: str | None
+    content: str
+    status: str
+    error_type: str | None
+    sequence: int
+    message_id: str | None = None
+
+
+@dataclass
+class Observation:
+    text_chunks: list[str] = field(default_factory=list)
+    first_content_ms: float | None = None
+    ended: bool = False
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    tool_results: list[ToolResult] = field(default_factory=list)
+    provider_fallback: bool = False
+    provider_error_type: str | None = None
+
+    @property
+    def text(self) -> str:
+        return "".join(self.text_chunks)
+
+
+@dataclass
+class SmokeResult:
+    model: str
+    case: CaseName
+    passed: bool
+    detail: str
+    category: ErrorCategory | None = None
+    first_content_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["model"] = redact_text(self.model)
+        data["detail"] = redact_text(self.detail)
+        data["case"] = self.case.value
+        data["category"] = self.category.value if self.category else None
+        return data
+
+
+class Runtime(Protocol):
+    def list_models(self) -> list[str]: ...
+
+    def run_case(self, model: str, case: CaseSpec, thread_id: str, user_id: str) -> SmokeResult: ...
+
+    def cleanup(self, thread_id: str, user_id: str) -> None: ...
+
+
+_BEARER_RE = re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._~+/=-]+")
+_OPENAI_KEY_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b")
+_URL_USERINFO_RE = re.compile(r"([a-zA-Z][\w+.-]*://)([^/?#\s@]+)@")
+_NAMED_SECRET_RE = re.compile(r"(?i)((?:api[_-]?key|access[_-]?token|token|secret|password|authorization)\s*[=:]\s*)([^\s&]+)")
+_SECRET_ENV_NAME_RE = re.compile(r"(?i)(api[_-]?key|access[_-]?key|token|secret|password|passwd|credential|authorization|cookie|dsn)")
+
+
+def redact_text(value: object) -> str:
+    """Remove common credential forms from free-form runner output."""
+    text = str(value)
+    text = _URL_USERINFO_RE.sub(r"\1<redacted>@", text)
+    text = _BEARER_RE.sub(r"\1<redacted>", text)
+    text = _NAMED_SECRET_RE.sub(r"\1<redacted>", text)
+    text = _OPENAI_KEY_RE.sub("sk-<redacted>", text)
+    for name, secret in os.environ.items():
+        if _SECRET_ENV_NAME_RE.search(name) and len(secret) >= 6:
+            text = text.replace(secret, "<redacted>")
+    return text
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run explicit live smoke checks against configured DeerFlow models.",
+        epilog="WARNING: smoke checks call real models and may incur API charges.",
+    )
+    selection = parser.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--model", dest="models", action="append", help="Configured model name; repeat to test multiple models.")
+    selection.add_argument("--all-models", action="store_true", help="Test every configured model.")
+    selection.add_argument("--list-models", action="store_true", help="List configured model names without calling a model.")
+    parser.add_argument("--case", dest="cases", action="append", choices=[case.value for case in CaseName], help="Run only this case; repeat to select several.")
+    parser.add_argument("--json-output", type=Path, help="Write the redacted result report to this path.")
+    parser.add_argument("--keep-workspaces", action="store_true", help="Keep isolated smoke workspaces for debugging.")
+    return parser
+
+
+def select_models(requested: list[str], all_models: bool, configured: list[str]) -> list[str]:
+    configured_unique = list(dict.fromkeys(configured))
+    if all_models:
+        if not configured_unique:
+            raise ValueError("no models are configured")
+        return configured_unique
+
+    selected = list(dict.fromkeys(requested))
+    unknown = [name for name in selected if name not in configured_unique]
+    if unknown:
+        raise ValueError(f"unknown model(s): {', '.join(unknown)}")
+    return selected
+
+
+def _message_meta(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    additional = data.get("additional_kwargs")
+    if not isinstance(additional, Mapping):
+        return {}
+    meta = additional.get("deerflow_tool_meta")
+    return meta if isinstance(meta, Mapping) else {}
+
+
+def _upsert_tool_result(results: list[ToolResult], data: Mapping[str, Any], sequence: int) -> None:
+    message_id = data.get("id")
+    call_id = data.get("tool_call_id")
+    existing = next(
+        (result for result in results if (message_id and result.message_id == message_id) or (call_id and result.call_id == call_id)),
+        None,
+    )
+    meta = _message_meta(data)
+    content = str(data.get("content") or "")
+    status = str(meta.get("status") or ("error" if content.lstrip().lower().startswith("error:") else "success"))
+    error_type = str(meta["error_type"]) if meta.get("error_type") else None
+    if existing:
+        existing.content = content or existing.content
+        existing.status = status
+        existing.error_type = error_type
+        return
+    results.append(
+        ToolResult(
+            name=str(data.get("name") or ""),
+            call_id=str(call_id) if call_id else None,
+            content=content,
+            status=status,
+            error_type=error_type,
+            sequence=sequence,
+            message_id=str(message_id) if message_id else None,
+        )
+    )
+
+
+def observe_events(events: Iterable[Any], *, clock: Callable[[], float] = time.monotonic) -> Observation:
+    started = clock()
+    observation = Observation()
+    sequence = 0
+    for event in events:
+        sequence += 1
+        event_type = getattr(event, "type", None)
+        data = getattr(event, "data", {})
+        if not isinstance(data, Mapping):
+            continue
+        if event_type == "end":
+            observation.ended = True
+            continue
+        if event_type == "values":
+            messages = data.get("messages") or []
+            for message in messages:
+                if isinstance(message, Mapping) and message.get("type") == "tool":
+                    _upsert_tool_result(observation.tool_results, message, sequence)
+            continue
+        if event_type != "messages-tuple":
+            continue
+
+        if data.get("type") == "ai":
+            content = str(data.get("content") or "")
+            if content:
+                if observation.first_content_ms is None:
+                    observation.first_content_ms = (clock() - started) * 1000
+                observation.text_chunks.append(content)
+            additional = data.get("additional_kwargs")
+            if isinstance(additional, Mapping) and additional.get("deerflow_error_fallback") is True:
+                observation.provider_fallback = True
+                if additional.get("error_type"):
+                    observation.provider_error_type = str(additional["error_type"])
+            for raw_call in data.get("tool_calls") or []:
+                if not isinstance(raw_call, Mapping):
+                    continue
+                args = raw_call.get("args")
+                observation.tool_calls.append(
+                    ToolCall(
+                        name=str(raw_call.get("name") or ""),
+                        call_id=str(raw_call["id"]) if raw_call.get("id") else None,
+                        args=dict(args) if isinstance(args, Mapping) else {},
+                        sequence=sequence,
+                    )
+                )
+        elif data.get("type") == "tool":
+            _upsert_tool_result(observation.tool_results, data, sequence)
+    return observation
+
+
+def _failure(model: str, case: CaseName, category: ErrorCategory, detail: str, observation: Observation) -> SmokeResult:
+    return SmokeResult(
+        model=model,
+        case=case,
+        passed=False,
+        category=category,
+        detail=detail,
+        first_content_ms=observation.first_content_ms,
+    )
+
+
+def _calls(observation: Observation, name: str) -> list[ToolCall]:
+    return [call for call in observation.tool_calls if call.name == name]
+
+
+def _result_for(observation: Observation, call: ToolCall) -> ToolResult | None:
+    return next((result for result in observation.tool_results if result.call_id == call.call_id or (not call.call_id and result.name == call.name)), None)
+
+
+def evaluate_case(
+    model: str,
+    case: CaseName,
+    observation: Observation,
+    *,
+    artifact: bytes | None = None,
+    artifact_error: str | None = None,
+) -> SmokeResult:
+    if observation.provider_fallback:
+        detail = f"model provider fallback ({observation.provider_error_type or 'unknown error'})"
+        return _failure(model, case, ErrorCategory.CONFIGURATION, detail, observation)
+
+    if case is CaseName.BASIC_CHAT:
+        if "DEERFLOW_SMOKE_CHAT_OK" not in observation.text:
+            return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "expected basic-chat marker was not returned", observation)
+    elif case is CaseName.STREAMING:
+        if observation.first_content_ms is None:
+            return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "stream produced no content", observation)
+        if not observation.ended:
+            return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "stream ended without an end event", observation)
+    else:
+        write_calls = _calls(observation, "write_file")
+        if not write_calls:
+            return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "model did not call write_file", observation)
+
+        for call in write_calls:
+            result = _result_for(observation, call)
+            if result is not None and result.status == "error":
+                return _failure(model, case, ErrorCategory.TOOL_FAILURE, f"write_file failed ({result.error_type or 'unknown error'})", observation)
+
+        if case is CaseName.WRITE_READ:
+            read_calls = _calls(observation, "read_file")
+            if not read_calls or read_calls[-1].sequence <= write_calls[0].sequence:
+                return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "model did not call read_file after write_file", observation)
+            read_result = _result_for(observation, read_calls[-1])
+            if read_result is not None and read_result.status == "error":
+                return _failure(model, case, ErrorCategory.TOOL_FAILURE, f"read_file failed ({read_result.error_type or 'unknown error'})", observation)
+            if read_result is None or "DEERFLOW_SMOKE_CHAIN_OK" not in read_result.content:
+                return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "read_file did not return the expected marker", observation)
+
+        if case is CaseName.TOOL_ERROR_RECOVERY:
+            read_calls = _calls(observation, "read_file")
+            if not read_calls:
+                return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "model did not attempt the expected failing read_file call", observation)
+            read_result = _result_for(observation, read_calls[0])
+            if read_result is None or read_result.status != "error":
+                return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "expected read_file failure was not observed", observation)
+            if write_calls[-1].sequence == read_calls[0].sequence:
+                return _failure(
+                    model,
+                    case,
+                    ErrorCategory.MODEL_INCOMPATIBLE,
+                    "model issued read_file and write_file in parallel instead of recovering after the tool error",
+                    observation,
+                )
+            if write_calls[-1].sequence < read_calls[0].sequence:
+                return _failure(model, case, ErrorCategory.MODEL_INCOMPATIBLE, "model did not recover with write_file after the tool error", observation)
+
+        expected = next(spec.expected_artifact for spec in CASES if spec.name is case)
+        if artifact_error:
+            return _failure(model, case, ErrorCategory.TOOL_FAILURE, f"artifact verification failed: {artifact_error}", observation)
+        if artifact != expected:
+            actual_size = len(artifact) if artifact is not None else 0
+            return _failure(
+                model,
+                case,
+                ErrorCategory.TOOL_FAILURE,
+                f"artifact content did not match the expected marker ({actual_size} bytes)",
+                observation,
+            )
+
+    return SmokeResult(
+        model=model,
+        case=case,
+        passed=True,
+        detail="contract satisfied",
+        first_content_ms=observation.first_content_ms,
+    )
+
+
+def _summary(results: list[SmokeResult]) -> dict[str, int]:
+    passed = sum(result.passed for result in results)
+    return {"passed": passed, "failed": len(results) - passed, "total": len(results)}
+
+
+def _print_results(results: list[SmokeResult]) -> None:
+    print("MODEL\tCASE\tSTATUS\tCATEGORY\tFIRST_CONTENT_MS\tDETAIL")
+    for result in results:
+        latency = f"{result.first_content_ms:.1f}" if result.first_content_ms is not None else "-"
+        print(
+            "\t".join(
+                [
+                    redact_text(result.model),
+                    result.case.value,
+                    "PASS" if result.passed else "FAIL",
+                    result.category.value if result.category else "-",
+                    latency,
+                    redact_text(result.detail),
+                ]
+            )
+        )
+    summary = _summary(results)
+    print(f"Summary: {summary['passed']} passed, {summary['failed']} failed, {summary['total']} total")
+
+
+def run_cli(
+    argv: list[str] | None = None,
+    *,
+    environ: Mapping[str, str] = os.environ,
+    runtime_factory: Callable[[], Runtime],
+    id_factory: Callable[[], str] = lambda: uuid.uuid4().hex,
+) -> ExitCode:
+    args = build_parser().parse_args(argv)
+    if "CI" in environ:
+        print("configuration_error: live model smoke checks are disabled in CI", file=sys.stderr)
+        return ExitCode.CONFIGURATION
+    if not args.list_models and environ.get(LIVE_OPT_IN) != "1":
+        print(
+            f"configuration_error: set {LIVE_OPT_IN}=1 to acknowledge that this command calls a real model and may incur charges",
+            file=sys.stderr,
+        )
+        return ExitCode.CONFIGURATION
+
+    try:
+        runtime = runtime_factory()
+        configured = runtime.list_models()
+        if args.list_models:
+            for model in configured:
+                print(redact_text(model))
+            return ExitCode.OK
+        models = select_models(args.models or [], args.all_models, configured)
+    except ConfigurationError as exc:
+        print(f"configuration_error: {redact_text(exc)}", file=sys.stderr)
+        return ExitCode.CONFIGURATION
+    except ValueError as exc:
+        print(f"configuration_error: {redact_text(exc)}", file=sys.stderr)
+        return ExitCode.CONFIGURATION
+    except Exception as exc:
+        print(f"runner_error: {redact_text(exc)}", file=sys.stderr)
+        return ExitCode.RUNNER_ERROR
+
+    selected_cases = set(args.cases or [case.value for case in CaseName])
+    specs = [spec for spec in CASES if spec.name.value in selected_cases]
+    results: list[SmokeResult] = []
+    runner_failed = False
+    for model in models:
+        for spec in specs:
+            thread_id = f"smoke-{id_factory()[:24]}"
+            user_id = f"smoke-{id_factory()[:24]}"
+            result: SmokeResult | None = None
+            try:
+                result = runtime.run_case(model, spec, thread_id, user_id)
+            except ConfigurationError as exc:
+                result = SmokeResult(model, spec.name, False, redact_text(exc), ErrorCategory.CONFIGURATION)
+            except Exception as exc:
+                runner_failed = True
+                result = SmokeResult(model, spec.name, False, redact_text(exc), ErrorCategory.RUNNER)
+            finally:
+                if not args.keep_workspaces:
+                    try:
+                        runtime.cleanup(thread_id, user_id)
+                    except Exception as exc:
+                        runner_failed = True
+                        if result is None:
+                            original_status = "not completed"
+                        elif result.passed:
+                            original_status = "passed"
+                        else:
+                            original_status = f"failed ({result.category.value if result.category else 'uncategorized'})"
+                        result = SmokeResult(
+                            model,
+                            spec.name,
+                            False,
+                            f"cleanup failed (original check: {original_status}): {redact_text(exc)}",
+                            ErrorCategory.RUNNER,
+                        )
+            if result is None:  # pragma: no cover - a BaseException propagates before this point
+                raise RuntimeError("smoke case completed without a result")
+            results.append(result)
+
+    _print_results(results)
+    if args.json_output:
+        payload = {"results": [result.to_dict() for result in results], "summary": _summary(results)}
+        try:
+            args.json_output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        except OSError as exc:
+            print(f"runner_error: could not write JSON report: {redact_text(exc)}", file=sys.stderr)
+            return ExitCode.RUNNER_ERROR
+
+    if runner_failed or any(result.category is ErrorCategory.RUNNER for result in results):
+        return ExitCode.RUNNER_ERROR
+    if any(result.category is ErrorCategory.CONFIGURATION for result in results):
+        return ExitCode.CONFIGURATION
+    if any(not result.passed for result in results):
+        return ExitCode.CHECK_FAILED
+    return ExitCode.OK

--- a/backend/tests/test_model_compat_smoke.py
+++ b/backend/tests/test_model_compat_smoke.py
@@ -1,0 +1,684 @@
+"""Offline tests for the explicit model/tool compatibility smoke runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SMOKE_DIR = Path(__file__).parent / "model_compat"
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = BACKEND_ROOT.parent
+sys.path.insert(0, str(SMOKE_DIR))
+
+from run_smoke import (  # noqa: E402
+    DeerFlowRuntime,
+    isolate_client_config,
+    make_runtime,
+)
+from smoke import (  # noqa: E402
+    CaseName,
+    ErrorCategory,
+    ExitCode,
+    SmokeResult,
+    build_parser,
+    evaluate_case,
+    observe_events,
+    redact_text,
+    run_cli,
+    select_models,
+)
+
+
+class Event:
+    def __init__(self, event_type: str, data: dict):
+        self.type = event_type
+        self.data = data
+
+
+class FakeRuntime:
+    def __init__(self, models: tuple[str, ...] = ("alpha", "beta")):
+        self.models = models
+        self.calls: list[tuple[str, CaseName, str, str]] = []
+        self.cleaned: list[tuple[str, str]] = []
+
+    def list_models(self) -> list[str]:
+        return list(self.models)
+
+    def run_case(self, model: str, case, thread_id: str, user_id: str) -> SmokeResult:
+        self.calls.append((model, case.name, thread_id, user_id))
+        return SmokeResult(model=model, case=case.name, passed=True, detail="ok")
+
+    def cleanup(self, thread_id: str, user_id: str) -> None:
+        self.cleaned.append((thread_id, user_id))
+
+
+def test_parser_requires_an_explicit_model_selection() -> None:
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+    args = parser.parse_args(["--model", "alpha", "--model", "beta"])
+
+    assert args.models == ["alpha", "beta"]
+    assert args.all_models is False
+
+
+def test_select_models_rejects_unknown_and_preserves_configuration_order() -> None:
+    assert select_models(["beta", "alpha", "beta"], False, ["alpha", "beta"]) == ["beta", "alpha"]
+    assert select_models([], True, ["alpha", "beta"]) == ["alpha", "beta"]
+
+    with pytest.raises(ValueError, match="unknown model"):
+        select_models(["missing"], False, ["alpha"])
+
+
+def test_observer_records_first_content_latency_tool_order_and_error_metadata() -> None:
+    times = iter([10.0, 10.025, 10.040, 10.050, 10.060])
+    events = [
+        Event("messages-tuple", {"type": "ai", "content": "", "id": "a1"}),
+        Event("messages-tuple", {"type": "ai", "content": "hello", "id": "a1"}),
+        Event(
+            "messages-tuple",
+            {"type": "ai", "content": "", "id": "a2", "tool_calls": [{"id": "c1", "name": "read_file", "args": {"file_path": "/missing"}}]},
+        ),
+        Event("messages-tuple", {"type": "tool", "id": "t1", "tool_call_id": "c1", "name": "read_file", "content": "Error: not found"}),
+        Event(
+            "values",
+            {
+                "messages": [
+                    {
+                        "type": "tool",
+                        "id": "t1",
+                        "tool_call_id": "c1",
+                        "name": "read_file",
+                        "content": "Error: not found",
+                        "additional_kwargs": {"deerflow_tool_meta": {"status": "error", "error_type": "not_found"}},
+                    }
+                ]
+            },
+        ),
+    ]
+
+    observation = observe_events(events, clock=lambda: next(times))
+
+    assert observation.first_content_ms == pytest.approx(25.0)
+    assert observation.text == "hello"
+    assert [call.name for call in observation.tool_calls] == ["read_file"]
+    assert observation.tool_results[0].status == "error"
+    assert observation.tool_results[0].error_type == "not_found"
+
+
+@pytest.mark.parametrize(
+    ("case", "events", "artifact", "passed", "category"),
+    [
+        (CaseName.BASIC_CHAT, [Event("messages-tuple", {"type": "ai", "content": "DEERFLOW_SMOKE_CHAT_OK", "id": "a"})], None, True, None),
+        (CaseName.STREAMING, [Event("messages-tuple", {"type": "ai", "content": "stream", "id": "a"}), Event("end", {})], None, True, None),
+        (
+            CaseName.WRITE_FILE,
+            [
+                Event("messages-tuple", {"type": "ai", "content": "", "id": "a", "tool_calls": [{"id": "c", "name": "write_file", "args": {}}]}),
+                Event("messages-tuple", {"type": "tool", "id": "t", "tool_call_id": "c", "name": "write_file", "content": "ok"}),
+            ],
+            b"DEERFLOW_SMOKE_WRITE_OK",
+            True,
+            None,
+        ),
+        (
+            CaseName.WRITE_READ,
+            [
+                Event("messages-tuple", {"type": "ai", "content": "", "id": "a1", "tool_calls": [{"id": "c1", "name": "write_file", "args": {}}]}),
+                Event("messages-tuple", {"type": "tool", "id": "t1", "tool_call_id": "c1", "name": "write_file", "content": "ok"}),
+                Event("messages-tuple", {"type": "ai", "content": "", "id": "a2", "tool_calls": [{"id": "c2", "name": "read_file", "args": {}}]}),
+                Event("messages-tuple", {"type": "tool", "id": "t2", "tool_call_id": "c2", "name": "read_file", "content": "DEERFLOW_SMOKE_CHAIN_OK"}),
+            ],
+            b"DEERFLOW_SMOKE_CHAIN_OK",
+            True,
+            None,
+        ),
+        (
+            CaseName.TOOL_ERROR_RECOVERY,
+            [
+                Event("messages-tuple", {"type": "ai", "content": "", "id": "a1", "tool_calls": [{"id": "c1", "name": "read_file", "args": {}}]}),
+                Event(
+                    "messages-tuple",
+                    {
+                        "type": "tool",
+                        "id": "t1",
+                        "tool_call_id": "c1",
+                        "name": "read_file",
+                        "content": "Error: not found",
+                        "additional_kwargs": {"deerflow_tool_meta": {"status": "error", "error_type": "not_found"}},
+                    },
+                ),
+                Event("messages-tuple", {"type": "ai", "content": "", "id": "a2", "tool_calls": [{"id": "c2", "name": "write_file", "args": {}}]}),
+                Event("messages-tuple", {"type": "tool", "id": "t2", "tool_call_id": "c2", "name": "write_file", "content": "ok"}),
+            ],
+            b"DEERFLOW_SMOKE_RECOVERY_OK",
+            True,
+            None,
+        ),
+    ],
+)
+def test_case_contracts_are_evaluated_offline(case, events, artifact, passed, category) -> None:
+    result = evaluate_case("alpha", case, observe_events(events), artifact=artifact)
+
+    assert result.passed is passed
+    assert result.category is category
+
+
+def test_missing_tool_call_is_model_incompatibility_but_failed_tool_is_tool_failure() -> None:
+    missing = evaluate_case("alpha", CaseName.WRITE_FILE, observe_events([]), artifact=None)
+    failed = evaluate_case(
+        "alpha",
+        CaseName.WRITE_FILE,
+        observe_events(
+            [
+                Event("messages-tuple", {"type": "ai", "content": "", "tool_calls": [{"id": "c", "name": "write_file", "args": {}}]}),
+                Event(
+                    "messages-tuple",
+                    {
+                        "type": "tool",
+                        "name": "write_file",
+                        "tool_call_id": "c",
+                        "content": "Error: denied",
+                        "additional_kwargs": {"deerflow_tool_meta": {"status": "error", "error_type": "permission"}},
+                    },
+                ),
+            ]
+        ),
+        artifact=None,
+    )
+
+    assert missing.category is ErrorCategory.MODEL_INCOMPATIBLE
+    assert failed.category is ErrorCategory.TOOL_FAILURE
+
+
+def test_recovery_reports_parallel_read_and_write_as_a_distinct_incompatibility() -> None:
+    observation = observe_events(
+        [
+            Event(
+                "messages-tuple",
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [
+                        {"id": "read", "name": "read_file", "args": {}},
+                        {"id": "write", "name": "write_file", "args": {}},
+                    ],
+                },
+            ),
+            Event(
+                "messages-tuple",
+                {
+                    "type": "tool",
+                    "name": "read_file",
+                    "tool_call_id": "read",
+                    "content": "Error: not found",
+                    "additional_kwargs": {"deerflow_tool_meta": {"status": "error"}},
+                },
+            ),
+            Event(
+                "messages-tuple",
+                {
+                    "type": "tool",
+                    "name": "write_file",
+                    "tool_call_id": "write",
+                    "content": "ok",
+                },
+            ),
+        ]
+    )
+
+    result = evaluate_case(
+        "alpha",
+        CaseName.TOOL_ERROR_RECOVERY,
+        observation,
+        artifact=b"DEERFLOW_SMOKE_RECOVERY_OK",
+    )
+
+    assert result.category is ErrorCategory.MODEL_INCOMPATIBLE
+    assert "parallel" in result.detail
+
+
+def test_artifact_mismatch_reports_size_without_echoing_content() -> None:
+    secret_content = b"wrong-model-output-that-must-not-be-printed"
+    observation = observe_events(
+        [
+            Event(
+                "messages-tuple",
+                {
+                    "type": "ai",
+                    "content": "",
+                    "tool_calls": [{"id": "write", "name": "write_file", "args": {}}],
+                },
+            ),
+            Event(
+                "messages-tuple",
+                {
+                    "type": "tool",
+                    "name": "write_file",
+                    "tool_call_id": "write",
+                    "content": "ok",
+                },
+            ),
+        ]
+    )
+
+    result = evaluate_case(
+        "alpha",
+        CaseName.WRITE_FILE,
+        observation,
+        artifact=secret_content,
+    )
+
+    assert f"{len(secret_content)} bytes" in result.detail
+    assert secret_content.decode() not in result.detail
+
+
+def test_provider_fallback_is_configuration_error() -> None:
+    observation = observe_events(
+        [
+            Event(
+                "messages-tuple",
+                {
+                    "type": "ai",
+                    "content": "provider failed",
+                    "id": "a",
+                    "additional_kwargs": {"deerflow_error_fallback": True, "error_type": "AuthenticationError"},
+                },
+            )
+        ]
+    )
+
+    result = evaluate_case("alpha", CaseName.BASIC_CHAT, observation)
+
+    assert result.category is ErrorCategory.CONFIGURATION
+
+
+def test_cli_is_fail_closed_in_ci_and_without_opt_in(capsys) -> None:
+    runtime = FakeRuntime()
+
+    no_opt_in = run_cli(["--model", "alpha"], environ={}, runtime_factory=lambda: runtime)
+    in_ci = run_cli(
+        ["--model", "alpha"],
+        environ={"DEER_FLOW_RUN_LIVE_TESTS": "1", "CI": "true"},
+        runtime_factory=lambda: runtime,
+    )
+
+    assert no_opt_in == ExitCode.CONFIGURATION
+    assert in_ci == ExitCode.CONFIGURATION
+    assert runtime.calls == []
+    assert "real model" in capsys.readouterr().err.lower()
+
+
+def test_cli_rejects_ci_variable_even_when_its_value_is_empty() -> None:
+    runtime = FakeRuntime()
+
+    exit_code = run_cli(
+        ["--model", "alpha"],
+        environ={"DEER_FLOW_RUN_LIVE_TESTS": "1", "CI": ""},
+        runtime_factory=lambda: runtime,
+    )
+
+    assert exit_code == ExitCode.CONFIGURATION
+    assert runtime.calls == []
+
+
+def test_cli_runs_all_cases_with_unique_isolation_and_cleanup(tmp_path: Path) -> None:
+    runtime = FakeRuntime(("alpha",))
+
+    exit_code = run_cli(
+        ["--model", "alpha", "--json-output", str(tmp_path / "result.json")],
+        environ={"DEER_FLOW_RUN_LIVE_TESTS": "1"},
+        runtime_factory=lambda: runtime,
+        id_factory=iter([f"id-{index}" for index in range(20)]).__next__,
+    )
+
+    assert exit_code == ExitCode.OK
+    assert [call[1] for call in runtime.calls] == list(CaseName)
+    assert len({call[2] for call in runtime.calls}) == len(CaseName)
+    assert len({call[3] for call in runtime.calls}) == len(CaseName)
+    assert runtime.cleaned == [(call[2], call[3]) for call in runtime.calls]
+    payload = json.loads((tmp_path / "result.json").read_text())
+    assert payload["summary"] == {"passed": 5, "failed": 0, "total": 5}
+
+
+def test_cli_exit_codes_distinguish_check_failures_and_runner_errors() -> None:
+    class FailedRuntime(FakeRuntime):
+        def run_case(self, model, case, thread_id, user_id):
+            return SmokeResult(model=model, case=case.name, passed=False, category=ErrorCategory.MODEL_INCOMPATIBLE, detail="no tool call")
+
+    class BrokenRuntime(FakeRuntime):
+        def run_case(self, model, case, thread_id, user_id):
+            raise RuntimeError("runner exploded")
+
+    class ConfigurationRuntime(FakeRuntime):
+        def run_case(self, model, case, thread_id, user_id):
+            return SmokeResult(
+                model=model,
+                case=case.name,
+                passed=False,
+                category=ErrorCategory.CONFIGURATION,
+                detail="provider authentication failed",
+            )
+
+    env = {"DEER_FLOW_RUN_LIVE_TESTS": "1"}
+
+    assert run_cli(["--model", "alpha"], environ=env, runtime_factory=FailedRuntime) == ExitCode.CHECK_FAILED
+    assert run_cli(["--model", "alpha"], environ=env, runtime_factory=ConfigurationRuntime) == ExitCode.CONFIGURATION
+    assert run_cli(["--model", "alpha"], environ=env, runtime_factory=BrokenRuntime) == ExitCode.RUNNER_ERROR
+
+
+def test_cleanup_failure_replaces_case_result_without_double_counting(tmp_path: Path) -> None:
+    class CleanupRuntime(FakeRuntime):
+        def cleanup(self, thread_id, user_id):
+            raise RuntimeError("cleanup exploded")
+
+    output = tmp_path / "result.json"
+
+    exit_code = run_cli(
+        ["--model", "alpha", "--case", "basic_chat", "--json-output", str(output)],
+        environ={"DEER_FLOW_RUN_LIVE_TESTS": "1"},
+        runtime_factory=CleanupRuntime,
+    )
+
+    payload = json.loads(output.read_text())
+    assert exit_code == ExitCode.RUNNER_ERROR
+    assert payload["summary"] == {"passed": 0, "failed": 1, "total": 1}
+    assert len(payload["results"]) == 1
+    assert payload["results"][0]["category"] == "runner_error"
+    assert "original check: passed" in payload["results"][0]["detail"]
+
+
+def test_json_report_redacts_result_strings_at_serialization_boundary(tmp_path: Path) -> None:
+    class SecretRuntime(FakeRuntime):
+        def run_case(self, model, case, thread_id, user_id):
+            return SmokeResult(
+                model="model?api_key=sk-1234567890",
+                case=case.name,
+                passed=False,
+                category=ErrorCategory.RUNNER,
+                detail="Authorization: Bearer abc.def",
+            )
+
+    output = tmp_path / "result.json"
+
+    run_cli(
+        ["--model", "alpha", "--case", "basic_chat", "--json-output", str(output)],
+        environ={"DEER_FLOW_RUN_LIVE_TESTS": "1"},
+        runtime_factory=SecretRuntime,
+    )
+
+    report = output.read_text()
+    assert "sk-1234567890" not in report
+    assert "abc.def" not in report
+    assert report.count("<redacted>") >= 2
+
+
+def test_output_redaction_masks_common_credentials(monkeypatch) -> None:
+    monkeypatch.setenv("CUSTOM_PROVIDER_API_KEY", "provider-secret-value-123")
+    text = "Authorization: Bearer abc.def api_key=sk-1234567890 https://user:pass@example.test?q=1&token=secret provider-secret-value-123"
+
+    redacted = redact_text(text)
+
+    assert "abc.def" not in redacted
+    assert "sk-1234567890" not in redacted
+    assert "user:pass" not in redacted
+    assert "token=secret" not in redacted
+    assert "provider-secret-value-123" not in redacted
+    assert "<redacted>" in redacted
+
+
+def test_deerflow_adapter_uses_isolated_user_and_verifies_artifact() -> None:
+    events = [
+        Event("messages-tuple", {"type": "ai", "content": "", "tool_calls": [{"id": "c", "name": "write_file", "args": {}}]}),
+        Event("messages-tuple", {"type": "tool", "name": "write_file", "tool_call_id": "c", "content": "ok"}),
+    ]
+    created_for: list[str | None] = []
+    context_events: list[tuple[str, object]] = []
+
+    class Client:
+        def list_models(self):
+            return {"models": [{"name": "alpha"}]}
+
+        def stream(self, prompt, *, thread_id, user_id):
+            assert "DEERFLOW_SMOKE_WRITE_OK" in prompt
+            assert thread_id == "thread-1"
+            assert user_id == "user-1"
+            return iter(events)
+
+        def get_artifact(self, thread_id, path):
+            assert path.endswith("model_compat_write.txt")
+            return b"DEERFLOW_SMOKE_WRITE_OK", "text/plain"
+
+    runtime = DeerFlowRuntime(
+        client_factory=lambda model: created_for.append(model) or Client(),
+        set_user=lambda user: context_events.append(("set", user.id)) or "token",
+        reset_user=lambda token: context_events.append(("reset", token)),
+        delete_thread=lambda thread_id, user_id: context_events.append(("delete", (thread_id, user_id))),
+    )
+    case = next(spec for spec in runtime.cases if spec.name is CaseName.WRITE_FILE)
+
+    result = runtime.run_case("alpha", case, "thread-1", "user-1")
+    runtime.cleanup("thread-1", "user-1")
+
+    assert result.passed is True
+    assert runtime.list_models() == ["alpha"]
+    assert created_for == ["alpha", None]
+    assert context_events == [("set", "user-1"), ("reset", "token"), ("delete", ("thread-1", "user-1"))]
+
+
+def test_client_config_is_copied_and_disables_auxiliary_model_and_memory_paths() -> None:
+    class Node:
+        def __init__(self, **values):
+            self.__dict__.update(values)
+
+        def model_copy(self, *, deep=False, update=None):
+            import copy
+
+            copied = copy.deepcopy(self) if deep else copy.copy(self)
+            copied.__dict__.update(update or {})
+            return copied
+
+    original = Node(
+        title=Node(enabled=True, model_name="title-model"),
+        summarization=Node(enabled=True, model_name="summary-model"),
+        memory=Node(enabled=True, injection_enabled=True),
+    )
+    client = Node(_app_config=original)
+
+    isolate_client_config(client)
+
+    assert client._app_config is not original
+    assert client._app_config.title.enabled is False
+    assert client._app_config.title.model_name is None
+    assert client._app_config.summarization.enabled is False
+    assert client._app_config.summarization.model_name is None
+    assert client._app_config.memory.enabled is False
+    assert client._app_config.memory.injection_enabled is False
+    assert original.title.enabled is True
+    assert original.summarization.enabled is True
+    assert original.memory.enabled is True
+
+
+@pytest.mark.parametrize(
+    ("exception_type", "category"),
+    [
+        (type("AuthenticationError", (Exception,), {}), ErrorCategory.CONFIGURATION),
+        (type("SandboxUnavailable", (Exception,), {}), ErrorCategory.TOOL_FAILURE),
+        (RuntimeError, ErrorCategory.RUNNER),
+    ],
+)
+def test_adapter_classifies_invocation_exceptions_by_boundary(exception_type, category) -> None:
+    class Client:
+        def stream(self, *args, **kwargs):
+            raise exception_type("failed")
+
+    runtime = DeerFlowRuntime(
+        client_factory=lambda model: Client(),
+        set_user=lambda user: "token",
+        reset_user=lambda token: None,
+        delete_thread=lambda thread_id, user_id: None,
+    )
+    case = next(spec for spec in runtime.cases if spec.name is CaseName.BASIC_CHAT)
+
+    result = runtime.run_case("alpha", case, "thread-1", "user-1")
+
+    assert result.category is category
+
+
+def test_make_runtime_fails_before_importing_when_config_is_missing(tmp_path: Path) -> None:
+    imported = False
+
+    def importer():
+        nonlocal imported
+        imported = True
+        raise AssertionError("must not import")
+
+    with pytest.raises(Exception, match="config.yaml"):
+        make_runtime(tmp_path / "config.yaml", importer=importer)
+
+    assert imported is False
+
+
+def test_make_runtime_applies_auxiliary_model_isolation_to_every_client(tmp_path: Path) -> None:
+    import copy
+
+    class Node:
+        def __init__(self, **values):
+            self.__dict__.update(values)
+
+        def model_copy(self, *, deep=False, update=None):
+            copied = copy.deepcopy(self) if deep else copy.copy(self)
+            copied.__dict__.update(update or {})
+            return copied
+
+    original = Node(
+        title=Node(enabled=True, model_name="title-model"),
+        summarization=Node(enabled=True, model_name="summary-model"),
+        memory=Node(enabled=True, injection_enabled=True),
+    )
+    clients = []
+
+    class Client:
+        def __init__(self, **kwargs):
+            self._app_config = original
+            clients.append(self)
+
+        def list_models(self):
+            return {"models": [{"name": "alpha"}]}
+
+    class Paths:
+        def delete_thread_dir(self, thread_id, *, user_id):
+            pass
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("models: []\n")
+    runtime = make_runtime(
+        config_path,
+        importer=lambda: (Client, object, lambda: Paths(), lambda user: "token", lambda token: None),
+    )
+
+    assert runtime.list_models() == ["alpha"]
+    assert clients[0]._app_config.title.enabled is False
+    assert clients[0]._app_config.summarization.enabled is False
+    assert clients[0]._app_config.memory.enabled is False
+    assert clients[0]._app_config.memory.injection_enabled is False
+    assert original.title.enabled is True
+    assert original.summarization.enabled is True
+    assert original.memory.enabled is True
+
+
+@pytest.mark.parametrize(
+    ("extra_env", "expected"),
+    [({}, "set DEER_FLOW_RUN_LIVE_TESTS=1"), ({"DEER_FLOW_RUN_LIVE_TESTS": "1", "CI": "true"}, "disabled in CI")],
+)
+def test_script_refuses_live_execution_before_loading_deerflow(extra_env, expected) -> None:
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONUTF8": "1",
+        **extra_env,
+    }
+
+    result = subprocess.run(
+        [sys.executable, str(SMOKE_DIR / "run_smoke.py"), "--model", "alpha"],
+        cwd=BACKEND_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == ExitCode.CONFIGURATION
+    assert expected in result.stderr
+    assert "config.yaml not found" not in result.stderr
+
+
+def test_default_pytest_collection_does_not_collect_manual_runner() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+            str(SMOKE_DIR),
+        ],
+        cwd=BACKEND_ROOT,
+        env={
+            "PATH": os.environ.get("PATH", ""),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTEST_DISABLE_PLUGIN_AUTOLOAD": "1",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == pytest.ExitCode.NO_TESTS_COLLECTED
+    assert "no tests collected" in output
+    assert "run_smoke" not in output
+
+
+def test_make_target_is_explicit_and_default_target_stays_offline() -> None:
+    default = subprocess.run(["make", "-n", "test"], cwd=BACKEND_ROOT, capture_output=True, text=True, check=False)
+    smoke = subprocess.run(
+        ["make", "-n", "model-smoke", "ARGS=--model alpha"],
+        cwd=BACKEND_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert default.returncode == 0
+    assert smoke.returncode == 0
+    assert "DEER_FLOW_RUN_LIVE_TESTS" not in default.stdout
+    assert 'pytest -m "not live"' in default.stdout
+    assert "DEER_FLOW_RUN_LIVE_TESTS=1" in smoke.stdout
+    assert "tests/model_compat/run_smoke.py --model alpha" in smoke.stdout
+    assert "pytest" not in smoke.stdout
+
+
+def test_smoke_documentation_warns_about_costs_and_default_exclusion() -> None:
+    dedicated = (SMOKE_DIR / "README.md").read_text(encoding="utf-8")
+    backend_readme = (BACKEND_ROOT / "README.md").read_text(encoding="utf-8")
+    backend_agents = (BACKEND_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    for docs in (dedicated, backend_readme, backend_agents, contributing):
+        assert "make model-smoke" in docs
+        assert "DEER_FLOW_RUN_LIVE_TESTS" in docs
+        assert "API" in docs
+    assert "exit code" in dedicated.lower()
+    assert "CI" in dedicated
+    assert "--model" in dedicated
+    assert "--json-output" in dedicated


### PR DESCRIPTION
Fixes #3179

## Why

DeerFlow has no focused way to check whether a configured model satisfies the
core chat, streaming, and sandbox-tool contracts. Reusing the normal test suite
for this purpose risks accidental external API requests and quota consumption.

This adds a deliberately manual compatibility runner that stays outside default
pytest and CI while making live costs and failure categories explicit.

## What changed

- Added an explicit `make model-smoke ARGS="--model NAME"` entry point covering
  basic chat, streaming health with first-content latency, `write_file`,
  write-then-read, and recovery after a tool error.
- Added offline-tested model/case selection, event analysis, redacted text and
  JSON summaries, error categories, and exit codes.
- Isolated every model/case pair with unique user/thread IDs, an in-memory
  checkpointer, and default local workspace cleanup.
- Disabled title generation, summarization, and memory injection/writes in a
  process-local config copy so the smoke run cannot silently call auxiliary
  models or persist smoke-user memory.
- Documented the cost warning, configuration, explicit commands, output, and
  default pytest/CI exclusion.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this is a backend command-line test utility.

## Validation

- `31 passed` — `tests/test_model_compat_smoke.py` using offline fakes/stubs
- `4 passed` — applicable existing `test_client_live_policy.py` checks
- `ruff check .`
- `ruff format --check .`
- `git diff --check upstream/main...HEAD`
- verified no-opt-in and `CI` execution both exit before live runtime creation
- verified `make -n test` remains `pytest -m "not live"`
- verified `make -n model-smoke ARGS='--model alpha'` uses the explicit opt-in entry point

The real live smoke runner was intentionally not executed because it would use
configured model API quota. The full backend suite was not run in this local
worktree because the reusable environment lacks the latest workspace-installed
`deerflow_extension_api`; no dependencies were installed or changed.

## AI assistance

**Tool(s) used:** Codex and Claude Code

**How you used it:** Codex investigated the current architecture, implemented
the runner and offline tests with TDD, and ran the listed validation. Claude
Code performed a separate read-only review; its diagnostic hardening feedback
was verified against the codebase before being applied.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
