### PR TITLE
fix(uploads): expose converted markdown companion to the agent (fixes…

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -88,6 +88,12 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         size_str = f"{size_kb:.1f} KB" if size_kb < 1024 else f"{size_kb / 1024:.1f} MB"
         lines.append(f"- {neutralize_untrusted_tags(file['filename'])} ({size_str})")
         lines.append(f"  Path: {neutralize_untrusted_tags(file['path'])}")
+        markdown_file = file.get("markdown_file")
+        if markdown_file:
+            lines.append(
+                f"  Converted text: {neutralize_untrusted_tags(f'/mnt/user-data/uploads/{markdown_file}')} "
+                "(read this instead of the binary; outline line numbers below refer to it)"
+            )
         if file.get("selection_reason") == "query_match":
             lines.append("  Selected because: matched the current query.")
         outline = file.get("outline") or []
@@ -188,14 +194,25 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
                 continue
             if uploads_dir is not None and not (uploads_dir / filename).is_file():
                 continue
-            files.append(
-                {
-                    "filename": filename,
-                    "size": int(f.get("size") or 0),
-                    "path": f"/mnt/user-data/uploads/{filename}",
-                    "extension": Path(filename).suffix,
-                }
-            )
+            entry: dict = {
+                "filename": filename,
+                "size": int(f.get("size") or 0),
+                "path": f"/mnt/user-data/uploads/{filename}",
+                "extension": Path(filename).suffix,
+            }
+            # Carry the UTF-8 companion produced by document conversion (e.g.
+            # `report.md` next to `report.pdf`) so the context can point the
+            # model at the readable text instead of the binary original (#4981).
+            markdown_file = f.get("markdown_file")
+            if (
+                isinstance(markdown_file, str)
+                and markdown_file
+                and Path(markdown_file).name == markdown_file
+                and not is_upload_staging_file(markdown_file)
+            ):
+                if uploads_dir is None or (uploads_dir / markdown_file).is_file():
+                    entry["markdown_file"] = markdown_file
+            files.append(entry)
         return files if files else None
 
     @override
@@ -243,10 +260,13 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
 
         context_files, omitted_files = self._select_files_for_context(new_files)
 
-        # Attach outlines to context files
+        # Attach outlines to context files. When the upload has a converted
+        # UTF-8 companion, extract the outline from that text file (the binary
+        # original is not UTF-8 readable), matching the path shown to the model.
         if uploads_dir:
             for file in context_files:
-                phys_path = uploads_dir / file["filename"]
+                md_name = file.get("markdown_file")
+                phys_path = uploads_dir / (md_name or file["filename"])
                 outline, preview = extract_outline_for_file(phys_path)
                 file["outline"] = outline
                 file["outline_preview"] = preview

--- a/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/uploads_middleware.py
@@ -90,10 +90,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
         lines.append(f"  Path: {neutralize_untrusted_tags(file['path'])}")
         markdown_file = file.get("markdown_file")
         if markdown_file:
-            lines.append(
-                f"  Converted text: {neutralize_untrusted_tags(f'/mnt/user-data/uploads/{markdown_file}')} "
-                "(read this instead of the binary; outline line numbers below refer to it)"
-            )
+            lines.append(f"  Converted text: {neutralize_untrusted_tags(f'/mnt/user-data/uploads/{markdown_file}')} (read this instead of the binary; outline line numbers below refer to it)")
         if file.get("selection_reason") == "query_match":
             lines.append("  Selected because: matched the current query.")
         outline = file.get("outline") or []
@@ -204,12 +201,7 @@ class UploadsMiddleware(AgentMiddleware[UploadsMiddlewareState]):
             # `report.md` next to `report.pdf`) so the context can point the
             # model at the readable text instead of the binary original (#4981).
             markdown_file = f.get("markdown_file")
-            if (
-                isinstance(markdown_file, str)
-                and markdown_file
-                and Path(markdown_file).name == markdown_file
-                and not is_upload_staging_file(markdown_file)
-            ):
+            if isinstance(markdown_file, str) and markdown_file and Path(markdown_file).name == markdown_file and not is_upload_staging_file(markdown_file):
                 if uploads_dir is None or (uploads_dir / markdown_file).is_file():
                     entry["markdown_file"] = markdown_file
             files.append(entry)

--- a/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
+++ b/backend/packages/harness/deerflow/tools/builtins/list_uploaded_files_tool.py
@@ -115,23 +115,15 @@ def _list_uploaded_files_impl(
     # Skip .md files that are conversion artifacts (have a same-stem non-.md sibling).
     candidates: list[tuple[float, Path, int]] = []
     try:
-        # Collect file entries once to build the name set and iterate.
+        # Collect file entries once.
         entries = [e for e in os.scandir(uploads_dir) if e.is_file() and not e.is_symlink() and not is_upload_staging_file(e.name)]
-        all_names: set[str] = {e.name for e in entries}
 
         for entry in entries:
             if entry.name in current_run_filenames:
                 continue
-            # Skip .md files that are conversion artifacts of another file.
-            # Known limitation: if a user manually uploads both report.pdf and
-            # report.md, the .md is hidden as a "conversion artifact".  This is
-            # acceptable for the MVP — triggering this requires uploading files
-            # whose stems collide with converted documents, which is rare.
-            if entry.name.endswith(".md"):
-                stem = entry.name[:-3]  # remove ".md"
-                non_md_siblings = {n for n in all_names if n != entry.name and Path(n).stem == stem}
-                if non_md_siblings:
-                    continue
+            # Conversion companions (e.g. `report.md` next to `report.pdf`) are
+            # listed like any other file so the agent can discover the readable
+            # text and read it instead of the binary original (#4981).
             stat = entry.stat()
             candidates.append((stat.st_mtime, Path(entry.path), stat.st_size))
     except OSError:
@@ -157,6 +149,13 @@ def _list_uploaded_files_impl(
             "path": neutralize_untrusted_tags(f"/mnt/user-data/uploads/{filename}"),
             "extension": neutralize_untrusted_tags(file_path.suffix),
         }
+
+        # If this file has a same-stem `.md` conversion companion, expose it so
+        # the model can read the UTF-8 text instead of a binary original (#4981).
+        if file_path.suffix.lower() != ".md":
+            md_path = file_path.with_suffix(".md")
+            if md_path.is_file():
+                file_info["converted_text"] = neutralize_untrusted_tags(f"/mnt/user-data/uploads/{md_path.name}")
 
         should_include_outline = outline_for_all or filename in outline_filenames
         if should_include_outline:

--- a/backend/tests/test_list_uploaded_files_tool.py
+++ b/backend/tests/test_list_uploaded_files_tool.py
@@ -182,10 +182,15 @@ class TestListUploadedFiles:
 
         result = _list_uploaded_files_impl(include_outline=True, runtime=_runtime(), _paths=_paths(tmp_path))
 
-        assert len(result["files"]) == 1
-        assert "outline" in result["files"][0]
-        assert result["files"][0]["outline"][0]["title"] == "Heading 1"
-        assert result["files"][0]["outline"][1]["title"] == "Heading 2"
+        # The conversion companion is listed too (#4981), so both files appear.
+        files_by_name = {f["filename"]: f for f in result["files"]}
+        assert len(result["files"]) == 2
+        assert "outline" in files_by_name["doc.pdf"]
+        assert files_by_name["doc.pdf"]["outline"][0]["title"] == "Heading 1"
+        assert files_by_name["doc.pdf"]["outline"][1]["title"] == "Heading 2"
+        # the binary points at its readable companion
+        assert files_by_name["doc.pdf"]["converted_text"] == "/mnt/user-data/uploads/doc.md"
+        assert "outline" in files_by_name["doc.md"]
 
     def test_include_outline_list(self, tmp_path):
         uploads_dir = _uploads_dir(tmp_path)
@@ -231,6 +236,31 @@ class TestListUploadedFiles:
         f = result["files"][0]
         assert "outline" not in f
         assert "outline_preview" not in f
+
+    def test_does_not_hide_md_conversion_companion(self, tmp_path):
+        """A conversion companion (.md next to a binary) must stay discoverable."""
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"%PDF")
+        (uploads_dir / "report.md").write_text("# Title", encoding="utf-8")
+        os.utime(uploads_dir / "report.pdf", (100, 100))
+        os.utime(uploads_dir / "report.md", (200, 200))
+
+        result = _list_uploaded_files_impl(runtime=_runtime(), _paths=_paths(tmp_path))
+
+        names = {f["filename"] for f in result["files"]}
+        assert names == {"report.pdf", "report.md"}
+
+    def test_exposes_converted_text_for_binary_with_md_sibling(self, tmp_path):
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"%PDF")
+        (uploads_dir / "report.md").write_text("# Title", encoding="utf-8")
+
+        result = _list_uploaded_files_impl(include_outline=True, runtime=_runtime(), _paths=_paths(tmp_path))
+
+        by_name = {f["filename"]: f for f in result["files"]}
+        assert by_name["report.pdf"]["converted_text"] == "/mnt/user-data/uploads/report.md"
+        # the .md itself is its own entry, no self-referential converted_text
+        assert "converted_text" not in by_name["report.md"]
 
     def test_cross_turn_state_clear_does_not_exclude_historical_file(self, tmp_path):
         """Two-turn regression: file uploaded in turn 1 must appear in turn 2.
@@ -685,14 +715,15 @@ class TestListUploadedFilesNeutralization:
 
         result = _list_uploaded_files_impl(include_outline=True, runtime=_runtime(), _paths=_paths(tmp_path))
 
-        # Structural integrity
+        # Structural integrity — the malicious .md companion is now discoverable
+        # (#4981) but its content is still neutralized before reaching the model.
         assert isinstance(result, dict)
         assert isinstance(result["files"], list)
-        assert len(result["files"]) == 1
-        assert result["total_count"] == 1
+        assert len(result["files"]) == 2
+        assert result["total_count"] == 2
         assert "truncated" not in result  # only present when truncated
 
-        f = result["files"][0]
+        f = next(f for f in result["files"] if f["filename"] == "evil.pdf")
         assert f["size"] > 0  # numeric, unchanged
         assert isinstance(f["outline"][0]["line"], int)  # line number, unchanged
 
@@ -704,7 +735,7 @@ class TestListUploadedFilesNeutralization:
 
         text = json.dumps(result, ensure_ascii=False)
         parsed = json.loads(text)
-        assert parsed["total_count"] == 1
+        assert parsed["total_count"] == 2
 
     # -- 20.2.7: boundary markers neutralized --
 
@@ -758,7 +789,8 @@ def test_list_uploaded_files_toolmessage_neutralization(tmp_path):
     # Valid JSON round-trip
     parsed = json.loads(tool_message_content)
     assert "files" in parsed
-    assert len(parsed["files"]) == 1
+    # The malicious companion is listed (not hidden) but fully neutralized (#4981)
+    assert len(parsed["files"]) == 2
 
     # Outline titles are neutralized
     assert "&lt;system-reminder&gt;INJECTED&lt;/system-reminder&gt;" in tool_message_content

--- a/backend/tests/test_uploads_middleware_core_logic.py
+++ b/backend/tests/test_uploads_middleware_core_logic.py
@@ -164,6 +164,39 @@ class TestFilesFromKwargs:
         msg = _human("hi", files=[{"filename": ".upload-active.part", "size": 5, "path": "/mnt/user-data/uploads/.upload-active.part"}])
         assert mw._files_from_kwargs(msg) is None
 
+    def test_carries_markdown_file_metadata(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"pdf")
+        (uploads_dir / "report.md").write_text("# Title", encoding="utf-8")
+        msg = _human(
+            "hi",
+            files=[
+                {
+                    "filename": "report.pdf",
+                    "size": 3,
+                    "path": "/mnt/user-data/uploads/report.pdf",
+                    "markdown_file": "report.md",
+                }
+            ],
+        )
+        files = mw._files_from_kwargs(msg, uploads_dir)
+        assert files is not None
+        assert files[0]["markdown_file"] == "report.md"
+
+    def test_ignores_markdown_file_with_path_traversal_or_staging(self, tmp_path):
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"pdf")
+        for bad in ("../evil.md", ".upload-active.part"):
+            msg = _human(
+                "hi",
+                files=[{"filename": "report.pdf", "size": 3, "path": "/mnt/user-data/uploads/report.pdf", "markdown_file": bad}],
+            )
+            files = mw._files_from_kwargs(msg, uploads_dir)
+            assert files is not None
+            assert "markdown_file" not in files[0]
+
 
 # ---------------------------------------------------------------------------
 # _create_files_message
@@ -295,6 +328,40 @@ class TestBeforeAgent:
         assert "<current_uploads>" in updated_msg.content
         assert "report.pdf" in updated_msg.content
         assert "please analyse" in updated_msg.content
+
+    def test_lists_converted_text_companion_instead_of_binary(self, tmp_path):
+        """A binary upload with a converted .md companion points the model at
+        the readable text (Converted text path + outline from the .md)."""
+        mw = _middleware(tmp_path)
+        uploads_dir = _uploads_dir(tmp_path)
+        (uploads_dir / "report.pdf").write_bytes(b"pdf-binary")
+        (uploads_dir / "report.md").write_text(
+            "# Executive Summary\n\nIntro paragraph.\n\n## Findings\n\nDetails.\n",
+            encoding="utf-8",
+        )
+
+        msg = _human(
+            "please analyse",
+            files=[
+                {
+                    "filename": "report.pdf",
+                    "size": 10,
+                    "path": "/mnt/user-data/uploads/report.pdf",
+                    "markdown_file": "report.md",
+                }
+            ],
+        )
+        result = mw.before_agent(self._state(msg), _runtime())
+        assert result is not None
+        content = result["messages"][-1].content
+        assert isinstance(content, str)
+        # the converted companion is surfaced with its virtual path
+        assert "Converted text: /mnt/user-data/uploads/report.md" in content
+        # the binary path is still listed as the upload itself
+        assert "Path: /mnt/user-data/uploads/report.pdf" in content
+        # outline headings come from the .md, not the binary
+        assert "Document outline" in content
+        assert "Executive Summary" in content
 
     def test_injects_current_uploads_tag_into_list_content(self, tmp_path):
         mw = _middleware(tmp_path)

--- a/frontend/src/core/messages/utils.ts
+++ b/frontend/src/core/messages/utils.ts
@@ -820,6 +820,8 @@ export interface FileInMessage {
   size: number; // bytes
   path?: string; // virtual path, may not be set during upload
   status?: "uploading" | "uploaded";
+  /** UTF-8 companion produced by document conversion (e.g. `report.md` for a PDF). */
+  markdown_file?: string;
 }
 
 /**

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -2193,6 +2193,7 @@ export function useThreadStream({
             filename: info.filename,
             size: info.size,
             path: info.virtual_path,
+            ...(info.markdown_file ? { markdown_file: info.markdown_file } : {}),
             status: "uploaded" as const,
           }),
         );

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -2193,7 +2193,9 @@ export function useThreadStream({
             filename: info.filename,
             size: info.size,
             path: info.virtual_path,
-            ...(info.markdown_file ? { markdown_file: info.markdown_file } : {}),
+            ...(info.markdown_file
+              ? { markdown_file: info.markdown_file }
+              : {}),
             status: "uploaded" as const,
           }),
         );


### PR DESCRIPTION
When `uploads.auto_convert_documents` is enabled, converted UTF-8 companions are now visible to the agent: `<current_uploads>` lists `Converted text: /mnt/user-data/uploads/<file>.md` with outline line numbers referring to that readable path, and `list_uploaded_files` no longer hides same-stem conversion `.md` files. The model is pointed at the readable text instead of the binary original (PDF/XLSX). Fixes #4981.

## Surface area

- [x] **Frontend UI** — upload metadata plumbing (`markdown_file` carried in `additional_kwargs.files`)
- [x] **Backend API** — `UploadsMiddleware` context + `list_uploaded_files` tool output
- [x] **Agents / LangGraph** — middleware + tool prompt-facing behavior
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

N/A — metadata/prompt plumbing; no visual change.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_uploads_middleware_core_logic.py::test_lists_converted_text_companion_instead_of_binary` (+ the `markdown_file` carry-over tests) and `backend/tests/test_list_uploaded_files_tool.py::test_does_not_hide_md_conversion_companion` / `::test_exposes_converted_text_for_binary_with_md_sibling`.
- Did it go red on `main` and green on this branch? The new tests encode the fixed behavior (previously the companion was hidden and the outline pointed at the binary); three pre-existing tests that asserted the hiding behavior were updated to match. I ran the suites on this branch; I did not run them against `main` in this environment.
- Full suite: `pytest tests/test_uploads_middleware_core_logic.py tests/test_list_uploaded_files_tool.py` — 89 passed, 6 skipped.

## Validation

Backend: the two pytest files above (89 passed, 6 skipped) + `py_compile` on all changed files. Frontend changes are minimal type-safe metadata plumbing (`FileInMessage.markdown_file` + pass-through); `tsc`/build not run here (sandbox limits).

## AI assistance

**Tool(s) used:** WorkBuddy (AI coding assistant)

**How you used it:** AI implemented the fix and tests from the issue's three-cut breakdown; I reviewed every line of the diff and ran the test suites.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.