### PR TITLE
feat(community): add Playwright web_fetch provider

### DIFF
--- a/backend/packages/harness/deerflow/community/playwright/__init__.py
+++ b/backend/packages/harness/deerflow/community/playwright/__init__.py
@@ -1,0 +1,3 @@
+from .tools import web_fetch_tool
+
+__all__ = ["web_fetch_tool"]

--- a/backend/packages/harness/deerflow/community/playwright/tools.py
+++ b/backend/packages/harness/deerflow/community/playwright/tools.py
@@ -1,0 +1,169 @@
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+
+from langchain.tools import tool
+
+from deerflow.community.url_safety import validate_public_http_url
+from deerflow.config import get_app_config
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PLAYWRIGHT_ENDPOINT = "http://localhost:3000/scrape"
+DEFAULT_WAIT_FOR_MS = 3_000
+DEFAULT_TIMEOUT_S = 120.0
+DEFAULT_MAX_CHARS = 20_000
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_DELAY_S = 2.0
+RETRYABLE_HTTP_STATUS_CODES = {408, 425, 429, 500, 502, 503, 504}
+
+
+def _get_tool_config(tool_name: str) -> dict:
+    config = get_app_config().get_tool_config(tool_name)
+    return dict(config.model_extra or {}) if config is not None else {}
+
+
+def _coerce_bool(value: object, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _coerce_int(value: object, default: int, *, minimum: int = 0, maximum: int | None = None) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    if parsed < minimum:
+        return default
+    if maximum is not None and parsed > maximum:
+        return maximum
+    return parsed
+
+
+def _coerce_float(value: object, default: float, *, minimum: float = 0.0) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > minimum else default
+
+
+def _truncate(value: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(value) <= max_chars:
+        return value
+    return f"{value[:max_chars]}\n\n[truncated to {max_chars} characters]"
+
+
+def _extract_response_content(raw: str, fallback_status: int) -> tuple[str, int]:
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw, fallback_status
+
+    if not isinstance(parsed, dict):
+        return raw, fallback_status
+
+    status = parsed.get("pageStatusCode") or parsed.get("statusCode") or parsed.get("status") or fallback_status
+    content = parsed.get("markdown") or parsed.get("content") or parsed.get("html") or ""
+    return str(content), _coerce_int(status, fallback_status)
+
+
+def _fetch_with_playwright(
+    url: str,
+    *,
+    endpoint: str,
+    wait_for_ms: int,
+    timeout_s: float,
+    retries: int,
+    retry_delay_s: float,
+) -> tuple[str, int]:
+    payload = json.dumps({"url": url, "waitFor": wait_for_ms}).encode("utf-8")
+    last_error: Exception | None = None
+
+    total_attempts = retries + 1
+    attempts_made = 0
+    for attempt in range(total_attempts):
+        attempts_made = attempt + 1
+        try:
+            request = urllib.request.Request(
+                endpoint,
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=timeout_s) as response:
+                raw = response.read().decode("utf-8", "replace")
+                return _extract_response_content(raw, response.status)
+        except urllib.error.HTTPError as exc:
+            last_error = exc
+            if exc.code not in RETRYABLE_HTTP_STATUS_CODES or attempt >= total_attempts - 1:
+                break
+            time.sleep(retry_delay_s)
+        except (TimeoutError, urllib.error.URLError) as exc:
+            last_error = exc
+            if attempt >= total_attempts - 1:
+                break
+            time.sleep(retry_delay_s)
+
+    return f"Error: Playwright fetch failed after {attempts_made} attempt(s): {last_error}", 0
+
+
+def _fetch_with_config(tool_name: str, url: str, wait_for: int | None) -> tuple[str, int, int]:
+    cfg = _get_tool_config(tool_name)
+    allow_private_addresses = _coerce_bool(cfg.get("allow_private_addresses"), False)
+    url_error = validate_public_http_url(url, allow_private_addresses=allow_private_addresses, action="fetch")
+    if url_error:
+        return url_error, 0, _coerce_int(cfg.get("max_chars"), DEFAULT_MAX_CHARS, minimum=0)
+
+    wait_for_ms = wait_for if wait_for is not None else _coerce_int(cfg.get("wait_for_ms", cfg.get("waitFor")), DEFAULT_WAIT_FOR_MS)
+    wait_for_ms = _coerce_int(wait_for_ms, DEFAULT_WAIT_FOR_MS, minimum=0, maximum=60_000)
+    timeout_s = _coerce_float(cfg.get("timeout_s"), DEFAULT_TIMEOUT_S)
+    retries = _coerce_int(cfg.get("retries"), DEFAULT_RETRIES, minimum=0, maximum=10)
+    retry_delay_s = _coerce_float(cfg.get("retry_delay_s"), DEFAULT_RETRY_DELAY_S)
+    max_chars = _coerce_int(cfg.get("max_chars"), DEFAULT_MAX_CHARS, minimum=0)
+    endpoint = str(cfg.get("base_url") or DEFAULT_PLAYWRIGHT_ENDPOINT)
+
+    content, status = _fetch_with_playwright(
+        url,
+        endpoint=endpoint,
+        wait_for_ms=wait_for_ms,
+        timeout_s=timeout_s,
+        retries=retries,
+        retry_delay_s=retry_delay_s,
+    )
+    return content, status, max_chars
+
+
+@tool("web_fetch", parse_docstring=True)
+def web_fetch_tool(url: str, wait_for: int | None = None) -> str:
+    """Fetch rendered content from a public page through a self-hosted Playwright HTTP service.
+
+    Use this provider for JavaScript-heavy pages where a plain HTTP fetch cannot obtain rendered content.
+
+    Args:
+        url: The full http(s) URL to fetch.
+        wait_for: Optional milliseconds to wait after page load before capture.
+    """
+    try:
+        content, status, max_chars = _fetch_with_config("web_fetch", url, wait_for)
+        if status == 0:
+            return content
+        if not 200 <= status < 300 or not content:
+            return f"Error: no content (status={status})"
+        return _truncate(content, max_chars)
+    except Exception as exc:
+        logger.exception("Error in web_fetch_tool")
+        return f"Error: {exc}"

--- a/backend/tests/test_playwright_tools.py
+++ b/backend/tests/test_playwright_tools.py
@@ -1,0 +1,181 @@
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _config(**extra):
+    cfg = MagicMock()
+    cfg.model_extra = extra
+    return cfg
+
+
+def test_playwright_web_fetch_uses_config_and_truncates():
+    from deerflow.community.playwright import tools
+
+    def get_tool_config(name):
+        if name == "web_fetch":
+            return _config(
+                base_url="http://playwright:3000/scrape",
+                wait_for_ms=1234,
+                timeout_s=9,
+                retries=0,
+                max_chars=10,
+            )
+        return None
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps({"content": "abcdefghijklmnopqrstuvwxyz", "pageStatusCode": 200}).encode()
+    response.__enter__.return_value = response
+
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.urllib.request.urlopen", return_value=response) as mock_urlopen,
+    ):
+        mock_get_app_config.return_value.get_tool_config.side_effect = get_tool_config
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert result == "abcdefghij\n\n[truncated to 10 characters]"
+    mock_get_app_config.return_value.get_tool_config.assert_called_with("web_fetch")
+    request = mock_urlopen.call_args.args[0]
+    assert request.full_url == "http://playwright:3000/scrape"
+    assert request.get_method() == "POST"
+    assert request.headers["Content-type"] == "application/json"
+    assert mock_urlopen.call_args.kwargs["timeout"] == 9
+    assert json.loads(request.data.decode()) == {"url": "https://example.com/page", "waitFor": 1234}
+
+
+def test_playwright_web_fetch_prefers_markdown_content():
+    from deerflow.community.playwright import tools
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps(
+        {
+            "html": "<h1>Rendered HTML</h1>",
+            "content": "Rendered text",
+            "markdown": "# Rendered markdown",
+            "pageStatusCode": 200,
+        }
+    ).encode()
+    response.__enter__.return_value = response
+
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.urllib.request.urlopen", return_value=response),
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config(retries=0)
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert result == "# Rendered markdown"
+
+
+def test_playwright_web_fetch_rejects_json_without_content():
+    from deerflow.community.playwright import tools
+
+    response = MagicMock()
+    response.status = 200
+    response.read.return_value = json.dumps({"status": 200}).encode()
+    response.__enter__.return_value = response
+
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.urllib.request.urlopen", return_value=response),
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config(retries=0)
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert result == "Error: no content (status=200)"
+
+
+def test_playwright_web_fetch_retries_after_initial_attempt():
+    from deerflow.community.playwright import tools
+
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.time.sleep") as mock_sleep,
+        patch(
+            "deerflow.community.playwright.tools.urllib.request.urlopen",
+            side_effect=tools.urllib.error.URLError("temporary failure"),
+        ) as mock_urlopen,
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config(retries=2, retry_delay_s=0.01)
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert mock_urlopen.call_count == 3
+    assert mock_sleep.call_count == 2
+    assert result.startswith("Error: Playwright fetch failed after 3 attempt(s):")
+
+
+def test_playwright_web_fetch_does_not_retry_non_retryable_http_error():
+    from deerflow.community.playwright import tools
+
+    error = tools.urllib.error.HTTPError(
+        url="http://playwright:3000/scrape",
+        code=400,
+        msg="Bad Request",
+        hdrs=None,
+        fp=None,
+    )
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.time.sleep") as mock_sleep,
+        patch("deerflow.community.playwright.tools.urllib.request.urlopen", side_effect=error) as mock_urlopen,
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config(retries=2, retry_delay_s=0.01)
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert mock_urlopen.call_count == 1
+    assert mock_sleep.call_count == 0
+    assert result.startswith("Error: Playwright fetch failed after 1 attempt(s):")
+
+
+def test_playwright_web_fetch_retries_retryable_http_error():
+    from deerflow.community.playwright import tools
+
+    error = tools.urllib.error.HTTPError(
+        url="http://playwright:3000/scrape",
+        code=503,
+        msg="Service Unavailable",
+        hdrs=None,
+        fp=None,
+    )
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value=None),
+        patch("deerflow.community.playwright.tools.time.sleep") as mock_sleep,
+        patch("deerflow.community.playwright.tools.urllib.request.urlopen", side_effect=error) as mock_urlopen,
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config(retries=2, retry_delay_s=0.01)
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert mock_urlopen.call_count == 3
+    assert mock_sleep.call_count == 2
+    assert result.startswith("Error: Playwright fetch failed after 3 attempt(s):")
+
+
+def test_playwright_web_fetch_rejects_private_url_by_default():
+    from deerflow.community.playwright import tools
+
+    with patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config:
+        mock_get_app_config.return_value.get_tool_config.return_value = _config()
+        result = tools.web_fetch_tool.invoke({"url": "http://127.0.0.1/admin"})
+
+    assert result.startswith("Error: Refusing to fetch")
+
+
+def test_playwright_web_fetch_returns_validation_error_verbatim():
+    from deerflow.community.playwright import tools
+
+    with (
+        patch("deerflow.community.playwright.tools.get_app_config") as mock_get_app_config,
+        patch("deerflow.community.playwright.tools.validate_public_http_url", return_value="Blocked by policy"),
+    ):
+        mock_get_app_config.return_value.get_tool_config.return_value = _config()
+        result = tools.web_fetch_tool.invoke({"url": "https://example.com/page"})
+
+    assert result == "Blocked by policy"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -832,6 +832,19 @@ tools:
   #   # wait_for_timeout_ms: 2000        # Extra wait after page load in milliseconds
   #   # wait_for_selector: "article"     # CSS selector to wait for before returning
 
+  # Web fetch tool (uses a self-hosted Playwright HTTP service).
+  # Use for JavaScript-rendered pages. Enable only one web_fetch provider.
+  # Service API: POST {url, waitFor}; returns content/html/markdown.
+  # - name: web_fetch
+  #   group: web
+  #   use: deerflow.community.playwright.tools:web_fetch_tool
+  #   base_url: http://localhost:3000/scrape  # Docker: use a Gateway-reachable service URL
+  #   wait_for_ms: 3000
+  #   timeout_s: 120
+  #   retries: 3  # Additional retries after the first attempt
+  #   max_chars: 20000
+  #   # allow_private_addresses: false  # SSRF guard; keep false in production.
+
   # Web fetch tool (uses Crawl4AI - self-hosted headless Chromium, no third-party API key)
   # Crawl4AI returns server-cleaned "fit" markdown directly (no readability step needed),
   # ideal for JavaScript-heavy sites. Self-host it:


### PR DESCRIPTION
## Why

Some web pages require JavaScript rendering before their useful content is available. The existing `web_fetch` providers work well for many pages, but a self-hosted Playwright service gives operators an opt-in fallback for rendered-page fetching without changing the default DeerFlow behavior.

This PR adds Playwright as an optional `web_fetch` provider that users can enable in `config.yaml` when they need JavaScript-rendered page content.

## What changed

- Added an optional Playwright-backed `web_fetch` provider under `deerflow.community.playwright`.
- The provider sends `POST {url, waitFor}` to a configured Playwright scrape endpoint.
- The provider reads config from the standard `web_fetch` tool entry.
- Markdown output is preferred over plain content and HTML when the service returns structured JSON.
- URL validation blocks private/internal URLs by default unless explicitly allowed.
- Retry behavior now treats `retries` as additional attempts after the first request and only retries retryable HTTP failures.
- Added a commented `config.example.yaml` block showing how to enable the provider.
- Added unit tests for config lookup, payload shape, markdown preference, empty JSON handling, retry behavior, URL validation, and truncation.