### PR TITLE
docs: sync Sister Projects section across i18n READMEs

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -20,6 +20,12 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 
 Découvrez-en plus et regardez des **démos réelles** sur notre [**site officiel**](https://deerflow.tech).
 
+## Projets associés
+
+<img width="446" height="280" alt="image" align="middle" src="https://github.com/user-attachments/assets/077edef4-d560-41af-bb0d-d0a5f14fcc20" />
+
+- [**LLM Space**](https://github.com/deer-flow/llm-space) - Découvrez notre arme secrète derrière DeerFlow — un outil de bureau pour prototyper des idées d'agents, inspecter chaque étape du harness, rejouer les échecs et tester les performances.
+
 ## Coding Plan de ByteDance Volcengine
 
 - Nous recommandons fortement d'utiliser Doubao-Seed-2.0-Code, DeepSeek v3.2 et Kimi 2.5 pour exécuter DeerFlow

--- a/README_ja.md
+++ b/README_ja.md
@@ -20,6 +20,12 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 
 **実際のデモ**は[**公式ウェブサイト**](https://deerflow.tech)でご覧いただけます。
 
+## 姉妹プロジェクト
+
+<img width="446" height="280" alt="image" align="middle" src="https://github.com/user-attachments/assets/077edef4-d560-41af-bb0d-d0a5f14fcc20" />
+
+- [**LLM Space**](https://github.com/deer-flow/llm-space) - DeerFlow の秘密兵器をご紹介 — agent のアイデアをプロトタイピングし、ハーネスの各ステップを検査し、失敗を再生し、パフォーマンスをベンチマークするためのデスクトップツールです。
+
 ## ByteDance Volcengine のコーディングプラン
 
 - DeerFlowの実行には、Doubao-Seed-2.0-Code、DeepSeek v3.2、Kimi 2.5の使用を強く推奨します

--- a/README_ru.md
+++ b/README_ru.md
@@ -21,6 +21,12 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 
 Больше информации и живые демо на [**официальном сайте**](https://deerflow.tech).
 
+## Родственные проекты
+
+<img width="446" height="280" alt="image" align="middle" src="https://github.com/user-attachments/assets/077edef4-d560-41af-bb0d-d0a5f14fcc20" />
+
+- [**LLM Space**](https://github.com/deer-flow/llm-space) - Познакомьтесь с нашим секретным оружием за DeerFlow — настольный инструмент для прототипирования идей агентов, проверки каждого шага харнесса, воспроизведения сбоев и тестирования производительности.
+
 ## Coding Plan от ByteDance Volcengine
 
 - Рекомендуем Doubao-Seed-2.0-Code, DeepSeek v3.2 и Kimi 2.5 для запуска DeerFlow

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,6 +20,12 @@ https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 
 想了解更多，或者直接看**真实演示**，可以访问[**官网**](https://deerflow.tech)。
 
+## 姐妹项目
+
+<img width="446" height="280" alt="image" align="middle" src="https://github.com/user-attachments/assets/077edef4-d560-41af-bb0d-d0a5f14fcc20" />
+
+- [**LLM Space**](https://github.com/deer-flow/llm-space) - 认识 DeerFlow 背后的秘密武器——一款桌面工具，用于原型化 agent 想法、检查 harness 的每个步骤、回放失败用例并基准测试性能。
+
 ## 字节跳动火山引擎方舟 Coding Plan
 
 - 我们推荐使用 Doubao-Seed-2.0-Code、DeepSeek v3.2 和 Kimi 2.5 运行 DeerFlow


### PR DESCRIPTION
## Summary

The English `README.md` has a **Sister Projects** section (right after *Official Website*) that links to the [LLM Space](https://github.com/deer-flow/llm-space) desktop tool. This section was missing from the Chinese, Japanese, French, and Russian READMEs, leaving their structure out of sync with the English source (19 vs 18 H2 sections).

This PR adds the translated **Sister Projects** section to `README_zh.md`, `README_ja.md`, `README_fr.md`, and `README_ru.md`, in the same position as in the English README.

## Changes

- `README_zh.md` — added 姐妹项目 section
- `README_ja.md` — added 姉妹プロジェクト section
- `README_fr.md` — added Projets associés section
- `README_ru.md` — added Родственные проекты section

Each section mirrors the English version (same image + LLM Space link) with a localized description.

## Checklist

- [x] Documentation-only change, no code/logic affected
- [x] All four i18n READMEs now match the English README's section count (19 H2)
- [x] Translations reviewed for natural phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)