### PR TITLE
test(gateway): sweep mcp_tasks and subagent_batches in thread_id route contract, fixes #5061

### DIFF
--- a/backend/tests/test_thread_id_route_contract.py
+++ b/backend/tests/test_thread_id_route_contract.py
@@ -73,16 +73,31 @@ def _collect_thread_id_routes():
         artifacts,
         browser,
         feedback,
+        mcp_tasks,
         runs,
         scheduled_tasks,
         skills,
+        subagent_batches,
         suggestions,
         thread_runs,
         threads,
         uploads,
     )
 
-    routers = [artifacts, browser, feedback, runs, scheduled_tasks, skills, suggestions, thread_runs, threads, uploads]
+    routers = [
+        artifacts,
+        browser,
+        feedback,
+        mcp_tasks,
+        runs,
+        scheduled_tasks,
+        skills,
+        subagent_batches,
+        suggestions,
+        thread_runs,
+        threads,
+        uploads,
+    ]
     cases = []
     for module in routers:
         for route in module.router.routes:
@@ -121,6 +136,26 @@ def test_sweep_covers_expected_surface():
     """Sanity: the sweep must actually see the known thread_id routes."""
     assert len(_THREAD_ID_ROUTES) >= 30
     assert any("suggestions" in name for name, _, _ in _THREAD_ID_ROUTES)
+    assert any("mcp_tasks" in name for name, _, _ in _THREAD_ID_ROUTES)
+    assert any("subagent_batches" in name for name, _, _ in _THREAD_ID_ROUTES)
+
+
+def test_sweep_covers_every_router_module_with_thread_id_routes():
+    """No router module declaring ``{thread_id}`` route paths may fall out of
+    the runtime sweep (a file merely mentioning thread_id in a body field
+    does not count)."""
+    import importlib
+
+    swept = {name for name, _, _ in _THREAD_ID_ROUTES}
+    missing = []
+    for path in sorted(ROUTERS_DIR.glob("*.py")):
+        module = importlib.import_module(f"app.gateway.routers.{path.stem}")
+        routes = getattr(getattr(module, "router", None), "routes", None) or []
+        if not any("{thread_id}" in getattr(route, "path", "") for route in routes):
+            continue
+        if path.stem not in swept:
+            missing.append(path.stem)
+    assert not missing, f"routers with thread_id routes missing from the runtime sweep: {missing}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Why

Issue #5061 asked for explicit `thread_id` format validation to prevent path
traversal into thread storage paths. Auditing current `main`, the substantive
validation is already in place (RFC #4588):

- every route handler annotates `thread_id` as `ThreadId`
  (`deerflow.utils.thread_id`, `^[A-Za-z0-9_-]{1,64}$`),
- `Paths.thread_dir()` / `delete_thread_dir()` and the JSONL event store both
  re-validate before interpolating IDs into host paths,
- `DELETE /api/threads/{thread_id}` keeps a deliberate legacy-cleanup escape
  hatch that skips filesystem interpolation entirely.

However, the runtime half of the route-contract guard
(`test_noncanonical_thread_id_gets_422`) walks a hand-maintained import list,
and that list is missing two routers that declare `{thread_id}` routes:
`mcp_tasks` and `subagent_batches`. Their handlers are correctly typed today,
but a regression there would not be caught by the 422 sweep — only by the
static AST check.

## What changed

Test-only change to `backend/tests/test_thread_id_route_contract.py`:

- Added `mcp_tasks` and `subagent_batches` to the runtime sweep import list, so
  their `{thread_id}` routes are now exercised with a non-canonical ID and must
  return a 422 naming `thread_id` (7 newly covered routes).
- Added `test_sweep_covers_every_router_module_with_thread_id_routes`, which
  imports every module in `app/gateway/routers/` and fails if any router that
  actually declares a `{thread_id}` route path is absent from the sweep — the
  hand-maintained list can no longer silently go stale.

Externally observable behavior is unchanged; this only closes a coverage gap in
the guard that protects the contract issue #5061 asked for.

## Surface area

- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Frontend UI**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [x] **Docs / tests / CI only**

## Validation

- `cd backend && PYTHONPATH=. uv run pytest tests/test_thread_id_route_contract.py tests/test_thread_id_validation.py -v` → **76 passed**
- `cd backend && PYTHONPATH=. uv run pytest tests/test_threads_router.py -q` → **92 passed** (untouched, sanity)
- `cd backend && uv run ruff check tests/test_thread_id_route_contract.py` → clean
- `cd backend && uv run ruff format --check tests/test_thread_id_route_contract.py` → clean

Fixes #5061

## AI assistance

**Tool(s) used:** ZCode (GLM-5.3)

**How you used it:** AI audited the existing thread_id validation surface, identified the sweep coverage gap, and extended the contract tests. I reviewed the change.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
