### PR TITLE
refactor(sandbox): name the E2B ledger meta-field count

### DIFF
--- a/backend/packages/harness/deerflow/community/e2b_sandbox/capacity/redis.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/capacity/redis.py
@@ -18,6 +18,13 @@ local function now_ms()
     return tonumber(current[1]) * 1000 + math.floor(tonumber(current[2]) / 1000)
 end
 
+-- Number of 'meta:*' fields initialize() writes. Live entries ('r:'/'s:') are
+-- counted as HLEN minus this, so the two must move together: adding a meta
+-- field without updating this constant makes the ledger over-count usage and
+-- reject one reservation early. test_ledger_meta_field_count_matches_constant
+-- pins it against initialize()'s actual output.
+local META_FIELD_COUNT = 3
+
 local function initialize(hard_limit)
     redis.call('HSET', KEYS[1],
         'meta:state', 'initializing',
@@ -57,7 +64,7 @@ if operation == 'reserve' then
     if redis.call('HEXISTS', KEYS[1], field) == 1 then
         return 'GRANTED'
     end
-    if redis.call('HLEN', KEYS[1]) - 3 >= tonumber(hard_limit) then
+    if redis.call('HLEN', KEYS[1]) - META_FIELD_COUNT >= tonumber(hard_limit) then
         return 'FULL'
     end
     redis.call('HSET', KEYS[1], field, tostring(now_ms()))

--- a/backend/tests/test_e2b_capacity_store_redis.py
+++ b/backend/tests/test_e2b_capacity_store_redis.py
@@ -176,3 +176,33 @@ def test_mismatched_hard_limits_fail_closed(make_store) -> None:
         gateway_b.revision()
     with pytest.raises(CapacityBackendError, match="configuration mismatch"):
         gateway_b.reserve("reservation")
+
+
+def test_ledger_meta_field_count_matches_constant(make_store) -> None:
+    # Admission derives the live-entry count as HLEN - META_FIELD_COUNT, so the
+    # Lua constant must equal the number of 'meta:*' fields initialize() writes.
+    # Adding a meta field without updating the constant also trips the existing
+    # concurrency tests, but those report an unexpected reservation outcome; this
+    # one names the cause.
+    store = make_store(3)
+    _initialize(store)
+    fields = store._redis.hkeys(store.key)
+
+    assert _counts(store) == (0, 0)
+    assert sorted(fields) == ["meta:hard_limit", "meta:revision", "meta:state"]
+    assert len(fields) == 3
+
+
+def test_reserve_admits_exactly_hard_limit_entries(make_store) -> None:
+    # Locks the invariant the constant exists to protect: an off-by-one in the
+    # HLEN offset shifts the ceiling, which this catches regardless of how the
+    # offset happens to be spelled.
+    store = make_store(3)
+    _initialize(store)
+
+    granted = [store.reserve(f"reservation-{index}") for index in range(3)]
+
+    assert granted == [ReserveStatus.GRANTED] * 3
+    assert _counts(store) == (0, 3)
+    assert store.reserve("reservation-overflow") is ReserveStatus.FULL
+    assert store.reserve("reservation-0") is ReserveStatus.GRANTED


### PR DESCRIPTION
References #4575

Follow-up to a review comment on the already-merged #4575. @willem-bd flagged the
implicit coupling in the capacity ledger's admission check; @MiaoRuidx agreed and
replied that it was fixed in `95620c2c`. That commit exists, but it was pushed
23 minutes **after** the PR merged (merge `2026-07-31T09:13Z`, commit
`2026-07-31T09:36Z`), so it never reached `main`:

```
$ gh api repos/bytedance/deer-flow/compare/main...95620c2c -q '.status'
diverged          # ahead_by=5, behind_by=64

$ git grep -n META_FIELD_COUNT origin/main
(no output)
```

The thread reads as closed, which is likely why nobody picked this up. The
original comment:

> **Nit (maintainability):** the live-entry count is derived as
> `HLEN(KEYS[1]) - 3`, where `3` is the number of meta fields (`meta:state`,
> `meta:hard_limit`, `meta:revision`). **The coupling is implicit** [...]
> Consider counting `s:` + `r:` entries directly [...] or at least derive the
> offset from a named meta-count constant so the invariant is explicit.

## Why

`initialize()` writes the three `meta:*` fields at `capacity/redis.py:21-26`.
Admission counts live `r:`/`s:` entries as `HLEN - 3` at line 60 — 35 lines
away, with nothing connecting them. Adding a fourth meta field silently shifts
the capacity ceiling.

Two corrections to the original comment, both confirmed by experiment rather
than reasoning (I added a fourth `meta:` field to `initialize()` without
touching the offset, and ran the suite):

**1. The failure direction is the opposite of what the comment states.** It says
the ledger would "under-count by one and silently allow `hard_limit + 1`". It
actually over-counts and rejects early — `HLEN` grows by one while the
subtrahend does not, so `(entries + 4) - 3 = entries + 1`. Measured with
`hard_limit=3`, the **third** reservation was refused:

```
At index 2 diff: <ReserveStatus.FULL> != <ReserveStatus.GRANTED>
```

@MiaoRuidx made this same correction in the thread ("conservatively over-count
usage and reject early, rather than under-count and admit `hard_limit + 1`").
So this is a capacity-utilisation bug, not a paid-resource over-allocation.

**2. The regression is not invisible today.** The comment says "the existing
tests [...] wouldn't be caught". In fact the fourth-field injection turned
**five** tests red, three of them pre-existing (`test_two_gateways_...`, both
`test_reconcile_*`). What those failures don't do is *name the cause* — they
report an unexpected reservation outcome, leaving you to work backwards to the
meta-field count. That diagnostic gap is what this PR closes, and it is a
weaker claim than the original comment made.

## What changed

No behavioural change. The ledger writes three meta fields and the constant is
three, so admission decisions are byte-for-byte identical. The difference only
materialises the day someone adds a fourth field — then a named guard test
fails instead of three concurrency tests failing obliquely.

- `META_FIELD_COUNT` is declared immediately above `initialize()`, with a
  comment stating the real failure mode.
- `test_ledger_meta_field_count_matches_constant` asserts a freshly initialized
  ledger holds exactly `meta:state`, `meta:hard_limit`, `meta:revision`.
- `test_reserve_admits_exactly_hard_limit_entries` pins the invariant the
  constant protects: `hard_limit=3` admits three reservations and refuses the
  fourth, independent of how the offset is spelled.

I kept the O(1) `HLEN` check rather than the `HKEYS` prefix-count the comment
lists first. `reserve` is a hot path, and prefix-counting would put an
`O(hard_limit)` scan that blocks the Redis single thread on every admission, to
remove a coupling that a test can hold instead. Happy to switch if you'd rather
have the offset gone entirely.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox** — E2B capacity ledger admission (Lua), no behaviour change
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Validation

```
cd backend
make lint                                            # ruff check + format --check, clean
make format                                          # 1106 files unchanged
PYTHONPATH=. uv run pytest tests/test_e2b_capacity_store_redis.py \
                          tests/test_e2b_sandbox_provider.py -q     # 155 passed
make test                                            # 11141 passed, 9 failed
```

The integration tier ran against a real Redis (`redis:6-alpine`), so the Lua
actually executed.

The 9 `make test` failures are pre-existing and unrelated: `test_checkpointer`,
`test_docker_sandbox_mode_detection`, `test_subagent_prompt_security`. I
stashed this change and re-ran them on clean `main` — the same 9 fail, with the
same assertion (`assert '\x1b[3 qlocal' == 'local'`). My local shell injects an
ANSI cursor-shape sequence into subprocess stdout, which those tests compare
verbatim. No E2B or capacity test is among them.

**Guard verification.** To confirm the new test is not vacuous, I added
`'meta:future_field', 'x'` to `initialize()` and left `META_FIELD_COUNT` at 3.
`test_ledger_meta_field_count_matches_constant` failed on the field list and
`test_reserve_admits_exactly_hard_limit_entries` failed on the third
reservation (the measurement quoted above). Reverted afterwards; the committed
tree is green.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted coding. It traced the review thread, verified
the claimed fix commit against `main`, located the coupling, and drafted the
constant and both tests. I directed the design decision (named constant plus a
guard test, rather than the `HKEYS` prefix count) based on the hot-path cost.

Human verification I actually performed:

- Confirmed `HLEN - 3` is still on `main` and `META_FIELD_COUNT` is not, by grep.
- Confirmed `95620c2c` exists but is not an ancestor of `main`, via
  `gh api compare` — the claim in the thread is not false, just never landed.
- Worked out the failure direction by hand `((n+4)-3 = n+1)` before running the
  experiment, then confirmed it against a live Redis rather than trusting either
  the reviewer's or the author's account.
- Ran the fourth-field injection myself and read every failure, which is how I
  found that the "wouldn't be caught" half of the original comment is also
  wrong — and narrowed this PR's claim accordingly.
- Established the 9-failure baseline on stashed-clean `main` before attributing
  them to the environment, and verified my restored diff was byte-identical to
  the pre-stash backup.
- Ran every command in the Validation section and read the output.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
