### PR TITLE
fix(present_files): fail loudly when presenting a nonexistent file

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/present_file_tool.py
@@ -77,6 +77,15 @@ def _normalize_presented_filepath(
     except ValueError as exc:
         raise ValueError(f"Only files in {OUTPUTS_VIRTUAL_PREFIX} can be presented: {filepath}") from exc
 
+    # The file must actually exist: silently "presenting" a file that was never
+    # written (e.g. the agent's write command failed earlier) produces a success
+    # message here but a 404 for every downstream consumer. Failing loudly lets
+    # the agent self-correct by writing the file first.
+    if not actual_path.exists():
+        raise ValueError(f"File not found: {filepath} — write the file to {OUTPUTS_VIRTUAL_PREFIX} before presenting it")
+    if not actual_path.is_file():
+        raise ValueError(f"Path is not a file: {filepath}")
+
     return f"{OUTPUTS_VIRTUAL_PREFIX}/{relative_path.as_posix()}"
 
 

--- a/backend/tests/test_present_file_tool_core_logic.py
+++ b/backend/tests/test_present_file_tool_core_logic.py
@@ -127,3 +127,42 @@ def test_present_files_rejects_paths_outside_outputs(tmp_path):
 
     assert "artifacts" not in result.update
     assert result.update["messages"][0].content == f"Error: Only files in /mnt/user-data/outputs can be presented: {leaked_path}"
+
+
+def test_present_files_rejects_nonexistent_file(tmp_path):
+    """Presenting a file that was never written must fail loudly.
+
+    Without an existence check the tool returns "Successfully presented files"
+    for a path that was never created (e.g. the agent's write step failed
+    earlier), and every downstream consumer then 404s on artifact fetch.
+    """
+    outputs_dir = tmp_path / "threads" / "thread-1" / "user-data" / "outputs"
+    outputs_dir.mkdir(parents=True)
+    missing_path = outputs_dir / "research_package.json"  # never written
+
+    result = present_file_tool_module.present_file_tool.func(
+        runtime=_make_runtime(str(outputs_dir)),
+        filepaths=[str(missing_path)],
+        tool_call_id="tc-missing",
+    )
+
+    assert "artifacts" not in result.update
+    content = result.update["messages"][0].content
+    assert content.startswith("Error:")
+    assert "not found" in content.lower()
+
+
+def test_present_files_rejects_directory_path(tmp_path):
+    """A directory inside outputs cannot be presented as a file artifact."""
+    outputs_dir = tmp_path / "threads" / "thread-1" / "user-data" / "outputs"
+    sub_dir = outputs_dir / "subdir"
+    sub_dir.mkdir(parents=True)
+
+    result = present_file_tool_module.present_file_tool.func(
+        runtime=_make_runtime(str(outputs_dir)),
+        filepaths=[str(sub_dir)],
+        tool_call_id="tc-dir",
+    )
+
+    assert "artifacts" not in result.update
+    assert result.update["messages"][0].content.startswith("Error:")


### PR DESCRIPTION
## Problem

`present_files` returns **\"Successfully presented files\"** even when the target file was never written — e.g. the agent's preceding write step failed (blocked command, sandbox error, typo'd path). Every downstream consumer (frontend artifact viewer, `GET /api/threads/{id}/artifacts/...`) then 404s, and the surfaced error misleads both the user and the agent about what went wrong.

## Fix

Validate existence (and file-ness) during path normalization in `_normalize_presented_filepath`:

- nonexistent path → `Error: File not found: ... — write the file to /mnt/user-data/outputs before presenting it`
- directory path → `Error: Path is not a file: ...`

Failing loudly lets the agent self-correct by actually writing the file first, instead of the run appearing successful.

## Tests

Two regression tests added to `test_present_file_tool_core_logic.py` (nonexistent file, directory path). Full related suites pass locally: `test_present_file_tool_core_logic.py`, `test_present_files_e2e_user_isolation.py`, `test_run_journal.py`, `test_run_manager.py`, `test_run_worker_delivery.py`, `test_tool_progress_middleware.py` (240 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)