### PR TITLE
docs: remove duplicated preamble from backend/AGENTS.md

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,7 +1,5 @@
 # AGENTS.md
 
-This file provides guidance to AI coding agents (Claude Code, Codex, and others) when working with code in this repository. It is the source of truth; the sibling `CLAUDE.md` imports it via `@AGENTS.md`.
-
 ## Project Overview
 
 DeerFlow is a LangGraph-based AI super agent system with a full-stack architecture. The backend provides a "super agent" with sandbox execution, persistent memory, subagent delegation, and extensible tool integration - all operating in per-thread isolated environments.


### PR DESCRIPTION
`backend/AGENTS.md` opens with the same sentence as the root `AGENTS.md`:

> This file provides guidance to AI coding agents (Claude Code, Codex, and others) when working with code in this repository. It is the source of truth; the sibling `CLAUDE.md` imports it via `@AGENTS.md`.

The root file is loaded as parent context whenever an agent reads the backend
guide, so the line ends up in the context stack twice. This drops the copy in
`backend/AGENTS.md`; the root keeps it, and the backend guide now starts at its
Project Overview.

Found with [conman](https://github.com/bronsonhill/conman), an offline linter for
a repo's agent context stack. It flags this as a 53-token block duplicated
parent-to-child, and it is the only error on the 20 `backend/*` entry points it
checks. No content change.
