### PR TITLE
fix(skills): reject a blank SKILL.md description at the write gate

### DIFF
--- a/backend/packages/harness/deerflow/skills/validation.py
+++ b/backend/packages/harness/deerflow/skills/validation.py
@@ -64,11 +64,14 @@ def _validate_skill_frontmatter(skill_dir: Path) -> tuple[bool, str, str | None]
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}", None
     description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)", None
-        if len(description) > 1024:
-            return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters.", None
+    # The loader (parse_skill_file) drops a skill whose description is blank, so
+    # accepting one here would write a SKILL.md that never loads again.
+    if not description:
+        return False, "Description cannot be empty", None
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)", None
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters.", None
 
     try:
         parse_allowed_tools(frontmatter.get("allowed-tools"), skill_md)

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -398,6 +398,56 @@ def test_custom_skill_update_static_scan_failure_blocks_edit_before_llm(monkeypa
     assert (custom_dir / "SKILL.md").read_text(encoding="utf-8") == original_content
 
 
+def test_custom_skill_update_rejects_blank_description_before_write(monkeypatch, tmp_path):
+    """A blank description must be rejected at the write gate, not after the file is committed.
+
+    The loader drops a skill whose description is blank, so letting the edit
+    through would overwrite a working SKILL.md with content that no longer
+    loads -- the skill would vanish from every consumer.
+    """
+    skills_root = tmp_path / "skills"
+    from deerflow.config.paths import Paths
+
+    custom_dir = _user_custom_dir(tmp_path, "default") / "demo-skill"
+    custom_dir.mkdir(parents=True, exist_ok=True)
+    original_content = _skill_content("demo-skill")
+    (custom_dir / "SKILL.md").write_text(original_content, encoding="utf-8")
+    config = SimpleNamespace(
+        skills=SimpleNamespace(get_skills_path=lambda: skills_root, container_path="/mnt/skills", use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage"),
+        skill_evolution=SimpleNamespace(enabled=True, moderation_model_name=None),
+    )
+    monkeypatch.setattr("deerflow.config.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: Paths(base_dir=tmp_path))
+    monkeypatch.setattr("deerflow.config.paths._paths", None)
+    refresh_calls = []
+    scan_calls = []
+
+    async def _refresh(user_id: str):
+        refresh_calls.append(("refresh", user_id))
+
+    async def _scan(*args, **kwargs):
+        scan_calls.append({"args": args, "kwargs": kwargs})
+        return await _async_scan("allow", "ok")
+
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_user_skills_system_prompt_cache_async", _refresh)
+    monkeypatch.setattr("app.gateway.routers.skills.get_effective_user_id", lambda: "default")
+    monkeypatch.setattr("app.gateway.routers.skills.scan_skill_content", _scan)
+
+    app = _make_test_app(config)
+
+    with TestClient(app) as client:
+        response = client.put(
+            "/api/skills/custom/demo-skill",
+            json={"content": "---\nname: demo-skill\ndescription: ''\n---\n\n# demo-skill\n"},
+        )
+
+    assert response.status_code == 400
+    assert "empty" in response.json()["detail"].lower()
+    assert scan_calls == []
+    assert refresh_calls == []
+    assert (custom_dir / "SKILL.md").read_text(encoding="utf-8") == original_content
+
+
 def test_custom_skill_rollback_blocked_by_scanner(monkeypatch, tmp_path):
     skills_root = tmp_path / "skills"
     from deerflow.config.paths import Paths

--- a/backend/tests/test_skills_custom_router.py
+++ b/backend/tests/test_skills_custom_router.py
@@ -501,6 +501,72 @@ def test_custom_skill_rollback_blocked_by_scanner(monkeypatch, tmp_path):
         assert history_response.json()["history"][-1]["scanner"]["decision"] == "block"
 
 
+def test_custom_skill_rollback_rejects_blank_description_before_write(monkeypatch, tmp_path):
+    """Rolling back to a history entry whose stored content has a blank
+    description must be refused at the gate, not committed.
+
+    The loader drops a skill whose description is blank, so restoring such an
+    entry would overwrite a working SKILL.md with content that never loads
+    again. This pins the status-code contract for the rollback path: it must
+    return 400 (validation) rather than the old destructive 404, and the
+    on-disk file must be left untouched.
+    """
+    skills_root = tmp_path / "skills"
+    from deerflow.config.paths import Paths
+
+    user_custom = _user_custom_dir(tmp_path, "default")
+    custom_dir = user_custom / "demo-skill"
+    custom_dir.mkdir(parents=True, exist_ok=True)
+    current_content = _skill_content("demo-skill", "Edited skill")
+    (custom_dir / "SKILL.md").write_text(current_content, encoding="utf-8")
+    # A previous revision whose description is an empty string.
+    blank_content = "---\nname: demo-skill\ndescription: ''\n---\n\n# demo-skill\n"
+
+    config = SimpleNamespace(
+        skills=SimpleNamespace(get_skills_path=lambda: skills_root, container_path="/mnt/skills", use="deerflow.skills.storage.local_skill_storage:LocalSkillStorage"),
+        skill_evolution=SimpleNamespace(enabled=True, moderation_model_name=None),
+    )
+    monkeypatch.setattr("deerflow.config.get_app_config", lambda: config)
+    monkeypatch.setattr("deerflow.config.paths.get_paths", lambda: Paths(base_dir=tmp_path))
+    monkeypatch.setattr("deerflow.config.paths._paths", None)
+
+    # Roll back target is prev_content, so store the blank revision there.
+    storage = UserScopedSkillStorage("default", host_path=str(skills_root))
+    history_file = storage.get_skill_history_file("demo-skill")
+    history_file.parent.mkdir(parents=True, exist_ok=True)
+    history_file.write_text(
+        '{"action":"human_edit","prev_content":' + json.dumps(blank_content) + ',"new_content":' + json.dumps(current_content) + "}\n",
+        encoding="utf-8",
+    )
+
+    refresh_calls = []
+    scan_calls = []
+
+    async def _refresh(user_id: str):
+        refresh_calls.append(("refresh", user_id))
+
+    async def _scan(*args, **kwargs):
+        scan_calls.append({"args": args, "kwargs": kwargs})
+        return await _async_scan("allow", "ok")
+
+    monkeypatch.setattr("app.gateway.routers.skills.refresh_user_skills_system_prompt_cache_async", _refresh)
+    monkeypatch.setattr("app.gateway.routers.skills.get_effective_user_id", lambda: "default")
+    monkeypatch.setattr("app.gateway.routers.skills.scan_skill_content", _scan)
+
+    app = _make_test_app(config)
+
+    with TestClient(app) as client:
+        rollback_response = client.post("/api/skills/custom/demo-skill/rollback", json={"history_index": -1})
+
+    assert rollback_response.status_code == 400
+    assert "Description cannot be empty" in rollback_response.json()["detail"]
+    # The gate runs before the scanner and before any write, so the current
+    # file survives untouched and no prompt-cache refresh is triggered.
+    assert scan_calls == []
+    assert refresh_calls == []
+    assert (custom_dir / "SKILL.md").read_text(encoding="utf-8") == current_content
+
+
 def test_custom_skill_delete_preserves_history_and_allows_restore(monkeypatch, tmp_path):
     skills_root = tmp_path / "skills"
     from deerflow.config.paths import Paths

--- a/backend/tests/test_skills_validation.py
+++ b/backend/tests/test_skills_validation.py
@@ -192,6 +192,37 @@ class TestValidateSkillFrontmatter:
         assert valid is False
         assert "too long" in msg.lower()
 
+    def test_description_at_max_length_accepted(self, tmp_path):
+        max_desc = "a" * 1024
+        skill_dir = _write_skill(
+            tmp_path,
+            f"---\nname: my-skill\ndescription: {max_desc}\n---\n\nBody\n",
+        )
+        valid, msg, name = _validate_skill_frontmatter(skill_dir)
+        assert valid is True
+        assert msg == "Skill is valid!"
+        assert name == "my-skill"
+
+    def test_empty_description_rejected(self, tmp_path):
+        skill_dir = _write_skill(
+            tmp_path,
+            "---\nname: my-skill\ndescription: ''\n---\n\nBody\n",
+        )
+        valid, msg, name = _validate_skill_frontmatter(skill_dir)
+        assert valid is False
+        assert "empty" in msg.lower()
+        assert name is None
+
+    def test_whitespace_only_description_rejected(self, tmp_path):
+        skill_dir = _write_skill(
+            tmp_path,
+            "---\nname: my-skill\ndescription: '   '\n---\n\nBody\n",
+        )
+        valid, msg, name = _validate_skill_frontmatter(skill_dir)
+        assert valid is False
+        assert "empty" in msg.lower()
+        assert name is None
+
     def test_empty_name_rejected(self, tmp_path):
         skill_dir = _write_skill(
             tmp_path,


### PR DESCRIPTION
## Why

Editing a custom skill and leaving the description blank destroys the skill. The write gate accepts a blank description, but the loader rejects one, so the file lands on disk and then vanishes from everything that reads skills.

`_validate_skill_frontmatter` only checks the description when it is non-empty:

```python
description = description.strip()
if description:
    if "<" in description or ">" in description: ...
    if len(description) > 1024: ...
```

`backend/packages/harness/deerflow/skills/validation.py`

The loader is explicit that this is not allowed. `parse_skill_file` comments *"Extract required fields. Both must be non-empty strings."* and returns `None` for a blank description. The same validator already rejects an empty **name** with `"Name cannot be empty"` — description was the only field where the gate and the loader disagreed.

What that costs in practice, on `PUT /api/skills/custom/{name}`: validation passes, `prev_content` is read, the new content is **written to disk**, history is appended, and only then does the handler re-read through `load_skills`, find nothing, and raise `404 Custom skill not found`. The write is never rolled back, so a working skill is gone and its name is wedged — `custom_skill_exists` says yes, `load_skills` says no, and recreating it fails with "already exists".

The same gate backs the `.skill` archive install path and the agent-callable `skill_manage` tool, and that last one is the part I'd flag hardest: it returns `Created custom skill '<name>'.` while the skill never loads. An agent can do this unattended and get a success string back.

## What changed

A blank or whitespace-only description is now rejected up front with `Description cannot be empty`, matching the existing empty-name behaviour. Callers get a `400` from validation instead of a `404` after their skill has already been overwritten.

One behaviour change worth calling out: rolling back to a history entry whose stored content has a blank description now fails with `400` rather than today's destructive `404`. That is the intended effect, but it is a status-code change on an existing path.

Nothing else was touched. I compared the gate against the loader field by field — name, allowed-tools, required-secrets, secrets-autonomous, license, and the frontmatter split — and description was the only drift, so this stays a few lines rather than a sweep.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [x] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test paths that reproduce the bug:
  - `backend/tests/test_skills_validation.py::TestValidateSkillFrontmatter::test_empty_description_rejected`
  - `...::test_whitespace_only_description_rejected`
  - `backend/tests/test_skills_custom_router.py` — end-to-end through the edit endpoint, asserting the stored skill survives a rejected edit
- Did they go red on `main` and green on this branch? **Yes.** On `main` the two unit tests fail with `assert True is False`, and the router test fails with `assert 404 == 400` — which is the bug itself: the edit is committed and then reported as missing.

## Validation

- `cd backend && uv sync --frozen` (from `uv.lock`, no substitutions)
- Clean-HEAD baseline across the 8 skills suites: **191 passed**
- Full backend suite with the fix: **11763 passed, 78 skipped, 0 failed** (6m27s)
- `ruff check .` → all checks passed; `ruff format --check .` → 1150 files already formatted
- Swept all 23 bundled public skills to confirm none ships a blank description, so no in-repo skill regresses

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** I used it to explore the skills package and to draft the tests. I read the validator and the loader myself to confirm the mismatch, traced the write ordering in the `PUT` handler to establish that the write commits before the 404, and enumerated the router to check which paths are actually affected — there is no create endpoint, so this is the edit endpoint, the archive install path, and the `skill_manage` tool. The fix is the one-line non-empty check plus the comment explaining why the loader makes it necessary.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
