### PR TITLE
fix(docker): keep runtime data out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -65,6 +65,14 @@ frontend/node_modules
 backend/.venv
 backend/htmlcov
 backend/.coverage
+
+# Runtime data written by a running DeerFlow, not build inputs. backend/Dockerfile
+# does `COPY backend ./backend`, so leaving these in the context both bakes the
+# sqlite database, per-user uploads and the JWT secret into the image and breaks
+# the build outright once the app has created directories owned by the container's
+# root that the build client cannot read.
+**/.deer-flow/
+backend/sandbox/
 *.md
 !README.md
 !frontend/README.md

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.env
+**/.env
 Dockerfile
 .dockerignore
 .git

--- a/backend/tests/test_dockerignore_excludes_runtime_data.py
+++ b/backend/tests/test_dockerignore_excludes_runtime_data.py
@@ -1,10 +1,12 @@
-"""Regression test keeping runtime data out of the Docker build context.
+"""Regression test keeping host-local data out of the Docker build context.
 
 ``backend/Dockerfile`` copies the backend tree wholesale (``COPY backend ./backend``),
 so every path under ``backend/`` that ``.dockerignore`` does not exclude is shipped
 into the image. The runtime directories are written by a *running* DeerFlow, not by
-a build:
+a build or local deployment:
 
+- Exact ``.env`` files hold deployment secrets at the repository root and in
+  the backend/frontend projects.
 - ``DEER_FLOW_HOME`` (``backend/.deer-flow`` by default) holds the sqlite database,
   per-user agent definitions and uploads, and ``.jwt_secret``.
 - ``backend/sandbox`` is the local sandbox provider's workspace root, created by
@@ -19,20 +21,25 @@ fails outright::
     target gateway: failed to solve: error from sender:
     open .../.deer-flow/users/<uuid>/integrations/lark-cli: permission denied
 
-Neither directory has any tracked content, so excluding them costs the build nothing.
+None of these paths has tracked content, so excluding them costs the build nothing.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+from fnmatch import fnmatchcase
+from pathlib import Path, PurePosixPath
 
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERIGNORE = REPO_ROOT / ".dockerignore"
 
-# Paths a running DeerFlow creates that must never enter the build context.
-RUNTIME_PATHS = [
+# Host-local runtime and secret paths that must never enter the build context.
+HOST_LOCAL_PATHS = [
+    ".env",
+    "backend/.env",
+    "frontend/.env",
+    ".deer-flow/integrations/skills/provider/pack/SKILL.md",
     "backend/.deer-flow/data/deerflow.db",
     "backend/.deer-flow/.jwt_secret",
     "backend/.deer-flow/users/some-user/agents/my-agent/config.yaml",
@@ -41,6 +48,8 @@ RUNTIME_PATHS = [
 
 # Paths the build genuinely needs; the exclusions must not swallow them.
 BUILD_INPUT_PATHS = [
+    ".env.example",
+    "frontend/.env.example",
     "backend/pyproject.toml",
     "backend/app/gateway/app.py",
     "backend/packages/harness/deerflow/config/extensions_config.py",
@@ -52,31 +61,55 @@ def _ignore_patterns() -> list[str]:
     return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
 
 
-def _matches(pattern: str, path: str) -> bool:
-    """Whether *pattern* excludes *path*, for the pattern shapes this file uses.
+def _pattern_matches(pattern: str, path: str) -> bool:
+    """Whether one non-negated pattern matches *path*.
 
-    Docker matches ``.dockerignore`` entries against context-relative paths. Only
-    two shapes are needed here: a directory prefix (``backend/sandbox/``) and a
-    leading ``**/`` that anchors a directory name at any depth.
+    This intentionally models the pattern shapes used by this repository rather
+    than reimplementing Docker's full matcher: root-relative names/globs,
+    directory prefixes, trailing ``/**``, and leading ``**/name`` patterns.
     """
-    if pattern.startswith("!"):
-        return False
     pattern = pattern.rstrip("/")
     if pattern.startswith("**/"):
         name = pattern[3:]
-        return name in Path(path).parts
+        return name in PurePosixPath(path).parts
+    if pattern.endswith("/**"):
+        pattern = pattern[:-3].rstrip("/")
+    if "/" not in pattern:
+        root_name = PurePosixPath(path).parts[0]
+        return fnmatchcase(root_name, pattern)
     prefix = f"{pattern}/"
     return path == pattern or path.startswith(prefix)
 
 
-@pytest.mark.parametrize("runtime_path", RUNTIME_PATHS)
-def test_runtime_data_is_excluded_from_build_context(runtime_path: str) -> None:
+def _is_excluded(patterns: list[str], path: str) -> bool:
+    """Resolve Docker's last-matching-pattern-wins exclusion state."""
+    excluded = False
+    for raw_pattern in patterns:
+        negated = raw_pattern.startswith("!")
+        pattern = raw_pattern[1:] if negated else raw_pattern
+        if _pattern_matches(pattern, path):
+            excluded = not negated
+    return excluded
+
+
+@pytest.mark.parametrize(
+    ("patterns", "expected"),
+    [
+        (["backend/runtime.json", "!backend/runtime.json"], False),
+        (["!backend/runtime.json", "backend/runtime.json"], True),
+    ],
+)
+def test_exclusion_uses_last_matching_pattern(patterns: list[str], expected: bool) -> None:
+    assert _is_excluded(patterns, "backend/runtime.json") is expected
+
+
+@pytest.mark.parametrize("local_path", HOST_LOCAL_PATHS)
+def test_host_local_data_is_excluded_from_build_context(local_path: str) -> None:
     patterns = _ignore_patterns()
-    assert any(_matches(pattern, runtime_path) for pattern in patterns), f"{runtime_path} would be copied into the image; add a .dockerignore entry covering it"
+    assert _is_excluded(patterns, local_path), f"{local_path} would be copied into the image; add a .dockerignore entry covering it"
 
 
 @pytest.mark.parametrize("build_input", BUILD_INPUT_PATHS)
 def test_build_inputs_are_still_included(build_input: str) -> None:
     patterns = _ignore_patterns()
-    matching = [pattern for pattern in patterns if _matches(pattern, build_input)]
-    assert not matching, f"{build_input} is needed by the build but is excluded by {matching}"
+    assert not _is_excluded(patterns, build_input), f"{build_input} is needed by the build but is excluded"

--- a/backend/tests/test_dockerignore_excludes_runtime_data.py
+++ b/backend/tests/test_dockerignore_excludes_runtime_data.py
@@ -1,0 +1,82 @@
+"""Regression test keeping runtime data out of the Docker build context.
+
+``backend/Dockerfile`` copies the backend tree wholesale (``COPY backend ./backend``),
+so every path under ``backend/`` that ``.dockerignore`` does not exclude is shipped
+into the image. The runtime directories are written by a *running* DeerFlow, not by
+a build:
+
+- ``DEER_FLOW_HOME`` (``backend/.deer-flow`` by default) holds the sqlite database,
+  per-user agent definitions and uploads, and ``.jwt_secret``.
+- ``backend/sandbox`` is the local sandbox provider's workspace root, created by
+  ``backend/Makefile`` and written by agent runs.
+
+Leaving them in the context has two consequences. Anyone who builds an image on a
+host that has run DeerFlow bakes that state — including the JWT secret and the user
+database — into the image. And because the Gateway container creates some of those
+directories as root, the build client eventually cannot read them and the build
+fails outright::
+
+    target gateway: failed to solve: error from sender:
+    open .../.deer-flow/users/<uuid>/integrations/lark-cli: permission denied
+
+Neither directory has any tracked content, so excluding them costs the build nothing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERIGNORE = REPO_ROOT / ".dockerignore"
+
+# Paths a running DeerFlow creates that must never enter the build context.
+RUNTIME_PATHS = [
+    "backend/.deer-flow/data/deerflow.db",
+    "backend/.deer-flow/.jwt_secret",
+    "backend/.deer-flow/users/some-user/agents/my-agent/config.yaml",
+    "backend/sandbox/some-thread/scratch.py",
+]
+
+# Paths the build genuinely needs; the exclusions must not swallow them.
+BUILD_INPUT_PATHS = [
+    "backend/pyproject.toml",
+    "backend/app/gateway/app.py",
+    "backend/packages/harness/deerflow/config/extensions_config.py",
+]
+
+
+def _ignore_patterns() -> list[str]:
+    lines = DOCKERIGNORE.read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+
+
+def _matches(pattern: str, path: str) -> bool:
+    """Whether *pattern* excludes *path*, for the pattern shapes this file uses.
+
+    Docker matches ``.dockerignore`` entries against context-relative paths. Only
+    two shapes are needed here: a directory prefix (``backend/sandbox/``) and a
+    leading ``**/`` that anchors a directory name at any depth.
+    """
+    if pattern.startswith("!"):
+        return False
+    pattern = pattern.rstrip("/")
+    if pattern.startswith("**/"):
+        name = pattern[3:]
+        return name in Path(path).parts
+    prefix = f"{pattern}/"
+    return path == pattern or path.startswith(prefix)
+
+
+@pytest.mark.parametrize("runtime_path", RUNTIME_PATHS)
+def test_runtime_data_is_excluded_from_build_context(runtime_path: str) -> None:
+    patterns = _ignore_patterns()
+    assert any(_matches(pattern, runtime_path) for pattern in patterns), f"{runtime_path} would be copied into the image; add a .dockerignore entry covering it"
+
+
+@pytest.mark.parametrize("build_input", BUILD_INPUT_PATHS)
+def test_build_inputs_are_still_included(build_input: str) -> None:
+    patterns = _ignore_patterns()
+    matching = [pattern for pattern in patterns if _matches(pattern, build_input)]
+    assert not matching, f"{build_input} is needed by the build but is excluded by {matching}"


### PR DESCRIPTION
## Why

`make up` fails on any host that has already run DeerFlow:

```
target gateway: failed to solve: error from sender:
open /home/<user>/deer-flow/backend/.deer-flow/users/<uuid>/integrations/lark-cli: permission denied
```

`backend/Dockerfile` copies the backend tree wholesale (`COPY backend ./backend`),
and `.dockerignore` excludes build artifacts (`backend/.venv`, `backend/htmlcov`,
`backend/.coverage`) but not the directories a *running* DeerFlow writes:

- `DEER_FLOW_HOME` — `backend/.deer-flow` by default (`backend/Makefile:1`), holding
  the sqlite database, per-user agent definitions and uploads, and `.jwt_secret`.
- `backend/sandbox` — the local sandbox provider's workspace root, created by
  `backend/Makefile:3` and written by agent runs.

That has two effects. The Gateway container creates some of those directories as
root, so once the app has been used the build client can no longer read them and the
build dies during context transfer — the error above. And when the files *are*
readable, the build quietly succeeds and ships that runtime state inside the image:
anyone who then pushes or shares the image is distributing their JWT secret and user
database with it.

A fresh clone builds fine, which is why this is easy to miss — the directories do not
exist until the app has run at least once.

## What changed

- `.dockerignore` now excludes `**/.deer-flow/` and `backend/sandbox/`.
- `make up` / `docker build` no longer fail on a host where DeerFlow has been used,
  and no longer copy runtime state into the image.

Neither directory has any tracked content (`git ls-files` returns nothing for both),
so nothing the build needs is lost. No code, API or config change.

## Surface area

- [x] **Sandbox** — `docker/` or sandboxed execution
- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path that reproduces the bug:
  `backend/tests/test_dockerignore_excludes_runtime_data.py`
- Red on `main`, green on this branch: **yes**. With the `.dockerignore` change
  stashed the run is `4 failed, 3 passed` (one failure per runtime path); with it
  restored, `7 passed`. The `test_build_inputs_are_still_included` cases guard the
  other direction — that the new patterns do not swallow real build inputs.

Also verified as a real Docker build on the affected host (Ubuntu 22.04, Docker
29.1.3) carrying 6.5 MB of runtime data including root-owned unreadable paths. Same
context, same throwaway Dockerfile (`FROM alpine` + `COPY backend /b`), the only
variable being the new ignore entry:

```
A: with the exclusion    → build succeeds
B: exclusion removed     → ERROR: failed to solve: error from sender:
                           open backend/.deer-flow/users/<uuid>/integrations/lark-cli: permission denied
```

## Validation

- `cd backend && make format` — clean
- `cd backend && make lint` — `All checks passed!`, 1151 files already formatted
- `cd backend && PYTHONPATH=. uv run pytest tests/test_dockerignore_excludes_runtime_data.py` — `7 passed`
- Real `docker build` A/B on the affected host as shown above

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Hit the build failure while deploying; used Claude Code to trace
it to the missing `.dockerignore` entries, to run the A/B build-context experiment
quoted above, and to draft the fix and tests. I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it.
