### PR TITLE
fix(sandbox): reject non-finite ownership timing

### DIFF
--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -29,6 +29,7 @@ class SandboxOwnershipConfig(BaseModel):
     renewal_interval_seconds: float = Field(
         default=30.0,
         gt=0,
+        allow_inf_nan=False,
         description=(
             "How often an owning instance refreshes its leases. The lease TTL is derived from this (interval x ttl_multiplier), so ownership liveness is independent of sandbox.idle_timeout: "
             "renewal keeps running even when idle cleanup is disabled (idle_timeout: 0)."
@@ -37,6 +38,7 @@ class SandboxOwnershipConfig(BaseModel):
     ttl_multiplier: float = Field(
         default=4.0,
         ge=2,
+        allow_inf_nan=False,
         description="Lease TTL as a multiple of renewal_interval_seconds. At least 2, so a single missed renewal (slow host, brief Redis blip) cannot expire a live owner's lease. Default 4 tolerates three consecutive misses.",
     )
     key_prefix: str = Field(

--- a/backend/tests/test_sandbox_ownership_store.py
+++ b/backend/tests/test_sandbox_ownership_store.py
@@ -356,6 +356,13 @@ def test_ttl_multiplier_below_two_is_rejected():
         SandboxOwnershipConfig(ttl_multiplier=1.0)
 
 
+@pytest.mark.parametrize("field", ["renewal_interval_seconds", "ttl_multiplier"])
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_ownership_timing_rejects_non_finite_values(field: str, value: float):
+    with pytest.raises(ValueError):
+        SandboxOwnershipConfig(**{field: value})
+
+
 def test_owner_ids_are_unique_per_instance():
     """Two workers on one host must not share an owner id."""
     assert generate_owner_id() != generate_owner_id()


### PR DESCRIPTION
Fixes #4947

## Why

A valid `SandboxOwnershipConfig` could contain YAML `.inf` for either lease timing field. Redis ownership then crashed during startup while converting the derived infinite TTL to milliseconds, before it attempted a Redis connection.

## What changed

- Reject NaN and positive/negative infinity for both ownership timing fields during Pydantic configuration validation.
- Add focused coverage for every non-finite value on both fields.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Test path: `backend/tests/test_sandbox_ownership_store.py::test_ownership_timing_rejects_non_finite_values`
- Red on `main`: yes. The equivalent assertion reports both `renewal_interval_seconds` and `ttl_multiplier` accepted `+inf`; constructing the Redis store then raises `OverflowError: cannot convert float infinity to integer`.
- Green on this branch: yes, all six field/value combinations pass as part of the focused suite.

## Validation

```text
cd backend
uv sync --locked
uv run --locked --no-sync pytest tests/test_sandbox_ownership_store.py -q
# 42 passed, 24 skipped

uv run --locked --no-sync ruff check packages/harness/deerflow/config/sandbox_config.py tests/test_sandbox_ownership_store.py
# All checks passed

uv run --locked --no-sync ruff format --check packages/harness/deerflow/config/sandbox_config.py tests/test_sandbox_ownership_store.py
# 2 files already formatted

uv lock --check
# Resolved 248 packages

git diff --check
# clean
```

Redis integration cases skipped because no test Redis service was configured; this validation change executes before any Redis connection.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Repository audit, minimal reproduction, duplicate search, implementation, and test execution. Human line-by-line review is pending; this PR remains Draft until that review is complete.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
