### PR TITLE
fix(scheduler): coerce serialized task timestamps

### DIFF
--- a/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
@@ -12,6 +12,18 @@ from deerflow.utils.time import coerce_iso
 TERMINAL_TASK_STATUSES: frozenset[str] = frozenset({"completed", "failed", "cancelled"})
 
 
+def _coerce_datetime(value: datetime | str | None) -> datetime | None:
+    """Convert serialized task timestamps back before binding DateTime fields."""
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise ValueError(f"invalid scheduled task timestamp: {value!r}") from exc
+    raise TypeError(f"scheduled task timestamp must be datetime, str, or None: {type(value).__name__}")
+
+
 class ScheduledTaskRepository:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._sf = session_factory
@@ -161,7 +173,7 @@ class ScheduledTaskRepository:
         *,
         status: str,
         next_run_at: datetime | None,
-        last_run_at: datetime | None,
+        last_run_at: datetime | str | None,
         last_run_id: str | None,
         last_thread_id: str | None,
         last_error: str | None,
@@ -182,7 +194,7 @@ class ScheduledTaskRepository:
                 row.status = status
                 row.last_error = last_error
             row.next_run_at = next_run_at
-            row.last_run_at = last_run_at
+            row.last_run_at = _coerce_datetime(last_run_at)
             row.last_run_id = last_run_id
             row.last_thread_id = last_thread_id
             if increment_run_count:

--- a/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
+++ b/backend/packages/harness/deerflow/persistence/scheduled_tasks/sql.py
@@ -18,9 +18,15 @@ def _coerce_datetime(value: datetime | str | None) -> datetime | None:
         return value
     if isinstance(value, str):
         try:
-            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+            text = value
+            if text.endswith("Z"):
+                text = f"{text[:-1]}+00:00"
+            dt = datetime.fromisoformat(text)
         except ValueError as exc:
             raise ValueError(f"invalid scheduled task timestamp: {value!r}") from exc
+        if dt.tzinfo is None:
+            return dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
     raise TypeError(f"scheduled task timestamp must be datetime, str, or None: {type(value).__name__}")
 
 

--- a/backend/tests/test_scheduled_task_repository.py
+++ b/backend/tests/test_scheduled_task_repository.py
@@ -269,6 +269,46 @@ async def test_update_after_launch_protect_terminal_keeps_hook_result(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_update_after_launch_coerces_serialized_last_run_at(tmp_path):
+    """Task rows returned by the repository serialize timestamps as ISO strings."""
+    await init_engine_from_config(DatabaseConfig(backend="sqlite", sqlite_dir=str(tmp_path)))
+    sf = get_session_factory()
+    assert sf is not None
+
+    repo = ScheduledTaskRepository(sf)
+    await repo.create(
+        task_id="task-serialized-timestamp",
+        user_id="user-1",
+        thread_id=None,
+        context_mode="fresh_thread_per_run",
+        assistant_id="lead_agent",
+        title="serialized timestamp",
+        prompt="p",
+        schedule_type="cron",
+        schedule_spec={"cron": "0 9 * * *"},
+        timezone="UTC",
+        next_run_at=datetime(2026, 7, 2, 1, 0, tzinfo=UTC),
+    )
+
+    await repo.update_after_launch(
+        "task-serialized-timestamp",
+        status="enabled",
+        next_run_at=datetime(2026, 7, 3, 1, 0, tzinfo=UTC),
+        last_run_at="2026-07-02T01:00:00+00:00",
+        last_run_id="run-serialized",
+        last_thread_id="thread-serialized",
+        last_error=None,
+        increment_run_count=True,
+    )
+
+    task = await repo.get("task-serialized-timestamp", user_id="user-1")
+    assert task is not None
+    assert task["last_run_at"] == "2026-07-02T01:00:00+00:00"
+
+    await close_engine()
+
+
+@pytest.mark.asyncio
 async def test_list_by_task_paginates(tmp_path):
     await init_engine_from_config(DatabaseConfig(backend="sqlite", sqlite_dir=str(tmp_path)))
     sf = get_session_factory()


### PR DESCRIPTION
## Summary
- coerce ISO timestamp strings returned by scheduled-task reads before writing DateTime columns
- prevent overlap-policy skip handling from passing serialized `last_run_at` values into SQLAlchemy/asyncpg
- add a repository regression test for the serialized timestamp path

## Validation
- `uv run pytest tests/test_scheduled_task_repository.py tests/test_scheduled_task_service.py -q`
- `uv run ruff check packages/harness/deerflow/persistence/scheduled_tasks/sql.py tests/test_scheduled_task_repository.py`
- `git diff --check