### PR TITLE
fix(frontend): truncate long subtask card titles to a single line

### DIFF
--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -138,7 +138,7 @@ export function SubtaskCard({
           >
             <div className="flex w-full items-center justify-between">
               <ChainOfThoughtStep
-                className="min-w-0 flex-1 font-normal"
+                className="min-w-24 flex-1 font-normal"
                 label={
                   <span className="block truncate" title={task.description}>
                     {task.status === "in_progress" ? (
@@ -157,11 +157,11 @@ export function SubtaskCard({
                 }
                 icon={<ClipboardListIcon />}
               ></ChainOfThoughtStep>
-              <div className="flex shrink-0 items-center gap-1">
+              <div className="flex min-w-0 items-center gap-1">
                 {collapsed && (
                   <div
                     className={cn(
-                      "text-muted-foreground flex items-center gap-1 text-xs font-normal",
+                      "text-muted-foreground flex min-w-0 items-center gap-1 text-xs font-normal",
                       task.status === "failed" ? "text-red-500 opacity-67" : "",
                     )}
                   >

--- a/frontend/src/components/workspace/messages/subtask-card.tsx
+++ b/frontend/src/components/workspace/messages/subtask-card.tsx
@@ -138,19 +138,26 @@ export function SubtaskCard({
           >
             <div className="flex w-full items-center justify-between">
               <ChainOfThoughtStep
-                className="font-normal"
+                className="min-w-0 flex-1 font-normal"
                 label={
-                  task.status === "in_progress" ? (
-                    <Shimmer duration={3} spread={3}>
-                      {task.description}
-                    </Shimmer>
-                  ) : (
-                    task.description
-                  )
+                  <span className="block truncate" title={task.description}>
+                    {task.status === "in_progress" ? (
+                      <Shimmer
+                        as="span"
+                        className="inline"
+                        duration={3}
+                        spread={3}
+                      >
+                        {task.description}
+                      </Shimmer>
+                    ) : (
+                      task.description
+                    )}
+                  </span>
                 }
                 icon={<ClipboardListIcon />}
               ></ChainOfThoughtStep>
-              <div className="flex items-center gap-1">
+              <div className="flex shrink-0 items-center gap-1">
                 {collapsed && (
                   <div
                     className={cn(

--- a/frontend/tests/e2e/subtask-card.spec.ts
+++ b/frontend/tests/e2e/subtask-card.spec.ts
@@ -1,11 +1,20 @@
-import { expect, test } from "@playwright/test";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
 
-import { mockLangGraphAPI, MOCK_THREAD_ID } from "./utils/mock-api";
+import { expect, test, type Locator } from "@playwright/test";
+
+import {
+  mockLangGraphAPI,
+  MOCK_RUN_ID,
+  MOCK_THREAD_ID,
+} from "./utils/mock-api";
 
 const STOPPED_TASK_PROMPT =
   "Investigate why the stopped subtask card should not remain running after reload.";
 const LONG_TASK_PROMPT =
   "你的任务：分析 bytedance/deer-flow 前端核心线程同步文件 `frontend/src/core/threads/hooks.ts`（约 108KB），提取其消息流同步机制的关键信息。背景：用户在 DeerFlow 前端发现子代理任务卡片标题过长，需要确认截断行为。请重点关注消息合并、流式节流与本地排序逻辑，并输出结构化结论。";
+const LONG_RUNNING_STATUS =
+  "Writing the quarterly infrastructure cost breakdown report to workspace/reports/q3-infra-cost-breakdown-final-v2.md";
 
 const stoppedSubtaskMessages = [
   {
@@ -39,6 +48,167 @@ const stoppedSubtaskMessages = [
   },
 ];
 
+const longSubtaskThread = {
+  thread_id: MOCK_THREAD_ID,
+  title: "Long subtask title",
+  updated_at: "2026-06-18T12:00:00Z",
+  messages: [
+    stoppedSubtaskMessages[0],
+    {
+      ...stoppedSubtaskMessages[1],
+      id: "msg-ai-long-subtask",
+      tool_calls: [
+        {
+          id: "call-long-subtask",
+          name: "task",
+          args: {
+            subagent_type: "general-purpose",
+            prompt: LONG_TASK_PROMPT,
+          },
+          type: "tool_call",
+        },
+      ],
+    },
+  ],
+};
+
+async function expectSingleLineEllipsis(title: Locator) {
+  await expect(title).toHaveClass(/truncate/);
+
+  const metrics = await title.evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+    height: el.getBoundingClientRect().height,
+  }));
+  expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+  // A pixel budget instead of `parseFloat(lineHeight)`: the `normal` keyword
+  // parses to NaN and fails with an opaque "Received NaN" rather than pointing
+  // at the layout. One line of `text-sm` is 20px; 32px leaves slack without
+  // admitting a wrapped second line.
+  expect(metrics.height).toBeLessThanOrEqual(32);
+}
+
+/**
+ * SSE server that emits one `values` frame carrying an unresolved `task` tool
+ * call and then holds the connection open, keeping `thread.isLoading` true so
+ * the subtask card renders its running (shimmer) branch. Closed via
+ * `closeAllConnections` in test teardown.
+ */
+async function startRunningSubtaskStream() {
+  const aiMessage = {
+    type: "ai",
+    id: "msg-ai-running-subtask",
+    content: "",
+    additional_kwargs: {},
+    response_metadata: {},
+    tool_calls: [
+      {
+        id: "call-running-subtask",
+        name: "task",
+        args: {
+          subagent_type: "general-purpose",
+          prompt: LONG_TASK_PROMPT,
+        },
+        type: "tool_call",
+      },
+    ],
+    invalid_tool_calls: [],
+  };
+  const server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk: Buffer) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => {
+      let inputMessages: unknown[] = [];
+      let bodyThreadId: string | undefined;
+      try {
+        const parsed = JSON.parse(body) as {
+          input?: { messages?: unknown[] };
+          thread_id?: string;
+        };
+        inputMessages = parsed.input?.messages ?? [];
+        bodyThreadId = parsed.thread_id;
+      } catch {
+        inputMessages = [];
+      }
+      const threadId =
+        /\/threads\/([^/]+)\/runs\/stream/.exec(request.url ?? "")?.[1] ??
+        bodyThreadId ??
+        MOCK_THREAD_ID;
+      const frames = [
+        {
+          event: "metadata",
+          data: { run_id: MOCK_RUN_ID, thread_id: threadId },
+        },
+        {
+          event: "values",
+          data: { messages: [...inputMessages, aiMessage] },
+        },
+        {
+          // A `task_running` step whose last tool call carries a long
+          // description: the collapsed header's status pill renders it via
+          // `explainLastToolCall`, growing the right-hand cluster past the
+          // width of a narrow card.
+          event: "custom",
+          data: {
+            type: "task_running",
+            task_id: "call-running-subtask",
+            message: {
+              type: "ai",
+              id: "msg-ai-running-subtask-step",
+              content: "",
+              additional_kwargs: {},
+              response_metadata: {},
+              tool_calls: [
+                {
+                  id: "call-running-subtask-step",
+                  name: "write_file",
+                  args: { description: LONG_RUNNING_STATUS },
+                  type: "tool_call",
+                },
+              ],
+              invalid_tool_calls: [],
+            },
+            message_index: 1,
+          },
+        },
+      ]
+        .map(
+          (event) =>
+            `event: ${event.event}\ndata: ${JSON.stringify(event.data)}\n\n`,
+        )
+        .join("");
+      response.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache",
+        "Content-Type": "text/event-stream",
+      });
+      response.write(frames);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const handleError = (error: Error) => reject(error);
+    server.once("error", handleError);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", handleError);
+      resolve();
+    });
+  });
+
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/runs/stream`,
+    async close() {
+      server.closeAllConnections();
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}
+
 test.describe("Subtask card", () => {
   test("shows failed after a stopped task thread is reloaded", async ({
     page,
@@ -65,31 +235,7 @@ test.describe("Subtask card", () => {
   });
   test("truncates a long task title to a single line", async ({ page }) => {
     mockLangGraphAPI(page, {
-      threads: [
-        {
-          thread_id: MOCK_THREAD_ID,
-          title: "Long subtask title",
-          updated_at: "2026-06-18T12:00:00Z",
-          messages: [
-            stoppedSubtaskMessages[0],
-            {
-              ...stoppedSubtaskMessages[1],
-              id: "msg-ai-long-subtask",
-              tool_calls: [
-                {
-                  id: "call-long-subtask",
-                  name: "task",
-                  args: {
-                    subagent_type: "general-purpose",
-                    prompt: LONG_TASK_PROMPT,
-                  },
-                  type: "tool_call",
-                },
-              ],
-            },
-          ],
-        },
-      ],
+      threads: [longSubtaskThread],
     });
 
     await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
@@ -97,18 +243,107 @@ test.describe("Subtask card", () => {
 
     const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
     await expect(title).toBeVisible({ timeout: 15_000 });
-    await expect(title).toHaveClass(/truncate/);
+    await expectSingleLineEllipsis(title);
+  });
+  test("keeps the header inside the card on a 375px viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    mockLangGraphAPI(page, {
+      threads: [longSubtaskThread],
+    });
 
-    const metrics = await title.evaluate((el) => {
-      const style = getComputedStyle(el);
-      return {
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await page.reload();
+
+    const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
+    await expect(title).toBeVisible({ timeout: 15_000 });
+
+    // The status cluster is shrinkable (`min-w-0`, per-item `truncate`), so a
+    // narrow card ellipsizes the cluster instead of collapsing the title to
+    // zero width and overflowing the row.
+    const row = title.locator(
+      "xpath=ancestor::div[contains(@class,'justify-between')][1]",
+    );
+    const rowMetrics = await row.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(rowMetrics.scrollWidth).toBeLessThanOrEqual(rowMetrics.clientWidth);
+    await expectSingleLineEllipsis(title);
+  });
+  test("truncates a running task title with the shimmer inline", async ({
+    page,
+  }) => {
+    const streamServer = await startRunningSubtaskStream();
+    mockLangGraphAPI(page, {
+      runStreamHandler: (route) => route.continue({ url: streamServer.url }),
+    });
+
+    try {
+      await page.goto("/workspace/chats/new");
+      const textarea = page.getByPlaceholder(/how can i assist you/i);
+      await expect(textarea).toBeVisible({ timeout: 15_000 });
+      await textarea.fill("Run a subtask with a long title");
+      await textarea.press("Enter");
+
+      const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
+      await expect(title).toBeVisible({ timeout: 15_000 });
+
+      // The shimmer must stay one inline text run inside the truncating span:
+      // `as="span"` avoids nesting the component's default <p>, and
+      // `className="inline"` overrides its `inline-block` so the parent span's
+      // nowrap/ellipsis still apply.
+      const shimmer = title.locator("span").first();
+      await expect(shimmer).toHaveCSS("display", "inline");
+      await expectSingleLineEllipsis(title);
+    } finally {
+      await streamServer.close();
+    }
+  });
+  test("keeps a running card inside the row on a 375px viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    const streamServer = await startRunningSubtaskStream();
+    mockLangGraphAPI(page, {
+      runStreamHandler: (route) => route.continue({ url: streamServer.url }),
+    });
+
+    try {
+      await page.goto("/workspace/chats/new");
+      const textarea = page.getByPlaceholder(/how can i assist you/i);
+      await expect(textarea).toBeVisible({ timeout: 15_000 });
+      await textarea.fill("Run a subtask with a long status");
+      await textarea.press("Enter");
+
+      // The long `task_running` status pushes the right-hand cluster's
+      // max-content past the card width. The cluster must absorb that by
+      // ellipsizing (`min-w-0` on both wrappers + per-item `truncate`), not by
+      // pinning its width with `shrink-0` and overflowing the row; the title's
+      // `min-w-24` floor keeps it visible instead of collapsing to zero.
+      const status = page.getByText(LONG_RUNNING_STATUS, { exact: true });
+      await expect(status).toBeVisible({ timeout: 15_000 });
+      const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
+      await expect(title).toBeVisible();
+      await expectSingleLineEllipsis(title);
+      const pill = status.locator("xpath=..");
+      const row = status.locator(
+        "xpath=ancestor::div[contains(@class,'justify-between')][1]",
+      );
+      const metrics = await row.evaluate((el) => ({
         scrollWidth: el.scrollWidth,
         clientWidth: el.clientWidth,
-        height: el.getBoundingClientRect().height,
-        lineHeight: parseFloat(style.lineHeight),
-      };
-    });
-    expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
-    expect(metrics.height).toBeLessThanOrEqual(metrics.lineHeight * 1.5);
+      }));
+      expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth);
+
+      const pillMetrics = await pill.evaluate((el) => ({
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+      }));
+      expect(pillMetrics.scrollWidth).toBeGreaterThan(pillMetrics.clientWidth);
+    } finally {
+      await streamServer.close();
+    }
   });
 });

--- a/frontend/tests/e2e/subtask-card.spec.ts
+++ b/frontend/tests/e2e/subtask-card.spec.ts
@@ -4,6 +4,8 @@ import { mockLangGraphAPI, MOCK_THREAD_ID } from "./utils/mock-api";
 
 const STOPPED_TASK_PROMPT =
   "Investigate why the stopped subtask card should not remain running after reload.";
+const LONG_TASK_PROMPT =
+  "你的任务：分析 bytedance/deer-flow 前端核心线程同步文件 `frontend/src/core/threads/hooks.ts`（约 108KB），提取其消息流同步机制的关键信息。背景：用户在 DeerFlow 前端发现子代理任务卡片标题过长，需要确认截断行为。请重点关注消息合并、流式节流与本地排序逻辑，并输出结构化结论。";
 
 const stoppedSubtaskMessages = [
   {
@@ -60,5 +62,53 @@ test.describe("Subtask card", () => {
     });
     await expect(page.getByText("Subtask failed")).toBeVisible();
     await expect(page.getByText("Running subtask")).toHaveCount(0);
+  });
+  test("truncates a long task title to a single line", async ({ page }) => {
+    mockLangGraphAPI(page, {
+      threads: [
+        {
+          thread_id: MOCK_THREAD_ID,
+          title: "Long subtask title",
+          updated_at: "2026-06-18T12:00:00Z",
+          messages: [
+            stoppedSubtaskMessages[0],
+            {
+              ...stoppedSubtaskMessages[1],
+              id: "msg-ai-long-subtask",
+              tool_calls: [
+                {
+                  id: "call-long-subtask",
+                  name: "task",
+                  args: {
+                    subagent_type: "general-purpose",
+                    prompt: LONG_TASK_PROMPT,
+                  },
+                  type: "tool_call",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    await page.goto(`/workspace/chats/${MOCK_THREAD_ID}`);
+    await page.reload();
+
+    const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
+    await expect(title).toBeVisible({ timeout: 15_000 });
+    await expect(title).toHaveClass(/truncate/);
+
+    const metrics = await title.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        scrollWidth: el.scrollWidth,
+        clientWidth: el.clientWidth,
+        height: el.getBoundingClientRect().height,
+        lineHeight: parseFloat(style.lineHeight),
+      };
+    });
+    expect(metrics.scrollWidth).toBeGreaterThan(metrics.clientWidth);
+    expect(metrics.height).toBeLessThanOrEqual(metrics.lineHeight * 1.5);
   });
 });

--- a/frontend/tests/e2e/subtask-card.spec.ts
+++ b/frontend/tests/e2e/subtask-card.spec.ts
@@ -15,6 +15,8 @@ const LONG_TASK_PROMPT =
   "你的任务：分析 bytedance/deer-flow 前端核心线程同步文件 `frontend/src/core/threads/hooks.ts`（约 108KB），提取其消息流同步机制的关键信息。背景：用户在 DeerFlow 前端发现子代理任务卡片标题过长，需要确认截断行为。请重点关注消息合并、流式节流与本地排序逻辑，并输出结构化结论。";
 const LONG_RUNNING_STATUS =
   "Writing the quarterly infrastructure cost breakdown report to workspace/reports/q3-infra-cost-breakdown-final-v2.md";
+const LONG_TASK_USER_TEXT =
+  "Analyze the thread sync hooks and report how the subtask card renders.";
 
 const stoppedSubtaskMessages = [
   {
@@ -53,7 +55,13 @@ const longSubtaskThread = {
   title: "Long subtask title",
   updated_at: "2026-06-18T12:00:00Z",
   messages: [
-    stoppedSubtaskMessages[0],
+    {
+      // Reuse the stopped test's message *shape* only: its human text narrates
+      // the stop scenario, which none of the long-title tests exercise.
+      ...stoppedSubtaskMessages[0],
+      id: "msg-human-long-subtask",
+      content: [{ type: "text", text: LONG_TASK_USER_TEXT }],
+    },
     {
       ...stoppedSubtaskMessages[1],
       id: "msg-ai-long-subtask",
@@ -325,7 +333,7 @@ test.describe("Subtask card", () => {
       const status = page.getByText(LONG_RUNNING_STATUS, { exact: true });
       await expect(status).toBeVisible({ timeout: 15_000 });
       const title = page.getByTitle(LONG_TASK_PROMPT, { exact: true });
-      await expect(title).toBeVisible();
+      await expect(title).toBeVisible({ timeout: 15_000 });
       await expectSingleLineEllipsis(title);
       const pill = status.locator("xpath=..");
       const row = status.locator(


### PR DESCRIPTION
## Why

When the lead agent delegates to a subagent via the `task` tool, the model-visible `description`
argument is optional. When a provider omits it, the frontend falls back to the full `prompt` as the
subtask card title (by design, to never render a blank title). That prompt can be hundreds of
characters, and the card header had no width constraint — so the title rendered as a single
unwrapped line that overflowed the card and broke the chat layout.

## What changed

- Subtask card titles are now truncated to a single line with an ellipsis. The full text is still
available two ways: a `title` tooltip on hover, and the expanded card body, which continues to
render the complete prompt.
- The running-state shimmer animation on the title is preserved (rendered inline inside the
truncating container).
- The right-hand status cluster (model label, token usage, status text, chevron) stays shrinkable:
`min-w-0` on the cluster and its inner pill lets it ellipsize on narrow viewports instead of
overflowing the header row, and the title keeps a `min-w-24` floor so it cannot collapse to zero
width.
- No data-model or API change; this is display-only. Short titles render exactly as before.

## Surface area

- [x] **Frontend UI** — page / component / setting / interaction under `frontend/`

## Screenshots / Recording

**Before:** long delegation prompt renders as one overflowing line, header text running past the
card edge.

**After:** the same card truncates to one line with an ellipsis; the model label, token usage,
status icon and expand chevron on the right stay visible.

<!-- TODO: attach before/after screenshots; I can generate the "after" one from the mocked e2e
environment if you want. -->

## Bug fix verification

- Test path: `frontend/tests/e2e/subtask-card.spec.ts` → "truncates a long task title to a single
line". It mocks a thread whose `task` tool call carries a long CJK prompt and no `description`,
then asserts the header title has the `truncate` class, actually ellipsizes (`scrollWidth >
clientWidth`), and stays within a 32px single-line pixel budget. Two more tests cover the running
state ("truncates a running task title with the shimmer inline" pins the shimmer's computed
`display: inline` plus the same truncation metrics) and narrow viewports ("keeps the header inside
the card on a 375px viewport", "keeps a running card inside the row on a 375px viewport" — the
latter serves a held-open SSE stream with a long `task_running` status and asserts no header-row
overflow plus the status pill actually ellipsizing).
- Red on `main`: the `truncate` class assertion fails there by construction (no truncating element
exists); I did not run a separate red pass against `main` — flagged for transparency. The 375px
running-card test was verified red against the earlier `shrink-0` layout (row scrollWidth 456 >
clientWidth 275). Green on this branch: all five spec tests pass.
- The pre-existing "shows failed after a stopped task thread is reloaded" test in the same spec
still passes, confirming the header restructure didn't disturb existing card behavior.

## Validation

- `cd frontend && pnpm lint` — pass
- `cd frontend && pnpm typecheck` — pass
- `cd frontend && npx rstest run tests/unit/core/tasks` — pass
- `npx playwright test tests/e2e/subtask-card.spec.ts` — 5 passed (Playwright webServer runs `next
build && next start` with `DEER_FLOW_AUTH_DISABLED=1`, no live gateway, matching CI conditions; the
two running-state tests serve a held-open SSE stream from a local `node:http` server via
`route.continue` URL rewriting)
- Pre-commit hooks (eslint + prettier) — pass

Not run: `pnpm build` (no env/auth/routing changes), full e2e suite (only the touched spec was
run).

## AI assistance

**Tool(s) used:** Kimi (k3) via the Oh My Pi coding harness.

**How you used it:** Implemented the component fix and the e2e test from a reported UI issue; drove
local verification (lint, typecheck, playwright) iteratively, including working around a broken
local Playwright browser install.

- [x] I've read and understand every line of this change and take responsibility for it — it's not
unreviewed AI output.
