### PR TITLE
fix(runtime): preserve LLM call indices across concurrent calls

### DIFF
--- a/backend/docs/RUN_EVENT_STREAM.md
+++ b/backend/docs/RUN_EVENT_STREAM.md
@@ -76,6 +76,12 @@ through run-event or specialized APIs:
 | `context:memory` | `context` | `record_memory_context()` |
 | `middleware:{tag}` | `middleware` | `record_middleware()` |
 
+`llm.ai.response.metadata.llm_call_index` is a one-based ordinal assigned when
+the corresponding LangChain LLM run first starts. The ordinal stays bound to
+that callback `run_id`, so parallel calls retain start order even if they finish
+out of order. If a provider omits its start callback, `on_llm_end()` assigns the
+ordinal as a compatibility fallback.
+
 Current middleware tags are `guardrail`, `safety_termination`,
 `skill_activation`, and `skill_secrets`. The pattern is intentionally open so
 new middleware tags are additive. Because the full event type is limited to 32

--- a/backend/packages/harness/deerflow/runtime/AGENTS.md
+++ b/backend/packages/harness/deerflow/runtime/AGENTS.md
@@ -1,3 +1,12 @@
+### Run Event Journal (`runtime/journal.py`)
+
+`RunJournal` assigns `llm.ai.response.metadata.llm_call_index` when it first
+observes a LangChain LLM callback `run_id` in either `on_chat_model_start()` or
+`on_llm_start()`. The run-id mapping is authoritative at `on_llm_end()`, so
+parallel calls keep their start-order indices when they complete out of order;
+the end callback allocates an index only as a compatibility fallback for
+providers that omit start callbacks.
+
 ### Checkpoint Channel Modes (`full` / `delta`)
 
 Checkpointer storage runs in one of two channel modes, selected by `checkpoint_channel_mode` in `config.yaml` (default `full`). `delta` mode adopts LangGraph 1.2's `DeltaChannel` for `messages`: checkpoints store a sentinel + per-step writes instead of the full message list, so storage/serde grows O(N) instead of O(N²) in turns. All checkpointer backends (memory/sqlite/postgres) serve both modes unchanged — the semantics live in the compiled graph's channel table, not in the saver.

--- a/backend/packages/harness/deerflow/runtime/journal.py
+++ b/backend/packages/harness/deerflow/runtime/journal.py
@@ -11,6 +11,8 @@ Key design decisions:
   on_chain_start (fires on every node) — messages here are fully structured.
 - on_chain_start with parent_run_id=None emits a run.start trace marking root invocation.
 - on_llm_end emits llm.ai.response in checkpoint-aligned AIMessage.model_dump() format
+- llm_call_index is assigned by LangChain run_id at LLM start, so concurrent calls keep
+  their start-order index even when their responses finish out of order
 - Token usage accumulated in memory, written to RunRow on run completion
 - Caller identification via tags injection (lead_agent / subagent:{name} / middleware:{name})
 """
@@ -280,7 +282,7 @@ class RunJournal(BaseCallbackHandler):
 
         # LLM request/response tracking
         self._llm_call_index = 0
-        self._seen_llm_starts: set[str] = set()  # langchain run_ids that fired on_chat_model_start
+        self._llm_call_indices: dict[str, int] = {}  # langchain run_id -> start-order index
         self._current_run_tool_call_names: dict[str, str] = {}
         self._persisted_tool_message_identities: set[str] = set()
 
@@ -308,6 +310,16 @@ class RunJournal(BaseCallbackHandler):
             text = self._message_text(message).strip()
             if text:
                 self._last_ai_msg = text[:2000]
+
+    def _get_or_assign_llm_call_index(self, run_id: UUID | str) -> int:
+        """Return the stable start-order index for one LangChain LLM run."""
+        rid = str(run_id)
+        call_index = self._llm_call_indices.get(rid)
+        if call_index is None:
+            self._llm_call_index += 1
+            call_index = self._llm_call_index
+            self._llm_call_indices[rid] = call_index
+        return call_index
 
     def on_chain_start(
         self,
@@ -380,8 +392,7 @@ class RunJournal(BaseCallbackHandler):
         """
         rid = str(run_id)
         self._llm_start_times[rid] = time.monotonic()
-        self._llm_call_index += 1
-        self._seen_llm_starts.add(rid)
+        self._get_or_assign_llm_call_index(rid)
 
         logger.debug(
             "on_chat_model_start %s: tags=%s num_batches=%d message_counts=%s",
@@ -411,8 +422,10 @@ class RunJournal(BaseCallbackHandler):
                     break
 
     def on_llm_start(self, serialized: dict, prompts: list[str], *, run_id: UUID, parent_run_id: UUID | None = None, tags: list[str] | None = None, metadata: dict[str, Any] | None = None, **kwargs: Any) -> None:
-        # Fallback: on_chat_model_start is preferred. This just tracks latency.
-        self._llm_start_times[str(run_id)] = time.monotonic()
+        # Fallback for non-chat models; chat models use on_chat_model_start.
+        rid = str(run_id)
+        self._llm_start_times[rid] = time.monotonic()
+        self._get_or_assign_llm_call_index(rid)
 
     def on_llm_end(
         self,
@@ -457,13 +470,9 @@ class RunJournal(BaseCallbackHandler):
                 elif fallback_text:
                     self._llm_error_fallback_message = fallback_text[:2000]
 
-            # Resolve call index
-            call_index = self._llm_call_index
-            if rid not in self._seen_llm_starts:
-                # Fallback: on_chat_model_start was not called
-                self._llm_call_index += 1
-                call_index = self._llm_call_index
-                self._seen_llm_starts.add(rid)
+            # Resolve the index assigned when this call started. The helper's
+            # fallback preserves events from providers that omit start callbacks.
+            call_index = self._get_or_assign_llm_call_index(rid)
 
             # Message event: checkpoint-aligned llm.ai.response payload.
             self._put(

--- a/backend/tests/test_run_journal.py
+++ b/backend/tests/test_run_journal.py
@@ -98,6 +98,40 @@ class TestLlmCallbacks:
         assert trace_events[0]["category"] == "message"
 
     @pytest.mark.anyio
+    async def test_concurrent_chat_model_responses_keep_start_order_call_indices(self, journal_setup):
+        j, store = journal_setup
+        first_run_id = uuid4()
+        second_run_id = uuid4()
+
+        j.on_chat_model_start({}, [[]], run_id=first_run_id, tags=["lead_agent"])
+        j.on_chat_model_start({}, [[]], run_id=second_run_id, tags=["middleware:title"])
+        j.on_llm_end(_make_llm_response("second"), run_id=second_run_id, parent_run_id=None, tags=["middleware:title"])
+        j.on_llm_end(_make_llm_response("first"), run_id=first_run_id, parent_run_id=None, tags=["lead_agent"])
+        await j.flush()
+
+        events = await store.list_events("t1", "r1", event_types=["llm.ai.response"])
+        indices_by_content = {event["content"]["content"]: event["metadata"]["llm_call_index"] for event in events}
+
+        assert indices_by_content == {"first": 1, "second": 2}
+
+    @pytest.mark.anyio
+    async def test_concurrent_llm_responses_keep_start_order_call_indices(self, journal_setup):
+        j, store = journal_setup
+        first_run_id = uuid4()
+        second_run_id = uuid4()
+
+        j.on_llm_start({}, [], run_id=first_run_id, tags=["lead_agent"])
+        j.on_llm_start({}, [], run_id=second_run_id, tags=["subagent:research"])
+        j.on_llm_end(_make_llm_response("second"), run_id=second_run_id, parent_run_id=None, tags=["subagent:research"])
+        j.on_llm_end(_make_llm_response("first"), run_id=first_run_id, parent_run_id=None, tags=["lead_agent"])
+        await j.flush()
+
+        events = await store.list_events("t1", "r1", event_types=["llm.ai.response"])
+        indices_by_content = {event["content"]["content"]: event["metadata"]["llm_call_index"] for event in events}
+
+        assert indices_by_content == {"first": 1, "second": 2}
+
+    @pytest.mark.anyio
     async def test_on_llm_end_lead_agent_produces_ai_message(self, journal_setup):
         j, store = journal_setup
         run_id = uuid4()


### PR DESCRIPTION
## Why

`RunJournal` used one mutable `_llm_call_index` counter for both assigning and
reading persisted call indices. When two LLM calls overlapped, the later call
advanced the counter before the earlier call completed, so both responses could
be persisted with the same index. The non-chat callback path assigned its index
at completion time, which made indices follow completion order instead of start
order.

Incorrect indices make concurrent run-event timelines ambiguous for debugging,
evaluation, and other consumers of `llm.ai.response` metadata.

## What changed

- Assign each LangChain callback `run_id` a stable, one-based index when its LLM
  call starts.
- Share the allocator across chat and non-chat start callbacks, while preserving
  the existing end-only fallback for providers that omit start callbacks.
- Add regression tests for two calls that start in order and finish in reverse
  order through both callback paths.
- Document the start-order semantics of `llm_call_index`.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this change has no UI surface.

## Bug fix verification

- Test paths that reproduce the bug:
  - `backend/tests/test_run_journal.py::TestLlmCallbacks::test_concurrent_chat_model_responses_keep_start_order_call_indices`
  - `backend/tests/test_run_journal.py::TestLlmCallbacks::test_concurrent_llm_responses_keep_start_order_call_indices`
- Did they go red on `main` and green on this branch? **Yes.** On `main`, the
  chat path produced indices `2, 2`, and the non-chat path followed reverse
  completion order; both pass with start-order indices on this branch.

## Validation

- `cd backend && make lint`
- `cd backend && make test` — 11,752 passed, 78 skipped
- `cd backend && PYTHONPATH=. uv run pytest tests/test_run_journal.py tests/test_run_event_stream_contract.py -q` — 124 passed

## AI assistance

**Tool(s) used:** OpenAI Codex

**How you used it:** Codex analyzed the callback ordering bug, added red-first
regression tests, implemented the run-id-to-index mapping, updated the relevant
documentation, and ran the validation commands listed above.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
