### PR TITLE
fix(frontend): route / to setup or login instead of the landing page

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,26 +1,29 @@
-import { Footer } from "@/components/landing/footer";
-import { Header } from "@/components/landing/header";
-import { Hero } from "@/components/landing/hero";
-import { CaseStudySection } from "@/components/landing/sections/case-study-section";
-import { CommunitySection } from "@/components/landing/sections/community-section";
-import { SandboxSection } from "@/components/landing/sections/sandbox-section";
-import { SkillsSection } from "@/components/landing/sections/skills-section";
-import { WhatsNewSection } from "@/components/landing/sections/whats-new-section";
-import { DEFAULT_LOCALE } from "@/core/i18n/locale";
+import { redirect } from "next/navigation";
 
-export default function LandingPage() {
-  return (
-    <div className="min-h-screen w-full overflow-x-clip bg-[#0a0a0a]">
-      <Header locale={DEFAULT_LOCALE} />
-      <main className="flex w-full flex-col">
-        <Hero />
-        <CaseStudySection />
-        <SkillsSection />
-        <SandboxSection />
-        <WhatsNewSection />
-        <CommunitySection />
-      </main>
-      <Footer />
-    </div>
-  );
+import LandingPage from "@/components/landing/landing-page";
+import { getServerSideUser } from "@/core/auth/server";
+import { isStaticWebsiteOnly } from "@/core/static-mode";
+
+export const dynamic = "force-dynamic";
+
+// Static-website deployments have no gateway session to inspect, so they
+// keep the marketing landing page as the homepage. A full deployment instead
+// routes `/` by auth state: first boot goes straight to admin setup, signed-in
+// users to the workspace, and everyone else to login.
+export default async function HomePage() {
+  if (isStaticWebsiteOnly()) {
+    return <LandingPage />;
+  }
+
+  const result = await getServerSideUser();
+
+  switch (result.tag) {
+    case "authenticated":
+      redirect("/workspace");
+    case "needs_setup":
+    case "system_setup_required":
+      redirect("/setup");
+    default:
+      redirect("/login");
+  }
 }

--- a/frontend/src/components/landing/landing-page.tsx
+++ b/frontend/src/components/landing/landing-page.tsx
@@ -1,0 +1,26 @@
+import { Footer } from "@/components/landing/footer";
+import { Header } from "@/components/landing/header";
+import { Hero } from "@/components/landing/hero";
+import { CaseStudySection } from "@/components/landing/sections/case-study-section";
+import { CommunitySection } from "@/components/landing/sections/community-section";
+import { SandboxSection } from "@/components/landing/sections/sandbox-section";
+import { SkillsSection } from "@/components/landing/sections/skills-section";
+import { WhatsNewSection } from "@/components/landing/sections/whats-new-section";
+import { DEFAULT_LOCALE } from "@/core/i18n/locale";
+
+export default function LandingPage() {
+  return (
+    <div className="min-h-screen w-full overflow-x-clip bg-[#0a0a0a]">
+      <Header locale={DEFAULT_LOCALE} />
+      <main className="flex w-full flex-col">
+        <Hero />
+        <CaseStudySection />
+        <SkillsSection />
+        <SandboxSection />
+        <WhatsNewSection />
+        <CommunitySection />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/tests/unit/app/home-page.test.tsx
+++ b/frontend/tests/unit/app/home-page.test.tsx
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, rs, test } from "@rstest/core";
+
+import { type AuthResult } from "@/core/auth/types";
+
+const USER = {
+  id: "user-1",
+  email: "admin@example.com",
+  system_role: "admin" as const,
+  needs_setup: false,
+};
+
+const authState: { result: AuthResult } = {
+  result: { tag: "authenticated", user: USER },
+};
+
+rs.mock("@/core/auth/server", () => ({
+  getServerSideUser: rs.fn(async () => authState.result),
+}));
+
+async function loadHomePage() {
+  rs.resetModules();
+  return (await import("@/app/page")).default;
+}
+
+// next/navigation redirect() throws NEXT_REDIRECT errors with the target
+// encoded in the digest — exactly how App Router layouts assert redirects.
+async function expectRedirectTo(target: string) {
+  const HomePage = await loadHomePage();
+  try {
+    await HomePage();
+    expect.unreachable(`expected a redirect to ${target}`);
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("NEXT_REDIRECT");
+    expect((error as { digest?: string }).digest).toContain(target);
+  }
+}
+
+describe("root home page (issue #3909)", () => {
+  afterEach(() => {
+    rs.unstubAllEnvs();
+  });
+
+  test("sends first-boot installs straight to /setup", async () => {
+    authState.result = { tag: "system_setup_required" };
+    await expectRedirectTo("/setup");
+  });
+
+  test("sends authenticated users to /workspace", async () => {
+    authState.result = { tag: "authenticated", user: USER };
+    await expectRedirectTo("/workspace");
+  });
+
+  test("sends unauthenticated visitors to /login", async () => {
+    authState.result = { tag: "unauthenticated" };
+    await expectRedirectTo("/login");
+  });
+});


### PR DESCRIPTION
Fixes #3909

The homepage (`/`) unconditionally rendered the marketing landing page even for users who should go straight to setup or login.

This change routes `/` based on app state: unconfigured → setup, unauthenticated → login, otherwise the normal app entry.

Posted earlier as a compare link on the issue; opening as draft per maintainer workflow.