### PR TITLE
fix(sandbox): apply bounded capture and process-tree kill to Windows LocalSandbox

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
+++ b/backend/packages/harness/deerflow/sandbox/local/local_sandbox.py
@@ -522,21 +522,7 @@ class LocalSandbox(Sandbox):
                             "MSYS2_ARG_CONV_EXCL": exclusions,
                         }
 
-            try:
-                result = subprocess.run(
-                    args,
-                    shell=False,
-                    capture_output=True,
-                    text=True,
-                    timeout=timeout,
-                    env=sandbox_env,
-                )
-                stdout, stderr, returncode = result.stdout, result.stderr, result.returncode
-            except subprocess.TimeoutExpired as exc:
-                timed_out = True
-                stdout = self._coerce_process_output(exc.stdout if exc.stdout is not None else exc.output)
-                stderr = self._coerce_process_output(exc.stderr)
-                returncode = 0
+            stdout, stderr, returncode, timed_out = self._run_windows_command(args, timeout, sandbox_env)
         else:
             args = [shell, "-c", resolved_command]
             stdout, stderr, returncode, timed_out = self._run_posix_command(args, timeout, sandbox_env)
@@ -655,6 +641,95 @@ class LocalSandbox(Sandbox):
             process.wait(timeout=10)
         except subprocess.TimeoutExpired:
             logger.warning("Process group for pid %s did not exit after SIGKILL", process.pid)
+
+    @staticmethod
+    def _terminate_process_tree_windows(process: subprocess.Popen) -> None:
+        """Kill the command's whole process tree on Windows, then reap it.
+
+        Uses ``taskkill /F /T`` to send a forced tree-kill signal.  Falls back
+        to killing just the direct child if ``taskkill`` is unavailable or the
+        process already exited.
+        """
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                capture_output=True,
+                timeout=10,
+            )
+        except Exception:
+            try:
+                process.kill()
+            except OSError:
+                logger.debug("Process %s already exited before fallback kill", process.pid)
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("Process tree for pid %s did not exit after taskkill", process.pid)
+
+    @staticmethod
+    def _run_windows_command(
+        args: list[str],
+        timeout: float,
+        env: dict[str, str] | None = None,
+    ) -> tuple[str, str, int, bool]:
+        """Run a command on Windows with bounded pipe capture and process-tree kill.
+
+        Mirrors :meth:`_run_posix_command` but uses ``taskkill /F /T`` for
+        process-tree termination instead of POSIX ``killpg``.  ``stdin`` is
+        taken from ``NUL`` so commands that read stdin get immediate EOF, and
+        ``start_new_session`` puts the command in its own process group so a
+        genuinely blocking foreground command can be killed in full (children
+        included) when it times out.
+
+        Returns ``(stdout, stderr, returncode, timed_out)``.
+        """
+        timed_out = False
+        stdout_read_fd, stdout_write_fd = os.pipe()
+        stderr_read_fd, stderr_write_fd = os.pipe()
+        try:
+            process = subprocess.Popen(
+                args,
+                shell=False,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout_write_fd,
+                stderr=stderr_write_fd,
+                start_new_session=True,
+                env=env,
+            )
+        except Exception:
+            for fd in (stdout_read_fd, stdout_write_fd, stderr_read_fd, stderr_write_fd):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            raise
+        finally:
+            for fd in (stdout_write_fd, stderr_write_fd):
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+
+        stdout_capture, stdout_thread = LocalSandbox._start_pipe_drain(stdout_read_fd, "deerflow-bash-stdout-drain")
+        stderr_capture, stderr_thread = LocalSandbox._start_pipe_drain(stderr_read_fd, "deerflow-bash-stderr-drain")
+
+        try:
+            try:
+                process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                timed_out = True
+                LocalSandbox._terminate_process_tree_windows(process)
+            returncode = process.returncode if process.returncode is not None else 0
+        finally:
+            join_timeout = 10 if timed_out else _PIPE_DRAIN_JOIN_TIMEOUT_SECONDS
+            for thread in (stdout_thread, stderr_thread):
+                thread.join(timeout=join_timeout)
+                if thread.is_alive():
+                    logger.debug("Subprocess output drain thread still active after command returned")
+
+        stdout = stdout_capture.read()
+        stderr = stderr_capture.read()
+        return stdout, stderr, returncode, timed_out
 
     def list_dir(self, path: str, max_depth=2) -> list[str]:
         resolved_path = self._resolve_path(path)


### PR DESCRIPTION
## What Problem This Solves

On Windows, `LocalSandbox.execute_command()` uses `subprocess.run(capture_output=True, timeout=...)` which has two defects (the Windows counterpart of the POSIX issues fixed in #3864):

1. **Unbounded process-tree capture**: `subprocess.run` accumulates all stdout/stderr in memory without limit. A command emitting 12,000,000 characters returns all 12,000,000 even though `_COMMAND_CAPTURE_LIMIT_BYTES` is 10,485,760.

2. **Broken timeout enforcement**: When `subprocess.run` kills the direct shell at timeout, a child process that inherited the capture pipes can keep `subprocess.run` blocked until that child exits. On current `main`, a command configured with a 0.2 second timeout took about 4.2 seconds to return.

## Why This Change Was Made

The POSIX `_run_posix_command` method already solves both problems using `Popen` + `start_new_session` + daemon drain threads writing to `_BoundedPipeCapture` + `os.killpg` for process-tree termination. This PR applies the identical pattern to Windows, substituting `taskkill /F /T /PID` for `os.killpg` (the Windows equivalent of killing a process group).

## User Impact

Windows users get the same bounded-output and reliable-timeout behavior that POSIX users have had since #3864. No API surface changes; the fix is internal to `LocalSandbox`.

## How Tested

Structurally identical to the battle-tested POSIX `_run_posix_command` method:
- Same `Popen` with `start_new_session=True` (creates `CREATE_NEW_PROCESS_GROUP` on Windows)
- Same `os.pipe()` + `_start_pipe_drain` daemon threads + `_BoundedPipeCapture` for bounded capture
- Same `process.wait(timeout=timeout)` with `TimeoutExpired` handling
- Platform-appropriate termination: `taskkill /F /T /PID` (Windows) instead of `os.killpg` (POSIX)

Full integration tests require the complete dev environment (`uv` + Docker); the existing `test_local_sandbox.py` suite covers the POSIX path and can serve as a template for Windows-specific test additions.

## Refs

Closes #4941 (Windows counterpart of POSIX #3864)
