### PR TITLE
fix(frontend): keep renamed thread titles in sync

### DIFF
--- a/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
+++ b/frontend/src/app/workspace/agents/[agent_name]/chats/[thread_id]/page.tsx
@@ -275,7 +275,11 @@ export default function AgentChatPage() {
               </div>
 
               <div className="flex min-w-0 flex-1 items-center text-sm font-medium">
-                <ThreadTitle threadId={threadId} thread={thread} />
+                <ThreadTitle
+                  threadId={threadId}
+                  thread={thread}
+                  canonicalTitle={threadMetadata.data?.values?.title}
+                />
               </div>
               <div className="flex shrink-0 items-center sm:mr-4">
                 {!isNewThread &&

--- a/frontend/src/components/workspace/chats/chat-page.tsx
+++ b/frontend/src/components/workspace/chats/chat-page.tsx
@@ -288,7 +288,11 @@ export default function ChatPage() {
             >
               {!isMock && <SidebarTrigger className="md:hidden" />}
               <div className="flex min-w-0 flex-1 items-center text-sm font-medium">
-                <ThreadTitle threadId={threadId} thread={thread} />
+                <ThreadTitle
+                  threadId={threadId}
+                  thread={thread}
+                  canonicalTitle={threadMetadata.data?.values?.title}
+                />
               </div>
               <div className="flex shrink-0 items-center gap-2">
                 {!isNewThread &&

--- a/frontend/src/components/workspace/thread-title.tsx
+++ b/frontend/src/components/workspace/thread-title.tsx
@@ -7,21 +7,27 @@ import type { AgentThreadState } from "@/core/threads";
 import { useThreadChat } from "./chats";
 import { FlipDisplay } from "./flip-display";
 
-export function ThreadTitle({
-  threadId,
-  thread,
-}: {
+export type ThreadTitleProps = {
   className?: string;
   threadId: string;
   thread: BaseStream<AgentThreadState>;
-}) {
+  canonicalTitle?: string;
+};
+
+export function ThreadTitle({
+  threadId,
+  thread,
+  canonicalTitle,
+}: ThreadTitleProps) {
   const { t } = useI18n();
   const { isNewThread } = useThreadChat();
+  const title = canonicalTitle ?? thread.values?.title;
+
   useEffect(() => {
     let _title = t.pages.untitled;
 
-    if (thread.values?.title) {
-      _title = thread.values.title;
+    if (title) {
+      _title = title;
     } else if (isNewThread) {
       _title = t.pages.newChat;
     }
@@ -36,15 +42,11 @@ export function ThreadTitle({
     t.pages.untitled,
     t.pages.appName,
     thread.isThreadLoading,
-    thread.values,
+    title,
   ]);
 
-  if (!thread.values?.title) {
+  if (!title) {
     return null;
   }
-  return (
-    <FlipDisplay uniqueKey={threadId}>
-      {thread.values.title ?? "Untitled"}
-    </FlipDisplay>
-  );
+  return <FlipDisplay uniqueKey={threadId}>{title}</FlipDisplay>;
 }

--- a/frontend/src/components/workspace/thread-title.tsx
+++ b/frontend/src/components/workspace/thread-title.tsx
@@ -21,7 +21,7 @@ export function ThreadTitle({
 }: ThreadTitleProps) {
   const { t } = useI18n();
   const { isNewThread } = useThreadChat();
-  const title = canonicalTitle ?? thread.values?.title;
+  const title = canonicalTitle?.length ? canonicalTitle : thread.values?.title;
 
   useEffect(() => {
     let _title = t.pages.untitled;

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -1733,47 +1733,10 @@ export function useThreadStream({
       );
       for (const update of updates) {
         if (update && "title" in update && update.title) {
-          void queryClient.setQueriesData(
-            {
-              queryKey: ["threads", "search"],
-              exact: false,
-            },
-            (oldData: Array<AgentThread> | undefined) => {
-              return oldData?.map((t) => {
-                if (t.thread_id === threadIdRef.current) {
-                  return {
-                    ...t,
-                    values: {
-                      ...t.values,
-                      title: update.title,
-                    },
-                  };
-                }
-                return t;
-              });
-            },
-          );
-          const nextTitle: string = update.title;
-          void queryClient.setQueriesData(
-            {
-              queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
-              exact: false,
-            },
-            (oldData: InfiniteData<AgentThread[]> | undefined) =>
-              mapInfiniteThreadsCache(
-                oldData,
-                (t): AgentThread =>
-                  t.thread_id === threadIdRef.current
-                    ? {
-                        ...t,
-                        values: {
-                          ...t.values,
-                          title: nextTitle,
-                        },
-                      }
-                    : t,
-              ),
-          );
+          const currentThreadId = threadIdRef.current;
+          if (currentThreadId) {
+            setThreadTitleInCaches(queryClient, currentThreadId, update.title);
+          }
         }
       }
     },
@@ -2846,6 +2809,16 @@ function mergeThreadMetadata(
   };
 }
 
+function mergeThreadTitle(thread: AgentThread, title: string): AgentThread {
+  return {
+    ...thread,
+    values: {
+      ...thread.values,
+      title,
+    },
+  };
+}
+
 function setThreadMetadataInCaches(
   queryClient: QueryClient,
   threadId: string,
@@ -2886,6 +2859,49 @@ function setThreadMetadataInCaches(
     },
     (oldData: AgentThread | null | undefined) =>
       oldData ? mergeThreadMetadata(oldData, metadata) : oldData,
+  );
+}
+
+export function setThreadTitleInCaches(
+  queryClient: QueryClient,
+  threadId: string,
+  title: string,
+): void {
+  queryClient.setQueriesData(
+    {
+      queryKey: ["threads", "search"],
+      exact: false,
+    },
+    (oldData: Array<AgentThread> | undefined) => {
+      if (!oldData) {
+        return oldData;
+      }
+      return oldData.map((thread) =>
+        thread.thread_id === threadId
+          ? mergeThreadTitle(thread, title)
+          : thread,
+      );
+    },
+  );
+  queryClient.setQueriesData(
+    {
+      queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
+      exact: false,
+    },
+    (oldData: InfiniteData<AgentThread[]> | undefined) =>
+      mapInfiniteThreadsCache(oldData, (thread) =>
+        thread.thread_id === threadId
+          ? mergeThreadTitle(thread, title)
+          : thread,
+      ),
+  );
+  queryClient.setQueriesData(
+    {
+      queryKey: ["thread", "metadata", threadId],
+      exact: false,
+    },
+    (oldData: AgentThread | null | undefined) =>
+      oldData ? mergeThreadTitle(oldData, title) : oldData,
   );
 }
 
@@ -3245,44 +3261,7 @@ export function useRenameThread() {
       });
     },
     onSuccess(_, { threadId, title }) {
-      queryClient.setQueriesData(
-        {
-          queryKey: ["threads", "search"],
-          exact: false,
-        },
-        (oldData: Array<AgentThread>) => {
-          return oldData.map((t) => {
-            if (t.thread_id === threadId) {
-              return {
-                ...t,
-                values: {
-                  ...t.values,
-                  title,
-                },
-              };
-            }
-            return t;
-          });
-        },
-      );
-      queryClient.setQueriesData(
-        {
-          queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
-          exact: false,
-        },
-        (oldData: InfiniteData<AgentThread[]> | undefined) =>
-          mapInfiniteThreadsCache(oldData, (t) =>
-            t.thread_id === threadId
-              ? {
-                  ...t,
-                  values: {
-                    ...t.values,
-                    title,
-                  },
-                }
-              : t,
-          ),
-      );
+      setThreadTitleInCaches(queryClient, threadId, title);
     },
   });
 }

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -3233,8 +3233,16 @@ export function useRenameThread() {
         values: { title },
       });
     },
-    onSuccess(_, { threadId, title }) {
+    async onSuccess(_, { threadId, title }) {
+      const metadataQuery = {
+        queryKey: ["thread", "metadata", threadId],
+        exact: false,
+      };
+
+      // Prevent a pre-rename metadata request from restoring the stale title.
+      await queryClient.cancelQueries(metadataQuery);
       setThreadTitleInCaches(queryClient, threadId, title);
+      void queryClient.invalidateQueries(metadataQuery);
     },
   });
 }

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -2819,53 +2819,10 @@ function mergeThreadTitle(thread: AgentThread, title: string): AgentThread {
   };
 }
 
-function setThreadMetadataInCaches(
+function setThreadInCaches(
   queryClient: QueryClient,
   threadId: string,
-  metadata: ThreadMetadataPatch,
-) {
-  queryClient.setQueriesData(
-    {
-      queryKey: ["threads", "search"],
-      exact: false,
-    },
-    (oldData: Array<AgentThread> | undefined) => {
-      if (!oldData) {
-        return oldData;
-      }
-      return oldData.map((thread) =>
-        thread.thread_id === threadId
-          ? mergeThreadMetadata(thread, metadata)
-          : thread,
-      );
-    },
-  );
-  queryClient.setQueriesData(
-    {
-      queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
-      exact: false,
-    },
-    (oldData: InfiniteData<AgentThread[]> | undefined) =>
-      mapInfiniteThreadsCache(oldData, (thread) =>
-        thread.thread_id === threadId
-          ? mergeThreadMetadata(thread, metadata)
-          : thread,
-      ),
-  );
-  queryClient.setQueriesData(
-    {
-      queryKey: ["thread", "metadata", threadId],
-      exact: false,
-    },
-    (oldData: AgentThread | null | undefined) =>
-      oldData ? mergeThreadMetadata(oldData, metadata) : oldData,
-  );
-}
-
-export function setThreadTitleInCaches(
-  queryClient: QueryClient,
-  threadId: string,
-  title: string,
+  mapper: (thread: AgentThread) => AgentThread,
 ): void {
   queryClient.setQueriesData(
     {
@@ -2877,9 +2834,7 @@ export function setThreadTitleInCaches(
         return oldData;
       }
       return oldData.map((thread) =>
-        thread.thread_id === threadId
-          ? mergeThreadTitle(thread, title)
-          : thread,
+        thread.thread_id === threadId ? mapper(thread) : thread,
       );
     },
   );
@@ -2890,9 +2845,7 @@ export function setThreadTitleInCaches(
     },
     (oldData: InfiniteData<AgentThread[]> | undefined) =>
       mapInfiniteThreadsCache(oldData, (thread) =>
-        thread.thread_id === threadId
-          ? mergeThreadTitle(thread, title)
-          : thread,
+        thread.thread_id === threadId ? mapper(thread) : thread,
       ),
   );
   queryClient.setQueriesData(
@@ -2901,7 +2854,27 @@ export function setThreadTitleInCaches(
       exact: false,
     },
     (oldData: AgentThread | null | undefined) =>
-      oldData ? mergeThreadTitle(oldData, title) : oldData,
+      oldData ? mapper(oldData) : oldData,
+  );
+}
+
+function setThreadMetadataInCaches(
+  queryClient: QueryClient,
+  threadId: string,
+  metadata: ThreadMetadataPatch,
+) {
+  setThreadInCaches(queryClient, threadId, (thread) =>
+    mergeThreadMetadata(thread, metadata),
+  );
+}
+
+export function setThreadTitleInCaches(
+  queryClient: QueryClient,
+  threadId: string,
+  title: string,
+): void {
+  setThreadInCaches(queryClient, threadId, (thread) =>
+    mergeThreadTitle(thread, title),
   );
 }
 

--- a/frontend/src/core/threads/hooks.ts
+++ b/frontend/src/core/threads/hooks.ts
@@ -4,6 +4,7 @@ import { useStream } from "@langchain/langgraph-sdk/react";
 import {
   type QueryClient,
   type InfiniteData,
+  type QueryFilters,
   useInfiniteQuery,
   useMutation,
   useQuery,
@@ -2819,16 +2820,32 @@ function mergeThreadTitle(thread: AgentThread, title: string): AgentThread {
   };
 }
 
+function getThreadSnapshotCacheFilters(threadId: string) {
+  return {
+    search: {
+      queryKey: ["threads", "search"],
+      exact: false,
+    },
+    infiniteSearch: {
+      queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
+      exact: false,
+    },
+    metadata: {
+      queryKey: ["thread", "metadata", threadId],
+      exact: false,
+    },
+  } as const;
+}
+
 function setThreadInCaches(
   queryClient: QueryClient,
   threadId: string,
   mapper: (thread: AgentThread) => AgentThread,
 ): void {
+  const filters = getThreadSnapshotCacheFilters(threadId);
+
   queryClient.setQueriesData(
-    {
-      queryKey: ["threads", "search"],
-      exact: false,
-    },
+    filters.search,
     (oldData: Array<AgentThread> | undefined) => {
       if (!oldData) {
         return oldData;
@@ -2839,20 +2856,14 @@ function setThreadInCaches(
     },
   );
   queryClient.setQueriesData(
-    {
-      queryKey: INFINITE_THREADS_QUERY_KEY_PREFIX,
-      exact: false,
-    },
+    filters.infiniteSearch,
     (oldData: InfiniteData<AgentThread[]> | undefined) =>
       mapInfiniteThreadsCache(oldData, (thread) =>
         thread.thread_id === threadId ? mapper(thread) : thread,
       ),
   );
   queryClient.setQueriesData(
-    {
-      queryKey: ["thread", "metadata", threadId],
-      exact: false,
-    },
+    filters.metadata,
     (oldData: AgentThread | null | undefined) =>
       oldData ? mapper(oldData) : oldData,
   );
@@ -3234,15 +3245,18 @@ export function useRenameThread() {
       });
     },
     async onSuccess(_, { threadId, title }) {
-      const metadataQuery = {
-        queryKey: ["thread", "metadata", threadId],
-        exact: false,
-      };
+      const filters: QueryFilters[] = Object.values(
+        getThreadSnapshotCacheFilters(threadId),
+      );
 
-      // Prevent a pre-rename metadata request from restoring the stale title.
-      await queryClient.cancelQueries(metadataQuery);
+      // Prevent pre-rename snapshot requests from restoring the stale title.
+      await Promise.all(
+        filters.map((filter) => queryClient.cancelQueries(filter)),
+      );
       setThreadTitleInCaches(queryClient, threadId, title);
-      void queryClient.invalidateQueries(metadataQuery);
+      for (const filter of filters) {
+        void queryClient.invalidateQueries(filter);
+      }
     },
   });
 }

--- a/frontend/tests/e2e/thread-title-sync.spec.ts
+++ b/frontend/tests/e2e/thread-title-sync.spec.ts
@@ -179,7 +179,6 @@ test("a stale metadata response cannot restore the old title after rename", asyn
   await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
 
   await freshMetadataRequestStarted;
-  expect(metadataRequestCount).toBeGreaterThanOrEqual(2);
   releaseFreshMetadataResponse();
   await freshMetadataResponseCompleted;
 

--- a/frontend/tests/e2e/thread-title-sync.spec.ts
+++ b/frontend/tests/e2e/thread-title-sync.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test, type BrowserContext } from "@playwright/test";
+
+import { mockLangGraphAPI } from "./utils/mock-api";
+
+const THREAD_ID = "00000000-0000-0000-0000-000000000321";
+const ORIGINAL_TITLE = "Original title";
+const RENAMED_TITLE = "Renamed title";
+
+async function ensureAuthenticated(context: BrowserContext) {
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+  const meResponse = await context.request.get(`${baseURL}/api/v1/auth/me`);
+  if (meResponse.ok()) return;
+
+  expect(meResponse.status()).toBe(401);
+
+  const email = `e2e-${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.com`;
+  const registerResponse = await context.request.post(
+    `${baseURL}/api/v1/auth/register`,
+    {
+      data: { email, password: "very-strong-password-123" },
+    },
+  );
+  expect(registerResponse.status(), await registerResponse.text()).toBe(201);
+}
+
+test.beforeEach(async ({ context }) => {
+  await ensureAuthenticated(context);
+});
+
+test("renaming a thread updates the sidebar, header, and document title", async ({
+  page,
+}) => {
+  mockLangGraphAPI(page, {
+    threads: [
+      {
+        thread_id: THREAD_ID,
+        title: ORIGINAL_TITLE,
+        updated_at: "2026-07-05T10:00:00Z",
+      },
+    ],
+  });
+
+  await page.goto(`/workspace/chats/${THREAD_ID}`);
+  await expect(page.getByText(ORIGINAL_TITLE).first()).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page).toHaveTitle(`${ORIGINAL_TITLE} - DeerFlow`);
+
+  const threadItem = page
+    .locator(
+      `a[data-sidebar="menu-button"][href="/workspace/chats/${THREAD_ID}"]`,
+    )
+    .locator("xpath=..");
+  await threadItem.hover();
+  await threadItem.getByRole("button", { name: "More" }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("textbox").fill(RENAMED_TITLE);
+  await dialog.getByRole("button", { name: "Save" }).click();
+
+  await expect(dialog).toBeHidden();
+  await expect(threadItem).toContainText(RENAMED_TITLE);
+  await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible();
+  await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
+
+  await page.reload();
+  await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
+});

--- a/frontend/tests/e2e/thread-title-sync.spec.ts
+++ b/frontend/tests/e2e/thread-title-sync.spec.ts
@@ -1,31 +1,10 @@
-import { expect, test, type BrowserContext } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { mockLangGraphAPI } from "./utils/mock-api";
 
 const THREAD_ID = "00000000-0000-0000-0000-000000000321";
 const ORIGINAL_TITLE = "Original title";
 const RENAMED_TITLE = "Renamed title";
-
-async function ensureAuthenticated(context: BrowserContext) {
-  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
-  const meResponse = await context.request.get(`${baseURL}/api/v1/auth/me`);
-  if (meResponse.ok()) return;
-
-  expect(meResponse.status()).toBe(401);
-
-  const email = `e2e-${Date.now()}-${Math.floor(Math.random() * 1e6)}@example.com`;
-  const registerResponse = await context.request.post(
-    `${baseURL}/api/v1/auth/register`,
-    {
-      data: { email, password: "very-strong-password-123" },
-    },
-  );
-  expect(registerResponse.status(), await registerResponse.text()).toBe(201);
-}
-
-test.beforeEach(async ({ context }) => {
-  await ensureAuthenticated(context);
-});
 
 test("renaming a thread updates the sidebar, header, and document title", async ({
   page,
@@ -65,6 +44,7 @@ test("renaming a thread updates the sidebar, header, and document title", async 
   await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
 
   await page.reload();
+  await expect(threadItem).toContainText(RENAMED_TITLE);
   await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible({
     timeout: 15_000,
   });

--- a/frontend/tests/e2e/thread-title-sync.spec.ts
+++ b/frontend/tests/e2e/thread-title-sync.spec.ts
@@ -50,3 +50,140 @@ test("renaming a thread updates the sidebar, header, and document title", async 
   });
   await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
 });
+
+test("a stale metadata response cannot restore the old title after rename", async ({
+  page,
+}) => {
+  mockLangGraphAPI(page, {
+    threads: [
+      {
+        thread_id: THREAD_ID,
+        title: ORIGINAL_TITLE,
+        updated_at: "2026-07-05T10:00:00Z",
+      },
+    ],
+  });
+
+  let releaseStaleMetadataResponse!: () => void;
+  const staleMetadataResponseGate = new Promise<void>((resolve) => {
+    releaseStaleMetadataResponse = resolve;
+  });
+  let markStaleMetadataRequestStarted!: () => void;
+  const staleMetadataRequestStarted = new Promise<void>((resolve) => {
+    markStaleMetadataRequestStarted = resolve;
+  });
+  let markStaleMetadataResponseCompleted!: () => void;
+  const staleMetadataResponseCompleted = new Promise<void>((resolve) => {
+    markStaleMetadataResponseCompleted = resolve;
+  });
+  let releaseFreshMetadataResponse!: () => void;
+  const freshMetadataResponseGate = new Promise<void>((resolve) => {
+    releaseFreshMetadataResponse = resolve;
+  });
+  let markFreshMetadataRequestStarted!: () => void;
+  const freshMetadataRequestStarted = new Promise<void>((resolve) => {
+    markFreshMetadataRequestStarted = resolve;
+  });
+  let markFreshMetadataResponseCompleted!: () => void;
+  const freshMetadataResponseCompleted = new Promise<void>((resolve) => {
+    markFreshMetadataResponseCompleted = resolve;
+  });
+  let delayMetadataResponses = false;
+  let metadataRequestCount = 0;
+
+  await page.route("**/api/langgraph/threads/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (
+      route.request().method() !== "GET" ||
+      url.pathname !== `/api/langgraph/threads/${THREAD_ID}`
+    ) {
+      return route.fallback();
+    }
+
+    if (!delayMetadataResponses) {
+      return route.fallback();
+    }
+
+    metadataRequestCount += 1;
+    if (metadataRequestCount > 1) {
+      markFreshMetadataRequestStarted();
+      await freshMetadataResponseGate;
+      await route.fallback();
+      markFreshMetadataResponseCompleted();
+      return;
+    }
+
+    markStaleMetadataRequestStarted();
+    await staleMetadataResponseGate;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        thread_id: THREAD_ID,
+        created_at: "2026-07-05T10:00:00Z",
+        updated_at: "2026-07-05T10:00:00Z",
+        metadata: {},
+        status: "idle",
+        values: { title: ORIGINAL_TITLE, goal: null },
+      }),
+    });
+    markStaleMetadataResponseCompleted();
+  });
+
+  await page.goto(`/workspace/chats/${THREAD_ID}`);
+  await expect(page.locator("header").getByText(ORIGINAL_TITLE)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  delayMetadataResponses = true;
+  await page.getByRole("link", { name: "Chats", exact: true }).click();
+  await expect(page).toHaveURL(/\/workspace\/chats$/);
+  await page
+    .locator(
+      `a[data-sidebar="menu-button"][href="/workspace/chats/${THREAD_ID}"]`,
+    )
+    .click();
+  await staleMetadataRequestStarted;
+
+  const threadItem = page
+    .locator(
+      `a[data-sidebar="menu-button"][href="/workspace/chats/${THREAD_ID}"]`,
+    )
+    .locator("xpath=..");
+  await expect(threadItem).toContainText(ORIGINAL_TITLE);
+  await threadItem.hover();
+  await threadItem.getByRole("button", { name: "More" }).click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await dialog.getByRole("textbox").fill(RENAMED_TITLE);
+  await dialog.getByRole("button", { name: "Save" }).click();
+  await expect(dialog).toBeHidden();
+  await expect(threadItem).toContainText(RENAMED_TITLE);
+  await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible();
+  await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
+
+  releaseStaleMetadataResponse();
+  await staleMetadataResponseCompleted;
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+
+  // The stale response has completed while the fresh refetch is still blocked.
+  // The title must remain renamed without relying on the refetch to repair it.
+  await expect(threadItem).toContainText(RENAMED_TITLE);
+  await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible();
+  await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
+
+  await freshMetadataRequestStarted;
+  expect(metadataRequestCount).toBeGreaterThanOrEqual(2);
+  releaseFreshMetadataResponse();
+  await freshMetadataResponseCompleted;
+
+  await expect(threadItem).toContainText(RENAMED_TITLE);
+  await expect(page.locator("header").getByText(RENAMED_TITLE)).toBeVisible();
+  await expect(page).toHaveTitle(`${RENAMED_TITLE} - DeerFlow`);
+});

--- a/frontend/tests/e2e/utils/mock-api.ts
+++ b/frontend/tests/e2e/utils/mock-api.ts
@@ -375,6 +375,18 @@ export function mockLangGraphAPI(page: Page, options?: MockAPIOptions) {
     return updated;
   };
 
+  const patchThreadTitle = (threadId: string, title: string) => {
+    let updated: MockThread | undefined;
+    threads = threads.map((thread) => {
+      if (thread.thread_id !== threadId) {
+        return thread;
+      }
+      updated = { ...thread, title };
+      return updated;
+    });
+    return updated;
+  };
+
   // Auth — keep workspace tests independent from a real gateway session.
   void page.route("**/api/v1/auth/me", (route) => {
     if (route.request().method() === "GET") {
@@ -1054,9 +1066,13 @@ export function mockLangGraphAPI(page: Page, options?: MockAPIOptions) {
 
   // Thread state — getState for individual thread
   void page.route("**/api/langgraph/threads/*/state", (route) => {
+    const url = new URL(route.request().url());
+    const threadId = decodeURIComponent(url.pathname.split("/").at(-2) ?? "");
+    const matchingThread = threads.find(
+      (thread) => thread.thread_id === threadId,
+    );
+
     if (route.request().method() === "GET") {
-      const url = route.request().url();
-      const matchingThread = threads.find((t) => url.includes(t.thread_id));
       return route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -1083,6 +1099,33 @@ export function mockLangGraphAPI(page: Page, options?: MockAPIOptions) {
           next: [],
           metadata: {},
           created_at: "2025-01-01T00:00:00Z",
+        }),
+      });
+    }
+    if (route.request().method() === "POST") {
+      const body = route.request().postDataJSON() as {
+        values?: { title?: unknown };
+      };
+      const updated =
+        typeof body.values?.title === "string"
+          ? patchThreadTitle(threadId, body.values.title)
+          : matchingThread;
+      if (!updated) {
+        return route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "Thread not found" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          configurable: {
+            thread_id: threadId,
+            checkpoint_ns: "",
+            checkpoint_id: "mock-checkpoint",
+          },
         }),
       });
     }

--- a/frontend/tests/unit/components/workspace/thread-title.dom.test.tsx
+++ b/frontend/tests/unit/components/workspace/thread-title.dom.test.tsx
@@ -1,0 +1,61 @@
+import type { BaseStream } from "@langchain/langgraph-sdk";
+import { afterEach, expect, rs, test } from "@rstest/core";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import { ThreadTitle } from "@/components/workspace/thread-title";
+import type { AgentThreadState } from "@/core/threads";
+
+rs.mock("@/core/i18n/hooks", () => ({
+  useI18n: () => ({
+    t: {
+      pages: {
+        appName: "DeerFlow",
+        newChat: "New chat",
+        untitled: "Untitled",
+      },
+    },
+  }),
+}));
+
+rs.mock("@/components/workspace/chats", () => ({
+  useThreadChat: () => ({ isNewThread: false }),
+}));
+
+rs.mock("@/components/workspace/flip-display", () => ({
+  FlipDisplay: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+function makeThread(title: string): BaseStream<AgentThreadState> {
+  return {
+    isThreadLoading: false,
+    values: { title },
+  } as unknown as BaseStream<AgentThreadState>;
+}
+
+afterEach(() => {
+  cleanup();
+  document.title = "";
+});
+
+test("prefers the canonical metadata title over a stale stream title", () => {
+  const { container } = render(
+    <ThreadTitle
+      threadId="thread-1"
+      thread={makeThread("Stream title")}
+      canonicalTitle="Renamed title"
+    />,
+  );
+
+  expect(container.textContent).toBe("Renamed title");
+  expect(document.title).toBe("Renamed title - DeerFlow");
+});
+
+test("falls back to the stream title when metadata is unavailable", () => {
+  const { container } = render(
+    <ThreadTitle threadId="thread-1" thread={makeThread("Stream title")} />,
+  );
+
+  expect(container.textContent).toBe("Stream title");
+  expect(document.title).toBe("Stream title - DeerFlow");
+});

--- a/frontend/tests/unit/components/workspace/thread-title.dom.test.tsx
+++ b/frontend/tests/unit/components/workspace/thread-title.dom.test.tsx
@@ -59,3 +59,16 @@ test("falls back to the stream title when metadata is unavailable", () => {
   expect(container.textContent).toBe("Stream title");
   expect(document.title).toBe("Stream title - DeerFlow");
 });
+
+test("falls back to the stream title when metadata title is empty", () => {
+  const { container } = render(
+    <ThreadTitle
+      threadId="thread-1"
+      thread={makeThread("Stream title")}
+      canonicalTitle=""
+    />,
+  );
+
+  expect(container.textContent).toBe("Stream title");
+  expect(document.title).toBe("Stream title - DeerFlow");
+});

--- a/frontend/tests/unit/core/threads/rename-thread.dom.test.tsx
+++ b/frontend/tests/unit/core/threads/rename-thread.dom.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, expect, rs, test } from "@rstest/core";
+import {
+  type InfiniteData,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+
+const apiMocks = rs.hoisted(() => ({
+  updateState: rs.fn(),
+}));
+
+rs.mock("@/core/api", () => ({
+  getAPIClient: () => ({
+    threads: {
+      updateState: apiMocks.updateState,
+    },
+  }),
+}));
+
+import {
+  INFINITE_THREADS_QUERY_KEY_PREFIX,
+  useRenameThread,
+} from "@/core/threads/hooks";
+import { DEFAULT_THREAD_SEARCH_PARAMS } from "@/core/threads/thread-search-query";
+import type { AgentThread } from "@/core/threads/types";
+
+const THREAD_ID = "thread-1";
+const ORIGINAL_TITLE = "Original title";
+const RENAMED_TITLE = "Renamed title";
+
+function makeThread(title: string): AgentThread {
+  return {
+    thread_id: THREAD_ID,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    metadata: {},
+    status: "idle",
+    values: { title },
+  } as unknown as AgentThread;
+}
+
+function createDelayedResult<T>(value: T) {
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let markCompleted!: () => void;
+  const completed = new Promise<void>((resolve) => {
+    markCompleted = resolve;
+  });
+
+  return {
+    completed,
+    queryFn: async () => {
+      markStarted();
+      await gate;
+      markCompleted();
+      return value;
+    },
+    release,
+    started,
+  };
+}
+
+function readSearchTitle(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+) {
+  return queryClient.getQueryData<AgentThread[]>(queryKey)?.[0]?.values.title;
+}
+
+function readInfiniteSearchTitle(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+) {
+  return queryClient.getQueryData<InfiniteData<AgentThread[]>>(queryKey)
+    ?.pages[0]?.[0]?.values.title;
+}
+
+test("stale list responses cannot restore the old title after rename", async () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const infiniteParams = {
+    sortBy: "updated_at",
+    sortOrder: "desc",
+    select: ["thread_id", "updated_at", "values", "metadata"],
+  };
+  const searchKey = [
+    "threads",
+    "search",
+    DEFAULT_THREAD_SEARCH_PARAMS,
+  ] as const;
+  const infiniteSearchKey = [
+    ...INFINITE_THREADS_QUERY_KEY_PREFIX,
+    infiniteParams,
+  ] as const;
+  const originalThread = makeThread(ORIGINAL_TITLE);
+  const staleSearch = createDelayedResult([originalThread]);
+  const staleInfiniteSearch = createDelayedResult([originalThread]);
+
+  queryClient.setQueryData(searchKey, [originalThread]);
+  queryClient.setQueryData<InfiniteData<AgentThread[]>>(infiniteSearchKey, {
+    pages: [[originalThread]],
+    pageParams: [0],
+  });
+
+  const searchFetch = queryClient
+    .fetchQuery({
+      queryKey: searchKey,
+      queryFn: staleSearch.queryFn,
+    })
+    .catch(() => undefined);
+  const infiniteSearchFetch = queryClient
+    .fetchInfiniteQuery({
+      queryKey: infiniteSearchKey,
+      initialPageParam: 0,
+      queryFn: staleInfiniteSearch.queryFn,
+      getNextPageParam: () => undefined,
+    })
+    .catch(() => undefined);
+
+  await Promise.all([staleSearch.started, staleInfiniteSearch.started]);
+  apiMocks.updateState.mockResolvedValue(undefined);
+  const { result } = renderHook(() => useRenameThread(), { wrapper });
+
+  await act(async () => {
+    await result.current.mutateAsync({
+      threadId: THREAD_ID,
+      title: RENAMED_TITLE,
+    });
+  });
+
+  expect(readSearchTitle(queryClient, searchKey)).toBe(RENAMED_TITLE);
+  expect(readInfiniteSearchTitle(queryClient, infiniteSearchKey)).toBe(
+    RENAMED_TITLE,
+  );
+
+  staleSearch.release();
+  staleInfiniteSearch.release();
+  await Promise.all([staleSearch.completed, staleInfiniteSearch.completed]);
+  await Promise.all([searchFetch, infiniteSearchFetch]);
+
+  expect(readSearchTitle(queryClient, searchKey)).toBe(RENAMED_TITLE);
+  expect(readInfiniteSearchTitle(queryClient, infiniteSearchKey)).toBe(
+    RENAMED_TITLE,
+  );
+
+  queryClient.clear();
+});
+
+beforeEach(() => {
+  apiMocks.updateState.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
Fixes bytedance/deer-flow#5043

## Why

Renaming an open thread updates the recent-chat entry, but the active chat header and document title can continue to show the previous title until the thread is reloaded. This leaves different parts of the UI displaying different titles for the same thread.

## What changed

- Centralized title updates across search results, infinite thread lists, and per-thread metadata caches.
- Made `ThreadTitle` prefer the canonical metadata title while retaining the stream title as a fallback.
- Passed canonical metadata titles through both regular and agent chat pages.
- Added unit and E2E regression tests for sidebar, header, document-title, and reload consistency.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — renamed thread titles now update consistently without a reload
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not included. The affected interaction is covered by the focused E2E regression test.

## Bug fix verification

- Test path that reproduces the affected flow: `frontend/tests/e2e/thread-title-sync.spec.ts`
- Additional component coverage: `frontend/tests/unit/components/workspace/thread-title.dom.test.tsx`
- Did it go red on `main` and green on this branch? No separate clean-`main` red run was captured; the regression flow is encoded in the added tests and passes on this branch.

## Validation

- Pre-commit ESLint and Prettier hooks passed.
- `pnpm check` passed.
- Targeted frontend unit tests passed (29/29).
- `pnpm build` passed.
- `pnpm exec playwright test --workers=1` passed (145/145).

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codebase analysis, implementation, regression-test creation, local validation, and PR preparation.

- [x] I have read and understand every line of this change and take responsibility for it — it is not unreviewed AI output.