### PR TITLE
fix(frontend): preserve interrupted uniform-run order

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -675,7 +675,9 @@ export function restoreLocalTurnMessageOrder(
  * accepted transient, far safer than pulling a completed turn's answer
  * below the next user message. A resent turn after an interrupted run and
  * pagination orphans from older turns (#4399) fail the checks as well and
- * are left untouched.
+ * are left untouched. When an interrupted turn and the next turn share one
+ * synthetic run_id, the previous human anchor plus the missing terminal
+ * answer makes step ownership ambiguous, so that layout is also preserved.
  */
 export function restoreReconnectedTurnMessageOrder(
   messages: Message[],
@@ -719,6 +721,21 @@ export function restoreReconnectedTurnMessageOrder(
     ) {
       candidateStart = index + 1;
     }
+  }
+
+  const previousHumanRunId =
+    segmentStart > 0 ? getMessageRunId(messages[segmentStart - 1]!) : undefined;
+  const hasUniformRunIdSincePreviousHuman =
+    previousHumanRunId !== undefined &&
+    messages
+      .slice(segmentStart - 1)
+      .every(
+        (message) =>
+          isHiddenFromUIMessage(message) ||
+          getMessageRunId(message) === previousHumanRunId,
+      );
+  if (candidateStart === segmentStart && hasUniformRunIdSincePreviousHuman) {
+    return messages;
   }
 
   const runIdsAfter = new Set<string>();

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -1688,6 +1688,46 @@ test("reconnected turn order leaves a resent turn after an interrupted run untou
   ).toEqual([interruptedStep, human, newStep]);
 });
 
+test("reconnected turn order keeps interrupted uniform-run history in its original turn", () => {
+  // Branch-seeded and mocked feeds can stamp every message with one run_id.
+  // Without a terminal answer, that synthetic id cannot prove that the older
+  // tool step belongs to the newer human turn.
+  const human1 = {
+    id: "human-1",
+    type: "human",
+    content: "First question",
+    run_id: "run-x",
+  } as Message;
+  const interruptedStep = {
+    id: "step-1",
+    type: "ai",
+    content: "Working on the first question",
+    tool_calls: [{ id: "tc-1", name: "web_search", args: {} }],
+    run_id: "run-x",
+  } as unknown as Message;
+  const human2 = {
+    id: "human-2",
+    type: "human",
+    content: "Second question",
+    run_id: "run-x",
+  } as Message;
+  const step2 = {
+    id: "step-2",
+    type: "ai",
+    content: "Working on the second question",
+    run_id: "run-x",
+  } as Message;
+
+  expect(
+    restoreReconnectedTurnMessageOrder([
+      human1,
+      interruptedStep,
+      human2,
+      step2,
+    ]),
+  ).toEqual([human1, interruptedStep, human2, step2]);
+});
+
 test("reconnected turn order only moves steps of the sandwiched run in multi-turn history", () => {
   const human1 = { id: "human-1", type: "human", content: "First" } as Message;
   const step1 = {


### PR DESCRIPTION
## Why

This is a follow-up to the review edge case identified on #4660:
https://github.com/bytedance/deer-flow/pull/4660#discussion_r3710161557

Branch-seeded and mocked history can stamp multiple turns with one synthetic `run_id`. When the earlier turn was interrupted and has no terminal assistant answer, reconnect order repair treated its tool step as part of the newer turn and moved it below the newer human message.

## What changed

- Preserve an interrupted segment when a previous visible human anchors it, there is no terminal-answer boundary, and every visible message from that anchor shares one `run_id`.
- Add the four-message regression from the review thread.
- Retain the existing self-healing behavior for genuine reconnect sandwiches, live-only steps, distinct-run retries, and completed turns.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not included: this corrects message ordering without changing the visual layout. The exact before/after sequence is covered by a regression test.

## Bug fix verification

- Test path: `frontend/tests/unit/core/threads/message-merge.test.ts`
- Red on `main`, green on this branch: yes. The four-message interrupted-turn fixture is reordered incorrectly without the implementation and remains stable with it.

## Validation

Current rebased head (latest `upstream/main`):

- `pnpm test` — 138 files, 1,058 tests passed
- `pnpm check` — ESLint and TypeScript passed
- `pnpm exec prettier --check src/core/threads/hooks.ts tests/unit/core/threads/message-merge.test.ts` — passed
- `git diff --check upstream/main...HEAD` — passed

## AI assistance

**Tool(s) used:** Codex

**How you used it:** I used Codex to inspect the review edge case, add the regression test, implement the focused ordering fix, rebase it onto the latest main, and run the validation above. I reviewed the resulting diff and test behavior.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
