### PR TITLE
fix(journal): exclude control messages from first-human-input capture (#3337)

### DIFF
--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -48,7 +48,23 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_LEGACY_SUMMARY_MESSAGE_NAME = "summary"
+# Request-only control messages appended by middleware ``wrap_model_call`` /
+# ``before_model`` hooks. They are model-facing nudges, not user input, but they
+# are not always tagged ``hide_from_ui`` (some paths deliberately keep them out
+# of state so they never reach the UI). Name them here so a control message at
+# the tail of a compacted context is never mistaken for the run's real prompt
+# and persisted as ``llm.human.input`` — which would clobber the actual user
+# text in the history feed (issue #3337, second problem).
+_CONTROL_MESSAGE_NAMES = frozenset(
+    {
+        "summary",
+        "loop_warning",
+        "budget_warning",
+        "progress_hint",
+        "todo_reminder",
+        "todo_completion_reminder",
+    }
+)
 _RECONCILED_TOOL_MESSAGE_NAMES = frozenset({"ask_clarification"})
 _PERSISTED_HIDDEN_HUMAN_INPUT_RESPONSE_SOURCES = frozenset({"ask_clarification"})
 
@@ -56,7 +72,7 @@ _PERSISTED_HIDDEN_HUMAN_INPUT_RESPONSE_SOURCES = frozenset({"ask_clarification"}
 def _should_persist_human_input_message(message: BaseMessage) -> bool:
     if not isinstance(message, HumanMessage):
         return False
-    if message.name == _LEGACY_SUMMARY_MESSAGE_NAME:
+    if message.name in _CONTROL_MESSAGE_NAMES:
         return False
     if message.additional_kwargs.get("hide_from_ui") is not True:
         return True

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -1082,6 +1082,52 @@ class TestChatModelStartHumanMessage:
         assert not any(e["event_type"] == "llm.human.input" for e in events)
 
     @pytest.mark.anyio
+    @pytest.mark.parametrize(
+        "control_name",
+        ["summary", "loop_warning", "budget_warning", "progress_hint", "todo_reminder", "todo_completion_reminder"],
+    )
+    async def test_named_control_messages_are_not_captured(self, journal_setup, control_name):
+        """Middleware-injected control messages are model-facing nudges, not user input.
+
+        These messages are appended by ``wrap_model_call`` / ``before_model`` hooks
+        and are not always tagged ``hide_from_ui`` (some paths keep them out of
+        state entirely). A control message at the tail of a compacted context must
+        not be mistaken for the run's real prompt and persisted as
+        ``llm.human.input`` — that clobbers the actual user text in the history
+        feed (issue #3337, second problem)."""
+        from langchain_core.messages import HumanMessage
+
+        j, store = journal_setup
+        control_message = HumanMessage(
+            content="<system_reminder>internal control nudge</system_reminder>",
+            name=control_name,
+        )
+        j.on_chat_model_start({}, [[control_message]], run_id=uuid4(), tags=["lead_agent"])
+        await j.flush()
+
+        assert j._first_human_msg is None
+        events = await store.list_events("t1", "r1")
+        assert not any(e["event_type"] == "llm.human.input" for e in events)
+
+    @pytest.mark.anyio
+    async def test_control_message_does_not_shadow_real_user_prompt(self, journal_setup):
+        """A trailing control message must not displace the real user prompt."""
+        from langchain_core.messages import HumanMessage
+
+        j, store = journal_setup
+        real_prompt = HumanMessage(content="Summarize the quarterly report")
+        control_message = HumanMessage(content="<system_reminder>loop</system_reminder>", name="loop_warning")
+        # Control message appended after the real prompt (reversed scan order).
+        j.on_chat_model_start({}, [[real_prompt, control_message]], run_id=uuid4(), tags=["lead_agent"])
+        await j.flush()
+
+        assert j._first_human_msg == "Summarize the quarterly report"
+        events = await store.list_events("t1", "r1")
+        human_events = [e for e in events if e["event_type"] == "llm.human.input"]
+        assert len(human_events) == 1
+        assert human_events[0]["content"]["content"] == "Summarize the quarterly report"
+
+    @pytest.mark.anyio
     async def test_hidden_human_input_response_is_captured(self, journal_setup):
         """Hidden HumanInputCard replies are user-authored and must survive compaction."""
         from langchain_core.messages import HumanMessage


### PR DESCRIPTION
## Problem

In the history feed, a conversation turn can show an internal `<system_reminder>` block instead of what the user actually typed. This is the **second problem** reported in #3337: after context compression, the run's recorded human input is replaced by a control message, so the real prompt disappears from the UI.

The earlier fix for #3337 only handled messages tagged `hide_from_ui=True`. Several middleware-injected control messages are appended via `wrap_model_call` / `before_model` and are **not** tagged `hide_from_ui` (some paths deliberately keep them out of state so they never reach the UI), so they slipped through.

## Root cause

`RunJournal.on_chat_model_start` captures the run's first human input by scanning the outgoing messages **in reverse** and taking the first message for which `_should_persist_human_input_message` returns true. That check returns `True` for any `HumanMessage` that is not `hide_from_ui` and not named `summary`.

When a control message — `loop_warning`, `budget_warning`, `progress_hint`, `todo_reminder`, or `todo_completion_reminder` — is appended at the tail of a compacted context, the reverse scan hits it first and persists it as `llm.human.input`, overwriting the real user prompt.

Reproduced with a unit test: a bare `loop_warning` (etc.) `HumanMessage` with no `hide_from_ui` flag was captured as `llm.human.input`.

## Fix

Exclude these control messages by name in `_should_persist_human_input_message`. This helper is shared by both the live journal path (`on_chat_model_start`) and the checkpoint history-seed path (`_build_history_seed_events`), so the fix covers both.

This is distinct from open PR #4696, which touches `journal.py` only in `_should_reconcile_tool_message` (ToolMessage reconciliation), not the human-input capture path.

## Tests

- New parametrized regression test: each control-message name is not captured as `llm.human.input`.
- New test: a trailing control message does not shadow the real user prompt.
- `backend/tests/test_run_journal.py`: 95 passed (was 88); `test_todo_middleware.py`: 143 passed together.
- `ruff check` / `ruff format --check`: clean.

Fixes #3337