### PR TITLE
docs(zh): add missing Agentic Browser Control section

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -71,6 +71,7 @@ DeerFlow 新近集成了 BytePlus 自研的智能搜索与抓取工具集——[
     - [手动上下文压缩](#手动上下文压缩)
     - [Sub-Agents](#sub-agents)
     - [Sandbox 与文件系统](#sandbox-与文件系统)
+    - [Agentic Browser Control](#agentic-browser-control)
     - [Context Engineering](#context-engineering)
     - [长期记忆](#长期记忆)
   - [推荐模型](#推荐模型)
@@ -669,6 +670,24 @@ DeerFlow 不只是“会说它能做”，它是真的有一台自己的“电�
 ├── workspace/        ← agents 的工作目录
 └── outputs/          ← 最终交付物
 ```
+
+### Agentic Browser Control
+
+读取页面和真正“使用”页面不是一回事。除了只读的 `web_fetch` 和 `web_capture` 工具外，DeerFlow 还提供一组可选的 agentic browser 工具，为每次对话保持一个实时浏览器会话，让 agent 真正操作页面——导航、读取可交互元素、点击、输入、提交表单，并在重度 JavaScript 站点上完成多步流程。
+
+每次操作都会返回页面可交互元素的最新快照，每个元素用稳定的 `[ref]` 编号寻址，因此 agent 基于刚观察到的内容行动，而不是猜测选择器。出站 URL 默认会经过 SSRF 筛查。该能力由 Playwright 提供，作为 optional extra 发布，以保持核心安装精简：
+
+```bash
+cd backend
+uv sync --extra browser
+uv run playwright install chromium
+```
+
+然后在 `config.yaml` 中取消注释 `group: browser` 工具项（`browser_navigate`、`browser_snapshot`、`browser_click`、`browser_type`、`browser_get_text`、`browser_back`、`browser_screenshot`、`browser_close`）。`make dev` / Docker 启动时如果检测到已启用 `browser_navigate`，会在依赖同步时保留 `browser` extra。如果配置了 browser control 但缺少 Playwright，Gateway 会启动失败；`/api/features` 也会在后端无法提供该能力时隐藏 Browser UI。除本地、受信任的调试外，请保持 `headless: true` 和 `allow_private_addresses: false`。通过 `cdp_url` 连接到已有 Chrome 时，DeerFlow 无法强制执行子资源和重定向的 SSRF 防护，因此会 fail closed，除非显式设置 `allow_unguarded_cdp: true` 确认该风险；仅用于受信任的本地浏览器。Browser session 是进程本地的；启用该工具组时请保持 `GATEWAY_WORKERS=1`，因为普通 uvicorn worker 调度不提供 thread affinity。
+
+已有的、非 mock 的 Custom Agent 对话会在 browser control 可用、且该 agent 未限制 `tool_groups` 或已包含 `browser` 组时，展示同样的 Browser Live 控件。如果显式 allowlist 里没有 `browser`，这些控件会保持隐藏。
+
+workspace 的 Browser Live 客户端通过二进制 JPEG WebSocket 帧协商画面，每个显示刷新只保留最新的待处理帧，并回收被替换的 object URL。Gateway 控制消息仍是 JSON；未请求二进制能力的客户端继续使用旧的 JSON/base64 帧协议。
 
 ### Context Engineering
 


### PR DESCRIPTION
## Why

Chinese README was missing the Agentic Browser Control section that already exists in `README.md`. Chinese-only readers would not see the Playwright extra install, `group: browser` tool list, or the SSRF / `GATEWAY_WORKERS=1` constraints.

## What changed

- Added the matching section and TOC entry in `README_zh.md`.
- Commands, tool names, and config keys follow the English source.

## Surface area

- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

Compared `README.md` “Agentic Browser Control” with the new Chinese section; `git diff` is `README_zh.md` only.

## AI assistance

**Tool(s) used:** Grok 4.5 (Codex)

**How you used it:** Located the README_zh gap against current `main`, drafted the Chinese section from the English source, and checked the diff.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
