### PR TITLE
chore: Extend frontend startup timeout from 120s to 300s.

### DIFF
--- a/backend/tests/test_gateway_startup.py
+++ b/backend/tests/test_gateway_startup.py
@@ -50,7 +50,7 @@ def test_local_frontend_ignores_public_docker_port() -> None:
 
     assert "env PORT=3000" in serve
     assert 'run_service "Frontend"' in serve
-    assert "3000 120" in serve
+    assert "3000 300" in serve
 
 
 def test_production_gateway_has_a_real_readiness_probe() -> None:

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -470,7 +470,7 @@ run_service "Gateway" \
 # 2. Frontend
 run_service "Frontend" \
     "cd frontend && $FRONTEND_CMD > ../logs/frontend.log 2>&1" \
-    3000 120
+    3000 300
 
 # 3. Nginx
 run_service "Nginx" \


### PR DESCRIPTION
When launching the project using `make start-daemon` on an 8-core, 32GB RAM VM, the frontend startup has repeatedly exceeded the current 120-second limit, resulting in startup failure.