### PR TITLE
test(wecom): cover SDK compatibility fallback in shutdown

### DIFF
--- a/backend/tests/test_channels.py
+++ b/backend/tests/test_channels.py
@@ -6738,6 +6738,72 @@ class TestWeComChannel:
 
         _run(go())
 
+    def test_stop_uses_sync_disconnect_fallback_without_sdk_async_helpers(self):
+        """A client that exposes neither ``_ws_manager`` (and therefore no
+        ``_async_disconnect`` / ``_stop_heartbeat`` / ``_clear_pending_messages``)
+        nor an awaitable ``disconnect()`` takes the compatibility fallback:
+        ``disconnect()`` is invoked once and ``stop()`` still clears its
+        lifecycle references."""
+        from app.channels.wecom import WeComChannel
+
+        async def go():
+            channel = WeComChannel(MessageBus(), config={})
+            disconnect_called = asyncio.Event()
+            ws_task = asyncio.create_task(asyncio.sleep(0))
+            await ws_task
+
+            class LegacySyncSDKClient:
+                def disconnect(self) -> None:
+                    disconnect_called.set()
+
+            client = LegacySyncSDKClient()
+            channel._running = True
+            channel._ws_client = client
+            channel._ws_task = ws_task
+
+            await channel.stop()
+
+            assert disconnect_called.is_set()
+            assert channel._ws_client is None
+            assert channel._ws_task is None
+            assert channel._ws_shutdown_task is None
+
+        _run(go())
+
+    def test_stop_awaits_awaitable_disconnect_fallback(self):
+        """A client whose ``disconnect()`` returns an awaitable (but has no
+        ``_ws_manager``) takes the fallback path and ``stop()`` waits for that
+        awaitable to finish before clearing its lifecycle references."""
+        from app.channels.wecom import WeComChannel
+
+        async def go():
+            channel = WeComChannel(MessageBus(), config={})
+            disconnect_called = asyncio.Event()
+            disconnect_finished = asyncio.Event()
+            ws_task = asyncio.create_task(asyncio.sleep(0))
+            await ws_task
+
+            class AwaitableSDKClient:
+                async def disconnect(self):
+                    disconnect_called.set()
+                    await asyncio.sleep(0)
+                    disconnect_finished.set()
+
+            client = AwaitableSDKClient()
+            channel._running = True
+            channel._ws_client = client
+            channel._ws_task = ws_task
+
+            await channel.stop()
+
+            assert disconnect_called.is_set()
+            assert disconnect_finished.is_set()
+            assert channel._ws_client is None
+            assert channel._ws_task is None
+            assert channel._ws_shutdown_task is None
+
+        _run(go())
+
     def test_concurrent_start_waits_for_stop_before_installing_new_client(self, monkeypatch):
         from app.channels.wecom import WeComChannel
 


### PR DESCRIPTION
References #4762

Follow-up to a review comment on the already-merged #4762. @willem-bd flagged that `_begin_ws_shutdown()`'s compatibility fallback — the path taken when the WeCom SDK client does not expose the 1.0.2 async shutdown helpers (`_async_disconnect` / `_stop_heartbeat` / `_clear_pending_messages`) — had no test coverage: every shutdown test went through the 1.0.2 primary path. The PR author replied "Thanks, agreed" and left it out of that PR.

## Why

`_begin_ws_shutdown()` has two branches: the 1.0.2 primary path (coroutine `_async_disconnect` + heartbeat/pending-message helpers) and a fallback for older/foreign SDK shapes that only expose `disconnect()` — which may be synchronous or return an awaitable. The fallback carries real behavior (`stop()` awaits the returned awaitable; lifecycle references are cleared either way), but nothing pinned it. A regression there would silently break shutdown for any SDK version other than the pinned one.

## What changed

Two new tests in `TestWeComChannel`:

- `test_stop_uses_sync_disconnect_fallback_without_sdk_async_helpers` — a client with only a synchronous `disconnect()` (no `_ws_manager`, so none of the async helpers) takes the fallback path: `disconnect()` is invoked once and `stop()` clears `_ws_client` / `_ws_task` / `_ws_shutdown_task`.
- `test_stop_awaits_awaitable_disconnect_fallback` — a client whose `disconnect()` returns an awaitable: `stop()` waits for it to finish before clearing the lifecycle references.

No production code changes. Both tests were mutation-checked: temporarily neutering the `isawaitable` branch or the `disconnect()` call makes the corresponding test fail.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

Run from `backend/`:

- `make lint` — `ruff check` clean, `ruff format --check` reports all 1117 files already formatted
- `uv run pytest tests/test_channels.py::TestWeComChannel -q` — 18 passed
- `uv run pytest tests/test_channels.py -q` — 344 passed
- Mutation checks: with `if inspect.isawaitable(result):` temporarily replaced by `if False:`, `test_stop_awaits_awaitable_disconnect_fallback` fails; with `result = ws_client.disconnect()` temporarily replaced by `result = None`, `test_stop_uses_sync_disconnect_fallback_without_sdk_async_helpers` fails. Both mutations were reverted and the file verified clean.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted coding. It located the fallback branch in `backend/app/channels/wecom.py`, read the existing `_ControlledWeComManager` fixtures, and drafted the two tests and this description. I reviewed and finalized every line.

Human verification performed for this change:

- Read and understood every line of the diff — one file, 66 insertions.
- Read the fallback branch in `backend/app/channels/wecom.py::_begin_ws_shutdown()` (lines ~148-155) and the `stop()` lifecycle-cleanup block before writing the tests, so the assertions match the actual contract.
- Ran the full `TestWeComChannel` class and the full `test_channels.py` file (344 tests) to confirm the new tests don't disturb existing channel tests.
- Ran both mutation checks above to prove the tests exercise the fallback (and not the 1.0.2 path), and verified the source file was restored byte-for-byte afterwards.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.


## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** AI-assisted. It wrote the two tests from your review comment on #4762, ran the validation and mutation checks listed above, and drafted this description. I reviewed and finalized every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.