### PR TITLE
fix: block bash commands referencing disabled skill paths

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1782,6 +1782,15 @@ def bash_tool(runtime: Runtime, description: str, command: str) -> str:
     """
     try:
         sandbox = ensure_sandbox_initialized(runtime)
+        # Block bash commands that reference disabled skill paths.
+        # The structured read tools (read_file, ls, glob, grep) already gate
+        # disabled skills, but bash can bypass them via cat/grep/find.
+        user_id = resolve_runtime_user_id(runtime)
+        _skill_path_re = re.compile(r"/mnt/skills/(?:public|custom|legacy|integrations)/([^/\s"'"]+)")
+        for _m in _skill_path_re.finditer(command):
+            _skill_name = _m.group(1)
+            if _is_disabled_skill_path(f"/mnt/skills/public/{_skill_name}/placeholder", user_id=user_id):
+                return f"Error: Skill '{_skill_name}' is disabled. Access to its files is blocked. Enable the skill in settings before using it."
         # Request-scoped secrets resolved for the active skill (#3861), plus a
         # short-lived GitHub App installation token threaded through by the
         # GitHub channel. Both are injected as per-call env into the subprocess,


### PR DESCRIPTION
## Problem

The structured read tools (`read_file`, `ls`, `glob`, `grep`) enforce the disabled-skill gate via `_is_disabled_skill_path()`, but `bash_tool` had no such check. Users could run `cat`, `grep`, `find` on disabled skill files via the bash tool, bypassing the access control.

## Solution

Add a regex scan of the bash command for `/mnt/skills/` paths and check each against `_is_disabled_skill_path()`. If the skill is disabled, return an error message instead of executing the command.

The check runs before command execution, matching the same pattern used by `ls_tool` (line 1861).

## How to verify

1. Disable a skill in settings
2. Try `cat /mnt/skills/public/<disabled-skill>/file.txt` via bash
3. Verify the command is blocked with an error message
4. Try the same with an enabled skill — should succeed

## Risk

Low — only adds a pre-execution check, no changes to command execution logic. The regex only matches `/mnt/skills/` paths, which is the standard skills mount point.

Fixes #4107