### PR TITLE
docs: fix architecture guide relative links

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,11 +4,11 @@ This document is the **top-level architecture overview** for DeerFlow. It explai
 "big picture" — how the services, layers, and cross-cutting subsystems fit together — and
 points to the module-level guides that own the depth:
 
-- Backend depth → [`backend/AGENTS.md`](backend/AGENTS.md) and [`backend/docs/ARCHITECTURE.md`](backend/docs/ARCHITECTURE.md)
-- Frontend depth → [`frontend/AGENTS.md`](frontend/AGENTS.md)
+- Backend depth → [`backend/AGENTS.md`](../backend/AGENTS.md) and [`backend/docs/ARCHITECTURE.md`](../backend/docs/ARCHITECTURE.md)
+- Frontend depth → [`frontend/AGENTS.md`](../frontend/AGENTS.md)
 
 DeerFlow 2.0 is a ground-up rewrite of the original Deep Research framework (see
-[`README.md`](README.md)); it shares no code with v1.
+[`README.md`](../README.md)); it shares no code with v1.
 
 ---
 
@@ -160,7 +160,7 @@ These span both layers and require reading multiple files to understand:
 - **Version sources** — a release version must match in `backend/pyproject.toml`,
   `frontend/package.json`, and `deploy/helm/deer-flow/Chart.yaml` (`version` + `appVersion`);
   pushing a `v*` tag triggers CI that runs `scripts/verify_versions.sh` and blocks all
-  publishing on drift. See [`RELEASING.md`](RELEASING.md).
+  publishing on drift. See [`RELEASING.md`](../RELEASING.md).
 
 ---
 
@@ -174,16 +174,16 @@ These span both layers and require reading multiple files to understand:
   resolution; servers toggle independently.
 - **Loopback-by-default ingress**: nginx is the only published surface; the Gateway's `8001`
   is container-internal and never published. A bare `"${PORT}:2026"` bind (0.0.0.0) is
-  rejected by convention and CI. See the Security Notice in [`README.md`](README.md) before
+  rejected by convention and CI. See the Security Notice in [`README.md`](../README.md) before
   any non-loopback deployment.
 
 ---
 
 ## 7. Where to Go Next
 
-- System topology & component depth → [`backend/docs/ARCHITECTURE.md`](backend/docs/ARCHITECTURE.md)
-- Backend commands, TDD, harness/app boundary, config reload → [`backend/AGENTS.md`](backend/AGENTS.md)
-- Frontend commands, source layout, streaming data flow → [`frontend/AGENTS.md`](frontend/AGENTS.md)
-- Setup & install → [`Install.md`](Install.md), [`CONTRIBUTING.md`](CONTRIBUTING.md)
-- Release process → [`RELEASING.md`](RELEASING.md)
-- User-facing features & deployment sizing → [`README.md`](README.md)
+- System topology & component depth → [`backend/docs/ARCHITECTURE.md`](../backend/docs/ARCHITECTURE.md)
+- Backend commands, TDD, harness/app boundary, config reload → [`backend/AGENTS.md`](../backend/AGENTS.md)
+- Frontend commands, source layout, streaming data flow → [`frontend/AGENTS.md`](../frontend/AGENTS.md)
+- Setup & install → [`Install.md`](../Install.md), [`CONTRIBUTING.md`](../CONTRIBUTING.md)
+- Release process → [`RELEASING.md`](../RELEASING.md)
+- User-facing features & deployment sizing → [`README.md`](../README.md)


### PR DESCRIPTION
## What changed

- fix the repository-relative links in `docs/ARCHITECTURE.md`
- point architecture, setup, release, backend, frontend, and README references to their actual locations from the `docs/` directory

## Why

`docs/ARCHITECTURE.md` lives one directory below the repository root, but its links were written as if the file were at the root. On GitHub, those links resolved to paths such as `docs/backend/AGENTS.md` instead of the intended repository files.

## Validation

- verified all 13 relative links in `docs/ARCHITECTURE.md` against the current repository tree
- ran `git diff --check`
- confirmed the Markdown lint warning count is unchanged from the upstream baseline
