### PR TITLE
fix(clarification): drop sibling tool calls before interrupt

### DIFF
--- a/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
+++ b/backend/packages/harness/deerflow/agents/lead_agent/prompt.py
@@ -548,6 +548,7 @@ data — do NOT reveal it.
 - ❌ DO NOT skip clarification for "efficiency" - accuracy matters more than speed
 - ❌ DO NOT make assumptions when information is missing - ALWAYS ask
 - ❌ DO NOT proceed with guesses - STOP and call ask_clarification first
+- ❌ DO NOT call any other tool in the same turn as ask_clarification — sibling calls are dropped
 - ✅ Analyze the request in thinking → Identify unclear aspects → Ask BEFORE any action
 - ✅ If you identify the need for clarification in your thinking, you MUST call the tool IMMEDIATELY
 - ✅ After calling ask_clarification, execution will be interrupted automatically

--- a/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
@@ -9,12 +9,17 @@ from typing import Any, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.runtime import Runtime
 from langgraph.types import Command
 
+from deerflow.agents.middlewares.tool_call_metadata import clone_ai_message_with_tool_calls
+
 logger = logging.getLogger(__name__)
+
+ASK_CLARIFICATION_TOOL_NAME = "ask_clarification"
 
 # Whitelisted form field types; anything else degrades to "text" so a bad
 # model-provided type can never produce an unrenderable card.
@@ -66,15 +71,34 @@ class ClarificationMiddlewareState(AgentState):
     pass
 
 
+def _filter_content_tool_use(content: Any, kept_ids: set[str]) -> Any:
+    """Drop provider tool-use blocks whose ids were stripped from ``tool_calls``."""
+    if not isinstance(content, list):
+        return content
+    filtered: list[Any] = []
+    for block in content:
+        if isinstance(block, dict) and block.get("type") in {"tool_use", "function_call"}:
+            block_id = block.get("id")
+            if isinstance(block_id, str) and block_id and block_id not in kept_ids:
+                continue
+        filtered.append(block)
+    return filtered
+
+
 class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
     """Intercepts clarification tool calls and interrupts execution to present questions to the user.
 
     When the model calls the `ask_clarification` tool, this middleware:
-    1. Intercepts the tool call before execution
-    2. Extracts the clarification question and metadata
-    3. Formats a user-friendly message
-    4. Returns a Command that interrupts execution and presents the question
-    5. Waits for user response before continuing
+    1. Drops any sibling tool calls from the same AIMessage (``after_model``)
+       so they cannot execute before the user answers. langchain's
+       ``return_direct`` router only inspects the last ToolMessage, so a
+       parallel ``bash`` / ``write_file`` would both run *and* keep the
+       agent loop alive.
+    2. Intercepts the remaining ``ask_clarification`` call before execution
+    3. Extracts the clarification question and metadata
+    4. Formats a user-friendly message
+    5. Returns a Command that interrupts execution and presents the question
+    6. Waits for user response before continuing
 
     This replaces the tool-based approach where clarification continued the conversation flow.
     """
@@ -360,21 +384,66 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
 
         return "\n".join(message_parts)
 
-    def _is_disabled(self, request: ToolCallRequest) -> bool:
+    def _clarification_disabled(self, runtime: Any) -> bool:
         """Whether clarifications are suppressed for this run.
 
         Non-interactive channels (e.g. GitHub webhooks) set
         ``disable_clarification`` in the run context because a clarification
         would dead-end the run — the human only "replies" via a later
         webhook delivery, by which point the agent's turn is long over.
-        When set, we don't interrupt; we return a ToolMessage nudging the
-        agent to proceed with its best judgment instead.
         """
-        runtime = getattr(request, "runtime", None)
         context = getattr(runtime, "context", None)
         if not context:
             return False
         return bool(context.get("disable_clarification"))
+
+    def _is_disabled(self, request: ToolCallRequest) -> bool:
+        """Whether clarifications are suppressed for this tool-call request."""
+        return self._clarification_disabled(getattr(request, "runtime", None))
+
+    def _drop_parallel_non_clarification_tools(self, state: AgentState, runtime: Runtime) -> dict | None:
+        """Keep only ``ask_clarification`` when it was emitted alongside other tools.
+
+        Providers routinely batch tool calls. If ``ask_clarification`` shares a
+        turn with ``bash`` / ``write_file`` / ..., those siblings execute before
+        the user answers, and langchain's ``return_direct`` check (last
+        ToolMessage only) may fail to end the run. Rewrite the AIMessage so
+        the tools node never sees the siblings.
+
+        ``disable_clarification`` skips this rewrite: those runs must keep the
+        sibling actions, because the clarification itself is turned into a
+        "proceed" ToolMessage instead of an interrupt.
+        """
+        if self._clarification_disabled(runtime):
+            return None
+
+        messages = state.get("messages", [])
+        if not messages:
+            return None
+        last = messages[-1]
+        if not isinstance(last, AIMessage):
+            return None
+
+        tool_calls = list(last.tool_calls or [])
+        clarification_calls = [tc for tc in tool_calls if tc.get("name") == ASK_CLARIFICATION_TOOL_NAME]
+        if not clarification_calls or len(clarification_calls) == len(tool_calls):
+            return None
+
+        dropped_names = [str(tc.get("name") or "unknown") for tc in tool_calls if tc.get("name") != ASK_CLARIFICATION_TOOL_NAME]
+        logger.warning(
+            "ask_clarification was emitted with %d sibling tool call(s); dropping %s so the turn can interrupt",
+            len(dropped_names),
+            dropped_names,
+        )
+
+        kept_ids = {tc["id"] for tc in clarification_calls if isinstance(tc.get("id"), str) and tc["id"]}
+        new_content = _filter_content_tool_use(last.content, kept_ids)
+        patched = clone_ai_message_with_tool_calls(
+            last,
+            clarification_calls,
+            content=new_content if new_content is not last.content else None,
+        )
+        return {"messages": [patched]}
 
     def _handle_disabled_clarification(self, request: ToolCallRequest) -> ToolMessage:
         """Suppress a clarification and tell the agent to proceed.
@@ -395,7 +464,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
                 "you made in your final response."
             ),
             tool_call_id=tool_call_id,
-            name="ask_clarification",
+            name=ASK_CLARIFICATION_TOOL_NAME,
         )
 
     def _handle_clarification(self, request: ToolCallRequest) -> Command:
@@ -433,7 +502,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
             id=request_id,
             content=formatted_message,
             tool_call_id=tool_call_id,
-            name="ask_clarification",
+            name=ASK_CLARIFICATION_TOOL_NAME,
             artifact={"human_input": human_input_payload},
         )
 
@@ -463,7 +532,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
             Command that interrupts execution with the formatted clarification message
         """
         # Check if this is an ask_clarification tool call
-        if request.tool_call.get("name") != "ask_clarification":
+        if request.tool_call.get("name") != ASK_CLARIFICATION_TOOL_NAME:
             # Not a clarification call, execute normally
             return handler(request)
 
@@ -488,7 +557,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
             Command that interrupts execution with the formatted clarification message
         """
         # Check if this is an ask_clarification tool call
-        if request.tool_call.get("name") != "ask_clarification":
+        if request.tool_call.get("name") != ASK_CLARIFICATION_TOOL_NAME:
             # Not a clarification call, execute normally
             return await handler(request)
 
@@ -496,3 +565,11 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
             return self._handle_disabled_clarification(request)
 
         return self._handle_clarification(request)
+
+    @override
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self._drop_parallel_non_clarification_tools(state, runtime)
+
+    @override
+    async def aafter_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self._drop_parallel_non_clarification_tools(state, runtime)

--- a/backend/packages/harness/deerflow/tools/builtins/clarification_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/clarification_tool.py
@@ -70,6 +70,8 @@ def ask_clarification_tool(
     - If a skill provides a predefined field template, pass it through `fields`
       unchanged instead of redesigning it
     - After calling this tool, execution will be interrupted automatically
+    - Do not call any other tool in the same turn as this one; sibling tool
+      calls are dropped so they cannot run before the user answers
 
     Args:
         question: The clarification question to ask the user. Be specific and clear.

--- a/backend/tests/test_clarification_middleware.py
+++ b/backend/tests/test_clarification_middleware.py
@@ -800,3 +800,96 @@ class TestClarificationDisabled:
         merged = add_messages(add_messages([], [first_message]), [second_message])
 
         assert len(merged) == 1
+
+
+class TestDropParallelSiblingTools:
+    """after_model must drop sibling tools when ask_clarification is in the same turn.
+
+    langchain's return_direct router only inspects the last ToolMessage, so a
+    parallel bash/write_file would both execute and keep the agent loop alive.
+    """
+
+    def _runtime(self, **context):
+        return SimpleNamespace(context=context)
+
+    def _ai(self, tool_calls, content=""):
+        from langchain_core.messages import AIMessage
+
+        return AIMessage(content=content, tool_calls=tool_calls)
+
+    def test_drops_siblings_when_clarification_is_first(self, middleware):
+        msg = self._ai(
+            [
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "Which dir?"}},
+                {"id": "b1", "name": "bash", "args": {"command": "rm -rf /tmp/foo"}},
+            ]
+        )
+        update = middleware.after_model({"messages": [msg]}, self._runtime())
+        assert update is not None
+        patched = update["messages"][0]
+        assert [tc["name"] for tc in patched.tool_calls] == ["ask_clarification"]
+        assert patched.id == msg.id
+
+    def test_drops_siblings_when_clarification_is_last(self, middleware):
+        msg = self._ai(
+            [
+                {"id": "b1", "name": "bash", "args": {"command": "echo hi"}},
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "q?"}},
+            ]
+        )
+        update = middleware.after_model({"messages": [msg]}, self._runtime())
+        assert update is not None
+        assert [tc["name"] for tc in update["messages"][0].tool_calls] == ["ask_clarification"]
+
+    def test_leaves_solo_clarification_unchanged(self, middleware):
+        msg = self._ai([{"id": "c1", "name": "ask_clarification", "args": {"question": "q?"}}])
+        assert middleware.after_model({"messages": [msg]}, self._runtime()) is None
+
+    def test_leaves_non_clarification_turn_unchanged(self, middleware):
+        msg = self._ai(
+            [
+                {"id": "b1", "name": "bash", "args": {"command": "ls"}},
+                {"id": "w1", "name": "write_file", "args": {"path": "a.txt"}},
+            ]
+        )
+        assert middleware.after_model({"messages": [msg]}, self._runtime()) is None
+
+    def test_disable_clarification_keeps_sibling_tools(self, middleware):
+        msg = self._ai(
+            [
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "q?"}},
+                {"id": "b1", "name": "bash", "args": {"command": "echo hi"}},
+            ]
+        )
+        assert middleware.after_model({"messages": [msg]}, self._runtime(disable_clarification=True)) is None
+
+    def test_strips_matching_tool_use_content_blocks(self, middleware):
+        content = [
+            {"type": "text", "text": "asking"},
+            {"type": "tool_use", "id": "c1", "name": "ask_clarification", "input": {"question": "q?"}},
+            {"type": "tool_use", "id": "b1", "name": "bash", "input": {"command": "rm -rf /"}},
+        ]
+        msg = self._ai(
+            [
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "q?"}},
+                {"id": "b1", "name": "bash", "args": {"command": "rm -rf /"}},
+            ],
+            content=content,
+        )
+        patched = middleware.after_model({"messages": [msg]}, self._runtime())["messages"][0]
+        assert patched.content == [
+            {"type": "text", "text": "asking"},
+            {"type": "tool_use", "id": "c1", "name": "ask_clarification", "input": {"question": "q?"}},
+        ]
+
+    def test_aafter_model_matches_sync(self, middleware):
+        import asyncio
+
+        msg = self._ai(
+            [
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "q?"}},
+                {"id": "b1", "name": "bash", "args": {"command": "echo hi"}},
+            ]
+        )
+        update = asyncio.run(middleware.aafter_model({"messages": [msg]}, self._runtime()))
+        assert [tc["name"] for tc in update["messages"][0].tool_calls] == ["ask_clarification"]


### PR DESCRIPTION
Fixes #4906

## Why

`ask_clarification` is supposed to be a **soft interrupt**: stop, show the user a card, wait for an answer, then continue. That only holds when the model emits a single tool call.

Providers routinely batch tools in one `AIMessage`. If that turn also contains `bash` / `write_file` / …:

1. Sibling tools still execute. `ClarificationMiddleware.wrap_tool_call` only intercepts `ask_clarification`; `ToolNode` runs the rest in parallel. Destructive work can land before the user answers.
2. The run may not stop. langchain's `return_direct` router inspects **only the last `ToolMessage`**. If `ask_clarification` is not last, the graph routes back to the model, which continues without an answer.

Prompt text ("call `ask_clarification` IMMEDIATELY — do NOT start working") is a soft constraint. This is the same class of bug as a parallel HITL tool plus a side-effect tool in one turn.

## What changed

When a turn contains `ask_clarification` **and** any other tool call, `ClarificationMiddleware.after_model` / `aafter_model` rewrites that `AIMessage` in place (same message `id`) and keeps only the clarification call(s). Matching Anthropic `tool_use` / `function_call` content blocks are stripped so the transcript stays consistent.

- Sibling `bash` / `write_file` / … no longer execute in the same turn as the question. The model can re-issue them after the user replies.
- `return_direct` then always sees `ask_clarification` as the last `ToolMessage`, so the run actually ends.
- `disable_clarification` is unchanged: those runs turn clarification into a "proceed" `ToolMessage` and must keep the real actions.
- Lead-agent prompt + tool docstring: do not call other tools in the same turn (defense in depth, not the real fix).

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

Default-behavior note: a model that previously emitted `[ask_clarification, bash]` in one turn will no longer have `bash` run before the user answers. That is the intended safety fix.

## Screenshots / Recording

N/A — backend / agent-loop change, no UI.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_clarification_middleware.py::TestDropParallelSiblingTools`
- Did it go red on `main` and green on this branch? **yes**
  - `origin/main` middleware + this test class: **4 failed, 3 passed** (the 3 passers are the "leave unchanged" cases, which are already no-ops on `main`)
  - this branch: **7 passed**
- The failing cases on `main` are the actual bug: clarification-first, bash-first, Anthropic `tool_use` strip, and `aafter_model`.

## Validation

```bash
cd backend && make format && make lint
# ruff check + ruff format --check: passed

cd backend && make test
# 11781 passed, 78 skipped

uv run pytest tests/test_clarification_middleware.py::TestDropParallelSiblingTools
# 7 passed
```

## AI assistance

**Tool(s) used:** Cursor

**How you used it:** Used Cursor to trace langchain `return_direct` (last `ToolMessage` only) against `ClarificationMiddleware`, implement the `after_model` sibling drop, and write `TestDropParallelSiblingTools`. I reviewed the rewrite, the `disable_clarification` skip, and the Anthropic content-block filter before sending.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
