### PR TITLE
test: isolate Docker bridge gateway fallback from host DNS

### DIFF
--- a/backend/tests/test_aio_sandbox_local_backend.py
+++ b/backend/tests/test_aio_sandbox_local_backend.py
@@ -323,6 +323,7 @@ def test_start_container_brackets_bare_ipv6_bind_override(monkeypatch):
 
 
 def test_start_container_binds_dood_port_to_bridge_gateway(monkeypatch):
+    """Force resolver failure so host DNS cannot bypass the bridge-gateway fallback."""
     backend = LocalContainerBackend(
         image="sandbox:latest",
         base_port=8080,

--- a/backend/tests/test_aio_sandbox_local_backend.py
+++ b/backend/tests/test_aio_sandbox_local_backend.py
@@ -333,6 +333,10 @@ def test_start_container_binds_dood_port_to_bridge_gateway(monkeypatch):
     monkeypatch.setenv("DEER_FLOW_SANDBOX_HOST", "host.docker.internal")
     monkeypatch.delenv("DEER_FLOW_SANDBOX_BIND_HOST", raising=False)
     monkeypatch.setattr(
+        "deerflow.community.aio_sandbox.local_backend._resolve_sandbox_host_address",
+        lambda host: None,
+    )
+    monkeypatch.setattr(
         "deerflow.community.aio_sandbox.local_backend._docker_bridge_gateway_ip",
         lambda: "172.17.0.1",
     )


### PR DESCRIPTION
Fixes #5106

## Why

The Docker bridge fallback test allowed real host DNS resolution.
Clash fake-IP mode resolved `host.docker.internal` to `28.0.0.166`.
This bypassed the mocked bridge gateway and made the test fail.

## What changed

- Force sandbox-host resolution to fail in the fallback-path test.
- Keep the existing bridge gateway mock as the controlled result.
- Leave production bind-host resolution unchanged.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded dependency
- [ ] **Default behavior change** — changes existing runtime behavior
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Test path: `backend/tests/test_aio_sandbox_local_backend.py`
- The existing test failed on `main` while Clash was active.
- The isolated test passes on this branch with Clash inactive.
- The test now replaces the DNS resolver, so host DNS cannot affect this path.

## Validation

```shell
uv run pytest tests/test_aio_sandbox_local_backend.py::test_start_container_binds_dood_port_to_bridge_gateway -q
# 1 passed

uv run pytest tests/test_aio_sandbox_local_backend.py -q
# 62 passed

uv run ruff check tests/test_aio_sandbox_local_backend.py
uv run ruff format --check tests/test_aio_sandbox_local_backend.py
# passed
```

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Traced the resolver path, added the test mock, and ran validation.

- [ ] I've read and understand every line of this change and take responsibility for it.
