### PR TITLE
fix(runtime): evict terminal RunRecords from RunManager after grace period

### DIFF
--- a/backend/packages/harness/deerflow/runtime/AGENTS.md
+++ b/backend/packages/harness/deerflow/runtime/AGENTS.md
@@ -109,3 +109,7 @@ PYTHONPATH=. uv run python scripts/benchmark/checkpoint/bench_production.py \
 PYTHONPATH=. uv run python scripts/benchmark/checkpoint/summarize_production.py \
   /tmp/production-bench.jsonl
 ```
+
+### Terminal RunRecord Eviction
+
+`run_agent()`'s finalization path schedules `RunManager.schedule_cleanup(run_id)` after `bridge.publish_end` (worker.py). With a durable RunStore, the terminal record is evicted from `_runs`/`_runs_by_thread` after a 300-second grace period — `get`/`list_by_thread` re-hydrate from the store, so history reads are unaffected; without a store the call is a no-op because memory is the only history source. The delayed eviction task is strongly referenced in `RunManager._cleanup_tasks` until completion, so the event loop cannot garbage-collect it mid-sleep (same class of bug as the deferred-cleanup retention fixes).

--- a/backend/packages/harness/deerflow/runtime/runs/manager.py
+++ b/backend/packages/harness/deerflow/runtime/runs/manager.py
@@ -250,6 +250,7 @@ class RunManager:
         self._heartbeat_task: asyncio.Task | None = None
         self._heartbeat_stop: asyncio.Event | None = None
         self._orphan_recovery_task: asyncio.Task[None] | None = None
+        self._cleanup_tasks: set[asyncio.Task[None]] = set()
 
     def _index_run_locked(self, record: RunRecord) -> None:
         """Register *record* in the thread index. Caller must hold ``self._lock``."""
@@ -1860,6 +1861,25 @@ class RunManager:
             if record is not None:
                 self._unindex_run_locked(run_id, record.thread_id)
         logger.debug("Run record %s cleaned up", run_id)
+
+    def schedule_cleanup(self, run_id: str, *, delay: float = 300) -> asyncio.Task[None] | None:
+        """Schedule eviction of a terminal run's in-memory record after *delay*.
+
+        Only meaningful when a durable RunStore backs this manager: evicted
+        records stay readable through the store fallback in ``get`` and
+        ``list_by_thread``, so run history survives the eviction. Memory-only
+        managers keep terminal records in memory — it is their only history
+        source — and return ``None`` without scheduling.
+
+        The delayed task is strongly referenced until it completes, so the
+        event loop cannot garbage-collect a pending eviction mid-sleep.
+        """
+        if self._store is None:
+            return None
+        task = asyncio.create_task(self.cleanup(run_id, delay=delay))
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+        return task
 
     # ------------------------------------------------------------------
     # Lease heartbeat

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -1342,6 +1342,10 @@ async def run_agent(
 
         await bridge.publish_end(run_id)
         asyncio.create_task(bridge.cleanup(run_id, delay=60))
+        # Terminal RunRecords are evicted after a grace period when a durable
+        # RunStore is configured (historical reads fall back to the store);
+        # memory-only managers keep them as their only history source.
+        run_manager.schedule_cleanup(run_id)
 
         if deferred_stop_interrupt is not None:
             raise deferred_stop_interrupt

--- a/backend/tests/test_gateway_services.py
+++ b/backend/tests/test_gateway_services.py
@@ -3027,6 +3027,7 @@ async def test_run_agent_full_mode_rejects_delta_before_graph_invocation():
         wait_for_prior_finalizing=AsyncMock(),
         set_status=set_status,
         set_status_if_not_cancelled=AsyncMock(side_effect=set_status_if_not_cancelled),
+        schedule_cleanup=lambda *args, **kwargs: None,
     )
     record = RunRecord(
         run_id="run-checkpoint-mode",
@@ -3106,6 +3107,7 @@ async def test_run_agent_full_mode_checks_selected_checkpoint_before_graph():
         wait_for_prior_finalizing=AsyncMock(),
         set_status=set_status,
         set_status_if_not_cancelled=AsyncMock(side_effect=set_status_if_not_cancelled),
+        schedule_cleanup=lambda *args, **kwargs: None,
     )
     record = RunRecord(
         run_id="run-selected-checkpoint-mode",

--- a/backend/tests/test_goal_worker.py
+++ b/backend/tests/test_goal_worker.py
@@ -631,6 +631,9 @@ async def test_run_agent_does_not_stream_continuation_after_abort(monkeypatch):
         async def update_run_completion(self, *_args, **_kwargs):
             return None
 
+        def schedule_cleanup(self, *_args, **_kwargs):
+            return None
+
         async def wait_for_prior_finalizing(self, *_args, **_kwargs):
             return None
 
@@ -714,6 +717,9 @@ async def test_run_agent_reuses_goal_evaluator_model_for_goal_loop(monkeypatch):
             return None
 
         async def update_run_completion(self, *_args, **_kwargs):
+            return None
+
+        def schedule_cleanup(self, *_args, **_kwargs):
             return None
 
         async def wait_for_prior_finalizing(self, *_args, **_kwargs):
@@ -898,6 +904,9 @@ async def test_run_agent_strips_branch_checkpoint_for_goal_continuation(monkeypa
             return None
 
         async def update_run_completion(self, *_args, **_kwargs):
+            return None
+
+        def schedule_cleanup(self, *_args, **_kwargs):
             return None
 
         async def wait_for_prior_finalizing(self, *_args, **_kwargs):

--- a/backend/tests/test_run_manager.py
+++ b/backend/tests/test_run_manager.py
@@ -1,9 +1,11 @@
 """Tests for RunManager."""
 
 import asyncio
+import gc
 import logging
 import re
 import sqlite3
+import weakref
 from typing import Any
 
 import pytest
@@ -669,6 +671,58 @@ async def test_cleanup(manager: RunManager):
 
     await manager.cleanup(run_id, delay=0)
     assert await manager.get(run_id) is None
+
+
+@pytest.mark.anyio
+async def test_schedule_cleanup_evicts_terminal_run_with_durable_store():
+    """With a durable store, a scheduled cleanup evicts the record yet history stays readable."""
+    store = MemoryRunStore()
+    manager = RunManager(store=store)
+    record = await manager.create("thread-evict")
+    await manager.set_status(record.run_id, RunStatus.success)
+
+    task = manager.schedule_cleanup(record.run_id, delay=0)
+    assert task is not None
+    await task
+
+    assert record.run_id not in manager._runs
+    assert "thread-evict" not in manager._runs_by_thread
+    hydrated = await manager.get(record.run_id)
+    assert hydrated is not None
+    assert hydrated.run_id == record.run_id
+    assert hydrated.status == RunStatus.success
+
+
+@pytest.mark.anyio
+async def test_schedule_cleanup_noop_without_durable_store(manager: RunManager):
+    """Memory-only managers keep terminal records: memory is their only history source."""
+    record = await manager.create("thread-memory-only")
+
+    assert manager.schedule_cleanup(record.run_id, delay=0) is None
+    assert await manager.get(record.run_id) is record
+
+
+@pytest.mark.anyio
+async def test_schedule_cleanup_retains_task_until_done(monkeypatch):
+    """The delayed eviction task must survive garbage collection until it completes."""
+    orig_sleep = asyncio.sleep
+    monkeypatch.setattr("deerflow.runtime.runs.manager.asyncio.sleep", lambda _delay: orig_sleep(0))
+
+    manager = RunManager(store=MemoryRunStore())
+    record = await manager.create("thread-evict-gc")
+
+    task = manager.schedule_cleanup(record.run_id)
+    assert task is not None
+    assert task in manager._cleanup_tasks
+
+    weak_task = weakref.ref(task)
+    del task
+    gc.collect()
+    assert weak_task() is not None
+
+    await weak_task()
+    assert record.run_id not in manager._runs
+    assert not manager._cleanup_tasks
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_run_worker_rollback.py
+++ b/backend/tests/test_run_worker_rollback.py
@@ -158,6 +158,45 @@ async def test_remote_cancel_wins_when_graph_finishes_before_owner_heartbeat():
     assert record.status == RunStatus.error
 
 
+@pytest.mark.anyio
+async def test_terminal_run_schedules_run_record_eviction():
+    """The run_agent finalization path must schedule RunManager eviction of the terminal record."""
+    run_manager = RunManager(store=MemoryRunStore())
+    record = await run_manager.create("thread-evict-wiring")
+    bridge = SimpleNamespace(
+        publish=AsyncMock(),
+        publish_end=AsyncMock(),
+        cleanup=AsyncMock(),
+    )
+    scheduled = []
+
+    def fake_schedule_cleanup(run_id, *, delay=300):
+        scheduled.append((run_id, delay))
+
+    run_manager.schedule_cleanup = fake_schedule_cleanup
+
+    class _OkAgent:
+        async def astream(self, graph_input, config=None, stream_mode=None, subgraphs=False):
+            del graph_input, config, stream_mode, subgraphs
+            yield {"messages": []}
+
+    task = asyncio.create_task(
+        run_agent(
+            bridge,
+            run_manager,
+            record,
+            ctx=RunContext(checkpointer=None),
+            agent_factory=lambda **_kwargs: _OkAgent(),
+            graph_input={},
+            config={},
+        )
+    )
+    record.task = task
+    await asyncio.wait_for(task, timeout=5)
+
+    assert scheduled == [(record.run_id, 300)]
+
+
 def _make_rollback_point(*, checkpoint_id="ckpt-1", messages=("before",), pending_writes=()):
     materialized_messages = tuple(messages)
     return RollbackPoint(

--- a/backend/tests/test_worker_langfuse_metadata.py
+++ b/backend/tests/test_worker_langfuse_metadata.py
@@ -67,6 +67,9 @@ class _FakeRunManager:
     async def update_run_completion(self, *_args, **_kwargs) -> None:
         return None
 
+    def schedule_cleanup(self, *_args, **_kwargs) -> None:
+        return None
+
 
 class _FakeBridge:
     def __init__(self) -> None:

--- a/backend/tests/test_worker_stream_subgraph_namespace.py
+++ b/backend/tests/test_worker_stream_subgraph_namespace.py
@@ -336,6 +336,9 @@ class _IntegrationRunManager:
     async def update_run_completion(self, *_args, **_kwargs):
         return None
 
+    def schedule_cleanup(self, *_args, **_kwargs):
+        return None
+
     async def has_later_started_run(self, *_args, **_kwargs):
         return False
 


### PR DESCRIPTION
Fixes #5009

## Why

Completed runs stayed in `RunManager._runs` and `_runs_by_thread` for the lifetime of the Gateway process. `RunManager.cleanup()` existed but had no production caller — `run_agent()`'s finalization path scheduled only `bridge.cleanup(run_id, delay=60)` (verifiable via `git grep -n "run_manager.cleanup" -- backend`: test-only). Every terminal `RunRecord` retains its request `kwargs`, result/error metadata, and completed asyncio `Task`, so repeated runs grow the in-memory registries linearly — unbounded retention rather than an unreachable-object leak.

## What changed

- `RunManager` gains `schedule_cleanup(run_id, *, delay=300)`: schedules eviction of a terminal run's in-memory record after a grace period. It is a no-op (returns `None`) for memory-only managers, since memory is their only history source — current memory-only semantics are unchanged. When a durable RunStore is configured, the record is evicted from both `_runs` and `_runs_by_thread` after 300s; historical reads keep working because `get()` and `list_by_thread()` already re-hydrate from the store.
- `run_agent()`'s finalization path (after `bridge.publish_end`) now calls `run_manager.schedule_cleanup(run_id)`, covering success/error/interrupt exits.
- The delayed eviction task is strongly referenced in `RunManager._cleanup_tasks` until completion, so the event loop cannot garbage-collect it mid-sleep (same class of bug as the deferred-cleanup retention fixes, e.g. #4928).

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape) — with a durable RunStore, terminal records are now evicted after 300s instead of being retained for the process lifetime; no API response shape changes.
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_run_manager.py::test_schedule_cleanup_evicts_terminal_run_with_durable_store` plus the wiring regression `backend/tests/test_run_worker_rollback.py::test_terminal_run_schedules_run_record_eviction`, and two more in the same files (memory-only no-op, GC retention).
- Did it go red on `main` and green on this branch? **Yes** — the manager-level tests failed on `main` with `AttributeError: 'RunManager' object has no attribute 'schedule_cleanup'` before the implementation landed; all green after.

## Validation

- `cd backend && PYTHONPATH=. uv run pytest tests/ -q --ignore=tests/blocking_io` — **12133 passed, 81 skipped**
- `uv run ruff check` + `uv run ruff format --check` on all changed files — clean
- Focused suites re-run individually: `test_run_manager.py`, `test_run_worker_rollback.py`, `test_gateway_services.py`, `test_goal_worker.py`, `test_worker_langfuse_metadata.py`, `test_worker_stream_subgraph_namespace.py`

## AI assistance

**Tool(s) used:** ZCode (Claude-based interactive coding agent)

**How you used it:** Issue analysis (locating the missing production call site for `RunManager.cleanup`, confirming `get()`/`list_by_thread()` store fallback make eviction safe), writing the failing tests first, then the implementation and doc updates. I reviewed the full diff, re-verified the edge cases (all `run_agent` exit paths funnel through the finalization block; memory-only mode unchanged), and ran the full validation suite myself.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
