### PR TITLE
fix(sandbox): stop misreporting BOM-marked text as binary

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -291,6 +291,16 @@ For models with `supports_vision: true`:
 - `view_image_tool` added to agent's toolset
 - Images are converted to base64 and injected into a hidden message carrying both a reserved ID prefix and a server-owned metadata marker for the model call; Gateway strips that marker from untrusted input, and the middleware requires both identifiers before removing the message. The `before_model` and `model` node checkpoints for that call still contain the payload; after `after_model` cleanup, subsequent checkpoints retain only lightweight `viewed_images` metadata, while client-chosen IDs survive
 
+### Text Decoding
+
+`deerflow.utils.text_decoding` owns which workspace bytes count as text, for all three readers: `LocalSandbox.read_file` (the agent's `read_file`), `sandbox.search.find_grep_matches` (`grep`), and `workspace_changes.scanner` (the change panel). Splitting the rule is what let them drift — #3966 taught the scanner UTF-8 BOM and BOM-marked UTF-16 while the read path kept a bare `utf-8` codec and grep's NUL screen rejected every wide file, so one file could render in the panel, be reported binary to the agent, and stay invisible to search.
+
+The rule accepts UTF-8 with or without a BOM (`utf-8-sig` is the default codec, not a special case, so a Windows-authored file no longer carries a stray `﻿` that breaks a leading `str_replace` match or a YAML parse) and UTF-16 only when a BOM declares byte order. Legacy encodings (CP949, Shift-JIS, GBK) are never guessed: a wrong guess decodes without raising and yields silently corrupted text. `read_file`'s `UnicodeDecodeError` message therefore names both causes — binary content vs. another encoding — and offers `iconv`, since blaming a spreadsheet sends the model to `view_image`/pandas for a plain `.txt`.
+
+`detect_text_encoding()` needs only `BOM_PREFIX_SIZE` bytes, so ranged reads still stream rather than buffering to pick a codec (pinned by `test_read_file_line_range_streams_without_full_read`), and grep derives its binary screen and codec from one head read. `detect_append_encoding()` binds the write side: append continues the file's existing codec (BOM-less UTF-16 variants, since `utf-16` would emit a second BOM mid-file), because appending UTF-8 onto UTF-16 leaves a file no decoder can read back — reachable only once `read_file` began accepting UTF-16. Overwrite stays UTF-8, so a `str_replace` round-trip still rewrites a wide file as UTF-8.
+
+Two divergences are deliberate. BOM-less UTF-16 is not recognized: ASCII-range UTF-16-LE is itself valid UTF-8, so it decodes NUL-riddled instead of raising, and the NUL screen that saves the scanner would reject files that read (badly) today. Legacy-encoded text is the one input where grep and `read_file` differ, correctly: grep uses `errors="replace"` and still matches ASCII, because a search that silently skips a file is worse than a lossy preview, while a read must be faithful or fail.
+
 ## Code Style
 
 - Uses `ruff` for linting and formatting

--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -18,6 +18,7 @@ from deerflow.sandbox.local.list_dir import list_dir
 from deerflow.sandbox.path_patterns import build_output_mask_pattern
 from deerflow.sandbox.sandbox import Sandbox, _validate_extra_env
 from deerflow.sandbox.search import GrepMatch, find_glob_matches, find_grep_matches
+from deerflow.utils.text_decoding import BOM_PREFIX_SIZE, detect_append_encoding, detect_text_encoding
 
 logger = logging.getLogger(__name__)
 
@@ -678,6 +679,20 @@ class LocalSandbox(Sandbox):
 
         return sorted(result)
 
+    @staticmethod
+    def _read_bom_prefix(resolved_path: str) -> bytes:
+        """Return the leading bytes a codec choice is made from.
+
+        A missing file yields an empty prefix rather than raising: append creates
+        the file, and the read path surfaces the real ``OSError`` from its own open
+        a moment later, with the caller-facing path already restored.
+        """
+        try:
+            with open(resolved_path, "rb") as probe:
+                return probe.read(BOM_PREFIX_SIZE)
+        except OSError:
+            return b""
+
     def read_file(
         self,
         path: str,
@@ -687,7 +702,12 @@ class LocalSandbox(Sandbox):
         resolved_path = self._resolve_path(path)
         should_slice = start_line is not None or end_line is not None
         try:
-            with open(resolved_path, encoding="utf-8") as f:
+            # Sniff the BOM before opening in text mode so a ranged read still
+            # streams (``enumerate(f)`` below) instead of buffering the file to
+            # pick a codec. ``deerflow.utils.text_decoding`` owns which prefixes
+            # mean what, shared with the workspace change scanner and grep.
+            encoding = detect_text_encoding(self._read_bom_prefix(resolved_path))
+            with open(resolved_path, encoding=encoding) as f:
                 if not should_slice:
                     content = f.read()
 
@@ -747,7 +767,13 @@ class LocalSandbox(Sandbox):
             # using the content-specific resolver (forward-slash safe)
             resolved_content = self._resolve_paths_in_content(content)
             mode = "a" if append else "w"
-            with open(resolved_path, mode, encoding="utf-8") as f:
+            # Appending must continue the file's existing codec. read_file accepts
+            # BOM-marked UTF-16, so the agent can now read a file that appending
+            # UTF-8 onto would corrupt into something no decoder — including the
+            # read it just did — can parse. A full overwrite carries no such
+            # obligation and stays UTF-8, the encoding agent-authored content uses.
+            encoding = detect_append_encoding(self._read_bom_prefix(resolved_path)) if append else "utf-8"
+            with open(resolved_path, mode, encoding=encoding) as f:
                 f.write(resolved_content)
             # Track this path so read_file knows to reverse-resolve on read.
             # Only agent-written files get reverse-resolved; user uploads and

--- a/backend/packages/harness/deerflow/sandbox/search.py
+++ b/backend/packages/harness/deerflow/sandbox/search.py
@@ -4,6 +4,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 
+from deerflow.utils.text_decoding import UTF16_BOMS, detect_text_encoding
+
 IGNORE_PATTERNS = [
     ".git",
     ".svn",
@@ -60,6 +62,10 @@ IGNORE_PATTERNS = [
 DEFAULT_MAX_FILE_SIZE_BYTES = 1_000_000
 DEFAULT_LINE_SUMMARY_LENGTH = 200
 
+# Head bytes screened for NULs before a file is scanned, and the same bytes the
+# codec is chosen from.
+_BINARY_SAMPLE_BYTES = 8192
+
 
 @dataclass(frozen=True)
 class GrepMatch:
@@ -106,12 +112,27 @@ def truncate_line(line: str, max_chars: int = DEFAULT_LINE_SUMMARY_LENGTH) -> st
     return line[: max_chars - 3] + "..."
 
 
-def is_binary_file(path: Path, sample_size: int = 8192) -> bool:
+def _read_head(path: Path, sample_size: int = _BINARY_SAMPLE_BYTES) -> bytes | None:
+    """Return the file's leading bytes, or ``None`` when it cannot be opened."""
     try:
         with path.open("rb") as handle:
-            return b"\0" in handle.read(sample_size)
+            return handle.read(sample_size)
     except OSError:
-        return True
+        return None
+
+
+def _sample_is_binary(sample: bytes) -> bool:
+    """Screen a file's head for content grep should not scan.
+
+    Split from the read so one head serves both this screen and the codec choice.
+    UTF-16 is half NUL bytes by construction, so the NUL test alone would skip
+    every wide-encoded file: `read_file` and the workspace change panel both treat
+    a BOM-marked one as text, and grep returning "no matches" for a file the agent
+    can open and read is the same drift wearing an empty result instead of an error.
+    """
+    if sample.startswith(UTF16_BOMS):
+        return False
+    return b"\0" in sample
 
 
 def find_glob_matches(root: Path, pattern: str, *, include_dirs: bool = False, max_results: int = 200) -> tuple[list[str], bool]:
@@ -203,9 +224,14 @@ def find_grep_matches(
             file_path = candidate_path.resolve()
             if not root_is_file and not file_path.is_relative_to(root):
                 continue
-            if file_path.stat().st_size > max_file_size or is_binary_file(file_path):
+            if file_path.stat().st_size > max_file_size:
                 continue
-            with file_path.open(encoding="utf-8", errors="replace") as handle:
+            # One head read serves both the binary screen and the codec choice;
+            # the line scan below then opens the file exactly once more.
+            sample = _read_head(file_path)
+            if sample is None or _sample_is_binary(sample):
+                continue
+            with file_path.open(encoding=detect_text_encoding(sample), errors="replace") as handle:
                 for line_number, line in enumerate(handle, start=1):
                     if len(line) > _max_line_chars:
                         continue

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -2202,9 +2202,11 @@ def read_file_tool(
         return f"Error: Path is a directory, not a file: {requested_path}"
     except UnicodeDecodeError:
         return (
-            f"Error: cannot read '{requested_path}' as text — it appears to be a binary file "
-            "(e.g. .xlsx, .pdf, or an image). read_file only supports UTF-8 text. Use bash with a "
-            "suitable library instead (pandas/openpyxl for spreadsheets), or view_image for images."
+            f"Error: cannot read '{requested_path}' as text — read_file supports UTF-8 and "
+            "BOM-marked UTF-16 only. Either it is a binary file (e.g. .xlsx, .pdf, or an image) — "
+            "use bash with a suitable library instead (pandas/openpyxl for spreadsheets), or "
+            "view_image for images — or it is text in another encoding (e.g. CP949, Shift-JIS, "
+            "GBK), which bash can convert first: `iconv -f cp949 -t utf-8 <path> > <path>.utf8`."
         )
     except Exception as e:
         return f"Error: Unexpected error reading file: {_sanitize_error(e, runtime)}"

--- a/backend/packages/harness/deerflow/utils/text_decoding.py
+++ b/backend/packages/harness/deerflow/utils/text_decoding.py
@@ -1,0 +1,91 @@
+"""Single owner of the rule deciding which workspace bytes count as text.
+
+Two independent readers turn the same workspace files into text for a human or a
+model to look at: ``LocalSandbox.read_file`` (what the ``read_file`` tool shows
+the agent) and ``workspace_changes.scanner`` (what the change panel diffs). When
+they disagree, a file the panel renders fine is reported to the agent as binary —
+the exact drift #3966 fixed on the scanner side alone, leaving the tool behind.
+Keeping the rule here means a third reader cannot quietly invent a fourth answer.
+
+The rule is deliberately narrow:
+
+- UTF-8, with or without a BOM. ``utf-8-sig`` is the default codec rather than a
+  special case because it decodes plain UTF-8 unchanged and strips a BOM when one
+  is present, so a Windows-authored file no longer arrives with a stray ``\\ufeff``
+  at offset 0 — invisible in the model's context, but enough to break a leading
+  ``str_replace`` match or a YAML/JSON parse.
+- UTF-16, only when the file declares its byte order with a BOM. Without one there
+  is nothing to separate UTF-16 from bytes that merely resemble it, and ASCII-range
+  UTF-16-LE is itself valid UTF-8 (the NUL padding decodes to U+0000), so such a
+  file comes back NUL-riddled rather than raising. Callers that must reject it can
+  screen for embedded NULs the way ``workspace_changes.scanner`` already does.
+
+Legacy encodings (CP949, Shift-JIS, GBK, latin-1, ...) are **not** guessed. A
+wrong guess decodes without raising and yields silently corrupted text, which is
+strictly worse for a caller that cannot see the original bytes than an explicit
+failure it can report and route around.
+"""
+
+from __future__ import annotations
+
+from codecs import BOM_UTF16_BE, BOM_UTF16_LE
+
+#: Byte-order marks that select the UTF-16 codec. Public so readers that sniff a
+#: file themselves classify the same prefixes this module does.
+UTF16_BOMS = (BOM_UTF16_LE, BOM_UTF16_BE)
+
+#: Codec to continue an existing file with, per byte-order mark. These are the
+#: BOM-less UTF-16 variants on purpose: the ``utf-16`` codec emits a fresh BOM on
+#: its first write, which mid-file is data, not a mark.
+_APPEND_ENCODING_BY_BOM = ((BOM_UTF16_LE, "utf-16-le"), (BOM_UTF16_BE, "utf-16-be"))
+
+#: Bytes a caller must supply to :func:`detect_text_encoding`. Streaming readers
+#: need only this many; the UTF-8 BOM needs no sniffing because ``utf-8-sig``
+#: handles its presence and absence alike.
+BOM_PREFIX_SIZE = max(len(bom) for bom in UTF16_BOMS)
+
+UTF8_ENCODING = "utf-8-sig"
+UTF16_ENCODING = "utf-16"
+
+
+def detect_text_encoding(prefix: bytes) -> str:
+    """Return the codec to decode a file whose leading bytes are ``prefix``.
+
+    ``prefix`` need only hold :data:`BOM_PREFIX_SIZE` bytes; passing the whole
+    file is allowed but never necessary, which is what lets a streaming reader
+    pick a codec without buffering the content.
+
+    The returned codec may still fail on the full content — that failure is how
+    non-text bytes are rejected — so callers must handle ``UnicodeDecodeError``.
+    """
+    return UTF16_ENCODING if prefix.startswith(UTF16_BOMS) else UTF8_ENCODING
+
+
+def detect_append_encoding(prefix: bytes) -> str:
+    """Return the codec that continues a file whose leading bytes are ``prefix``.
+
+    This is not :func:`detect_text_encoding`: appending must match the existing
+    bytes without re-emitting a byte-order mark, so a UTF-16 file continues in its
+    BOM-less variant. Writing UTF-8 onto UTF-16 (or a second BOM into the middle)
+    leaves a file that no decoder can read back — including the one that was
+    reading it a moment earlier.
+
+    A UTF-8 BOM needs no special case: appending UTF-8 after it stays valid.
+    """
+    for bom, encoding in _APPEND_ENCODING_BY_BOM:
+        if prefix.startswith(bom):
+            return encoding
+    return "utf-8"
+
+
+def decode_text_bytes(data: bytes) -> str | None:
+    """Decode ``data`` as text, or return ``None`` when it is not text.
+
+    ``None`` covers both genuinely binary content and text in an encoding this
+    rule declines to guess; callers that need to tell those apart must do so from
+    the content itself.
+    """
+    try:
+        return data.decode(detect_text_encoding(data))
+    except UnicodeDecodeError:
+        return None

--- a/backend/packages/harness/deerflow/workspace_changes/scanner.py
+++ b/backend/packages/harness/deerflow/workspace_changes/scanner.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import fnmatch
 import hashlib
 import os
-from codecs import BOM_UTF16_BE, BOM_UTF16_LE, getincrementaldecoder
+from codecs import getincrementaldecoder
 from pathlib import Path
 
 from deerflow.constants import BROWSER_FRAMES_DIRNAME, MCP_INTERNAL_DIRNAME, TOOL_RESULTS_DIRNAME
+from deerflow.utils.text_decoding import UTF16_BOMS, decode_text_bytes
 
 from .types import (
     DiffUnavailableReason,
@@ -92,7 +93,6 @@ SENSITIVE_PATH_PATTERNS = (
 )
 
 SAMPLE_BYTES = 4096
-_UTF16_BOMS = (BOM_UTF16_LE, BOM_UTF16_BE)
 
 
 def is_sensitive_workspace_path(path: str) -> bool:
@@ -236,7 +236,7 @@ def _snapshot_file(
             raw = host_file.read_bytes()
         except OSError:
             return None
-        decoded = _decode_text_bytes(raw)
+        decoded = decode_text_bytes(raw)
         if decoded is None:
             binary = True
             reason = "binary"
@@ -314,22 +314,6 @@ def _sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def _decode_text_bytes(data: bytes) -> str | None:
-    for encoding in ("utf-8-sig", "utf-8"):
-        try:
-            return data.decode(encoding)
-        except UnicodeDecodeError:
-            continue
-
-    if data.startswith(_UTF16_BOMS):
-        try:
-            return data.decode("utf-16")
-        except UnicodeDecodeError:
-            return None
-
-    return None
-
-
 def _sample_decodes_as_text(sample: bytes, encoding: str) -> bool:
     try:
         decoder = getincrementaldecoder(encoding)()
@@ -340,7 +324,7 @@ def _sample_decodes_as_text(sample: bytes, encoding: str) -> bool:
 
 
 def _looks_binary(sample: bytes) -> bool:
-    if sample.startswith(_UTF16_BOMS) and _sample_decodes_as_text(sample, "utf-16"):
+    if sample.startswith(UTF16_BOMS) and _sample_decodes_as_text(sample, "utf-16"):
         return False
     if b"\x00" in sample:
         return True

--- a/backend/tests/test_local_sandbox_provider_mounts.py
+++ b/backend/tests/test_local_sandbox_provider_mounts.py
@@ -7,6 +7,7 @@ import pytest
 
 from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
 from deerflow.sandbox.local.local_sandbox_provider import LocalSandboxProvider
+from deerflow.utils.text_decoding import BOM_PREFIX_SIZE
 
 
 def _symlink_to(target, link, *, target_is_directory=False):
@@ -833,7 +834,16 @@ class TestLocalSandboxProviderMounts:
             ],
         )
 
+        peeked: list[int] = []
+
         class GuardedFile:
+            """Fails the test on an unbounded read; records bounded ones.
+
+            The BOM sniff that picks the codec (``deerflow.utils.text_decoding``)
+            legitimately reads a couple of bytes, so the invariant is not "never
+            call read" but "never pull in more than the byte-order mark".
+            """
+
             def __init__(self, wrapped):
                 self._wrapped = wrapped
 
@@ -850,8 +860,13 @@ class TestLocalSandboxProviderMounts:
             def __next__(self):
                 return next(self._wrapped)
 
-            def read(self, *args, **kwargs):
-                raise AssertionError("full read() should not be used for ranged reads")
+            def read(self, size=-1, *args, **kwargs):
+                if size is None or size < 0:
+                    raise AssertionError("full read() should not be used for ranged reads")
+                if size > BOM_PREFIX_SIZE:
+                    raise AssertionError(f"ranged reads should peek at most {BOM_PREFIX_SIZE} bytes, got read({size})")
+                peeked.append(size)
+                return self._wrapped.read(size, *args, **kwargs)
 
             def __getattr__(self, name):
                 return getattr(self._wrapped, name)
@@ -870,6 +885,8 @@ class TestLocalSandboxProviderMounts:
             content = sandbox.read_file("/mnt/data/huge.log", start_line=1, end_line=10)
 
         assert content == "\n".join(f"line {i}" for i in range(1, 11))
+        # One BOM peek, and only one: the line range itself must come from iteration.
+        assert peeked == [BOM_PREFIX_SIZE]
 
     def test_read_file_single_sided_line_ranges_supported(self, tmp_path):
         """LocalSandbox should support partial reads when only one bound is provided."""

--- a/backend/tests/test_read_file_tool_encoding.py
+++ b/backend/tests/test_read_file_tool_encoding.py
@@ -1,0 +1,286 @@
+"""``read_file`` text-decoding contract.
+
+``LocalSandbox.read_file`` decoded with a bare ``utf-8`` codec, so two kinds of
+ordinary text file reached the model wrong: a UTF-8 file saved with a BOM kept a
+stray ``\\ufeff`` at offset 0, and a BOM-marked UTF-16 file raised
+``UnicodeDecodeError`` and was reported as "binary" — steering the model to
+``view_image``/pandas for what is plain text.
+
+The workspace change scanner already decoded both correctly (#3966). These tests
+pin the shared rule that both readers now use, so the two cannot drift apart
+again, and keep the genuinely-binary and legacy-encoding paths distinguishable.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from deerflow.sandbox.local.local_sandbox import LocalSandbox, PathMapping
+from deerflow.sandbox.tools import grep_tool, read_file_tool
+from deerflow.utils.text_decoding import decode_text_bytes, detect_text_encoding
+
+WORKSPACE_VIRTUAL = "/mnt/user-data/workspace"
+
+
+def _local_runtime(tmp_path: Path) -> SimpleNamespace:
+    for sub in ("workspace", "uploads", "outputs"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    thread_data = {
+        "workspace_path": str(tmp_path / "workspace"),
+        "uploads_path": str(tmp_path / "uploads"),
+        "outputs_path": str(tmp_path / "outputs"),
+    }
+    return SimpleNamespace(
+        state={"sandbox": {"sandbox_id": "local:t1"}, "thread_data": thread_data},
+        context={"thread_id": "t1"},
+    )
+
+
+def _read(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, filename: str, raw: bytes, **kwargs) -> str:
+    runtime = _local_runtime(tmp_path)
+    (tmp_path / "workspace" / filename).write_bytes(raw)
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+    return read_file_tool.func(runtime=runtime, description="read fixture", path=f"{WORKSPACE_VIRTUAL}/{filename}", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# The shared decoding rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("prefix", "expected"),
+    [
+        (b"", "utf-8-sig"),
+        (b"pl", "utf-8-sig"),
+        (b"\xef\xbb\xbf", "utf-8-sig"),  # UTF-8 BOM: utf-8-sig strips it, so no special case
+        (b"\xff\xfe", "utf-16"),
+        (b"\xfe\xff", "utf-16"),
+    ],
+)
+def test_detect_text_encoding_reads_only_the_bom(prefix: bytes, expected: str) -> None:
+    assert detect_text_encoding(prefix) == expected
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (b"plain", "plain"),
+        ("bom".encode("utf-8-sig"), "bom"),
+        ("wide".encode("utf-16"), "wide"),
+        ("한글".encode("cp949"), None),  # legacy encodings are never guessed
+        (b"PK\x03\x04\x14\x00\x00\x00\x08\x00\x82\x6a\xb1\x55", None),
+    ],
+)
+def test_decode_text_bytes_accepts_only_utf8_and_bom_marked_utf16(raw: bytes, expected: str | None) -> None:
+    assert decode_text_bytes(raw) == expected
+
+
+def test_bomless_utf16_is_not_recognized_as_utf16() -> None:
+    """Pins a limit of the rule that predates it and is deliberately kept.
+
+    Without a BOM there is nothing to distinguish UTF-16 from bytes that merely
+    look like it, and ASCII-range UTF-16-LE *is* valid UTF-8 — the NUL padding
+    decodes to U+0000 rather than raising. So the content comes back NUL-riddled
+    instead of either decoding correctly or being rejected. The workspace scanner
+    never reaches this case because ``_looks_binary`` rejects embedded NULs first;
+    the read path has no such pre-check, and adding one would reject files that
+    read (badly) today.
+    """
+    assert decode_text_bytes("wide".encode("utf-16-le")) == "w\x00i\x00d\x00e\x00"
+
+
+# ---------------------------------------------------------------------------
+# UTF-8 BOM
+# ---------------------------------------------------------------------------
+
+
+def test_utf8_bom_is_stripped_from_full_read(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, "bom.md", "# Title\nbody\n".encode("utf-8-sig"))
+
+    assert not result.startswith("﻿"), repr(result)
+    assert result == "# Title\nbody\n"
+
+
+def test_utf8_bom_is_stripped_from_ranged_read(tmp_path, monkeypatch) -> None:
+    # The BOM sits on line 1, so a range starting there is what would leak it.
+    result = _read(tmp_path, monkeypatch, "bom.md", "# Title\nbody\ntail\n".encode("utf-8-sig"), start_line=1, end_line=2)
+
+    assert "﻿" not in result, repr(result)
+    assert result == "# Title\nbody"
+
+
+# ---------------------------------------------------------------------------
+# BOM-marked UTF-16
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("encoding", ["utf-16", "utf-16-le", "utf-16-be"])
+def test_bom_marked_utf16_reads_as_text(tmp_path, monkeypatch, encoding: str) -> None:
+    raw = "# Title\nbody\n".encode(encoding)
+    if encoding != "utf-16":
+        # utf-16-le / utf-16-be do not emit a BOM; prepend the matching one so the
+        # file declares its byte order the way a real editor would.
+        raw = (b"\xff\xfe" if encoding.endswith("le") else b"\xfe\xff") + raw
+
+    result = _read(tmp_path, monkeypatch, "wide.md", raw)
+
+    assert "binary" not in result.lower(), result
+    assert result == "# Title\nbody\n"
+
+
+def test_bom_marked_utf16_supports_ranged_read(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, "wide.md", "one\ntwo\nthree\n".encode("utf-16"), start_line=2, end_line=3)
+
+    assert result == "two\nthree"
+
+
+# ---------------------------------------------------------------------------
+# Unchanged paths
+# ---------------------------------------------------------------------------
+
+
+def test_plain_utf8_is_unaffected(tmp_path, monkeypatch) -> None:
+    result = _read(tmp_path, monkeypatch, "notes.txt", "hello 你好 안녕\nsecond line\n".encode())
+
+    assert result == "hello 你好 안녕\nsecond line\n"
+
+
+def test_binary_file_still_reports_binary(tmp_path, monkeypatch) -> None:
+    # .xlsx is a zip container: PK header plus a byte no UTF-8 decoder accepts.
+    result = _read(tmp_path, monkeypatch, "data.xlsx", b"PK\x03\x04\x14\x00\x00\x00\x08\x00\x82\x6a\xb1\x55")
+
+    assert "Unexpected error" not in result, result
+    assert "binary" in result.lower(), result
+    assert "bash" in result.lower(), result
+
+
+def test_legacy_encoding_error_names_the_encoding_cause(tmp_path, monkeypatch) -> None:
+    # CP949 text is not binary, but it cannot be decoded under this rule either.
+    # The error must say so, or the model retries as if the file were a spreadsheet.
+    result = _read(tmp_path, monkeypatch, "legacy.txt", "안녕하세요\n한글 파일\n".encode("cp949"))
+
+    assert "encoding" in result.lower(), result
+    assert "cp949" in result.lower(), result
+
+
+# ---------------------------------------------------------------------------
+# Drift guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"plain\n",
+        "bom\n".encode("utf-8-sig"),
+        "wide\n".encode("utf-16"),
+        "한글\n".encode("cp949"),
+        b"PK\x03\x04\x14\x00\x00\x00\x08\x00\x82\x6a\xb1\x55",
+    ],
+)
+def test_streaming_read_matches_the_buffered_rule(tmp_path, monkeypatch, raw: bytes) -> None:
+    """The tool streams through ``open(encoding=...)``; the rule decodes a buffer.
+
+    Those are separate code paths, and the workspace change panel reads through the
+    buffered one. If they ever disagree, a file the panel renders is reported to the
+    agent as unreadable — the drift #3966 fixed on the scanner side alone.
+    """
+    tool_result = _read(tmp_path, monkeypatch, "sample.md", raw)
+    tool_says_text = "as text" not in tool_result
+
+    assert tool_says_text is (decode_text_bytes(raw) is not None), tool_result
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: what read_file can now open, the write path must not corrupt
+# ---------------------------------------------------------------------------
+
+
+def test_append_preserves_utf16_so_the_file_stays_readable(tmp_path) -> None:
+    """Appending UTF-8 onto UTF-16 would leave a file no decoder can read back.
+
+    Reachable only because read_file accepts BOM-marked UTF-16: before that, the
+    agent could not read such a file and had no reason to append to it.
+    """
+    workspace = tmp_path / "data"
+    workspace.mkdir()
+    target = workspace / "wide.md"
+    target.write_bytes("first\n".encode("utf-16"))
+
+    sandbox = LocalSandbox("t1", [PathMapping(container_path="/mnt/data", local_path=str(workspace))])
+    sandbox.write_file("/mnt/data/wide.md", "second\n", append=True)
+
+    assert sandbox.read_file("/mnt/data/wide.md") == "first\nsecond\n"
+    # Exactly one BOM: the utf-16 codec would have emitted a second one mid-file.
+    assert target.read_bytes().count(b"\xff\xfe") == 1
+
+
+def test_append_preserves_utf8_bom(tmp_path) -> None:
+    workspace = tmp_path / "data"
+    workspace.mkdir()
+    target = workspace / "bom.md"
+    target.write_bytes("first\n".encode("utf-8-sig"))
+
+    sandbox = LocalSandbox("t1", [PathMapping(container_path="/mnt/data", local_path=str(workspace))])
+    sandbox.write_file("/mnt/data/bom.md", "second\n", append=True)
+
+    assert sandbox.read_file("/mnt/data/bom.md") == "first\nsecond\n"
+    assert target.read_bytes().startswith(b"\xef\xbb\xbf")
+
+
+def test_append_to_a_new_file_is_utf8(tmp_path) -> None:
+    workspace = tmp_path / "data"
+    workspace.mkdir()
+
+    sandbox = LocalSandbox("t1", [PathMapping(container_path="/mnt/data", local_path=str(workspace))])
+    sandbox.write_file("/mnt/data/fresh.md", "안녕\n", append=True)
+
+    assert (workspace / "fresh.md").read_bytes() == "안녕\n".encode()
+
+
+def test_overwrite_still_writes_utf8(tmp_path) -> None:
+    """A full rewrite replaces the content, so agent-authored UTF-8 is the contract."""
+    workspace = tmp_path / "data"
+    workspace.mkdir()
+    (workspace / "wide.md").write_bytes("first\n".encode("utf-16"))
+
+    sandbox = LocalSandbox("t1", [PathMapping(container_path="/mnt/data", local_path=str(workspace))])
+    sandbox.write_file("/mnt/data/wide.md", "replaced\n")
+
+    assert (workspace / "wide.md").read_bytes() == b"replaced\n"
+
+
+# ---------------------------------------------------------------------------
+# grep: the third reader of the same rule
+# ---------------------------------------------------------------------------
+
+
+def test_grep_finds_matches_in_bom_marked_utf16(tmp_path, monkeypatch) -> None:
+    """UTF-16 is half NUL bytes, so the plain NUL test used to skip it silently.
+
+    A file read_file opens happily returning "no matches" is the same drift as the
+    binary misreport, only shaped like an empty result instead of an error.
+    """
+    runtime = _local_runtime(tmp_path)
+    (tmp_path / "workspace" / "wide.md").write_bytes("needle here\nsecond\n".encode("utf-16"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+
+    result = grep_tool.func(runtime=runtime, description="find needle", pattern="needle", path=WORKSPACE_VIRTUAL)
+
+    assert "wide.md" in result, result
+    assert "needle here" in result, result
+
+
+def test_grep_still_skips_real_binary(tmp_path, monkeypatch) -> None:
+    runtime = _local_runtime(tmp_path)
+    (tmp_path / "workspace" / "blob.bin").write_bytes(b"needle\x00\x00\x01\x02binary")
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_sandbox_initialized", lambda runtime: LocalSandbox("t1"))
+    monkeypatch.setattr("deerflow.sandbox.tools.ensure_thread_directories_exist", lambda runtime: None)
+
+    result = grep_tool.func(runtime=runtime, description="find needle", pattern="needle", path=WORKSPACE_VIRTUAL)
+
+    assert "blob.bin" not in result, result


### PR DESCRIPTION
## Why

While reading a `.md` file that a Windows editor had saved, `read_file` returned
`Error: cannot read '...' as text — it appears to be a binary file (e.g. .xlsx,
.pdf, or an image)`. The file was plain text. The agent then did what that message
tells it to do: reached for `view_image` and pandas, and got nowhere.

Two decoding problems sit behind it, and the repo has already fixed both — in a
different reader:

- **UTF-8 with a BOM** decodes, but keeps a stray `U+FEFF` at offset 0. It is
  invisible in the model's context and still enough to break a leading
  `str_replace` match or a YAML/JSON parse.
- **BOM-marked UTF-16** raises `UnicodeDecodeError` and is reported as binary.

#3966 taught `workspace_changes.scanner` to handle both after UTF-16 markdown
showed up as binary in the change panel. That fix stopped at the scanner. So one
file could render in the change panel, be reported binary to the agent, and — since
grep's binary screen is a plain NUL test and UTF-16 is half NUL bytes — silently
return no matches from search. Three readers, three answers about the same bytes.

This is the same duplicated-rule failure that cost two rounds on the host→virtual
output-mask regex (#4035, then #4053), which #4108 resolved by giving the rule one
owner. Same prescription here.

## What changed

**`read_file` now reads text that Windows and other editors actually produce.** A
UTF-8 BOM is stripped instead of being handed to the model, and a BOM-marked UTF-16
file reads as text instead of being called binary.

**`grep` finds matches in those same files.** It previously skipped every
wide-encoded file as binary, which surfaced as "no results" rather than an error —
the same drift in a shape that is harder to notice.

**Appending no longer corrupts a wide-encoded file.** Accepting UTF-16 on read
opens a path that was previously unreachable: the agent can now open such a file,
and appending UTF-8 onto it leaves bytes no decoder — including the read it just
did — can parse. Append now continues the file's existing codec. A full overwrite
still writes UTF-8, the encoding agent-authored content uses, so a `str_replace`
round-trip continues to normalize a wide file to UTF-8.

**The error message stops blaming the wrong thing.** Text in a legacy encoding
(CP949, Shift-JIS, GBK) still cannot be read — guessing an encoding decodes without
raising and yields silently corrupted text, which is worse for a caller that cannot
see the original bytes than an explicit failure. But the message now names that
possibility alongside binary content and offers `iconv`, instead of asserting the
file is a spreadsheet.

Structurally: the rule lives in `deerflow/utils/text_decoding.py` and all three
readers use it. Ranged reads still stream (`detect_text_encoding()` needs only the
BOM prefix, so `read_file` sniffs and then iterates rather than buffering to pick a
codec); grep derives its binary screen and its codec from one head read, leaving
its per-file open count unchanged. `is_binary_file()` had no callers left after
that and is removed.

Two limits are deliberate and documented in `backend/AGENTS.md`: BOM-less UTF-16 is
not recognized (ASCII-range UTF-16-LE is itself valid UTF-8, so it decodes
NUL-riddled rather than raising, and the NUL screen that saves the scanner would
reject files that read — badly — today), and legacy-encoded text is the one input
where grep and `read_file` answer differently, correctly so: a search that silently
skips a file is worse than a lossy preview, while a read must be faithful or fail.

No config, API, or default-behavior change. Remote sandbox providers (AIO, E2B, …)
keep their own read paths and are untouched.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [ ] **Docs / tests / CI only** — no runtime behavior change

`read_file`, `grep`, and `write_file` are agent-facing tools, hence both boxes. No
`docker/` change; the sandbox box covers `LocalSandbox`.

## Bug fix verification

- **Test path that reproduces the bug:** `backend/tests/test_read_file_tool_encoding.py`
  (plus one assertion tightened in
  `backend/tests/test_local_sandbox_provider_mounts.py::test_read_file_line_range_streams_without_full_read`).
- **Did it go red on `main` and green on this branch?** Yes. With the source changes
  reverted and the tests kept, 12 tests fail on `main`'s behavior:

  ```
  test_utf8_bom_is_stripped_from_full_read
  test_utf8_bom_is_stripped_from_ranged_read
  test_bom_marked_utf16_reads_as_text[utf-16 | utf-16-le | utf-16-be]
  test_bom_marked_utf16_supports_ranged_read
  test_legacy_encoding_error_names_the_encoding_cause
  test_streaming_read_matches_the_buffered_rule[utf-16 case]
  test_append_preserves_utf16_so_the_file_stays_readable
  test_append_preserves_utf8_bom
  test_grep_finds_matches_in_bom_marked_utf16
  test_read_file_line_range_streams_without_full_read
  ```

  The last one is the tightened assertion rather than a bug repro: it previously
  banned every `read()` on the file, which a bounded BOM peek would trip. It now
  bans an *unbounded* read and asserts the peek happens exactly once and reads at
  most `BOM_PREFIX_SIZE` bytes — a stricter invariant than before, not a relaxed one.

## Validation

```
cd backend && make lint              # All checks passed
cd backend && uv run ruff format --check .   # 1230 files already formatted
cd backend && make test              # 12335 passed, 81 skipped
cd backend && make test-blocking-io  # 72 passed
```

Also verified end to end against a local sandbox that the four readers
(`read_file`, `grep`, the change-panel scanner, and the shared rule) now agree on
UTF-8, UTF-8 BOM, BOM-marked UTF-16, and genuinely binary content, and that a
read → append → read round-trip is lossless for all three text encodings.

## AI assistance

**Tool(s) used:** Claude Code (Opus 5)

**How you used it:** Paired throughout. The investigation started as a question
about `read_file`'s cross-platform behavior; Claude reproduced the BOM and UTF-16
cases against a real `LocalSandbox`, then found #3966 in the history and showed
that the identical decoding rule already existed in `workspace_changes/scanner.py`
— which is what turned "read_file has a bug" into "three readers disagree". Tests
were written before the fix and confirmed red against `main` by reverting only the
source changes. A self-review pass afterwards surfaced two problems in the first
draft that are now part of this PR: the append-corruption path that accepting
UTF-16 on read had newly opened, and grep as an unaccounted-for third reader. It
also caught a performance regression (grep opening each file three times) and the
`backend/AGENTS.md` size budget failing in CI, both fixed before this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
