### PR TITLE
docs: fix broken star history charts across READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1454,4 +1454,4 @@ Your unwavering commitment and expertise have been the driving force behind Deer
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.com/#bytedance/deer-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.dera.page/#bytedance/deer-flow&Date)

--- a/README_fr.md
+++ b/README_fr.md
@@ -775,4 +775,4 @@ Votre engagement sans faille et votre expertise sont le moteur du succès de Dee
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.com/#bytedance/deer-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.dera.page/#bytedance/deer-flow&Date)

--- a/README_ja.md
+++ b/README_ja.md
@@ -762,4 +762,4 @@ DeerFlowはオープンソースコミュニティの素晴らしい成果の上
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.com/#bytedance/deer-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.dera.page/#bytedance/deer-flow&Date)

--- a/README_ru.md
+++ b/README_ru.md
@@ -693,4 +693,4 @@ DeerFlow стоит на плечах open-source сообщества. Спас
 
 ## История звёзд
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.com/#bytedance/deer-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.dera.page/#bytedance/deer-flow&Date)

--- a/README_zh.md
+++ b/README_zh.md
@@ -795,4 +795,4 @@ DeerFlow 建立在开源社区大量优秀工作的基础上。所有让 DeerFlo
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.com/#bytedance/deer-flow&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=bytedance/deer-flow&type=Date)](https://star-history.dera.page/#bytedance/deer-flow&Date)


### PR DESCRIPTION
The Star History charts on our READMEs are currently broken: the chart service depends on GitHub stargazer data that is now restricted, so the images no longer load. This change points the charts at a working alternative that requires no API token and keeps the same chart on every localized README (English, Simplified Chinese, Japanese, French, and Russian).