### PR TITLE
fix(frontend): default to Webpack over Turbopack in dev to avoid PostCSS worker leak on macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ cd backend && make lint       # ruff check
 cd backend && make format     # ruff format
 
 # Frontend (see frontend/AGENTS.md for the full set)
-cd frontend && pnpm dev       # Dev server: Webpack on Windows, Turbopack elsewhere (override with DEER_FLOW_DEV_BUNDLER)
+cd frontend && pnpm dev       # Dev server: Webpack by default (override with DEER_FLOW_DEV_BUNDLER=turbo)
 cd frontend && pnpm check     # Lint + type check (run before committing)
 cd frontend && pnpm test      # Unit tests
 ```

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -17,22 +17,22 @@ DeerFlow Frontend is a Next.js 16 web interface for an AI agent system. It commu
 
 ## Commands
 
-| Command          | Purpose                                                             |
-| ---------------- | ------------------------------------------------------------------- |
-| `pnpm dev`       | Platform-aware dev server (Webpack on Windows, Turbopack elsewhere) |
-| `pnpm build`     | Production build                                                    |
-| `pnpm check`     | Lint + type check (run before committing)                           |
-| `pnpm lint`      | ESLint only                                                         |
-| `pnpm lint:fix`  | ESLint with auto-fix                                                |
-| `pnpm format`    | Prettier check (`pnpm format:write` to apply)                       |
-| `pnpm test`      | Run unit tests with Rstest                                          |
-| `pnpm test:e2e`  | Run E2E tests with Playwright (Chromium)                            |
-| `pnpm typecheck` | TypeScript type check (`tsc --noEmit`)                              |
-| `pnpm start`     | Start production server                                             |
+| Command          | Purpose                                       |
+| ---------------- | --------------------------------------------- |
+| `pnpm dev`       | Start the development server with Webpack     |
+| `pnpm build`     | Production build                              |
+| `pnpm check`     | Lint + type check (run before committing)     |
+| `pnpm lint`      | ESLint only                                   |
+| `pnpm lint:fix`  | ESLint with auto-fix                          |
+| `pnpm format`    | Prettier check (`pnpm format:write` to apply) |
+| `pnpm test`      | Run unit tests with Rstest                    |
+| `pnpm test:e2e`  | Run E2E tests with Playwright (Chromium)      |
+| `pnpm typecheck` | TypeScript type check (`tsc --noEmit`)        |
+| `pnpm start`     | Start production server                       |
 
 Unit tests live under `tests/unit/` and mirror the `src/` layout (e.g., `tests/unit/core/api/stream-mode.test.ts` tests `src/core/api/stream-mode.ts`). Powered by Rstest; import source modules via the `@/` path alias.
 
-Use `DEER_FLOW_DEV_BUNDLER=turbo` or `DEER_FLOW_DEV_BUNDLER=webpack` with `pnpm dev` to override the platform default when diagnosing a local Next.js bundler issue.
+Webpack is the default development bundler. Use `DEER_FLOW_DEV_BUNDLER=turbo` with `pnpm dev` to opt in to Turbopack when diagnosing a local Next.js bundler issue.
 
 Rstest runs them as two projects (`rstest.config.ts`). `*.test.ts` / `*.test.tsx` run in a plain **node** environment — that is nearly the whole suite, and it is the default for anything that is pure logic. `*.dom.test.ts` / `*.dom.test.tsx` run in **happy-dom**, for tests that need a document: hooks driven through `renderHook` from `@testing-library/react`, and components. Keep the split — a DOM environment costs roughly 3x the runtime of the node suite, so tests that do not render should not opt into it. A hook whose behavior only exists under real React (effect ordering, cleanup on unmount, re-render on store change) belongs in a `.dom.test.*` file rather than a node test that mocks `react` itself.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -127,24 +127,24 @@ src/
 
 ## Scripts
 
-| Command             | Description                                                        |
-| ------------------- | ------------------------------------------------------------------ |
-| `pnpm dev`          | Start development server (Webpack on Windows, Turbopack elsewhere) |
-| `pnpm build`        | Build for production                                               |
-| `pnpm start`        | Start production server                                            |
-| `pnpm test`         | Run unit tests with Rstest                                         |
-| `pnpm test:e2e`     | Run E2E tests with Playwright                                      |
-| `pnpm format`       | Check formatting with Prettier                                     |
-| `pnpm format:write` | Apply formatting with Prettier                                     |
-| `pnpm lint`         | Run ESLint                                                         |
-| `pnpm lint:fix`     | Fix ESLint issues                                                  |
-| `pnpm typecheck`    | Run TypeScript type checking                                       |
-| `pnpm check`        | Run both lint and typecheck                                        |
+| Command             | Description                           |
+| ------------------- | ------------------------------------- |
+| `pnpm dev`          | Start development server with Webpack |
+| `pnpm build`        | Build for production                  |
+| `pnpm start`        | Start production server               |
+| `pnpm test`         | Run unit tests with Rstest            |
+| `pnpm test:e2e`     | Run E2E tests with Playwright         |
+| `pnpm format`       | Check formatting with Prettier        |
+| `pnpm format:write` | Apply formatting with Prettier        |
+| `pnpm lint`         | Run ESLint                            |
+| `pnpm lint:fix`     | Fix ESLint issues                     |
+| `pnpm typecheck`    | Run TypeScript type checking          |
+| `pnpm check`        | Run both lint and typecheck           |
 
 ## Development Notes
 
 - Uses pnpm workspaces (see `packageManager` in package.json)
-- Turbopack is used by default in development except on Windows, where Webpack avoids known Turbopack runtime instability. Set `DEER_FLOW_DEV_BUNDLER=turbo` or `DEER_FLOW_DEV_BUNDLER=webpack` to override the platform default for local diagnosis.
+- Webpack is used by default in development to avoid known Turbopack runtime instability. Set `DEER_FLOW_DEV_BUNDLER=turbo` to opt in to Turbopack for local diagnosis, or `DEER_FLOW_DEV_BUNDLER=webpack` to select Webpack explicitly.
 - Environment validation can be skipped with `SKIP_ENV_VALIDATION=1` (useful for Docker)
 - Backend API URLs are optional; nginx proxy is used by default in development
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -144,7 +144,7 @@ src/
 ## Development Notes
 
 - Uses pnpm workspaces (see `packageManager` in package.json)
-- Webpack is used by default in development to avoid known Turbopack runtime instability. Set `DEER_FLOW_DEV_BUNDLER=turbo` to opt in to Turbopack for local diagnosis, or `DEER_FLOW_DEV_BUNDLER=webpack` to select Webpack explicitly.
+- Webpack is the default development bundler until the upstream Turbopack PostCSS worker leak is fixed in a stable Next.js release (#5132). Set `DEER_FLOW_DEV_BUNDLER=turbo` to opt in to Turbopack for local diagnosis, or `DEER_FLOW_DEV_BUNDLER=webpack` to select Webpack explicitly. Reconsider the default after the stable fix is verified on macOS arm64 and Linux.
 - Environment validation can be skipped with `SKIP_ENV_VALIDATION=1` (useful for Docker)
 - Backend API URLs are optional; nginx proxy is used by default in development
 

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -18,6 +18,10 @@ export function getDevBundler(_platform = process.platform, env = process.env) {
     }
     return override;
   }
+  // Keep Webpack as the cross-platform default while #5132's Turbopack
+  // PostCSS worker leak remains unfixed in a stable Next.js release. Retain
+  // the platform parameter so restoring the platform-aware default stays a
+  // small change once the upstream fix is stable and verified on macOS/Linux.
   return "webpack";
 }
 

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -5,10 +5,10 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 /**
- * @param {string} platform
+ * @param {string} _platform
  * @param {Record<string, string | undefined>} env
  */
-export function getDevBundler(platform = process.platform, env = process.env) {
+export function getDevBundler(_platform = process.platform, env = process.env) {
   const override = env.DEER_FLOW_DEV_BUNDLER?.trim();
   if (override) {
     if (override !== "turbo" && override !== "webpack") {
@@ -18,7 +18,7 @@ export function getDevBundler(platform = process.platform, env = process.env) {
     }
     return override;
   }
-  return platform === "win32" ? "webpack" : "turbo";
+  return "webpack";
 }
 
 /**

--- a/frontend/tests/unit/scripts/dev.test.ts
+++ b/frontend/tests/unit/scripts/dev.test.ts
@@ -32,9 +32,9 @@ describe("frontend dev launcher", () => {
     ]);
   });
 
-  test("keeps Turbopack for non-Windows development", () => {
-    expect(getDevBundler("linux")).toBe("turbo");
-    expect(getDevBundler("darwin")).toBe("turbo");
-    expect(getNextDevArgs("linux")).toEqual(["dev", "--turbo"]);
+  test("uses webpack by default on every platform", () => {
+    expect(getDevBundler("linux")).toBe("webpack");
+    expect(getDevBundler("darwin")).toBe("webpack");
+    expect(getNextDevArgs("linux")).toEqual(["dev", "--webpack"]);
   });
 });

--- a/frontend/tests/unit/scripts/dev.test.ts
+++ b/frontend/tests/unit/scripts/dev.test.ts
@@ -3,11 +3,6 @@ import { describe, expect, test } from "@rstest/core";
 import { getDevBundler, getNextDevArgs } from "../../../scripts/dev.mjs";
 
 describe("frontend dev launcher", () => {
-  test("uses webpack on Windows to avoid Turbopack runtime instability", () => {
-    expect(getDevBundler("win32")).toBe("webpack");
-    expect(getNextDevArgs("win32")).toEqual(["dev", "--webpack"]);
-  });
-
   test("allows an explicit bundler override on every platform", () => {
     expect(getDevBundler("win32", { DEER_FLOW_DEV_BUNDLER: "turbo" })).toBe(
       "turbo",
@@ -33,8 +28,10 @@ describe("frontend dev launcher", () => {
   });
 
   test("uses webpack by default on every platform", () => {
+    expect(getDevBundler("win32")).toBe("webpack");
     expect(getDevBundler("linux")).toBe("webpack");
     expect(getDevBundler("darwin")).toBe("webpack");
+    expect(getNextDevArgs("win32")).toEqual(["dev", "--webpack"]);
     expect(getNextDevArgs("linux")).toEqual(["dev", "--webpack"]);
   });
 });


### PR DESCRIPTION
## Summary

On macOS arm64, Turbopack + Next.js 16.2.11 + Tailwind CSS v4 causes an unbounded spawn of PostCSS evaluator processes that consume high CPU and memory and never return a response. Webpack is unaffected.

Change the no-override default in `getDevBundler()` from platform-dependent Turbopack (all non-Windows) to Webpack. `DEER_FLOW_DEV_BUNDLER=turbo` continues to work as an explicit opt-in for local diagnosis.

Fixes #5132

## Changes

- **frontend/scripts/dev.mjs**: `getDevBundler()` now returns `webpack` by default on every platform, with `turbo` retained as an explicit override
- **frontend/tests/unit/scripts/dev.test.ts**: covers the platform-independent Webpack default, override validation, and argument passthrough
- **AGENTS.md**, **frontend/AGENTS.md**, and **frontend/README.md**: document the new default consistently

## Testing

- `python3 scripts/pnpm.py exec prettier --check AGENTS.md README.md scripts/dev.mjs tests/unit/scripts/dev.test.ts`
- `python3 scripts/pnpm.py rstest run tests/unit/scripts/dev.test.ts`

## Upstream context

The observed worker growth matches [Next.js discussion #95927](https://github.com/vercel/next.js/discussions/95927). A related macOS arm64 / pnpm workspace livelock is tracked in [Next.js issue #97850](https://github.com/vercel/next.js/issues/97850) and fixed by [Next.js PR #96808](https://github.com/vercel/next.js/pull/96808). At the time of testing, `16.4.0-canary.6` was the first verified build containing the scheduler fix.

## When to reconsider Turbopack as the default

Switch the default back only after the upstream fixes ship in a stable Next.js release and DeerFlow verifies cold compilation, HMR, repeated route compilation, and bounded PostCSS worker cleanup on macOS arm64 and Linux.
