### PR TITLE
fix(frontend): format structured upload error details

### DIFF
--- a/frontend/src/core/uploads/api.ts
+++ b/frontend/src/core/uploads/api.ts
@@ -37,12 +37,85 @@ export interface UploadLimits {
   max_total_size: number;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatValidationIssue(issue: unknown): string | null {
+  if (!isRecord(issue) || typeof issue.msg !== "string") {
+    return null;
+  }
+
+  if (issue.msg.trim().length === 0) {
+    return null;
+  }
+
+  const location = Array.isArray(issue.loc)
+    ? issue.loc
+        .filter(
+          (part): part is string | number =>
+            typeof part === "string" || typeof part === "number",
+        )
+        .map(String)
+        .filter((part) => part.length > 0)
+        .join(".")
+    : "";
+
+  return location.length > 0 ? `${location}: ${issue.msg}` : issue.msg;
+}
+
+function serializeStructuredDetail(
+  detail: Record<string, unknown> | unknown[],
+): string | null {
+  if (
+    (Array.isArray(detail) && detail.length === 0) ||
+    (!Array.isArray(detail) && Object.keys(detail).length === 0)
+  ) {
+    return null;
+  }
+
+  try {
+    return JSON.stringify(detail);
+  } catch {
+    return null;
+  }
+}
+
+function formatErrorDetail(detail: unknown): string | null {
+  if (typeof detail === "string") {
+    return detail.trim().length > 0 ? detail : null;
+  }
+
+  if (Array.isArray(detail)) {
+    if (detail.length === 0) {
+      return null;
+    }
+
+    const validationIssues = detail.map(formatValidationIssue);
+    if (validationIssues.every((issue) => issue !== null)) {
+      return validationIssues.join("; ");
+    }
+
+    return serializeStructuredDetail(detail);
+  }
+
+  if (isRecord(detail)) {
+    return formatValidationIssue(detail) ?? serializeStructuredDetail(detail);
+  }
+
+  return null;
+}
+
 async function readErrorDetail(
   response: Response,
   fallback: string,
 ): Promise<string> {
-  const error = await response.json().catch(() => ({ detail: fallback }));
-  return error.detail ?? fallback;
+  const error = (await response.json().catch(() => null)) as unknown;
+  if (!isRecord(error)) {
+    return fallback;
+  }
+
+  return formatErrorDetail(error.detail) ?? fallback;
 }
 
 /**

--- a/frontend/src/core/uploads/api.ts
+++ b/frontend/src/core/uploads/api.ts
@@ -42,7 +42,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function formatValidationIssue(issue: unknown): string | null {
-  if (!isRecord(issue) || typeof issue.msg !== "string") {
+  if (
+    !isRecord(issue) ||
+    typeof issue.msg !== "string" ||
+    !Array.isArray(issue.loc)
+  ) {
     return null;
   }
 
@@ -50,16 +54,14 @@ function formatValidationIssue(issue: unknown): string | null {
     return null;
   }
 
-  const location = Array.isArray(issue.loc)
-    ? issue.loc
-        .filter(
-          (part): part is string | number =>
-            typeof part === "string" || typeof part === "number",
-        )
-        .map(String)
-        .filter((part) => part.length > 0)
-        .join(".")
-    : "";
+  const location = issue.loc
+    .filter(
+      (part): part is string | number =>
+        typeof part === "string" || typeof part === "number",
+    )
+    .map(String)
+    .filter((part) => part.length > 0)
+    .join(".");
 
   return location.length > 0 ? `${location}: ${issue.msg}` : issue.msg;
 }

--- a/frontend/tests/e2e/chat.spec.ts
+++ b/frontend/tests/e2e/chat.spec.ts
@@ -1060,6 +1060,45 @@ test.describe("Chat workspace", () => {
     await expect(page.getByRole("tooltip")).toContainText("100 MiB");
   });
 
+  test("shows structured upload errors as readable messages", async ({
+    page,
+  }) => {
+    await page.route("**/api/threads/*/uploads", (route) =>
+      route.fulfill({
+        status: 422,
+        contentType: "application/json",
+        body: JSON.stringify({
+          detail: [
+            {
+              type: "missing",
+              loc: ["body", "files"],
+              msg: "Field required",
+              input: null,
+            },
+          ],
+        }),
+      }),
+    );
+
+    await page.goto("/workspace/chats/new");
+    const textarea = page.getByPlaceholder(/how can i assist you/i);
+    await expect(textarea).toBeVisible({ timeout: 15_000 });
+
+    await page.getByLabel("Upload files").setInputFiles({
+      name: "report.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("report"),
+    });
+    await textarea.fill("Summarize this report");
+    await textarea.press("Enter");
+
+    const errorToast = page
+      .locator("[data-sonner-toast]")
+      .filter({ hasText: "body.files: Field required" });
+    await expect(errorToast).toBeVisible();
+    await expect(errorToast).not.toContainText("[object Object]");
+  });
+
   test("rejects an oversized attachment before upload", async ({ page }) => {
     let uploadCalled = false;
     await page.route("**/api/threads/*/uploads", (route) => {

--- a/frontend/tests/unit/core/uploads/api.test.ts
+++ b/frontend/tests/unit/core/uploads/api.test.ts
@@ -88,6 +88,27 @@ describe("uploads api", () => {
   });
 
   test.each([
+    [
+      "object",
+      { msg: "Archive rejected", code: "invalid_archive", retryable: false },
+      '{"msg":"Archive rejected","code":"invalid_archive","retryable":false}',
+    ],
+    [
+      "array",
+      [{ msg: "Archive rejected", code: "invalid_archive", retryable: false }],
+      '[{"msg":"Archive rejected","code":"invalid_archive","retryable":false}]',
+    ],
+  ])(
+    "serializes a generic %s detail containing msg without a validation loc",
+    async (_label, detail, expected) => {
+      const error = await uploadError(jsonResponse(400, { detail }));
+
+      expect(error.message).toBe(expected);
+      expect(error.message).not.toContain("[object Object]");
+    },
+  );
+
+  test.each([
     ["missing", {}],
     ["null", { detail: null }],
     ["blank string", { detail: "   " }],

--- a/frontend/tests/unit/core/uploads/api.test.ts
+++ b/frontend/tests/unit/core/uploads/api.test.ts
@@ -9,7 +9,7 @@ rs.mock("@/core/config", () => ({
 }));
 
 import { fetch as fetcher } from "@/core/api/fetcher";
-import { deleteUploadedFile } from "@/core/uploads/api";
+import { deleteUploadedFile, uploadFiles } from "@/core/uploads/api";
 
 const mockedFetch = rs.mocked(fetcher);
 
@@ -21,11 +21,96 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+async function uploadError(response: Response): Promise<Error> {
+  mockedFetch.mockResolvedValueOnce(response);
+
+  let thrown: unknown;
+  try {
+    await uploadFiles("thread-1", []);
+  } catch (error) {
+    thrown = error;
+  }
+
+  expect(thrown).toBeInstanceOf(Error);
+  return thrown as Error;
+}
+
 beforeEach(() => {
   mockedFetch.mockReset();
 });
 
 describe("uploads api", () => {
+  test("preserves string error details", async () => {
+    const error = await uploadError(
+      jsonResponse(413, { detail: "File exceeds the upload limit" }),
+    );
+
+    expect(error.message).toBe("File exceeds the upload limit");
+  });
+
+  test("formats FastAPI validation error details", async () => {
+    const error = await uploadError(
+      jsonResponse(422, {
+        detail: [
+          {
+            type: "missing",
+            loc: ["body", "files"],
+            msg: "Field required",
+            input: null,
+          },
+          {
+            type: "value_error",
+            loc: ["body", "files", 0],
+            msg: "File is empty",
+            input: "",
+          },
+        ],
+      }),
+    );
+
+    expect(error.message).toBe(
+      "body.files: Field required; body.files.0: File is empty",
+    );
+    expect(error.message).not.toContain("[object Object]");
+  });
+
+  test("serializes object error details", async () => {
+    const error = await uploadError(
+      jsonResponse(400, {
+        detail: { code: "invalid_archive", reason: "Archive is corrupt" },
+      }),
+    );
+
+    expect(error.message).toBe(
+      '{"code":"invalid_archive","reason":"Archive is corrupt"}',
+    );
+    expect(error.message).not.toContain("[object Object]");
+  });
+
+  test.each([
+    ["missing", {}],
+    ["null", { detail: null }],
+    ["blank string", { detail: "   " }],
+    ["empty array", { detail: [] }],
+    ["empty object", { detail: {} }],
+    ["unexpected scalar", { detail: 42 }],
+  ])("uses the upload fallback for %s detail", async (_label, body) => {
+    const error = await uploadError(jsonResponse(400, body));
+
+    expect(error.message).toBe("Upload failed");
+  });
+
+  test("uses the upload fallback for non-JSON responses", async () => {
+    const error = await uploadError(
+      new Response("Bad Gateway", {
+        status: 502,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    expect(error.message).toBe("Upload failed");
+  });
+
   test("encodes uploaded filenames in delete request paths", async () => {
     mockedFetch.mockResolvedValueOnce(
       jsonResponse(200, {


### PR DESCRIPTION
## Why

Chat attachment upload failures can currently surface as `[object Object]` when the backend returns a structured `detail` value, such as a FastAPI validation error. This hides the actionable message and makes upload failures harder to diagnose.

This follows up on #1113, which introduced the shared upload error reader but only handled string details safely.

## Root cause

`readErrorDetail()` returned `error.detail` directly. When `detail` was an object or array, passing it to `new Error(...)` triggered JavaScript's implicit string conversion and produced `[object Object]`.

## What changed

- Preserve non-empty string details unchanged.
- Format FastAPI validation issues using their location and message.
- Serialize other non-empty object and array details as JSON.
- Use the operation-specific fallback for missing, null, blank, empty, non-JSON, or unexpected scalar details.
- Add focused unit coverage and a Chat E2E regression test that verifies the user-visible toast never contains `[object Object]`.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — upload failures now display structured backend details correctly
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

After: the Chat upload failure toast shows the readable FastAPI validation message while preserving the existing layout.

<img width="1280" height="720" alt="Chat upload failure showing a readable FastAPI validation message" src="https://github.com/user-attachments/assets/e027dbc6-8f2b-452d-b9d5-40522869e62f" />

## Bug fix verification

- Test paths:
  - `frontend/tests/unit/core/uploads/api.test.ts`
  - `frontend/tests/e2e/chat.spec.ts`
- Did it go red on `main` and green on this branch? **Yes.**
- The regression cases fail against the upstream implementation and pass on this branch.

## Validation

- `pnpm format` — passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `BETTER_AUTH_SECRET=local-dev-secret pnpm build` — passed
- `make test` — 1,074 tests passed
- `make test-e2e` — 146 tests passed

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex assisted with parts of the implementation and test coverage; the changes were reviewed and refined manually.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.