### PR TITLE
fix(middleware): strip sibling tool calls when ask_clarification is batched in the same turn

### DIFF
--- a/backend/docs/middleware-execution-flow.md
+++ b/backend/docs/middleware-execution-flow.md
@@ -19,7 +19,7 @@
 | 10 | ViewImageMiddleware | | ✓ | | | | | ✓ | ✗ | `vision` |
 | 11 | SubagentLimitMiddleware | | | ✓ | | | | ✓ | ✗ | `subagent` |
 | 12 | LoopDetectionMiddleware | ✓ | | ✓ | ✓ | ✓ | | ✓ | ✗ | 始终开启 |
-| 13 | ClarificationMiddleware | | | | | | ✓ | ✓ | ✗ | 始终最后 |
+| 13 | ClarificationMiddleware | | | ✓ | | | ✓ | ✓ | ✗ | 始终最后 |
 
 主 agent **14 个** middleware（`make_lead_agent`），subagent **4 个**（ThreadData、Sandbox、Guardrail、ToolErrorHandling）。`create_deerflow_agent` Phase 1 实现 **13 个**（Guardrail 仅支持自定义实例，无内置默认）。
 
@@ -174,6 +174,7 @@ sequenceDiagram
 > [!important] 核心规则
 > 列表最后的 middleware，其 `after_model` **最先执行**。
 > ClarificationMiddleware 在列表末尾，所以它第一个拦截 model 输出。
+> 这个"始终最后"不变式对 `after_model` 链同样关键：剥离兄弟 tool calls 依赖 ClarificationMiddleware 作为第一个 after_* 钩子看到**未经改动**的 AIMessage（`messages[-1]`）。任何排在其后、会追加消息的钩子都会把 `messages[-1]` 移走，使剥离静默失效——因此 ClarificationMiddleware 必须保持列表最后。
 
 ## 对比：真正的洋葱 vs DeerFlow 的实际情况
 

--- a/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/clarification_middleware.py
@@ -9,10 +9,13 @@ from typing import Any, override
 
 from langchain.agents import AgentState
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import AIMessage, ToolMessage
 from langgraph.graph import END
 from langgraph.prebuilt.tool_node import ToolCallRequest
+from langgraph.runtime import Runtime
 from langgraph.types import Command
+
+from deerflow.agents.middlewares.tool_call_metadata import clone_ai_message_with_tool_calls
 
 logger = logging.getLogger(__name__)
 
@@ -370,11 +373,7 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
         When set, we don't interrupt; we return a ToolMessage nudging the
         agent to proceed with its best judgment instead.
         """
-        runtime = getattr(request, "runtime", None)
-        context = getattr(runtime, "context", None)
-        if not context:
-            return False
-        return bool(context.get("disable_clarification"))
+        return self._clarification_disabled(getattr(request, "runtime", None))
 
     def _handle_disabled_clarification(self, request: ToolCallRequest) -> ToolMessage:
         """Suppress a clarification and tell the agent to proceed.
@@ -471,6 +470,65 @@ class ClarificationMiddleware(AgentMiddleware[ClarificationMiddlewareState]):
             return self._handle_disabled_clarification(request)
 
         return self._handle_clarification(request)
+
+    @override
+    def after_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self._strip_sibling_tool_calls(state, runtime)
+
+    @override
+    async def aafter_model(self, state: AgentState, runtime: Runtime) -> dict | None:
+        return self._strip_sibling_tool_calls(state, runtime)
+
+    def _strip_sibling_tool_calls(self, state: AgentState, runtime: Runtime) -> dict | None:
+        """Strip sibling tool calls from any AIMessage that also calls `ask_clarification`.
+
+        Providers routinely batch tool calls into a single AIMessage. If that
+        turn contains `ask_clarification` next to `bash` / `write_file` / ...,
+        the clarification interrupt (`wrap_tool_call` -> `Command(goto=END)`)
+        only holds for the single intercepted call: the siblings still run in
+        parallel, and langchain's `return_direct` router only inspects the last
+        ToolMessage, so interrupt-vs-continue becomes order-dependent (#4906).
+
+        The model's text instruction ("call ask_clarification IMMEDIATELY, do
+        NOT start working") is a soft constraint; this rewrite makes it
+        structural. The replacement keeps the original message id so
+        `add_messages` replaces the batch instead of appending a duplicate.
+
+        When clarifications are suppressed (`disable_clarification`), the
+        agent is expected to proceed with its tools, so nothing is stripped.
+        """
+        if self._clarification_disabled(runtime):
+            return None
+        messages = state.get("messages") or []
+        if not messages:
+            return None
+        last = messages[-1]
+        if not isinstance(last, AIMessage):
+            return None
+        tool_calls = getattr(last, "tool_calls", None) or []
+        if not tool_calls:
+            return None
+
+        clarification_calls = [call for call in tool_calls if call.get("name") == "ask_clarification"]
+        if not clarification_calls:
+            return None
+        if len(clarification_calls) == len(tool_calls):
+            # Already a pure clarification turn — nothing to strip.
+            return None
+
+        # clone_ai_message_with_tool_calls keeps raw provider tool-call
+        # metadata (additional_kwargs) in sync with the filtered structured
+        # tool_calls and preserves the message id and usage metadata via
+        # model_copy, instead of hand-rebuilding the message.
+        replacement = clone_ai_message_with_tool_calls(last, clarification_calls)
+        return {"messages": [replacement]}
+
+    @staticmethod
+    def _clarification_disabled(runtime: Runtime | None) -> bool:
+        context = getattr(runtime, "context", None)
+        if not context:
+            return False
+        return bool(context.get("disable_clarification"))
 
     @override
     async def awrap_tool_call(

--- a/backend/tests/test_clarification_middleware.py
+++ b/backend/tests/test_clarification_middleware.py
@@ -4,6 +4,7 @@ import json
 from types import SimpleNamespace
 
 import pytest
+from langchain_core.messages import AIMessage
 from langgraph.graph.message import add_messages
 
 from deerflow.agents.middlewares.clarification_middleware import ClarificationMiddleware
@@ -800,3 +801,198 @@ class TestClarificationDisabled:
         merged = add_messages(add_messages([], [first_message]), [second_message])
 
         assert len(merged) == 1
+
+
+class TestAfterModelStripsSiblingToolCalls:
+    """Regression tests for #4906: when ask_clarification is batched with
+    sibling tool calls in one AIMessage, the siblings must be stripped so the
+    clarification interrupt can fire before any action runs."""
+
+    @staticmethod
+    def _state(last_message: object) -> dict:
+        return {"messages": [{"role": "user", "content": "hi"}, last_message]}
+
+    def test_strips_sibling_tool_calls(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-1",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "Which dir?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "rm -rf /tmp/x"}},
+                {"id": "c3", "name": "write_file", "args": {"path": "/tmp/x.txt", "content": "y"}},
+            ],
+        )
+        result = middleware.after_model(self._state(ai), None)
+        assert result is not None
+        updated = result["messages"][0]
+        assert updated.id == "msg-1", "replacement must keep the original id so add_messages replaces it"
+        assert [tc["name"] for tc in updated.tool_calls] == ["ask_clarification"]
+
+    def test_single_clarification_unchanged(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-2",
+            tool_calls=[{"id": "c1", "name": "ask_clarification", "args": {"question": "?"}}],
+        )
+        assert middleware.after_model(self._state(ai), None) is None
+
+    def test_multiple_clarifications_kept_no_siblings(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-5",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "ask_clarification", "args": {"question": "?"}},
+            ],
+        )
+        assert middleware.after_model(self._state(ai), None) is None
+
+    def test_no_clarification_unchanged(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-3",
+            tool_calls=[{"id": "c2", "name": "bash", "args": {"cmd": "ls"}}],
+        )
+        assert middleware.after_model(self._state(ai), None) is None
+
+    def test_non_ai_last_message_unchanged(self, middleware):
+        assert middleware.after_model({"messages": [{"role": "user", "content": "hi"}]}, None) is None
+
+    def test_empty_tool_calls_unchanged(self, middleware):
+        ai = AIMessage(content="plain text", id="msg-6")
+        assert middleware.after_model(self._state(ai), None) is None
+
+    def test_async_version_strips_siblings(self, middleware):
+        import asyncio
+
+        ai = AIMessage(
+            content="",
+            id="msg-4",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "ls"}},
+            ],
+        )
+        result = asyncio.run(middleware.aafter_model(self._state(ai), None))
+        assert result is not None
+        assert [tc["name"] for tc in result["messages"][0].tool_calls] == ["ask_clarification"]
+
+
+class TestAfterModelRespectsDisabledClarification:
+    """#4906 follow-up: when disable_clarification is set in the run context,
+    ask_clarification is suppressed and the agent is expected to proceed with
+    its tools — siblings must NOT be stripped in that mode."""
+
+    @staticmethod
+    def _state(last_message: object) -> dict:
+        return {"messages": [{"role": "user", "content": "hi"}, last_message]}
+
+    @staticmethod
+    def _disabled_runtime() -> object:
+        return SimpleNamespace(context={"disable_clarification": True})
+
+    def test_does_not_strip_when_clarification_disabled(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-1",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "ls"}},
+            ],
+        )
+        result = middleware.after_model(self._state(ai), self._disabled_runtime())
+        assert result is None, "siblings must be kept when clarification is suppressed"
+
+    def test_async_does_not_strip_when_clarification_disabled(self, middleware):
+        import asyncio
+
+        ai = AIMessage(
+            content="",
+            id="msg-2",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "write_file", "args": {"path": "/tmp/x", "content": "y"}},
+            ],
+        )
+        result = asyncio.run(middleware.aafter_model(self._state(ai), self._disabled_runtime()))
+        assert result is None
+
+    def test_strips_normally_without_context(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-3",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "ls"}},
+            ],
+        )
+        result = middleware.after_model(self._state(ai), SimpleNamespace(context={}))
+        assert result is not None
+        assert [tc["name"] for tc in result["messages"][0].tool_calls] == ["ask_clarification"]
+
+
+class TestAfterModelPreservesMetadata:
+    """The replacement AIMessage must keep usage/response metadata so token
+    tracking and provider diagnostics survive the sibling-strip."""
+
+    def test_preserves_usage_and_response_metadata(self, middleware):
+        ai = AIMessage(
+            content="",
+            id="msg-meta",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "ls"}},
+            ],
+            response_metadata={"finish_reason": "tool_calls"},
+            usage_metadata={"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        )
+        result = middleware.after_model({"messages": [{"role": "user", "content": "hi"}, ai]}, None)
+        assert result is not None
+        replacement = result["messages"][0]
+        assert replacement.response_metadata == {"finish_reason": "tool_calls"}
+        assert replacement.usage_metadata == {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+    def test_raw_tool_call_metadata_synced(self, middleware):
+        """additional_kwargs['tool_calls'] (raw provider metadata) must be
+        filtered to the kept calls, not dropped wholesale."""
+        ai = AIMessage(
+            content="",
+            id="msg-raw",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "ls"}},
+            ],
+            additional_kwargs={
+                "tool_calls": [
+                    {"id": "c1", "type": "function", "function": {"name": "ask_clarification", "arguments": "{}"}},
+                    {"id": "c2", "type": "function", "function": {"name": "bash", "arguments": "{}"}},
+                ]
+            },
+        )
+        result = middleware.after_model({"messages": [{"role": "user", "content": "hi"}, ai]}, None)
+        assert result is not None
+        replacement = result["messages"][0]
+        raw = replacement.additional_kwargs.get("tool_calls")
+        assert raw is not None, "raw tool-call metadata must survive the rewrite"
+        assert [entry["id"] for entry in raw] == ["c1"], "raw metadata must be filtered to the kept call"
+
+    def test_add_messages_merge_replaces_the_batch(self, middleware):
+        """The whole fix hinges on add_messages replacing the sibling-bearing
+        AIMessage by id rather than appending a second copy. Assert the merge
+        directly so a regression (e.g. a helper change that drops the id)
+        fails here instead of silently surviving in state."""
+        ai = AIMessage(
+            content="",
+            id="msg-merge",
+            tool_calls=[
+                {"id": "c1", "name": "ask_clarification", "args": {"question": "?"}},
+                {"id": "c2", "name": "bash", "args": {"cmd": "rm -rf /tmp/x"}},
+            ],
+        )
+        result = middleware.after_model({"messages": [{"role": "user", "content": "hi"}, ai]}, None)
+        assert result is not None
+        merged = add_messages([{"role": "user", "content": "hi"}, ai], result["messages"])
+        assert len(merged) == 2, "the original AIMessage must be replaced, not appended"
+        last = merged[-1]
+        assert isinstance(last, AIMessage)
+        assert [tc["name"] for tc in last.tool_calls] == ["ask_clarification"]


### PR DESCRIPTION
Fixes #4906.

Problem
ask_clarification is meant to pause the agent and ask the user a question before any work is done. But providers often send multiple tool calls in one message. If ask_clarification is sent together with bash or write_file, those tools still run before the user answers, and whether the run stops depends on the order of the tool calls.

Fix
When a message contains ask_clarification together with other tool calls, the middleware now keeps only the clarification call and drops the rest, before any tool executes. The original message id is preserved so the replacement replaces the old message instead of being appended. The disabled-clarification mode (webhook channels) is respected, and usage and response metadata are kept.

Verification
58 tests pass in the clarification middleware suite, including 12 new tests. Each new behavior was verified to fail when disabled. Ruff lint and format checks are clean.
