### PR TITLE
fix(agent): align autonomous interaction guidance

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -267,11 +267,14 @@ context, make minimal reversible assumptions, list material assumptions, or
 return a structured blocked result for high-risk ambiguity; they must never
 wait for a synchronous human response. Legacy `non_interactive` and
 `disable_clarification` context flags remain supported while entry points
-migrate to an explicit interaction mode. `interaction_mode` is an
-internal-caller-only Gateway context key, just like `non_interactive`; public
-run requests cannot use it to disable clarification or override a scheduled
-run back to interactive behavior. An explicitly supplied unknown mode is a
-configuration error rather than silently falling back to interactive mode.
+migrate to an explicit interaction mode. `interaction_mode`, `non_interactive`,
+`disable_clarification`, and `channel_name` are internal-caller-only Gateway
+context keys; the latter two remain runtime-only and are never copied into
+checkpoint-persisted `configurable`. Public run requests cannot use these keys
+to disable clarification, impersonate a webhook channel, or override a
+scheduled run back to interactive behavior. An explicitly supplied unknown
+mode is a configuration error rather than silently falling back to interactive
+mode.
 
 ### Context Summarization
 

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -257,6 +257,18 @@ TodoList middleware for complex multi-step tasks:
 
 See [docs/plan_mode_usage.md](docs/plan_mode_usage.md) for details.
 
+### Run Interaction Policy
+
+The harness resolves a `RunInteractionPolicy` from the run context and uses it
+as the single source for lead-agent tool visibility, clarification middleware
+behavior, and system-prompt guidance. Interactive runs may ask a human for
+clarification. Scheduled and webhook/autonomous runs must use the available
+context, make minimal reversible assumptions, list material assumptions, or
+return a structured blocked result for high-risk ambiguity; they must never
+wait for a synchronous human response. Legacy `non_interactive` and
+`disable_clarification` context flags remain supported while entry points
+migrate to an explicit interaction mode.
+
 ### Context Summarization
 
 Automatic conversation summarization when approaching token limits:

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -267,7 +267,11 @@ context, make minimal reversible assumptions, list material assumptions, or
 return a structured blocked result for high-risk ambiguity; they must never
 wait for a synchronous human response. Legacy `non_interactive` and
 `disable_clarification` context flags remain supported while entry points
-migrate to an explicit interaction mode.
+migrate to an explicit interaction mode. `interaction_mode` is an
+internal-caller-only Gateway context key, just like `non_interactive`; public
+run requests cannot use it to disable clarification or override a scheduled
+run back to interactive behavior. An explicitly supplied unknown mode is a
+configuration error rather than silently falling back to interactive mode.
 
 ### Context Summarization
 

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -304,9 +304,10 @@ _CONTEXT_CONFIGURABLE_KEYS: frozenset[str] = frozenset(
 )
 
 # Keys honored only for internally-authenticated callers (the scheduler path).
-# ``non_interactive`` strips ``ask_clarification`` from the lead-agent toolset;
-# arbitrary HTTP/IM clients must not be able to force autonomous execution.
-_CONTEXT_INTERNAL_CALLER_KEYS: frozenset[str] = frozenset({"non_interactive"})
+# ``non_interactive`` and its explicit successor ``interaction_mode`` control
+# whether ``ask_clarification`` is exposed; arbitrary HTTP/IM clients must not
+# be able to force autonomous execution or override a server-selected mode.
+_CONTEXT_INTERNAL_CALLER_KEYS: frozenset[str] = frozenset({"interaction_mode", "non_interactive"})
 
 # Server-owned authorization identity fields. These must never be accepted from
 # client-supplied ``body.config.context`` or ``body.config.configurable``. They

--- a/backend/app/gateway/services.py
+++ b/backend/app/gateway/services.py
@@ -309,6 +309,11 @@ _CONTEXT_CONFIGURABLE_KEYS: frozenset[str] = frozenset(
 # be able to force autonomous execution or override a server-selected mode.
 _CONTEXT_INTERNAL_CALLER_KEYS: frozenset[str] = frozenset({"interaction_mode", "non_interactive"})
 
+# Internal-caller-only values that must remain runtime-only rather than being
+# copied into checkpoint-persisted ``configurable``. ChannelManager supplies
+# both values over an internally authenticated request path.
+_CONTEXT_INTERNAL_RUNTIME_ONLY_KEYS: frozenset[str] = frozenset({"channel_name", "disable_clarification"})
+
 # Server-owned authorization identity fields. These must never be accepted from
 # client-supplied ``body.config.context`` or ``body.config.configurable``. They
 # are either produced by Gateway auth state, admitted from a separately
@@ -339,10 +344,7 @@ _SERVER_OWNED_AUTHZ_CONTEXT_KEYS: frozenset[str] = frozenset(
 #                              channel; the bash tool exposes it as
 #                              ``GH_TOKEN``/``GITHUB_TOKEN`` so ``gh`` and
 #                              ``git`` push as the bot, not the host user.
-#   ``disable_clarification`` — set for non-interactive channels (GitHub
-#                              webhooks) so ClarificationMiddleware proceeds
-#                              instead of dead-ending the run.
-_CONTEXT_RUNTIME_ONLY_KEYS: frozenset[str] = frozenset({"github_token", "disable_clarification"})
+_CONTEXT_RUNTIME_ONLY_KEYS: frozenset[str] = frozenset({"github_token"})
 
 
 def strip_internal_context_keys(config: dict[str, Any]) -> None:
@@ -356,7 +358,7 @@ def strip_internal_context_keys(config: dict[str, Any]) -> None:
     for section in ("context", "configurable"):
         value = config.get(section)
         if isinstance(value, dict):
-            for key in _CONTEXT_INTERNAL_CALLER_KEYS:
+            for key in _CONTEXT_INTERNAL_CALLER_KEYS | _CONTEXT_INTERNAL_RUNTIME_ONLY_KEYS:
                 value.pop(key, None)
 
 
@@ -376,11 +378,16 @@ def merge_run_context_overrides(config: dict[str, Any], context: Mapping[str, An
     is True; for non-internal callers those keys are dropped from client requests
     by :func:`strip_internal_context_keys`.
 
-    A second set of keys (``_CONTEXT_RUNTIME_ONLY_KEYS`` — e.g. ``github_token``,
-    ``disable_clarification``) is forwarded into ``config['context']`` only, never
-    ``configurable``. These are secrets / runtime flags read by tools and middlewares
-    from ``runtime.context``; keeping them out of ``configurable`` avoids persisting a
-    short-lived token in the checkpoint store.
+    :data:`_CONTEXT_INTERNAL_RUNTIME_ONLY_KEYS` are accepted only for internal
+    callers and forwarded into runtime context only. This keeps channel policy
+    inputs out of persisted checkpoints while preventing public callers from
+    selecting autonomous or webhook behavior through legacy flags.
+
+    A final set of keys (``_CONTEXT_RUNTIME_ONLY_KEYS`` — e.g. ``github_token``)
+    is forwarded into ``config['context']`` only, never ``configurable``. These
+    are request-scoped secrets read by tools from ``runtime.context``; keeping
+    them out of ``configurable`` avoids persisting a short-lived token in the
+    checkpoint store.
     """
     if not context:
         return
@@ -392,6 +399,10 @@ def merge_run_context_overrides(config: dict[str, Any], context: Mapping[str, An
             if isinstance(configurable, dict):
                 configurable.setdefault(key, context[key])
             if isinstance(runtime_context, dict):
+                runtime_context.setdefault(key, context[key])
+    if internal and isinstance(runtime_context, dict):
+        for key in _CONTEXT_INTERNAL_RUNTIME_ONLY_KEYS:
+            if key in context:
                 runtime_context.setdefault(key, context[key])
     # Context-only keys (secrets / runtime flags) land in ``config['context']``
     # only — never ``configurable`` (which is persisted in checkpoints).

--- a/backend/packages/harness/deerflow/agents/interaction_policy.py
+++ b/backend/packages/harness/deerflow/agents/interaction_policy.py
@@ -1,0 +1,167 @@
+"""Shared interaction policy for lead-agent tools and prompt guidance."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+ASK_CLARIFICATION_TOOL_NAME = "ask_clarification"
+
+
+class RunInteractionMode(StrEnum):
+    """Interaction modes that can be selected by a trusted run entry point."""
+
+    INTERACTIVE = "interactive"
+    AUTONOMOUS = "autonomous"
+    WEBHOOK = "webhook"
+    SCHEDULED = "scheduled"
+
+
+_INTERACTIVE_CLARIFICATION_SYSTEM = """<clarification_system>
+**WORKFLOW PRIORITY: CLARIFY -> PLAN -> ACT**
+1. **FIRST**: Analyze the request in your thinking - identify what's unclear, missing, or ambiguous
+2. **SECOND**: If clarification is needed, call `ask_clarification` tool IMMEDIATELY - do NOT start working
+3. **THIRD**: Only after all clarifications are resolved, proceed with planning and execution
+
+**CRITICAL RULE: Clarification ALWAYS comes BEFORE action. Never start working and clarify mid-execution.**
+
+**MANDATORY Clarification Scenarios - You MUST call ask_clarification BEFORE starting work when:**
+
+1. **Missing Information** (`missing_info`): Required details not provided
+   - Example: User says "create a web scraper" but doesn't specify the target website
+   - Example: "Deploy the app" without specifying environment
+   - **REQUIRED ACTION**: Call ask_clarification to get the missing information
+
+2. **Ambiguous Requirements** (`ambiguous_requirement`): Multiple valid interpretations exist
+   - Example: "Optimize the code" could mean performance, readability, or memory usage
+   - Example: "Make it better" is unclear what aspect to improve
+   - **REQUIRED ACTION**: Call ask_clarification to clarify the exact requirement
+
+3. **Approach Choices** (`approach_choice`): Several valid approaches exist
+   - Example: "Add authentication" could use JWT, OAuth, session-based, or API keys
+   - Example: "Store data" could use database, files, cache, etc.
+   - **REQUIRED ACTION**: Call ask_clarification to let user choose the approach
+
+4. **Risky Operations** (`risk_confirmation`): Destructive actions need confirmation
+   - Example: Deleting files, modifying production configs, database operations
+   - Example: Overwriting existing code or data
+   - **REQUIRED ACTION**: Call ask_clarification to get explicit confirmation
+
+5. **Suggestions** (`suggestion`): You have a recommendation but want approval
+   - Example: "I recommend refactoring this code. Should I proceed?"
+   - **REQUIRED ACTION**: Call ask_clarification to get approval
+
+**STRICT ENFORCEMENT:**
+- DO NOT start working and then ask for clarification mid-execution - clarify FIRST
+- DO NOT skip clarification for "efficiency" - accuracy matters more than speed
+- DO NOT make assumptions when information is missing - ALWAYS ask
+- DO NOT proceed with guesses - STOP and call ask_clarification first
+- Analyze the request in thinking -> Identify unclear aspects -> Ask BEFORE any action
+- If you identify the need for clarification in your thinking, you MUST call the tool IMMEDIATELY
+- After calling ask_clarification, execution will be interrupted automatically
+- Wait for user response - do NOT continue with assumptions
+
+**How to Use:**
+```python
+ask_clarification(
+    question="Your specific question here?",
+    clarification_type="missing_info",  # or other type
+    context="Why you need this information",  # optional but recommended
+    options=["option1", "option2"]  # optional, for choices
+)
+```
+</clarification_system>"""
+
+_AUTONOMOUS_CLARIFICATION_SYSTEM = """<clarification_system>
+**WORKFLOW PRIORITY: ASSESS -> CHOOSE THE LOWEST-RISK PATH -> ACT**
+
+There is no human available to answer a synchronous question during this run.
+Do not wait for clarification or approval. Resolve ambiguity from the request,
+the available repository/event context, and existing configuration.
+
+- For low-risk and reversible work, make the smallest reasonable assumption and continue.
+- State every material assumption in the final result.
+- For high-risk or irreversible work without sufficient authorization, do not guess:
+  stop with a concise structured `BLOCKED` result that names the missing decision.
+- Prefer inspection and read-only checks before changing state.
+</clarification_system>"""
+
+
+@dataclass(frozen=True, slots=True)
+class RunInteractionPolicy:
+    """The single source for interaction-sensitive tools and prompt guidance."""
+
+    mode: RunInteractionMode
+
+    @property
+    def allows_clarification(self) -> bool:
+        return self.mode is RunInteractionMode.INTERACTIVE
+
+    @property
+    def disabled_tool_names(self) -> frozenset[str]:
+        if self.allows_clarification:
+            return frozenset()
+        return frozenset({ASK_CLARIFICATION_TOOL_NAME})
+
+    @property
+    def thinking_guidance(self) -> str:
+        if self.allows_clarification:
+            return "- **PRIORITY CHECK: If anything is unclear, missing, or has multiple interpretations, you MUST ask for clarification FIRST - do NOT proceed with work**"
+        return "- **INTERACTION CHECK: This run has no synchronous human. Resolve ambiguity with the run context, choose the lowest-risk reversible path, and record material assumptions.**"
+
+    @property
+    def clarification_system(self) -> str:
+        if self.allows_clarification:
+            return _INTERACTIVE_CLARIFICATION_SYSTEM
+        if self.mode is RunInteractionMode.WEBHOOK:
+            return _AUTONOMOUS_CLARIFICATION_SYSTEM.replace(
+                "the available repository/event context, and existing configuration",
+                "the issue, pull request, repository, and event context, then existing configuration",
+            )
+        return _AUTONOMOUS_CLARIFICATION_SYSTEM
+
+    @property
+    def clarification_reminder(self) -> str:
+        if self.allows_clarification:
+            return "- **Clarification First**: ALWAYS clarify unclear/missing/ambiguous requirements BEFORE starting work - never assume or guess"
+        return "- **Autonomous Interaction**: Do not wait for a human response; make minimal reversible assumptions, list them, or return a structured `BLOCKED` result for high-risk ambiguity"
+
+    @classmethod
+    def interactive(cls) -> RunInteractionPolicy:
+        return cls(RunInteractionMode.INTERACTIVE)
+
+
+def resolve_run_interaction_policy(config: Mapping[str, Any] | None) -> RunInteractionPolicy:
+    """Resolve one policy from legacy runtime flags and channel context.
+
+    ``non_interactive`` is the scheduler's trusted legacy flag. GitHub and
+    other webhook channels currently use ``disable_clarification`` and/or
+    ``channel_name``; both remain supported while callers migrate to an
+    explicit mode.
+    """
+
+    merged: dict[str, Any] = {}
+    if config:
+        configurable = config.get("configurable")
+        context = config.get("context")
+        if isinstance(configurable, Mapping):
+            merged.update(configurable)
+        if isinstance(context, Mapping):
+            merged.update(context)
+
+    raw_mode = merged.get("interaction_mode")
+    try:
+        if raw_mode is not None:
+            return RunInteractionPolicy(RunInteractionMode(str(raw_mode)))
+    except ValueError:
+        pass
+
+    if merged.get("non_interactive"):
+        return RunInteractionPolicy(RunInteractionMode.SCHEDULED)
+    if merged.get("channel_name") == "github":
+        return RunInteractionPolicy(RunInteractionMode.WEBHOOK)
+    if merged.get("disable_clarification"):
+        return RunInteractionPolicy(RunInteractionMode.AUTONOMOUS)
+    return RunInteractionPolicy.interactive()

--- a/backend/packages/harness/deerflow/agents/interaction_policy.py
+++ b/backend/packages/harness/deerflow/agents/interaction_policy.py
@@ -20,7 +20,7 @@ class RunInteractionMode(StrEnum):
 
 
 _INTERACTIVE_CLARIFICATION_SYSTEM = """<clarification_system>
-**WORKFLOW PRIORITY: CLARIFY -> PLAN -> ACT**
+**WORKFLOW PRIORITY: CLARIFY → PLAN → ACT**
 1. **FIRST**: Analyze the request in your thinking - identify what's unclear, missing, or ambiguous
 2. **SECOND**: If clarification is needed, call `ask_clarification` tool IMMEDIATELY - do NOT start working
 3. **THIRD**: Only after all clarifications are resolved, proceed with planning and execution
@@ -54,14 +54,14 @@ _INTERACTIVE_CLARIFICATION_SYSTEM = """<clarification_system>
    - **REQUIRED ACTION**: Call ask_clarification to get approval
 
 **STRICT ENFORCEMENT:**
-- DO NOT start working and then ask for clarification mid-execution - clarify FIRST
-- DO NOT skip clarification for "efficiency" - accuracy matters more than speed
-- DO NOT make assumptions when information is missing - ALWAYS ask
-- DO NOT proceed with guesses - STOP and call ask_clarification first
-- Analyze the request in thinking -> Identify unclear aspects -> Ask BEFORE any action
-- If you identify the need for clarification in your thinking, you MUST call the tool IMMEDIATELY
-- After calling ask_clarification, execution will be interrupted automatically
-- Wait for user response - do NOT continue with assumptions
+- ❌ DO NOT start working and then ask for clarification mid-execution - clarify FIRST
+- ❌ DO NOT skip clarification for "efficiency" - accuracy matters more than speed
+- ❌ DO NOT make assumptions when information is missing - ALWAYS ask
+- ❌ DO NOT proceed with guesses - STOP and call ask_clarification first
+- ✅ Analyze the request in thinking → Identify unclear aspects → Ask BEFORE any action
+- ✅ If you identify the need for clarification in your thinking, you MUST call the tool IMMEDIATELY
+- ✅ After calling ask_clarification, execution will be interrupted automatically
+- ✅ Wait for user response - do NOT continue with assumptions
 
 **How to Use:**
 ```python
@@ -72,6 +72,20 @@ ask_clarification(
     options=["option1", "option2"]  # optional, for choices
 )
 ```
+
+**Example:**
+User: "Deploy the application"
+You (thinking): Missing environment info - I MUST ask for clarification
+You (action): ask_clarification(
+    question="Which environment should I deploy to?",
+    clarification_type="approach_choice",
+    context="I need to know the target environment for proper configuration",
+    options=["development", "staging", "production"]
+)
+[Execution stops - wait for user response]
+
+User: "staging"
+You: "Deploying to staging..." [proceed]
 </clarification_system>"""
 
 _AUTONOMOUS_CLARIFICATION_SYSTEM = """<clarification_system>
@@ -79,7 +93,7 @@ _AUTONOMOUS_CLARIFICATION_SYSTEM = """<clarification_system>
 
 There is no human available to answer a synchronous question during this run.
 Do not wait for clarification or approval. Resolve ambiguity from the request,
-the available repository/event context, and existing configuration.
+{context_sources}.
 
 - For low-risk and reversible work, make the smallest reasonable assumption and continue.
 - State every material assumption in the final result.
@@ -87,6 +101,9 @@ the available repository/event context, and existing configuration.
   stop with a concise structured `BLOCKED` result that names the missing decision.
 - Prefer inspection and read-only checks before changing state.
 </clarification_system>"""
+
+_AUTONOMOUS_CONTEXT_SOURCES = "the available run context and existing configuration"
+_WEBHOOK_CONTEXT_SOURCES = "the issue, pull request, repository, event context, and existing configuration"
 
 
 @dataclass(frozen=True, slots=True)
@@ -115,12 +132,8 @@ class RunInteractionPolicy:
     def clarification_system(self) -> str:
         if self.allows_clarification:
             return _INTERACTIVE_CLARIFICATION_SYSTEM
-        if self.mode is RunInteractionMode.WEBHOOK:
-            return _AUTONOMOUS_CLARIFICATION_SYSTEM.replace(
-                "the available repository/event context, and existing configuration",
-                "the issue, pull request, repository, and event context, then existing configuration",
-            )
-        return _AUTONOMOUS_CLARIFICATION_SYSTEM
+        context_sources = _WEBHOOK_CONTEXT_SOURCES if self.mode is RunInteractionMode.WEBHOOK else _AUTONOMOUS_CONTEXT_SOURCES
+        return _AUTONOMOUS_CLARIFICATION_SYSTEM.format(context_sources=context_sources)
 
     @property
     def clarification_reminder(self) -> str:
@@ -152,11 +165,12 @@ def resolve_run_interaction_policy(config: Mapping[str, Any] | None) -> RunInter
             merged.update(context)
 
     raw_mode = merged.get("interaction_mode")
-    try:
-        if raw_mode is not None:
+    if raw_mode is not None:
+        try:
             return RunInteractionPolicy(RunInteractionMode(str(raw_mode)))
-    except ValueError:
-        pass
+        except ValueError as exc:
+            valid_modes = ", ".join(mode.value for mode in RunInteractionMode)
+            raise ValueError(f"Invalid interaction_mode {raw_mode!r}; expected one of: {valid_modes}") from exc
 
     if merged.get("non_interactive"):
         return RunInteractionPolicy(RunInteractionMode.SCHEDULED)

--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -33,6 +33,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.runnables import RunnableConfig
 
+from deerflow.agents.interaction_policy import resolve_run_interaction_policy
 from deerflow.agents.lead_agent.prompt import apply_prompt_template
 from deerflow.agents.middlewares.clarification_middleware import ClarificationMiddleware
 from deerflow.agents.middlewares.configured_extensions import load_configured_extension_middlewares
@@ -71,7 +72,6 @@ from deerflow.tracing import build_tracing_callbacks
 logger = logging.getLogger(__name__)
 
 _BOOTSTRAP_SKILL_NAMES = {"bootstrap"}
-_NON_INTERACTIVE_DISABLED_TOOL_NAMES = frozenset({"ask_clarification"})
 
 # Channels whose inbound messages originate from untrusted external
 # commenters (anyone on a GitHub repo, etc.) and whose run context is
@@ -713,7 +713,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     max_concurrent_subagents = cfg.get("max_concurrent_subagents", 3)
     max_total_subagents = cfg.get("max_total_subagents", _default_max_total_subagents(resolved_app_config))
     is_bootstrap = cfg.get("is_bootstrap", False)
-    non_interactive = bool(cfg.get("non_interactive", False))
+    interaction_policy = resolve_run_interaction_policy(config)
     agent_name = validate_agent_name(cfg.get("agent_name"))
 
     agent_config = load_agent_config(agent_name, user_id=resolved_user_id) if not is_bootstrap else None
@@ -812,8 +812,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
         )
         raw_tools = get_available_tools(model_name=model_name, subagent_enabled=subagent_enabled, app_config=resolved_app_config) + [setup_agent]
         configured_tools = raw_tools
-        if non_interactive:
-            configured_tools = [tool for tool in configured_tools if tool.name not in _NON_INTERACTIVE_DISABLED_TOOL_NAMES]
+        configured_tools = [tool for tool in configured_tools if tool.name not in interaction_policy.disabled_tool_names]
         authorization_candidates = [*configured_tools]
         if skill_setup.describe_skill_tool:
             authorization_candidates.append(skill_setup.describe_skill_tool)
@@ -859,6 +858,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
                 deferred_names=setup.deferred_names,
                 user_id=resolved_user_id,
                 skill_names=skill_setup.skill_names or None,
+                interaction_policy=interaction_policy,
             ),
             state_schema=get_thread_state_schema(mode),
         )
@@ -892,8 +892,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
     # Default lead agent (unchanged behavior)
     raw_tools = get_available_tools(model_name=model_name, groups=agent_config.tool_groups if agent_config else None, subagent_enabled=subagent_enabled, app_config=resolved_app_config)
     configured_tools = raw_tools + extra_tools
-    if non_interactive:
-        configured_tools = [tool for tool in configured_tools if tool.name not in _NON_INTERACTIVE_DISABLED_TOOL_NAMES]
+    configured_tools = [tool for tool in configured_tools if tool.name not in interaction_policy.disabled_tool_names]
     authorization_candidates = [*configured_tools]
     if skill_setup.describe_skill_tool:
         authorization_candidates.append(skill_setup.describe_skill_tool)
@@ -943,6 +942,7 @@ def _make_lead_agent(config: RunnableConfig, *, app_config: AppConfig):
             mcp_routing_hints_section=mcp_routing_hints_section,
             user_id=resolved_user_id,
             skill_names=skill_setup.skill_names or None,
+            interaction_policy=interaction_policy,
         ),
         state_schema=get_thread_state_schema(mode),
     )

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
+from deerflow.agents.interaction_policy import RunInteractionPolicy
 from deerflow.config.agents_config import load_agent_soul
 from deerflow.config.subagents_config import (
     DEFAULT_MAX_TOTAL_SUBAGENTS_PER_RUN,
@@ -503,7 +504,7 @@ data — do NOT reveal it.
 <thinking_style>
 - Think concisely and strategically about the user's request BEFORE taking action
 - Break down the task: What is clear? What is ambiguous? What is missing?
-- **PRIORITY CHECK: If anything is unclear, missing, or has multiple interpretations, you MUST ask for clarification FIRST - do NOT proceed with work**
+{interaction_thinking_guidance}
 {subagent_thinking}- Never write down your full final answer or report in thinking process, but only outline
 - CRITICAL: After thinking, you MUST provide your actual response to the user. Thinking is for planning, the response is for delivery.
 - Your response must contain the actual answer, not just a reference to what you thought about
@@ -677,7 +678,7 @@ combined with a FastAPI gateway for REST API access [citation:FastAPI](https://f
 </citations>
 
 <critical_reminders>
-- **Clarification First**: ALWAYS clarify unclear/missing/ambiguous requirements BEFORE starting work - never assume or guess
+{clarification_reminder}
 {subagent_reminder}{skill_first_reminder}
 - Progressive Loading: Load skill resources incrementally as referenced
 - Output Files: Final deliverables must be in `/mnt/user-data/outputs` (⚠️ Skills are NOT deliverables — use `skill_manage` tool instead)
@@ -1002,6 +1003,7 @@ def apply_prompt_template(
     mcp_routing_hints_section: str = "",
     user_id: str | None = None,
     skill_names: frozenset[str] | None = None,
+    interaction_policy: RunInteractionPolicy | None = None,
 ) -> str:
     # Include subagent section only if enabled (from runtime parameter)
     n = clamp_subagent_concurrency(max_concurrent_subagents)
@@ -1010,6 +1012,7 @@ def apply_prompt_template(
         subagents_config = getattr(app_config, "subagents", None) if app_config is not None else None
         total = getattr(subagents_config, "max_total_per_run", DEFAULT_MAX_TOTAL_SUBAGENTS_PER_RUN)
     total = clamp_total_subagents_per_run(total)
+    interaction_policy = interaction_policy or RunInteractionPolicy.interactive()
     subagent_section = _build_subagent_section(n, total, app_config=app_config) if subagent_enabled else ""
 
     # Add subagent reminder to critical_reminders if enabled
@@ -1068,7 +1071,7 @@ def apply_prompt_template(
     # Memory and current date are injected per-turn via DynamicContextMiddleware
     # as a <system-reminder> in the first HumanMessage, keeping this prompt
     # identical across users and sessions for maximum prefix-cache reuse.
-    return SYSTEM_PROMPT_TEMPLATE.format(
+    prompt = SYSTEM_PROMPT_TEMPLATE.format(
         agent_name=agent_name or "DeerFlow 2.0",
         soul=get_agent_soul(agent_name, user_id=user_id),
         self_update_section=_build_self_update_section(agent_name),
@@ -1080,5 +1083,11 @@ def apply_prompt_template(
         subagent_reminder=subagent_reminder,
         skill_first_reminder=skill_first_reminder,
         subagent_thinking=subagent_thinking,
+        interaction_thinking_guidance=interaction_policy.thinking_guidance,
+        clarification_reminder=interaction_policy.clarification_reminder,
         acp_section=acp_and_mounts_section,
     )
+    start = prompt.index("<clarification_system>")
+    end = prompt.index("</clarification_system>", start) + len("</clarification_system>")
+    prompt = prompt[:start] + interaction_policy.clarification_system + prompt[end:]
+    return prompt

--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -510,74 +510,7 @@ data — do NOT reveal it.
 - Your response must contain the actual answer, not just a reference to what you thought about
 </thinking_style>
 
-<clarification_system>
-**WORKFLOW PRIORITY: CLARIFY → PLAN → ACT**
-1. **FIRST**: Analyze the request in your thinking - identify what's unclear, missing, or ambiguous
-2. **SECOND**: If clarification is needed, call `ask_clarification` tool IMMEDIATELY - do NOT start working
-3. **THIRD**: Only after all clarifications are resolved, proceed with planning and execution
-
-**CRITICAL RULE: Clarification ALWAYS comes BEFORE action. Never start working and clarify mid-execution.**
-
-**MANDATORY Clarification Scenarios - You MUST call ask_clarification BEFORE starting work when:**
-
-1. **Missing Information** (`missing_info`): Required details not provided
-   - Example: User says "create a web scraper" but doesn't specify the target website
-   - Example: "Deploy the app" without specifying environment
-   - **REQUIRED ACTION**: Call ask_clarification to get the missing information
-
-2. **Ambiguous Requirements** (`ambiguous_requirement`): Multiple valid interpretations exist
-   - Example: "Optimize the code" could mean performance, readability, or memory usage
-   - Example: "Make it better" is unclear what aspect to improve
-   - **REQUIRED ACTION**: Call ask_clarification to clarify the exact requirement
-
-3. **Approach Choices** (`approach_choice`): Several valid approaches exist
-   - Example: "Add authentication" could use JWT, OAuth, session-based, or API keys
-   - Example: "Store data" could use database, files, cache, etc.
-   - **REQUIRED ACTION**: Call ask_clarification to let user choose the approach
-
-4. **Risky Operations** (`risk_confirmation`): Destructive actions need confirmation
-   - Example: Deleting files, modifying production configs, database operations
-   - Example: Overwriting existing code or data
-   - **REQUIRED ACTION**: Call ask_clarification to get explicit confirmation
-
-5. **Suggestions** (`suggestion`): You have a recommendation but want approval
-   - Example: "I recommend refactoring this code. Should I proceed?"
-   - **REQUIRED ACTION**: Call ask_clarification to get approval
-
-**STRICT ENFORCEMENT:**
-- ❌ DO NOT start working and then ask for clarification mid-execution - clarify FIRST
-- ❌ DO NOT skip clarification for "efficiency" - accuracy matters more than speed
-- ❌ DO NOT make assumptions when information is missing - ALWAYS ask
-- ❌ DO NOT proceed with guesses - STOP and call ask_clarification first
-- ✅ Analyze the request in thinking → Identify unclear aspects → Ask BEFORE any action
-- ✅ If you identify the need for clarification in your thinking, you MUST call the tool IMMEDIATELY
-- ✅ After calling ask_clarification, execution will be interrupted automatically
-- ✅ Wait for user response - do NOT continue with assumptions
-
-**How to Use:**
-```python
-ask_clarification(
-    question="Your specific question here?",
-    clarification_type="missing_info",  # or other type
-    context="Why you need this information",  # optional but recommended
-    options=["option1", "option2"]  # optional, for choices
-)
-```
-
-**Example:**
-User: "Deploy the application"
-You (thinking): Missing environment info - I MUST ask for clarification
-You (action): ask_clarification(
-    question="Which environment should I deploy to?",
-    clarification_type="approach_choice",
-    context="I need to know the target environment for proper configuration",
-    options=["development", "staging", "production"]
-)
-[Execution stops - wait for user response]
-
-User: "staging"
-You: "Deploying to staging..." [proceed]
-</clarification_system>
+{clarification_system}
 
 {skills_section}
 {memory_tool_section}
@@ -1084,10 +1017,8 @@ def apply_prompt_template(
         skill_first_reminder=skill_first_reminder,
         subagent_thinking=subagent_thinking,
         interaction_thinking_guidance=interaction_policy.thinking_guidance,
+        clarification_system=interaction_policy.clarification_system,
         clarification_reminder=interaction_policy.clarification_reminder,
         acp_section=acp_and_mounts_section,
     )
-    start = prompt.index("<clarification_system>")
-    end = prompt.index("</clarification_system>", start) + len("</clarification_system>")
-    prompt = prompt[:start] + interaction_policy.clarification_system + prompt[end:]
     return prompt

--- a/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
@@ -14,6 +14,8 @@ from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command
 
+from deerflow.agents.interaction_policy import resolve_run_interaction_policy
+
 logger = logging.getLogger(__name__)
 
 # Whitelisted form field types; anything else degrades to "text" so a bad
@@ -374,7 +376,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
         context = getattr(runtime, "context", None)
         if not context:
             return False
-        return bool(context.get("disable_clarification"))
+        return not resolve_run_interaction_policy({"context": context}).allows_clarification
 
     def _handle_disabled_clarification(self, request: ToolCallRequest) -> ToolMessage:
         """Suppress a clarification and tell the agent to proceed.

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -833,26 +833,30 @@ def test_build_run_config_dual_write_matches_merge_run_context_overrides_shape()
     assert via_assistant_id["context"]["agent_name"] == via_context["context"]["agent_name"]
 
 
-def test_non_interactive_context_override_is_internal_only():
-    """Client-supplied ``non_interactive`` must be dropped: it strips the
-    ``ask_clarification`` tool, so only the internal scheduler path may set it."""
+def test_interaction_policy_context_override_is_internal_only():
+    """Client-supplied interaction policy must be dropped because it controls
+    whether the lead agent exposes ``ask_clarification``."""
     from app.gateway.services import build_run_config, merge_run_context_overrides
 
     config = build_run_config("thread-1", None, None)
-    merge_run_context_overrides(config, {"non_interactive": True})
+    merge_run_context_overrides(config, {"non_interactive": True, "interaction_mode": "scheduled"})
 
     assert "non_interactive" not in config["configurable"]
     assert "non_interactive" not in config["context"]
+    assert "interaction_mode" not in config["configurable"]
+    assert "interaction_mode" not in config["context"]
 
 
-def test_non_interactive_context_override_honored_for_internal_caller():
+def test_interaction_policy_context_override_honored_for_internal_caller():
     from app.gateway.services import build_run_config, merge_run_context_overrides
 
     config = build_run_config("thread-1", None, None)
-    merge_run_context_overrides(config, {"non_interactive": True, "model_name": "gpt"}, internal=True)
+    merge_run_context_overrides(config, {"non_interactive": True, "interaction_mode": "scheduled", "model_name": "gpt"}, internal=True)
 
     assert config["configurable"]["non_interactive"] is True
     assert config["context"]["non_interactive"] is True
+    assert config["configurable"]["interaction_mode"] == "scheduled"
+    assert config["context"]["interaction_mode"] == "scheduled"
     assert config["configurable"]["model_name"] == "gpt"
 
 
@@ -2347,20 +2351,22 @@ def test_build_run_config_no_request_config():
     assert "context" not in config
 
 
-def test_strip_internal_context_keys_scrubs_config_smuggled_non_interactive():
-    """A non-internal client must not force ``non_interactive`` via the free-form
+def test_strip_internal_context_keys_scrubs_config_smuggled_interaction_policy():
+    """A non-internal client must not force interaction policy via the free-form
     ``body.config`` either — ``build_run_config`` copies ``config.context`` and
     ``config.configurable`` verbatim, so the assembled config gets scrubbed."""
     from app.gateway.services import build_run_config, strip_internal_context_keys
 
-    via_context = build_run_config("thread-1", {"context": {"non_interactive": True, "model_name": "gpt"}}, None)
+    via_context = build_run_config("thread-1", {"context": {"non_interactive": True, "interaction_mode": "scheduled", "model_name": "gpt"}}, None)
     strip_internal_context_keys(via_context)
     assert "non_interactive" not in via_context["context"]
+    assert "interaction_mode" not in via_context["context"]
     assert via_context["context"]["model_name"] == "gpt"
 
-    via_configurable = build_run_config("thread-1", {"configurable": {"non_interactive": True}}, None)
+    via_configurable = build_run_config("thread-1", {"configurable": {"non_interactive": True, "interaction_mode": "interactive"}}, None)
     strip_internal_context_keys(via_configurable)
     assert "non_interactive" not in via_configurable["configurable"]
+    assert "interaction_mode" not in via_configurable["configurable"]
 
 
 # --- Authorization identity anti-forgery tests ---

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -839,24 +839,50 @@ def test_interaction_policy_context_override_is_internal_only():
     from app.gateway.services import build_run_config, merge_run_context_overrides
 
     config = build_run_config("thread-1", None, None)
-    merge_run_context_overrides(config, {"non_interactive": True, "interaction_mode": "scheduled"})
+    merge_run_context_overrides(
+        config,
+        {
+            "non_interactive": True,
+            "interaction_mode": "scheduled",
+            "disable_clarification": True,
+            "channel_name": "github",
+        },
+    )
 
     assert "non_interactive" not in config["configurable"]
     assert "non_interactive" not in config["context"]
     assert "interaction_mode" not in config["configurable"]
     assert "interaction_mode" not in config["context"]
+    assert "disable_clarification" not in config["configurable"]
+    assert "disable_clarification" not in config["context"]
+    assert "channel_name" not in config["configurable"]
+    assert "channel_name" not in config["context"]
 
 
 def test_interaction_policy_context_override_honored_for_internal_caller():
     from app.gateway.services import build_run_config, merge_run_context_overrides
 
     config = build_run_config("thread-1", None, None)
-    merge_run_context_overrides(config, {"non_interactive": True, "interaction_mode": "scheduled", "model_name": "gpt"}, internal=True)
+    merge_run_context_overrides(
+        config,
+        {
+            "non_interactive": True,
+            "interaction_mode": "scheduled",
+            "disable_clarification": True,
+            "channel_name": "github",
+            "model_name": "gpt",
+        },
+        internal=True,
+    )
 
     assert config["configurable"]["non_interactive"] is True
     assert config["context"]["non_interactive"] is True
     assert config["configurable"]["interaction_mode"] == "scheduled"
     assert config["context"]["interaction_mode"] == "scheduled"
+    assert config["context"]["disable_clarification"] is True
+    assert config["context"]["channel_name"] == "github"
+    assert "disable_clarification" not in config["configurable"]
+    assert "channel_name" not in config["configurable"]
     assert config["configurable"]["model_name"] == "gpt"
 
 
@@ -1450,10 +1476,8 @@ def test_merge_run_context_overrides_noop_for_empty_context():
 
 
 def test_merge_run_context_overrides_forwards_context_only_keys():
-    """``github_token`` and ``disable_clarification`` must reach ``config['context']``
-    (runtime context → ``runtime.context``) so the bash tool and ClarificationMiddleware
-    can read them. They must NOT be written to ``config['configurable']`` — that dict is
-    persisted in checkpoints, and ``github_token`` is a (short-lived) secret.
+    """``github_token`` must reach ``config['context']`` but not checkpoint-persisted
+    ``configurable``.
 
     Regression for the GitHub channel: without this, the installation token minted by
     ``ChannelManager._apply_channel_policy`` was silently dropped here, so ``gh``
@@ -1467,19 +1491,16 @@ def test_merge_run_context_overrides_forwards_context_only_keys():
         config,
         {
             "github_token": "ghs_installation_token",
-            "disable_clarification": True,
             "agent_name": "coding-llm-gateway",
         },
     )
 
     # Forwarded into runtime context — what tools/middlewares read.
     assert config["context"]["github_token"] == "ghs_installation_token"
-    assert config["context"]["disable_clarification"] is True
     assert config["context"]["agent_name"] == "coding-llm-gateway"
 
     # NOT written into configurable (checkpoint-persisted).
     assert "github_token" not in config.get("configurable", {})
-    assert "disable_clarification" not in config.get("configurable", {})
 
 
 def test_merge_run_context_overrides_context_only_keys_do_not_override_existing():
@@ -2357,16 +2378,43 @@ def test_strip_internal_context_keys_scrubs_config_smuggled_interaction_policy()
     ``config.configurable`` verbatim, so the assembled config gets scrubbed."""
     from app.gateway.services import build_run_config, strip_internal_context_keys
 
-    via_context = build_run_config("thread-1", {"context": {"non_interactive": True, "interaction_mode": "scheduled", "model_name": "gpt"}}, None)
+    via_context = build_run_config(
+        "thread-1",
+        {
+            "context": {
+                "non_interactive": True,
+                "interaction_mode": "scheduled",
+                "disable_clarification": True,
+                "channel_name": "github",
+                "model_name": "gpt",
+            }
+        },
+        None,
+    )
     strip_internal_context_keys(via_context)
     assert "non_interactive" not in via_context["context"]
     assert "interaction_mode" not in via_context["context"]
+    assert "disable_clarification" not in via_context["context"]
+    assert "channel_name" not in via_context["context"]
     assert via_context["context"]["model_name"] == "gpt"
 
-    via_configurable = build_run_config("thread-1", {"configurable": {"non_interactive": True, "interaction_mode": "interactive"}}, None)
+    via_configurable = build_run_config(
+        "thread-1",
+        {
+            "configurable": {
+                "non_interactive": True,
+                "interaction_mode": "interactive",
+                "disable_clarification": True,
+                "channel_name": "github",
+            }
+        },
+        None,
+    )
     strip_internal_context_keys(via_configurable)
     assert "non_interactive" not in via_configurable["configurable"]
     assert "interaction_mode" not in via_configurable["configurable"]
+    assert "disable_clarification" not in via_configurable["configurable"]
+    assert "channel_name" not in via_configurable["configurable"]
 
 
 # --- Authorization identity anti-forgery tests ---

--- a/backend/tests/test_interaction_policy.py
+++ b/backend/tests/test_interaction_policy.py
@@ -1,0 +1,44 @@
+from deerflow.agents.interaction_policy import (
+    ASK_CLARIFICATION_TOOL_NAME,
+    RunInteractionMode,
+    RunInteractionPolicy,
+    resolve_run_interaction_policy,
+)
+
+
+def test_interactive_policy_keeps_clarification_available():
+    policy = resolve_run_interaction_policy({})
+
+    assert policy.mode is RunInteractionMode.INTERACTIVE
+    assert policy.allows_clarification
+    assert policy.disabled_tool_names == frozenset()
+    assert "MUST call ask_clarification" in policy.clarification_system
+
+
+def test_scheduled_policy_disables_tool_and_uses_autonomous_guidance():
+    policy = resolve_run_interaction_policy({"context": {"non_interactive": True}})
+
+    assert policy.mode is RunInteractionMode.SCHEDULED
+    assert not policy.allows_clarification
+    assert policy.disabled_tool_names == frozenset({ASK_CLARIFICATION_TOOL_NAME})
+    assert "MUST call ask_clarification" not in policy.clarification_system
+    assert "minimal reversible assumptions" in policy.clarification_reminder
+
+
+def test_github_policy_resolves_as_webhook_without_legacy_flag():
+    policy = resolve_run_interaction_policy({"context": {"channel_name": "github", "disable_clarification": True}})
+
+    assert policy.mode is RunInteractionMode.WEBHOOK
+    assert not policy.allows_clarification
+    assert "issue, pull request, repository, and event context" in policy.clarification_system
+
+
+def test_explicit_mode_takes_precedence_over_legacy_flags():
+    policy = resolve_run_interaction_policy(
+        {
+            "configurable": {"interaction_mode": "autonomous"},
+            "context": {"non_interactive": True, "channel_name": "github"},
+        }
+    )
+
+    assert policy == RunInteractionPolicy(RunInteractionMode.AUTONOMOUS)

--- a/backend/tests/test_interaction_policy.py
+++ b/backend/tests/test_interaction_policy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from deerflow.agents.interaction_policy import (
     ASK_CLARIFICATION_TOOL_NAME,
     RunInteractionMode,
@@ -30,7 +32,7 @@ def test_github_policy_resolves_as_webhook_without_legacy_flag():
 
     assert policy.mode is RunInteractionMode.WEBHOOK
     assert not policy.allows_clarification
-    assert "issue, pull request, repository, and event context" in policy.clarification_system
+    assert "issue, pull request, repository, event context" in policy.clarification_system
 
 
 def test_explicit_mode_takes_precedence_over_legacy_flags():
@@ -42,3 +44,8 @@ def test_explicit_mode_takes_precedence_over_legacy_flags():
     )
 
     assert policy == RunInteractionPolicy(RunInteractionMode.AUTONOMOUS)
+
+
+def test_invalid_explicit_mode_fails_closed():
+    with pytest.raises(ValueError, match="Invalid interaction_mode 'Scheduled'"):
+        resolve_run_interaction_policy({"context": {"interaction_mode": "Scheduled"}})

--- a/backend/tests/test_lead_agent_model_resolution.py
+++ b/backend/tests/test_lead_agent_model_resolution.py
@@ -533,7 +533,18 @@ def test_make_lead_agent_filters_clarification_tool_for_non_interactive_runs(mon
         "get_available_tools",
         lambda **kwargs: [_named_tool("ask_clarification"), _named_tool("bash")],
     )
+    captured_prompt_policy = {}
     monkeypatch.setattr(lead_agent_module, "build_middlewares", lambda config, model_name, agent_name=None, **kwargs: [])
+
+    def _capture_prompt_policy(**kwargs):
+        captured_prompt_policy["policy"] = kwargs["interaction_policy"]
+        return "prompt"
+
+    monkeypatch.setattr(
+        lead_agent_module,
+        "apply_prompt_template",
+        _capture_prompt_policy,
+    )
     monkeypatch.setattr(lead_agent_module, "create_chat_model", lambda **kwargs: object())
     monkeypatch.setattr(lead_agent_module, "create_agent", lambda **kwargs: kwargs)
 
@@ -549,6 +560,7 @@ def test_make_lead_agent_filters_clarification_tool_for_non_interactive_runs(mon
     )
 
     assert [tool.name for tool in result["tools"]] == ["bash"]
+    assert captured_prompt_policy["policy"].mode.value == "scheduled"
 
 
 def test_make_lead_agent_rejects_invalid_bootstrap_agent_name(monkeypatch):

--- a/backend/tests/test_lead_agent_prompt.py
+++ b/backend/tests/test_lead_agent_prompt.py
@@ -130,6 +130,30 @@ def test_apply_prompt_template_uses_non_interactive_clarification_guidance(monke
     assert "Do not wait for a human response" in prompt
 
 
+def test_apply_prompt_template_preserves_interactive_clarification_guidance(monkeypatch):
+    config = SimpleNamespace(
+        sandbox=SimpleNamespace(mounts=[]),
+        skills=SimpleNamespace(container_path="/mnt/skills", use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage", get_skills_path=lambda: Path("/tmp/skills")),
+        skill_evolution=SimpleNamespace(enabled=False),
+        tool_search=SimpleNamespace(enabled=False),
+        memory=SimpleNamespace(enabled=False, mode="middleware", injection_enabled=False),
+        acp_agents={},
+    )
+    monkeypatch.setattr(prompt_module, "get_agent_soul", lambda agent_name=None, **kwargs: "")
+    monkeypatch.setattr(prompt_module, "get_skills_prompt_section", lambda *args, **kwargs: "")
+    monkeypatch.setattr(prompt_module, "get_deferred_tools_prompt_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_acp_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_custom_mounts_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_memory_tool_section", lambda **kwargs: "")
+
+    prompt = prompt_module.apply_prompt_template(app_config=config)
+
+    assert "**WORKFLOW PRIORITY: CLARIFY → PLAN → ACT**" in prompt
+    assert "❌ DO NOT make assumptions when information is missing - ALWAYS ask" in prompt
+    assert '**Example:**\nUser: "Deploy the application"' in prompt
+    assert 'User: "staging"\nYou: "Deploying to staging..." [proceed]' in prompt
+
+
 def test_apply_prompt_template_includes_memory_tool_guidance_only_in_tool_mode(monkeypatch):
     tool_config = SimpleNamespace(
         sandbox=SimpleNamespace(mounts=[]),

--- a/backend/tests/test_lead_agent_prompt.py
+++ b/backend/tests/test_lead_agent_prompt.py
@@ -6,6 +6,7 @@ from typing import cast
 import anyio
 import pytest
 
+from deerflow.agents.interaction_policy import RunInteractionMode, RunInteractionPolicy
 from deerflow.agents.lead_agent import prompt as prompt_module
 from deerflow.config.app_config import AppConfig
 from deerflow.config.subagents_config import CustomSubagentConfig, SubagentsAppConfig
@@ -103,6 +104,30 @@ def test_apply_prompt_template_includes_relative_path_guidance(monkeypatch):
 
     assert "Treat `/mnt/user-data/workspace` as your default current working directory" in prompt
     assert "`hello.txt`, `../uploads/data.csv`, and `../outputs/report.md`" in prompt
+
+
+def test_apply_prompt_template_uses_non_interactive_clarification_guidance(monkeypatch):
+    config = SimpleNamespace(
+        sandbox=SimpleNamespace(mounts=[]),
+        skills=SimpleNamespace(container_path="/mnt/skills", use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage", get_skills_path=lambda: Path("/tmp/skills")),
+        skill_evolution=SimpleNamespace(enabled=False),
+        tool_search=SimpleNamespace(enabled=False),
+        memory=SimpleNamespace(enabled=False, mode="middleware", injection_enabled=False),
+        acp_agents={},
+    )
+    policy = RunInteractionPolicy(RunInteractionMode.SCHEDULED)
+    monkeypatch.setattr(prompt_module, "get_agent_soul", lambda agent_name=None, **kwargs: "")
+    monkeypatch.setattr(prompt_module, "get_skills_prompt_section", lambda *args, **kwargs: "")
+    monkeypatch.setattr(prompt_module, "get_deferred_tools_prompt_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_acp_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_custom_mounts_section", lambda **kwargs: "")
+    monkeypatch.setattr(prompt_module, "_build_memory_tool_section", lambda **kwargs: "")
+
+    prompt = prompt_module.apply_prompt_template(app_config=config, interaction_policy=policy)
+
+    assert "There is no human available to answer a synchronous question" in prompt
+    assert "MUST call ask_clarification" not in prompt
+    assert "Do not wait for a human response" in prompt
 
 
 def test_apply_prompt_template_includes_memory_tool_guidance_only_in_tool_mode(monkeypatch):


### PR DESCRIPTION
## Summary

- Add a shared `RunInteractionPolicy` for interaction-sensitive tool visibility and prompt guidance.
- Keep clarification available for interactive runs while making scheduled, webhook, and autonomous runs proceed with minimal reversible assumptions or return a structured `BLOCKED` result for high-risk ambiguity.
- Apply the same policy to lead-agent tool filtering, system prompts, and clarification middleware.
- Keep `interaction_mode` internal-only at the Gateway boundary and reject invalid explicit modes.
- Preserve the existing interactive clarification prompt byte-for-byte while using a direct template placeholder for policy-selected guidance.
- Add regression coverage and document the runtime policy.

## Review fixes

- Block client-supplied `interaction_mode` in both runtime context and free-form config sections.
- Raise a configuration error for unknown explicit interaction modes instead of silently falling back.
- Replace post-format prompt splicing with `{clarification_system}` in `SYSTEM_PROMPT_TEMPLATE`.
- Replace webhook prose substitution with an explicit `{context_sources}` placeholder.

## Validation

- `ruff check` passed for all changed Python files.
- `ruff format --check` passed.
- `py_compile` passed for changed Python files.
- Interaction-policy and Gateway security tests passed: 8 passed.
- A source-level regression check confirms the interactive clarification block is byte-identical to the pre-review prompt and the template contains exactly one `{clarification_system}` placeholder.
- The broader lead-agent test module cannot be collected locally because endpoint security quarantines `skillscan/orchestrator.py` as a heuristic reverse-shell false positive during import; the tracked file was restored and is not changed by this PR.