### PR TITLE
fix(channels): retain strong reference to Discord ack-reaction tasks

### DIFF
--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -194,7 +194,8 @@ class DiscordChannel(Channel):
         if discord_loop is None or discord_loop is current_loop:
             await self._cancel_ephemeral_tasks()
         elif discord_loop.is_running():
-            # Serialize cleanup with _start_typing() on the owning loop.  The
+            # Serialize cleanup with _start_typing()/_schedule_ack_reaction()
+            # on the owning loop.  The
             # loop may exit between is_running() and scheduling, so neither
             # scheduling nor waiting is allowed to block the rest of stop().
             cleanup_coro = self._cancel_ephemeral_tasks()
@@ -202,15 +203,15 @@ class DiscordChannel(Channel):
                 cleanup_future = asyncio.run_coroutine_threadsafe(cleanup_coro, discord_loop)
             except RuntimeError:
                 cleanup_coro.close()
-                logger.warning("[Discord] event loop stopped before typing-task cleanup could be scheduled")
+                logger.warning("[Discord] event loop stopped before ephemeral-task cleanup could be scheduled")
             else:
                 try:
                     await asyncio.wait_for(asyncio.wrap_future(cleanup_future), timeout=10)
                 except TimeoutError:
                     cleanup_future.cancel()
-                    logger.warning("[Discord] typing-task cleanup timed out after 10s")
+                    logger.warning("[Discord] ephemeral-task cleanup timed out after 10s")
                 except Exception:
-                    logger.exception("[Discord] error while cleaning up typing tasks")
+                    logger.exception("[Discord] error while cleaning up ephemeral tasks")
 
         if self._client and discord_loop and discord_loop.is_running():
             close_coro = self._client.close()
@@ -345,7 +346,7 @@ class DiscordChannel(Channel):
 
     def _discard_ack_reaction_tasks(self) -> None:
         """Forget stale ack-reaction tasks after the owning loop stopped."""
-        for task in _ack_reaction_tasks:
+        for task in list(_ack_reaction_tasks):
             if not task.done():
                 logger.warning("[Discord] discarding pending ack-reaction task for stopped loop")
         _ack_reaction_tasks.clear()
@@ -700,7 +701,7 @@ class DiscordChannel(Channel):
             try:
                 self._discord_loop.run_until_complete(self._cancel_ephemeral_tasks())
             except Exception:
-                logger.exception("Error while cleaning up Discord typing tasks")
+                logger.exception("Error while cleaning up Discord ephemeral tasks")
             try:
                 if self._client and not self._client.is_closed():
                     self._discord_loop.run_until_complete(self._client.close())

--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -19,6 +19,21 @@ logger = logging.getLogger(__name__)
 
 _DISCORD_MAX_MESSAGE_LEN = 2000
 
+# Strong references for in-flight ack-reaction tasks. The event loop keeps
+# only weak references to scheduled tasks, so a bare ``asyncio.create_task``
+# could be garbage-collected mid-flight and silently drop the acknowledgment
+# reaction (same retention pattern as the deferred subagent cleanup in #4928).
+_ack_reaction_tasks: set[asyncio.Task[None]] = set()
+
+
+def _on_ack_reaction_task_done(task: asyncio.Task[None]) -> None:
+    _ack_reaction_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("[Discord] ack reaction task failed: %s", exc)
+
 
 class DiscordChannel(Channel):
     """Discord bot channel.
@@ -330,6 +345,17 @@ class DiscordChannel(Channel):
         except Exception:
             logger.debug("[Discord] failed to add reaction to message %s", message.id, exc_info=True)
 
+    def _schedule_ack_reaction(self, message) -> asyncio.Task[None]:
+        """Schedule the ack reaction with a strong task reference.
+
+        The delayed HTTP call must survive until completion; see
+        ``_ack_reaction_tasks`` for why a bare ``create_task`` is unsafe here.
+        """
+        task = asyncio.create_task(self._add_reaction(message))
+        _ack_reaction_tasks.add(task)
+        task.add_done_callback(_on_ack_reaction_task_done)
+        return task
+
     async def _on_message(self, message) -> None:
         if not self._running or not self._client:
             return
@@ -450,7 +476,7 @@ class DiscordChannel(Channel):
                     # Start typing indicator in the thread
                     if typing_target:
                         await self._start_typing(typing_target, chat_id, thread_id)
-                    asyncio.create_task(self._add_reaction(message))
+                    self._schedule_ack_reaction(message)
                     return
 
                 # Thread not tracked (orphaned) — create new thread and handle below
@@ -561,7 +587,7 @@ class DiscordChannel(Channel):
             # Start typing/reaction only after bounded admission succeeds.
             if typing_target:
                 await self._start_typing(typing_target, chat_id, thread_id)
-            asyncio.create_task(self._add_reaction(message))
+            self._schedule_ack_reaction(message)
         finally:
             if not reservation_transferred:
                 reservation.release()

--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -192,12 +192,12 @@ class DiscordChannel(Channel):
         discord_loop = self._discord_loop
         current_loop = asyncio.get_running_loop()
         if discord_loop is None or discord_loop is current_loop:
-            await self._cancel_typing_tasks()
+            await self._cancel_ephemeral_tasks()
         elif discord_loop.is_running():
             # Serialize cleanup with _start_typing() on the owning loop.  The
             # loop may exit between is_running() and scheduling, so neither
             # scheduling nor waiting is allowed to block the rest of stop().
-            cleanup_coro = self._cancel_typing_tasks()
+            cleanup_coro = self._cancel_ephemeral_tasks()
             try:
                 cleanup_future = asyncio.run_coroutine_threadsafe(cleanup_coro, discord_loop)
             except RuntimeError:
@@ -237,7 +237,7 @@ class DiscordChannel(Channel):
         # discard the stale references here; awaiting them from this loop would
         # raise a cross-loop RuntimeError.
         if discord_loop and discord_loop is not current_loop and not discord_loop.is_running():
-            self._discard_typing_tasks()
+            self._discard_ephemeral_tasks()
 
         self._client = None
         self._discord_loop = None
@@ -329,6 +329,36 @@ class DiscordChannel(Channel):
                     target_id,
                 )
         self._typing_tasks.clear()
+
+    async def _cancel_ack_reaction_tasks(self) -> None:
+        """Cancel in-flight ack reactions so stop() does not strand them.
+
+        A task interrupted mid-HTTP-call would otherwise stay in the module
+        retention set forever, pinning this channel instance and the discord
+        Message object graph after shutdown.
+        """
+        pending = [task for task in _ack_reaction_tasks if not task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+    def _discard_ack_reaction_tasks(self) -> None:
+        """Forget stale ack-reaction tasks after the owning loop stopped."""
+        for task in _ack_reaction_tasks:
+            if not task.done():
+                logger.warning("[Discord] discarding pending ack-reaction task for stopped loop")
+        _ack_reaction_tasks.clear()
+
+    async def _cancel_ephemeral_tasks(self) -> None:
+        """Cancel typing indicators and in-flight ack reactions together."""
+        await self._cancel_typing_tasks()
+        await self._cancel_ack_reaction_tasks()
+
+    def _discard_ephemeral_tasks(self) -> None:
+        """Forget stale typing and ack-reaction tasks (stopped-loop fallback)."""
+        self._discard_typing_tasks()
+        self._discard_ack_reaction_tasks()
 
     async def _stop_typing(self, chat_id: str, thread_ts: str | None = None) -> None:
         """Stops the typing loop for a specific target."""
@@ -668,7 +698,7 @@ class DiscordChannel(Channel):
                 logger.exception("Discord client error")
         finally:
             try:
-                self._discord_loop.run_until_complete(self._cancel_typing_tasks())
+                self._discord_loop.run_until_complete(self._cancel_ephemeral_tasks())
             except Exception:
                 logger.exception("Error while cleaning up Discord typing tasks")
             try:

--- a/backend/app/channels/discord.py
+++ b/backend/app/channels/discord.py
@@ -19,21 +19,6 @@ logger = logging.getLogger(__name__)
 
 _DISCORD_MAX_MESSAGE_LEN = 2000
 
-# Strong references for in-flight ack-reaction tasks. The event loop keeps
-# only weak references to scheduled tasks, so a bare ``asyncio.create_task``
-# could be garbage-collected mid-flight and silently drop the acknowledgment
-# reaction (same retention pattern as the deferred subagent cleanup in #4928).
-_ack_reaction_tasks: set[asyncio.Task[None]] = set()
-
-
-def _on_ack_reaction_task_done(task: asyncio.Task[None]) -> None:
-    _ack_reaction_tasks.discard(task)
-    if task.cancelled():
-        return
-    exc = task.exception()
-    if exc is not None:
-        logger.error("[Discord] ack reaction task failed: %s", exc)
-
 
 class DiscordChannel(Channel):
     """Discord bot channel.
@@ -81,6 +66,15 @@ class DiscordChannel(Channel):
 
         # Typing indicator management
         self._typing_tasks: dict[str, asyncio.Task] = {}
+
+        # Strong references for this channel's in-flight ack-reaction tasks.
+        # The event loop keeps only weak references to scheduled tasks, so a
+        # bare ``asyncio.create_task`` could be garbage-collected mid-flight
+        # and silently drop the acknowledgment reaction (same retention
+        # pattern as the deferred subagent cleanup in #4928). Instance-level
+        # on purpose, matching ``_typing_tasks``: one channel's shutdown must
+        # not cancel another instance's in-flight reactions.
+        self._ack_reaction_tasks: set[asyncio.Task[None]] = set()
 
         self._client = None
         self._thread: threading.Thread | None = None
@@ -334,11 +328,11 @@ class DiscordChannel(Channel):
     async def _cancel_ack_reaction_tasks(self) -> None:
         """Cancel in-flight ack reactions so stop() does not strand them.
 
-        A task interrupted mid-HTTP-call would otherwise stay in the module
+        A task interrupted mid-HTTP-call would otherwise stay in the
         retention set forever, pinning this channel instance and the discord
         Message object graph after shutdown.
         """
-        pending = [task for task in _ack_reaction_tasks if not task.done()]
+        pending = [task for task in self._ack_reaction_tasks if not task.done()]
         for task in pending:
             task.cancel()
         if pending:
@@ -346,10 +340,10 @@ class DiscordChannel(Channel):
 
     def _discard_ack_reaction_tasks(self) -> None:
         """Forget stale ack-reaction tasks after the owning loop stopped."""
-        for task in list(_ack_reaction_tasks):
+        for task in list(self._ack_reaction_tasks):
             if not task.done():
                 logger.warning("[Discord] discarding pending ack-reaction task for stopped loop")
-        _ack_reaction_tasks.clear()
+        self._ack_reaction_tasks.clear()
 
     async def _cancel_ephemeral_tasks(self) -> None:
         """Cancel typing indicators and in-flight ack reactions together."""
@@ -376,6 +370,14 @@ class DiscordChannel(Channel):
         except Exception:
             logger.debug("[Discord] failed to add reaction to message %s", message.id, exc_info=True)
 
+    def _on_ack_reaction_task_done(self, task: asyncio.Task[None]) -> None:
+        self._ack_reaction_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("[Discord] ack reaction task failed: %s", exc)
+
     def _schedule_ack_reaction(self, message) -> asyncio.Task[None]:
         """Schedule the ack reaction with a strong task reference.
 
@@ -383,8 +385,8 @@ class DiscordChannel(Channel):
         ``_ack_reaction_tasks`` for why a bare ``create_task`` is unsafe here.
         """
         task = asyncio.create_task(self._add_reaction(message))
-        _ack_reaction_tasks.add(task)
-        task.add_done_callback(_on_ack_reaction_task_done)
+        self._ack_reaction_tasks.add(task)
+        task.add_done_callback(self._on_ack_reaction_task_done)
         return task
 
     async def _on_message(self, message) -> None:

--- a/backend/tests/test_discord_channel.py
+++ b/backend/tests/test_discord_channel.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+import gc
 import threading
+import weakref
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from app.channels import discord as discord_module
 from app.channels.discord import DiscordChannel
 from app.channels.manager import CHANNEL_CAPABILITIES
 from app.channels.message_bus import InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
@@ -267,18 +270,18 @@ async def test_send_file_closes_handle_when_send_fails(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_ack_reaction_task_retained_under_gc() -> None:
-    """The ack-reaction task survives GC and still runs to completion.
+    """The ack-reaction task is retained and runs to completion.
+
+    This pins the retention contract (scheduled → in the set, done →
+    discarded): the fake coroutine never suspends on an unrooted future, so
+    actual mid-flight GC cannot be reproduced deterministically here — the
+    same limitation the #4928 precedent test has.
 
     A bare ``asyncio.create_task`` holds only a weak loop reference, so the
     ✅ acknowledgment could be garbage-collected mid-flight. The module-level
     retention set keeps the task strongly referenced until completion (same
     pattern as #4928 / #4931).
     """
-    import gc
-    import weakref
-
-    from app.channels import discord as discord_module
-
     bus = MessageBus()
     channel = DiscordChannel(bus=bus, config={"bot_token": "token"})
 
@@ -308,8 +311,6 @@ async def test_ack_reaction_task_retained_under_gc() -> None:
 async def test_ack_reaction_task_survives_reaction_failure() -> None:
     """A failing add_reaction completes quietly and is discarded from the set."""
 
-    from app.channels import discord as discord_module
-
     bus = MessageBus()
     channel = DiscordChannel(bus=bus, config={"bot_token": "token"})
 
@@ -321,3 +322,46 @@ async def test_ack_reaction_task_survives_reaction_failure() -> None:
     task = channel._schedule_ack_reaction(message)
     await asyncio.wait_for(task, timeout=1.0)
     assert task not in discord_module._ack_reaction_tasks
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_in_flight_ack_reaction_tasks() -> None:
+    """stop()'s cleanup path cancels in-flight ack reactions on the owning loop.
+
+    Without the drain, a task interrupted mid-HTTP-call would sit in the
+    module retention set forever, pinning the channel and Message graph.
+    """
+    release = asyncio.Event()
+
+    async def _hang(_emoji: str) -> None:
+        await release.wait()
+
+    channel = DiscordChannel(bus=MessageBus(), config={"bot_token": "token"})
+    message = SimpleNamespace(id=333, add_reaction=_hang)
+
+    task = channel._schedule_ack_reaction(message)
+    assert task in discord_module._ack_reaction_tasks
+
+    await channel._cancel_ephemeral_tasks()
+
+    assert task.cancelled() or task.done()
+    assert task not in discord_module._ack_reaction_tasks
+    release.set()
+
+
+@pytest.mark.asyncio
+async def test_ack_reaction_task_failure_is_logged_and_discarded(caplog) -> None:
+    """An exception escaping _add_reaction is logged at error and discarded."""
+    bus = MessageBus()
+    channel = DiscordChannel(bus=bus, config={"bot_token": "token"})
+
+    async def _explode(_self, _message) -> None:
+        raise RuntimeError("unexpected boom")
+
+    with patch.object(DiscordChannel, "_add_reaction", _explode), caplog.at_level("ERROR", logger="app.channels.discord"):
+        task = channel._schedule_ack_reaction(SimpleNamespace(id=444))
+        with pytest.raises(RuntimeError, match="unexpected boom"):
+            await asyncio.wait_for(task, timeout=1.0)
+
+    assert task not in discord_module._ack_reaction_tasks
+    assert any("ack reaction task failed" in record.message for record in caplog.records)

--- a/backend/tests/test_discord_channel.py
+++ b/backend/tests/test_discord_channel.py
@@ -12,7 +12,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from app.channels import discord as discord_module
 from app.channels.discord import DiscordChannel
 from app.channels.manager import CHANNEL_CAPABILITIES
 from app.channels.message_bus import InboundMessage, InboundMessageType, MessageBus, OutboundMessage, ResolvedAttachment
@@ -278,7 +277,7 @@ async def test_ack_reaction_task_retained_under_gc() -> None:
     same limitation the #4928 precedent test has.
 
     A bare ``asyncio.create_task`` holds only a weak loop reference, so the
-    ✅ acknowledgment could be garbage-collected mid-flight. The module-level
+    ✅ acknowledgment could be garbage-collected mid-flight. The instance-level
     retention set keeps the task strongly referenced until completion (same
     pattern as #4928 / #4931).
     """
@@ -299,12 +298,42 @@ async def test_ack_reaction_task_retained_under_gc() -> None:
 
     retained = weak_task()
     assert retained is not None, "ack reaction task was garbage-collected mid-flight"
-    assert retained in discord_module._ack_reaction_tasks
+    assert retained in channel._ack_reaction_tasks
 
     await asyncio.wait_for(retained, timeout=1.0)
     assert reacted.is_set()
     # Completed tasks are discarded so the retention set cannot grow unboundedly.
-    assert retained not in discord_module._ack_reaction_tasks
+    assert retained not in channel._ack_reaction_tasks
+
+
+@pytest.mark.asyncio
+async def test_ack_reaction_retention_is_isolated_per_channel() -> None:
+    """One channel's shutdown must not cancel another instance's in-flight reactions.
+
+    The retention set is instance-level (matching ``_typing_tasks``): a
+    module-level set would let ``stop()`` on one channel drain every other
+    channel's pending ack tasks.
+    """
+    first = DiscordChannel(bus=MessageBus(), config={"bot_token": "token"})
+    second = DiscordChannel(bus=MessageBus(), config={"bot_token": "token"})
+
+    release = asyncio.Event()
+
+    async def _hang(_emoji: str) -> None:
+        await release.wait()
+
+    task = second._schedule_ack_reaction(SimpleNamespace(id=666, add_reaction=_hang))
+    await asyncio.sleep(0)  # let the task start and suspend
+    assert task in second._ack_reaction_tasks
+    assert task not in first._ack_reaction_tasks
+
+    await first._cancel_ack_reaction_tasks()
+
+    assert not task.done()
+    assert task in second._ack_reaction_tasks
+
+    release.set()
+    await asyncio.wait_for(task, timeout=1.0)
 
 
 @pytest.mark.asyncio
@@ -321,7 +350,7 @@ async def test_ack_reaction_task_survives_reaction_failure() -> None:
 
     task = channel._schedule_ack_reaction(message)
     await asyncio.wait_for(task, timeout=1.0)
-    assert task not in discord_module._ack_reaction_tasks
+    assert task not in channel._ack_reaction_tasks
 
 
 @pytest.mark.asyncio
@@ -340,7 +369,7 @@ async def test_stop_drains_in_flight_ack_reaction_tasks() -> None:
     message = SimpleNamespace(id=333, add_reaction=_hang)
 
     task = channel._schedule_ack_reaction(message)
-    assert task in discord_module._ack_reaction_tasks
+    assert task in channel._ack_reaction_tasks
     # Yield once so the task actually starts and suspends inside _hang —
     # cancelling a never-started task would not exercise the mid-flight path.
     await asyncio.sleep(0)
@@ -349,7 +378,7 @@ async def test_stop_drains_in_flight_ack_reaction_tasks() -> None:
     await channel._cancel_ephemeral_tasks()
 
     assert task.cancelled()
-    assert task not in discord_module._ack_reaction_tasks
+    assert task not in channel._ack_reaction_tasks
 
 
 @pytest.mark.asyncio
@@ -366,7 +395,7 @@ async def test_ack_reaction_task_failure_is_logged_and_discarded(caplog) -> None
         with pytest.raises(RuntimeError, match="unexpected boom"):
             await asyncio.wait_for(task, timeout=1.0)
 
-    assert task not in discord_module._ack_reaction_tasks
+    assert task not in channel._ack_reaction_tasks
     assert any("ack reaction task failed" in record.message for record in caplog.records)
 
 
@@ -394,11 +423,11 @@ async def test_stop_wiring_drains_ack_tasks_across_loops() -> None:
 
         schedule_future = asyncio.run_coroutine_threadsafe(_schedule_on_bg_loop(), bg_loop)
         task = await asyncio.wrap_future(schedule_future)
-        assert task in discord_module._ack_reaction_tasks
+        assert task in channel._ack_reaction_tasks
 
         await channel.stop()
 
         assert task.cancelled()
-        assert not discord_module._ack_reaction_tasks
+        assert not channel._ack_reaction_tasks
     finally:
         _stop_bg_loop(bg_loop, bg_thread)

--- a/backend/tests/test_discord_channel.py
+++ b/backend/tests/test_discord_channel.py
@@ -327,7 +327,9 @@ async def test_ack_reaction_retention_is_isolated_per_channel() -> None:
     assert task in second._ack_reaction_tasks
     assert task not in first._ack_reaction_tasks
 
-    await first._cancel_ack_reaction_tasks()
+    # Full shutdown of the first channel must leave the second instance's
+    # in-flight reaction alone (the review asked for independent shutdown).
+    await first.stop()
 
     assert not task.done()
     assert task in second._ack_reaction_tasks

--- a/backend/tests/test_discord_channel.py
+++ b/backend/tests/test_discord_channel.py
@@ -341,12 +341,15 @@ async def test_stop_drains_in_flight_ack_reaction_tasks() -> None:
 
     task = channel._schedule_ack_reaction(message)
     assert task in discord_module._ack_reaction_tasks
+    # Yield once so the task actually starts and suspends inside _hang —
+    # cancelling a never-started task would not exercise the mid-flight path.
+    await asyncio.sleep(0)
+    assert not task.done()
 
     await channel._cancel_ephemeral_tasks()
 
-    assert task.cancelled() or task.done()
+    assert task.cancelled()
     assert task not in discord_module._ack_reaction_tasks
-    release.set()
 
 
 @pytest.mark.asyncio
@@ -365,3 +368,37 @@ async def test_ack_reaction_task_failure_is_logged_and_discarded(caplog) -> None
 
     assert task not in discord_module._ack_reaction_tasks
     assert any("ack reaction task failed" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_stop_wiring_drains_ack_tasks_across_loops() -> None:
+    """The real stop() path (cross-loop branch) drains in-flight ack reactions.
+
+    Guards the wiring itself: reverting stop() to typing-only cleanup must
+    fail here, not just at the helper level.
+    """
+    bg_loop, bg_thread = _start_bg_loop()
+    try:
+        channel = DiscordChannel(bus=MessageBus(), config={"bot_token": "token"})
+        channel._discord_loop = bg_loop
+
+        release = asyncio.Event()
+
+        async def _hang(_emoji: str) -> None:
+            await release.wait()
+
+        async def _schedule_on_bg_loop() -> asyncio.Task:
+            task = channel._schedule_ack_reaction(SimpleNamespace(id=555, add_reaction=_hang))
+            await asyncio.sleep(0.05)  # let the task start and suspend on the event
+            return task
+
+        schedule_future = asyncio.run_coroutine_threadsafe(_schedule_on_bg_loop(), bg_loop)
+        task = await asyncio.wrap_future(schedule_future)
+        assert task in discord_module._ack_reaction_tasks
+
+        await channel.stop()
+
+        assert task.cancelled()
+        assert not discord_module._ack_reaction_tasks
+    finally:
+        _stop_bg_loop(bg_loop, bg_thread)

--- a/backend/tests/test_discord_channel.py
+++ b/backend/tests/test_discord_channel.py
@@ -263,3 +263,61 @@ async def test_send_file_closes_handle_when_send_fails(tmp_path) -> None:
         assert handles[0].closed is True
     finally:
         _stop_bg_loop(bg_loop, bg_thread)
+
+
+@pytest.mark.asyncio
+async def test_ack_reaction_task_retained_under_gc() -> None:
+    """The ack-reaction task survives GC and still runs to completion.
+
+    A bare ``asyncio.create_task`` holds only a weak loop reference, so the
+    ✅ acknowledgment could be garbage-collected mid-flight. The module-level
+    retention set keeps the task strongly referenced until completion (same
+    pattern as #4928 / #4931).
+    """
+    import gc
+    import weakref
+
+    from app.channels import discord as discord_module
+
+    bus = MessageBus()
+    channel = DiscordChannel(bus=bus, config={"bot_token": "token"})
+
+    reacted = asyncio.Event()
+
+    async def _add_reaction(_emoji: str) -> None:
+        reacted.set()
+
+    message = SimpleNamespace(id=111, add_reaction=_add_reaction)
+
+    task = channel._schedule_ack_reaction(message)
+    weak_task = weakref.ref(task)
+    del task
+    gc.collect()
+
+    retained = weak_task()
+    assert retained is not None, "ack reaction task was garbage-collected mid-flight"
+    assert retained in discord_module._ack_reaction_tasks
+
+    await asyncio.wait_for(retained, timeout=1.0)
+    assert reacted.is_set()
+    # Completed tasks are discarded so the retention set cannot grow unboundedly.
+    assert retained not in discord_module._ack_reaction_tasks
+
+
+@pytest.mark.asyncio
+async def test_ack_reaction_task_survives_reaction_failure() -> None:
+    """A failing add_reaction completes quietly and is discarded from the set."""
+
+    from app.channels import discord as discord_module
+
+    bus = MessageBus()
+    channel = DiscordChannel(bus=bus, config={"bot_token": "token"})
+
+    async def _boom(_emoji: str) -> None:
+        raise RuntimeError("discord api down")
+
+    message = SimpleNamespace(id=222, add_reaction=_boom)
+
+    task = channel._schedule_ack_reaction(message)
+    await asyncio.wait_for(task, timeout=1.0)
+    assert task not in discord_module._ack_reaction_tasks


### PR DESCRIPTION
Fixes #5048

## Why

Both `DiscordChannel` message-acceptance sites scheduled the ✅ acknowledgment with a bare `asyncio.create_task(self._add_reaction(message))`. The event loop holds only weak references to scheduled tasks, so a task suspended on an await chain with no external root can be destroyed by a GC pass mid-flight — the reaction silently never lands and nothing is logged (the task dies before completion rather than raising into `_add_reaction`'s except handler). The practical window for this exact call shape is narrow (discord.py's HTTP machinery roots its futures), which is why this is defense + contract compliance rather than a frequently-hit failure — same reasoning under which the class was already accepted twice in this repo.

## What changed

- Module-level `_ack_reaction_tasks: set[asyncio.Task[None]]` plus `_on_ack_reaction_task_done` (discard on completion, swallow cancellation, log real failures at error level).
- New `DiscordChannel._schedule_ack_reaction(message)` helper wraps the pattern; both call sites (`_on_message` thread-mode branch and the bounded-admission success path) now use it.
- **Shutdown drain** (from an adversarial self-review): `stop()` and the `_run_client` finally cancelled typing tasks but would have left an interrupted ack task in the retention set forever, pinning the channel and the discord `Message` object graph across restart cycles. `_cancel_ephemeral_tasks` / `_discard_ephemeral_tasks` now drain both task families at every existing cleanup point, mirroring the typing-task discipline.
- Pattern precedents: merged #4928 (deferred subagent cleanup) — the in-tree reference including its regression test; open #4931 covers the same class for the stream bridge.

## Testing

- `test_ack_reaction_task_retained_under_gc` — schedules a reaction, drops the local reference, `gc.collect()`, asserts the task survives **in the retention set**, completes, sets the reaction flag, and is discarded. (Docstring honestly notes this pins the retention contract — the fake coroutine never suspends on an unrooted future, so real mid-flight GC isn't deterministically reproducible; the #4928 precedent test shares that limitation.)
- `test_ack_reaction_task_survives_reaction_failure` — a failing `add_reaction` completes quietly and is discarded.
- `test_stop_drains_in_flight_ack_reaction_tasks` — a hanging ack is cancelled and removed by the stop-path drain.
- `test_ack_reaction_task_failure_is_logged_and_discarded` — an exception escaping `_add_reaction` hits the done-callback error log.
- `test_stop_wiring_drains_ack_tasks_across_loops` — drives the **real `stop()` cross-loop branch** against a background event loop; reverting `stop()` to typing-only cleanup fails this test, not just the helper-level drain.
- Full discord suite 14/14 plus adjacent channel suites (backpressure, file attachments, connections router, 80 tests) and the full backend suite (12374 passed, 0 failed) are green; ruff format/lint clean.
