### PR TITLE
fix(tools): retain strong reference to deferred subagent cleanup tasks

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/task_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/task_tool.py
@@ -84,10 +84,16 @@ def _log_cleanup_failure(cleanup_task: asyncio.Task[None], *, trace_id: str, exe
         logger.error(f"[trace={trace_id}] Deferred cleanup failed for execution {execution_id}: {exc}")
 
 
-def _schedule_deferred_subagent_cleanup(execution_id: str, trace_id: str, max_polls: int) -> None:
+_deferred_cleanup_tasks: set[asyncio.Task[None]] = set()
+
+
+def _schedule_deferred_subagent_cleanup(execution_id: str, trace_id: str, max_polls: int) -> asyncio.Task[None]:
     logger.debug(f"[trace={trace_id}] Scheduling deferred cleanup for cancelled execution {execution_id}")
     cleanup_task = asyncio.create_task(_deferred_cleanup_subagent_task(execution_id, trace_id, max_polls))
+    _deferred_cleanup_tasks.add(cleanup_task)
+    cleanup_task.add_done_callback(_deferred_cleanup_tasks.discard)
     cleanup_task.add_done_callback(lambda task: _log_cleanup_failure(task, trace_id=trace_id, execution_id=execution_id))
+    return cleanup_task
 
 
 def _find_usage_recorder(runtime: Any) -> Any | None:

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -1,8 +1,10 @@
 """Core behavior tests for task tool orchestration."""
 
 import asyncio
+import gc
 import importlib
 import inspect
+import weakref
 from enum import Enum
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -1858,7 +1860,6 @@ def test_terminal_event_usage_none_when_no_records(monkeypatch):
 @pytest.mark.asyncio
 async def test_deferred_cleanup_task_retained_and_survives_gc(monkeypatch):
     """Verify deferred cleanup task is retained in _deferred_cleanup_tasks and completes after GC."""
-    import gc, weakref
     cleaned = []
     orig_sleep = asyncio.sleep
 
@@ -1882,8 +1883,3 @@ async def test_deferred_cleanup_task_retained_and_survives_gc(monkeypatch):
 
     assert cleaned == ["exec-gc"]
     assert weak_task() not in task_tool_module._deferred_cleanup_tasks
-
-
-
-
-

--- a/backend/tests/test_task_tool_core_logic.py
+++ b/backend/tests/test_task_tool_core_logic.py
@@ -1853,3 +1853,37 @@ def test_terminal_event_usage_none_when_no_records(monkeypatch):
     completed = [e for e in events if e["type"] == "task_completed"]
     assert len(completed) == 1
     assert completed[0]["usage"] is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_cleanup_task_retained_and_survives_gc(monkeypatch):
+    """Verify deferred cleanup task is retained in _deferred_cleanup_tasks and completes after GC."""
+    import gc, weakref
+    cleaned = []
+    orig_sleep = asyncio.sleep
+
+    monkeypatch.setattr(task_tool_module, "SubagentStatus", FakeSubagentStatus)
+    monkeypatch.setattr(task_tool_module, "get_background_task_result", lambda _: _make_result(FakeSubagentStatus.COMPLETED, result="ok"))
+    monkeypatch.setattr(task_tool_module, "cleanup_background_task", cleaned.append)
+    monkeypatch.setattr(task_tool_module.asyncio, "sleep", lambda _: orig_sleep(0))
+
+    task = task_tool_module._schedule_deferred_subagent_cleanup("exec-gc", "trace-gc", 5)
+    assert task in task_tool_module._deferred_cleanup_tasks
+    weak_task = weakref.ref(task)
+    del task
+    gc.collect()
+
+    assert weak_task() is not None and weak_task() in task_tool_module._deferred_cleanup_tasks
+    for _ in range(10):
+        if cleaned:
+            break
+        await orig_sleep(0.01)
+    await orig_sleep(0.01)
+
+    assert cleaned == ["exec-gc"]
+    assert weak_task() not in task_tool_module._deferred_cleanup_tasks
+
+
+
+
+


### PR DESCRIPTION
Fixes #4927

## Why

In `deerflow.tools.builtins.task_tool._schedule_deferred_subagent_cleanup`, when a subagent is cancelled or reaches safety timeouts, a background polling task `_deferred_cleanup_subagent_task` is scheduled via `asyncio.create_task(...)` to poll until the subagent reaches a terminal state and invoke `cleanup_background_task(execution_id)`.

Because Python's `asyncio` event loop holds only weak references to scheduled tasks, when `_deferred_cleanup_subagent_task` pauses at `await asyncio.sleep(5)`, a garbage collection pass can sweep the unreferenced task with a runtime warning (`Task was destroyed but it is pending!`). When this occurs, `cleanup_background_task()` is never invoked, leaving cancelled subagent records, lock state, and memory structures permanently leaked in `SubagentExecutor`.

## What changed

- Retain strong references to deferred cleanup tasks in a module-level `_deferred_cleanup_tasks: set[asyncio.Task[None]]`.
- Discard finished tasks via `.add_done_callback(_deferred_cleanup_tasks.discard)`.
- Add regression coverage in `test_task_tool_core_logic.py` verifying cleanup tasks survive forced `gc.collect()` passes while sleeping.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path: `backend/tests/test_task_tool_core_logic.py::test_deferred_cleanup_task_retained_and_survives_gc`
- Did it go red on `main` and green on this branch? Yes — `main` does not retain background cleanup tasks, causing garbage collection to evict pending tasks mid-sleep; this branch retains tasks in `_deferred_cleanup_tasks` until completed.

## Validation

- `cd backend && uv run pytest tests/test_task_tool_core_logic.py`: 42 passed.
- `cd backend && uv run ruff check packages/harness/deerflow/tools/builtins/task_tool.py`: passed.
- `git diff --check`: passed.

## AI assistance

**Tool(s) used:** dsh

**How you used it:** Root-cause analysis, implementation of task retention set pattern, and regression test authoring. The diff was reviewed line by line and verified with the test commands listed above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
