### PR TITLE
fix(frontend): keep needYourHelp cards anchored to their own turn

### DIFF
--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -170,6 +170,7 @@ export function buildThreadSubmitMessages({
 const EMPTY_MESSAGES: Message[] = [];
 const EMPTY_RUN_MESSAGES: RunMessage[] = [];
 const EMPTY_MESSAGE_IDENTITIES: readonly string[] = [];
+const EMPTY_MESSAGE_IDENTITIES_SET: ReadonlySet<string> = new Set<string>();
 const INJECTED_USER_MESSAGE_ID_SUFFIX = "__user";
 
 const EMPTY_THREAD_VALUES: AgentThreadState = {
@@ -601,13 +602,17 @@ export function mergeMessages(
  * LangGraph `messages-tuple` events can publish the first AI/tool steps before
  * the `values` event containing the user message. Those steps are not part of
  * the pre-submit baseline, so move only that visible pending segment behind the
- * first new human message without disturbing established history or hidden
- * checkpoint controls. The caller keeps the baseline after stream completion
- * because the SDK may retain its transient event order until the next submit.
+ * first new human message. Conversely, a baseline message from an established
+ * turn can be woven after that human when history confirms the input before a
+ * live checkpoint tail; move those established messages back before the input.
+ * The caller keeps the baseline after stream completion because the SDK may
+ * retain its transient event order until the next submit.
  */
 export function restoreLocalTurnMessageOrder(
   messages: Message[],
   baselineMessageIdentities: ReadonlySet<string>,
+  confirmedHistoryIdentities: ReadonlySet<string> = EMPTY_MESSAGE_IDENTITIES_SET,
+  currentTurnRunIds: ReadonlySet<string> = EMPTY_MESSAGE_IDENTITIES_SET,
 ): Message[] {
   const pendingHumanIndex = messages.findIndex((message) => {
     const identity = messageIdentity(message);
@@ -622,6 +627,33 @@ export function restoreLocalTurnMessageOrder(
     return messages;
   }
 
+  // A message that canonical history (the REST /messages page) has already
+  // committed is an established part of a previous turn, no matter whether it
+  // also reached the live checkpoint baseline. Only a visible ai/tool step that
+  // is absent from BOTH sources is genuinely new output from the in-flight
+  // submit, and only that belongs after the new human input.
+  const isConfirmedHistoryMessage = (identity: string | undefined) =>
+    identity !== undefined && confirmedHistoryIdentities.has(identity);
+  // Steps of the CURRENT run must never be treated as displaced history: after
+  // an interrupt/stop the current turn's already-executed steps are persisted
+  // into canonical history, but they still belong AFTER the new human input.
+  // The pending human message itself carries the current run_id, so it is the
+  // most reliable anchor even when the live checkpoint no longer holds the
+  // current turn's steps (stop/interrupt can flush them to history).
+  const effectiveCurrentTurnRunIds =
+    currentTurnRunIds.size > 0
+      ? currentTurnRunIds
+      : (() => {
+          const runId = getMessageRunId(messages[pendingHumanIndex]!);
+          return runId ? new Set([runId]) : EMPTY_MESSAGE_IDENTITIES_SET;
+        })();
+  const isCurrentTurnStep = (message: Message) => {
+    const runId = getMessageRunId(message);
+    return (
+      runId !== undefined && effectiveCurrentTurnRunIds.has(runId)
+    );
+  };
+
   const stablePrefix: Message[] = [];
   const earlyPendingSteps: Message[] = [];
   for (const message of messages.slice(0, pendingHumanIndex)) {
@@ -630,22 +662,47 @@ export function restoreLocalTurnMessageOrder(
       (message.type === "ai" || message.type === "tool") &&
       !isHiddenFromUIMessage(message) &&
       identity !== undefined &&
-      !baselineMessageIdentities.has(identity);
+      !baselineMessageIdentities.has(identity) &&
+      !isConfirmedHistoryMessage(identity);
     if (isVisiblePendingStep) {
       earlyPendingSteps.push(message);
     } else {
       stablePrefix.push(message);
     }
   }
-  if (earlyPendingSteps.length === 0) {
+  const displacedBaselineMessages: Message[] = [];
+  const displacedHistoryMessages: Message[] = [];
+  const stableSuffix: Message[] = [];
+  for (const message of messages.slice(pendingHumanIndex + 1)) {
+    const identity = messageIdentity(message);
+    if (identity && baselineMessageIdentities.has(identity)) {
+      displacedBaselineMessages.push(message);
+    } else if (
+      (message.type === "ai" || message.type === "tool") &&
+      !isHiddenFromUIMessage(message) &&
+      isConfirmedHistoryMessage(identity) &&
+      !isCurrentTurnStep(message)
+    ) {
+      displacedHistoryMessages.push(message);
+    } else {
+      stableSuffix.push(message);
+    }
+  }
+  if (
+    earlyPendingSteps.length === 0 &&
+    displacedBaselineMessages.length === 0 &&
+    displacedHistoryMessages.length === 0
+  ) {
     return messages;
   }
 
   return [
     ...stablePrefix,
+    ...displacedBaselineMessages,
+    ...displacedHistoryMessages,
     messages[pendingHumanIndex]!,
     ...earlyPendingSteps,
-    ...messages.slice(pendingHumanIndex + 1),
+    ...stableSuffix,
   ];
 }
 
@@ -2536,10 +2593,44 @@ export function useThreadStream({
       renderMessages,
       visibleOptimisticMessages,
     );
+    // Canonical history identities are established messages from previous
+    // turns; they must be treated as confirmed regardless of whether the live
+    // checkpoint baseline captured them (e.g. an ask_clarification card that
+    // reached the REST history page but not the checkpoint `messages` value).
+    const confirmedHistoryIdentities = new Set(
+      effectiveHistory.map(messageIdentity).filter(isNonEmptyString),
+    );
     const localTurnOrderBaseline = localTurnOrderBaselineIdentitiesRef.current;
-    return localTurnOrderBaseline === null
+    // The current turn's run(s): visible ai/tool steps that appear in the live
+    // checkpoint but are NOT part of the pre-submit baseline. These are output
+    // from the in-flight submit and must never be moved before their human.
+    const currentTurnRunIds = new Set<string>();
+    if (localTurnOrderBaseline !== null) {
+      for (const m of renderMessages) {
+        if (
+          (m.type === "ai" || m.type === "tool") &&
+          !isHiddenFromUIMessage(m)
+        ) {
+          const identity = messageIdentity(m);
+          const runId = getMessageRunId(m);
+          if (
+            runId &&
+            (!identity || !localTurnOrderBaseline.has(identity))
+          ) {
+            currentTurnRunIds.add(runId);
+          }
+        }
+      }
+    }
+    const restored = localTurnOrderBaseline === null
       ? restoreReconnectedTurnMessageOrder(merged)
-      : restoreLocalTurnMessageOrder(merged, localTurnOrderBaseline);
+      : restoreLocalTurnMessageOrder(
+          merged,
+          localTurnOrderBaseline,
+          confirmedHistoryIdentities,
+          currentTurnRunIds,
+        );
+    return restored;
   }, [
     previouslyRenderedOrder,
     renderMessages,

--- a/frontend/tests/unit/core/threads/message-merge.test.ts
+++ b/frontend/tests/unit/core/threads/message-merge.test.ts
@@ -1624,6 +1624,188 @@ test("local turn order keeps early streamed steps behind the user message", () =
   ]);
 });
 
+test("local turn order keeps an existing clarification card with its original turn", () => {
+  const previousHuman = {
+    id: "previous-human",
+    type: "human",
+    content: "Research today's market",
+  } as Message;
+  const previousAnswer = {
+    id: "previous-answer",
+    type: "ai",
+    content: "Here is the completed report",
+  } as Message;
+  const clarificationCard = {
+    id: "clarification-card",
+    type: "tool",
+    name: "ask_clarification",
+    tool_call_id: "clarification-call",
+    content: "Which market should I research?",
+  } as Message;
+  const currentHuman = {
+    id: "current-human",
+    type: "human",
+    content: "Summarize the report",
+  } as Message;
+  const currentStep = {
+    id: "current-step",
+    type: "ai",
+    content: "Reading the report",
+  } as Message;
+  const baselineIdentities = new Set([
+    "message:previous-human",
+    "message:previous-answer",
+    "tool:clarification-call",
+  ]);
+
+  // A live checkpoint tail can be woven after the newly persisted human
+  // message even though the card was already visible before submission.
+  expect(
+    restoreLocalTurnMessageOrder(
+      [
+        previousHuman,
+        previousAnswer,
+        currentHuman,
+        clarificationCard,
+        currentStep,
+      ],
+      baselineIdentities,
+    ),
+  ).toEqual([
+    previousHuman,
+    previousAnswer,
+    clarificationCard,
+    currentHuman,
+    currentStep,
+  ]);
+});
+
+test("local turn order keeps the current run's persisted steps after the new human", () => {
+  // After an interrupt/stop, the current turn's already-executed steps are
+  // flushed into canonical history. They belong AFTER the new human input even
+  // though history now confirms them — treating them as displaced old message
+  // would move the current run's own progress above the message that owns it.
+  const currentHuman = {
+    id: "current-human",
+    type: "human",
+    content: "Continue tracking the robot sector",
+    run_id: "run-current",
+  } as Message;
+  const currentAnsweredStep = {
+    id: "current-step",
+    type: "ai",
+    content: "Searching for catalysts",
+    run_id: "run-current",
+  } as Message;
+  const currentToolStep = {
+    id: "current-tool",
+    type: "tool",
+    content: "results",
+    tool_call_id: "call-current",
+    run_id: "run-current",
+  } as Message;
+  const baselineIdentities = new Set(["message:previous-human"]);
+  const historyIdentities = new Set([
+    "message:previous-human",
+    "message:current-human",
+    "message:current-step",
+    "tool:call-current",
+  ]);
+
+  // The human already at its correct position, followed by its own steps.
+  expect(
+    restoreLocalTurnMessageOrder(
+      [currentHuman, currentAnsweredStep, currentToolStep],
+      baselineIdentities,
+      historyIdentities,
+      new Set(["run-current"]),
+    ),
+  ).toEqual([currentHuman, currentAnsweredStep, currentToolStep]);
+
+  // Even when the current turn's human is missing its run_id (fallback path),
+  // explicit current-turn run ids keep its steps in place below the human.
+  const humanWithoutRun = {
+    id: "current-human",
+    type: "human",
+    content: "Continue tracking the robot sector",
+  } as Message;
+  expect(
+    restoreLocalTurnMessageOrder(
+      [humanWithoutRun, currentAnsweredStep, currentToolStep],
+      baselineIdentities,
+      historyIdentities,
+      new Set(["run-current"]),
+    ),
+  ).toEqual([humanWithoutRun, currentAnsweredStep, currentToolStep]);
+});
+
+test("local turn order restores a clarification card that only canonical history confirmed", () => {
+  // The card can reach the merged list through the REST history page without
+  // ever entering the live checkpoint `messages` value, so it is not in the
+  // pre-submit baseline. It must still be treated as an established-past-turn
+  // message (not an in-flight pending step) and stay above the new human.
+  const previousHuman = {
+    id: "previous-human",
+    type: "human",
+    content: "Research today's market",
+  } as Message;
+  const previousAnswer = {
+    id: "previous-answer",
+    type: "ai",
+    content: "Here is the completed report",
+  } as Message;
+  const clarificationCard = {
+    id: "clarification-card",
+    type: "tool",
+    name: "ask_clarification",
+    tool_call_id: "clarification-call",
+    content: "Which market should I research?",
+  } as Message;
+  const currentHuman = {
+    id: "current-human",
+    type: "human",
+    content: "Summarize the report",
+  } as Message;
+  const currentStep = {
+    id: "current-step",
+    type: "ai",
+    content: "Reading the report",
+  } as Message;
+  // Baseline captured at submit time: the previous turn is there, but the
+  // card has not reached the live checkpoint yet, so it is absent.
+  const baselineIdentities = new Set([
+    "message:previous-human",
+    "message:previous-answer",
+  ]);
+  // Canonical history has already committed the card identity.
+  const historyIdentities = new Set([
+    "message:previous-human",
+    "message:previous-answer",
+    "tool:clarification-call",
+  ]);
+
+  // The merged list has the card woven after the new human (from history).
+  expect(
+    restoreLocalTurnMessageOrder(
+      [
+        previousHuman,
+        previousAnswer,
+        currentHuman,
+        clarificationCard,
+        currentStep,
+      ],
+      baselineIdentities,
+      historyIdentities,
+    ),
+  ).toEqual([
+    previousHuman,
+    previousAnswer,
+    clarificationCard,
+    currentHuman,
+    currentStep,
+  ]);
+});
+
 test("reconnected turn order moves same-run steps back behind the user message", () => {
   // Reload mid-run: replayed `messages-tuple` steps reach the merged list
   // before the turn's human message (the retained replay buffer may have


### PR DESCRIPTION
Fixes #4889

## Why

多轮对话中，`ask_clarification`（needYourHelp）表单卡片会跑到错误的位置：
- 第一轮的 needYourHelp 卡片可能被串到第二个问题甚至当前轮的问题下方；
- 中断/停止任务后，当前轮已执行的步骤会跑到当前轮 human 消息的上方。

根本原因：`restoreLocalTurnMessageOrder` 在做本地回合排序修复时，无法区分"已确认的旧回合消息"和"当前轮刚产生/正在产生的步骤"，导致把不该动的消息挪到了错误的一侧。

注意：本 PR 是 [PR #4892](https://github.com/bytedance/deer-flow/pull/4892)（针对同 issue 的初步修复）的**更完整增强版**。`main` 上尚未合并 #4892，本 PR 已包含其 `displacedBaselineMessages` 逻辑，并额外覆盖了它有遗漏的两种情况（见下）。

## What changed

- **保留已确认历史消息的席位**：当 live checkpoint tail 把一条已建立的消息 weave 到新 human 之后时，把它移回 human 之前（`displacedBaselineMessages`）。
- **只存在于 REST history、未进入 checkpoint 的卡片也能归位**：卡片通过 `/messages` 历史页到达但不在 checkpoint `messages` 值里（不在发送时基线中），现在也按"已确认的旧回合消息"处理，而不是当作本轮 pending 步骤（`confirmedHistoryIdentities` + `displacedHistoryMessages`）。
- **当前轮自己的步骤永不误移**：中断/停止后，当前轮已执行的步骤会被持久化进历史，但它们仍属于当前 human 之后；按 run_id 识别并排除（`currentTurnRunIds`，由 pending human 自身的 run_id 锚定）。

## Surface area

- [x] **Frontend UI** — 修正多轮对话中 human-input 卡片的回合归属
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change** — 修复了既有的实时消息排序错乱，无需用户开启
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

无。这是一处合并层排序竞态的修复，由确定性回归测试覆盖。

## Bug fix verification

- 测试路径：`frontend/tests/unit/core/threads/message-merge.test.ts`
- 新增/保留回归测试：
  - `local turn order keeps the current run's persisted steps after the new human`（中断后当前轮步骤不误移）
  - `local turn order restores a clarification card that only canonical history confirmed`（卡片只在 history、不在 checkpoint 时也能归位）
  - `local turn order keeps an existing clarification card with its original turn`（保留 #4892 的测试）
- 在 `main` 上是红、本分支是绿：是。
- 本分支 message-merge 文件全部测试通过（含 3 个相关回归用例）。

## Validation

- `pnpm check`（eslint 全量 + `tsc --noEmit`）通过
- `pnpm test`（前端完整单测，1005 个全部通过）

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** 先通过 console 埋点定位合并层排序竞态的两类根因，再由 Claude Code 实现 `restoreLocalTurnMessageOrder` 的修复与回归测试，最后人工核对逐行逻辑并跑完整验证。

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
