### PR TITLE
fix(docker): allow default dev frontend origins

### DIFF
--- a/backend/tests/test_compose_default_bind_host.py
+++ b/backend/tests/test_compose_default_bind_host.py
@@ -80,6 +80,14 @@ def test_bind_address_remains_overridable(variant: str):
     assert _bind_address(mapping) == "${BIND_HOST:-127.0.0.1}", f"{variant} compose must keep the bind address overridable via BIND_HOST; got: {mapping!r}"
 
 
+def test_dev_frontend_allows_default_loopback_origins():
+    """The Docker dev frontend must hydrate on its default published hosts."""
+    compose = yaml.safe_load(COMPOSE_PATHS["dev"].read_text(encoding="utf-8"))
+    environment = compose["services"]["frontend"]["environment"]
+
+    assert "DEER_FLOW_DEV_ALLOWED_ORIGINS=${DEER_FLOW_DEV_ALLOWED_ORIGINS:-127.0.0.1,::1}" in environment
+
+
 def _bind_address(mapping: str) -> str | None:
     """Return the bind-address segment of a compose port mapping, if any.
 

--- a/docker/docker-compose-dev.yaml
+++ b/docker/docker-compose-dev.yaml
@@ -138,6 +138,7 @@ services:
       - WATCHPACK_POLLING=true
       - CI=true
       - DEER_FLOW_INTERNAL_GATEWAY_BASE_URL=http://gateway:8001
+      - DEER_FLOW_DEV_ALLOWED_ORIGINS=${DEER_FLOW_DEV_ALLOWED_ORIGINS:-127.0.0.1,::1}
     env_file:
       - ../frontend/.env
     networks:


### PR DESCRIPTION
Fixes #4957

## Why

`make docker-start` publishes the documented default entry point on `127.0.0.1:2026`, but the Next.js dev server does not allow that host by default. The setup page therefore serves SSR `Loading...` HTML but cannot hydrate, leaving users stuck on the setup screen.

## What changed

- Docker dev Compose now passes `127.0.0.1` and `::1` as the default `DEER_FLOW_DEV_ALLOWED_ORIGINS`.
- The variable remains overridable so operators can add a custom LAN or proxy host.
- Added a regression test pinning the default frontend environment entry.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — Docker dev default host is now allowed by Next.js
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this changes Docker dev-server configuration and does not change the UI layout.

## Bug fix verification

- Test path: `backend/tests/test_compose_default_bind_host.py::test_dev_frontend_allows_default_loopback_origins`
- Red on `main`: yes, the expected environment entry is absent.
- Green on this branch: yes.

## Validation

- `cd backend && uv run --locked pytest tests/test_compose_default_bind_host.py -q` (7 passed)
- `git diff --check`

The full `docker compose config` check was not available locally because the ignored root `frontend/.env` file is absent. The compose YAML is parsed by the regression test.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Used Codex to inspect the repository and issue report, implement the focused Compose/test change, run validation, and prepare this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
