### PR TITLE
fix(harness): offload ACP workspace creation from event loop

### DIFF
--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -215,7 +215,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         client = _CollectingClient()
         cmd = agent_config.command
         args = agent_config.args or []
-        physical_cwd = _get_work_dir(thread_id)
+        physical_cwd = await asyncio.to_thread(_get_work_dir, thread_id)
         try:
             mcp_servers = _build_acp_mcp_servers()
         except ValueError as exc:

--- a/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py
@@ -217,7 +217,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
         args = agent_config.args or []
         physical_cwd = await asyncio.to_thread(_get_work_dir, thread_id)
         try:
-            mcp_servers = _build_acp_mcp_servers()
+            mcp_servers = await asyncio.to_thread(_build_acp_mcp_servers)
         except ValueError as exc:
             logger.warning(
                 "Invalid MCP server configuration for ACP agent '%s'; continuing without MCP servers: %s",
@@ -268,7 +268,7 @@ def build_invoke_acp_agent_tool(agents: dict) -> BaseTool:
             return result or "(no response)"
         except Exception as e:
             logger.error("ACP agent '%s' invocation failed: %s", agent, e)
-            return _format_invocation_error(agent, cmd, e)
+            return await asyncio.to_thread(_format_invocation_error, agent, cmd, e)
 
     return StructuredTool.from_function(
         name="invoke_acp_agent",

--- a/backend/tests/blocking_io/test_invoke_acp_agent_tool.py
+++ b/backend/tests/blocking_io/test_invoke_acp_agent_tool.py
@@ -1,7 +1,8 @@
-"""Regression test for ACP workspace setup on the event loop."""
+"""Regression test for ACP invocation setup on the event loop."""
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 from types import SimpleNamespace
 from typing import Any
@@ -15,7 +16,7 @@ from deerflow.tools.builtins import invoke_acp_agent_tool as acp_tool
 pytestmark = pytest.mark.asyncio
 
 
-async def test_invoke_acp_agent_creates_workspace_off_event_loop(monkeypatch, tmp_path) -> None:
+async def test_invoke_acp_agent_setup_does_not_block_event_loop(monkeypatch, tmp_path) -> None:
     from deerflow.config import paths as paths_module
 
     configured_paths = SimpleNamespace(
@@ -23,7 +24,13 @@ async def test_invoke_acp_agent_creates_workspace_off_event_loop(monkeypatch, tm
         acp_workspace_dir=lambda thread_id, user_id=None: tmp_path / "threads" / thread_id / "acp-workspace",
     )
     monkeypatch.setattr(paths_module, "get_paths", lambda: configured_paths)
-    monkeypatch.setattr(acp_tool, "_build_acp_mcp_servers", lambda: [])
+    config_path = tmp_path / "extensions_config.json"
+    await asyncio.to_thread(
+        config_path.write_text,
+        '{"mcpServers": {"test-server": {"enabled": true, "type": "http", "url": "https://example.test/mcp"}}, "skills": {}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DEER_FLOW_EXTENSIONS_CONFIG_PATH", str(config_path))
 
     captured: dict[str, Any] = {}
 
@@ -57,4 +64,5 @@ async def test_invoke_acp_agent_creates_workspace_off_event_loop(monkeypatch, tm
     expected_cwd = tmp_path / "threads" / "thread-1" / "acp-workspace"
     assert result == "(no response)"
     assert captured["cwd"] == str(expected_cwd)
+    assert captured["new_session"]["mcp_servers"] == [{"name": "test-server", "type": "http", "url": "https://example.test/mcp", "headers": []}]
     assert expected_cwd.is_dir()

--- a/backend/tests/blocking_io/test_invoke_acp_agent_tool.py
+++ b/backend/tests/blocking_io/test_invoke_acp_agent_tool.py
@@ -1,0 +1,60 @@
+"""Regression test for ACP workspace setup on the event loop."""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from typing import Any
+
+import acp
+import pytest
+
+from deerflow.config.acp_config import ACPAgentConfig
+from deerflow.tools.builtins import invoke_acp_agent_tool as acp_tool
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_invoke_acp_agent_creates_workspace_off_event_loop(monkeypatch, tmp_path) -> None:
+    from deerflow.config import paths as paths_module
+
+    configured_paths = SimpleNamespace(
+        base_dir=tmp_path,
+        acp_workspace_dir=lambda thread_id, user_id=None: tmp_path / "threads" / thread_id / "acp-workspace",
+    )
+    monkeypatch.setattr(paths_module, "get_paths", lambda: configured_paths)
+    monkeypatch.setattr(acp_tool, "_build_acp_mcp_servers", lambda: [])
+
+    captured: dict[str, Any] = {}
+
+    class _Connection:
+        async def initialize(self, **kwargs: Any) -> None:
+            captured["initialize"] = kwargs
+
+        async def new_session(self, **kwargs: Any) -> SimpleNamespace:
+            captured["new_session"] = kwargs
+            return SimpleNamespace(session_id="session-1")
+
+        async def prompt(self, **kwargs: Any) -> None:
+            captured["prompt"] = kwargs
+
+    @contextlib.asynccontextmanager
+    async def fake_spawn_agent_process(client, command, *args, env=None, cwd=None):
+        captured["cwd"] = cwd
+        yield _Connection(), SimpleNamespace()
+
+    monkeypatch.setattr(acp, "spawn_agent_process", fake_spawn_agent_process)
+
+    tool = acp_tool.build_invoke_acp_agent_tool(
+        {"test-agent": ACPAgentConfig(command="test-agent", description="Test agent")},
+    )
+    result = await tool.coroutine(
+        agent="test-agent",
+        prompt="run",
+        config={"configurable": {"thread_id": "thread-1"}},
+    )
+
+    expected_cwd = tmp_path / "threads" / "thread-1" / "acp-workspace"
+    assert result == "(no response)"
+    assert captured["cwd"] == str(expected_cwd)
+    assert expected_cwd.is_dir()


### PR DESCRIPTION
## Why

`invoke_acp_agent` performs setup and error handling from an async tool path. Several synchronous filesystem operations could run on the event loop: ACP workspace creation, `extensions_config.json` loading for MCP servers, and PATH scanning while formatting a missing-command error.

Under the strict Blockbuster runtime gate, these operations can raise blocking-IO errors and stall other async work.

## What changed

- Offload per-thread ACP workspace creation with `asyncio.to_thread()`.
- Offload MCP configuration loading and ACP MCP payload construction.
- Offload invocation error formatting so `shutil.which()` also runs outside the event loop.
- Add a regression test that uses a real temporary `extensions_config.json` and covers the complete ACP setup path.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path: `backend/tests/blocking_io/test_invoke_acp_agent_tool.py`
- The original regression test failed on `main` with a blocking-IO error and passes with this change: yes.
- The regression test now exercises real MCP configuration loading instead of stubbing the helper.

## Validation

- `uv run pytest -q tests/blocking_io/test_invoke_acp_agent_tool.py tests/test_invoke_acp_agent_tool.py`
  - `20 passed`
- `uv run pytest -q tests/blocking_io`
  - `72 passed`
- `make detect-blocking-io`
  - 21 findings remain in unrelated modules; the ACP tool is absent from the report
- `uv run ruff check packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py tests/blocking_io/test_invoke_acp_agent_tool.py`
  - passed
- `uv run ruff format --check packages/harness/deerflow/tools/builtins/invoke_acp_agent_tool.py tests/blocking_io/test_invoke_acp_agent_tool.py`
  - passed
- `git diff --check`
  - passed

## AI assistance

**Tool(s) used:** Codex

**How you used it:** There are three aspects: assisting with issue troubleshooting, making code modifications, and writing the non-AI‑assistance part of the PR information. At present, I have locally deployed and run the project to get hands‑on experience and a general understanding of the architecture. I want to participate in the development of deerflow. I first had AI thoroughly check the project and look for any minor issues. Then AI raised this particular issue. I asked AI several more rounds to make sure the issue really existed, so I had AI fix it. I also reviewed its code, and after the review, I felt there were no problems.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
