### PR TITLE
fix(agents): normalize Command-wrapped tool results

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_error_handling_middleware.py
@@ -133,7 +133,10 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         except Exception as exc:
             logger.exception("Tool execution failed (sync): name=%s id=%s", request.tool_call.get("name"), request.tool_call.get("id"))
             return self._build_error_message(request, exc)
-        return normalize_tool_result(self._maybe_stamp(result, request))
+        return normalize_tool_result(
+            self._maybe_stamp(result, request),
+            tool_call_id=str(request.tool_call.get("id") or ""),
+        )
 
     @override
     async def awrap_tool_call(
@@ -149,7 +152,10 @@ class ToolErrorHandlingMiddleware(AgentMiddleware[AgentState]):
         except Exception as exc:
             logger.exception("Tool execution failed (async): name=%s id=%s", request.tool_call.get("name"), request.tool_call.get("id"))
             return self._build_error_message(request, exc)
-        return normalize_tool_result(self._maybe_stamp(result, request))
+        return normalize_tool_result(
+            self._maybe_stamp(result, request),
+            tool_call_id=str(request.tool_call.get("id") or ""),
+        )
 
 
 def _build_runtime_middlewares(

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_progress_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_progress_middleware.py
@@ -64,7 +64,11 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.runtime import Runtime
 from langgraph.types import Command
 
-from deerflow.agents.middlewares.tool_result_meta import TOOL_META_KEY, ToolResultMeta
+from deerflow.agents.middlewares.tool_result_meta import (
+    TOOL_META_KEY,
+    ToolResultMeta,
+    tool_messages_from_result,
+)
 
 if TYPE_CHECKING:
     from deerflow.config.tool_progress_config import ToolProgressConfig
@@ -302,12 +306,20 @@ class ToolProgressMiddleware(AgentMiddleware[AgentState]):
         self,
         result: ToolMessage | Command,
         tool_name: str,
+        tool_call_id: str,
         runtime: Runtime,
     ) -> ToolMessage | Command:
         """Update the state machine from a tool result; queue hints if warranted."""
-        if not isinstance(result, ToolMessage):
+        if isinstance(result, ToolMessage):
+            message = result
+        else:
+            message = next(
+                (candidate for candidate in tool_messages_from_result(result) if str(candidate.tool_call_id) == tool_call_id),
+                None,
+            )
+        if message is None:
             return result
-        meta = _parse_tool_meta((result.additional_kwargs or {}).get(TOOL_META_KEY))
+        meta = _parse_tool_meta((message.additional_kwargs or {}).get(TOOL_META_KEY))
         if meta is None:
             if tool_name not in self._exempt_tools:
                 logger.warning(
@@ -315,7 +327,7 @@ class ToolProgressMiddleware(AgentMiddleware[AgentState]):
                     tool_name,
                 )
             return result
-        content = _message_content_str(result)
+        content = _message_content_str(message)
         thread_id = self._thread_id(runtime)
         with self._lock:
             state = self._get_state(thread_id, tool_name)
@@ -502,7 +514,13 @@ class ToolProgressMiddleware(AgentMiddleware[AgentState]):
                 block_reason,
             )
             return self._make_blocked_message(request, tool_name, block_reason)
-        return self._update_state_from_result(handler(request), tool_name, runtime)
+        tool_call_id = str(request.tool_call.get("id", ""))
+        return self._update_state_from_result(
+            handler(request),
+            tool_name,
+            tool_call_id,
+            runtime,
+        )
 
     @override
     async def awrap_tool_call(
@@ -525,7 +543,13 @@ class ToolProgressMiddleware(AgentMiddleware[AgentState]):
                 block_reason,
             )
             return self._make_blocked_message(request, tool_name, block_reason)
-        return self._update_state_from_result(await handler(request), tool_name, runtime)
+        tool_call_id = str(request.tool_call.get("id", ""))
+        return self._update_state_from_result(
+            await handler(request),
+            tool_name,
+            tool_call_id,
+            runtime,
+        )
 
     # ------------------------------------------------------------------
     # wrap_model_call: drain pending hints and inject before model sees messages

--- a/backend/packages/harness/deerflow/agents/middlewares/tool_result_meta.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/tool_result_meta.py
@@ -297,8 +297,27 @@ def normalize_tool_message(msg: ToolMessage) -> ToolMessage:
     return msg
 
 
-def normalize_tool_result(result: ToolMessage | Command) -> ToolMessage | Command:
-    """Normalize a tool result, handling Command wrappers transparently."""
+def tool_messages_from_result(result: ToolMessage | Command) -> tuple[ToolMessage, ...]:
+    """Return ToolMessages carried directly or inside a Command update."""
     if isinstance(result, ToolMessage):
-        return normalize_tool_message(result)
+        return (result,)
+
+    update = result.update
+    if not isinstance(update, dict):
+        return ()
+    messages = update.get("messages", ())
+    if isinstance(messages, ToolMessage):
+        return (messages,)
+    if not isinstance(messages, (list, tuple)):
+        return ()
+    return tuple(message for message in messages if isinstance(message, ToolMessage))
+
+
+def normalize_tool_result(result: ToolMessage | Command, *, tool_call_id: str = "") -> ToolMessage | Command:
+    """Normalize a tool result, handling Command wrappers transparently."""
+    is_command = isinstance(result, Command)
+    for message in tool_messages_from_result(result):
+        if is_command and tool_call_id and str(message.tool_call_id) != tool_call_id:
+            continue
+        normalize_tool_message(message)
     return result

--- a/backend/tests/test_command_tool_result_semantics.py
+++ b/backend/tests/test_command_tool_result_semantics.py
@@ -1,0 +1,441 @@
+"""Regression coverage for ToolMessages returned inside LangGraph Commands.
+
+Several built-in tools return ``Command(update={"messages": [...]})`` rather
+than a bare ``ToolMessage``.  Those messages must receive the same metadata,
+progress accounting, and receipts as direct tool results.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from _agent_e2e_helpers import build_single_tool_call_model
+from langchain_core.messages import HumanMessage, ToolMessage
+from langgraph.runtime import Runtime
+from langgraph.types import Command
+
+from deerflow.agents.middlewares.tool_error_handling_middleware import (
+    ToolErrorHandlingMiddleware,
+    build_lead_runtime_middlewares,
+)
+from deerflow.agents.middlewares.tool_progress_middleware import ToolProgressMiddleware
+from deerflow.agents.middlewares.tool_receipt import TOOL_RECEIPT_KEY
+from deerflow.agents.middlewares.tool_receipt_middleware import ToolReceiptMiddleware
+from deerflow.agents.middlewares.tool_result_meta import TOOL_META_KEY, normalize_tool_result
+from deerflow.config.app_config import AppConfig
+from deerflow.tools.builtins.setup_agent_tool import setup_agent
+from deerflow.tools.builtins.view_image_tool import view_image_tool
+
+
+def _request(tool_name: str = "command_tool", tool_call_id: str = "tc-command") -> SimpleNamespace:
+    runtime = SimpleNamespace(
+        context={"thread_id": "thread-command", "run_id": "run-command"},
+        tool_call_id=tool_call_id,
+    )
+    return SimpleNamespace(
+        tool_call={"name": tool_name, "id": tool_call_id, "args": {}},
+        runtime=runtime,
+    )
+
+
+def _command_result(
+    content: str,
+    *,
+    status: str = "success",
+    meta: dict[str, object] | None = None,
+) -> tuple[Command, ToolMessage]:
+    additional_kwargs = {TOOL_META_KEY: dict(meta)} if meta is not None else {}
+    message = ToolMessage(
+        content=content,
+        tool_call_id="tc-command",
+        name="command_tool",
+        status=status,
+        additional_kwargs=additional_kwargs,
+    )
+    command = Command(
+        update={"messages": [message], "preserved_state": "keep-me"},
+        goto="next_node",
+    )
+    return command, message
+
+
+def _recoverable_error_meta() -> dict[str, object]:
+    return {
+        "status": "error",
+        "error_type": "no_results",
+        "recoverable_by_model": True,
+        "recommended_next_action": "rewrite_query",
+        "source": "tool_return",
+    }
+
+
+def _success_meta() -> dict[str, object]:
+    return {
+        "status": "success",
+        "error_type": None,
+        "recoverable_by_model": True,
+        "recommended_next_action": "continue",
+        "source": "content_analysis",
+    }
+
+
+def _capture_model_messages(
+    middleware: ToolProgressMiddleware,
+    runtime: SimpleNamespace,
+) -> list:
+    request = MagicMock()
+    request.messages = []
+    request.runtime = runtime
+    request.override = lambda **kwargs: SimpleNamespace(
+        messages=kwargs["messages"],
+        runtime=runtime,
+    )
+    captured: list = []
+
+    def handler(current_request: SimpleNamespace) -> MagicMock:
+        captured.extend(current_request.messages)
+        return MagicMock()
+
+    middleware.wrap_model_call(request, handler)
+    return captured
+
+
+async def _capture_model_messages_async(
+    middleware: ToolProgressMiddleware,
+    runtime: SimpleNamespace,
+) -> list:
+    request = MagicMock()
+    request.messages = []
+    request.runtime = runtime
+    request.override = lambda **kwargs: SimpleNamespace(
+        messages=kwargs["messages"],
+        runtime=runtime,
+    )
+    captured: list = []
+
+    async def handler(current_request: SimpleNamespace) -> MagicMock:
+        captured.extend(current_request.messages)
+        return MagicMock()
+
+    await middleware.awrap_model_call(request, handler)
+    return captured
+
+
+def _real_command_error_message(
+    *,
+    tool,
+    tool_name: str,
+    tool_args: dict[str, object],
+) -> ToolMessage:
+    """Run a real Command-returning tool through production-built middleware."""
+    from langchain.agents import create_agent
+
+    app_config = AppConfig.model_validate(
+        {
+            "sandbox": {"use": "test"},
+            "tool_progress": {
+                "enabled": True,
+                "stagnation_threshold": 2,
+                "warn_escalation_count": 1,
+            },
+        }
+    )
+    middleware = build_lead_runtime_middlewares(app_config=app_config)
+    model = build_single_tool_call_model(
+        tool_name=tool_name,
+        tool_args=tool_args,
+        tool_call_id=f"tc-real-{tool_name}",
+    )
+    graph = create_agent(
+        model=model,
+        tools=[tool],
+        middleware=middleware,
+    )
+
+    thread_id = f"thread-real-{tool_name}"
+    runtime = Runtime(
+        context={"thread_id": thread_id, "run_id": f"run-real-{tool_name}"},
+        store=None,
+    )
+    config = {
+        "configurable": {
+            "thread_id": thread_id,
+            "__pregel_runtime": runtime,
+        },
+        "recursion_limit": 20,
+    }
+    result = graph.invoke(
+        {"messages": [HumanMessage(content=f"Call {tool_name}")]},
+        config=config,
+    )
+    return next(message for message in result["messages"] if isinstance(message, ToolMessage) and message.tool_call_id == f"tc-real-{tool_name}")
+
+
+_REAL_COMMAND_ERROR_CASES = [
+    pytest.param(
+        setup_agent,
+        "setup_agent",
+        {"soul": "   ", "description": "demo"},
+        id="setup-agent",
+    ),
+    pytest.param(
+        view_image_tool,
+        "view_image",
+        {"image_path": "/outside/image.png"},
+        id="view-image",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_status"),
+    [
+        ("Agent created successfully", "success"),
+        ("Error: no results found", "error"),
+        ("Partial results; additional sources were unavailable", "partial_success"),
+    ],
+    ids=("success", "error-prefix", "partial-success"),
+)
+def test_normalize_tool_result_normalizes_messages_inside_command(
+    content: str,
+    expected_status: str,
+) -> None:
+    command, message = _command_result(content)
+
+    result = normalize_tool_result(command)
+
+    assert result is command
+    assert command.update["preserved_state"] == "keep-me"
+    assert message.additional_kwargs[TOOL_META_KEY]["status"] == expected_status
+
+
+def test_normalize_command_preserves_existing_partial_success_meta() -> None:
+    command, message = _command_result(
+        "Tool-specific partial result",
+        meta={
+            "status": "partial_success",
+            "error_type": "provider_limit",
+            "recoverable_by_model": False,
+            "recommended_next_action": "summarize",
+            "source": "tool_return",
+        },
+    )
+    existing_meta = message.additional_kwargs[TOOL_META_KEY]
+
+    result = normalize_tool_result(command)
+
+    assert result is command
+    assert message.additional_kwargs[TOOL_META_KEY] is existing_meta
+
+
+def test_sync_tool_error_middleware_normalizes_command_message() -> None:
+    middleware = ToolErrorHandlingMiddleware()
+    request = _request()
+    command, message = _command_result("Error: no results found")
+
+    result = middleware.wrap_tool_call(request, lambda _request: command)
+
+    assert result is command
+    assert message.additional_kwargs.get(TOOL_META_KEY, {}).get("status") == "error"
+
+
+@pytest.mark.anyio
+async def test_async_tool_error_middleware_normalizes_command_message() -> None:
+    middleware = ToolErrorHandlingMiddleware()
+    request = _request()
+    command, message = _command_result("Error: no results found")
+
+    result = await middleware.awrap_tool_call(request, AsyncMock(return_value=command))
+
+    assert result is command
+    assert message.additional_kwargs.get(TOOL_META_KEY, {}).get("status") == "error"
+
+
+def test_direct_tool_message_control_gets_error_meta_and_receipt() -> None:
+    """The same middleware contract already works for an unwrapped result."""
+    request = _request()
+    message = ToolMessage(
+        content="Error: no results found",
+        tool_call_id="tc-command",
+        name="command_tool",
+    )
+    error_middleware = ToolErrorHandlingMiddleware()
+    receipt_middleware = ToolReceiptMiddleware()
+
+    result = receipt_middleware.wrap_tool_call(
+        request,
+        lambda current_request: error_middleware.wrap_tool_call(
+            current_request,
+            lambda _request: message,
+        ),
+    )
+
+    assert result is message
+    assert message.additional_kwargs[TOOL_META_KEY]["status"] == "error"
+    assert message.additional_kwargs[TOOL_RECEIPT_KEY]["status"] == "error"
+
+
+@pytest.mark.anyio
+async def test_async_receipt_chain_stamps_only_matching_command_error() -> None:
+    request = _request()
+    unrelated = ToolMessage(
+        content="Error: unrelated tool failed",
+        tool_call_id="tc-unrelated",
+        name="unrelated_tool",
+    )
+    command, matching = _command_result("Error: no results found")
+    command.update["messages"] = [unrelated, matching]
+    error_middleware = ToolErrorHandlingMiddleware()
+    receipt_middleware = ToolReceiptMiddleware()
+
+    async def run_error_middleware(current_request: SimpleNamespace) -> Command:
+        return await error_middleware.awrap_tool_call(
+            current_request,
+            AsyncMock(return_value=command),
+        )
+
+    result = await receipt_middleware.awrap_tool_call(
+        request,
+        run_error_middleware,
+    )
+
+    assert result is command
+    assert TOOL_META_KEY not in unrelated.additional_kwargs
+    assert TOOL_RECEIPT_KEY not in unrelated.additional_kwargs
+    assert matching.additional_kwargs[TOOL_RECEIPT_KEY]["status"] == "error"
+
+
+@pytest.mark.parametrize(
+    ("unrelated_meta", "matching_meta", "expects_hint"),
+    [
+        (_success_meta(), _recoverable_error_meta(), True),
+        (_recoverable_error_meta(), _success_meta(), False),
+    ],
+    ids=("matching-error", "unrelated-error"),
+)
+def test_progress_uses_matching_tool_message_inside_command(
+    unrelated_meta: dict[str, object],
+    matching_meta: dict[str, object],
+    expects_hint: bool,
+) -> None:
+    middleware = ToolProgressMiddleware(
+        stagnation_threshold=1,
+        warn_escalation_count=1,
+        inject_assessment=True,
+    )
+    request = _request()
+    unrelated = ToolMessage(
+        content=("Error: unrelated tool failed" if unrelated_meta["status"] == "error" else "Unrelated tool succeeded with useful output"),
+        tool_call_id="tc-unrelated",
+        name="unrelated_tool",
+        status=str(unrelated_meta["status"]),
+        additional_kwargs={TOOL_META_KEY: unrelated_meta},
+    )
+    command, matching = _command_result(
+        ("Error: no results found" if matching_meta["status"] == "error" else "Current tool succeeded with useful output"),
+        status=str(matching_meta["status"]),
+        meta=matching_meta,
+    )
+    command.update["messages"] = [unrelated, matching]
+
+    result = middleware.wrap_tool_call(request, lambda _request: command)
+
+    assert result is command
+    captured = _capture_model_messages(middleware, request.runtime)
+    has_hint = any(isinstance(message, HumanMessage) and "PROGRESS HINT" in str(message.content) for message in captured)
+    assert has_hint is expects_hint
+
+
+@pytest.mark.parametrize("command_wrapped", [False, True], ids=("direct-control", "command"))
+def test_sync_tool_progress_injects_hint_for_repeated_errors(
+    command_wrapped: bool,
+) -> None:
+    middleware = ToolProgressMiddleware(
+        stagnation_threshold=2,
+        warn_escalation_count=1,
+        inject_assessment=True,
+    )
+    request = _request()
+
+    for _ in range(2):
+        command, message = _command_result(
+            "Error: no results found",
+            status="error",
+            meta=_recoverable_error_meta(),
+        )
+        result = command if command_wrapped else message
+        assert (
+            middleware.wrap_tool_call(
+                request,
+                lambda _request, current_result=result: current_result,
+            )
+            is result
+        )
+
+    captured = _capture_model_messages(middleware, request.runtime)
+    assert any(isinstance(message, HumanMessage) and "PROGRESS HINT" in str(message.content) for message in captured)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("command_wrapped", [False, True], ids=("direct-control", "command"))
+async def test_async_tool_progress_injects_hint_for_repeated_errors(
+    command_wrapped: bool,
+) -> None:
+    middleware = ToolProgressMiddleware(
+        stagnation_threshold=2,
+        warn_escalation_count=1,
+        inject_assessment=True,
+    )
+    request = _request()
+
+    for _ in range(2):
+        command, message = _command_result(
+            "Error: no results found",
+            status="error",
+            meta=_recoverable_error_meta(),
+        )
+        result = command if command_wrapped else message
+        assert (
+            await middleware.awrap_tool_call(
+                request,
+                AsyncMock(return_value=result),
+            )
+            is result
+        )
+
+    captured = await _capture_model_messages_async(middleware, request.runtime)
+    assert any(isinstance(message, HumanMessage) and "PROGRESS HINT" in str(message.content) for message in captured)
+
+
+@pytest.mark.parametrize(("tool", "tool_name", "tool_args"), _REAL_COMMAND_ERROR_CASES)
+def test_real_graph_command_error_gets_structured_error_meta(
+    tool,
+    tool_name: str,
+    tool_args: dict[str, object],
+) -> None:
+    message = _real_command_error_message(
+        tool=tool,
+        tool_name=tool_name,
+        tool_args=tool_args,
+    )
+
+    assert str(message.content).startswith("Error:")
+    assert message.additional_kwargs[TOOL_META_KEY]["status"] == "error"
+
+
+@pytest.mark.parametrize(("tool", "tool_name", "tool_args"), _REAL_COMMAND_ERROR_CASES)
+def test_real_graph_command_error_gets_error_receipt(
+    tool,
+    tool_name: str,
+    tool_args: dict[str, object],
+) -> None:
+    message = _real_command_error_message(
+        tool=tool,
+        tool_name=tool_name,
+        tool_args=tool_args,
+    )
+
+    assert str(message.content).startswith("Error:")
+    assert message.additional_kwargs[TOOL_RECEIPT_KEY]["status"] == "error"


### PR DESCRIPTION
Closes #4976

## Why

ToolMessages returned inside Command(update={"messages": [...]}) bypassed result normalization and progress tracking. Error payloads could therefore receive a default success receipt even when their content started with Error:.

## What changed

- Normalize ToolMessages carried by Command results.
- Pass the current tool_call_id into normalization and only stamp the matching Command message.
- Make ToolProgressMiddleware assess the matching Command message for sync and async calls.
- Preserve producer-supplied metadata and unrelated Command update fields/messages.

## Verification

- Focused regression tests: 18 passed.
- Related middleware, receipt, built-in tool, and extension-ordering tests: 223 passed.
- Ruff check, format check, and git diff check passed.
- Includes real create_agent paths for setup_agent and view_image.

## Context

PR #4977 addresses the same issue. This PR is an independently validated alternative with production-chain coverage and matching by tool_call_id.

## AI assistance

Tool-assisted implementation and verification; author reviewed the complete change.
