### PR TITLE
fix(memory): reject non-finite mem0 timeout_seconds

### DIFF
--- a/backend/packages/harness/deerflow/agents/memory/backends/mem0/config.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/mem0/config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from math import isfinite
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -105,8 +106,8 @@ class Mem0Config:
             raise ValueError("mem0 score_threshold must be in [0, 1]")
         if config.max_injection_chars <= 0:
             raise ValueError("mem0 max_injection_chars must be positive")
-        if config.timeout_seconds <= 0:
-            raise ValueError("mem0 timeout_seconds must be positive")
+        if not isfinite(config.timeout_seconds) or config.timeout_seconds <= 0:
+            raise ValueError("mem0 timeout_seconds must be a finite value > 0")
         if not config.api_key_env.strip():
             raise ValueError("mem0 api_key_env must be a non-empty env var name")
         parsed_base_url = urlsplit(config.base_url)

--- a/backend/tests/test_mem0_memory_backend.py
+++ b/backend/tests/test_mem0_memory_backend.py
@@ -77,6 +77,9 @@ class TestMem0Config:
             ("score_threshold", 1.5),
             ("max_injection_chars", 0),
             ("timeout_seconds", 0),
+            ("timeout_seconds", float("nan")),
+            ("timeout_seconds", float("inf")),
+            ("timeout_seconds", float("-inf")),
         ],
     )
     def test_invalid_values_rejected(self, key: str, value: object) -> None:


### PR DESCRIPTION
Fixes #4821

## Why

`Mem0Config.from_backend_config()` claims `timeout_seconds` must be positive, but it only checks `<= 0`. IEEE 754 makes every comparison with `NaN` false, and `+Inf` is greater than zero, so both values are accepted.

YAML `safe_load` turns `.nan` / `.inf` into those floats. `httpx.Timeout` will construct them, then a later real HTTP call fails with `ValueError` / `OverflowError`. Default `startup_policy: fail_fast` hits this on `ping()`.

This is the same hole OpenViking already closed. Default `timeout_seconds: 10` is unchanged. Low severity; opt-in Mem0 backend only.

## What changed

`timeout_seconds` must now be finite and strictly positive, matching OpenViking. Valid positive finite values behave as before. `0`, negatives, `-inf`, `nan`, and `+inf` are rejected at config parse time.

## Surface area

- [x] **Agents / LangGraph** — mem0 backend config validation
- [x] **Docs / tests / CI only** — no endpoint, default, or runtime path change for valid configs

## Bug fix verification

- Test path: `backend/tests/test_mem0_memory_backend.py::TestMem0Config::test_invalid_values_rejected`
- Red on `main` for `nan` / `inf`, green on this branch: yes. Existing `0` rejection still passes.

## Validation

From `backend/`:

- `uv run pytest tests/test_mem0_memory_backend.py::TestMem0Config -q` — 19 passed
- `uv run pytest tests/test_mem0_memory_backend.py -q` — 70 passed
- `uv run ruff check` on the two touched files — clean
- `uv run ruff format --check` on the two touched files — already formatted

## AI assistance

**Tool(s) used:** Reasonix / Claude

**How you used it:** Located the `<= 0` check, compared it with OpenViking, reproduced `nan`/`inf` acceptance, drafted the one-line `isfinite` guard and regression cases. I reviewed every changed line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
