### PR TITLE
fix(skills): fail closed on drifted projection namespace on all platforms

### DIFF
--- a/backend/packages/harness/deerflow/skills/projection.py
+++ b/backend/packages/harness/deerflow/skills/projection.py
@@ -158,11 +158,18 @@ def _validate_projection_relative_path(relative_path: Path) -> None:
 def _remove_projection_relative(root: Path, relative_path: Path) -> None:
     """Remove a projected package without following a drifted namespace symlink."""
     current = root
-    for part in relative_path.parts:
+    parts = relative_path.parts
+    for index, part in enumerate(parts):
         current /= part
         if current.is_symlink():
             current.unlink()
             return
+        # A namespace component that exists as a regular file means the
+        # projection was externally replaced (drifted). Fail closed on every
+        # platform: os.unlink() reports this as ENOTDIR on POSIX but ENOENT
+        # on Windows, where unlink(missing_ok=True) swallows the ENOENT.
+        if index < len(parts) - 1 and current.exists() and not current.is_dir():
+            raise NotADirectoryError(errno.ENOTDIR, f"Projection namespace drifted to a file: {current}")
     _remove_projection_entry(current)
 
 

--- a/backend/tests/test_skill_projection.py
+++ b/backend/tests/test_skill_projection.py
@@ -283,6 +283,30 @@ def test_targeted_removal_failure_clears_drifted_projection_scope(projection_env
     assert not manifest.exists()
 
 
+def test_targeted_removal_drift_check_raises_when_underlying_unlink_swallows_error(projection_env, monkeypatch) -> None:
+    """Explicit drift check raises NotADirectoryError even if underlying unlink would swallow ENOENT (Windows semantics)."""
+    env = projection_env
+    _write_skill(env.skills_root / "public" / "team", "helper")
+    projected = rebuild_skill_projections(env.storage)
+    manifest = projected.public.parent / ".projection-manifest.json"
+    namespace = projected.public / "team"
+    shutil.rmtree(namespace)
+    namespace.write_text("drifted file", encoding="utf-8")
+
+    from deerflow.skills import projection as projection_module
+
+    # Simulate Windows Path.unlink(missing_ok=True) semantics where file-in-path
+    # returns ENOENT and is swallowed, so underlying removal would not raise ENOTDIR.
+    monkeypatch.setattr(projection_module, "_remove_projection_entry", lambda _target: None)
+
+    with pytest.raises(NotADirectoryError, match="Projection namespace drifted to a file"):
+        with skill_projection_mutation(env.storage, "public", remove_names=("helper",)):
+            env.extensions.skills["helper"] = SkillStateConfig(enabled=False)
+
+    assert list(projected.public.iterdir()) == []
+    assert not manifest.exists()
+
+
 def test_user_custom_skill_replaces_legacy_projection(projection_env) -> None:
     env = projection_env
     _write_skill(env.skills_root / "custom", "legacy-skill")


### PR DESCRIPTION
Fixes #4829

## Why

`_remove_projection_relative` relied on `os.unlink`'s errno to detect a drifted projection namespace (a directory externally replaced by a regular file). The errno differs by OS: POSIX raises `NotADirectoryError` (`ENOTDIR`), Windows raises `FileNotFoundError` (`ENOENT`). CPython's `Path.unlink(missing_ok=True)` catches only `FileNotFoundError`, so on Windows the drift error was silently swallowed, the fail-closed clear path never ran, and the drifted file survived in the projection the sandbox mounts.

The repo's own test `test_targeted_removal_failure_clears_drifted_projection_scope` (added with #4693) encodes the fail-closed contract — `NotADirectoryError` must propagate so `skill_projection_mutation` clears the scope. It passes on Linux (CI runs `ubuntu-latest` only) and fails on Windows.

## What changed

`_remove_projection_relative` now explicitly checks, for every namespace component before the final one, that an existing component is still a directory; a regular file means drift and raises `NotADirectoryError(errno.ENOTDIR, ...)` directly. No reliance on the OS errno mapping — pure Python, same behavior on every platform.

No public API, default, or endpoint change. The behavior on Linux is unchanged (it already raised `NotADirectoryError` via `ENOTDIR`); Windows now raises the same exception and the scope is cleared.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox** — projection fail-closed clear now works on Windows
- [x] **Skills** — `skills/projection.py` drift detection is platform-independent
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Bug fix verification

- Test path: `backend/tests/test_skill_projection.py::test_targeted_removal_failure_clears_drifted_projection_scope`
- Red on `main` (Windows): `DID NOT RAISE <class 'NotADirectoryError'>`; green on this branch: all 31 tests pass.
- Isolated repro (Windows) raised `NotADirectoryError` on this branch, was silent on `main`.

## Validation

From `backend/`:
- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pytest tests/test_skill_projection.py tests/test_skills_custom_router.py tests/test_skills_installer.py tests/test_skills_reload.py tests/test_skill_storage_lifecycle.py tests/test_skills_router_authz.py -q` — 127 passed

## AI assistance

**Tool(s) used:** Reasonix / Claude
**How you used it:** Traced the failing test on `main` to the `unlink(missing_ok=True)` errno asymmetry (verified against CPython stdlib source), reproduced in isolation, drafted the explicit platform-independent check. I reviewed every changed line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.