### PR TITLE
fix(sandbox): Redis sandbox ownership crashes on non-finite lease timing

### DIFF
--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -29,6 +29,7 @@ class SandboxOwnershipConfig(BaseModel):
     renewal_interval_seconds: float = Field(
         default=30.0,
         gt=0,
+        allow_inf_nan=False,
         description=(
             "How often an owning instance refreshes its leases. The lease TTL is derived from this (interval x ttl_multiplier), so ownership liveness is independent of sandbox.idle_timeout: "
             "renewal keeps running even when idle cleanup is disabled (idle_timeout: 0)."
@@ -37,6 +38,7 @@ class SandboxOwnershipConfig(BaseModel):
     ttl_multiplier: float = Field(
         default=4.0,
         ge=2,
+        allow_inf_nan=False,
         description="Lease TTL as a multiple of renewal_interval_seconds. At least 2, so a single missed renewal (slow host, brief Redis blip) cannot expire a live owner's lease. Default 4 tolerates three consecutive misses.",
     )
     key_prefix: str = Field(

--- a/backend/tests/test_sandbox_ownership_store.py
+++ b/backend/tests/test_sandbox_ownership_store.py
@@ -356,6 +356,13 @@ def test_ttl_multiplier_below_two_is_rejected():
         SandboxOwnershipConfig(ttl_multiplier=1.0)
 
 
+@pytest.mark.parametrize("field", ["renewal_interval_seconds", "ttl_multiplier"])
+@pytest.mark.parametrize("value", [float("inf"), float("-inf"), float("nan")])
+def test_lease_timing_rejects_non_finite_values(field, value):
+    with pytest.raises(ValueError):
+        SandboxOwnershipConfig(**{field: value})
+
+
 def test_owner_ids_are_unique_per_instance():
     """Two workers on one host must not share an owner id."""
     assert generate_owner_id() != generate_owner_id()


### PR DESCRIPTION
Fixes #4947

## Why

`SandboxOwnershipConfig` 原先只校验租约时间的下限，会接受 `NaN` 和 `+/-Infinity`。Redis ownership store 随后在将无限 TTL 转换为毫秒时抛出 `OverflowError`，配置错误直到启动阶段才暴露。

## What changed

- 为 `renewal_interval_seconds` 和 `ttl_multiplier` 增加 `allow_inf_nan=False`。
- 增加正无穷、负无穷和 NaN 的配置回归测试。
- 保持现有有限值和边界校验行为不变。

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox** — ownership 配置
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

不适用；这是后端配置校验变更。

## Bug fix verification

- 测试路径：`backend/tests/test_sandbox_ownership_store.py::test_lease_timing_rejects_non_finite_values`
- 修复前：非有限值可通过模型校验，随后可能在 Redis store 构造阶段触发 `OverflowError`。
- 修复后：非有限值在配置模型构造时被拒绝。

## Validation

- `cd backend && uv run --locked pytest tests/test_sandbox_ownership_store.py -q`（42 passed, 24 skipped）
- `cd backend && uv run --locked ruff check packages/harness/deerflow/config/sandbox_config.py tests/test_sandbox_ownership_store.py`
- `git diff --check`

## AI assistance

**Tool(s) used:** Codex

**How you used it:** 使用 Codex 检查 issue、实现配置校验和测试、运行验证并准备 PR。

- [x] 我已阅读并理解本次变更的每一行代码，并对其负责；这不是未经审阅的 AI 输出。