### PR TITLE
fix(mcp): reject non-finite poll intervals in TaskSnapshot

### DIFF
--- a/backend/packages/harness/deerflow/mcp/tasks/models.py
+++ b/backend/packages/harness/deerflow/mcp/tasks/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
@@ -50,8 +51,10 @@ class TaskSnapshot:
     def __post_init__(self) -> None:
         if not isinstance(self.status, TaskStatus):
             object.__setattr__(self, "status", TaskStatus(self.status))
-        if self.poll_after_seconds is not None and self.poll_after_seconds <= 0:
-            raise ValueError("poll_after_seconds must be positive")
+        if self.poll_after_seconds is not None and (
+            not math.isfinite(self.poll_after_seconds) or self.poll_after_seconds <= 0
+        ):
+            raise ValueError("poll_after_seconds must be a finite, positive number")
         if self.status == TaskStatus.INPUT_REQUIRED and self.input_required is None:
             raise ValueError("input_required status requires an input_required payload")
 

--- a/backend/tests/test_mcp_task_models.py
+++ b/backend/tests/test_mcp_task_models.py
@@ -14,6 +14,17 @@ def test_input_required_snapshot_requires_payload():
         TaskSnapshot(status=TaskStatus.INPUT_REQUIRED)
 
 
+@pytest.mark.parametrize("interval", [float("nan"), float("inf"), float("-inf"), 0.0, -1.0])
+def test_task_snapshot_rejects_non_finite_or_non_positive_poll_intervals(interval):
+    with pytest.raises(ValueError, match="finite, positive"):
+        TaskSnapshot(status=TaskStatus.WORKING, poll_after_seconds=interval)
+
+
+def test_task_snapshot_accepts_finite_positive_poll_interval():
+    snapshot = TaskSnapshot(status=TaskStatus.WORKING, poll_after_seconds=5)
+    assert snapshot.poll_after_seconds == 5
+
+
 def test_submission_rejects_empty_remote_id():
     with pytest.raises(ValueError, match="remote_task_id must not be empty"):
         TaskSubmission(remote_task_id="  ", snapshot=TaskSnapshot(status=TaskStatus.SUBMITTED))


### PR DESCRIPTION
Fixes #4749

## Why

`TaskSnapshot.poll_after_seconds` only rejected values `<= 0`, so `float("nan")` and `float("inf")` were accepted. Both later broke `McpTaskService` next-poll scheduling at `now + timedelta(seconds=interval)` inside `_next_poll_at`, raising `ValueError: cannot convert float NaN to integer` / `OverflowError: cannot convert float infinity to integer`. A driver could return a valid remote task status, but the snapshot could not be scheduled or persisted.

## What changed

- `TaskSnapshot.__post_init__` now rejects `poll_after_seconds` unless it is both **finite** (`math.isfinite`) and strictly positive. `NaN` and `±Infinity` (for which `math.isfinite` returns `False`), as well as `0` and negatives, are all rejected at construction time — before reaching the service layer.
- Added a parametrized test asserting `nan`/`inf`/`-inf`/`0`/`-1` all raise, plus a positive case asserting a finite positive interval is still accepted.
- Valid positive intervals are unchanged.

## Notes

- Validation is fail-fast at dataclass construction; `_next_poll_at` (`backend/app/mcp_tasks/service.py`) is the only downstream consumer of `timedelta(seconds=...)` and is now protected.
- `test_mcp_task_models.py` + `test_mcp_task_service.py` pass locally (21 passed).
