### PR TITLE
feat: add TrustedRouter as a setup-wizard LLM provider

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -573,6 +573,22 @@ models:
   #   max_tokens: 8192
   #   temperature: 0.7
 
+  # Example: TrustedRouter (OpenAI-compatible)
+  # Model ids are namespaced (anthropic/claude-opus-4-7); a bare id is rejected.
+  # Ids under trustedrouter/ are routing policies rather than single models: each
+  # picks an upstream per request and fails over, and trustedrouter/zdr restricts
+  # routing to providers that retain no data.
+  # - name: trustedrouter-auto
+  #   display_name: TrustedRouter Auto
+  #   use: langchain_openai:ChatOpenAI
+  #   model: trustedrouter/auto
+  #   api_key: $TRUSTEDROUTER_API_KEY
+  #   base_url: https://api.trustedrouter.com/v1
+  #   request_timeout: 600.0
+  #   max_retries: 2
+  #   max_tokens: 8192
+  #   temperature: 0.7
+
   # Example: Atlas Cloud (OpenAI-compatible)
   # Atlas Cloud exposes a single OpenAI-compatible endpoint in front of many open
   # models (DeepSeek, Qwen, Kimi, GLM, MiniMax, Llama, ...), so it uses the same

--- a/scripts/wizard/providers.py
+++ b/scripts/wizard/providers.py
@@ -435,6 +435,28 @@ LLM_PROVIDERS: list[LLMProvider] = [
         },
     ),
     LLMProvider(
+        name="trustedrouter",
+        display_name="TrustedRouter",
+        description="OpenAI-compatible router with per-request failover and privacy-constrained routes",
+        use="langchain_openai:ChatOpenAI",
+        models=[
+            "trustedrouter/auto",
+            "trustedrouter/zdr",
+            "anthropic/claude-opus-4-7",
+            "openai/gpt-5.4-mini",
+        ],
+        default_model="trustedrouter/auto",
+        env_var="TRUSTEDROUTER_API_KEY",
+        package="langchain-openai",
+        extra_config={
+            "base_url": "https://api.trustedrouter.com/v1",
+            "request_timeout": 600.0,
+            "max_retries": 2,
+            "max_tokens": 8192,
+            "temperature": 0.7,
+        },
+    ),
+    LLMProvider(
         name="orcarouter",
         display_name="OrcaRouter",
         description="OpenAI-compatible adaptive routing gateway",


### PR DESCRIPTION
Adds TrustedRouter to the setup wizard's LLM providers, plus a commented example in `config.example.yaml`.

TrustedRouter is an OpenAI-compatible router — one key reaches models from OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover. It reuses `langchain_openai:ChatOpenAI` with `base_url: https://api.trustedrouter.com/v1`, matching the existing `openrouter` and `orcarouter` entries, so no new adapter is involved.

Two behaviours are documented in the config example because neither is guessable:

- Model ids are namespaced — `anthropic/claude-opus-4-7` works, a bare `claude-opus-4-7` is rejected.
- Ids under `trustedrouter/` are routing policies rather than single models. Each picks an upstream per request and fails over, and `trustedrouter/zdr` restricts routing to providers that retain no data — relevant here since deep-research runs push retrieved page content through the model.

Verified by importing `wizard.providers` and checking the entry resolves (`base_url`, `env_var`, `default_model` present in `models`, `extra_config_for(default_model)` non-empty), and that the provider set asserted by `test_llm_providers_cover_config_example_families` is still a subset — that test uses `issubset`, so a new provider doesn't disturb it. `config.example.yaml` still parses as YAML.

I could not run `backend/tests/test_setup_wizard.py` end-to-end: its autouse fixtures import the `deerflow` package, which needs the full backend install. Happy to confirm against CI.
