### PR TITLE
fix: 基于gemini模型的 OpenAI 兼容网关无法调用tools工具，报错Unable to submit request because function call `default_api:web_fetch` in the 5. content block is missing a `thought_signature`

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ That prompt is intended for coding agents. It tells the agent to clone the repo 
 
    OpenRouter and similar OpenAI-compatible gateways should be configured with `langchain_openai:ChatOpenAI` plus `base_url`. If you prefer a provider-specific environment variable name, point `api_key` at that variable explicitly (for example `api_key: $OPENROUTER_API_KEY`).
 
+   Gemini models served through an OpenAI-compatible gateway may require their
+   function-call thought signatures to be replayed on the next request. For
+   those endpoints, use DeerFlow's compatibility provider instead:
+
+   ```yaml
+   use: deerflow.models.patched_gemini:PatchedChatOpenAI
+   ```
+
+   This preserves signatures returned by the gateway without generating or modifying them.
+
    To route OpenAI models through `/v1/responses`, keep using `langchain_openai:ChatOpenAI` and set `use_responses_api: true` with `output_version: responses/v1`.
 
    For vLLM 0.19.0, use `deerflow.models.vllm_provider:VllmChatModel`. For Qwen-style reasoning models, DeerFlow toggles reasoning with `extra_body.chat_template_kwargs.enable_thinking` and preserves vLLM's non-standard `reasoning` field across multi-turn tool-call conversations. Legacy `thinking` configs are normalized automatically for backward compatibility. If the endpoint reports a cumulative usage snapshot on every streaming chunk, set `cumulative_stream_usage: true` so DeerFlow converts those snapshots into per-chunk deltas; the option is disabled by default and leaves usage unchanged when a stable completion id is unavailable. Reasoning models may also require the server to be started with `--reasoning-parser ...`. If your local vLLM deployment accepts any non-empty API key, you can still set `VLLM_API_KEY` to a placeholder value.

--- a/backend/packages/harness/deerflow/models/patched_gemini.py
+++ b/backend/packages/harness/deerflow/models/patched_gemini.py
@@ -1,0 +1,86 @@
+"""OpenAI-compatible Gemini model with thought-signature replay support.
+
+Gemini's OpenAI-compatible API returns a thought signature alongside function
+calls and requires clients to submit that signature unchanged in subsequent
+requests. LangChain normalizes tool calls for execution, which can omit this
+provider-specific metadata when the assistant message is serialized again.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from langchain_core.messages import AIMessage
+from langchain_openai import ChatOpenAI
+
+_GEMINI_TOOL_CALL_METADATA = ("extra_content", "thought_signature")
+
+
+class PatchedChatOpenAI(ChatOpenAI):
+    """ChatOpenAI variant that replays Gemini function-call signatures."""
+
+    def _get_request_payload(
+        self,
+        input_: Any,
+        *,
+        stop: list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        payload = super()._get_request_payload(input_, stop=stop, **kwargs)
+        source_messages = _get_messages(input_)
+        assistant_messages = [
+            message for message in source_messages if isinstance(message, AIMessage)
+        ]
+        outgoing_messages = [
+            message
+            for message in payload.get("messages", [])
+            if message.get("role") == "assistant"
+        ]
+
+        for source, outgoing in zip(
+            assistant_messages, outgoing_messages, strict=False
+        ):
+            _restore_tool_call_metadata(source, outgoing)
+
+        return payload
+
+
+def _get_messages(input_: Any) -> list[Any]:
+    if isinstance(input_, (list, tuple)):
+        return list(input_)
+
+    to_messages = getattr(input_, "to_messages", None)
+    if callable(to_messages):
+        return list(to_messages())
+
+    return []
+
+
+def _restore_tool_call_metadata(
+    source: AIMessage, outgoing: dict[str, Any]
+) -> None:
+    raw_calls = source.additional_kwargs.get("tool_calls")
+    outgoing_calls = outgoing.get("tool_calls")
+    if not isinstance(raw_calls, list) or not isinstance(outgoing_calls, list):
+        return
+
+    raw_calls_by_id = {
+        call.get("id"): call
+        for call in raw_calls
+        if isinstance(call, dict) and call.get("id") is not None
+    }
+
+    for index, outgoing_call in enumerate(outgoing_calls):
+        if not isinstance(outgoing_call, dict):
+            continue
+
+        raw_call = raw_calls_by_id.get(outgoing_call.get("id"))
+        if raw_call is None and index < len(raw_calls):
+            raw_call = raw_calls[index]
+        if not isinstance(raw_call, dict):
+            continue
+
+        for key in _GEMINI_TOOL_CALL_METADATA:
+            if key in raw_call:
+                outgoing_call[key] = deepcopy(raw_call[key])

--- a/backend/tests/models/test_patched_gemini.py
+++ b/backend/tests/models/test_patched_gemini.py
@@ -1,0 +1,92 @@
+from langchain_core.messages import AIMessage, HumanMessage
+
+from deerflow.models.patched_gemini import PatchedChatOpenAI
+
+
+def _model() -> PatchedChatOpenAI:
+    return PatchedChatOpenAI(model="gemini-test", api_key="test-key")
+
+
+def test_replays_gemini_thought_signature_from_raw_tool_call() -> None:
+    raw_tool_call = {
+        "id": "call_1",
+        "type": "function",
+        "function": {
+            "name": "default_api:web_fetch",
+            "arguments": '{"url":"https://example.com"}',
+        },
+        "extra_content": {
+            "google": {"thought_signature": "opaque-signature"}
+        },
+    }
+    assistant = AIMessage(
+        content="",
+        additional_kwargs={"tool_calls": [raw_tool_call]},
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "default_api:web_fetch",
+                "args": {"url": "https://example.com"},
+                "type": "tool_call",
+            }
+        ],
+    )
+
+    payload = _model()._get_request_payload(
+        [HumanMessage(content="Fetch the page"), assistant]
+    )
+
+    assistant_payload = payload["messages"][1]
+    assert assistant_payload["tool_calls"][0]["extra_content"] == {
+        "google": {"thought_signature": "opaque-signature"}
+    }
+
+
+def test_replays_direct_thought_signature_used_by_compatible_gateways() -> None:
+    assistant = AIMessage(
+        content="",
+        additional_kwargs={
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "web_fetch", "arguments": "{}"},
+                    "thought_signature": "opaque-signature",
+                }
+            ]
+        },
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "web_fetch",
+                "args": {},
+                "type": "tool_call",
+            }
+        ],
+    )
+
+    payload = _model()._get_request_payload([assistant])
+
+    assert payload["messages"][0]["tool_calls"][0]["thought_signature"] == (
+        "opaque-signature"
+    )
+
+
+def test_leaves_standard_openai_tool_calls_unchanged() -> None:
+    assistant = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "name": "web_fetch",
+                "args": {},
+                "type": "tool_call",
+            }
+        ],
+    )
+
+    payload = _model()._get_request_payload([assistant])
+    tool_call = payload["messages"][0]["tool_calls"][0]
+
+    assert "extra_content" not in tool_call
+    assert "thought_signature" not in tool_call


### PR DESCRIPTION
Closes #1180

I used an AI coding assistant to help draft this patch, then reviewed the diff and ran the test suite locally before opening this PR. Happy to make adjustments if the approach doesn't fit the project's conventions.

Tests: `cd backend && uv run pytest tests/models/test_patched_gemini.py`