### PR TITLE
fix(mcp): reject unsafe request-scoped header values

### DIFF
--- a/backend/packages/harness/deerflow/mcp/context_headers.py
+++ b/backend/packages/harness/deerflow/mcp/context_headers.py
@@ -77,6 +77,25 @@ def _request_secrets(request: Any) -> dict[str, str]:
     return extract_request_secrets(getattr(runtime, "context", None))
 
 
+def _is_safe_header_value(value: str) -> bool:
+    """Return whether a request-scoped secret is safe to pass as an HTTP header.
+
+    Reject values that the HTTP transport may reject while echoing the original
+    bytes in its exception. Credential values should not contain control
+    characters or surrounding whitespace, and httpx encodes header strings as
+    Latin-1 before handing them to the HTTP protocol implementation.
+    """
+    if value != value.strip():
+        return False
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        return False
+    try:
+        value.encode("latin-1")
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
 def build_context_headers_interceptor(extensions_config: ExtensionsConfig) -> Any | None:
     """Build a tool interceptor injecting per-request headers, or ``None``.
 
@@ -128,14 +147,32 @@ def build_context_headers_interceptor(extensions_config: ExtensionsConfig) -> An
         secrets = _request_secrets(request)
         resolved: dict[str, str] = {}
         missing: list[str] = []
+        invalid: list[str] = []
         for header_name, secret_key in context_headers.headers.items():
             # Empty string covers a caller-side `$ENV_VAR` that was unset: an
             # empty credential must fail closed rather than send an empty header.
             value = secrets.get(secret_key, "")
-            if value:
+            if value and _is_safe_header_value(value):
                 resolved[header_name] = value
+            elif value:
+                invalid.append(secret_key)
             else:
                 missing.append(secret_key)
+
+        if invalid:
+            invalid_keys = ", ".join(sorted(invalid))
+            logger.warning(
+                "Denied MCP tool call to server '%s': request-scoped credential(s) %s contain invalid HTTP header characters or surrounding whitespace",
+                request.server_name,
+                invalid_keys,
+            )
+            # Never include the invalid value itself. HTTP client/protocol
+            # exceptions may echo rejected header bytes, which would move a
+            # request-scoped secret into model-visible tool errors and traces.
+            raise ToolException(
+                f"MCP server '{request.server_name}' received invalid request-scoped credential(s) {invalid_keys}. "
+                "Remove control characters or surrounding whitespace from the configured secret value."
+            )
 
         if missing and context_headers.on_missing == "deny":
             missing_keys = ", ".join(sorted(missing))

--- a/backend/tests/test_mcp_context_header_validation.py
+++ b/backend/tests/test_mcp_context_header_validation.py
@@ -1,0 +1,67 @@
+"""Regression tests for request-scoped MCP credential header validation."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.tools import ToolException
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest
+
+from deerflow.config.extensions_config import ExtensionsConfig, McpContextHeadersConfig, McpServerConfig
+from deerflow.mcp.context_headers import _is_safe_header_value, build_context_headers_interceptor
+
+
+def _config() -> ExtensionsConfig:
+    return ExtensionsConfig(
+        mcp_servers={
+            "shared-http": McpServerConfig(
+                enabled=True,
+                type="http",
+                url="https://mcp.example.com/mcp",
+                headers_from_context=McpContextHeadersConfig(headers={"Authorization": "tenant_token"}),
+            )
+        },
+        skills={},
+    )
+
+
+def _request(secret: str) -> MCPToolCallRequest:
+    runtime = SimpleNamespace(context={"secrets": {"tenant_token": secret}, "thread_id": "th-1"})
+    return MCPToolCallRequest(name="act", args={}, server_name="shared-http", headers=None, runtime=runtime)
+
+
+async def _echo_handler(request: MCPToolCallRequest) -> MCPToolCallRequest:
+    return request
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Bearer secret\n",
+        "Bearer secret\r",
+        "Bearer secret\x00",
+        " Bearer secret",
+        "Bearer secret ",
+        "Bearer secret\tvalue",
+        "Bearer secret-€",
+    ],
+)
+def test_unsafe_header_values_are_rejected(value: str):
+    assert _is_safe_header_value(value) is False
+
+
+def test_normal_credential_header_value_is_allowed():
+    assert _is_safe_header_value("Bearer tenant-scoped-token") is True
+
+
+def test_invalid_secret_fails_closed_without_echoing_value():
+    secret = "Bearer sk-tenant-secret-abc123\n"
+    interceptor = build_context_headers_interceptor(_config())
+
+    with pytest.raises(ToolException) as exc_info:
+        asyncio.run(interceptor(_request(secret), _echo_handler))
+
+    message = str(exc_info.value)
+    assert "tenant_token" in message
+    assert secret not in message
+    assert "sk-tenant-secret-abc123" not in message


### PR DESCRIPTION
<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Fixes #5065

## Why

Request-scoped MCP secrets can contain malformed header values. If those values reach the HTTP transport, downstream exceptions may echo the malformed credential text. This can expose secret material in logs or error messages.

## What changed

- Reject request-scoped MCP header values containing control characters or newlines.
- Reject surrounding whitespace and values that cannot be represented safely as Latin-1 HTTP header content.
- Raise validation errors that identify only the configured secret key name, never the secret value.
- Add regression coverage for unsafe values.

## Surface area

- [x] **Backend API**
- [ ] **Docs / tests / CI only**  <!-- only keep this checked if you consider the test portion separately; otherwise leave unchecked -->

## Bug fix verification

Test path: the new MCP header-validation regression test in this PR.

Executable tests were not run locally through the connected integration, so I am not claiming local green status. Upstream CI should validate the branch.

## Validation

Source, issue context, duplicate PRs, and the focused diff were inspected. No executable tests or lint were run locally.

## AI assistance

**Tool(s) used:** OpenAI GPT-5.6 Sol

**How you used it:** Assisted with issue analysis, implementation, regression-test design, and diff review.
