### PR TITLE
fix(workspace-changes): exclude MCP internal temp files from workspace changes

### DIFF
--- a/backend/packages/harness/deerflow/constants.py
+++ b/backend/packages/harness/deerflow/constants.py
@@ -20,6 +20,15 @@ BROWSER_FRAMES_DIRNAME = ".browser-frames"
 # snapshot capture as an extra excluded dir name.
 TOOL_RESULTS_DIRNAME = ".tool-results"
 
+# Hidden subdirectory (under a thread's workspace) that MCP stdio subprocesses
+# use as their temp dir (``_MCP_TMP_SUBDIR`` in ``deerflow.mcp.tools``). The
+# stdio server process's own scratch files land here — process feedback, not
+# deliverables — so the workspace-changes scanner excludes this directory and
+# it never shows up as an "edited N files" workspace change. Both the MCP
+# runtime (which writes here) and the scanner (which ignores it) import this
+# single source of truth so the name cannot drift between them.
+MCP_TMP_DIRNAME = ".mcp"
+
 # Default timeout (seconds) for MCP server bring-up: tool discovery (subprocess
 # spawn + initialize + tools/list) and persistent-session initialization. A hung
 # stdio server (e.g. npx blocked on a package download or a server that never

--- a/backend/packages/harness/deerflow/mcp/task_tool_caller.py
+++ b/backend/packages/harness/deerflow/mcp/task_tool_caller.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from deerflow.config.extensions_config import ExtensionsConfig
 from deerflow.config.paths import get_paths
+from deerflow.constants import MCP_TMP_DIRNAME
 from deerflow.mcp.client import build_server_params
 from deerflow.mcp.interceptors import build_mcp_tool_interceptors
 from deerflow.mcp.oauth import OAuthTokenManager, build_oauth_tool_interceptor
@@ -17,7 +18,7 @@ from deerflow.mcp.session_pool import get_session_pool
 
 logger = logging.getLogger(__name__)
 
-_MCP_TASK_TMP_SUBDIR = ".mcp/tmp"
+_MCP_TASK_TMP_SUBDIR = f"{MCP_TMP_DIRNAME}/tmp"
 
 
 def mcp_task_session_scope_key(*, user_id: str, thread_id: str) -> str:

--- a/backend/packages/harness/deerflow/mcp/tools.py
+++ b/backend/packages/harness/deerflow/mcp/tools.py
@@ -16,7 +16,7 @@ from langgraph.config import get_config
 
 from deerflow.config.extensions_config import ExtensionsConfig, McpServerConfig, resolve_effective_mcp_routing
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX, Paths, get_paths
-from deerflow.constants import DEFAULT_MCP_SESSION_INIT_TIMEOUT
+from deerflow.constants import DEFAULT_MCP_SESSION_INIT_TIMEOUT, MCP_TMP_DIRNAME
 from deerflow.mcp.client import build_servers_config
 from deerflow.mcp.interceptors import build_mcp_tool_interceptors
 from deerflow.mcp.oauth import build_oauth_tool_interceptor, get_initial_oauth_headers
@@ -51,7 +51,7 @@ _VALID_MCP_TOOL_NAME = re.compile(r"^[A-Za-z0-9_-]+$")
 # tools that write to ``os.tmpdir()`` / ``tempfile.gettempdir()`` land inside
 # the mounted user-data tree, where their output is resolvable by the
 # sandbox/artifact API — instead of on an unreachable host temp path.
-_MCP_TMP_SUBDIR = ".mcp/tmp"
+_MCP_TMP_SUBDIR = f"{MCP_TMP_DIRNAME}/tmp"
 
 # Matches local-file references embedded in free text returned by an MCP server.
 # Some servers (notably Playwright's ``browser_take_screenshot``) report saved

--- a/backend/packages/harness/deerflow/workspace_changes/scanner.py
+++ b/backend/packages/harness/deerflow/workspace_changes/scanner.py
@@ -6,7 +6,7 @@ import os
 from codecs import BOM_UTF16_BE, BOM_UTF16_LE, getincrementaldecoder
 from pathlib import Path
 
-from deerflow.constants import BROWSER_FRAMES_DIRNAME, TOOL_RESULTS_DIRNAME
+from deerflow.constants import BROWSER_FRAMES_DIRNAME, MCP_TMP_DIRNAME, TOOL_RESULTS_DIRNAME
 
 from .types import (
     DiffUnavailableReason,
@@ -35,6 +35,11 @@ EXCLUDED_DIR_NAMES = {
     # and fail as an error. Custom storage_subdir values are passed through
     # ``extra_excluded_dir_names`` instead.
     TOOL_RESULTS_DIRNAME,
+    # MCP stdio subprocess temp dir (``deerflow.mcp.tools`` pins the process
+    # tmpdir here): the MCP server's internal scratch/debug files, not
+    # workspace deliverables — same intent as the browser frames exclusion
+    # above. Shared constant with the MCP runtime so the name cannot drift.
+    MCP_TMP_DIRNAME,
     "__pycache__",
     "build",
     "dist",

--- a/backend/tests/test_workspace_changes.py
+++ b/backend/tests/test_workspace_changes.py
@@ -275,6 +275,23 @@ def test_scan_workspace_roots_skips_externalized_tool_results(tmp_path):
     assert "/mnt/user-data/outputs/.tool-results/bash-abcdef123456.log" not in snapshot.files
 
 
+def test_scan_workspace_roots_skips_mcp_tmp(tmp_path):
+    roots = _roots(tmp_path)
+    workspace = roots[0].host_path
+    (workspace / "paper.md").write_text("deliverable", encoding="utf-8")
+    mcp_tmp = workspace / ".mcp" / "tmp"
+    mcp_tmp.mkdir(parents=True)
+    (mcp_tmp / "semantic-scholar-debug.json").write_text(
+        "mcp server scratch file",
+        encoding="utf-8",
+    )
+
+    snapshot = scan_workspace_roots(roots)
+
+    assert "/mnt/user-data/workspace/paper.md" in snapshot.files
+    assert "/mnt/user-data/workspace/.mcp/tmp/semantic-scholar-debug.json" not in snapshot.files
+
+
 def test_scan_workspace_roots_skips_extra_excluded_dir_names(tmp_path):
     roots = _roots(tmp_path)
     outputs = roots[1].host_path


### PR DESCRIPTION
## What & why

When a stdio MCP server (e.g. a literature-search tool) runs, its subprocess
temp files land in `workspace/.mcp/tmp` (the MCP runtime pins the process
tmpdir there so sandbox/artifact APIs can resolve them). These internal
scratch/debug files were being counted as **"edited N files"** workspace
changes and mixed in with the user's actual deliverables.

This excludes the MCP temp dir from workspace-change scanning, following the
same pattern already used for browser frames (`.browser-frames`) and
externalized tool results (`.tool-results`).

## Changes

- `constants.py`: add `MCP_TMP_DIRNAME = ".mcp"` as the single source of
  truth, shared by the MCP runtime and the scanner (so the name can't drift).
- `mcp/tools.py` + `mcp/task_tool_caller.py`: build `_MCP_TMP_SUBDIR` from the
  shared constant.
- `workspace_changes/scanner.py`: exclude `MCP_TMP_DIRNAME` from
  `EXCLUDED_DIR_NAMES`.
- `tests/test_workspace_changes.py`: regression test
  `test_scan_workspace_roots_skips_mcp_tmp`.

## Verification

- `scan_workspace_roots` skips `workspace/.mcp/tmp/...` while keeping real
  deliverables (`paper.md`) in the snapshot.
- `ruff check` + `ruff format --check` clean on all changed files.

Closes #4893