### PR TITLE
fix(docker): allow 127.0.0.1 to hydrate the Next.js dev server

### DIFF
--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -11,7 +11,7 @@
 # Prerequisites:
 #   - Kubernetes cluster + kubeconfig are only required when using provisioner mode.
 #
-# Access: http://localhost:2026
+# Access: http://localhost:2026 or http://127.0.0.1:2026
 
 services:
   # ── Redis Stream Bridge ────────────────────────────────────────────────
@@ -138,6 +138,10 @@ services:
       - WATCHPACK_POLLING=true
       - CI=true
       - DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://gateway:8001
+      # next dev only allows localhost by default. The compose entry publishes
+      # nginx on BIND_HOST=127.0.0.1, so opening that URL 403s /_next/* and
+      # freezes /setup on "Loading…". See #4957.
+      - DEER_FLOW_DEV_ALLOWED_ORIGINS=${DEER_FLOW_DEV_ALLOWED_ORIGINS:-127.0.0.1,::1}
     env_file:
       - ../frontend/.env
     networks:


### PR DESCRIPTION
Fixes #4957

## Why

`make docker-start` is the recommended Docker **dev** path. It still runs `pnpm run dev`, and compose publishes nginx on `127.0.0.1:2026` by default. Opening that URL and clicking Get Started freezes `/setup` on `Loading…` because Next.js blocks `/_next/*` and HMR from `127.0.0.1`. `localhost:2026` works.

This is not #3385 / #3394 (`make dev` / remote hosts). Those asked people to use `localhost` or `make up`. Here the official Docker bind host itself is `127.0.0.1`.

## What changed

- `docker-compose-dev.yaml` now defaults `DEER_FLOW_DEV_ALLOWED_ORIGINS` to `127.0.0.1,::1` for the frontend container.
- Operators can still override the variable.
- `getAllowedDevOrigins()` stays localhost-only unless that env is set. Production `make up` is unchanged.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path: `make docker-start`, open `http://127.0.0.1:2026`, click Get Started.
- Did it go red on `main` and green on this branch? yes (manual)
- A unit test was not cheap: this is a Next.js `allowedDevOrigins` / Docker bind-host interaction. Existing `getAllowedDevOrigins()` tests still expect an empty default.

## Validation

- Recreated `deer-flow-frontend`; `DEER_FLOW_DEV_ALLOWED_ORIGINS=127.0.0.1,::1`
- Before: `http://127.0.0.1:2026/setup` stayed on Loading; frontend log showed blocked `/_next` from `127.0.0.1`
- After: same URL shows the create-admin form (verified in browser)

## AI assistance

**Tool(s) used:** Cursor

**How you used it:** AI helped reproduce the `/setup` Loading hang, distinguish it from #3385/#3394, draft the compose env change, and write this PR text. I reviewed every line.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.