### PR TITLE
fix(gateway): offload USER.md file IO in profile endpoints off the event loop

### DIFF
--- a/backend/app/gateway/routers/agents.py
+++ b/backend/app/gateway/routers/agents.py
@@ -490,12 +490,17 @@ async def get_user_profile() -> UserProfileResponse:
     """
     _require_agents_api_enabled()
 
-    try:
+    def _read_profile() -> UserProfileResponse:
+        # Worker thread: exists() + read_text() are filesystem IO that must
+        # stay off the event loop, matching list_agents/get_agent/etc.
         user_md_path = get_paths().user_md_file
         if not user_md_path.exists():
             return UserProfileResponse(content=None)
         raw = user_md_path.read_text(encoding="utf-8").strip()
         return UserProfileResponse(content=raw or None)
+
+    try:
+        return await asyncio.to_thread(_read_profile)
     except Exception as e:
         logger.error(f"Failed to read user profile: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Failed to read user profile: {str(e)}")
@@ -518,11 +523,16 @@ async def update_user_profile(request: UserProfileUpdateRequest) -> UserProfileR
     """
     _require_agents_api_enabled()
 
-    try:
+    def _write_profile() -> None:
+        # Worker thread: mkdir() + write_text() are filesystem IO that must
+        # stay off the event loop, matching create_agent_endpoint/etc.
         paths = get_paths()
         paths.base_dir.mkdir(parents=True, exist_ok=True)
         paths.user_md_file.write_text(request.content, encoding="utf-8")
         logger.info(f"Updated USER.md at {paths.user_md_file}")
+
+    try:
+        await asyncio.to_thread(_write_profile)
         return UserProfileResponse(content=request.content or None)
     except Exception as e:
         logger.error(f"Failed to update user profile: {e}", exc_info=True)

--- a/backend/tests/blocking_io/test_agents_router.py
+++ b/backend/tests/blocking_io/test_agents_router.py
@@ -7,6 +7,10 @@ config/SOUL writes, ``shutil.rmtree``) — all blocking IO. Both offload that wo
 via ``asyncio.to_thread``; if any of it regresses back onto the event loop, the
 strict Blockbuster gate raises ``BlockingError`` and these tests fail.
 
+``get_user_profile`` and ``update_user_profile`` are the same shape on the global
+``USER.md`` file (``exists``/``read_text``/``mkdir``/``write_text``); they offload
+via ``asyncio.to_thread`` too, and the two tests at the end anchor that.
+
 Imports live at module scope so the one-time FastAPI app construction (which
 reads files while building OpenAPI schemas) happens at collection time, not on
 the event loop under test. Test-side path resolution is itself offloaded with
@@ -23,11 +27,14 @@ import pytest
 
 from app.gateway.routers.agents import (
     AgentCreateRequest,
+    UserProfileUpdateRequest,
     check_agent_name,
     create_agent_endpoint,
     delete_agent,
     get_agent,
+    get_user_profile,
     list_agents,
+    update_user_profile,
 )
 from deerflow.config.agents_api_config import load_agents_api_config_from_dict
 from deerflow.config.paths import get_paths
@@ -90,5 +97,49 @@ async def test_read_endpoints_do_not_block_event_loop(tmp_path: Path, monkeypatc
         check = await check_agent_name("loop-read-agent")
         assert check["available"] is False
         assert (await check_agent_name("never-created-agent"))["available"] is True
+    finally:
+        load_agents_api_config_from_dict({})
+
+
+async def test_get_user_profile_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    # get_user_profile reads USER.md with exists()/read_text(); both must stay
+    # off the event loop via asyncio.to_thread, or the strict Blockbuster gate
+    # raises BlockingError. Covers both the "file absent" and "file present"
+    # branches.
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    monkeypatch.setattr("deerflow.config.paths._paths", None)
+    load_agents_api_config_from_dict({"enabled": True})
+    try:
+        # USER.md does not exist yet — exists() is the blocking call on this branch.
+        absent = await get_user_profile()
+        assert absent.content is None
+
+        # Seed USER.md off the loop, then read it back — read_text() is the
+        # blocking call on this branch.
+        user_md = await asyncio.to_thread(lambda: get_paths().user_md_file)
+        await asyncio.to_thread(user_md.parent.mkdir, parents=True, exist_ok=True)
+        await asyncio.to_thread(user_md.write_text, "# About me\nI like tests.", encoding="utf-8")
+
+        present = await get_user_profile()
+        assert present.content == "# About me\nI like tests."
+    finally:
+        load_agents_api_config_from_dict({})
+
+
+async def test_update_user_profile_does_not_block_event_loop(tmp_path: Path, monkeypatch) -> None:
+    # update_user_profile mkdir()s the base dir and write_text()s USER.md; both
+    # must stay off the event loop via asyncio.to_thread, or the strict
+    # Blockbuster gate raises BlockingError.
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    monkeypatch.setattr("deerflow.config.paths._paths", None)
+    load_agents_api_config_from_dict({"enabled": True})
+    try:
+        response = await update_user_profile(UserProfileUpdateRequest(content="I prefer concise answers."))
+        assert response.content == "I prefer concise answers."
+
+        # test-side check (read offloaded; not exercised on the loop)
+        user_md = await asyncio.to_thread(lambda: get_paths().user_md_file)
+        written = await asyncio.to_thread(user_md.read_text, encoding="utf-8")
+        assert written == "I prefer concise answers."
     finally:
         load_agents_api_config_from_dict({})


### PR DESCRIPTION
## Summary

`get_user_profile` and `update_user_profile` ran filesystem operations (`exists()` / `read_text()` / `mkdir()` / `write_text()`) **synchronously on the asyncio event loop**. Every other endpoint in `agents.py` already offloads this work via `asyncio.to_thread` (`list_agents`, `get_agent`, `create_agent_endpoint`, `delete_agent`, ...). Sync file IO on the loop blocks **every concurrent request**, not just the calling one, and violates the documented blocking-IO policy enforced by the Blockbuster runtime gate in `tests/blocking_io/` (CI hard-fails on it via `.github/workflows/backend-blocking-io-tests.yml`).

This PR wraps both handlers' file IO in worker functions and `await asyncio.to_thread(...)`, matching the exact pattern used by the sibling endpoints.

## Changes

- **`backend/app/gateway/routers/agents.py`** — `get_user_profile` and `update_user_profile` now wrap their `exists/read_text/mkdir/write_text` calls in a local worker function and `await asyncio.to_thread(worker)`, mirroring `list_agents`/`get_agent`/`create_agent_endpoint`.
- **`backend/tests/blocking_io/test_agents_router.py`** — two new regression anchors: `test_get_user_profile_does_not_block_event_loop` (covers both the file-absent and file-present branches) and `test_update_user_profile_does_not_block_event_loop` (covers the mkdir+write branch). They follow the exact setup pattern of the existing create/delete/read tests in the same file.
- **`backend/AGENTS.md`** — list `test_agents_router.py` in the regression-anchor catalog under the blocking-IO gate section.

## Why this is clearly correct

The fix is verifiable by parity, not judgment: every `skill_name`/`agent` endpoint in `agents.py` that touches the filesystem already uses `asyncio.to_thread`. `grep -n "asyncio.to_thread" agents.py` shows 9 sibling call sites; these two endpoints were the only outliers. A maintainer can confirm the fix by grepping for the pattern and seeing that the gap is closed.

## Checklist

- [x] Code follows existing `asyncio.to_thread` pattern exactly (no new abstraction)
- [x] `ruff check` + `ruff format --check` pass
- [x] Regression tests added under `tests/blocking_io/` following the existing setup pattern
- [x] `AGENTS.md` regression-anchor catalog updated (per the repo's doc-update policy)
- [x] No behavioral change beyond where the IO runs — return values, error handling, and HTTP semantics are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)