### PR TITLE
feat(memory): per-run opt-out of memory injection via configurable.disable_memory_injection

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/agent.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/agent.py
@@ -438,7 +438,10 @@ def build_middlewares(
     # first HumanMessage to keep the system prompt fully static for prefix-cache reuse.
     from deerflow.agents.middlewares.dynamic_context_middleware import DynamicContextMiddleware
 
-    middlewares.append(DynamicContextMiddleware(agent_name=agent_name, app_config=resolved_app_config))
+    # Per-run opt-out: configurable.disable_memory_injection=True skips memory (date kept).
+    cfg = _get_runtime_config(config)
+    disable_memory = bool(cfg.get("disable_memory_injection", False))
+    middlewares.append(DynamicContextMiddleware(agent_name=agent_name, app_config=resolved_app_config, disable_memory=disable_memory))
 
     # Deterministically load a full SKILL.md when the user starts the turn with
     # /skill-name. This keeps the base system prompt metadata-only while giving

--- a/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/dynamic_context_middleware.py
@@ -221,10 +221,14 @@ class DynamicContextMiddleware(AgentMiddleware):
     day see the corrected date in history and skip re-injection.
     """
 
-    def __init__(self, agent_name: str | None = None, *, app_config: AppConfig | None = None):
+    def __init__(self, agent_name: str | None = None, *, app_config: AppConfig | None = None, disable_memory: bool = False):
         super().__init__()
         self._agent_name = agent_name
         self._app_config = app_config
+        # Per-run opt-out (configurable.disable_memory_injection): skip the memory
+        # block while keeping the date reminder. The global memory.injection_enabled
+        # switch is unaffected.
+        self._disable_memory = disable_memory
 
     def _build_full_reminder(self, runtime: Runtime | None = None) -> tuple[str, str | None]:
         """Return (date_reminder, memory_block | None).
@@ -236,7 +240,7 @@ class DynamicContextMiddleware(AgentMiddleware):
         """
         from deerflow.agents.lead_agent.prompt import _get_memory_context
 
-        injection_enabled = self._app_config.memory.injection_enabled if self._app_config else True
+        injection_enabled = (not self._disable_memory) and (self._app_config.memory.injection_enabled if self._app_config else True)
         memory_context = (
             _get_memory_context(
                 self._agent_name,

--- a/backend/tests/test_dynamic_context_middleware.py
+++ b/backend/tests/test_dynamic_context_middleware.py
@@ -800,3 +800,60 @@ def test_no_recursive_id_swap_in_full_middleware_flow():
     msgs_v2 = result_v2["messages"]
     assert msgs_v2[0].id == "msg-2"  # reminder takes new message's ID
     assert msgs_v2[1].id == "msg-2__user"  # user content gets derived ID
+
+
+# ---------------------------------------------------------------------------
+# Per-run opt-out: configurable.disable_memory_injection
+# ---------------------------------------------------------------------------
+
+_MEMORY_BLOCK = "<memory>\nUser prefers Python.\n</memory>"
+
+
+def _app_config_with_injection_enabled():
+    """Minimal app_config stub: memory.injection_enabled=True (global switch on)."""
+    return SimpleNamespace(memory=SimpleNamespace(injection_enabled=True))
+
+
+def test_disable_memory_skips_memory_but_keeps_current_date():
+    """disable_memory=True → reminder has <current_date> but no <memory>."""
+    mw = _make_middleware(agent_name="test-agent", app_config=_app_config_with_injection_enabled(), disable_memory=True)
+
+    with mock.patch("deerflow.agents.lead_agent.prompt._get_memory_context", return_value=_MEMORY_BLOCK):
+        _date_reminder, memory_block = mw._build_full_reminder()
+
+    assert memory_block is None
+    assert "<current_date>" in _date_reminder
+
+
+def test_build_middlewares_propagates_disable_memory_injection_flag():
+    """configurable.disable_memory_injection=True → DynamicContextMiddleware gets disable_memory=True."""
+    from deerflow.agents.lead_agent.agent import build_middlewares
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    config = {"configurable": {"disable_memory_injection": True}}
+    middlewares = build_middlewares(config, model_name=None, agent_name="test-agent", app_config=AppConfig(sandbox=SandboxConfig(use="test")))
+
+    dcm = [m for m in middlewares if isinstance(m, DynamicContextMiddleware)]
+    assert len(dcm) == 1
+    assert dcm[0]._disable_memory is True
+
+
+def test_default_behavior_still_injects_memory():
+    """Regression: without the flag, memory is injected as before."""
+    from deerflow.agents.lead_agent.agent import build_middlewares
+    from deerflow.config.app_config import AppConfig
+    from deerflow.config.sandbox_config import SandboxConfig
+
+    middlewares = build_middlewares({"configurable": {}}, model_name=None, agent_name="test-agent", app_config=AppConfig(sandbox=SandboxConfig(use="test")))
+
+    dcm = [m for m in middlewares if isinstance(m, DynamicContextMiddleware)]
+    assert len(dcm) == 1
+    assert dcm[0]._disable_memory is False
+
+    mw = _make_middleware(agent_name="test-agent", app_config=_app_config_with_injection_enabled())
+    with mock.patch("deerflow.agents.lead_agent.prompt._get_memory_context", return_value=_MEMORY_BLOCK):
+        _date_reminder, memory_block = mw._build_full_reminder()
+
+    assert memory_block is not None and "<memory>" in memory_block
+    assert "<current_date>" in _date_reminder


### PR DESCRIPTION
## Problem

Memory injection is controlled only by the global `memory.injection_enabled` switch — all-or-nothing at process level. Automation callers that drive many runs through the API (batch pipelines, multi-tenant backends) may want memory **off for specific runs** while keeping it on for interactive users: injecting an operator's personal memory into unrelated batch jobs is both useless and token-wasteful.

## Change

- `DynamicContextMiddleware` accepts a new `disable_memory: bool = False` parameter; when set, the memory block is skipped while the `<current_date>` reminder is still injected.
- `build_middlewares()` wires it from `configurable.disable_memory_injection`, so callers opt out per run:

```python
config = {"configurable": {"disable_memory_injection": True}}
```

The global switch and default behavior are unchanged.

## Tests

Three tests added to `test_dynamic_context_middleware.py`:

- flag set → memory skipped, date kept
- flag propagation through `build_middlewares`
- regression: default behavior still injects memory

`test_dynamic_context_middleware.py` (31) plus `test_lead_agent_model_resolution.py`, `test_client.py`, `test_memory_middleware.py`, `test_lead_agent_prompt.py` (242) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)