### PR TITLE
fix(frontend): truncate selected model names

### DIFF
--- a/docs/superpowers/plans/2026-08-26-model-selector-overflow.md
+++ b/docs/superpowers/plans/2026-08-26-model-selector-overflow.md
@@ -1,0 +1,113 @@
+# Model Selector Overflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep long selected-model names inside the main and sidecar composer buttons with an ellipsis.
+
+**Architecture:** Preserve the existing shared `ModelSelectorName` truncation behavior and fix the two non-generated call sites that defeat it. Remove `items-start` from their column wrappers so the name span receives a constrained width through normal flex stretching.
+
+**Tech Stack:** React 19, TypeScript, Tailwind CSS 4, Rstest
+
+## Global Constraints
+
+- Do not edit generated files under `frontend/src/components/ai-elements/`.
+- Cover both the main chat composer and sidecar composer.
+- Add no dependency or abstraction.
+
+---
+
+### Task 1: Constrain selected-model labels
+
+**Files:**
+
+- Create: `frontend/tests/unit/components/workspace/model-selector-overflow.test.ts`
+- Modify: `frontend/src/components/workspace/input-box.tsx`
+- Modify: `frontend/src/components/workspace/sidecar/sidecar-panel.tsx`
+
+**Interfaces:**
+
+- Consumes: `ModelSelectorName`, whose default classes already include `truncate`.
+- Produces: selected-model wrappers that allow the name span to stretch to the available width.
+
+- [ ] **Step 1: Write the failing source-level regression test**
+
+```ts
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "@rstest/core";
+
+const FRONTEND_ROOT = path.resolve(__dirname, "../../../..");
+const SELECTED_MODEL_TRIGGER_PATTERN =
+  /<ModelSelectorTrigger asChild>[\s\S]*?<\/ModelSelectorTrigger>/;
+
+function source(relativePath: string) {
+  return readFileSync(path.join(FRONTEND_ROOT, relativePath), "utf8");
+}
+
+function selectedModelTrigger(relativePath: string) {
+  return SELECTED_MODEL_TRIGGER_PATTERN.exec(source(relativePath))?.[0];
+}
+
+describe("selected model name truncation", () => {
+  it.each([
+    "src/components/workspace/input-box.tsx",
+    "src/components/workspace/sidecar/sidecar-panel.tsx",
+  ])("lets ModelSelectorName stretch in %s", (relativePath) => {
+    const trigger = selectedModelTrigger(relativePath);
+
+    expect(trigger).toContain("<ModelSelectorName");
+    expect(trigger).not.toContain("items-start");
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+cd frontend && python3 ../scripts/pnpm.py rstest run tests/unit/components/workspace/model-selector-overflow.test.ts
+```
+
+Expected: both cases fail because the wrappers still include `items-start`.
+
+- [ ] **Step 3: Remove `items-start` from both selected-model wrappers**
+
+Use this wrapper in both production files:
+
+```tsx
+<div className="flex min-w-0 flex-col text-left">
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+cd frontend && python3 ../scripts/pnpm.py rstest run tests/unit/components/workspace/model-selector-overflow.test.ts
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 5: Run frontend verification**
+
+Run:
+
+```bash
+cd frontend && python3 ../scripts/pnpm.py test
+cd frontend && python3 ../scripts/pnpm.py check
+```
+
+Expected: all unit tests, lint, formatting, and type checks pass.
+
+- [ ] **Step 6: Commit the fix**
+
+```bash
+git add docs/superpowers/specs/2026-08-26-model-selector-overflow-design.md \
+  docs/superpowers/plans/2026-08-26-model-selector-overflow.md \
+  frontend/tests/unit/components/workspace/model-selector-overflow.test.ts \
+  frontend/src/components/workspace/input-box.tsx \
+  frontend/src/components/workspace/sidecar/sidecar-panel.tsx
+git commit -m "fix(frontend): truncate selected model names"
+```

--- a/docs/superpowers/specs/2026-08-26-model-selector-overflow-design.md
+++ b/docs/superpowers/specs/2026-08-26-model-selector-overflow-design.md
@@ -1,0 +1,17 @@
+# Model Selector Overflow Design
+
+## Problem
+
+Long selected-model display names can paint outside the model selector button in both the main chat composer and the sidecar composer.
+
+## Root cause
+
+Each selected-model trigger wraps `ModelSelectorName` in a `flex-col items-start` container. `items-start` prevents the name span from stretching across the container's horizontal cross axis. The span therefore keeps its content width, so its existing `truncate` styles never observe internal overflow.
+
+## Design
+
+Remove `items-start` from the two selected-model wrappers. The default flex cross-axis behavior stretches the name span to the wrapper width, allowing the existing shared `truncate` styles to render an ellipsis. Keep `text-left` for text alignment and leave the generated `ai-elements/model-selector.tsx` component unchanged.
+
+## Verification
+
+Add one source-level unit test covering both selected-model triggers. This is appropriate because happy-dom does not calculate layout widths; the regression is the presence of the specific flex alignment class that defeats truncation. Run the focused test, the complete frontend unit suite, and `pnpm check`.

--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -2673,7 +2673,7 @@ export function InputBox({
                   className="max-w-40 min-w-0 sm:max-w-56"
                   disabled={composerLocked}
                 >
-                  <div className="flex min-w-0 flex-col items-start text-left">
+                  <div className="flex min-w-0 flex-col text-left">
                     <ModelSelectorName className="text-xs font-normal">
                       {selectedModel?.display_name}
                     </ModelSelectorName>

--- a/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
+++ b/frontend/src/components/workspace/sidecar/sidecar-panel.tsx
@@ -939,7 +939,7 @@ function SidecarModelSelector({
     <ModelSelector open={open} onOpenChange={onOpenChange}>
       <ModelSelectorTrigger asChild>
         <PromptInputButton className={cn("min-w-0 px-2!", className)}>
-          <div className="flex min-w-0 flex-col items-start text-left">
+          <div className="flex min-w-0 flex-col text-left">
             <ModelSelectorName className="truncate text-xs font-normal">
               {selectedModel.display_name}
             </ModelSelectorName>

--- a/frontend/tests/unit/components/workspace/model-selector-overflow.test.ts
+++ b/frontend/tests/unit/components/workspace/model-selector-overflow.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "@rstest/core";
+
+const FRONTEND_ROOT = path.resolve(__dirname, "../../../..");
+const SELECTED_MODEL_TRIGGER_PATTERN =
+  /<ModelSelectorTrigger asChild>[\s\S]*?<\/ModelSelectorTrigger>/;
+
+function source(relativePath: string) {
+  return readFileSync(path.join(FRONTEND_ROOT, relativePath), "utf8");
+}
+
+function selectedModelTrigger(relativePath: string) {
+  return SELECTED_MODEL_TRIGGER_PATTERN.exec(source(relativePath))?.[0];
+}
+
+describe("selected model name truncation", () => {
+  it.each([
+    "src/components/workspace/input-box.tsx",
+    "src/components/workspace/sidecar/sidecar-panel.tsx",
+  ])("lets ModelSelectorName stretch in %s", (relativePath) => {
+    const trigger = selectedModelTrigger(relativePath);
+
+    expect(trigger).toContain("<ModelSelectorName");
+    expect(trigger).not.toContain("items-start");
+  });
+});


### PR DESCRIPTION
## Summary
- let selected model labels stretch to the constrained trigger width
- apply the fix to both the main composer and sidecar composer
- add regression coverage for both selected-model triggers

## Root cause
The flex-column wrappers used items-start, so ModelSelectorName kept its content width and its existing truncation styles never observed internal overflow.

## Test plan
- frontend unit suite: 1,059 tests passed
- pnpm check: ESLint and TypeScript passed
- changed files: Prettier check passed