### PR TITLE
test(replay): cover subagent delegation semantics

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -173,6 +173,14 @@ the tool graph or subagent executor during state/schema imports.
 - For lightweight config/utility modules, prefer pure unit tests with no external dependencies
 - If a module causes circular import issues in tests, add a `sys.modules` mock in `tests/conftest.py` (see existing example for `deerflow.subagents.executor`)
 
+`tests/test_replay_golden.py` also contains a key-free orchestration regression
+for Lead Agent → `task` → real `SubagentExecutor` → sandbox `write_file`. It
+subscribes to `values` and `custom`, then checks the correlated `task_*`
+lifecycle, delegated file side effect, returned task result, final Lead Agent
+answer, and stable SSE event shape. Because `tests/conftest.py` preloads a mock
+executor to break import cycles for unit tests, this scenario installs the real
+executor only for its own lifetime and restores the shared modules afterwards.
+
 ```bash
 # Run all offline tests
 make test

--- a/backend/docs/REPLAY_E2E.md
+++ b/backend/docs/REPLAY_E2E.md
@@ -1,8 +1,8 @@
 # Record/Replay E2E — front-back contract verification
 
 Deterministic, **key-free** end-to-end checks that a backend change can't
-silently break the frontend (and vice-versa). Two complementary layers, fed by a
-single recording.
+silently break the frontend (and vice-versa). Two complementary layers replay
+recorded or purpose-built model decisions through the real runtime.
 
 ## Why
 
@@ -16,7 +16,7 @@ so contract drift turns the build red instead.
 - **Layer 1 — backend golden** (`tests/test_replay_golden.py`): replays a fixture
   through the real FastAPI gateway with `ReplayChatModel` and asserts the streamed
   SSE event sequence equals a committed golden. Fast, no browser. Guards protocol
-  *shape*.
+  *shape* and scenario-specific runtime semantics.
 - **Layer 2 — full-stack render** (`frontend/tests/e2e-real-backend/`): real
   Next.js + real gateway (replay model) + Chromium; asserts the replayed
   auto-title and a follow-up suggestion render in the browser. Guards semantic
@@ -73,6 +73,31 @@ A swallowed hash-miss keeps the SSE *event shapes* identical (the gateway wraps 
 into a normal assistant error message), so the Layer-1 golden can't catch a miss
 by shape alone — it inspects `replay_provider.replay_misses()` and fails loud
 instead. Layer-2 already fails on a miss (the recorded turns never render).
+
+## Agent orchestration scenario: delegated file task
+
+`subagent_file_task.ultra.json` fixes four model decisions so the scenario is
+stable and key-free, then exercises the production runtime around those
+decisions:
+
+1. The Lead Agent calls the real `task` tool.
+2. The real `SubagentExecutor` runs a `general-purpose` subagent.
+3. The subagent calls the real sandbox `write_file` tool.
+4. The task result returns to the Lead Agent, which produces the final answer.
+
+The test subscribes to both `values` and `custom` streams. In addition to the
+event-shape golden, it asserts that one correlated task progresses from
+`task_started` through at least one `task_running` event to `task_completed`,
+never emits a failure terminal state, returns the expected result, creates the
+expected workspace file, and is reflected in the Lead Agent's final response.
+Raw payload values remain uncommitted; the golden stores only event names and
+sorted top-level keys so volatile IDs and paths cannot make CI flaky.
+
+`tests/conftest.py` installs a lightweight executor mock to break a package
+import cycle for unit tests. This scenario imports the production executor only
+after the Gateway graph has been imported, patches the already-loaded task tool
+for the duration of the test, and relies on `monkeypatch` to restore the shared
+test process afterwards.
 
 ## Record a new scenario (needs a real key — dev machine only)
 

--- a/backend/tests/_replay_fixture.py
+++ b/backend/tests/_replay_fixture.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import uuid
+from dataclasses import dataclass
 from pathlib import Path
 
 # mode -> (thinking_enabled, is_plan_mode, subagent_enabled). Mirrors the
@@ -111,12 +112,18 @@ def prepare_hermetic_extras(home: Path) -> Path:
     return extensions
 
 
-def sse_event_shapes(resp) -> list[dict]:
-    """Reduce an SSE stream to (event name, sorted top-level data keys).
+@dataclass(frozen=True)
+class ReplayRunResult:
+    """Captured replay run with raw events for semantic assertions."""
 
-    Snapshots the *shape* of the stream, not volatile values, so the golden is
-    stable across runs while still catching event-sequence / payload-shape drift.
-    """
+    thread_id: str
+    events: list[dict]
+    event_shapes: list[dict]
+
+
+def _parse_sse_events(resp) -> list[dict]:
+    """Parse an SSE response without committing volatile payload values."""
+
     events: list[dict] = []
     current: str | None = None
     for line in resp.iter_lines():
@@ -128,12 +135,27 @@ def sse_event_shapes(resp) -> list[dict]:
                 data = json.loads(raw) if raw else {}
             except json.JSONDecodeError:
                 data = {"_raw": raw[:200]}
-            events.append({"event": current, "keys": sorted(data.keys()) if isinstance(data, dict) else None})
+            events.append({"event": current, "data": data})
     return events
 
 
-def drive_gateway(app, *, prompt: str, context: dict) -> list[dict]:
-    """Register -> create thread -> POST /runs/stream; return SSE event shapes.
+def _sse_event_shapes(events: list[dict]) -> list[dict]:
+    """Reduce parsed SSE events to event names and top-level data keys.
+
+    Snapshots the *shape* of the stream, not volatile values, so the golden is
+    stable across runs while still catching event-sequence / payload-shape drift.
+    """
+    return [
+        {
+            "event": event["event"],
+            "keys": sorted(event["data"].keys()) if isinstance(event["data"], dict) else None,
+        }
+        for event in events
+    ]
+
+
+def drive_gateway(app, *, prompt: str, context: dict, stream_mode: list[str] | None = None) -> ReplayRunResult:
+    """Register -> create thread -> POST /runs/stream; capture raw + shape events.
 
     This is the exact wire path the React frontend uses (LangGraph SDK), driven
     in-process via Starlette's TestClient with the real auth flow.
@@ -161,8 +183,13 @@ def drive_gateway(app, *, prompt: str, context: dict) -> list[dict]:
             # graph steps without changing the streamed SSE contract.
             "config": {"recursion_limit": 100},
             "context": context,
-            "stream_mode": ["values"],
+            "stream_mode": stream_mode or ["values"],
         }
         with client.stream("POST", f"/api/threads/{thread_id}/runs/stream", json=body, headers={"X-CSRF-Token": csrf}) as resp:
             assert resp.status_code == 200, resp.read().decode()
-            return sse_event_shapes(resp)
+            events = _parse_sse_events(resp)
+            return ReplayRunResult(
+                thread_id=thread_id,
+                events=events,
+                event_shapes=_sse_event_shapes(events),
+            )

--- a/backend/tests/fixtures/replay/subagent_file_task.ultra.events.json
+++ b/backend/tests/fixtures/replay/subagent_file_task.ultra.events.json
@@ -1,0 +1,220 @@
+{
+  "scenario": "subagent_file_task",
+  "mode": "ultra",
+  "events": [
+    {
+      "event": "metadata",
+      "keys": [
+        "run_id",
+        "thread_id"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "custom",
+      "keys": [
+        "description",
+        "model_name",
+        "task_id",
+        "type"
+      ]
+    },
+    {
+      "event": "custom",
+      "keys": [
+        "message",
+        "message_index",
+        "model_name",
+        "task_id",
+        "total_messages",
+        "type",
+        "usage"
+      ]
+    },
+    {
+      "event": "custom",
+      "keys": [
+        "message",
+        "message_index",
+        "model_name",
+        "task_id",
+        "total_messages",
+        "type",
+        "usage"
+      ]
+    },
+    {
+      "event": "custom",
+      "keys": [
+        "message",
+        "message_index",
+        "model_name",
+        "task_id",
+        "total_messages",
+        "type",
+        "usage"
+      ]
+    },
+    {
+      "event": "custom",
+      "keys": [
+        "model_name",
+        "result",
+        "task_id",
+        "type",
+        "usage"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "values",
+      "keys": [
+        "artifacts",
+        "delegations",
+        "messages",
+        "skill_context",
+        "thread_data",
+        "title",
+        "uploaded_files",
+        "viewed_images"
+      ]
+    },
+    {
+      "event": "end",
+      "keys": null
+    }
+  ]
+}

--- a/backend/tests/fixtures/replay/subagent_file_task.ultra.json
+++ b/backend/tests/fixtures/replay/subagent_file_task.ultra.json
@@ -1,0 +1,126 @@
+{
+  "scenario": "subagent_file_task",
+  "mode": "ultra",
+  "model": "scenario-model",
+  "prompt": "Use the task tool to delegate this bounded job to the general-purpose subagent: create /mnt/user-data/workspace/subagent-note.txt with exactly this content: hi from subagent replay. The subagent must use the write_file tool and return that exact text. After the task completes, reply with exactly the subagent result. Do not use file tools yourself and do not ask any clarifying questions.",
+  "context": {
+    "is_bootstrap": false,
+    "mode": "ultra",
+    "thinking_enabled": true,
+    "is_plan_mode": true,
+    "subagent_enabled": true
+  },
+  "stream_mode": [
+    "values",
+    "custom"
+  ],
+  "requires_real_subagent": true,
+  "turns": [
+    {
+      "caller": "lead_agent",
+      "conversation_hash": "d5c7e4528930738579ce1301de4b0c07952bbf3ad2ce025042f10e730511ecbf",
+      "input_hash": "ac3cbd0d9008574398c55a8ea566e50a69482f4142a2cfa28d258d34aec189c2",
+      "output": {
+        "type": "ai",
+        "data": {
+          "content": "",
+          "additional_kwargs": {},
+          "response_metadata": {
+            "finish_reason": "tool_calls"
+          },
+          "type": "ai",
+          "name": null,
+          "id": "replay-lead-delegate",
+          "tool_calls": [
+            {
+              "name": "task",
+              "args": {
+                "description": "Create replay proof file",
+                "prompt": "Create /mnt/user-data/workspace/subagent-note.txt with exactly this content: hi from subagent replay. Use the write_file tool, then return exactly: hi from subagent replay.",
+                "subagent_type": "general-purpose"
+              },
+              "id": "call_subagent_replay_task",
+              "type": "tool_call"
+            }
+          ],
+          "invalid_tool_calls": [],
+          "usage_metadata": null
+        }
+      }
+    },
+    {
+      "caller": "subagent:general-purpose",
+      "conversation_hash": "ba657f7b66fec240fcf4f3b0fba485edb65526c4ee1879adfbdba8825cd07b56",
+      "input_hash": "2299469152379bac70c6685ccc743a2cba10da2d8372a6ead22f5f3ec32709b0",
+      "output": {
+        "type": "ai",
+        "data": {
+          "content": "",
+          "additional_kwargs": {},
+          "response_metadata": {
+            "finish_reason": "tool_calls"
+          },
+          "type": "ai",
+          "name": null,
+          "id": "replay-subagent-write",
+          "tool_calls": [
+            {
+              "name": "write_file",
+              "args": {
+                "description": "Create the delegated replay proof file",
+                "path": "/mnt/user-data/workspace/subagent-note.txt",
+                "content": "hi from subagent replay."
+              },
+              "id": "call_subagent_write_file",
+              "type": "tool_call"
+            }
+          ],
+          "invalid_tool_calls": [],
+          "usage_metadata": null
+        }
+      }
+    },
+    {
+      "caller": "subagent:general-purpose",
+      "conversation_hash": "8a1c2893e58f7118b1df7535c7081474ec24c457f3ed7b8c43ed124b3cdf63a1",
+      "input_hash": "f3cf9a86b49b6b610b9380172098de876dba643f0c408c41cad38780e7c8ca90",
+      "output": {
+        "type": "ai",
+        "data": {
+          "content": "hi from subagent replay.",
+          "additional_kwargs": {},
+          "response_metadata": {
+            "finish_reason": "stop"
+          },
+          "type": "ai",
+          "name": null,
+          "id": "replay-subagent-final",
+          "tool_calls": [],
+          "invalid_tool_calls": [],
+          "usage_metadata": null
+        }
+      }
+    },
+    {
+      "caller": "lead_agent",
+      "conversation_hash": "16f57d6e94768efb6f3a1b428a80c4094b191586ea2b63d5ce3ffc0986717799",
+      "input_hash": "551fdc67abfdacd64f65301839b7bb4db8dc7a3a4591c5f2f30b03ac3daa2ca1",
+      "output": {
+        "type": "ai",
+        "data": {
+          "content": "hi from subagent replay.",
+          "additional_kwargs": {},
+          "response_metadata": {
+            "finish_reason": "stop"
+          },
+          "type": "ai",
+          "name": null,
+          "id": "replay-lead-final",
+          "tool_calls": [],
+          "invalid_tool_calls": [],
+          "usage_metadata": null
+        }
+      }
+    }
+  ]
+}

--- a/backend/tests/test_replay_golden.py
+++ b/backend/tests/test_replay_golden.py
@@ -33,13 +33,18 @@ def _install_real_subagent_executor(monkeypatch: pytest.MonkeyPatch) -> None:
     the executor afterwards avoids the circular import that ``tests/conftest.py``
     protects lightweight unit tests from, while letting the already-imported task
     tool execute the real implementation. ``monkeypatch`` restores the mocked
-    module and every patched attribute after the test.
+    module, its parent-package binding, and every patched attribute after the test.
     """
     import deerflow.subagents as subagents_package
 
     task_tool_module = importlib.import_module("deerflow.tools.builtins.task_tool")
 
     module_name = "deerflow.subagents.executor"
+    # Importing a child module also writes ``executor`` onto its parent package.
+    # Track that dictionary entry explicitly so teardown cannot leave the real
+    # executor reachable after ``sys.modules`` has been restored to conftest's mock.
+    monkeypatch.setitem(subagents_package.__dict__, "executor", None)
+    monkeypatch.delitem(subagents_package.__dict__, "executor")
     monkeypatch.delitem(sys.modules, module_name)
     executor_module = importlib.import_module(module_name)
 
@@ -143,7 +148,7 @@ def _run_replay_scenario(
     return home, replay_run
 
 
-def _final_assistant_text(events: list[dict]) -> str | None:
+def _final_assistant_message(events: list[dict]) -> dict | None:
     for event in reversed(events):
         if event["event"] != "values" or not isinstance(event["data"], dict):
             continue
@@ -155,7 +160,7 @@ def _final_assistant_text(events: list[dict]) -> str | None:
                 continue
             content = message.get("content")
             if isinstance(content, str) and content:
-                return content
+                return message
     return None
 
 
@@ -176,10 +181,14 @@ def test_replay_subagent_file_task_ultra_matches_golden_and_semantics(tmp_path: 
     assert "task_running" in task_event_types
     assert task_event_types[-1] == "task_completed"
     assert not {"task_failed", "task_cancelled", "task_timed_out"}.intersection(task_event_types)
-    assert len({event["task_id"] for event in task_events}) == 1
+    assert {event["task_id"] for event in task_events} == {"call_subagent_replay_task"}
     assert task_events[-1]["result"] == "hi from subagent replay."
 
     workspace_files = list(home.glob(f"users/*/threads/{replay_run.thread_id}/user-data/workspace/subagent-note.txt"))
     assert len(workspace_files) == 1
     assert workspace_files[0].read_text(encoding="utf-8") == "hi from subagent replay."
-    assert _final_assistant_text(replay_run.events) == "hi from subagent replay."
+
+    final_assistant = _final_assistant_message(replay_run.events)
+    assert final_assistant is not None
+    assert final_assistant.get("id") == "replay-lead-final"
+    assert final_assistant.get("content") == "hi from subagent replay."

--- a/backend/tests/test_replay_golden.py
+++ b/backend/tests/test_replay_golden.py
@@ -4,23 +4,55 @@ assert the streamed SSE event sequence matches a committed golden.
 
 This catches backend protocol drift: if a change alters the shape/sequence of
 SSE the gateway emits for the recorded scenario, this test goes red. The replay
-model serves the recorded assistant turns by input hash, so the agent graph
-(write_file -> auto-title -> read_file -> final answer) reproduces offline.
+model serves the recorded assistant turns by input hash, so direct-tool and
+lead-to-subagent scenarios reproduce offline.
 
-Fixtures are produced by ``scripts/record_gateway.py`` +
-``scripts/build_fixture_from_jsonl.py`` (manual, needs a key).
+Recorded fixtures are produced by ``scripts/record_gateway.py`` +
+``scripts/build_fixture_from_jsonl.py`` (manual, needs a key); small deterministic
+orchestration scenarios can also supply purpose-built model decisions.
 """
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
+import sys
 from pathlib import Path
 
 import pytest
-from _replay_fixture import REPLAY_MODEL_BLOCK, build_config_yaml, drive_gateway, prepare_hermetic_extras
+from _replay_fixture import REPLAY_MODEL_BLOCK, ReplayRunResult, build_config_yaml, drive_gateway, prepare_hermetic_extras
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "replay"
+
+
+def _install_real_subagent_executor(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace conftest's cycle-breaking executor mock for this E2E scenario.
+
+    The full gateway import resolves the production import graph first. Importing
+    the executor afterwards avoids the circular import that ``tests/conftest.py``
+    protects lightweight unit tests from, while letting the already-imported task
+    tool execute the real implementation. ``monkeypatch`` restores the mocked
+    module and every patched attribute after the test.
+    """
+    import deerflow.subagents as subagents_package
+
+    task_tool_module = importlib.import_module("deerflow.tools.builtins.task_tool")
+
+    module_name = "deerflow.subagents.executor"
+    monkeypatch.delitem(sys.modules, module_name)
+    executor_module = importlib.import_module(module_name)
+
+    for name in ("SubagentExecutor", "SubagentResult"):
+        monkeypatch.setattr(subagents_package, name, getattr(executor_module, name))
+    for name in (
+        "SubagentExecutor",
+        "SubagentStatus",
+        "cleanup_background_task",
+        "get_background_task_result",
+        "request_cancel_background_task",
+    ):
+        monkeypatch.setattr(task_tool_module, name, getattr(executor_module, name))
 
 
 def _reset_process_singletons(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -43,9 +75,13 @@ def _reset_process_singletons(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(module, attr, None, raising=False)
 
 
-@pytest.mark.no_auto_user
-def test_replay_write_read_file_ultra_matches_golden(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    scenario, mode = "write_read_file", "ultra"
+def _run_replay_scenario(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    scenario: str,
+    mode: str,
+) -> tuple[Path, ReplayRunResult]:
     fixture_path = FIXTURE_DIR / f"{scenario}.{mode}.json"
     events_path = FIXTURE_DIR / f"{scenario}.{mode}.events.json"
     fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
@@ -73,9 +109,18 @@ def test_replay_write_read_file_ultra_matches_golden(tmp_path: Path, monkeypatch
 
     from app.gateway.app import create_app
 
+    if fixture.get("requires_real_subagent"):
+        _install_real_subagent_executor(monkeypatch)
+
     replay_provider.reset_replay_misses()
 
-    events = drive_gateway(create_app(), prompt=fixture["prompt"], context=fixture["context"])
+    replay_run = drive_gateway(
+        create_app(),
+        prompt=fixture["prompt"],
+        context=fixture["context"],
+        stream_mode=fixture.get("stream_mode"),
+    )
+    events = replay_run.event_shapes
 
     assert events, "replay produced no SSE events"
     assert events[0]["event"] == "metadata", f"first event should be metadata, got {events[0]!r}"
@@ -88,10 +133,53 @@ def test_replay_write_read_file_ultra_matches_golden(tmp_path: Path, monkeypatch
     #   DEERFLOW_WRITE_GOLDEN=1 uv run pytest tests/test_replay_golden.py
     if os.environ.get("DEERFLOW_WRITE_GOLDEN"):
         events_path.write_text(json.dumps({"scenario": scenario, "mode": mode, "events": events}, ensure_ascii=False, indent=2), encoding="utf-8")
-        return
+    else:
+        golden = json.loads(events_path.read_text(encoding="utf-8"))["events"]
+        # Guards backend SSE protocol drift: the event name + payload-key sequence
+        # must match the committed golden. (Replay divergence is caught by the miss
+        # assertion above, not here — a swallowed miss keeps the shapes identical.)
+        assert events == golden, f"SSE event-shape sequence drifted from the golden.\ngot  ({len(events)}): {[e['event'] for e in events]}\nwant ({len(golden)}): {[e['event'] for e in golden]}"
 
-    golden = json.loads(events_path.read_text(encoding="utf-8"))["events"]
-    # Guards backend SSE protocol drift: the event name + payload-key sequence
-    # must match the committed golden. (Replay divergence is caught by the miss
-    # assertion above, not here — a swallowed miss keeps the shapes identical.)
-    assert events == golden, f"SSE event-shape sequence drifted from the golden.\ngot  ({len(events)}): {[e['event'] for e in events]}\nwant ({len(golden)}): {[e['event'] for e in golden]}"
+    return home, replay_run
+
+
+def _final_assistant_text(events: list[dict]) -> str | None:
+    for event in reversed(events):
+        if event["event"] != "values" or not isinstance(event["data"], dict):
+            continue
+        messages = event["data"].get("messages")
+        if not isinstance(messages, list):
+            continue
+        for message in reversed(messages):
+            if not isinstance(message, dict) or message.get("type") != "ai":
+                continue
+            content = message.get("content")
+            if isinstance(content, str) and content:
+                return content
+    return None
+
+
+@pytest.mark.no_auto_user
+def test_replay_write_read_file_ultra_matches_golden(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _run_replay_scenario(tmp_path, monkeypatch, scenario="write_read_file", mode="ultra")
+
+
+@pytest.mark.no_auto_user
+def test_replay_subagent_file_task_ultra_matches_golden_and_semantics(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    home, replay_run = _run_replay_scenario(tmp_path, monkeypatch, scenario="subagent_file_task", mode="ultra")
+
+    task_events = [event["data"] for event in replay_run.events if event["event"] == "custom" and isinstance(event["data"], dict) and str(event["data"].get("type", "")).startswith("task_")]
+    assert task_events, "expected task lifecycle events in the custom stream"
+    task_event_types = [event["type"] for event in task_events]
+
+    assert task_event_types[0] == "task_started"
+    assert "task_running" in task_event_types
+    assert task_event_types[-1] == "task_completed"
+    assert not {"task_failed", "task_cancelled", "task_timed_out"}.intersection(task_event_types)
+    assert len({event["task_id"] for event in task_events}) == 1
+    assert task_events[-1]["result"] == "hi from subagent replay."
+
+    workspace_files = list(home.glob(f"users/*/threads/{replay_run.thread_id}/user-data/workspace/subagent-note.txt"))
+    assert len(workspace_files) == 1
+    assert workspace_files[0].read_text(encoding="utf-8") == "hi from subagent replay."
+    assert _final_assistant_text(replay_run.events) == "hi from subagent replay."


### PR DESCRIPTION
## Why

The current replay golden covers a direct tool call, but not Lead Agent delegation through `task`, the production `SubagentExecutor`, a subagent tool call, and the parent result path. This adds a narrow, key-free CI scenario without changing runtime behavior.

## What changed

- Capture raw replay SSE events for semantic assertions while keeping the golden limited to stable event names and payload keys.
- Add an Ultra-mode Lead → `task` → subagent → sandbox `write_file` → Lead scenario, using the real executor and restoring the suite's mock afterwards.
- Assert task lifecycle/correlation, no failure state, the delegated file, task result, final answer, and zero replay misses; document the boundary.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this PR changes backend tests and documentation only.

## Validation

- `cd backend && make lint`
- `cd backend && make test` — 11,760 passed, 78 skipped
- Repeated the replay test and ran it with Gateway import/subagent persistence tests to verify deterministic output and clean executor restoration

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex traced the test boundaries, implemented the fixture and assertions, updated docs, reviewed the diff, and ran validation. This remains a draft pending human review.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

```ai-signature
改动范围: backend replay helper、subagent delegation golden fixture、semantic assertions 与相关开发文档。
思考过程: 固定模型决策保证离线确定性，同时保留 Gateway、task tool、真实 SubagentExecutor 和 sandbox write_file 的执行；结构 golden 与语义断言分层以降低 flaky。
改动原因: 补齐现有 direct-tool replay 对 Agent 委派生命周期、真实工具副作用与父 Agent 结果回传缺少覆盖的问题。
Break Change: 否
```

Co-authored-by: BASE Infra Harness <ai@base-infra-harness.noreply.local>
AI-SHA256: c551dce88c32b2fde5f854e979874f53729b649b48644f8bba0ce0b0517eca33
