### PR TITLE
fix(frontend): stabilize Windows development startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ cd backend && make lint       # ruff check
 cd backend && make format     # ruff format
 
 # Frontend (see frontend/AGENTS.md for the full set)
-cd frontend && pnpm dev       # Dev server with Turbopack (port 3000)
+cd frontend && pnpm dev       # Dev server: Webpack on Windows, Turbopack elsewhere (port 3000)
 cd frontend && pnpm check     # Lint + type check (run before committing)
 cd frontend && pnpm test      # Unit tests
 ```
@@ -188,7 +188,7 @@ cd frontend && pnpm rstest run <pattern>     # e.g. pnpm rstest run my-component
 ### Logs
 
 - Docker stack: `make docker-logs` (or `docker compose -f docker/... logs -f <svc>`).
-- Local `make dev`: each service logs to its own terminal pane. Frontend Turbopack
+- Local `make dev`: each service logs to its own terminal pane. Frontend dev-server
   errors surface in the browser console at `localhost:3000`; backend tracebacks appear
   in the Gateway terminal.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,7 +151,7 @@ cd backend && make lint       # ruff check
 cd backend && make format     # ruff format
 
 # Frontend (see frontend/AGENTS.md for the full set)
-cd frontend && pnpm dev       # Dev server: Webpack on Windows, Turbopack elsewhere (port 3000)
+cd frontend && pnpm dev       # Dev server: Webpack on Windows, Turbopack elsewhere (override with DEER_FLOW_DEV_BUNDLER)
 cd frontend && pnpm check     # Lint + type check (run before committing)
 cd frontend && pnpm test      # Unit tests
 ```

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -32,6 +32,8 @@ DeerFlow Frontend is a Next.js 16 web interface for an AI agent system. It commu
 
 Unit tests live under `tests/unit/` and mirror the `src/` layout (e.g., `tests/unit/core/api/stream-mode.test.ts` tests `src/core/api/stream-mode.ts`). Powered by Rstest; import source modules via the `@/` path alias.
 
+Use `DEER_FLOW_DEV_BUNDLER=turbo` or `DEER_FLOW_DEV_BUNDLER=webpack` with `pnpm dev` to override the platform default when diagnosing a local Next.js bundler issue.
+
 Rstest runs them as two projects (`rstest.config.ts`). `*.test.ts` / `*.test.tsx` run in a plain **node** environment — that is nearly the whole suite, and it is the default for anything that is pure logic. `*.dom.test.ts` / `*.dom.test.tsx` run in **happy-dom**, for tests that need a document: hooks driven through `renderHook` from `@testing-library/react`, and components. Keep the split — a DOM environment costs roughly 3x the runtime of the node suite, so tests that do not render should not opt into it. A hook whose behavior only exists under real React (effect ordering, cleanup on unmount, re-render on store change) belongs in a `.dom.test.*` file rather than a node test that mocks `react` itself.
 
 E2E tests live under `tests/e2e/` and use Playwright with Chromium. They mock all backend APIs via `page.route()` network interception and test real page interactions (navigation, chat input, streaming responses). Config: `playwright.config.ts`.

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,18 +17,18 @@ DeerFlow Frontend is a Next.js 16 web interface for an AI agent system. It commu
 
 ## Commands
 
-| Command          | Purpose                                           |
-| ---------------- | ------------------------------------------------- |
-| `pnpm dev`       | Dev server with Turbopack (http://localhost:3000) |
-| `pnpm build`     | Production build                                  |
-| `pnpm check`     | Lint + type check (run before committing)         |
-| `pnpm lint`      | ESLint only                                       |
-| `pnpm lint:fix`  | ESLint with auto-fix                              |
-| `pnpm format`    | Prettier check (`pnpm format:write` to apply)     |
-| `pnpm test`      | Run unit tests with Rstest                        |
-| `pnpm test:e2e`  | Run E2E tests with Playwright (Chromium)          |
-| `pnpm typecheck` | TypeScript type check (`tsc --noEmit`)            |
-| `pnpm start`     | Start production server                           |
+| Command          | Purpose                                                             |
+| ---------------- | ------------------------------------------------------------------- |
+| `pnpm dev`       | Platform-aware dev server (Webpack on Windows, Turbopack elsewhere) |
+| `pnpm build`     | Production build                                                    |
+| `pnpm check`     | Lint + type check (run before committing)                           |
+| `pnpm lint`      | ESLint only                                                         |
+| `pnpm lint:fix`  | ESLint with auto-fix                                                |
+| `pnpm format`    | Prettier check (`pnpm format:write` to apply)                       |
+| `pnpm test`      | Run unit tests with Rstest                                          |
+| `pnpm test:e2e`  | Run E2E tests with Playwright (Chromium)                            |
+| `pnpm typecheck` | TypeScript type check (`tsc --noEmit`)                              |
+| `pnpm start`     | Start production server                                             |
 
 Unit tests live under `tests/unit/` and mirror the `src/` layout (e.g., `tests/unit/core/api/stream-mode.test.ts` tests `src/core/api/stream-mode.ts`). Powered by Rstest; import source modules via the `@/` path alias.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -127,24 +127,24 @@ src/
 
 ## Scripts
 
-| Command             | Description                             |
-| ------------------- | --------------------------------------- |
-| `pnpm dev`          | Start development server with Turbopack |
-| `pnpm build`        | Build for production                    |
-| `pnpm start`        | Start production server                 |
-| `pnpm test`         | Run unit tests with Rstest              |
-| `pnpm test:e2e`     | Run E2E tests with Playwright           |
-| `pnpm format`       | Check formatting with Prettier          |
-| `pnpm format:write` | Apply formatting with Prettier          |
-| `pnpm lint`         | Run ESLint                              |
-| `pnpm lint:fix`     | Fix ESLint issues                       |
-| `pnpm typecheck`    | Run TypeScript type checking            |
-| `pnpm check`        | Run both lint and typecheck             |
+| Command             | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `pnpm dev`          | Start development server (Webpack on Windows, Turbopack elsewhere) |
+| `pnpm build`        | Build for production                                               |
+| `pnpm start`        | Start production server                                            |
+| `pnpm test`         | Run unit tests with Rstest                                         |
+| `pnpm test:e2e`     | Run E2E tests with Playwright                                      |
+| `pnpm format`       | Check formatting with Prettier                                     |
+| `pnpm format:write` | Apply formatting with Prettier                                     |
+| `pnpm lint`         | Run ESLint                                                         |
+| `pnpm lint:fix`     | Fix ESLint issues                                                  |
+| `pnpm typecheck`    | Run TypeScript type checking                                       |
+| `pnpm check`        | Run both lint and typecheck                                        |
 
 ## Development Notes
 
 - Uses pnpm workspaces (see `packageManager` in package.json)
-- Turbopack enabled by default in development for faster builds
+- Turbopack is used by default in development except on Windows, where Webpack avoids known Turbopack runtime instability
 - Environment validation can be skipped with `SKIP_ENV_VALIDATION=1` (useful for Docker)
 - Backend API URLs are optional; nginx proxy is used by default in development
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -144,7 +144,7 @@ src/
 ## Development Notes
 
 - Uses pnpm workspaces (see `packageManager` in package.json)
-- Turbopack is used by default in development except on Windows, where Webpack avoids known Turbopack runtime instability
+- Turbopack is used by default in development except on Windows, where Webpack avoids known Turbopack runtime instability. Set `DEER_FLOW_DEV_BUNDLER=turbo` or `DEER_FLOW_DEV_BUNDLER=webpack` to override the platform default for local diagnosis.
 - Environment validation can be skipped with `SKIP_ENV_VALIDATION=1` (useful for Docker)
 - Backend API URLs are optional; nginx proxy is used by default in development
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 /**
  * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially useful
  * for Docker builds.
@@ -26,7 +28,7 @@ const config = {
     defaultLocale: "en",
   },
   turbopack: {
-    root: import.meta.dirname,
+    root: fileURLToPath(new URL(".", import.meta.url)),
   },
   devIndicators: false,
   allowedDevOrigins: getAllowedDevOrigins(),

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -25,6 +25,9 @@ const config = {
     locales: ["en", "zh"],
     defaultLocale: "en",
   },
+  turbopack: {
+    root: import.meta.dirname,
+  },
   devIndicators: false,
   allowedDevOrigins: getAllowedDevOrigins(),
   async rewrites() {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "demo:save": "node scripts/save-demo.js",
     "build": "next build",
     "check": "eslint . --ext .ts,.tsx && tsc --noEmit",
-    "dev": "next dev --turbo",
+    "dev": "node scripts/dev.mjs",
     "format": "prettier --check .",
     "format:write": "prettier --write .",
     "lint": "eslint . --ext .ts,.tsx",

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function getDevBundler(platform = process.platform) {
+  return platform === "win32" ? "webpack" : "turbo";
+}
+
+export function getNextDevArgs(platform = process.platform, extraArgs = []) {
+  const nextArgs = extraArgs[0] === "--" ? extraArgs.slice(1) : extraArgs;
+  return ["dev", `--${getDevBundler(platform)}`, ...nextArgs];
+}
+
+function startDevServer() {
+  const frontendDir = fileURLToPath(new URL("..", import.meta.url));
+  const nextBin = fileURLToPath(
+    new URL("../node_modules/next/dist/bin/next", import.meta.url),
+  );
+  const child = spawn(
+    process.execPath,
+    [nextBin, ...getNextDevArgs(process.platform, process.argv.slice(2))],
+    {
+      cwd: frontendDir,
+      env: process.env,
+      stdio: "inherit",
+    },
+  );
+
+  child.on("error", (error) => {
+    console.error(`Failed to start Next.js: ${error.message}`);
+    process.exitCode = 1;
+  });
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exitCode = code ?? 1;
+  });
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  startDevServer();
+}

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -4,13 +4,35 @@ import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-export function getDevBundler(platform = process.platform) {
+/**
+ * @param {string} platform
+ * @param {Record<string, string | undefined>} env
+ */
+export function getDevBundler(platform = process.platform, env = process.env) {
+  const override = env.DEER_FLOW_DEV_BUNDLER?.trim();
+  if (override) {
+    if (override !== "turbo" && override !== "webpack") {
+      throw new Error(
+        'DEER_FLOW_DEV_BUNDLER must be either "turbo" or "webpack"',
+      );
+    }
+    return override;
+  }
   return platform === "win32" ? "webpack" : "turbo";
 }
 
-export function getNextDevArgs(platform = process.platform, extraArgs = []) {
+/**
+ * @param {string} platform
+ * @param {string[]} extraArgs
+ * @param {Record<string, string | undefined>} env
+ */
+export function getNextDevArgs(
+  platform = process.platform,
+  extraArgs = [],
+  env = process.env,
+) {
   const nextArgs = extraArgs[0] === "--" ? extraArgs.slice(1) : extraArgs;
-  return ["dev", `--${getDevBundler(platform)}`, ...nextArgs];
+  return ["dev", `--${getDevBundler(platform, env)}`, ...nextArgs];
 }
 
 function startDevServer() {

--- a/frontend/tests/unit/scripts/dev.test.ts
+++ b/frontend/tests/unit/scripts/dev.test.ts
@@ -8,6 +8,21 @@ describe("frontend dev launcher", () => {
     expect(getNextDevArgs("win32")).toEqual(["dev", "--webpack"]);
   });
 
+  test("allows an explicit bundler override on every platform", () => {
+    expect(getDevBundler("win32", { DEER_FLOW_DEV_BUNDLER: "turbo" })).toBe(
+      "turbo",
+    );
+    expect(
+      getNextDevArgs("linux", [], { DEER_FLOW_DEV_BUNDLER: "webpack" }),
+    ).toEqual(["dev", "--webpack"]);
+  });
+
+  test("rejects an unsupported bundler override", () => {
+    expect(() =>
+      getDevBundler("linux", { DEER_FLOW_DEV_BUNDLER: "invalid" }),
+    ).toThrow('DEER_FLOW_DEV_BUNDLER must be either "turbo" or "webpack"');
+  });
+
   test("passes through extra Next.js arguments", () => {
     expect(getNextDevArgs("win32", ["--", "--port", "3302"])).toEqual([
       "dev",

--- a/frontend/tests/unit/scripts/dev.test.ts
+++ b/frontend/tests/unit/scripts/dev.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "@rstest/core";
+
+import { getDevBundler, getNextDevArgs } from "../../../scripts/dev.mjs";
+
+describe("frontend dev launcher", () => {
+  test("uses webpack on Windows to avoid Turbopack runtime instability", () => {
+    expect(getDevBundler("win32")).toBe("webpack");
+    expect(getNextDevArgs("win32")).toEqual(["dev", "--webpack"]);
+  });
+
+  test("passes through extra Next.js arguments", () => {
+    expect(getNextDevArgs("win32", ["--", "--port", "3302"])).toEqual([
+      "dev",
+      "--webpack",
+      "--port",
+      "3302",
+    ]);
+  });
+
+  test("keeps Turbopack for non-Windows development", () => {
+    expect(getDevBundler("linux")).toBe("turbo");
+    expect(getDevBundler("darwin")).toBe("turbo");
+    expect(getNextDevArgs("linux")).toEqual(["dev", "--turbo"]);
+  });
+});


### PR DESCRIPTION
## Why

On Windows, the frontend development command starts Next.js 16.2.11 with Turbopack. In a checkout with another lockfile under the user profile, Turbopack infers the wrong workspace root and emits a warning. On the same setup, its Windows runtime can repeatedly panic with `Every task must have a task type`, leaving the development server unusable.

The existing #4959 fix addresses the Docker development bind host by injecting loopback origins into Compose. It does not change direct `pnpm dev`, and the earlier #1832 launcher fix only covers the `make dev` shell path. This PR closes the remaining direct frontend startup path while keeping Turbopack on non-Windows platforms.

## What changed

- Added a small platform-aware frontend dev launcher.
- Use `next dev --webpack` on Windows to avoid the observed Turbopack runtime panic.
- Keep `next dev --turbo` on Linux and macOS.
- Set `turbopack.root` to the frontend directory for explicit Turbopack invocations and future non-Windows use.
- Preserve extra Next.js arguments such as `pnpm dev -- --port 3010`.
- Added unit coverage and updated frontend development documentation.

## Surface area

- [x] **Frontend UI** — local frontend development startup only
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [x] **Default behavior change** — Windows development now uses Webpack by default
- [x] **Docs / tests / CI only** — documentation and regression coverage included

## Screenshots / Recording

Not applicable; this changes the local development bundler and does not change the rendered UI.

## Bug fix verification

- Test path: `frontend/tests/unit/scripts/dev.test.ts`
- The test is red on unmodified `main` because the new launcher module does not exist, and it passes on this branch with 3/3 tests.
- On Windows 11 with Node.js 22.18.0 and Next.js 16.2.11:
  - Before: `pnpm dev` reported `(Turbopack)`, inferred `C:\Users\lichen\package-lock.json` as the workspace root, and reproduced the `TaskGuard` panic.
  - After: `pnpm dev -- --port 3010` reported `(webpack)`, emitted no workspace-root warning or `TaskGuard` panic, and returned HTTP 200 for `/` and `/setup`.

## Validation

- `corepack pnpm@10.26.2 format` — passed
- `corepack pnpm@10.26.2 check` — passed (ESLint and TypeScript)
- `corepack pnpm@10.26.2 test` — passed (139 files, 1060 tests)
- `corepack pnpm@10.26.2 exec rstest run tests/unit/scripts/dev.test.ts` — passed (3 tests)
- Windows dev-server smoke test on port 3010 — passed
- `git diff --check` — passed

Production build and browser E2E tests were not run; this PR only changes the development launcher and Next.js development configuration.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex searched existing DeerFlow pull requests, reproduced the Windows Turbopack warning and panic, implemented the platform-aware launcher, added regression tests, and ran the validation listed above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
