### PR TITLE
fix(config): reject non-finite lease timing in SandboxOwnershipConfig

### DIFF
--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -1,6 +1,8 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+import math
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 SandboxOwnershipType = Literal["memory", "redis"]
 SandboxOverflowPolicy = Literal["wait", "reject", "burst"]
@@ -43,6 +45,16 @@ class SandboxOwnershipConfig(BaseModel):
         default="deerflow:sandbox:owner",
         description="Redis key prefix for ownership leases. Only applies to the redis ownership type.",
     )
+
+    @model_validator(mode="after")
+    def _reject_non_finite_lease_timing(self):
+        for field_name in ("renewal_interval_seconds", "ttl_multiplier"):
+            value = getattr(self, field_name)
+            if not math.isfinite(value):
+                raise ValueError(
+                    f"{field_name} must be a finite number, got {value!r}"
+                )
+        return self
 
 
 class VolumeMountConfig(BaseModel):

--- a/backend/packages/harness/deerflow/config/sandbox_config.py
+++ b/backend/packages/harness/deerflow/config/sandbox_config.py
@@ -1,6 +1,5 @@
-from typing import Literal
-
 import math
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 


### PR DESCRIPTION
## Summary

Adds a `model_validator` that rejects `float('inf')`, `float('-inf')`, and `float('nan')` for `renewal_interval_seconds` and `ttl_multiplier` in `SandboxOwnershipConfig`.

Fixes #4947

## Motivation

Pydantic's `gt`/`ge` bounds accept non-finite values like `float('inf')`. When these propagate to `compute_lease_ttl()`, the Redis ownership store attempts `int(float(ttl_seconds) * 1000)` which raises `OverflowError` at startup.

## Changes

- Added `import math` and `model_validator` to `sandbox_config.py`
- Added `_reject_non_finite_lease_timing` validator that checks both fields with `math.isfinite()`

## Testing

Verified locally that:
- Valid configs (finite values) pass
- `float('inf')`, `float('-inf')`, `float('nan')` are rejected with clear error messages

## Impact

Configuration-only change. No behavior change for valid configs.
