### PR TITLE
feat(sandbox): surface structured mount upload result on E2B sandbox

### DIFF
--- a/backend/packages/harness/deerflow/AGENTS.md
+++ b/backend/packages/harness/deerflow/AGENTS.md
@@ -101,3 +101,8 @@ An invalid mount does not block later mounts.
 Each successful upload logs its source, destination, file count, byte count, and elapsed time.
 
 A stopped pass logs its limit reason and elapsed time. It reports attempted and completed upload totals separately.
+
+A ``_MountUploadResult`` is attached to ``E2BSandbox.mount_upload_result``
+after creation. Downstream code can inspect ``result.truncated`` and
+``result.reason`` to discover whether the sandbox received all configured
+mounts without re-parsing Gateway logs.

--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
@@ -5,12 +5,16 @@ import logging
 import re
 import shlex
 import threading
+from typing import TYPE_CHECKING
 
 from e2b_code_interpreter import Sandbox as E2BClientSandbox
 
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX
 from deerflow.sandbox.sandbox import Sandbox, _validate_extra_env
 from deerflow.sandbox.search import GrepMatch, path_matches, should_ignore_path, truncate_line
+
+if TYPE_CHECKING:
+    from deerflow.community.e2b_sandbox.e2b_sandbox_provider import _MountUploadResult
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +64,7 @@ class E2BSandbox(Sandbox):
         self._lock = threading.Lock()
         self._closed = False
         self._dead = False
+        self.mount_upload_result: _MountUploadResult | None = None
 
     # ── Properties / lifecycle ───────────────────────────────────────────
 

--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox_provider.py
@@ -119,6 +119,24 @@ class _MountPassLimitExceeded(Exception):
 
 
 @dataclass
+class _MountUploadResult:
+    """Structured outcome of a mount upload pass.
+
+    Carried on :attr:`E2BSandbox.mount_upload_result` so downstream code
+    (logging, system-prompt injection, Gateway status) can discover whether
+    the sandbox received all configured mounts without re-parsing Gateway
+    logs.
+    """
+
+    truncated: bool
+    reason: str | None
+    attempted_files: int
+    attempted_bytes: int
+    completed_files: int
+    completed_bytes: int
+
+
+@dataclass
 class _MountUploadBudget:
     deadline: float
     attempted_bytes: int = 0
@@ -1145,12 +1163,14 @@ class E2BSandboxProvider(SandboxProvider):
 
         # One-shot mount uploads.  e2b has no host bind-mount, so we copy
         # files from ``host_path`` into ``container_path`` at sandbox start.
+        mount_result: _MountUploadResult | None = None
         try:
-            self._apply_mounts(client, user_id=user_id)
+            mount_result = self._apply_mounts(client, user_id=user_id)
         except Exception as e:
             logger.warning("Failed to apply some mounts to e2b sandbox %s: %s", sandbox_id, e)
 
         sandbox = E2BSandbox(id=sandbox_id, client=client, home_dir=self._config["home_dir"])
+        sandbox.mount_upload_result = mount_result
 
         # Commit atomically.  If the provider shut down during bootstrap or
         # mounts, kill the VM rather than parking it under ``_sandboxes``
@@ -1799,9 +1819,10 @@ class E2BSandboxProvider(SandboxProvider):
             logger.warning("Could not ensure skills projection for user %s: %s", user_id, exc, exc_info=True)
             return []
 
-    def _apply_mounts(self, client: E2BClientSandbox, *, user_id: str | None = None) -> None:
+    def _apply_mounts(self, client: E2BClientSandbox, *, user_id: str | None = None) -> _MountUploadResult:
         started_at = time.monotonic()
         budget = _MountUploadBudget(deadline=started_at + _MOUNT_PASS_DEADLINE_SECONDS)
+        truncation_reason: str | None = None
 
         def warn_pass_stopped(reason: str) -> None:
             elapsed_ms = int((time.monotonic() - started_at) * 1000)
@@ -1838,7 +1859,8 @@ class E2BSandboxProvider(SandboxProvider):
 
         for host_path, container_path, read_only in mounts:
             if budget.expired:
-                warn_pass_stopped(_mount_deadline_reason())
+                truncation_reason = _mount_deadline_reason()
+                warn_pass_stopped(truncation_reason)
                 break
             if not host_path.exists():
                 logger.warning("Skipping e2b mount: host_path %s does not exist", host_path)
@@ -1860,10 +1882,20 @@ class E2BSandboxProvider(SandboxProvider):
             try:
                 self._upload_tree(client, host_path, container_path, read_only, budget=budget)
             except _MountPassLimitExceeded as e:
-                warn_pass_stopped(str(e))
+                truncation_reason = str(e)
+                warn_pass_stopped(truncation_reason)
                 break
             except Exception as e:
                 logger.warning("Failed to upload mount %s -> %s: %s", host_path, container_path, e)
+
+        return _MountUploadResult(
+            truncated=truncation_reason is not None,
+            reason=truncation_reason,
+            attempted_files=budget.attempted_files,
+            attempted_bytes=budget.attempted_bytes,
+            completed_files=budget.completed_files,
+            completed_bytes=budget.completed_bytes,
+        )
 
     # ── Output mirroring ────────────────────────────────────────────────
     _SYNC_BACK_SUBDIRS = ("outputs", "workspace")

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -745,6 +745,129 @@ def test_apply_mounts_deadline_stops_before_next_mount_preflight(monkeypatch, tm
     assert "time budget 1s" in caplog.text
 
 
+def test_apply_mounts_returns_result_on_success(monkeypatch, tmp_path):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(skills=SimpleNamespace(container_path="/mnt/skills")))
+    source = tmp_path / "mount"
+    source.mkdir()
+    (source / "first.txt").write_text("first", encoding="utf-8")
+    (source / "second.txt").write_text("second", encoding="utf-8")
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_skill_projection_mounts", lambda _user_id: [])
+    provider._config["mounts"] = [
+        SimpleNamespace(host_path=str(source), container_path="/mnt/data", read_only=False),
+    ]
+    client = FakeClient()
+
+    result = provider._apply_mounts(client, user_id="user-1")
+
+    assert result.truncated is False
+    assert result.reason is None
+    assert result.completed_files == 2
+    assert result.completed_bytes == 11
+    assert result.attempted_files == 2
+    assert result.attempted_bytes == 11
+
+
+def test_apply_mounts_returns_truncated_result_on_deadline(monkeypatch, tmp_path, caplog):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    monkeypatch.setattr(mod, "_MOUNT_PASS_DEADLINE_SECONDS", 1)
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(skills=SimpleNamespace(container_path="/mnt/skills")))
+    clock = [0.0]
+    monkeypatch.setattr(mod.time, "monotonic", lambda: clock[0])
+
+    class DeadlineFilesAPI(FakeFilesAPI):
+        def write(self, path: str, content: Any) -> None:
+            super().write(path, content)
+            clock[0] = 2.0
+
+    source = tmp_path / "mount"
+    source.mkdir()
+    (source / "first.txt").write_text("first", encoding="utf-8")
+    (source / "second.txt").write_text("second", encoding="utf-8")
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_skill_projection_mounts", lambda _user_id: [])
+    provider._config["mounts"] = [
+        SimpleNamespace(host_path=str(source), container_path="/mnt/data", read_only=False),
+    ]
+    client = FakeClient(files=DeadlineFilesAPI())
+
+    with caplog.at_level("WARNING"):
+        result = provider._apply_mounts(client, user_id="user-1")
+
+    assert result.truncated is True
+    assert result.reason is not None
+    assert "time budget" in result.reason
+    assert result.completed_files <= result.attempted_files
+
+
+def test_apply_mounts_returns_truncated_result_on_file_count(monkeypatch, tmp_path, caplog):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    monkeypatch.setattr(mod, "_MAX_MOUNT_PASS_FILES", 1)
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(skills=SimpleNamespace(container_path="/mnt/skills")))
+    first = tmp_path / "first"
+    first.mkdir()
+    (first / "first.txt").write_text("first", encoding="utf-8")
+    second = tmp_path / "second"
+    second.mkdir()
+    (second / "second.txt").write_text("second", encoding="utf-8")
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_skill_projection_mounts", lambda _user_id: [])
+    provider._config["mounts"] = [
+        SimpleNamespace(host_path=str(first), container_path="/mnt/first", read_only=False),
+        SimpleNamespace(host_path=str(second), container_path="/mnt/second", read_only=False),
+    ]
+    client = FakeClient()
+
+    with caplog.at_level("WARNING"):
+        result = provider._apply_mounts(client, user_id="user-1")
+
+    assert result.truncated is True
+    assert "file count cap" in result.reason
+
+
+def test_apply_mounts_returns_truncated_result_on_byte_budget(monkeypatch, tmp_path, caplog):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    monkeypatch.setattr(mod, "_MAX_MOUNT_PASS_TOTAL_BYTES", 7)
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(skills=SimpleNamespace(container_path="/mnt/skills")))
+    first = tmp_path / "first"
+    first.mkdir()
+    (first / "first.bin").write_bytes(b"1234")
+    second = tmp_path / "second"
+    second.mkdir()
+    (second / "second.bin").write_bytes(b"5678")
+    provider = _make_provider()
+    monkeypatch.setattr(provider, "_skill_projection_mounts", lambda _user_id: [])
+    provider._config["mounts"] = [
+        SimpleNamespace(host_path=str(first), container_path="/mnt/first", read_only=False),
+        SimpleNamespace(host_path=str(second), container_path="/mnt/second", read_only=False),
+    ]
+    client = FakeClient()
+
+    with caplog.at_level("WARNING"):
+        result = provider._apply_mounts(client, user_id="user-1")
+
+    assert result.truncated is True
+    assert "byte budget" in result.reason
+
+
+def test_create_sandbox_stores_mount_result_on_sandbox(monkeypatch):
+    mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
+    monkeypatch.setattr(mod, "get_app_config", lambda: SimpleNamespace(skills=SimpleNamespace(container_path="/mnt/skills")))
+    provider = _make_provider()
+    _install_fake_sdk(monkeypatch, provider)
+    monkeypatch.setattr(provider, "_skill_projection_mounts", lambda _user_id: [])
+    provider._config["mounts"] = []
+
+    sandbox_id = provider._create_sandbox("t1", user_id="u1")
+    sandbox = provider.get(sandbox_id)
+
+    assert sandbox is not None
+    assert sandbox.mount_upload_result is not None
+    assert sandbox.mount_upload_result.truncated is False
+    assert sandbox.mount_upload_result.reason is None
+
+
 def test_skill_projection_and_configured_mount_share_upload_budget(monkeypatch, tmp_path):
     mod = importlib.import_module("deerflow.community.e2b_sandbox.e2b_sandbox_provider")
     monkeypatch.setattr(mod, "_MAX_MOUNT_PASS_FILES", 1)


### PR DESCRIPTION
## Summary

Introduces `_MountUploadResult` and attaches it to `E2BSandbox.mount_upload_result` after sandbox creation. This makes mount truncation observable in code — downstream consumers can inspect the result without re-parsing Gateway logs.

## Problem

When `_apply_mounts()` hits a resource limit (deadline, file count, byte budget), it logs a warning and returns `None`. The sandbox is created anyway. The agent later hits "file not found" on a skill or mount that was truncated, with no way to connect it to the mount-upload pass.

## Changes

**`e2b_sandbox_provider.py`**:
- Add `_MountUploadResult` dataclass with `truncated`, `reason`, and upload totals
- `_apply_mounts()` returns `_MountUploadResult` instead of `None`
- `_create_sandbox()` captures the result and stores it on the sandbox

**`e2b_sandbox.py`**:
- Add `mount_upload_result: _MountUploadResult | None` attribute to `E2BSandbox`

**`AGENTS.md`**:
- Document the structured result on `E2BSandbox.mount_upload_result`

**Tests** (5 new):
- `test_apply_mounts_returns_result_on_success` — correct totals, `truncated=False`
- `test_apply_mounts_returns_truncated_result_on_deadline` — `truncated=True`, reason contains "time budget"
- `test_apply_mounts_returns_truncated_result_on_file_count` — reason contains "file count cap"
- `test_apply_mounts_returns_truncated_result_on_byte_budget` — reason contains "byte budget"
- `test_create_sandbox_stores_mount_result_on_sandbox` — end-to-end wiring

## Scope

This PR is the **structured-observability layer only**. It does NOT:
- Inject truncation warnings into the agent system prompt (follow-up PR via `DynamicContextMiddleware`)
- Change the `Sandbox` base class
- Add a Gateway API endpoint for mount status

## Follow-up chain

```
#4812 per-mount bounds
  ↓
#4842 aggregate bounds + deadline
  ↓
#4876 configurable deadline
  ↓
This PR — structured mount upload result  ← here
  ↓
Next — inject truncation warnings into agent system prompt
```