### PR TITLE
feat: support subagent defaults for custom agents

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -301,6 +301,20 @@ Provider note:
 - `models[*].use` references provider classes by module path (for example `langchain_openai:ChatOpenAI`).
 - If a provider module is missing, DeerFlow now returns an actionable error with install guidance (for example `uv add langchain-google-genai`).
 
+### Custom Agent Subagent Defaults
+
+A custom agent that depends on delegation can declare defaults in its own
+`config.yaml`:
+
+```yaml
+subagent_enabled: true
+max_concurrent_subagents: 2
+```
+
+Explicit runtime request values override these defaults. If neither is set,
+the runtime defaults remain `false` and `3`, respectively. The concurrency
+value must be between 1 and 4.
+
 ### Extensions Configuration (`extensions_config.json`)
 
 MCP servers and skill states in a single file:

--- a/backend/packages/harness/deerflow/agents/AGENTS.md
+++ b/backend/packages/harness/deerflow/agents/AGENTS.md
@@ -29,3 +29,8 @@
   Gateway and `DeerFlowClient.stream()` always provide the runtime `run_id`; custom
   graph integrations must do the same. If it is absent, enforcement deliberately
   counts the thread's full delegation ledger (fail-restrictive) and emits a warning.
+
+Custom-agent `config.yaml` files may set `subagent_enabled` and
+`max_concurrent_subagents` as defaults. Runtime request values take precedence,
+and `make_lead_agent()` writes the resolved pair to both `configurable` and
+`context` before constructing tools, prompt, and middleware.

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -103,6 +103,21 @@ def _resolve_runtime_option(cfg: dict, key: str, agent_value, default):
     return default
 
 
+def _inject_resolved_runtime_option(config: RunnableConfig, key: str, value) -> None:
+    """Expose a resolved option to both legacy and current runtime consumers."""
+    configurable = dict(config.get("configurable", {}) or {})
+    configurable[key] = value
+    config["configurable"] = configurable
+
+    context = config.get("context")
+    if context is None:
+        config["context"] = {key: value}
+    elif isinstance(context, dict):
+        runtime_context = dict(context)
+        runtime_context[key] = value
+        config["context"] = runtime_context
+
+
 def _append_memory_tools_without_name_conflicts(tools: list) -> None:
     """Append memory tools without dropping unrelated duplicate-named tools."""
     from deerflow.agents.memory.tools import get_memory_tools
@@ -709,8 +724,6 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
 
     requested_model_name: str | None = cfg.get("model_name") or cfg.get("model")
     is_plan_mode = cfg.get("is_plan_mode", False)
-    subagent_enabled = cfg.get("subagent_enabled", False)
-    max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
     max_total_subagents = cfg.get("max_total_subagents", _default_max_total_subagents(resolved_app_config))
     is_bootstrap = cfg.get("is_bootstrap", False)
     non_interactive = bool(cfg.get("non_interactive", False))
@@ -728,6 +741,17 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     agent_reasoning = getattr(agent_config, "reasoning_effort", None) if agent_config else None
     thinking_enabled = bool(_resolve_runtime_option(cfg, "thinking_enabled", agent_thinking, True))
     reasoning_effort = _resolve_runtime_option(cfg, "reasoning_effort", agent_reasoning, None)
+
+    # Subagent precedence: request > custom agent default > runtime default
+    # (issue #2381). Write the resolved pair back to both config sections so
+    # task injection, prompt rendering, middleware, and ToolRuntime consumers
+    # all observe the same values.
+    agent_subagent_enabled = getattr(agent_config, "subagent_enabled", None) if agent_config else None
+    agent_max_concurrent_subagents = getattr(agent_config, "max_concurrent_subagents", None) if agent_config else None
+    subagent_enabled = bool(_resolve_runtime_option(cfg, "subagent_enabled", agent_subagent_enabled, False))
+    max_concurrent_subagents = _resolve_runtime_option(cfg, "max_concurrent_subagents", agent_max_concurrent_subagents, 3)
+    _inject_resolved_runtime_option(config, "subagent_enabled", subagent_enabled)
+    _inject_resolved_runtime_option(config, "max_concurrent_subagents", max_concurrent_subagents)
 
     # Per-agent sampling overrides (temperature / max_tokens) layered on top of
     # the resolved model profile (issue #4336). None when the agent set none.

--- a/backend/packages/harness/deerflow/config/agents_config.py
+++ b/backend/packages/harness/deerflow/config/agents_config.py
@@ -15,6 +15,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from deerflow.config.paths import get_paths
+from deerflow.config.subagents_config import MAX_CONCURRENT_SUBAGENT_CALLS, MIN_CONCURRENT_SUBAGENT_CALLS
 from deerflow.runtime.user_context import get_effective_user_id
 
 logger = logging.getLogger(__name__)
@@ -210,6 +211,14 @@ class AgentConfig(BaseModel):
     # Per-agent reasoning-effort default for models that support it. None = do
     # not override (a request-supplied reasoning_effort still wins over this).
     reasoning_effort: Literal["low", "medium", "high"] | None = None
+    # Per-agent subagent defaults. None leaves the runtime defaults unchanged;
+    # explicit request values still take precedence over these fields.
+    subagent_enabled: bool | None = None
+    max_concurrent_subagents: int | None = Field(
+        default=None,
+        ge=MIN_CONCURRENT_SUBAGENT_CALLS,
+        le=MAX_CONCURRENT_SUBAGENT_CALLS,
+    )
     # Optional binding to GitHub repositories so this agent can respond to
     # webhook events from the gateway dispatcher. None means "no GitHub
     # integration", which is the case for every existing agent.

--- a/backend/tests/test_agent_model_settings.py
+++ b/backend/tests/test_agent_model_settings.py
@@ -1,9 +1,9 @@
-"""Tests for the per-agent model-settings block on :class:`AgentConfig` (#4336).
+"""Tests for per-agent runtime defaults on :class:`AgentConfig` (#4336, #2381).
 
-Covers the new ``model_settings`` / ``thinking_enabled`` / ``reasoning_effort``
-fields: validation bounds, YAML round-trip via ``load_agent_config``, backward
-compatibility (absent = None), and that they are treated as managed fields by
-``preserve_non_managed_fields``.
+Covers the per-agent model and runtime defaults: validation bounds, YAML
+round-trip via ``load_agent_config``, backward compatibility (absent = None),
+and preservation of hand-authored fields that are not exposed by an update
+surface.
 """
 
 from __future__ import annotations
@@ -29,6 +29,8 @@ def test_model_settings_default_to_none() -> None:
     assert cfg.model_settings is None
     assert cfg.thinking_enabled is None
     assert cfg.reasoning_effort is None
+    assert cfg.subagent_enabled is None
+    assert cfg.max_concurrent_subagents is None
 
 
 def test_model_settings_parse_full_shape() -> None:
@@ -37,12 +39,16 @@ def test_model_settings_parse_full_shape() -> None:
         model_settings={"temperature": 0.2, "max_tokens": 12000},
         thinking_enabled=True,
         reasoning_effort="high",
+        subagent_enabled=True,
+        max_concurrent_subagents=2,
     )
     assert isinstance(cfg.model_settings, AgentModelSettings)
     assert cfg.model_settings.temperature == 0.2
     assert cfg.model_settings.max_tokens == 12000
     assert cfg.thinking_enabled is True
     assert cfg.reasoning_effort == "high"
+    assert cfg.subagent_enabled is True
+    assert cfg.max_concurrent_subagents == 2
 
 
 @pytest.mark.parametrize("temperature", [-0.1, 2.1])
@@ -76,7 +82,13 @@ def test_reasoning_effort_rejects_codex_unsupported_minimal() -> None:
         AgentConfig(name="x", reasoning_effort="minimal")  # type: ignore[arg-type]
 
 
-def test_model_settings_are_managed_fields() -> None:
+@pytest.mark.parametrize("value", [0, 5])
+def test_max_concurrent_subagents_stays_within_runtime_limits(value: int) -> None:
+    with pytest.raises(ValidationError):
+        AgentConfig(name="x", max_concurrent_subagents=value)
+
+
+def test_agent_config_fields_follow_update_surface_contract() -> None:
     # These are managed by the HTTP agent settings API, so the generic
     # preserve_non_managed_fields helper must not also carry them. Surfaces that
     # do not expose them directly, such as the harness update_agent tool, need a
@@ -84,17 +96,27 @@ def test_model_settings_are_managed_fields() -> None:
     for field in ("model_settings", "thinking_enabled", "reasoning_effort"):
         assert field in MANAGED_AGENT_CONFIG_FIELDS
 
+    # Subagent defaults are intentionally config.yaml-only for this issue.
+    # Treating them as non-managed makes every rewrite surface preserve them
+    # without expanding the HTTP or LLM-facing update APIs.
+    for field in ("subagent_enabled", "max_concurrent_subagents"):
+        assert field not in MANAGED_AGENT_CONFIG_FIELDS
+
 
 def test_preserve_non_managed_excludes_model_settings() -> None:
     cfg = AgentConfig(
         name="a",
         model_settings={"temperature": 0.5},
         thinking_enabled=True,
+        subagent_enabled=True,
+        max_concurrent_subagents=2,
         github={"installation_id": 7},
     )
     preserved = preserve_non_managed_fields(cfg)
     assert "model_settings" not in preserved
     assert "thinking_enabled" not in preserved
+    assert preserved["subagent_enabled"] is True
+    assert preserved["max_concurrent_subagents"] == 2
     # github stays preserved (hand-authored, not managed by the update surfaces).
     assert "github" in preserved
 
@@ -117,6 +139,8 @@ def test_load_agent_config_round_trips_model_settings(tmp_path: Path, monkeypatc
         "model_settings": {"temperature": 0.2, "max_tokens": 12000},
         "thinking_enabled": True,
         "reasoning_effort": "high",
+        "subagent_enabled": True,
+        "max_concurrent_subagents": 2,
     }
     _write_agent(tmp_path, "default", "researcher", body)
 
@@ -127,6 +151,8 @@ def test_load_agent_config_round_trips_model_settings(tmp_path: Path, monkeypatc
     assert cfg.model_settings.max_tokens == 12000
     assert cfg.thinking_enabled is True
     assert cfg.reasoning_effort == "high"
+    assert cfg.subagent_enabled is True
+    assert cfg.max_concurrent_subagents == 2
 
 
 def test_load_agent_config_without_model_settings_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -142,3 +168,5 @@ def test_load_agent_config_without_model_settings_is_none(tmp_path: Path, monkey
     assert cfg.model_settings is None
     assert cfg.thinking_enabled is None
     assert cfg.reasoning_effort is None
+    assert cfg.subagent_enabled is None
+    assert cfg.max_concurrent_subagents is None

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -1287,6 +1287,102 @@ def test_request_thinking_overrides_agent_default(monkeypatch):
     assert captured["thinking_enabled"] is True  # request wins over agent's False
 
 
+def test_make_lead_agent_applies_agent_subagent_defaults_consistently(monkeypatch):
+    """Custom-agent subagent defaults drive tools, prompt, and middleware."""
+    app_config = _make_app_config([_make_model("agent-model", supports_thinking=True)])
+    agent_config = _make_agent_config(
+        model="agent-model",
+        subagent_enabled=True,
+        max_concurrent_subagents=2,
+    )
+
+    import deerflow.tools as tools_module
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(lead_agent_module, "load_agent_config", lambda name, *, user_id=None: agent_config)
+
+    def _fake_get_available_tools(**kwargs):
+        captured["tools_subagent_enabled"] = kwargs["subagent_enabled"]
+        return []
+
+    def _fake_build_middlewares(config, model_name, agent_name=None, **kwargs):
+        captured["middleware_config"] = config
+        captured["middleware_runtime"] = lead_agent_module._get_runtime_config(config)
+        return []
+
+    def _fake_prompt(**kwargs):
+        captured["prompt_subagent_enabled"] = kwargs["subagent_enabled"]
+        captured["prompt_max_concurrent"] = kwargs["max_concurrent_subagents"]
+        return "prompt"
+
+    monkeypatch.setattr(tools_module, "get_available_tools", _fake_get_available_tools)
+    monkeypatch.setattr(lead_agent_module, "build_middlewares", _fake_build_middlewares)
+    monkeypatch.setattr(lead_agent_module, "apply_prompt_template", _fake_prompt)
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: object())
+    monkeypatch.setattr(lead_agent_module, "create_agent", lambda **kwargs: kwargs)
+
+    lead_agent_module._make_lead_agent({"context": {"agent_name": "researcher"}}, app_config=app_config)
+
+    assert captured["tools_subagent_enabled"] is True
+    assert captured["prompt_subagent_enabled"] is True
+    assert captured["prompt_max_concurrent"] == 2
+    assert captured["middleware_runtime"]["subagent_enabled"] is True
+    assert captured["middleware_runtime"]["max_concurrent_subagents"] == 2
+    assert captured["middleware_config"]["context"]["subagent_enabled"] is True
+    assert captured["middleware_config"]["configurable"]["subagent_enabled"] is True
+
+
+def test_request_subagent_values_override_agent_defaults(monkeypatch):
+    """Explicit request values win, including a falsy subagent switch."""
+    app_config = _make_app_config([_make_model("agent-model", supports_thinking=True)])
+    agent_config = _make_agent_config(
+        model="agent-model",
+        subagent_enabled=True,
+        max_concurrent_subagents=2,
+    )
+
+    import deerflow.tools as tools_module
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(lead_agent_module, "load_agent_config", lambda name, *, user_id=None: agent_config)
+
+    def _fake_get_available_tools(**kwargs):
+        captured["tools_subagent_enabled"] = kwargs["subagent_enabled"]
+        return []
+
+    def _fake_build_middlewares(config, model_name, agent_name=None, **kwargs):
+        captured["middleware_runtime"] = lead_agent_module._get_runtime_config(config)
+        return []
+
+    monkeypatch.setattr(tools_module, "get_available_tools", _fake_get_available_tools)
+    monkeypatch.setattr(lead_agent_module, "build_middlewares", _fake_build_middlewares)
+    monkeypatch.setattr(
+        lead_agent_module,
+        "apply_prompt_template",
+        lambda **kwargs: captured.update(prompt_subagent_enabled=kwargs["subagent_enabled"], prompt_max_concurrent=kwargs["max_concurrent_subagents"]) or "prompt",
+    )
+    monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: object())
+    monkeypatch.setattr(lead_agent_module, "create_agent", lambda **kwargs: kwargs)
+
+    lead_agent_module._make_lead_agent(
+        {
+            "context": {
+                "agent_name": "researcher",
+                "subagent_enabled": False,
+                "max_concurrent_subagents": 4,
+            }
+        },
+        app_config=app_config,
+    )
+
+    assert captured["tools_subagent_enabled"] is False
+    assert captured["prompt_subagent_enabled"] is False
+    assert captured["prompt_max_concurrent"] == 4
+    assert captured["middleware_runtime"]["subagent_enabled"] is False
+    assert captured["middleware_runtime"]["max_concurrent_subagents"] == 4
+
+
 def test_make_lead_agent_no_agent_settings_passes_none_overrides(monkeypatch):
     """Without a custom agent, model_overrides is None (no behavior change)."""
     app_config = _make_app_config([_make_model("safe-model", supports_thinking=False)])


### PR DESCRIPTION
﻿Fixes #2381

## Why

Custom agents can require the `task` tool in their SOP or skills, but their `config.yaml` cannot currently enable subagent delegation by default. When a request omits the runtime flag, the tool is not injected and the agent silently falls back to doing delegated work itself.

## What changed

- Custom-agent `config.yaml` accepts optional `subagent_enabled` and `max_concurrent_subagents` defaults.
- Runtime values resolve with `request > custom-agent config > runtime default` precedence, including an explicit `false` request value.
- The resolved values are written to both `context` and `configurable`, so tool injection, prompt rendering, middleware limits, and `ToolRuntime` consumers use the same result.
- Hand-authored defaults survive config rewrites without expanding the HTTP or LLM-facing agent update APIs.
- The supported concurrency range is documented and validated as 1-4.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [x] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Not applicable; this is a custom-agent configuration and runtime change.

## Bug fix verification

- Test paths: `backend/tests/test_agent_model_settings.py`, `backend/tests/test_lead_agent_model_resolution.py`
- Red on `main`: yes (7 failed, 1 passed for the new focused cases).
- Green on this branch: yes (8 passed for the same focused cases).

## Validation

- `python -m pytest -q tests/test_agent_model_settings.py tests/test_lead_agent_model_resolution.py tests/test_agents_router_model_settings.py tests/test_update_agent_tool.py` - 93 passed.
- `python -m ruff check` on the four changed Python files - passed.
- `python -m ruff format --check .` - 1,131 files already formatted.
- `python -m ruff check .` - blocked by two pre-existing import-order findings in unchanged `tests/test_extension_app_loading.py` and `tests/test_extension_loader.py`.
- Full offline `pytest -m "not live" tests/ -v` was attempted after syncing all locked dependencies; it exceeded the local 20-minute command limit without producing a final summary.
- GNU `make` is unavailable in the Windows environment, so the underlying documented commands were run directly.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex was used to inspect the issue and repository contribution rules, write the regression tests and implementation, review the diff, and run the validation commands. This draft remains pending the contributor's line-by-line review before it is marked ready.

- [ ] I've read and understand every line of this change and take responsibility for it - it's not unreviewed AI output.
