### PR TITLE
test: isolate Jina timeout logging from missing-key warning

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -242,6 +242,10 @@ Direct pytest collection or execution of `tests/test_client_live.py` remains
 skipped unless `DEER_FLOW_RUN_LIVE_TESTS=1` is set. Do not add that opt-in to
 default CI workflows.
 
+Jina request-failure logging tests set a dummy API key so the separate once-per-process
+missing-key warning cannot make assertions depend on test order or shard placement.
+Missing-key behavior has its own tests in `tests/test_jina_client.py`.
+
 ### Running the Full Application
 
 From the **project root** directory:

--- a/backend/tests/test_jina_client.py
+++ b/backend/tests/test_jina_client.py
@@ -89,6 +89,9 @@ async def test_crawl_network_error(jina_client, monkeypatch):
 async def test_crawl_transient_failure_logs_without_traceback(jina_client, monkeypatch, caplog):
     """Transient network failures must log at WARNING without a traceback and include the exception type."""
 
+    # Keep the missing-key warning independent of test order and shard placement.
+    monkeypatch.setenv("JINA_API_KEY", "test-key")
+
     async def mock_post(self, url, **kwargs):
         raise httpx.ConnectTimeout("timed out")
 


### PR DESCRIPTION
## Why

Main's [Unit Tests run](https://github.com/bytedance/deer-flow/actions/runs/33591305316) fails shard 4 in `test_crawl_transient_failure_logs_without_traceback`: it expects one log record but receives both the missing-API-key warning and the request-failure warning.

On `fb722770`, running the test alone reproduces the failure, while running the whole Jina test file passes. The assertion implicitly depends on an earlier crawl having consumed the once-per-process missing-key warning, which test sharding does not guarantee.

## What changed

Set a dummy API key in this mocked request-failure test, keeping its logging assertions independent of test order and shard placement. The existing missing-key tests and all assertions about severity, traceback, exception type, and returned error stay unchanged. Document the isolation requirement in the backend guide. No runtime behavior changes.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

`uv run --no-sync pytest tests/test_jina_client.py::test_crawl_transient_failure_logs_without_traceback -q`

- Main: **1 failed** (`expected exactly one log record, got 2`).
- This branch: **1 passed**.

## Validation

Windows, Python 3.12.13, dependencies from `uv sync --frozen`:

- `uv run --no-sync pytest tests/test_jina_client.py -q`: **44 passed**.
- `uv run --no-sync ruff check .`: passed.
- `uv run --no-sync ruff format --check tests/test_jina_client.py`: passed.
- `git diff --check`: passed.

Full-suite validation is limited locally: default collection stops at the pre-existing `os.geteuid()` call in `test_acceptance_checks.py` on Windows. The blocking-I/O suite has the same **87 passed / 4 failed** before and after this change: three POSIX permission assertions and one missing `lark-cli` dependency. These unrelated failures are unchanged.

## AI assistance

**Tool(s) used:** Codex.

**How you used it:** Reproduced the CI failure, prepared the focused test/documentation change, and ran validation. I reviewed the complete diff before submission.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
