### PR TITLE
fix(sandbox): accept documented reconciliation settings in E2B config

### DIFF
--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
@@ -104,7 +104,20 @@ META_KEY_CREATED_AT = "deer_flow_created_at"
 META_KEY_CAPACITY_LEDGER = "deer_flow_capacity_ledger"
 META_KEY_CAPACITY_RESERVATION = "deer_flow_capacity_reservation"
 META_VAL_PROVIDER = "e2b_sandbox_provider"
-E2B_EXTRA_CONFIG_KEYS = frozenset({"api_key", "domain", "home_dir", "template"})
+E2B_EXTRA_CONFIG_KEYS = frozenset(
+    {
+        "api_key",
+        "domain",
+        "home_dir",
+        "template",
+        "reconciliation_interval_seconds",
+        "reconciliation_grace_seconds",
+        "reconciliation_orphan_ttl_seconds",
+        "reconciliation_max_pages",
+        "reconciliation_max_items",
+        "reconciliation_max_seconds",
+    }
+)
 
 
 @dataclass

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -1274,6 +1274,33 @@ def test_e2b_config_warns_about_unknown_fields(monkeypatch, caplog):
     assert "overflo_policy" in caplog.text
 
 
+def test_e2b_config_accepts_documented_reconciliation_fields(monkeypatch, caplog):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    config = SandboxConfig(
+        use="deerflow.community.e2b_sandbox:E2BSandboxProvider",
+        api_key="test-key",
+        reconciliation_interval_seconds=60,
+        reconciliation_grace_seconds=120,
+        reconciliation_orphan_ttl_seconds=3600,
+        reconciliation_max_pages=10,
+        reconciliation_max_items=200,
+        reconciliation_max_seconds=15,
+    )
+    provider = mod.E2BSandboxProvider.__new__(mod.E2BSandboxProvider)
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(sandbox=config))
+
+    with caplog.at_level("WARNING"):
+        loaded = provider._load_config()
+
+    assert "unknown sandbox config fields" not in caplog.text
+    assert loaded["reconciliation_interval_seconds"] == 60
+    assert loaded["reconciliation_grace_seconds"] == 120
+    assert loaded["reconciliation_orphan_ttl_seconds"] == 3600
+    assert loaded["reconciliation_max_pages"] == 10
+    assert loaded["reconciliation_max_items"] == 200
+    assert loaded["reconciliation_max_seconds"] == 15
+
+
 def test_evict_oldest_warm_keeps_slot_when_kill_lookup_raises(monkeypatch):
     p = _make_provider()
     fake_cls = _install_fake_sdk(monkeypatch, p)


### PR DESCRIPTION
Fixes #4771

## Why

`backend/docs/CONFIGURATION.md` documents six `reconciliation_*` sandbox settings, and `E2BSandboxProvider._load_config()` reads and applies every one of them. But `E2B_EXTRA_CONFIG_KEYS` — the allowlist behind the "unknown sandbox config fields" warning — only contained `api_key`, `domain`, `home_dir`, and `template`. Every deployment that configured the documented reconciliation settings got a startup warning telling them their valid configuration was invalid, alongside the genuinely-unknown-field warnings that warning exists to surface.

## What changed

- The six documented settings (`reconciliation_interval_seconds`, `reconciliation_grace_seconds`, `reconciliation_orphan_ttl_seconds`, `reconciliation_max_pages`, `reconciliation_max_items`, `reconciliation_max_seconds`) are now accepted without a warning.
- Truly unknown fields still produce the warning — the existing `overflo_policy` test pins that behavior.
- A new regression test configures all six documented settings and asserts both that no unknown-field warning is emitted and that `_load_config()` returns the configured values.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

(Strictly: one allowlist constant in the E2B sandbox provider plus its test. No endpoint, wiring, or default changes; the only observable difference is that valid documented configuration no longer produces a spurious warning.)

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_e2b_sandbox_provider.py::test_e2b_config_accepts_documented_reconciliation_fields`
- Did it go red on `main` and green on this branch? **yes** — before the allowlist change, the test failed with the log line `E2BSandboxProvider: unknown sandbox config fields: reconciliation_grace_seconds, reconciliation_interval_seconds, ...`; after the change it passes.

## Validation

Run from `backend/`:

- `uv run pytest tests/test_e2b_sandbox_provider.py -q` — 149 passed
- `uv run pytest tests/test_e2b_sandbox_provider.py::test_e2b_config_accepts_documented_reconciliation_fields tests/test_e2b_sandbox_provider.py::test_e2b_config_warns_about_unknown_fields -q` — 2 passed (new regression + existing unknown-field test)
- `make lint` — `ruff check` clean, `ruff format --check` reports all 1117 files already formatted

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted coding. It located the allowlist constant and the existing unknown-field warning test, and drafted the regression test and the one-line constant change. I reviewed and finalized every line.

Human verification performed for this change:

- Read and understood every line of the diff — two files, 41 insertions, 1 deletion.
- Confirmed the bug in the actual source before changing anything: `backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py` read all six `reconciliation_*` settings via `_opt(...)` while `E2B_EXTRA_CONFIG_KEYS` listed only four keys, and `backend/docs/CONFIGURATION.md` documents the six settings.
- Ran the new test before the fix and watched it fail with the exact spurious warning, then watched it pass after the fix.
- Verified the existing `test_e2b_config_warns_about_unknown_fields` still passes, so the warning path is unchanged for genuinely unknown fields.
- Verified the scope contains no incidental changes: the diff is the allowlist expansion plus one regression test.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
