### PR TITLE
fix(sandbox): accept documented E2B reconciliation config fields

### DIFF
--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
@@ -104,7 +104,24 @@ META_KEY_CREATED_AT = "deer_flow_created_at"
 META_KEY_CAPACITY_LEDGER = "deer_flow_capacity_ledger"
 META_KEY_CAPACITY_RESERVATION = "deer_flow_capacity_reservation"
 META_VAL_PROVIDER = "e2b_sandbox_provider"
-E2B_EXTRA_CONFIG_KEYS = frozenset({"api_key", "domain", "home_dir", "template"})
+# Config keys that ``SandboxConfig`` stores in ``model_extra`` (``extra="allow"``)
+# but E2B legitimately consumes. These are documented in
+# ``backend/docs/CONFIGURATION.md`` and read via ``_opt`` in ``_load_config``,
+# so they must not be reported as unknown sandbox fields (#4771).
+E2B_EXTRA_CONFIG_KEYS = frozenset(
+    {
+        "api_key",
+        "domain",
+        "home_dir",
+        "template",
+        "reconciliation_interval_seconds",
+        "reconciliation_grace_seconds",
+        "reconciliation_orphan_ttl_seconds",
+        "reconciliation_max_pages",
+        "reconciliation_max_items",
+        "reconciliation_max_seconds",
+    }
+)
 
 
 @dataclass

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -1274,6 +1274,32 @@ def test_e2b_config_warns_about_unknown_fields(monkeypatch, caplog):
     assert "overflo_policy" in caplog.text
 
 
+def test_e2b_config_accepts_documented_reconciliation_fields(monkeypatch, caplog):
+    """The six ``reconciliation_*`` settings are documented in
+    ``backend/docs/CONFIGURATION.md`` and consumed by the provider, so they
+    must not be reported as unknown sandbox fields (#4771)."""
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    config = SandboxConfig(
+        use="deerflow.community.e2b_sandbox:E2BSandboxProvider",
+        api_key="test-key",
+        reconciliation_interval_seconds=45,
+        reconciliation_grace_seconds=90,
+        reconciliation_orphan_ttl_seconds=1800,
+        reconciliation_max_pages=5,
+        reconciliation_max_items=50,
+        reconciliation_max_seconds=12,
+    )
+    provider = mod.E2BSandboxProvider.__new__(mod.E2BSandboxProvider)
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(sandbox=config))
+
+    with caplog.at_level("WARNING"):
+        loaded = provider._load_config()
+
+    assert "unknown sandbox config fields" not in caplog.text
+    assert loaded["reconciliation_interval_seconds"] == 45.0
+    assert loaded["reconciliation_max_pages"] == 5
+
+
 def test_evict_oldest_warm_keeps_slot_when_kill_lookup_raises(monkeypatch):
     p = _make_provider()
     fake_cls = _install_fake_sdk(monkeypatch, p)


### PR DESCRIPTION
Fixes #4771

## Why

`E2BSandboxProvider` reported the six documented `reconciliation_*` sandbox settings as unknown fields, even though the provider reads and applies them. These settings are documented in `backend/docs/CONFIGURATION.md` and consumed via `_opt()` in `_load_config`, so the warning misreported valid configuration as invalid.

## What changed

- Add the six documented reconciliation settings to `E2B_EXTRA_CONFIG_KEYS` so they are no longer reported as unknown:
  - `reconciliation_interval_seconds`
  - `reconciliation_grace_seconds`
  - `reconciliation_orphan_ttl_seconds`
  - `reconciliation_max_pages`
  - `reconciliation_max_items`
  - `reconciliation_max_seconds`
- Add a regression test (`test_e2b_config_accepts_documented_reconciliation_fields`) asserting these documented fields do not trigger the unknown-field warning and are loaded with the configured values.
- The existing unknown-field warning test (`test_e2b_config_warns_about_unknown_fields`) is kept unchanged — truly unknown fields still produce the warning.

## Notes

- Only the `E2B_EXTRA_CONFIG_KEYS` allowlist and the new test are touched; the unknown-field warning logic itself is unchanged.
- Full `tests/test_e2b_sandbox_provider.py` passes locally (149 passed).
