### PR TITLE
feat(skills): add zcode-to-deerflow and dsh-to-deerflow host skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,32 @@ DEERFLOW_LANGGRAPH_URL=http://localhost:2026/api/langgraph  # LangGraph API
 
 See [`skills/public/claude-to-deerflow/SKILL.md`](skills/public/claude-to-deerflow/SKILL.md) for the full API reference.
 
+#### ZCode Integration
+
+The `zcode-to-deerflow` skill brings the same DeerFlow access to [ZCode](https://zcode.z.ai) sessions: delegate research questions from a ZCode task, relay answers and artifact links back, and reuse threads across turns.
+
+**Install the skill**:
+
+```bash
+npx skills add https://github.com/bytedance/deer-flow --skill zcode-to-deerflow
+# or copy/symlink skills/public/zcode-to-deerflow into your project's .agents/skills/
+```
+
+See [`skills/public/zcode-to-deerflow/SKILL.md`](skills/public/zcode-to-deerflow/SKILL.md) for the workflow (skill-dir resolution, background-and-poll for long runs, thread reuse).
+
+#### DeepSeek Harness (dsh) Integration
+
+The `dsh-to-deerflow` skill lets a [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (dsh) agent call DeerFlow through its `bash` tool — including a nohup-and-poll pattern for multi-minute research runs that exceed a single bash tool budget.
+
+**Install the skill** (into the dsh task workspace, before launching the run):
+
+```bash
+cd <task-workdir> && mkdir -p .agents/skills
+cp -r <deer-flow-checkout>/skills/public/dsh-to-deerflow .agents/skills/
+```
+
+See [`skills/public/dsh-to-deerflow/SKILL.md`](skills/public/dsh-to-deerflow/SKILL.md) for the full workflow.
+
 ### Session Goals
 
 Use `/goal <completion condition>` to attach one active completion condition to the current thread. The goal is thread-scoped state, not a skill activation, so it stays active across turns until DeerFlow determines it has been satisfied or you clear it.

--- a/skills/public/claude-to-deerflow/SKILL.md
+++ b/skills/public/claude-to-deerflow/SKILL.md
@@ -98,7 +98,7 @@ data: <json_data>
 Key event types:
 - `metadata` — run metadata including `run_id`
 - `values` — full state snapshot with `messages` array
-- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `messages` — incremental message updates (AI text chunks, tool calls, tool results; produced when the `messages-tuple` stream mode is requested)
 - `end` — stream is complete
 
 **Context modes** (set via `context`):
@@ -170,7 +170,9 @@ curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
 ### 11. Get Thread History
 
 ```bash
-curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 10}'
 ```
 
 ### 12. List Threads
@@ -178,7 +180,7 @@ curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
 ```bash
 curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
   -H "Content-Type: application/json" \
-  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+  -d '{"limit": 20}'
 ```
 
 ## Usage Script

--- a/skills/public/claude-to-deerflow/scripts/chat.sh
+++ b/skills/public/claude-to-deerflow/scripts/chat.sh
@@ -24,7 +24,7 @@ THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -93,11 +93,14 @@ ENDJSON
 # --- Stream the run and extract final response ---
 # We collect the full SSE output, then parse the last values event to get the AI response.
 TMPFILE=$(mktemp)
-trap "rm -f '$TMPFILE'" EXIT
+trap 'rm -f "$TMPFILE"' EXIT
 
-curl -s -N -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"
+  -d "$BODY" > "$TMPFILE"; then
+  echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
 
 # Parse the SSE output: extract the last "event: values" data block and get the final AI message
 python3 - "$TMPFILE" "$GATEWAY_URL" "$THREAD_ID" << 'PYEOF'
@@ -194,6 +197,12 @@ def format_artifact_text(artifacts):
         return f"Created File: {urls[0]}"
     return "Created Files:\n" + "\n".join(urls)
 
+def first_error_event():
+    for event_type, data_str in events:
+        if event_type == "error":
+            return data_str
+    return None
+
 # Find the last "values" event with messages
 result_messages = None
 for event_type, data_str in reversed(events):
@@ -216,14 +225,17 @@ if result_messages is not None:
     if response_text:
         print(response_text)
     else:
+        err = first_error_event()
+        if err is not None:
+            print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+            sys.exit(1)
         print("(No response from agent)", file=sys.stderr)
         sys.exit(1)
 else:
-    # Check for error events
-    for event_type, data_str in events:
-        if event_type == "error":
-            print(f"ERROR from DeerFlow: {data_str}", file=sys.stderr)
-            sys.exit(1)
+    err = first_error_event()
+    if err is not None:
+        print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+        sys.exit(1)
     print("No AI response found in the stream.", file=sys.stderr)
     if len(raw) < 2000:
         print(f"Raw SSE output:\n{raw}", file=sys.stderr)

--- a/skills/public/claude-to-deerflow/scripts/chat.sh
+++ b/skills/public/claude-to-deerflow/scripts/chat.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # chat.sh — Send a message to DeerFlow and collect the streaming response.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash chat.sh "Your question here"
@@ -19,12 +21,19 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 MESSAGE="${1:?Usage: chat.sh <message> [thread_id] [mode]}"
 THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -34,10 +43,10 @@ fi
 
 # --- Create or reuse thread ---
 if [ -z "$THREAD_ID" ]; then
-  THREAD_RESP=$(curl -s -X POST "${LANGGRAPH_URL}/threads" \
+  THREAD_RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads" \
     -H "Content-Type: application/json" \
-    -d '{}')
-  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null)
+    -d '{}' || true)
+  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null || true)
   if [ -z "$THREAD_ID" ]; then
     echo "ERROR: Failed to create thread. Response: ${THREAD_RESP}" >&2
     exit 1
@@ -45,25 +54,26 @@ if [ -z "$THREAD_ID" ]; then
   echo "Thread: ${THREAD_ID}" >&2
 fi
 
-# --- Build context based on mode ---
+# --- Build context based on mode (json.dumps: safe for any thread_id) ---
 case "$MODE" in
-  flash)
-    CONTEXT='{"thinking_enabled":false,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  standard)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  pro)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  ultra)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":true,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
+  flash|standard|pro|ultra) ;;
   *)
     echo "ERROR: Unknown mode '${MODE}'. Use: flash, standard, pro, ultra" >&2
     exit 1
     ;;
 esac
+CONTEXT=$(python3 -c '
+import json, sys
+modes = {
+    "flash": (False, False, False),
+    "standard": (True, False, False),
+    "pro": (True, True, False),
+    "ultra": (True, True, True),
+}
+t, p, sg = modes[sys.argv[1]]
+print(json.dumps({"thinking_enabled": t, "is_plan_mode": p,
+                  "subagent_enabled": sg, "thread_id": sys.argv[2]}))
+' "$MODE" "$THREAD_ID")
 
 # --- Escape message for JSON ---
 ESCAPED_MSG=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$MESSAGE")
@@ -95,10 +105,19 @@ ENDJSON
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
-if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+STREAM_STATUS=$(curl -s -N --connect-timeout 10 --max-time "${DEERFLOW_TIMEOUT:-3600}" "${COOKIE_ARGS[@]}" \
+  -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"; then
+  -d "$BODY" -o "$TMPFILE" -w "%{http_code}" || true)
+STREAM_STATUS="${STREAM_STATUS:-000}"
+if [ "$STREAM_STATUS" = "000" ]; then
   echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
+if [ "$STREAM_STATUS" -ge 400 ] 2>/dev/null; then
+  echo "ERROR: DeerFlow returned HTTP ${STREAM_STATUS} for the stream request:" >&2
+  head -c 400 "$TMPFILE" >&2
+  echo >&2
   exit 1
 fi
 
@@ -139,14 +158,15 @@ for line in raw.split("\n"):
 if current_event and current_data_lines:
     events.append((current_event, "\n".join(current_data_lines)))
 
-import posixpath
-
 def extract_response_text(messages):
     """Mirror manager.py _extract_response_text: handles ask_clarification interrupt + regular AI."""
     for msg in reversed(messages):
         if not isinstance(msg, dict):
             continue
         msg_type = msg.get("type")
+        # anything before the last human message is a previous turn
+        if msg_type == "human":
+            break
         # ask_clarification interrupt: tool message with name ask_clarification
         if msg_type == "tool" and msg.get("name") == "ask_clarification":
             content = msg.get("content", "")
@@ -180,7 +200,13 @@ def extract_artifacts(messages):
         if msg.get("type") == "ai":
             for tc in msg.get("tool_calls", []):
                 if isinstance(tc, dict) and tc.get("name") == "present_files":
-                    paths = tc.get("args", {}).get("filepaths", [])
+                    args = tc.get("args") or {}
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except ValueError:
+                            args = {}
+                    paths = args.get("filepaths", []) if isinstance(args, dict) else []
                     if isinstance(paths, list):
                         artifacts.extend(p for p in paths if isinstance(p, str))
     return artifacts
@@ -242,6 +268,6 @@ else:
     sys.exit(1)
 PYEOF
 
-echo ""
-echo "---"
+echo "" >&2
+echo "---" >&2
 echo "Thread ID: ${THREAD_ID}" >&2

--- a/skills/public/claude-to-deerflow/scripts/status.sh
+++ b/skills/public/claude-to-deerflow/scripts/status.sh
@@ -26,7 +26,7 @@ ARG="${2:-}"
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"

--- a/skills/public/claude-to-deerflow/scripts/status.sh
+++ b/skills/public/claude-to-deerflow/scripts/status.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # status.sh — Check DeerFlow status and list available resources.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash status.sh                  # health + summary
@@ -20,14 +22,21 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 CMD="${1:-health}"
 ARG="${2:-}"
 
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
-HTTP_CODE="${HTTP_CODE:-000}"
+    HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"
       exit 1
@@ -39,25 +48,48 @@ HTTP_CODE="${HTTP_CODE:-000}"
     fi
     ;;
   models)
-    curl -s "${GATEWAY_URL}/api/models" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/models" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/models:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   skills)
-    curl -s "${GATEWAY_URL}/api/skills" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/skills" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/skills:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   agents)
-    curl -s "${GATEWAY_URL}/api/agents" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/agents" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/agents:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   threads)
-    curl -s -X POST "${LANGGRAPH_URL}/threads/search" \
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/search" \
       -H "Content-Type: application/json" \
-      -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc", "select": ["thread_id", "updated_at", "values"]}' \
+      -d '{"limit": 20}' \
       | python3 -c "
 import json, sys
 threads = json.load(sys.stdin)
+if not isinstance(threads, list):
+    print(f'Unexpected response (not a thread list): {str(threads)[:200]}')
+    sys.exit(1)
 if not threads:
     print('No threads found.')
     sys.exit(0)
 for t in threads:
+    if not isinstance(t, dict):
+        continue
     tid = t.get('thread_id', '?')
     updated = t.get('updated_at', '?')
     title = (t.get('values') or {}).get('title', '(untitled)')
@@ -65,14 +97,22 @@ for t in threads:
 "
     ;;
   memory)
-    curl -s "${GATEWAY_URL}/api/memory" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/memory" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/memory:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   thread)
     if [ -z "$ARG" ]; then
       echo "Usage: status.sh thread <thread_id>" >&2
       exit 1
     fi
-    curl -s "${LANGGRAPH_URL}/threads/${ARG}/history" | python3 -c "
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/${ARG}/history" \
+      -H "Content-Type: application/json" \
+      -d '{"limit": 10}' | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 if isinstance(data, list):
@@ -80,6 +120,8 @@ if isinstance(data, list):
         values = state.get('values', {})
         msgs = values.get('messages', [])
         for m in msgs[-5:]:
+            if not isinstance(m, dict):
+                continue
             role = m.get('type', '?')
             content = m.get('content', '')
             if isinstance(content, list):

--- a/skills/public/dsh-to-deerflow/SKILL.md
+++ b/skills/public/dsh-to-deerflow/SKILL.md
@@ -1,0 +1,276 @@
+---
+name: dsh-to-deerflow
+description: "Interact with DeerFlow AI agent platform via its HTTP API from a DeepSeek Harness (dsh) agent. Use this skill when a dsh headless task needs to delegate deep research or analysis to DeerFlow, start or continue a DeerFlow conversation thread, check DeerFlow status or health, or list DeerFlow models/skills/agents. Also use when the user mentions deerflow, deer flow, deepseek-harness, dsh, or wants a dsh-driven agent to run a deep research task that DeerFlow can handle."
+---
+
+# DeerFlow Skill (DeepSeek Harness host)
+
+Communicate with a running DeerFlow instance via its HTTP API from inside a DeepSeek Harness (dsh)
+agent. DeerFlow is an AI agent platform built on LangGraph that orchestrates sub-agents for
+research, code execution, web browsing, and more. dsh (github.com/deepseek-ai/deepseek-harness)
+is a plugin-based agent harness; its `bash` tool is the bridge to DeerFlow — everything here runs
+as plain `curl` / helper-script shell commands.
+
+## Architecture
+
+DeerFlow exposes two API surfaces behind an Nginx reverse proxy:
+
+| Service        | Direct Port | Via Proxy                        | Purpose                          |
+|----------------|-------------|----------------------------------|----------------------------------|
+| Gateway API    | 8001        | `$DEERFLOW_GATEWAY_URL`          | REST endpoints and embedded agent runtime |
+| LangGraph-compatible API | 8001 | `$DEERFLOW_LANGGRAPH_URL`       | Agent threads, runs, streaming   |
+
+## Environment Variables
+
+All URLs are configurable via environment variables. **Read these env vars before making any request.**
+
+| Variable                | Default                                  | Description                        |
+|-------------------------|------------------------------------------|------------------------------------|
+| `DEERFLOW_URL`          | `http://localhost:2026`                  | Unified proxy base URL             |
+| `DEERFLOW_GATEWAY_URL`  | `${DEERFLOW_URL}`                        | Gateway API base (models, skills, memory, uploads) |
+| `DEERFLOW_LANGGRAPH_URL`| `${DEERFLOW_URL}/api/langgraph`          | LangGraph API base (threads, runs) |
+
+When making curl calls, always resolve the URL like this:
+
+```bash
+# Resolve base URLs from env (do this FIRST before any API call)
+DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
+DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
+DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+```
+
+dsh note: the bash tool inherits the environment of the dsh process, so export
+`DEERFLOW_URL` (and overrides) **before launching the dsh run** — exporting them inside a bash
+tool call only affects that single call.
+
+## dsh Workflow
+
+### 1. Install this skill into the task workspace
+
+dsh discovers project skills from the task working directory. Copy the skill there (and make sure
+the workdir is a git repository — dsh resolves the project root by walking up to `.git`, so run
+`git init` in a fresh workdir first):
+
+```bash
+cd <task-workdir>
+git init -q 2>/dev/null || true
+mkdir -p .agents/skills
+cp -r <source-of-this-skill>/dsh-to-deerflow .agents/skills/
+```
+
+### 2. Check health first
+
+```bash
+bash .agents/skills/dsh-to-deerflow/scripts/status.sh health
+```
+
+If unreachable, DeerFlow is not running. Report that as a blocker with the start hint
+(`cd <deerflow-dir> && make dev`, or `make docker-start` for the Docker setup) instead of
+retrying in a loop.
+
+### 3. Ask DeerFlow
+
+```bash
+bash .agents/skills/dsh-to-deerflow/scripts/chat.sh "Your question here"
+```
+
+The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr.
+The response may also end with `Created File: <url>` artifact links (DeerFlow-generated files) —
+include both the text and the artifact URLs in the task result.
+
+### 4. Handle long research runs
+
+Deep research in pro/ultra mode can take minutes and may exceed a single bash tool call budget
+(`timeoutMs`). Run the chat script in the background, then poll across tool calls:
+
+```bash
+nohup bash .agents/skills/dsh-to-deerflow/scripts/chat.sh "Research question" \
+  > deerflow-out.txt 2> deerflow-err.txt &
+```
+
+- Poll with `read`/`cat` on `deerflow-out.txt`; the run is done when the file holds the final answer.
+- The `Thread ID:` line appears in `deerflow-err.txt` and can be read even while the run continues.
+- Alternatively pass a generous `timeoutMs` to the bash tool for one blocking call.
+
+### 5. Continue a conversation
+
+Reuse the `thread_id` from a previous run:
+
+```bash
+bash .agents/skills/dsh-to-deerflow/scripts/chat.sh "Follow-up question" "<thread_id>"
+```
+
+## Available Operations
+
+### 1. Health Check
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/health"
+```
+
+### 2. Send a Message (Streaming)
+
+This is the primary operation. It creates a thread and streams the agent's response.
+
+**Step 1: Create a thread**
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response: `{"thread_id": "<uuid>", ...}`
+
+**Step 2: Stream a run**
+
+```bash
+curl -s -N -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "lead_agent",
+    "input": {
+      "messages": [
+        {
+          "type": "human",
+          "content": [{"type": "text", "text": "YOUR MESSAGE HERE"}]
+        }
+      ]
+    },
+    "stream_mode": ["values", "messages-tuple"],
+    "stream_subgraphs": true,
+    "config": {
+      "recursion_limit": 1000
+    },
+    "context": {
+      "thinking_enabled": true,
+      "is_plan_mode": true,
+      "subagent_enabled": true,
+      "thread_id": "<thread_id>"
+    }
+  }'
+```
+
+The response is an SSE stream. Each event has the format
+```
+event: <event_type>
+data: <json_data>
+```
+
+Key event types:
+- `metadata` — run metadata including `run_id`
+- `values` — full state snapshot with `messages` array
+- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `end` — stream is complete
+
+**Context modes** (set via `context`):
+- Flash mode: `thinking_enabled: false, is_plan_mode: false, subagent_enabled: false`
+- Standard mode: `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
+- Pro mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: false`
+- Ultra mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: true`
+
+### 3. Continue a Conversation
+
+Reuse the same `thread_id` from step 2 and POST another run with the new message.
+
+### 4. List Models
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/models"
+```
+
+Returns: `{"models": [{"name": "...", "provider": "...", ...}, ...]}`
+
+### 5. List Skills
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/skills"
+```
+
+Returns: `{"skills": [{"name": "...", "enabled": true, ...}, ...]}`
+
+### 6. Enable/Disable a Skill
+
+```bash
+curl -s -X PUT "$DEERFLOW_GATEWAY_URL/api/skills/<skill_name>" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+```
+
+### 7. List Agents
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/agents"
+```
+
+Returns: `{"agents": [{"name": "...", ...}, ...]}`
+
+### 8. Get Memory
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/memory"
+```
+
+Returns user context, facts, and conversation history summaries.
+
+### 9. Upload Files to a Thread
+
+```bash
+curl -s -X POST "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads" \
+  -F "files=@/path/to/file.pdf"
+```
+
+Supports PDF, PPTX, XLSX, DOCX — automatically converts to Markdown.
+
+### 10. List Uploaded Files
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
+```
+
+### 11. Get Thread History
+
+```bash
+curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+```
+
+### 12. List Threads
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+```
+
+## Status Helper
+
+`scripts/status.sh` wraps the read-only operations:
+
+```bash
+bash .agents/skills/dsh-to-deerflow/scripts/status.sh health|models|skills|agents|threads|memory|thread <id>
+```
+
+## Parsing SSE Output
+
+The chat script already handles this. For manual curl streams, to extract the final AI response
+from a `values` event:
+- Look for the last `event: values` block
+- Parse its `data` JSON
+- The `messages` array contains all messages; the last one with `type: "ai"` is the response
+- The `content` field of that message is the AI's text reply
+
+## Error Handling
+
+- If health check fails, DeerFlow is not running. Report the start hint (`make dev` or
+  `make docker-start`) as the blocker and stop instead of retrying blindly.
+- If the stream returns an error event, extract and surface the error message verbatim.
+- Common issues: port not open, services still starting up, config errors.
+
+## Tips
+
+- For quick questions, use flash mode (fastest, no planning).
+- For research tasks, use pro or ultra mode (enables planning and sub-agents).
+- You can upload files first, then reference them in your message.
+- Thread IDs persist — you can return to a conversation later.
+- Prefer the helper scripts over hand-rolled curl: they resolve env vars, parse SSE,
+  and extract artifacts consistently.

--- a/skills/public/dsh-to-deerflow/SKILL.md
+++ b/skills/public/dsh-to-deerflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dsh-to-deerflow
-description: "Interact with DeerFlow AI agent platform via its HTTP API from a DeepSeek Harness (dsh) agent. Use this skill when a dsh headless task needs to delegate deep research or analysis to DeerFlow, start or continue a DeerFlow conversation thread, check DeerFlow status or health, or list DeerFlow models/skills/agents. Also use when the user mentions deerflow, deer flow, deepseek-harness, dsh, or wants a dsh-driven agent to run a deep research task that DeerFlow can handle."
+description: "Interact with DeerFlow AI agent platform via its HTTP API from a DeepSeek Harness (dsh) agent. Use this skill when a dsh headless task needs to delegate deep research or analysis to DeerFlow, start or continue a DeerFlow conversation thread, check DeerFlow status or health, or list DeerFlow models/skills/agents. Also use when the user mentions deerflow, deer flow, deepseek-harness, or dsh. Use only inside a DeepSeek Harness (dsh) run; from a ZCode session use zcode-to-deerflow instead."
 ---
 
 # DeerFlow Skill (DeepSeek Harness host)
@@ -9,11 +9,11 @@ Communicate with a running DeerFlow instance via its HTTP API from inside a Deep
 agent. DeerFlow is an AI agent platform built on LangGraph that orchestrates sub-agents for
 research, code execution, web browsing, and more. dsh (github.com/deepseek-ai/deepseek-harness)
 is a plugin-based agent harness; its `bash` tool is the bridge to DeerFlow — everything here runs
-as plain `curl` / helper-script shell commands.
+as plain `curl` calls and the bundled helper scripts.
 
 ## Architecture
 
-DeerFlow exposes two API surfaces behind an Nginx reverse proxy:
+DeerFlow exposes two URL prefixes on one gateway service behind an Nginx reverse proxy:
 
 | Service        | Direct Port | Via Proxy                        | Purpose                          |
 |----------------|-------------|----------------------------------|----------------------------------|
@@ -39,24 +39,34 @@ DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
 ```
 
+**Authentication prerequisite**: a default DeerFlow deployment requires authentication. Either start
+DeerFlow with `DEER_FLOW_AUTH_DISABLED=1` (local no-auth mode), or export
+`DEERFLOW_COOKIE="access_token=<jwt>"` (or a full `Cookie:` header value) — both scripts forward it
+to every request. The scripts require `curl` and `python3` on `PATH`.
+
 dsh note: the bash tool inherits the environment of the dsh process, so export
 `DEERFLOW_URL` (and overrides) **before launching the dsh run** — exporting them inside a bash
 tool call only affects that single call.
 
 ## dsh Workflow
 
-### 1. Install this skill into the task workspace
+### 1. Install this skill into the task workspace (for the orchestrator, before the dsh run)
 
-dsh discovers project skills from the task working directory. Copy the skill there (and make sure
-the workdir is a git repository — dsh resolves the project root by walking up to `.git`, so run
-`git init` in a fresh workdir first):
+dsh discovers project skills from the task working directory (recent dsh versions resolve the
+project root by walking up to the nearest `.git` — verify against current dsh docs). Copy this
+skill into the workdir's `.agents/skills/` before launching the dsh task, and make sure the
+workdir is a git repository (`git init` in a fresh workdir):
 
 ```bash
 cd <task-workdir>
 git init -q 2>/dev/null || true
 mkdir -p .agents/skills
-cp -r <source-of-this-skill>/dsh-to-deerflow .agents/skills/
+cp -r <deer-flow-checkout>/skills/public/dsh-to-deerflow .agents/skills/
 ```
+
+Source: the `skills/public/dsh-to-deerflow/` directory of the deer-flow repository
+(https://github.com/bytedance/deer-flow). Steps 2+ are for the dsh agent that already has this
+skill installed.
 
 ### 2. Check health first
 
@@ -74,14 +84,14 @@ retrying in a loop.
 bash .agents/skills/dsh-to-deerflow/scripts/chat.sh "Your question here"
 ```
 
-The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr.
+The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr (echoed again as `Thread ID:` when the run finishes).
 The response may also end with `Created File: <url>` artifact links (DeerFlow-generated files) —
 include both the text and the artifact URLs in the task result.
 
 ### 4. Handle long research runs
 
 Deep research in pro/ultra mode can take minutes and may exceed a single bash tool call budget
-(`timeoutMs`). Run the chat script in the background, then poll across tool calls:
+(`timeoutMs` in recent dsh versions — verify against current dsh docs). Run the chat script in the background, then poll across tool calls:
 
 ```bash
 nohup bash .agents/skills/dsh-to-deerflow/scripts/chat.sh "Research question" \
@@ -157,15 +167,15 @@ event: <event_type>
 data: <json_data>
 ```
 
-Key event types:
+Key event types (the request parameter is named `messages-tuple`, but the SSE event it produces is named `messages`):
 - `metadata` — run metadata including `run_id`
 - `values` — full state snapshot with `messages` array
-- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `messages` — incremental message updates (AI text chunks, tool calls, tool results)
 - `end` — stream is complete
 
 **Context modes** (set via `context`):
 - Flash mode: `thinking_enabled: false, is_plan_mode: false, subagent_enabled: false`
-- Standard mode: `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
+- Standard mode (shown as "thinking" in the web UI): `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
 - Pro mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: false`
 - Ultra mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: true`
 
@@ -179,7 +189,7 @@ Reuse the same `thread_id` from step 2 and POST another run with the new message
 curl -s "$DEERFLOW_GATEWAY_URL/api/models"
 ```
 
-Returns: `{"models": [{"name": "...", "provider": "...", ...}, ...]}`
+Returns: `{"models": [{"name": "...", "model": "...", "display_name": "...", ...}, ...]}`
 
 ### 5. List Skills
 
@@ -194,13 +204,13 @@ Returns: `{"skills": [{"name": "...", "enabled": true, ...}, ...]}`
 ```bash
 curl -s -X PUT "$DEERFLOW_GATEWAY_URL/api/skills/<skill_name>" \
   -H "Content-Type: application/json" \
-  -d '{"enabled": true}'
+  -d '{"enabled": true}'   # requires an admin user
 ```
 
 ### 7. List Agents
 
 ```bash
-curl -s "$DEERFLOW_GATEWAY_URL/api/agents"
+curl -s "$DEERFLOW_GATEWAY_URL/api/agents"   # needs agents_api.enabled=true (403 by default)
 ```
 
 Returns: `{"agents": [{"name": "...", ...}, ...]}`
@@ -220,7 +230,8 @@ curl -s -X POST "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads" \
   -F "files=@/path/to/file.pdf"
 ```
 
-Supports PDF, PPTX, XLSX, DOCX — automatically converts to Markdown.
+Supports PDF, PPTX, XLSX, DOCX (plus legacy PPT/XLS/DOC). Markdown conversion happens only when
+the server-side `uploads.auto_convert_documents` option is enabled (off by default).
 
 ### 10. List Uploaded Files
 
@@ -231,15 +242,18 @@ curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
 ### 11. Get Thread History
 
 ```bash
-curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 10}'
 ```
 
 ### 12. List Threads
 
 ```bash
+# ordered pinned-first, then most recently updated; sorting parameters are not supported
 curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
   -H "Content-Type: application/json" \
-  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+  -d '{"limit": 20}'
 ```
 
 ## Status Helper

--- a/skills/public/dsh-to-deerflow/scripts/chat.sh
+++ b/skills/public/dsh-to-deerflow/scripts/chat.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # chat.sh — Send a message to DeerFlow and collect the streaming response.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
 #
 # Usage:
 #   bash chat.sh "Your question here"

--- a/skills/public/dsh-to-deerflow/scripts/chat.sh
+++ b/skills/public/dsh-to-deerflow/scripts/chat.sh
@@ -25,7 +25,7 @@ THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -94,11 +94,14 @@ ENDJSON
 # --- Stream the run and extract final response ---
 # We collect the full SSE output, then parse the last values event to get the AI response.
 TMPFILE=$(mktemp)
-trap "rm -f '$TMPFILE'" EXIT
+trap 'rm -f "$TMPFILE"' EXIT
 
-curl -s -N -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"
+  -d "$BODY" > "$TMPFILE"; then
+  echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
 
 # Parse the SSE output: extract the last "event: values" data block and get the final AI message
 python3 - "$TMPFILE" "$GATEWAY_URL" "$THREAD_ID" << 'PYEOF'
@@ -195,6 +198,12 @@ def format_artifact_text(artifacts):
         return f"Created File: {urls[0]}"
     return "Created Files:\n" + "\n".join(urls)
 
+def first_error_event():
+    for event_type, data_str in events:
+        if event_type == "error":
+            return data_str
+    return None
+
 # Find the last "values" event with messages
 result_messages = None
 for event_type, data_str in reversed(events):
@@ -217,14 +226,17 @@ if result_messages is not None:
     if response_text:
         print(response_text)
     else:
+        err = first_error_event()
+        if err is not None:
+            print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+            sys.exit(1)
         print("(No response from agent)", file=sys.stderr)
         sys.exit(1)
 else:
-    # Check for error events
-    for event_type, data_str in events:
-        if event_type == "error":
-            print(f"ERROR from DeerFlow: {data_str}", file=sys.stderr)
-            sys.exit(1)
+    err = first_error_event()
+    if err is not None:
+        print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+        sys.exit(1)
     print("No AI response found in the stream.", file=sys.stderr)
     if len(raw) < 2000:
         print(f"Raw SSE output:\n{raw}", file=sys.stderr)

--- a/skills/public/dsh-to-deerflow/scripts/chat.sh
+++ b/skills/public/dsh-to-deerflow/scripts/chat.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # chat.sh — Send a message to DeerFlow and collect the streaming response.
 # Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash chat.sh "Your question here"
@@ -20,12 +21,19 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 MESSAGE="${1:?Usage: chat.sh <message> [thread_id] [mode]}"
 THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -35,10 +43,10 @@ fi
 
 # --- Create or reuse thread ---
 if [ -z "$THREAD_ID" ]; then
-  THREAD_RESP=$(curl -s -X POST "${LANGGRAPH_URL}/threads" \
+  THREAD_RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads" \
     -H "Content-Type: application/json" \
-    -d '{}')
-  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null)
+    -d '{}' || true)
+  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null || true)
   if [ -z "$THREAD_ID" ]; then
     echo "ERROR: Failed to create thread. Response: ${THREAD_RESP}" >&2
     exit 1
@@ -46,25 +54,26 @@ if [ -z "$THREAD_ID" ]; then
   echo "Thread: ${THREAD_ID}" >&2
 fi
 
-# --- Build context based on mode ---
+# --- Build context based on mode (json.dumps: safe for any thread_id) ---
 case "$MODE" in
-  flash)
-    CONTEXT='{"thinking_enabled":false,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  standard)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  pro)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  ultra)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":true,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
+  flash|standard|pro|ultra) ;;
   *)
     echo "ERROR: Unknown mode '${MODE}'. Use: flash, standard, pro, ultra" >&2
     exit 1
     ;;
 esac
+CONTEXT=$(python3 -c '
+import json, sys
+modes = {
+    "flash": (False, False, False),
+    "standard": (True, False, False),
+    "pro": (True, True, False),
+    "ultra": (True, True, True),
+}
+t, p, sg = modes[sys.argv[1]]
+print(json.dumps({"thinking_enabled": t, "is_plan_mode": p,
+                  "subagent_enabled": sg, "thread_id": sys.argv[2]}))
+' "$MODE" "$THREAD_ID")
 
 # --- Escape message for JSON ---
 ESCAPED_MSG=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$MESSAGE")
@@ -96,10 +105,19 @@ ENDJSON
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
-if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+STREAM_STATUS=$(curl -s -N --connect-timeout 10 --max-time "${DEERFLOW_TIMEOUT:-3600}" "${COOKIE_ARGS[@]}" \
+  -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"; then
+  -d "$BODY" -o "$TMPFILE" -w "%{http_code}" || true)
+STREAM_STATUS="${STREAM_STATUS:-000}"
+if [ "$STREAM_STATUS" = "000" ]; then
   echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
+if [ "$STREAM_STATUS" -ge 400 ] 2>/dev/null; then
+  echo "ERROR: DeerFlow returned HTTP ${STREAM_STATUS} for the stream request:" >&2
+  head -c 400 "$TMPFILE" >&2
+  echo >&2
   exit 1
 fi
 
@@ -140,14 +158,15 @@ for line in raw.split("\n"):
 if current_event and current_data_lines:
     events.append((current_event, "\n".join(current_data_lines)))
 
-import posixpath
-
 def extract_response_text(messages):
     """Mirror manager.py _extract_response_text: handles ask_clarification interrupt + regular AI."""
     for msg in reversed(messages):
         if not isinstance(msg, dict):
             continue
         msg_type = msg.get("type")
+        # anything before the last human message is a previous turn
+        if msg_type == "human":
+            break
         # ask_clarification interrupt: tool message with name ask_clarification
         if msg_type == "tool" and msg.get("name") == "ask_clarification":
             content = msg.get("content", "")
@@ -181,7 +200,13 @@ def extract_artifacts(messages):
         if msg.get("type") == "ai":
             for tc in msg.get("tool_calls", []):
                 if isinstance(tc, dict) and tc.get("name") == "present_files":
-                    paths = tc.get("args", {}).get("filepaths", [])
+                    args = tc.get("args") or {}
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except ValueError:
+                            args = {}
+                    paths = args.get("filepaths", []) if isinstance(args, dict) else []
                     if isinstance(paths, list):
                         artifacts.extend(p for p in paths if isinstance(p, str))
     return artifacts
@@ -243,6 +268,6 @@ else:
     sys.exit(1)
 PYEOF
 
-echo ""
-echo "---"
+echo "" >&2
+echo "---" >&2
 echo "Thread ID: ${THREAD_ID}" >&2

--- a/skills/public/dsh-to-deerflow/scripts/status.sh
+++ b/skills/public/dsh-to-deerflow/scripts/status.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # status.sh — Check DeerFlow status and list available resources.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
 #
 # Usage:
 #   bash status.sh                  # health + summary

--- a/skills/public/dsh-to-deerflow/scripts/status.sh
+++ b/skills/public/dsh-to-deerflow/scripts/status.sh
@@ -27,7 +27,7 @@ ARG="${2:-}"
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"

--- a/skills/public/dsh-to-deerflow/scripts/status.sh
+++ b/skills/public/dsh-to-deerflow/scripts/status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # status.sh — Check DeerFlow status and list available resources.
 # Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash status.sh                  # health + summary
@@ -21,14 +22,21 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 CMD="${1:-health}"
 ARG="${2:-}"
 
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
-HTTP_CODE="${HTTP_CODE:-000}"
+    HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"
       exit 1
@@ -40,25 +48,48 @@ HTTP_CODE="${HTTP_CODE:-000}"
     fi
     ;;
   models)
-    curl -s "${GATEWAY_URL}/api/models" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/models" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/models:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   skills)
-    curl -s "${GATEWAY_URL}/api/skills" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/skills" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/skills:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   agents)
-    curl -s "${GATEWAY_URL}/api/agents" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/agents" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/agents:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   threads)
-    curl -s -X POST "${LANGGRAPH_URL}/threads/search" \
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/search" \
       -H "Content-Type: application/json" \
-      -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc", "select": ["thread_id", "updated_at", "values"]}' \
+      -d '{"limit": 20}' \
       | python3 -c "
 import json, sys
 threads = json.load(sys.stdin)
+if not isinstance(threads, list):
+    print(f'Unexpected response (not a thread list): {str(threads)[:200]}')
+    sys.exit(1)
 if not threads:
     print('No threads found.')
     sys.exit(0)
 for t in threads:
+    if not isinstance(t, dict):
+        continue
     tid = t.get('thread_id', '?')
     updated = t.get('updated_at', '?')
     title = (t.get('values') or {}).get('title', '(untitled)')
@@ -66,14 +97,22 @@ for t in threads:
 "
     ;;
   memory)
-    curl -s "${GATEWAY_URL}/api/memory" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/memory" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/memory:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   thread)
     if [ -z "$ARG" ]; then
       echo "Usage: status.sh thread <thread_id>" >&2
       exit 1
     fi
-    curl -s "${LANGGRAPH_URL}/threads/${ARG}/history" | python3 -c "
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/${ARG}/history" \
+      -H "Content-Type: application/json" \
+      -d '{"limit": 10}' | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 if isinstance(data, list):
@@ -81,6 +120,8 @@ if isinstance(data, list):
         values = state.get('values', {})
         msgs = values.get('messages', [])
         for m in msgs[-5:]:
+            if not isinstance(m, dict):
+                continue
             role = m.get('type', '?')
             content = m.get('content', '')
             if isinstance(content, list):

--- a/skills/public/zcode-to-deerflow/SKILL.md
+++ b/skills/public/zcode-to-deerflow/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: zcode-to-deerflow
+description: "Interact with DeerFlow AI agent platform via its HTTP API from a ZCode session. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow while working in ZCode. Also use when the user mentions deerflow, deer flow, or wants to run a deep research task that DeerFlow can handle."
+---
+
+# DeerFlow Skill (ZCode host)
+
+Communicate with a running DeerFlow instance via its HTTP API from inside a ZCode session.
+DeerFlow is an AI agent platform built on LangGraph that orchestrates sub-agents for research,
+code execution, web browsing, and more. ZCode is a terminal coding agent: drive DeerFlow through
+its Bash tool with `curl` or with the helper scripts shipped in this skill.
+
+## Architecture
+
+DeerFlow exposes two API surfaces behind an Nginx reverse proxy:
+
+| Service        | Direct Port | Via Proxy                        | Purpose                          |
+|----------------|-------------|----------------------------------|----------------------------------|
+| Gateway API    | 8001        | `$DEERFLOW_GATEWAY_URL`          | REST endpoints and embedded agent runtime |
+| LangGraph-compatible API | 8001 | `$DEERFLOW_LANGGRAPH_URL`       | Agent threads, runs, streaming   |
+
+## Environment Variables
+
+All URLs are configurable via environment variables. **Read these env vars before making any request.**
+
+| Variable                | Default                                  | Description                        |
+|-------------------------|------------------------------------------|------------------------------------|
+| `DEERFLOW_URL`          | `http://localhost:2026`                  | Unified proxy base URL             |
+| `DEERFLOW_GATEWAY_URL`  | `${DEERFLOW_URL}`                        | Gateway API base (models, skills, memory, uploads) |
+| `DEERFLOW_LANGGRAPH_URL`| `${DEERFLOW_URL}/api/langgraph`          | LangGraph API base (threads, runs) |
+
+When making curl calls, always resolve the URL like this:
+
+```bash
+# Resolve base URLs from env (do this FIRST before any API call)
+DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
+DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
+DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+```
+
+## ZCode Workflow
+
+### 1. Locate this skill
+
+The skill is discovered from the standard skill locations. Resolve the scripts path to whichever
+copy exists first:
+
+```bash
+SKILL_DIR=""
+for d in ".agents/skills/zcode-to-deerflow" "$HOME/.agents/skills/zcode-to-deerflow"; do
+  [ -f "$d/scripts/chat.sh" ] && SKILL_DIR="$d" && break
+done
+```
+
+### 2. Check health first
+
+```bash
+bash "$SKILL_DIR/scripts/status.sh" health
+```
+
+If unreachable, tell the user DeerFlow is not running and suggest starting it
+(`cd <deerflow-dir> && make dev`, or `make docker-start` for the Docker setup).
+
+### 3. Ask DeerFlow
+
+```bash
+bash "$SKILL_DIR/scripts/chat.sh" "Your question here"
+```
+
+The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr.
+The response may also end with `Created File: <url>` artifact links (DeerFlow-generated files) —
+relay both the text and the artifact URLs to the user.
+
+### 4. Handle long research runs
+
+Deep research in pro/ultra mode can take minutes. Run the chat script in the background and poll,
+instead of blocking the session:
+
+```bash
+nohup bash "$SKILL_DIR/scripts/chat.sh" "Research question" \
+  > ~/tmp/deerflow-out.txt 2> ~/tmp/deerflow-err.txt &
+# poll: cat ~/tmp/deerflow-out.txt ; the run is done when the file holds the final answer
+```
+
+### 5. Continue a conversation
+
+Reuse the `thread_id` printed by a previous run:
+
+```bash
+bash "$SKILL_DIR/scripts/chat.sh" "Follow-up question" "<thread_id>"
+```
+
+## Available Operations
+
+### 1. Health Check
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/health"
+```
+
+### 2. Send a Message (Streaming)
+
+This is the primary operation. It creates a thread and streams the agent's response.
+
+**Step 1: Create a thread**
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+```
+
+Response: `{"thread_id": "<uuid>", ...}`
+
+**Step 2: Stream a run**
+
+```bash
+curl -s -N -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/runs/stream" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "assistant_id": "lead_agent",
+    "input": {
+      "messages": [
+        {
+          "type": "human",
+          "content": [{"type": "text", "text": "YOUR MESSAGE HERE"}]
+        }
+      ]
+    },
+    "stream_mode": ["values", "messages-tuple"],
+    "stream_subgraphs": true,
+    "config": {
+      "recursion_limit": 1000
+    },
+    "context": {
+      "thinking_enabled": true,
+      "is_plan_mode": true,
+      "subagent_enabled": true,
+      "thread_id": "<thread_id>"
+    }
+  }'
+```
+
+The response is an SSE stream. Each event has the format
+```
+event: <event_type>
+data: <json_data>
+```
+
+Key event types:
+- `metadata` — run metadata including `run_id`
+- `values` — full state snapshot with `messages` array
+- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `end` — stream is complete
+
+**Context modes** (set via `context`):
+- Flash mode: `thinking_enabled: false, is_plan_mode: false, subagent_enabled: false`
+- Standard mode: `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
+- Pro mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: false`
+- Ultra mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: true`
+
+### 3. Continue a Conversation
+
+Reuse the same `thread_id` from step 2 and POST another run with the new message.
+
+### 4. List Models
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/models"
+```
+
+Returns: `{"models": [{"name": "...", "provider": "...", ...}, ...]}`
+
+### 5. List Skills
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/skills"
+```
+
+Returns: `{"skills": [{"name": "...", "enabled": true, ...}, ...]}`
+
+### 6. Enable/Disable a Skill
+
+```bash
+curl -s -X PUT "$DEERFLOW_GATEWAY_URL/api/skills/<skill_name>" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled": true}'
+```
+
+### 7. List Agents
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/agents"
+```
+
+Returns: `{"agents": [{"name": "...", ...}, ...]}`
+
+### 8. Get Memory
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/memory"
+```
+
+Returns user context, facts, and conversation history summaries.
+
+### 9. Upload Files to a Thread
+
+```bash
+curl -s -X POST "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads" \
+  -F "files=@/path/to/file.pdf"
+```
+
+Supports PDF, PPTX, XLSX, DOCX — automatically converts to Markdown.
+
+### 10. List Uploaded Files
+
+```bash
+curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
+```
+
+### 11. Get Thread History
+
+```bash
+curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+```
+
+### 12. List Threads
+
+```bash
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+```
+
+## Status Helper
+
+`scripts/status.sh` wraps the read-only operations:
+
+```bash
+bash "$SKILL_DIR/scripts/status.sh" health|models|skills|agents|threads|memory|thread <id>
+```
+
+## Parsing SSE Output
+
+The chat script already handles this. For manual curl streams, to extract the final AI response
+from a `values` event:
+- Look for the last `event: values` block
+- Parse its `data` JSON
+- The `messages` array contains all messages; the last one with `type: "ai"` is the response
+- The `content` field of that message is the AI's text reply
+
+## Error Handling
+
+- If health check fails, DeerFlow is not running. Tell the user to start it (`make dev` or
+  `make docker-start`) and stop instead of retrying blindly.
+- If the stream returns an error event, extract and surface the error message verbatim.
+- Common issues: port not open, services still starting up, config errors.
+
+## Tips
+
+- For quick questions, use flash mode (fastest, no planning).
+- For research tasks, use pro or ultra mode (enables planning and sub-agents).
+- You can upload files first, then reference them in your message.
+- Thread IDs persist — you can return to a conversation later.
+- Prefer the helper scripts over hand-rolled curl: they resolve env vars, parse SSE,
+  and extract artifacts consistently.

--- a/skills/public/zcode-to-deerflow/SKILL.md
+++ b/skills/public/zcode-to-deerflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zcode-to-deerflow
-description: "Interact with DeerFlow AI agent platform via its HTTP API from a ZCode session. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow while working in ZCode. Also use when the user mentions deerflow, deer flow, or wants to run a deep research task that DeerFlow can handle."
+description: "Interact with DeerFlow AI agent platform via its HTTP API from a ZCode session. Use this skill when the user wants to send messages or questions to DeerFlow for research/analysis, start a DeerFlow conversation thread, check DeerFlow status or health, list available models/skills/agents in DeerFlow, manage DeerFlow memory, upload files to DeerFlow threads, or delegate complex research tasks to DeerFlow while working in ZCode. Also use when the user mentions deerflow or deer flow. Use only from a ZCode session; inside a DeepSeek Harness (dsh) run use dsh-to-deerflow instead."
 ---
 
 # DeerFlow Skill (ZCode host)
@@ -12,7 +12,7 @@ its Bash tool with `curl` or with the helper scripts shipped in this skill.
 
 ## Architecture
 
-DeerFlow exposes two API surfaces behind an Nginx reverse proxy:
+DeerFlow exposes two URL prefixes on one gateway service behind an Nginx reverse proxy:
 
 | Service        | Direct Port | Via Proxy                        | Purpose                          |
 |----------------|-------------|----------------------------------|----------------------------------|
@@ -38,6 +38,11 @@ DEERFLOW_GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 DEERFLOW_LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
 ```
 
+**Authentication prerequisite**: a default DeerFlow deployment requires authentication. Either start
+DeerFlow with `DEER_FLOW_AUTH_DISABLED=1` (local no-auth mode), or export
+`DEERFLOW_COOKIE="access_token=<jwt>"` (or a full `Cookie:` header value) — both scripts forward it
+to every request. The scripts require `curl` and `python3` on `PATH`.
+
 ## ZCode Workflow
 
 ### 1. Locate this skill
@@ -47,7 +52,9 @@ copy exists first:
 
 ```bash
 SKILL_DIR=""
-for d in ".agents/skills/zcode-to-deerflow" "$HOME/.agents/skills/zcode-to-deerflow"; do
+for d in "$(git rev-parse --show-toplevel 2>/dev/null)/.agents/skills/zcode-to-deerflow" \
+         ".agents/skills/zcode-to-deerflow" \
+         "$HOME/.agents/skills/zcode-to-deerflow"; do
   [ -f "$d/scripts/chat.sh" ] && SKILL_DIR="$d" && break
 done
 [ -n "$SKILL_DIR" ] || { echo "zcode-to-deerflow skill dir not found" >&2; exit 1; }
@@ -68,7 +75,7 @@ If unreachable, tell the user DeerFlow is not running and suggest starting it
 bash "$SKILL_DIR/scripts/chat.sh" "Your question here"
 ```
 
-The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr.
+The script prints the final AI response to stdout and `Thread: <thread_id>` to stderr (echoed again as `Thread ID:` when the run finishes).
 The response may also end with `Created File: <url>` artifact links (DeerFlow-generated files) —
 relay both the text and the artifact URLs to the user.
 
@@ -79,8 +86,8 @@ instead of blocking the session:
 
 ```bash
 nohup bash "$SKILL_DIR/scripts/chat.sh" "Research question" \
-  > ~/tmp/deerflow-out.txt 2> ~/tmp/deerflow-err.txt &
-# poll: cat ~/tmp/deerflow-out.txt ; the run is done when the file holds the final answer
+  > deerflow-out.txt 2> deerflow-err.txt &
+# poll: cat deerflow-out.txt ; the run is done when the file holds the final answer
 ```
 
 ### 5. Continue a conversation
@@ -148,15 +155,15 @@ event: <event_type>
 data: <json_data>
 ```
 
-Key event types:
+Key event types (the request parameter is named `messages-tuple`, but the SSE event it produces is named `messages`):
 - `metadata` — run metadata including `run_id`
 - `values` — full state snapshot with `messages` array
-- `messages-tuple` — incremental message updates (AI text chunks, tool calls, tool results)
+- `messages` — incremental message updates (AI text chunks, tool calls, tool results)
 - `end` — stream is complete
 
 **Context modes** (set via `context`):
 - Flash mode: `thinking_enabled: false, is_plan_mode: false, subagent_enabled: false`
-- Standard mode: `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
+- Standard mode (shown as "thinking" in the web UI): `thinking_enabled: true, is_plan_mode: false, subagent_enabled: false`
 - Pro mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: false`
 - Ultra mode: `thinking_enabled: true, is_plan_mode: true, subagent_enabled: true`
 
@@ -170,7 +177,7 @@ Reuse the same `thread_id` from step 2 and POST another run with the new message
 curl -s "$DEERFLOW_GATEWAY_URL/api/models"
 ```
 
-Returns: `{"models": [{"name": "...", "provider": "...", ...}, ...]}`
+Returns: `{"models": [{"name": "...", "model": "...", "display_name": "...", ...}, ...]}`
 
 ### 5. List Skills
 
@@ -185,13 +192,13 @@ Returns: `{"skills": [{"name": "...", "enabled": true, ...}, ...]}`
 ```bash
 curl -s -X PUT "$DEERFLOW_GATEWAY_URL/api/skills/<skill_name>" \
   -H "Content-Type: application/json" \
-  -d '{"enabled": true}'
+  -d '{"enabled": true}'   # requires an admin user
 ```
 
 ### 7. List Agents
 
 ```bash
-curl -s "$DEERFLOW_GATEWAY_URL/api/agents"
+curl -s "$DEERFLOW_GATEWAY_URL/api/agents"   # needs agents_api.enabled=true (403 by default)
 ```
 
 Returns: `{"agents": [{"name": "...", ...}, ...]}`
@@ -211,7 +218,8 @@ curl -s -X POST "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads" \
   -F "files=@/path/to/file.pdf"
 ```
 
-Supports PDF, PPTX, XLSX, DOCX — automatically converts to Markdown.
+Supports PDF, PPTX, XLSX, DOCX (plus legacy PPT/XLS/DOC). Markdown conversion happens only when
+the server-side `uploads.auto_convert_documents` option is enabled (off by default).
 
 ### 10. List Uploaded Files
 
@@ -222,15 +230,18 @@ curl -s "$DEERFLOW_GATEWAY_URL/api/threads/<thread_id>/uploads/list"
 ### 11. Get Thread History
 
 ```bash
-curl -s "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history"
+curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/<thread_id>/history" \
+  -H "Content-Type: application/json" \
+  -d '{"limit": 10}'
 ```
 
 ### 12. List Threads
 
 ```bash
+# ordered pinned-first, then most recently updated; sorting parameters are not supported
 curl -s -X POST "$DEERFLOW_LANGGRAPH_URL/threads/search" \
   -H "Content-Type: application/json" \
-  -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc"}'
+  -d '{"limit": 20}'
 ```
 
 ## Status Helper

--- a/skills/public/zcode-to-deerflow/SKILL.md
+++ b/skills/public/zcode-to-deerflow/SKILL.md
@@ -50,6 +50,7 @@ SKILL_DIR=""
 for d in ".agents/skills/zcode-to-deerflow" "$HOME/.agents/skills/zcode-to-deerflow"; do
   [ -f "$d/scripts/chat.sh" ] && SKILL_DIR="$d" && break
 done
+[ -n "$SKILL_DIR" ] || { echo "zcode-to-deerflow skill dir not found" >&2; exit 1; }
 ```
 
 ### 2. Check health first

--- a/skills/public/zcode-to-deerflow/scripts/chat.sh
+++ b/skills/public/zcode-to-deerflow/scripts/chat.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # chat.sh — Send a message to DeerFlow and collect the streaming response.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
 #
 # Usage:
 #   bash chat.sh "Your question here"

--- a/skills/public/zcode-to-deerflow/scripts/chat.sh
+++ b/skills/public/zcode-to-deerflow/scripts/chat.sh
@@ -25,7 +25,7 @@ THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -94,11 +94,14 @@ ENDJSON
 # --- Stream the run and extract final response ---
 # We collect the full SSE output, then parse the last values event to get the AI response.
 TMPFILE=$(mktemp)
-trap "rm -f '$TMPFILE'" EXIT
+trap 'rm -f "$TMPFILE"' EXIT
 
-curl -s -N -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"
+  -d "$BODY" > "$TMPFILE"; then
+  echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
 
 # Parse the SSE output: extract the last "event: values" data block and get the final AI message
 python3 - "$TMPFILE" "$GATEWAY_URL" "$THREAD_ID" << 'PYEOF'
@@ -195,6 +198,12 @@ def format_artifact_text(artifacts):
         return f"Created File: {urls[0]}"
     return "Created Files:\n" + "\n".join(urls)
 
+def first_error_event():
+    for event_type, data_str in events:
+        if event_type == "error":
+            return data_str
+    return None
+
 # Find the last "values" event with messages
 result_messages = None
 for event_type, data_str in reversed(events):
@@ -217,14 +226,17 @@ if result_messages is not None:
     if response_text:
         print(response_text)
     else:
+        err = first_error_event()
+        if err is not None:
+            print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+            sys.exit(1)
         print("(No response from agent)", file=sys.stderr)
         sys.exit(1)
 else:
-    # Check for error events
-    for event_type, data_str in events:
-        if event_type == "error":
-            print(f"ERROR from DeerFlow: {data_str}", file=sys.stderr)
-            sys.exit(1)
+    err = first_error_event()
+    if err is not None:
+        print(f"ERROR from DeerFlow: {err}", file=sys.stderr)
+        sys.exit(1)
     print("No AI response found in the stream.", file=sys.stderr)
     if len(raw) < 2000:
         print(f"Raw SSE output:\n{raw}", file=sys.stderr)

--- a/skills/public/zcode-to-deerflow/scripts/chat.sh
+++ b/skills/public/zcode-to-deerflow/scripts/chat.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # chat.sh — Send a message to DeerFlow and collect the streaming response.
 # Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash chat.sh "Your question here"
@@ -20,12 +21,19 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 MESSAGE="${1:?Usage: chat.sh <message> [thread_id] [mode]}"
 THREAD_ID="${2:-}"
 MODE="${3:-pro}"
 
 # --- Health check ---
-HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
 if [ "$HTTP_CODE" = "000" ] || [ "$HTTP_CODE" -ge 400 ]; then
   echo "ERROR: DeerFlow is not reachable at ${GATEWAY_URL} (HTTP ${HTTP_CODE})" >&2
@@ -35,10 +43,10 @@ fi
 
 # --- Create or reuse thread ---
 if [ -z "$THREAD_ID" ]; then
-  THREAD_RESP=$(curl -s -X POST "${LANGGRAPH_URL}/threads" \
+  THREAD_RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads" \
     -H "Content-Type: application/json" \
-    -d '{}')
-  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null)
+    -d '{}' || true)
+  THREAD_ID=$(echo "$THREAD_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin)['thread_id'])" 2>/dev/null || true)
   if [ -z "$THREAD_ID" ]; then
     echo "ERROR: Failed to create thread. Response: ${THREAD_RESP}" >&2
     exit 1
@@ -46,25 +54,26 @@ if [ -z "$THREAD_ID" ]; then
   echo "Thread: ${THREAD_ID}" >&2
 fi
 
-# --- Build context based on mode ---
+# --- Build context based on mode (json.dumps: safe for any thread_id) ---
 case "$MODE" in
-  flash)
-    CONTEXT='{"thinking_enabled":false,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  standard)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":false,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  pro)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":false,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
-  ultra)
-    CONTEXT='{"thinking_enabled":true,"is_plan_mode":true,"subagent_enabled":true,"thread_id":"'"$THREAD_ID"'"}'
-    ;;
+  flash|standard|pro|ultra) ;;
   *)
     echo "ERROR: Unknown mode '${MODE}'. Use: flash, standard, pro, ultra" >&2
     exit 1
     ;;
 esac
+CONTEXT=$(python3 -c '
+import json, sys
+modes = {
+    "flash": (False, False, False),
+    "standard": (True, False, False),
+    "pro": (True, True, False),
+    "ultra": (True, True, True),
+}
+t, p, sg = modes[sys.argv[1]]
+print(json.dumps({"thinking_enabled": t, "is_plan_mode": p,
+                  "subagent_enabled": sg, "thread_id": sys.argv[2]}))
+' "$MODE" "$THREAD_ID")
 
 # --- Escape message for JSON ---
 ESCAPED_MSG=$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$MESSAGE")
@@ -96,10 +105,19 @@ ENDJSON
 TMPFILE=$(mktemp)
 trap 'rm -f "$TMPFILE"' EXIT
 
-if ! curl -s -N --connect-timeout 10 -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
+STREAM_STATUS=$(curl -s -N --connect-timeout 10 --max-time "${DEERFLOW_TIMEOUT:-3600}" "${COOKIE_ARGS[@]}" \
+  -X POST "${LANGGRAPH_URL}/threads/${THREAD_ID}/runs/stream" \
   -H "Content-Type: application/json" \
-  -d "$BODY" > "$TMPFILE"; then
+  -d "$BODY" -o "$TMPFILE" -w "%{http_code}" || true)
+STREAM_STATUS="${STREAM_STATUS:-000}"
+if [ "$STREAM_STATUS" = "000" ]; then
   echo "ERROR: Stream request to DeerFlow failed (connection error or timeout)." >&2
+  exit 1
+fi
+if [ "$STREAM_STATUS" -ge 400 ] 2>/dev/null; then
+  echo "ERROR: DeerFlow returned HTTP ${STREAM_STATUS} for the stream request:" >&2
+  head -c 400 "$TMPFILE" >&2
+  echo >&2
   exit 1
 fi
 
@@ -140,14 +158,15 @@ for line in raw.split("\n"):
 if current_event and current_data_lines:
     events.append((current_event, "\n".join(current_data_lines)))
 
-import posixpath
-
 def extract_response_text(messages):
     """Mirror manager.py _extract_response_text: handles ask_clarification interrupt + regular AI."""
     for msg in reversed(messages):
         if not isinstance(msg, dict):
             continue
         msg_type = msg.get("type")
+        # anything before the last human message is a previous turn
+        if msg_type == "human":
+            break
         # ask_clarification interrupt: tool message with name ask_clarification
         if msg_type == "tool" and msg.get("name") == "ask_clarification":
             content = msg.get("content", "")
@@ -181,7 +200,13 @@ def extract_artifacts(messages):
         if msg.get("type") == "ai":
             for tc in msg.get("tool_calls", []):
                 if isinstance(tc, dict) and tc.get("name") == "present_files":
-                    paths = tc.get("args", {}).get("filepaths", [])
+                    args = tc.get("args") or {}
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except ValueError:
+                            args = {}
+                    paths = args.get("filepaths", []) if isinstance(args, dict) else []
                     if isinstance(paths, list):
                         artifacts.extend(p for p in paths if isinstance(p, str))
     return artifacts
@@ -243,6 +268,6 @@ else:
     sys.exit(1)
 PYEOF
 
-echo ""
-echo "---"
+echo "" >&2
+echo "---" >&2
 echo "Thread ID: ${THREAD_ID}" >&2

--- a/skills/public/zcode-to-deerflow/scripts/status.sh
+++ b/skills/public/zcode-to-deerflow/scripts/status.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # status.sh — Check DeerFlow status and list available resources.
+# Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
 #
 # Usage:
 #   bash status.sh                  # health + summary

--- a/skills/public/zcode-to-deerflow/scripts/status.sh
+++ b/skills/public/zcode-to-deerflow/scripts/status.sh
@@ -27,7 +27,7 @@ ARG="${2:-}"
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
 HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"

--- a/skills/public/zcode-to-deerflow/scripts/status.sh
+++ b/skills/public/zcode-to-deerflow/scripts/status.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # status.sh — Check DeerFlow status and list available resources.
 # Host-agnostic helper shared by the claude/zcode/dsh -to-deerflow skills.
+# Keep in sync with the other *-to-deerflow copies when changing behavior.
 #
 # Usage:
 #   bash status.sh                  # health + summary
@@ -21,14 +22,21 @@ set -euo pipefail
 DEERFLOW_URL="${DEERFLOW_URL:-http://localhost:2026}"
 GATEWAY_URL="${DEERFLOW_GATEWAY_URL:-$DEERFLOW_URL}"
 LANGGRAPH_URL="${DEERFLOW_LANGGRAPH_URL:-$DEERFLOW_URL/api/langgraph}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+GATEWAY_URL="${GATEWAY_URL%/}"
+LANGGRAPH_URL="${LANGGRAPH_URL%/}"
+COOKIE_ARGS=()
+if [ -n "${DEERFLOW_COOKIE:-}" ]; then
+  COOKIE_ARGS=(-b "$DEERFLOW_COOKIE")
+fi
 CMD="${1:-health}"
 ARG="${2:-}"
 
 case "$CMD" in
   health)
     echo "Checking DeerFlow at ${GATEWAY_URL}..."
-    HTTP_CODE=$(curl -s --connect-timeout 10 -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
-HTTP_CODE="${HTTP_CODE:-000}"
+    HTTP_CODE=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" -o /dev/null -w "%{http_code}" "${GATEWAY_URL}/health" 2>/dev/null || true)
+    HTTP_CODE="${HTTP_CODE:-000}"
     if [ "$HTTP_CODE" = "000" ]; then
       echo "UNREACHABLE — DeerFlow is not running at ${GATEWAY_URL}"
       exit 1
@@ -40,25 +48,48 @@ HTTP_CODE="${HTTP_CODE:-000}"
     fi
     ;;
   models)
-    curl -s "${GATEWAY_URL}/api/models" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/models" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/models:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   skills)
-    curl -s "${GATEWAY_URL}/api/skills" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/skills" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/skills:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   agents)
-    curl -s "${GATEWAY_URL}/api/agents" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/agents" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/agents:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   threads)
-    curl -s -X POST "${LANGGRAPH_URL}/threads/search" \
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/search" \
       -H "Content-Type: application/json" \
-      -d '{"limit": 20, "sort_by": "updated_at", "sort_order": "desc", "select": ["thread_id", "updated_at", "values"]}' \
+      -d '{"limit": 20}' \
       | python3 -c "
 import json, sys
 threads = json.load(sys.stdin)
+if not isinstance(threads, list):
+    print(f'Unexpected response (not a thread list): {str(threads)[:200]}')
+    sys.exit(1)
 if not threads:
     print('No threads found.')
     sys.exit(0)
 for t in threads:
+    if not isinstance(t, dict):
+        continue
     tid = t.get('thread_id', '?')
     updated = t.get('updated_at', '?')
     title = (t.get('values') or {}).get('title', '(untitled)')
@@ -66,14 +97,22 @@ for t in threads:
 "
     ;;
   memory)
-    curl -s "${GATEWAY_URL}/api/memory" | python3 -m json.tool
+    RESP=$(curl -s --connect-timeout 10 "${COOKIE_ARGS[@]}" "${GATEWAY_URL}/api/memory" || true)
+    printf '%s' "$RESP" | python3 -m json.tool 2>/dev/null || {
+      echo "ERROR: non-JSON or failed response from ${GATEWAY_URL}/api/memory:" >&2
+      printf '%s' "$RESP" | head -c 200 >&2
+      echo >&2
+      exit 1
+    }
     ;;
   thread)
     if [ -z "$ARG" ]; then
       echo "Usage: status.sh thread <thread_id>" >&2
       exit 1
     fi
-    curl -s "${LANGGRAPH_URL}/threads/${ARG}/history" | python3 -c "
+    curl -s "${COOKIE_ARGS[@]}" -X POST "${LANGGRAPH_URL}/threads/${ARG}/history" \
+      -H "Content-Type: application/json" \
+      -d '{"limit": 10}' | python3 -c "
 import json, sys
 data = json.load(sys.stdin)
 if isinstance(data, list):
@@ -81,6 +120,8 @@ if isinstance(data, list):
         values = state.get('values', {})
         msgs = values.get('messages', [])
         for m in msgs[-5:]:
+            if not isinstance(m, dict):
+                continue
             role = m.get('type', '?')
             content = m.get('content', '')
             if isinstance(content, list):


### PR DESCRIPTION
## Why

`claude-to-deerflow` shows how a host agent can delegate deep-research tasks to a running DeerFlow instance over its HTTP API. Two more agent hosts want the same pattern, and today they re-implement it by hand:

- **ZCode** (terminal coding agent): sessions want to hand research/analysis questions to DeerFlow and relay the answer plus artifact links back to the user.
- **DeepSeek Harness (dsh)** (github.com/deepseek-ai/deepseek-harness): headless agents want the same, with dsh-specific constraints — project skill discovery from the task workdir `.agents/skills/`, bash tool timeout budgets for multi-minute research runs, and env inheritance from the dsh process.

Scope boundary: this follows the existing `claude-to-deerflow` precedent — one self-contained skill per host agent that talks to DeerFlow over HTTP. Hosts are added when they are real, publicly documented agent platforms with users asking for DeerFlow integration; happy to split into a discussion if maintainers prefer a different collection policy.

## What changed

- New public skill `skills/public/zcode-to-deerflow/` — SKILL.md + `chat.sh`/`status.sh` for the ZCode host: skill-dir resolution (project `.agents/skills/` then `~/.agents/skills/`), background-and-poll guidance for long runs, thread reuse.
- New public skill `skills/public/dsh-to-deerflow/` — SKILL.md + scripts for DeepSeek Harness agents: install-into-workdir flow (`git init` project-root note), env-before-launch note, `nohup` + poll pattern for long research runs.
- Bug fix in the shared scripts (including the existing `claude-to-deerflow` copies): the health check was false-positive when DeerFlow is down. `curl -w %{http_code}` already prints `000` on connection failure, so the `|| echo "000"` fallback produced `HTTP_CODE=000000`, which passed both the `= "000"` and `-ge 400` checks and printed "OK — DeerFlow is running (HTTP 000000)". The fallback is now `|| true` with an explicit `:-000` default.
- Follow-up: a 4-reviewer adversarial pass (maintainer / bash+python correctness / docs-vs-backend / live fuzz) drove a further hardening commit — thread-create failures now surface their error instead of exiting silently, response extraction stops at the last human message (continuing a thread no longer echoes the previous turn's answer), thread ids go through `json.dumps` (injection-proof), the stream gains `--max-time` + HTTP-status surfacing, `DEERFLOW_COOKIE` supports authenticated deployments, `tool_calls.args` as JSON string is handled, thread history uses the real POST route (no GET exists upstream), `threads/search` drops params the backend ignores, `status.sh` gains shape guards, and all three copies are byte-identical with an explicit keep-in-sync header. Docs corrected against backend source: SSE event `messages` (not `messages-tuple`), auth prerequisite, agents 403-by-default, skill toggle admin-only, uploads auto-convert off-by-default, models response fields. README gains ZCode and dsh integration sections.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [x] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Shell-only skills, no UI to screenshot.

## Bug fix verification

- Test path / repro: with DeerFlow stopped, run `bash skills/public/claude-to-deerflow/scripts/status.sh health`.
  - On `main`: prints `OK — DeerFlow is running (HTTP 000000)` and exits 0 (red — false positive).
  - On this branch: prints `UNREACHABLE — DeerFlow is not running at http://localhost:2026` and exits 1; `chat.sh` likewise aborts with a clear error.
- There is no automated test harness for `skills/` shell scripts, so the repro above plus the checks below stand in for a committed red/green test.

## Validation

- `bash -n` on all six scripts (3 skills × `chat.sh`/`status.sh`) — pass
- `shellcheck -S warning` — fully clean on all six scripts
- Frontmatter check: `name` matches directory name, description present and within limits
- Smoke test against a stopped instance for all three skills: health → `UNREACHABLE`, exit 1; unknown subcommand → usage error
- Repo skill-review CLI (`deerflow.skills.review.cli --fail-on error --fail-on-incomplete`): 0 errors for all three skills
- E2E against a local DeerFlow-compatible mock server (SSE): health/models/threads, new-thread chat returning `present_files` artifact URLs (incl. string-type `tool_calls.args`), thread continuation by id, `ask_clarification` handling, mid-stream error event surfacing, malformed-SSE degradation, dead LangGraph port → clear thread-create error, injected/quoted thread ids → valid request body, HTTP 500 stream → status surfaced, stalled stream → `--max-time` cutoff, unreachable endpoint → exit 1. 15/15 scenarios pass.

Note: the branch carries three commits for review readability (add / harden / review-fixes) and can be squashed on merge; multilingual READMEs (ru/fr/etc.) can mirror the new integration sections in a follow-up.

## AI assistance

**Tool(s) used:** ZCode (Z.ai coding agent)

**How you used it:** AI authored both new skills and the health-check fix end-to-end, using upstream `claude-to-deerflow` as the reference, ran all validation commands above, and drafted this PR. A human directed the task and reviews the result.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.