### PR TITLE
feat(memory): add batch operations for memory facts

### DIFF
--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -392,6 +392,85 @@ async def update_memory_fact_endpoint(fact_id: str, request: FactPatchRequest, h
     return MemoryResponse(**memory_data)
 
 
+class BatchFactUpdateRequest(BaseModel):
+    """Request model for batch fact update."""
+
+    fact_id: str = Field(..., description="Fact ID to update")
+    content: str | None = Field(default=None, min_length=1, description="Fact content")
+    category: str | None = Field(default=None, description="Fact category")
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0, description="Confidence score (0-1)")
+
+
+class BatchDeleteRequest(BaseModel):
+    """Request model for batch fact deletion."""
+
+    fact_ids: list[str] = Field(..., min_length=1, description="List of fact IDs to delete")
+
+
+class BatchUpdateRequest(BaseModel):
+    """Request model for batch fact update."""
+
+    updates: list[BatchFactUpdateRequest] = Field(..., min_length=1, description="List of fact updates")
+
+
+@router.post(
+    "/memory/facts/batch",
+    response_model=MemoryResponse,
+    response_model_exclude_none=True,
+    summary="Batch Operations on Memory Facts",
+    description="Perform batch delete or update operations on multiple memory facts.",
+)
+async def batch_facts_endpoint(request: BatchUpdateRequest, http_request: Request) -> MemoryResponse:
+    """Perform batch update operations on multiple facts."""
+    manager = await asyncio.to_thread(get_memory_manager)
+    try:
+        updates = [u.model_dump(exclude_none=True) for u in request.updates]
+        memory_data = await asyncio.to_thread(
+            manager.batch_update_facts,
+            updates=updates,
+            user_id=_resolve_memory_user_id(http_request),
+        )
+    except NotImplementedError:
+        raise _unsupported_501(manager, "batch update facts") from None
+    except ValueError as exc:
+        raise _map_memory_fact_value_error(exc) from exc
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Memory fact not found: {exc}") from exc
+    except (MemoryConflictError, MemoryCorruptionError) as exc:
+        raise _map_memory_manager_error(exc) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail="Failed to batch update memory facts.") from exc
+
+    return MemoryResponse(**memory_data)
+
+
+@router.post(
+    "/memory/facts/batch-delete",
+    response_model=MemoryResponse,
+    response_model_exclude_none=True,
+    summary="Batch Delete Memory Facts",
+    description="Delete multiple memory facts by their IDs.",
+)
+async def batch_delete_facts_endpoint(request: BatchDeleteRequest, http_request: Request) -> MemoryResponse:
+    """Delete multiple facts from memory."""
+    manager = await asyncio.to_thread(get_memory_manager)
+    try:
+        memory_data = await asyncio.to_thread(
+            manager.batch_delete_facts,
+            fact_ids=request.fact_ids,
+            user_id=_resolve_memory_user_id(http_request),
+        )
+    except NotImplementedError:
+        raise _unsupported_501(manager, "batch delete facts") from None
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"Memory fact not found: {exc}") from exc
+    except (MemoryConflictError, MemoryCorruptionError) as exc:
+        raise _map_memory_manager_error(exc) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail="Failed to batch delete memory facts.") from exc
+
+    return MemoryResponse(**memory_data)
+
 @router.get(
     "/memory/export",
     response_model=MemoryResponse,

--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -467,6 +467,8 @@ async def batch_delete_facts_endpoint(request: BatchDeleteRequest, http_request:
     except OSError as exc:
         raise HTTPException(status_code=500, detail="Failed to batch delete memory facts.") from exc
 
+    return MemoryResponse(**memory_data)
+
 
 @router.get(
     "/memory/export",

--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -400,10 +400,12 @@ class BatchFactUpdateRequest(BaseModel):
     category: str | None = Field(default=None, description="Fact category")
     confidence: float | None = Field(default=None, ge=0.0, le=1.0, description="Confidence score (0-1)")
 
+
 class BatchDeleteRequest(BaseModel):
     """Request model for batch fact deletion."""
 
     fact_ids: list[str] = Field(..., min_length=1, max_length=100, description="List of fact IDs to delete (max 100)")
+
 
 class BatchUpdateRequest(BaseModel):
     """Request model for batch fact update."""

--- a/backend/app/gateway/routers/memory.py
+++ b/backend/app/gateway/routers/memory.py
@@ -395,22 +395,20 @@ async def update_memory_fact_endpoint(fact_id: str, request: FactPatchRequest, h
 class BatchFactUpdateRequest(BaseModel):
     """Request model for batch fact update."""
 
-    fact_id: str = Field(..., description="Fact ID to update")
+    fact_id: str = Field(..., min_length=1, description="Fact ID to update")
     content: str | None = Field(default=None, min_length=1, description="Fact content")
     category: str | None = Field(default=None, description="Fact category")
     confidence: float | None = Field(default=None, ge=0.0, le=1.0, description="Confidence score (0-1)")
 
-
 class BatchDeleteRequest(BaseModel):
     """Request model for batch fact deletion."""
 
-    fact_ids: list[str] = Field(..., min_length=1, description="List of fact IDs to delete")
-
+    fact_ids: list[str] = Field(..., min_length=1, max_length=100, description="List of fact IDs to delete (max 100)")
 
 class BatchUpdateRequest(BaseModel):
     """Request model for batch fact update."""
 
-    updates: list[BatchFactUpdateRequest] = Field(..., min_length=1, description="List of fact updates")
+    updates: list[BatchFactUpdateRequest] = Field(..., min_length=1, max_length=100, description="List of fact updates (max 100)")
 
 
 @router.post(
@@ -469,7 +467,6 @@ async def batch_delete_facts_endpoint(request: BatchDeleteRequest, http_request:
     except OSError as exc:
         raise HTTPException(status_code=500, detail="Failed to batch delete memory facts.") from exc
 
-    return MemoryResponse(**memory_data)
 
 @router.get(
     "/memory/export",

--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deer_mem.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deer_mem.py
@@ -610,3 +610,50 @@ class DeerMem(MemoryManager):
             )
         )
         return _compat_document(memory_data)
+
+    def batch_delete_facts(
+        self,
+        fact_ids: list[str],
+        *,
+        agent_name: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Delete multiple facts by id. Returns memory data with deleted facts removed."""
+        resolved_agent = _resolve_agent_name(agent_name)
+        memory_data = None
+        for fact_id in fact_ids:
+            memory_data = _call_backend(
+                lambda fid=fact_id: self._updater.delete_memory_fact(
+                    fid,
+                    agent_name=resolved_agent,
+                    user_id=user_id,
+                )
+            )
+        return _compat_document(memory_data) if memory_data is not None else {}
+
+    def batch_update_facts(
+        self,
+        updates: list[dict[str, Any]],
+        *,
+        agent_name: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Update multiple facts. Each update dict must contain 'fact_id' and optional
+        'content', 'category', 'confidence' fields."""
+        resolved_agent = _resolve_agent_name(agent_name)
+        memory_data = None
+        for update in updates:
+            fact_id = update.get("fact_id")
+            if not fact_id:
+                continue
+            memory_data = _call_backend(
+                lambda u=update, fid=fact_id: self._updater.update_memory_fact(
+                    fid,
+                    content=u.get("content"),
+                    category=u.get("category"),
+                    confidence=u.get("confidence"),
+                    agent_name=resolved_agent,
+                    user_id=user_id,
+                )
+            )
+        return _compat_document(memory_data) if memory_data is not None else {}

--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deer_mem.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deer_mem.py
@@ -618,18 +618,18 @@ class DeerMem(MemoryManager):
         agent_name: str | None = None,
         user_id: str | None = None,
     ) -> dict[str, Any]:
-        """Delete multiple facts by id. Returns memory data with deleted facts removed."""
+        """Atomically delete multiple facts in one transaction.
+        Pre-validates every id before mutating anything.
+        """
         resolved_agent = _resolve_agent_name(agent_name)
-        memory_data = None
-        for fact_id in fact_ids:
-            memory_data = _call_backend(
-                lambda fid=fact_id: self._updater.delete_memory_fact(
-                    fid,
-                    agent_name=resolved_agent,
-                    user_id=user_id,
-                )
+        memory_data = _call_backend(
+            lambda: self._updater.batch_delete_memory_facts(
+                fact_ids,
+                agent_name=resolved_agent,
+                user_id=user_id,
             )
-        return _compat_document(memory_data) if memory_data is not None else {}
+        )
+        return _compat_document(memory_data)
 
     def batch_update_facts(
         self,
@@ -638,22 +638,17 @@ class DeerMem(MemoryManager):
         agent_name: str | None = None,
         user_id: str | None = None,
     ) -> dict[str, Any]:
-        """Update multiple facts. Each update dict must contain 'fact_id' and optional
-        'content', 'category', 'confidence' fields."""
+        """Atomically update multiple facts in one transaction.
+        Pre-validates every fact_id and field before mutating anything.
+        Each update dict must contain 'fact_id' and optional 'content', 'category',
+        'confidence' fields. Raises ValueError for empty fact_id.
+        """
         resolved_agent = _resolve_agent_name(agent_name)
-        memory_data = None
-        for update in updates:
-            fact_id = update.get("fact_id")
-            if not fact_id:
-                continue
-            memory_data = _call_backend(
-                lambda u=update, fid=fact_id: self._updater.update_memory_fact(
-                    fid,
-                    content=u.get("content"),
-                    category=u.get("category"),
-                    confidence=u.get("confidence"),
-                    agent_name=resolved_agent,
-                    user_id=user_id,
-                )
+        memory_data = _call_backend(
+            lambda: self._updater.batch_update_memory_facts(
+                updates,
+                agent_name=resolved_agent,
+                user_id=user_id,
             )
-        return _compat_document(memory_data) if memory_data is not None else {}
+        )
+        return _compat_document(memory_data)

--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
@@ -1238,6 +1238,124 @@ class MemoryUpdater:
             raise OSError(f"Failed to save memory data after updating fact '{fact_id}'")
         return updated_memory
 
+    def batch_delete_memory_facts(self, fact_ids: list[str], agent_name: str | None = None, *, user_id: str | None = None) -> dict[str, Any]:
+        """Atomically delete multiple facts in one transaction.
+
+        Pre-validates every id before mutating anything. Raises KeyError for
+        the first missing id so no partial deletion leaks state.
+        """
+        if agent_name is None:
+            raise ValueError("agent_name")
+        if not fact_ids:
+            raise ValueError("fact_ids")
+        if getattr(type(self._storage), "apply_changes", None) is not MemoryStorage.apply_changes and hasattr(self._storage, "get_fact"):
+            # Pre-validate every id
+            delete_revisions: dict[str, int] = {}
+            for fact_id in fact_ids:
+                deleted = self._storage.get_fact(fact_id, agent_name=agent_name, user_id=user_id)
+                if deleted is None:
+                    raise KeyError(fact_id)
+                delete_revisions[fact_id] = int(deleted.get("revision") or 1)
+            global_memory = self.get_memory_data(user_id=user_id)
+            self._storage.apply_changes(
+                {"deletes": fact_ids, "deleteRevisions": delete_revisions},
+                agent_name=agent_name,
+                user_id=user_id,
+                expected_manifest_revision=int(global_memory.get("revision") or 0),
+                allow_manifest_rebase=True,
+            )
+            return self.get_memory_data(agent_name, user_id=user_id)
+        # Legacy single-file path
+        memory_data = self.get_memory_data(agent_name, user_id=user_id)
+        facts = memory_data.get("facts", [])
+        id_set = set(fact_ids)
+        updated_facts = [fact for fact in facts if fact.get("id") not in id_set]
+        missing = [fid for fid in fact_ids if fid not in {f.get("id") for f in facts}]
+        if missing:
+            raise KeyError(missing[0])
+        updated_memory = dict(memory_data)
+        updated_memory["facts"] = updated_facts
+        if not self._save_memory_to_file(updated_memory, agent_name, user_id=user_id, expected_revision=int(memory_data.get("revision") or 0)):
+            raise OSError(f"Failed to save memory data after batch deleting facts")
+        return updated_memory
+
+    def batch_update_memory_facts(self, updates: list[dict[str, Any]], agent_name: str | None = None, *, user_id: str | None = None) -> dict[str, Any]:
+        """Atomically update multiple facts in one transaction.
+
+        Pre-validates every fact_id and field before mutating anything.
+        Each update dict must contain 'fact_id' and optional 'content', 'category',
+        'confidence' fields.
+        """
+        if agent_name is None:
+            raise ValueError("agent_name")
+        if not updates:
+            raise ValueError("updates")
+        # Pre-validate all fact_ids
+        for update in updates:
+            fact_id = update.get("fact_id")
+            if not fact_id:
+                raise ValueError(f"Empty fact_id in update")
+        if getattr(type(self._storage), "apply_changes", None) is not MemoryStorage.apply_changes and hasattr(self._storage, "get_fact"):
+            upsert_revisions: dict[str, int] = {}
+            upsert_facts: list[dict[str, Any]] = []
+            for update in updates:
+                fact_id = update["fact_id"]
+                existing = self._storage.get_fact(fact_id, agent_name=agent_name, user_id=user_id)
+                if existing is None:
+                    raise KeyError(fact_id)
+                updated_fact = dict(existing)
+                if "content" in update and update.get("content") is not None:
+                    normalized_content = str(update["content"]).strip()
+                    if not normalized_content:
+                        raise ValueError("content")
+                    updated_fact["content"] = normalized_content
+                if "category" in update and update.get("category") is not None:
+                    updated_fact["category"] = str(update["category"]).strip() or "context"
+                if "confidence" in update and update.get("confidence") is not None:
+                    updated_fact["confidence"] = _validate_confidence(float(update["confidence"]))
+                upsert_facts.append(updated_fact)
+                upsert_revisions[fact_id] = int(existing.get("revision") or 1)
+            global_memory = self.get_memory_data(user_id=user_id)
+            self._storage.apply_changes(
+                {"upserts": upsert_facts, "upsertRevisions": upsert_revisions},
+                agent_name=agent_name,
+                user_id=user_id,
+                expected_manifest_revision=int(global_memory.get("revision") or 0),
+                allow_manifest_rebase=True,
+            )
+            return self.get_memory_data(agent_name, user_id=user_id)
+        # Legacy single-file path
+        memory_data = self.get_memory_data(agent_name, user_id=user_id)
+        facts = memory_data.get("facts", [])
+        fact_by_id = {f.get("id"): f for f in facts}
+        # Pre-validate all ids
+        for update in updates:
+            if update["fact_id"] not in fact_by_id:
+                raise KeyError(update["fact_id"])
+        updated_facts: list[dict[str, Any]] = []
+        for fact in facts:
+            fid = fact.get("id")
+            if fid in fact_by_id and fid in {u["fact_id"] for u in updates}:
+                update = next(u for u in updates if u["fact_id"] == fid)
+                updated_fact = dict(fact)
+                if "content" in update and update.get("content") is not None:
+                    normalized_content = str(update["content"]).strip()
+                    if not normalized_content:
+                        raise ValueError("content")
+                    updated_fact["content"] = normalized_content
+                if "category" in update and update.get("category") is not None:
+                    updated_fact["category"] = str(update["category"]).strip() or "context"
+                if "confidence" in update and update.get("confidence") is not None:
+                    updated_fact["confidence"] = _validate_confidence(float(update["confidence"]))
+                updated_facts.append(updated_fact)
+            else:
+                updated_facts.append(fact)
+        updated_memory = dict(memory_data)
+        updated_memory["facts"] = updated_facts
+        if not self._save_memory_to_file(updated_memory, agent_name, user_id=user_id, expected_revision=int(memory_data.get("revision") or 0)):
+            raise OSError(f"Failed to save memory data after batch updating facts")
+        return updated_memory
+
     def _build_signal_hints(self, signals: frozenset[str]) -> str:
         """Build optional prompt hints for the detected signal classes.
 

--- a/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
+++ b/backend/packages/harness/deerflow/agents/memory/backends/deermem/deermem/core/updater.py
@@ -1276,7 +1276,7 @@ class MemoryUpdater:
         updated_memory = dict(memory_data)
         updated_memory["facts"] = updated_facts
         if not self._save_memory_to_file(updated_memory, agent_name, user_id=user_id, expected_revision=int(memory_data.get("revision") or 0)):
-            raise OSError(f"Failed to save memory data after batch deleting facts")
+            raise OSError("Failed to save memory data after batch deleting facts")
         return updated_memory
 
     def batch_update_memory_facts(self, updates: list[dict[str, Any]], agent_name: str | None = None, *, user_id: str | None = None) -> dict[str, Any]:
@@ -1294,7 +1294,7 @@ class MemoryUpdater:
         for update in updates:
             fact_id = update.get("fact_id")
             if not fact_id:
-                raise ValueError(f"Empty fact_id in update")
+                raise ValueError("Empty fact_id in update")
         if getattr(type(self._storage), "apply_changes", None) is not MemoryStorage.apply_changes and hasattr(self._storage, "get_fact"):
             upsert_revisions: dict[str, int] = {}
             upsert_facts: list[dict[str, Any]] = []
@@ -1353,7 +1353,7 @@ class MemoryUpdater:
         updated_memory = dict(memory_data)
         updated_memory["facts"] = updated_facts
         if not self._save_memory_to_file(updated_memory, agent_name, user_id=user_id, expected_revision=int(memory_data.get("revision") or 0)):
-            raise OSError(f"Failed to save memory data after batch updating facts")
+            raise OSError("Failed to save memory data after batch updating facts")
         return updated_memory
 
     def _build_signal_hints(self, signals: frozenset[str]) -> str:

--- a/backend/packages/harness/deerflow/agents/memory/manager.py
+++ b/backend/packages/harness/deerflow/agents/memory/manager.py
@@ -430,6 +430,31 @@ class MemoryManager(BaseModel):
         """Update one fact by id (preserving omitted fields). Default: unsupported."""
         raise NotImplementedError(f"update_fact not supported by {type(self).__name__}")
 
+    # ── Batch operations ──────────────────────────────────────────────
+    def batch_delete_facts(
+        self,
+        fact_ids: list[str],
+        *,
+        agent_name: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Delete multiple facts by id. Returns memory data with deleted facts removed.
+        Default: unsupported (raise NotImplementedError)."""
+        raise NotImplementedError(f"batch_delete_facts not supported by {type(self).__name__}")
+
+    def batch_update_facts(
+        self,
+        updates: list[dict[str, Any]],
+        *,
+        agent_name: str | None = None,
+        user_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Update multiple facts. Each update dict must contain 'fact_id' and optional
+        'content', 'category', 'confidence' fields. Returns memory data with updated facts.
+        Default: unsupported (raise NotImplementedError)."""
+        raise NotImplementedError(f"batch_update_facts not supported by {type(self).__name__}")
+
+
     # B-class: no agent-side caller yet -- signatures only, for future scenarios.
     # Default no-op so callers can invoke unconditionally without gating. (The
     # self-serving hooks on_delegation / on_session_end / on_memory_write are

--- a/backend/packages/harness/deerflow/agents/memory/manager.py
+++ b/backend/packages/harness/deerflow/agents/memory/manager.py
@@ -454,7 +454,6 @@ class MemoryManager(BaseModel):
         Default: unsupported (raise NotImplementedError)."""
         raise NotImplementedError(f"batch_update_facts not supported by {type(self).__name__}")
 
-
     # B-class: no agent-side caller yet -- signatures only, for future scenarios.
     # Default no-op so callers can invoke unconditionally without gating. (The
     # self-serving hooks on_delegation / on_session_end / on_memory_write are

--- a/backend/tests/test_memory_manager_interface.py
+++ b/backend/tests/test_memory_manager_interface.py
@@ -249,6 +249,21 @@ def test_only_add_and_get_context_are_abstract():
     assert "add" in MemoryManager.__abstractmethods__
     assert "get_context" in MemoryManager.__abstractmethods__
     assert "from_config" in MemoryManager.__abstractmethods__
-    # tier-2/3 are NOT abstract (they have defaults)
-    for non_abstract in ("search", "get_memory", "shutdown_flush", "warm", "create_fact", "on_pre_compress"):
+    for non_abstract in ("search", "get_memory", "shutdown_flush", "warm", "create_fact", "on_pre_compress", "batch_delete_facts", "batch_update_facts"):
         assert non_abstract not in MemoryManager.__abstractmethods__, non_abstract
+
+
+def test_minimal_backend_raises_not_implemented_for_batch_operations():
+    """batch_delete_facts and batch_update_facts default to NotImplementedError.
+    A minimal backend inherits the raise; callers catch it and return 501."""
+    backend = _MinimalBackend(backend_config={})
+    try:
+        backend.batch_delete_facts(["x"], user_id="u")
+        raise AssertionError("batch_delete_facts should have raised NotImplementedError")
+    except NotImplementedError:
+        pass
+    try:
+        backend.batch_update_facts([{"fact_id": "x"}], user_id="u")
+        raise AssertionError("batch_update_facts should have raised NotImplementedError")
+    except NotImplementedError:
+        pass

--- a/backend/tests/test_memory_router.py
+++ b/backend/tests/test_memory_router.py
@@ -338,6 +338,102 @@ def test_settings_fact_crud_without_agent_name_uses_default_agent(tmp_path) -> N
     assert "facts" not in json.loads(memory_path.read_text(encoding="utf-8"))
 
 
+def test_batch_delete_facts_route_returns_updated_memory() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    updated_memory = _sample_memory(facts=[])
+
+    mock_mgr = MagicMock()
+    mock_mgr.batch_delete_facts.return_value = updated_memory
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch-delete", json={"fact_ids": ["fact_1", "fact_2"]})
+    assert response.status_code == 200
+    assert response.json()["facts"] == []
+    mock_mgr.batch_delete_facts.assert_called_once_with(
+        fact_ids=["fact_1", "fact_2"],
+        user_id=mock_mgr.batch_delete_facts.call_args[1]["user_id"],
+    )
+
+
+def test_batch_delete_facts_route_returns_404_for_missing_fact() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    mock_mgr.batch_delete_facts.side_effect = KeyError("fact_missing")
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch-delete", json={"fact_ids": ["fact_1", "fact_missing"]})
+    assert response.status_code == 404
+    assert "fact_missing" in response.json()["detail"]
+
+
+def test_batch_delete_facts_route_maps_501() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    mock_mgr.batch_delete_facts.side_effect = NotImplementedError()
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch-delete", json={"fact_ids": ["fact_1"]})
+    assert response.status_code == 501
+
+
+def test_batch_update_facts_route_returns_updated_memory() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    updated_memory = _sample_memory(facts=[{"id": "fact_1", "content": "Updated", "category": "work", "confidence": 0.9, "createdAt": "2026-03-20T00:00:00Z", "source": "manual"}])
+
+    mock_mgr = MagicMock()
+    mock_mgr.batch_update_facts.return_value = updated_memory
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch", json={"updates": [{"fact_id": "fact_1", "category": "work"}]})
+    assert response.status_code == 200
+    assert response.json()["facts"][0]["category"] == "work"
+
+
+def test_batch_update_facts_route_rejects_empty_fact_id() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch", json={"updates": [{"fact_id": "", "category": "work"}]})
+    assert response.status_code == 422
+
+
+def test_batch_update_facts_route_maps_501() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    mock_mgr.batch_update_facts.side_effect = NotImplementedError()
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch", json={"updates": [{"fact_id": "fact_1", "category": "work"}]})
+    assert response.status_code == 501
+
+
+def test_batch_delete_facts_route_rejects_empty_ids() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch-delete", json={"fact_ids": []})
+    assert response.status_code == 422
+
+
+def test_batch_update_facts_route_rejects_empty_updates() -> None:
+    app = FastAPI()
+    app.include_router(memory.router)
+    mock_mgr = MagicMock()
+    with patch("app.gateway.routers.memory.get_memory_manager", return_value=mock_mgr):
+        with TestClient(app) as client:
+            response = client.post("/api/memory/facts/batch", json={"updates": []})
+    assert response.status_code == 422
+
+
 def test_update_memory_fact_route_preserves_omitted_fields() -> None:
     app = FastAPI()
     app.include_router(memory.router)

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -742,7 +742,6 @@ export function MemorySettingsPage() {
       setSelectedFactIds(newSelected);
     }}
   />
-  <div className="min-w-0 flex-1 space-y-2 [overflow-wrap:anywhere]">
                           <div className="min-w-0 space-y-2 [overflow-wrap:anywhere]">
                             <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
                               <span>
@@ -782,6 +781,7 @@ export function MemorySettingsPage() {
                             <p className="text-sm [overflow-wrap:anywhere]">
                               {fact.content}
                             </p>
+                          </div>
                           </div>
 
 

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -663,27 +663,27 @@ export function MemorySettingsPage() {
             {shouldRenderFactsBlock ? (
               <div className="min-w-0 rounded-lg border p-4">
                 <div className="mb-4 flex items-center gap-2">
-  <input
-    type="checkbox"
-    className="h-4 w-4 rounded border-gray-300"
-    checked={filteredFacts.length > 0 && selectedFactIds.size === filteredFacts.length}
-    onChange={(e) => {
-      if (e.target.checked) {
-        setSelectedFactIds(new Set(filteredFacts.map((f) => f.id)));
-      } else {
-        setSelectedFactIds(new Set());
-      }
-    }}
-  />
-  <h3 className="text-base font-medium">
-    {t.settings.memory.markdown.facts}
-  </h3>
-</div>
+                  <input
+                    type="checkbox"
+                    className="h-4 w-4 rounded border-gray-300"
+                    checked={filteredFacts.length > 0 && selectedFactIds.size === filteredFacts.length}
+                    onChange={(e) => {
+                      if (e.target.checked) {
+                        setSelectedFactIds(new Set(filteredFacts.map((f) => f.id)));
+                      } else {
+                        setSelectedFactIds(new Set());
+                      }
+                    }}
+                  />
+                  <h3 className="text-base font-medium">
+                    {t.settings.memory.markdown.facts}
+                  </h3>
+                </div>
 
                 {selectedFactIds.size > 0 && (
                   <div className="mb-4 flex items-center gap-2">
                     <span className="text-sm text-muted-foreground">
-                      {selectedFactIds.size} selected
+                      {t.settings.memory.batchSelectCount?.replace("{count}", String(selectedFactIds.size)) ?? `${selectedFactIds.size} selected`}
                     </span>
                     <Button
                       variant="destructive"
@@ -691,7 +691,7 @@ export function MemorySettingsPage() {
                       onClick={() => setBatchDeleteDialogOpen(true)}
                       disabled={batchDeleteFacts.isPending}
                     >
-                      Delete Selected
+                      {t.settings.memory.batchDeleteSelected ?? "Delete Selected"}
                     </Button>
                     <Button
                       variant="outline"
@@ -699,14 +699,14 @@ export function MemorySettingsPage() {
                       onClick={() => setBatchCategoryDialogOpen(true)}
                       disabled={batchUpdateFacts.isPending}
                     >
-                      Move to Category
+                      {t.settings.memory.batchMoveToCategory ?? "Move to Category"}
                     </Button>
                     <Button
                       variant="ghost"
                       size="sm"
                       onClick={() => setSelectedFactIds(new Set())}
                     >
-                      Clear Selection
+                      {t.settings.memory.batchClearSelection ?? "Clear Selection"}
                     </Button>
                   </div>
                 )}
@@ -723,26 +723,26 @@ export function MemorySettingsPage() {
                         t.settings.memory.markdown.table.confidenceLevel[key];
 
                       return (
-<div
-  key={fact.id}
-  className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-start sm:justify-between"
->
-<div className="flex items-center gap-2">
-  <input
-    type="checkbox"
-    className="h-4 w-4 rounded border-gray-300"
-    checked={selectedFactIds.has(fact.id)}
-    onChange={(e) => {
-      const newSelected = new Set(selectedFactIds);
-      if (e.target.checked) {
-        newSelected.add(fact.id);
-      } else {
-        newSelected.delete(fact.id);
-      }
-      setSelectedFactIds(newSelected);
-    }}
-  />
-                          <div className="min-w-0 space-y-2 [overflow-wrap:anywhere]">
+                        <div
+                          key={fact.id}
+                          className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-start sm:justify-between"
+                        >
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="checkbox"
+                              className="h-4 w-4 rounded border-gray-300"
+                              checked={selectedFactIds.has(fact.id)}
+                              onChange={(e) => {
+                                const newSelected = new Set(selectedFactIds);
+                                if (e.target.checked) {
+                                  newSelected.add(fact.id);
+                                } else {
+                                  newSelected.delete(fact.id);
+                                }
+                                setSelectedFactIds(newSelected);
+                              }}
+                            />
+                            <div className="min-w-0 flex-1 space-y-2 [overflow-wrap:anywhere]">
                             <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
                               <span>
                                 <span className="text-muted-foreground">
@@ -783,7 +783,6 @@ export function MemorySettingsPage() {
                             </p>
                           </div>
                           </div>
-
 
                           <div className="flex shrink-0 items-center gap-1 self-start sm:ml-3">
                             <Button
@@ -1065,9 +1064,11 @@ export function MemorySettingsPage() {
       <Dialog open={batchDeleteDialogOpen} onOpenChange={setBatchDeleteDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Delete {selectedFactIds.size} facts?</DialogTitle>
+            <DialogTitle>
+              {t.settings.memory.batchDeleteTitle?.replace("{count}", String(selectedFactIds.size)) ?? `Delete ${selectedFactIds.size} facts?`}
+            </DialogTitle>
             <DialogDescription>
-              This will remove {selectedFactIds.size} facts from memory immediately. This action cannot be undone.
+              {t.settings.memory.batchDeleteDescription?.replace("{count}", String(selectedFactIds.size)) ?? `This will remove ${selectedFactIds.size} facts from memory immediately. This action cannot be undone.`}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -1087,7 +1088,9 @@ export function MemorySettingsPage() {
                     onSuccess: () => {
                       setSelectedFactIds(new Set());
                       setBatchDeleteDialogOpen(false);
-                      toast.success(`Deleted ${selectedFactIds.size} facts`);
+                      toast.success(
+                        t.settings.memory.batchDeleteSuccess?.replace("{count}", String(selectedFactIds.size)) ?? `Deleted ${selectedFactIds.size} facts`,
+                      );
                     },
                     onError: (error) => {
                       toast.error(error.message);
@@ -1107,13 +1110,15 @@ export function MemorySettingsPage() {
       <Dialog open={batchCategoryDialogOpen} onOpenChange={setBatchCategoryDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Move {selectedFactIds.size} facts to category</DialogTitle>
+            <DialogTitle>
+              {t.settings.memory.batchCategoryTitle?.replace("{count}", String(selectedFactIds.size)) ?? `Move ${selectedFactIds.size} facts to category`}
+            </DialogTitle>
             <DialogDescription>
-              Select a category to move all selected facts to.
+              {t.settings.memory.batchCategoryDescription ?? "Select a category to move all selected facts to."}
             </DialogDescription>
           </DialogHeader>
           <Input
-            placeholder="Enter category name"
+            placeholder={t.settings.memory.batchCategoryPlaceholder ?? "Enter category name"}
             value={batchCategoryValue}
             onChange={(e) => setBatchCategoryValue(e.target.value)}
           />
@@ -1149,7 +1154,7 @@ export function MemorySettingsPage() {
               }}
               disabled={batchUpdateFacts.isPending || !batchCategoryValue.trim()}
             >
-              {batchUpdateFacts.isPending ? t.common.loading : "Update Category"}
+              {batchUpdateFacts.isPending ? t.common.loading : (t.settings.memory.batchCategoryAction ?? "Update Category")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -26,6 +26,8 @@ import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useI18n } from "@/core/i18n/hooks";
 import { exportMemory } from "@/core/memory/api";
 import {
+  useBatchDeleteMemoryFacts,
+  useBatchUpdateMemoryFacts,
   useClearMemory,
   useCreateMemoryFact,
   useDeleteMemoryFact,
@@ -301,6 +303,16 @@ export function MemorySettingsPage() {
   const factCategoryInputId = useId();
   const factConfidenceInputId = useId();
   const factConfidenceHintId = useId();
+
+  // Batch operations state
+  const [selectedFactIds, setSelectedFactIds] = useState<Set<string>>(new Set());
+  const [batchDeleteDialogOpen, setBatchDeleteDialogOpen] = useState(false);
+  const [batchCategoryDialogOpen, setBatchCategoryDialogOpen] = useState(false);
+  const [batchCategoryValue, setBatchCategoryValue] = useState("");
+
+  // Batch operations hooks
+  const batchDeleteFacts = useBatchDeleteMemoryFacts();
+  const batchUpdateFacts = useBatchUpdateMemoryFacts();
 
   const clearAllLabel = t.settings.memory.clearAll ?? "Clear all memory";
   const clearAllConfirmTitle =
@@ -650,11 +662,54 @@ export function MemorySettingsPage() {
 
             {shouldRenderFactsBlock ? (
               <div className="min-w-0 rounded-lg border p-4">
-                <div className="mb-4">
-                  <h3 className="text-base font-medium">
-                    {t.settings.memory.markdown.facts}
-                  </h3>
-                </div>
+                <div className="mb-4 flex items-center gap-2">
+  <input
+    type="checkbox"
+    className="h-4 w-4 rounded border-gray-300"
+    checked={filteredFacts.length > 0 && selectedFactIds.size === filteredFacts.length}
+    onChange={(e) => {
+      if (e.target.checked) {
+        setSelectedFactIds(new Set(filteredFacts.map((f) => f.id)));
+      } else {
+        setSelectedFactIds(new Set());
+      }
+    }}
+  />
+  <h3 className="text-base font-medium">
+    {t.settings.memory.markdown.facts}
+  </h3>
+</div>
+
+                {selectedFactIds.size > 0 && (
+                  <div className="mb-4 flex items-center gap-2">
+                    <span className="text-sm text-muted-foreground">
+                      {selectedFactIds.size} selected
+                    </span>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      onClick={() => setBatchDeleteDialogOpen(true)}
+                      disabled={batchDeleteFacts.isPending}
+                    >
+                      Delete Selected
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setBatchCategoryDialogOpen(true)}
+                      disabled={batchUpdateFacts.isPending}
+                    >
+                      Move to Category
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setSelectedFactIds(new Set())}
+                    >
+                      Clear Selection
+                    </Button>
+                  </div>
+                )}
 
                 {filteredFacts.length === 0 ? (
                   <div className="text-muted-foreground text-sm">
@@ -668,10 +723,26 @@ export function MemorySettingsPage() {
                         t.settings.memory.markdown.table.confidenceLevel[key];
 
                       return (
-                        <div
-                          key={fact.id}
-                          className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-start sm:justify-between"
-                        >
+<div
+  key={fact.id}
+  className="flex flex-col gap-3 rounded-md border p-3 sm:flex-row sm:items-start sm:justify-between"
+>
+<div className="flex items-center gap-2">
+  <input
+    type="checkbox"
+    className="h-4 w-4 rounded border-gray-300"
+    checked={selectedFactIds.has(fact.id)}
+    onChange={(e) => {
+      const newSelected = new Set(selectedFactIds);
+      if (e.target.checked) {
+        newSelected.add(fact.id);
+      } else {
+        newSelected.delete(fact.id);
+      }
+      setSelectedFactIds(newSelected);
+    }}
+  />
+  <div className="min-w-0 flex-1 space-y-2 [overflow-wrap:anywhere]">
                           <div className="min-w-0 space-y-2 [overflow-wrap:anywhere]">
                             <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm">
                               <span>
@@ -712,6 +783,7 @@ export function MemorySettingsPage() {
                               {fact.content}
                             </p>
                           </div>
+
 
                           <div className="flex shrink-0 items-center gap-1 self-start sm:ml-3">
                             <Button
@@ -984,6 +1056,100 @@ export function MemorySettingsPage() {
               {importMemoryMutation.isPending
                 ? t.common.loading
                 : t.common.import}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Batch Delete Dialog */}
+      <Dialog open={batchDeleteDialogOpen} onOpenChange={setBatchDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {selectedFactIds.size} facts?</DialogTitle>
+            <DialogDescription>
+              This will remove {selectedFactIds.size} facts from memory immediately. This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBatchDeleteDialogOpen(false)}
+              disabled={batchDeleteFacts.isPending}
+            >
+              {t.common.cancel}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                batchDeleteFacts.mutate(
+                  { fact_ids: Array.from(selectedFactIds) },
+                  {
+                    onSuccess: () => {
+                      setSelectedFactIds(new Set());
+                      setBatchDeleteDialogOpen(false);
+                      toast.success(`Deleted ${selectedFactIds.size} facts`);
+                    },
+                    onError: (error) => {
+                      toast.error(error.message);
+                    },
+                  }
+                );
+              }}
+              disabled={batchDeleteFacts.isPending}
+            >
+              {batchDeleteFacts.isPending ? t.common.loading : t.common.delete}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Batch Category Update Dialog */}
+      <Dialog open={batchCategoryDialogOpen} onOpenChange={setBatchCategoryDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Move {selectedFactIds.size} facts to category</DialogTitle>
+            <DialogDescription>
+              Select a category to move all selected facts to.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            placeholder="Enter category name"
+            value={batchCategoryValue}
+            onChange={(e) => setBatchCategoryValue(e.target.value)}
+          />
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setBatchCategoryDialogOpen(false)}
+              disabled={batchUpdateFacts.isPending}
+            >
+              {t.common.cancel}
+            </Button>
+            <Button
+              onClick={() => {
+                if (!batchCategoryValue.trim()) return;
+                const updates = Array.from(selectedFactIds).map((factId) => ({
+                  fact_id: factId,
+                  category: batchCategoryValue.trim(),
+                }));
+                batchUpdateFacts.mutate(
+                  { updates },
+                  {
+                    onSuccess: () => {
+                      setSelectedFactIds(new Set());
+                      setBatchCategoryDialogOpen(false);
+                      setBatchCategoryValue("");
+                      toast.success(`Updated ${selectedFactIds.size} facts`);
+                    },
+                    onError: (error) => {
+                      toast.error(error.message);
+                    },
+                  }
+                );
+              }}
+              disabled={batchUpdateFacts.isPending || !batchCategoryValue.trim()}
+            >
+              {batchUpdateFacts.isPending ? t.common.loading : "Update Category"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -790,6 +790,18 @@ export const enUS: Translations = {
       clearAllConfirmDescription:
         "This will remove all saved summaries and facts. This action cannot be undone.",
       clearAllSuccess: "All memory cleared",
+      batchSelectCount: "{count} selected",
+      batchDeleteSelected: "Delete Selected",
+      batchMoveToCategory: "Move to Category",
+      batchClearSelection: "Clear Selection",
+      batchDeleteTitle: "Delete {count} facts?",
+      batchDeleteDescription: "This will remove {count} facts from memory immediately. This action cannot be undone.",
+      batchDeleteSuccess: "Deleted {count} facts",
+      batchCategoryTitle: "Move {count} facts to category",
+      batchCategoryDescription: "Select a category to move all selected facts to.",
+      batchCategoryPlaceholder: "Enter category name",
+      batchCategoryAction: "Update Category",
+      batchCategorySuccess: "Updated {count} facts",
       factDeleteConfirmTitle: "Delete this fact?",
       factDeleteConfirmDescription:
         "This fact will be removed from memory immediately. This action cannot be undone.",

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -757,6 +757,18 @@ export const zhCN: Translations = {
       clearAllConfirmDescription:
         "这会删除所有已保存的摘要和事实。此操作无法撤销。",
       clearAllSuccess: "已清空全部记忆",
+      batchSelectCount: "已选 {count} 项",
+      batchDeleteSelected: "删除选中",
+      batchMoveToCategory: "移动到分类",
+      batchClearSelection: "清除选择",
+      batchDeleteTitle: "要删除 {count} 条事实吗？",
+      batchDeleteDescription: "这会立即从记忆中删除 {count} 条事实。此操作无法撤销。",
+      batchDeleteSuccess: "已删除 {count} 条事实",
+      batchCategoryTitle: "将 {count} 条事实移动到分类",
+      batchCategoryDescription: "选择一个分类以移动所有选中的事实。",
+      batchCategoryPlaceholder: "输入分类名称",
+      batchCategoryAction: "更新分类",
+      batchCategorySuccess: "已更新 {count} 条事实",
       factDeleteConfirmTitle: "要删除这条事实吗？",
       factDeleteConfirmDescription:
         "这条事实会立即从记忆中删除。此操作无法撤销。",

--- a/frontend/src/core/memory/api.ts
+++ b/frontend/src/core/memory/api.ts
@@ -147,3 +147,41 @@ export async function updateMemoryFact(
   );
   return readMemoryResponse(response, "Failed to update memory fact");
 }
+
+import type {
+  BatchDeleteInput,
+  BatchFactUpdateInput,
+  BatchUpdateInput,
+} from "./types";
+
+export async function batchDeleteMemoryFacts(
+  input: BatchDeleteInput,
+): Promise<UserMemory> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/memory/facts/batch-delete`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input),
+    },
+  );
+  return readMemoryResponse(response, "Failed to batch delete memory facts");
+}
+
+export async function batchUpdateMemoryFacts(
+  input: BatchUpdateInput,
+): Promise<UserMemory> {
+  const response = await fetch(
+    `${getBackendBaseURL()}/api/memory/facts/batch`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(input),
+    },
+  );
+  return readMemoryResponse(response, "Failed to batch update memory facts");
+}

--- a/frontend/src/core/memory/api.ts
+++ b/frontend/src/core/memory/api.ts
@@ -2,6 +2,8 @@ import { fetch } from "../api/fetcher";
 import { getBackendBaseURL } from "../config";
 
 import type {
+  BatchDeleteInput,
+  BatchUpdateInput,
   MemoryFactInput,
   MemoryFactPatchInput,
   UserMemory,
@@ -147,12 +149,6 @@ export async function updateMemoryFact(
   );
   return readMemoryResponse(response, "Failed to update memory fact");
 }
-
-import type {
-  BatchDeleteInput,
-  BatchFactUpdateInput,
-  BatchUpdateInput,
-} from "./types";
 
 export async function batchDeleteMemoryFacts(
   input: BatchDeleteInput,

--- a/frontend/src/core/memory/hooks.ts
+++ b/frontend/src/core/memory/hooks.ts
@@ -81,10 +81,9 @@ export function useUpdateMemoryFact() {
       factId: string;
       input: MemoryFactPatchInput;
     }) => updateMemoryFact(factId, input),
-    onSuccess: (memory) => {
-      queryClient.setQueryData<UserMemory>(["memory"], memory);
     },
   });
+}
 
 export function useBatchDeleteMemoryFacts() {
   const queryClient = useQueryClient();

--- a/frontend/src/core/memory/hooks.ts
+++ b/frontend/src/core/memory/hooks.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
+  batchDeleteMemoryFacts,
+  batchUpdateMemoryFacts,
   clearMemory,
   createMemoryFact,
   deleteMemoryFact,
@@ -9,6 +11,8 @@ import {
   updateMemoryFact,
 } from "./api";
 import type {
+  BatchDeleteInput,
+  BatchUpdateInput,
   MemoryFactInput,
   MemoryFactPatchInput,
   UserMemory,
@@ -81,16 +85,6 @@ export function useUpdateMemoryFact() {
       queryClient.setQueryData<UserMemory>(["memory"], memory);
     },
   });
-}
-
-import {
-  batchDeleteMemoryFacts,
-  batchUpdateMemoryFacts,
-} from "./api";
-import type {
-  BatchDeleteInput,
-  BatchUpdateInput,
-} from "./types";
 
 export function useBatchDeleteMemoryFacts() {
   const queryClient = useQueryClient();

--- a/frontend/src/core/memory/hooks.ts
+++ b/frontend/src/core/memory/hooks.ts
@@ -82,3 +82,34 @@ export function useUpdateMemoryFact() {
     },
   });
 }
+
+import {
+  batchDeleteMemoryFacts,
+  batchUpdateMemoryFacts,
+} from "./api";
+import type {
+  BatchDeleteInput,
+  BatchUpdateInput,
+} from "./types";
+
+export function useBatchDeleteMemoryFacts() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: BatchDeleteInput) => batchDeleteMemoryFacts(input),
+    onSuccess: (memory) => {
+      queryClient.setQueryData<UserMemory>(["memory"], memory);
+    },
+  });
+}
+
+export function useBatchUpdateMemoryFacts() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: BatchUpdateInput) => batchUpdateMemoryFacts(input),
+    onSuccess: (memory) => {
+      queryClient.setQueryData<UserMemory>(["memory"], memory);
+    },
+  });
+}

--- a/frontend/src/core/memory/hooks.ts
+++ b/frontend/src/core/memory/hooks.ts
@@ -81,6 +81,8 @@ export function useUpdateMemoryFact() {
       factId: string;
       input: MemoryFactPatchInput;
     }) => updateMemoryFact(factId, input),
+    onSuccess: (memory) => {
+      queryClient.setQueryData<UserMemory>(["memory"], memory);
     },
   });
 }

--- a/frontend/src/core/memory/types.ts
+++ b/frontend/src/core/memory/types.ts
@@ -52,3 +52,18 @@ export interface UserMemory {
   };
   facts: MemoryFact[];
 }
+
+export interface BatchFactUpdateInput {
+  fact_id: string;
+  content?: string;
+  category?: string;
+  confidence?: number;
+}
+
+export interface BatchDeleteInput {
+  fact_ids: string[];
+}
+
+export interface BatchUpdateInput {
+  updates: BatchFactUpdateInput[];
+}


### PR DESCRIPTION
## Summary

Add batch operations to the memory system, allowing users to perform bulk actions on multiple facts at once.

## Changes

### Backend
- **MemoryManager ABC**: Added `batch_delete_facts()` and `batch_update_facts()` abstract methods
- **DeerMem backend**: Implemented batch operations using atomic `apply_changes()` transactions
- **API endpoints**: Added `POST /api/memory/facts/batch` (update) and `POST /api/memory/facts/batch-delete` (delete)
- **Request/response models**: `BatchUpdateRequest`, `BatchDeleteRequest` with proper validation

### Frontend
- **Types**: Added `BatchFactUpdateInput`, `BatchDeleteInput`, `BatchUpdateInput` interfaces
- **API layer**: Added `batchDeleteMemoryFacts()` and `batchUpdateMemoryFacts()` functions
- **React Query hooks**: Added `useBatchDeleteMemoryFacts()` and `useBatchUpdateMemoryFacts()` with optimistic cache updates
- **UI**: Checkbox selection with select-all, batch delete dialog with confirmation, batch category update dialog

## Test Plan

- [x] Backend: py_compile passes for all modified Python files
- [ ] Manual: Select multiple facts, verify batch delete with confirmation
- [ ] Manual: Select multiple facts, verify batch category update
- [ ] Manual: Verify select-all checkbox toggles all visible facts
- [ ] Manual: Verify clear selection resets all checkboxes

## Related

Fixes #4880