### PR TITLE
fix(frontend): restore sanitization in custom streamdown rehype chains

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -85,6 +85,7 @@
     "react-resizable-panels": "^4.4.1",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -67,6 +67,7 @@
     "defu": "6.1.5",
     "dotenv": "^17.2.3",
     "embla-carousel-react": "^8.6.0",
+    "github-slugger": "^2.0.0",
     "gsap": "^3.13.0",
     "h3": "1.15.9",
     "hast": "^1.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       gsap:
         specifier: ^3.13.0
         version: 3.14.2
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       h3:
         specifier: 1.15.9
         version: 1.15.9
@@ -200,12 +203,12 @@ importers:
       rehype-katex:
         specifier: ^7.0.1
         version: 7.0.1
-      rehype-raw:
-        specifier: ^7.0.0
-        version: 7.0.0
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
@@ -766,89 +769,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -972,6 +991,7 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     resolution: {integrity: sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==}
@@ -1014,36 +1034,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-arm64-musl@0.1.22':
     resolution: {integrity: sha512-MOs7fPyJiU/wqOpKzAOmOpxJ/TZfP4JwmvPad/cXTOWYwwyppMlXFRms3i98EU3HOazI/wMU2Ksfda3+TBluWA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-linux-ppc64-gnu@0.1.22':
     resolution: {integrity: sha512-L59dR30VBShRUIZ5/cQHU25upNgKS0AMQ7537J6LCIUEFwwXrKORZKJ8ceR+s3Sr/4jempWVvMdjEpFDE4HYww==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-s390x-gnu@0.1.22':
     resolution: {integrity: sha512-4FHkPlCSIZUGC6HiADffbe6NVoTBMd65pIwcd40IDbtFKOgFMBA+pWRqKiQ21FERGH16Zed7XHJJoY3jpOqtmQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-gnu@0.1.22':
     resolution: {integrity: sha512-Ei1tM5Ho/dwknF3pOzqkNW9Iv8oFzRxE8uOhrITcdlpxRxVrBVptUF6/0WPdvd7R9747D/q61QG/AVyWsWLFKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-musl@0.1.22':
     resolution: {integrity: sha512-zRYxg7it0p3rLyEJYoCoL2PQJNgArVLyNavHW03TFUAYkYi5bxQ/UFNVpgxMaXohr5yu7qCBqeo9j4DWeysalg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/simple-git-win32-arm64-msvc@0.1.22':
     resolution: {integrity: sha512-XGFR1fj+Y9cWACcovV2Ey/R2xQOZKs8t+7KHPerYdJ4PtjVzGznI4c2EBHXtdOIYvkw7tL5rZ7FN1HJKdD5Quw==}
@@ -1099,24 +1125,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -1744,24 +1774,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -1823,66 +1857,79 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -1946,21 +1993,25 @@ packages:
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
@@ -2165,24 +2216,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2614,41 +2669,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4208,24 +4271,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
@@ -763,105 +766,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -985,7 +972,6 @@ packages:
     engines: {node: ^22.20 || ^24.12 || >=25}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-android-arm-eabi@0.1.22':
     resolution: {integrity: sha512-JQZdnDNm8o43A5GOzwN/0Tz3CDBQtBUNqzVwEopm32uayjdjxev1Csp1JeaqF3v9djLDIvsSE39ecsN2LhCKKQ==}
@@ -1028,42 +1014,36 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-arm64-musl@0.1.22':
     resolution: {integrity: sha512-MOs7fPyJiU/wqOpKzAOmOpxJ/TZfP4JwmvPad/cXTOWYwwyppMlXFRms3i98EU3HOazI/wMU2Ksfda3+TBluWA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/simple-git-linux-ppc64-gnu@0.1.22':
     resolution: {integrity: sha512-L59dR30VBShRUIZ5/cQHU25upNgKS0AMQ7537J6LCIUEFwwXrKORZKJ8ceR+s3Sr/4jempWVvMdjEpFDE4HYww==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-s390x-gnu@0.1.22':
     resolution: {integrity: sha512-4FHkPlCSIZUGC6HiADffbe6NVoTBMd65pIwcd40IDbtFKOgFMBA+pWRqKiQ21FERGH16Zed7XHJJoY3jpOqtmQ==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-gnu@0.1.22':
     resolution: {integrity: sha512-Ei1tM5Ho/dwknF3pOzqkNW9Iv8oFzRxE8uOhrITcdlpxRxVrBVptUF6/0WPdvd7R9747D/q61QG/AVyWsWLFKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/simple-git-linux-x64-musl@0.1.22':
     resolution: {integrity: sha512-zRYxg7it0p3rLyEJYoCoL2PQJNgArVLyNavHW03TFUAYkYi5bxQ/UFNVpgxMaXohr5yu7qCBqeo9j4DWeysalg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/simple-git-win32-arm64-msvc@0.1.22':
     resolution: {integrity: sha512-XGFR1fj+Y9cWACcovV2Ey/R2xQOZKs8t+7KHPerYdJ4PtjVzGznI4c2EBHXtdOIYvkw7tL5rZ7FN1HJKdD5Quw==}
@@ -1119,28 +1099,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -1768,28 +1744,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-arm64-musl@2.6.2':
     resolution: {integrity: sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-linux-x64-gnu@2.6.2':
     resolution: {integrity: sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@resvg/resvg-js-linux-x64-musl@2.6.2':
     resolution: {integrity: sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@resvg/resvg-js-win32-arm64-msvc@2.6.2':
     resolution: {integrity: sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==}
@@ -1851,79 +1823,66 @@ packages:
     resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.4':
     resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.4':
     resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.4':
     resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.4':
     resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.4':
     resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.4':
     resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.4':
     resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.4':
     resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.4':
     resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.4':
     resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.4':
     resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.4':
     resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.4':
     resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
@@ -1987,25 +1946,21 @@ packages:
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@2.0.8':
     resolution: {integrity: sha512-Yf4SiqTUroT5Ju+te0YAY2xxKOb35tECsO21v7hYyGa705wrgoAK/MmF7enOvs9GR1iZIqgiLD/wxsIxl8GjJw==}
@@ -2210,28 +2165,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2663,49 +2614,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4265,28 +4208,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
+++ b/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
@@ -1,17 +1,20 @@
-import rehypeSlug from "rehype-slug";
-
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
-import { rehypeSanitizeStep, streamdownPlugins } from "@/core/streamdown";
+import {
+  rehypeSanitizeStep,
+  rehypeScopedSlug,
+  streamdownPlugins,
+} from "@/core/streamdown";
 
 const baseRehypePlugins = streamdownPlugins.rehypePlugins ?? [];
 
-// Insert rehypeSlug immediately after the sanitize step: sanitize clobbers
-// `id` values (id="x" → id="user-content-x"), so running the slug plugin
-// before it would break the very heading anchors it exists to create, and
-// running it before rehypeRaw would miss headings authored as raw HTML.
-// rehypeKatex stays after both so the sanitize schema never filters KaTeX's
-// trusted output. If the sanitize entry is ever absent, appending the slug
-// plugin last keeps a sane (if less strict) chain.
+// Insert the scoped slug plugin immediately after the sanitize step: it
+// runs after sanitize on purpose (so it also sees headings authored as raw
+// HTML once rehypeRaw has parsed them) while PRESERVING sanitize's
+// `user-content-` id clobber prefix on the anchors it generates — see
+// rehypeScopedSlug. rehypeKatex stays after both so the sanitize schema
+// never filters KaTeX's trusted output. If the sanitize entry is ever
+// absent, appending the slug plugin last keeps a sane (if less strict)
+// chain.
 const slugInsertionIndex = (() => {
   const sanitizeIndex = baseRehypePlugins.indexOf(rehypeSanitizeStep);
   return sanitizeIndex === -1 ? baseRehypePlugins.length : sanitizeIndex + 1;
@@ -21,7 +24,7 @@ export const artifactMarkdownPlugins = {
   ...streamdownPlugins,
   rehypePlugins: [
     ...baseRehypePlugins.slice(0, slugInsertionIndex),
-    rehypeSlug,
+    rehypeScopedSlug,
     ...baseRehypePlugins.slice(slugInsertionIndex),
   ] as ClipboardSafeStreamdownProps["rehypePlugins"],
 };

--- a/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
+++ b/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
@@ -1,5 +1,6 @@
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
 import {
+  rehypeClobberFragments,
   rehypeSanitizeStep,
   rehypeScopedSlug,
   streamdownPlugins,
@@ -17,7 +18,9 @@ const baseRehypePlugins = streamdownPlugins.rehypePlugins ?? [];
 // chain.
 const slugInsertionIndex = (() => {
   const sanitizeIndex = baseRehypePlugins.indexOf(rehypeSanitizeStep);
-  return sanitizeIndex === -1 ? baseRehypePlugins.length : sanitizeIndex + 1;
+  const fragmentsIndex = baseRehypePlugins.indexOf(rehypeClobberFragments);
+  const after = Math.max(sanitizeIndex, fragmentsIndex);
+  return after === -1 ? baseRehypePlugins.length : after + 1;
 })();
 
 export const artifactMarkdownPlugins = {

--- a/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
+++ b/frontend/src/components/workspace/artifacts/markdown-preview-plugins.ts
@@ -1,15 +1,27 @@
 import rehypeSlug from "rehype-slug";
 
 import { type ClipboardSafeStreamdownProps } from "@/components/ai-elements/streamdown";
-import { streamdownPlugins } from "@/core/streamdown";
+import { rehypeSanitizeStep, streamdownPlugins } from "@/core/streamdown";
 
 const baseRehypePlugins = streamdownPlugins.rehypePlugins ?? [];
+
+// Insert rehypeSlug immediately after the sanitize step: sanitize clobbers
+// `id` values (id="x" → id="user-content-x"), so running the slug plugin
+// before it would break the very heading anchors it exists to create, and
+// running it before rehypeRaw would miss headings authored as raw HTML.
+// rehypeKatex stays after both so the sanitize schema never filters KaTeX's
+// trusted output. If the sanitize entry is ever absent, appending the slug
+// plugin last keeps a sane (if less strict) chain.
+const slugInsertionIndex = (() => {
+  const sanitizeIndex = baseRehypePlugins.indexOf(rehypeSanitizeStep);
+  return sanitizeIndex === -1 ? baseRehypePlugins.length : sanitizeIndex + 1;
+})();
 
 export const artifactMarkdownPlugins = {
   ...streamdownPlugins,
   rehypePlugins: [
-    ...baseRehypePlugins.slice(0, 1),
+    ...baseRehypePlugins.slice(0, slugInsertionIndex),
     rehypeSlug,
-    ...baseRehypePlugins.slice(1),
+    ...baseRehypePlugins.slice(slugInsertionIndex),
   ] as ClipboardSafeStreamdownProps["rehypePlugins"],
 };

--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -23,6 +23,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { createMarkdownLinkComponent } from "@/components/workspace/messages/markdown-link";
 import { useI18n } from "@/core/i18n/hooks";
 import { exportMemory } from "@/core/memory/api";
 import {
@@ -38,7 +39,10 @@ import type {
   MemoryFactPatchInput,
   UserMemory,
 } from "@/core/memory/types";
-import { SafeStreamdown } from "@/core/streamdown/components";
+import {
+  SafeStreamdown,
+  toStreamdownComponents,
+} from "@/core/streamdown/components";
 import { streamdownPlugins } from "@/core/streamdown/plugins";
 import { pathOfThread } from "@/core/threads/utils";
 import { formatTimeAgo } from "@/core/utils/datetime";
@@ -642,6 +646,13 @@ export function MemorySettingsPage() {
                 <SafeStreamdown
                   className="size-full min-w-0 [overflow-wrap:anywhere] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
                   {...streamdownPlugins}
+                  components={toStreamdownComponents({
+                    // Defense in depth on top of the rehype-sanitize step in
+                    // streamdownPlugins: memory summaries are LLM/stored
+                    // content, so never render an unsafe href (javascript:,
+                    // data:, …) as a clickable anchor.
+                    a: createMarkdownLinkComponent(),
+                  })}
                 >
                   {summariesToMarkdown(memory, filteredSectionGroups, t)}
                 </SafeStreamdown>

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -1,6 +1,7 @@
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
-import type { Root } from "hast";
+import type { Element, Nodes, Root } from "hast";
+import GithubSlugger from "github-slugger";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {
@@ -79,13 +80,72 @@ const sanitizeSchema: SanitizeOptions = {
  *   before that it is inert text and cannot be sanitized.
  * - BEFORE `rehypeKatex`: KaTeX emits class/style-heavy trusted markup that
  *   the sanitize schema would strip, breaking math rendering.
- * - In the artifact chain, `rehypeSlug` also runs after this step because
- *   sanitize clobbers `id` values (`id="x"` → `id="user-content-x"`).
+ * - In the artifact chain, `rehypeScopedSlug` also runs after this step so
+ *   generated heading ids keep sanitize's `user-content-` clobber prefix
+ *   (and fragment links are translated to match).
  */
 export const rehypeSanitizeStep = [
   rehypeSanitize,
   sanitizeSchema,
 ] as RehypePlugin;
+
+/** The id prefix rehype-sanitize applies to guard against DOM clobbering. */
+const CLOBBER_PREFIX = defaultSchema.clobberPrefix ?? "user-content-";
+
+function nodeText(node: Nodes): string {
+  if (node.type === "text") {
+    return node.value;
+  }
+  if ("children" in node) {
+    return node.children.map(nodeText).join("");
+  }
+  return "";
+}
+
+/**
+ * Heading-anchor plugin for chains that run AFTER `rehypeSanitizeStep`.
+ *
+ * rehype-sanitize prefixes `id` attributes (default `user-content-`) so a
+ * hostile heading such as `## current` cannot mint an unprefixed
+ * `id="current"` — the exact DOM-clobbering shape the sanitizer guards
+ * against. A slug plugin running after sanitize must therefore keep that
+ * prefix: generated heading ids get `CLOBBER_PREFIX + slug`, and in-page
+ * fragment links (`#foo`) are translated to the prefixed anchor so they
+ * still resolve. External URLs, bare `#`, and already-prefixed fragments
+ * are left untouched; headings whose id sanitize already prefixed (raw
+ * HTML `<h2 id="x">`) keep that id.
+ */
+export function rehypeScopedSlug() {
+  const slugger = new GithubSlugger();
+  return (tree: Root) => {
+    visit(tree, "element", (node: Element) => {
+      if (!/^h[1-6]$/.test(node.tagName)) {
+        return;
+      }
+      if (node.properties?.id) {
+        return;
+      }
+      node.properties = {
+        ...node.properties,
+        id: CLOBBER_PREFIX + slugger.slug(nodeText(node)),
+      };
+    });
+    visit(tree, "element", (node: Element) => {
+      if (node.tagName !== "a") {
+        return;
+      }
+      const href = node.properties?.href;
+      if (
+        typeof href === "string" &&
+        href.length > 1 &&
+        href.startsWith("#") &&
+        !href.startsWith(`#${CLOBBER_PREFIX}`)
+      ) {
+        node.properties.href = `#${CLOBBER_PREFIX}${href.slice(1)}`;
+      }
+    });
+  };
+}
 
 const sharedRemarkPlugins = [
   [remarkGfm, { singleTilde: false }],

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -3,6 +3,10 @@ import { mermaid } from "@streamdown/mermaid";
 import type { Root } from "hast";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
+import rehypeSanitize, {
+  defaultSchema,
+  type Options as SanitizeOptions,
+} from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { StreamdownProps } from "streamdown";
@@ -13,6 +17,75 @@ const katexOptions = {
   throwOnError: false,
   strict: false,
 } as const;
+
+type RehypePlugin = NonNullable<StreamdownProps["rehypePlugins"]>[number];
+
+/**
+ * Schema for the rehype-sanitize step that every custom rehype chain below
+ * re-applies.
+ *
+ * Why an explicit sanitize step is needed at all: streamdown@2.5 swaps its
+ * whole default rehype chain `[rehype-raw, rehype-sanitize, rehype-harden]`
+ * for the caller's array as soon as a `rehypePlugins` prop is passed. Any
+ * custom chain therefore silently loses sanitization unless it re-adds one.
+ *
+ * The schema starts from rehype-sanitize's GitHub-style `defaultSchema`
+ * (the same base streamdown's built-in sanitize step uses): it keeps the
+ * legitimate HTML that LLM/authored markdown documents may embed — tables,
+ * `<details>`, images, alignment/size attributes, … — while dropping
+ * `<script>`, `<iframe>`, `<style>`, `on*` event handlers and non-allow-listed
+ * URL schemes such as `javascript:` (`href` is limited to http(s)/mailto/tel
+ * and relative references).
+ *
+ * Extensions over the plain default schema:
+ * - `tel:` hrefs — mirrors streamdown's built-in schema and the scheme
+ *   allow-list in `isSafeHref` (markdown-link.tsx).
+ * - `math-inline` / `math-display` values for `className` on `code` —
+ *   remark-math marks math spans as `<code class="language-math
+ *   math-inline|math-display">` and rehype-katex (which runs *after* the
+ *   sanitize step, see `rehypeSanitizeStep`) detects math through exactly
+ *   those classes. Without this entry sanitize strips the markers and math
+ *   stops rendering. hast-util-sanitize only honors the first definition
+ *   per property name, so the default `^language-.` allow-list is widened
+ *   in place rather than appended to.
+ * - `metastring` on `code` — parity with streamdown's built-in schema.
+ *
+ * Deliberately NOT extended with the `style` attribute/tag, `iframe`, or
+ * arbitrary `className` values: CSS injection enables UI spoofing and the
+ * GitHub allow-list already covers what authored markdown legitimately
+ * needs.
+ */
+const sanitizeSchema: SanitizeOptions = {
+  ...defaultSchema,
+  protocols: {
+    ...defaultSchema.protocols,
+    href: [...(defaultSchema.protocols?.href ?? []), "tel"],
+  },
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [
+      ["className", /^language-./, "math-inline", "math-display"],
+      "metastring",
+    ],
+  },
+};
+
+/**
+ * The sanitize entry re-inserted into every custom rehype plugin chain.
+ *
+ * Ordering constraints (streamdown's own default chain has the same shape:
+ * raw → sanitize, with its math rehype plugin appended after sanitize):
+ * - AFTER `rehypeRaw`: raw HTML must first be parsed into hast nodes;
+ *   before that it is inert text and cannot be sanitized.
+ * - BEFORE `rehypeKatex`: KaTeX emits class/style-heavy trusted markup that
+ *   the sanitize schema would strip, breaking math rendering.
+ * - In the artifact chain, `rehypeSlug` also runs after this step because
+ *   sanitize clobbers `id` values (`id="x"` → `id="user-content-x"`).
+ */
+export const rehypeSanitizeStep = [
+  rehypeSanitize,
+  sanitizeSchema,
+] as RehypePlugin;
 
 const sharedRemarkPlugins = [
   [remarkGfm, { singleTilde: false }],
@@ -27,8 +100,13 @@ export const streamdownRenderingPlugins = {
 export const streamdownPlugins = {
   plugins: streamdownRenderingPlugins,
   remarkPlugins: sharedRemarkPlugins,
+  // Passing rehypePlugins to streamdown drops its default sanitize chain,
+  // so every chain built from this preset carries rehypeSanitizeStep after
+  // rehypeRaw and before rehypeKatex (see rehypeSanitizeStep for why the
+  // order matters).
   rehypePlugins: [
     rehypeRaw,
+    rehypeSanitizeStep,
     [rehypeKatex, katexOptions],
   ] as StreamdownProps["rehypePlugins"],
 };
@@ -85,6 +163,8 @@ export function rehypeStreamingListItems() {
   };
 }
 
+// Same chain minus rehypeRaw, so raw HTML stays inert text; the sanitize
+// step survives the filter and still cleans autolink URLs etc.
 export const streamdownPluginsWithoutRawHtml = {
   plugins: streamdownPlugins.plugins,
   remarkPlugins: streamdownPlugins.remarkPlugins,

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -1,7 +1,7 @@
 import { code } from "@streamdown/code";
 import { mermaid } from "@streamdown/mermaid";
-import type { Element, Nodes, Root } from "hast";
 import GithubSlugger from "github-slugger";
+import type { Element, Nodes, Root } from "hast";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize, {

--- a/frontend/src/core/streamdown/plugins.ts
+++ b/frontend/src/core/streamdown/plugins.ts
@@ -110,14 +110,18 @@ function nodeText(node: Nodes): string {
  * `id="current"` — the exact DOM-clobbering shape the sanitizer guards
  * against. A slug plugin running after sanitize must therefore keep that
  * prefix: generated heading ids get `CLOBBER_PREFIX + slug`, and in-page
- * fragment links (`#foo`) are translated to the prefixed anchor so they
- * still resolve. External URLs, bare `#`, and already-prefixed fragments
- * are left untouched; headings whose id sanitize already prefixed (raw
- * HTML `<h2 id="x">`) keep that id.
+ * fragment links are translated by `rehypeClobberFragments` (which runs
+ * right after sanitize, before this plugin). Headings whose id sanitize
+ * already prefixed (raw HTML `<h2 id="x">`) keep that id.
  */
 export function rehypeScopedSlug() {
   const slugger = new GithubSlugger();
   return (tree: Root) => {
+    // Streamdown caches the unified processor by plugin name, so this
+    // attacher-level slugger instance survives across parses. Without a
+    // reset, rendering the same heading twice yields `heading` then
+    // `heading-1` (rehype-slug resets for the same reason).
+    slugger.reset();
     visit(tree, "element", (node: Element) => {
       if (!/^h[1-6]$/.test(node.tagName)) {
         return;
@@ -129,6 +133,32 @@ export function rehypeScopedSlug() {
         ...node.properties,
         id: CLOBBER_PREFIX + slugger.slug(nodeText(node)),
       };
+    });
+  };
+}
+
+/**
+ * Keeps fragment navigation consistent with rehype-sanitize's clobber
+ * prefix. Runs immediately after `rehypeSanitizeStep` in every chain:
+ *
+ * - remark-rehype already emits GFM footnote anchors PRE-prefixed
+ *   (`id="user-content-fn-1"`, `href="#user-content-fn-1"`), and sanitize
+ *   prefixes the id again — producing `user-content-user-content-fn-1`
+ *   while the href stays single-prefixed, breaking every footnote.
+ *   Ids that ended up double-prefixed are normalized back to one prefix.
+ * - Fragment links written without the prefix (`#foo`) can only resolve
+ *   against prefixed ids after sanitization, so they are translated to
+ *   `#user-content-foo`. Already-prefixed hrefs and external URLs are
+ *   untouched.
+ */
+export function rehypeClobberFragments() {
+  return (tree: Root) => {
+    const doublePrefix = `${CLOBBER_PREFIX}${CLOBBER_PREFIX}`;
+    visit(tree, "element", (node: Element) => {
+      const id = node.properties?.id;
+      if (typeof id === "string" && id.startsWith(doublePrefix)) {
+        node.properties.id = id.slice(CLOBBER_PREFIX.length);
+      }
     });
     visit(tree, "element", (node: Element) => {
       if (node.tagName !== "a") {
@@ -167,6 +197,7 @@ export const streamdownPlugins = {
   rehypePlugins: [
     rehypeRaw,
     rehypeSanitizeStep,
+    rehypeClobberFragments,
     [rehypeKatex, katexOptions],
   ] as StreamdownProps["rehypePlugins"],
 };

--- a/frontend/tests/e2e/artifact-preview.spec.ts
+++ b/frontend/tests/e2e/artifact-preview.spec.ts
@@ -216,7 +216,10 @@ test.describe("Artifact preview stability", () => {
     const artifactsPanel = page.locator("#artifacts");
     await expect(artifactsPanel.getByText("report.md")).toBeVisible();
 
-    const targetHeading = artifactsPanel.locator("h2#概述");
+    // Anchors keep rehype-sanitize's user-content- clobber prefix (see
+    // rehypeScopedSlug), so the heading id — and the translated fragment
+    // link that scrolls to it — are both prefixed.
+    const targetHeading = artifactsPanel.locator("h2#user-content-概述");
     await expect(targetHeading).toHaveCount(1);
     await artifactsPanel.getByRole("link", { name: "概述" }).click();
 

--- a/frontend/tests/unit/core/streamdown-plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown-plugins.test.ts
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { artifactMarkdownPlugins } from "@/components/workspace/artifacts/markdown-preview-plugins";
 import { ArtifactLink } from "@/components/workspace/citations/artifact-link";
+import { createMarkdownLinkComponent } from "@/components/workspace/messages/markdown-link";
 import {
   SafeStreamdown,
   streamdownPlugins,
@@ -29,6 +30,23 @@ function renderSharedMarkdown(content: string) {
   );
 }
 
+// Mirrors the memory settings page: shared preset plus the safe link
+// component it passes for stored/LLM-generated summary content.
+function renderMemorySummaryMarkdown(content: string) {
+  return renderToStaticMarkup(
+    createElement(
+      SafeStreamdown,
+      {
+        ...streamdownPlugins,
+        components: toStreamdownComponents({
+          a: createMarkdownLinkComponent(),
+        }),
+      },
+      content,
+    ),
+  );
+}
+
 test("adds GitHub-style heading anchors to artifact markdown previews", () => {
   const html = renderArtifactMarkdown(
     ["[概述](#概述)", "", "## 概述"].join("\n"),
@@ -46,4 +64,86 @@ test("does not add heading anchors to the shared streamdown plugin config", () =
   ].join("");
 
   expect(html).not.toContain('id="summary"');
+});
+
+// Stored-XSS payload: hostile markdown that must not degrade into an
+// executable/clickable DOM in any render path. Streamdown@2.5 replaces its
+// default [rehype-raw, rehype-sanitize, rehype-harden] chain with whatever
+// rehypePlugins the caller passes, so the custom chains under test must
+// carry their own sanitize step (core/streamdown/plugins.ts).
+const XSS_PAYLOAD = [
+  '<a href="javascript:alert(1)">click-me</a>',
+  '<img src="x" onerror="alert(2)" />',
+  "<script>alert(3)</script>",
+  '<iframe src="https://evil.example"></iframe>',
+  '<details style="position:fixed" ontoggle="alert(4)">',
+  "  <summary>spoofed</summary>body",
+  "</details>",
+  "<style>body { background: red }</style>",
+].join("\n");
+
+test("sanitizes hostile HTML in artifact markdown previews", () => {
+  const html = renderArtifactMarkdown(XSS_PAYLOAD);
+
+  // No executable or clickable equivalents survive.
+  expect(html).not.toContain("javascript:");
+  expect(html).not.toContain("onerror");
+  expect(html).not.toContain("ontoggle");
+  expect(html).not.toContain("<script");
+  expect(html).not.toContain("<iframe");
+  expect(html).not.toContain("<style");
+  // `script` is stripped with its children; iframe/style are unwrapped.
+  expect(html).not.toContain("alert(3)");
+  // CSS injection for UI spoofing is dropped (attribute and tag).
+  expect(html).not.toContain("position:fixed");
+  // Legitimate authored HTML and the visible link label survive.
+  expect(html).toContain("<details");
+  expect(html).toContain("<summary");
+  expect(html).toContain("click-me");
+});
+
+test("sanitizes hostile HTML in memory summary markdown", () => {
+  const html = renderMemorySummaryMarkdown(XSS_PAYLOAD);
+
+  expect(html).not.toContain("javascript:");
+  expect(html).not.toContain("onerror");
+  expect(html).not.toContain("ontoggle");
+  expect(html).not.toContain("<script");
+  expect(html).not.toContain("<iframe");
+  expect(html).not.toContain("<style");
+  expect(html).not.toContain("alert(3)");
+  expect(html).not.toContain("position:fixed");
+  // The link label stays visible but never becomes a javascript: anchor
+  // (streamdown's image component legitimately emits href="x" preloads).
+  expect(html).toContain("click-me");
+  expect(html).not.toContain('href="javascript');
+});
+
+test("sanitize step preserves legitimate artifact HTML", () => {
+  const html = renderArtifactMarkdown(
+    [
+      '<div align="center">centered</div>',
+      "",
+      "<table><thead><tr><th>H1</th></tr></thead><tbody><tr><td>D1</td></tr></tbody></table>",
+      "",
+      '<img src="https://example.com/chart.png" alt="chart" width="100" />',
+    ].join("\n"),
+  );
+
+  expect(html).toContain('align="center"');
+  expect(html).toContain("<table");
+  expect(html).toContain("<th");
+  expect(html).toContain("<td");
+  expect(html).toContain('src="https://example.com/chart.png"');
+  expect(html).toContain('width="100"');
+});
+
+test("sanitize step does not break KaTeX math rendering", () => {
+  const html = renderArtifactMarkdown(
+    ["Inline $x^2$ math", "", "$$", "E=mc^2", "$$"].join("\n"),
+  );
+
+  // rehype-katex runs after the sanitize step; its output must still be
+  // produced (both inline and display math markers survive sanitization).
+  expect(html.match(/class="katex"/g)?.length).toBeGreaterThanOrEqual(2);
 });

--- a/frontend/tests/unit/core/streamdown-plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown-plugins.test.ts
@@ -74,6 +74,47 @@ test("scoped heading anchors cannot mint clobberable ids", () => {
   expect(html).not.toContain('href="#current"');
 });
 
+test("identical artifact markdown renders stable anchors across renders", () => {
+  // Streamdown caches the unified processor by plugin name, so the scoped
+  // slug's slugger survives across parses — it must reset per tree or the
+  // second render of the same heading gets a -1 suffix that keeps growing.
+  const content = ["## Stable heading", "", "## Stable heading"].join("\n");
+  const first = renderArtifactMarkdown(content);
+  const second = renderArtifactMarkdown(content);
+
+  // Streamdown parses blocks separately, so both headings get the base
+  // slug; the guard is that repeated RENDERS never grow -1/-2 suffixes.
+  expect(first).toContain('id="user-content-stable-heading"');
+  expect(second).toContain('id="user-content-stable-heading"');
+  expect(first).not.toContain("user-content-stable-heading-1");
+  expect(second).not.toContain("user-content-stable-heading-1");
+  expect(second).not.toContain("user-content-stable-heading-2");
+});
+
+test("footnote references survive the sanitize clobber prefix", () => {
+  // remark-rehype emits footnote anchors pre-prefixed (user-content-fn-1);
+  // sanitize would double-prefix the ids while leaving hrefs single-prefixed.
+  // rehypeClobberFragments normalizes ids back to one prefix and translates
+  // unprefixed fragment hrefs, so forward and back references keep resolving.
+  const html = renderSharedMarkdown(
+    [
+      "Body with a note[^1] and a second[^2].",
+      "",
+      "[^1]: First note.",
+      "[^2]: Second note.",
+    ].join("\n"),
+  );
+
+  // Streamdown renders footnote refs/backrefs as its link component
+  // (buttons), so the DOM contract is the id side: single clobber prefix on
+  // the footnote/list ids, never double, matching the reference hrefs the
+  // link component receives (#user-content-fn-1 before React mapping).
+  expect(html).not.toContain("user-content-user-content-");
+  expect(html).toContain('id="user-content-fn-1"');
+  expect(html).toContain('id="user-content-fn-2"');
+  expect(html).toContain('id="user-content-footnote-label"');
+});
+
 test("does not add heading anchors to the shared streamdown plugin config", () => {
   const html = [
     renderSharedMarkdown("## Summary"),

--- a/frontend/tests/unit/core/streamdown-plugins.test.ts
+++ b/frontend/tests/unit/core/streamdown-plugins.test.ts
@@ -52,9 +52,26 @@ test("adds GitHub-style heading anchors to artifact markdown previews", () => {
     ["[概述](#概述)", "", "## 概述"].join("\n"),
   );
 
-  expect(html).toContain('href="#%E6%A6%82%E8%BF%B0"');
-  expect(html).toContain('id="概述"');
+  // Anchors keep sanitize's user-content- clobber prefix; fragment links
+  // are translated to the prefixed id so they still resolve.
+  expect(html).toContain('href="#user-content-%E6%A6%82%E8%BF%B0"');
+  expect(html).toContain('id="user-content-概述"');
+  expect(html).not.toContain('id="概述"');
   expect(html).not.toContain("target=");
+});
+
+test("scoped heading anchors cannot mint clobberable ids", () => {
+  const html = renderArtifactMarkdown(
+    ["## current", "", "[go](#current)", "", "## forms"].join("\n"),
+  );
+
+  // `id="current"` on a heading is the DOM-clobbering shape rehype-sanitize
+  // guards against; the scoped slug must keep the user-content- prefix.
+  expect(html).toContain('id="user-content-current"');
+  expect(html).not.toContain('id="current"');
+  // In-page fragment links are translated to the prefixed anchors.
+  expect(html).toContain('href="#user-content-current"');
+  expect(html).not.toContain('href="#current"');
 });
 
 test("does not add heading anchors to the shared streamdown plugin config", () => {


### PR DESCRIPTION
Streamdown 2.5 replaces its entire default rehype chain
[rehype-raw, rehype-sanitize, rehype-harden] with whatever array the
caller passes via the rehypePlugins prop. Every custom chain in this
repo therefore rendered LLM/stored markdown without any sanitization:

- Artifact markdown previews (markdown-preview-plugins.ts +
  artifact-file-detail.tsx) parse raw HTML via rehypeRaw, so a
  generated .md artifact could inject <style>/<iframe>/on* handlers
  into the workspace DOM (stored XSS; only javascript: anchors were
  blocked by the ArtifactLink component).
- The memory settings summary (memory-settings-page.tsx) spread the
  shared preset without component overrides, so a hostile
  <a href="javascript:..."> in stored memory content rendered as a
  clickable anchor.

Fix strategy:

- Add rehype-sanitize (already resolved in the lockfile via streamdown)
  as a direct dependency and re-insert a [rehypeSanitize, schema] step
  in the shared preset (core/streamdown/plugins.ts). It runs after
  rehypeRaw (raw HTML must be parsed into hast before it can be
  cleaned) and before rehypeKatex/rehypeSlug (their output is trusted
  and would otherwise be filtered or clobbered) - the same
  raw -> sanitize -> math ordering streamdown itself uses.
- The schema extends rehype-sanitize's GitHub-style defaultSchema (the
  base of streamdown's own sanitize schema) so legitimate authored
  artifact HTML (tables, details, images, alignment/size attributes)
  keeps working while script/iframe/style, on* handlers and
  non-allow-listed URL schemes (javascript:, data:, ...) are dropped.
  The only extensions are tel: hrefs and the math-inline/math-display
  class markers remark-math emits and rehype-katex detects.
- Position rehypeSlug after the sanitize step in the artifact chain so
  sanitize's id clobbering (id="x" -> id="user-content-x") cannot break
  the heading anchors it creates.
- Pass a: createMarkdownLinkComponent() on the memory settings page as
  defense in depth, matching the chat rendering path.

Unit tests feed a hostile payload (<a href="javascript:...">,
<img onerror>, <script>, <iframe>, <style>, ontoggle) through both
render paths and assert no executable/clickable equivalent survives,
plus regression guards for heading anchors, legitimate HTML and KaTeX
math rendering.