### PR TITLE
fix(browser): keep references to detached live-frame tasks

### DIFF
--- a/backend/packages/harness/deerflow/community/browser_automation/session.py
+++ b/backend/packages/harness/deerflow/community/browser_automation/session.py
@@ -316,6 +316,16 @@ class BrowserSession:
         self._input_live_frame_generation = 0
         self._input_live_frame_pending = False
         self._page_listener_bound = False
+        # The event loop only holds weak references to tasks, so a fire-and-forget
+        # task can be collected mid-execution. The schedulers below clear their
+        # ``*_pending`` guards in a ``finally`` block, which would then never run.
+        self._background_tasks: set[asyncio.Future[Any]] = set()
+
+    def _spawn_background(self, coro: Coroutine[Any, Any, Any]) -> None:
+        """Run *coro* detached, keeping a strong reference until it settles."""
+        task = asyncio.ensure_future(coro)
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     @property
     def active_refs(self) -> int:
@@ -403,7 +413,7 @@ class BrowserSession:
         """
         self._page = page
         if self._on_frame is not None and not self._screencast_binding and page is not self._screencast_page:
-            asyncio.ensure_future(self._rebind_screencast_safe())
+            self._spawn_background(self._rebind_screencast_safe())
 
     def _bind_new_page_listener(self) -> None:
         """Follow popups/new tabs so auth flows stay visible and controllable.
@@ -570,7 +580,7 @@ class BrowserSession:
         if self._settle_live_frames_pending:
             return
         self._settle_live_frames_pending = True
-        asyncio.ensure_future(self._settle_live_frames())
+        self._spawn_background(self._settle_live_frames())
 
     async def _push_live_frame(self) -> None:
         if self._on_frame is None:
@@ -604,7 +614,7 @@ class BrowserSession:
         if self._input_live_frame_pending:
             return
         self._input_live_frame_pending = True
-        asyncio.ensure_future(self._flush_input_live_frames())
+        self._spawn_background(self._flush_input_live_frames())
 
     async def _back(self) -> PageSnapshot:
         page = await self._ensure_page()

--- a/backend/tests/test_browser_automation.py
+++ b/backend/tests/test_browser_automation.py
@@ -8,6 +8,7 @@ skipped automatically when Playwright (or its browser binary) is unavailable.
 from __future__ import annotations
 
 import asyncio
+import gc
 import sys
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1124,3 +1125,51 @@ async def test_request_guard_not_installed_for_cdp_sessions():
     await session._install_request_guard()
     assert context.routed is False
     assert session._request_guard_bound is False
+
+
+@pytest.mark.parametrize(
+    ("schedule_attr", "coro_attr", "pending_attr"),
+    [
+        ("_schedule_settle_live_frames", "_settle_live_frames", "_settle_live_frames_pending"),
+        ("_schedule_input_live_frame", "_flush_input_live_frames", "_input_live_frame_pending"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_live_frame_schedulers_retain_task_reference(schedule_attr, coro_attr, pending_attr):
+    """Detached live-frame tasks must stay referenced until they finish.
+
+    The event loop only holds weak references to tasks, so an unreferenced task
+    can be collected before it runs. Both schedulers clear their ``*_pending``
+    guard in a ``finally`` block, so losing the task would strand the guard at
+    ``True`` and silently stop every later refresh for the session.
+    """
+    session = BrowserSession(
+        MagicMock(),
+        headless=True,
+        timeout_ms=1000,
+        viewport={"width": 1000, "height": 500},
+    )
+    release = asyncio.Event()
+
+    async def _blocked() -> None:
+        try:
+            await release.wait()
+        finally:
+            setattr(session, pending_attr, False)
+
+    setattr(session, coro_attr, _blocked)
+
+    getattr(session, schedule_attr)()
+    assert getattr(session, pending_attr) is True
+    assert len(session._background_tasks) == 1
+
+    # A weakly-referenced task would be collectable at this point.
+    gc.collect()
+    assert len(session._background_tasks) == 1
+
+    release.set()
+    await asyncio.gather(*session._background_tasks)
+    await asyncio.sleep(0)  # let the done callback run
+
+    assert session._background_tasks == set()
+    assert getattr(session, pending_attr) is False


### PR DESCRIPTION
## Why

`BrowserSession` schedules three coroutines with a bare `asyncio.ensure_future()` and keeps no reference to the resulting task. The event loop only holds weak references, so [the docs warn](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) such a task "may get garbage collected at any time, even before it's done".

For the two live-frame schedulers the consequence is worse than losing the task. Each sets a `*_pending` guard *before* scheduling and clears it in a `finally` block:

```python
def _schedule_settle_live_frames(self) -> None:
    if self._settle_live_frames_pending:
        return
    self._settle_live_frames_pending = True
    asyncio.ensure_future(self._settle_live_frames())   # clears the guard in `finally`
```

If that task is collected before it runs, the `finally` never executes, `_settle_live_frames_pending` stays `True` for the life of the session, and every later `_schedule_settle_live_frames()` returns early. Live frame refresh stops for that session with no error and nothing in the logs. `_schedule_input_live_frame()` has the same shape via `_input_live_frame_pending`.

This is the same failure mode as #4930 (premature GC of a delayed cleanup task), just in the browser session rather than the stream bridge.

I want to be straight about the strength of the claim: I did not reproduce a collection deterministically, because GC timing isn't controllable — that's what makes this latent rather than always-visible. The case rests on the documented weak-reference behaviour, the identical pattern already treated as a bug in #4930, and the fact that the surrounding code already guards against it elsewhere.

## What changed

No user-visible behaviour change when the tasks survive; it removes a path where the browser Live view can silently stop updating.

Added `BrowserSession._spawn_background()`, which retains the task in a set and discards it on completion, and routed the three `ensure_future` call sites through it. This is the pattern already used in `tools/builtins/task_tool.py`, `mcp/session_pool.py`, `extensions/notify.py`, `runtime/journal.py` and others.

Worth noting `ruff.toml` selects `E,F,I,UP`, so `RUF006` (`asyncio-dangling-task`) never fires — these three were the only production hits when I ran it manually.

## Surface area

- [x] **Backend API** — `packages/harness/deerflow/community/browser_automation/session.py`

## Bug fix verification

- Test path: `backend/tests/test_browser_automation.py::test_live_frame_schedulers_retain_task_reference`
- Red on `main`, green on this branch: **yes**

```
# new tests against unfixed main
$ git stash push backend/packages/harness/deerflow/community/browser_automation/session.py
$ uv run pytest tests/test_browser_automation.py -k retain_task_reference
FAILED ...[_schedule_settle_live_frames-...]
FAILED ...[_schedule_input_live_frame-...]
2 failed, 50 deselected

# with the fix
$ uv run pytest tests/test_browser_automation.py -k retain_task_reference
2 passed, 50 deselected
```

The test asserts the task survives an explicit `gc.collect()` while suspended, and that the reference is released once it completes so the set can't grow unbounded.

## Validation

```
$ cd backend && make lint
All checks passed!
1317 files already formatted

$ cd backend && make test
13729 passed, 62 skipped, 1 deselected, 19 warnings in 276.39s
```

## AI assistance

**Tool(s) used:** GitHub Copilot (Claude)

**How you used it:** Used it to scan the backend with ruff rule sets the repo doesn't enable (`ASYNC`, `B`, `RUF006`), triage the hits, and draft the fix and tests. I reviewed the full diff and discarded the other findings as false positives — the `B023` loop-variable hits in `runtime/runs/manager.py` are safe because those lambdas are awaited within the same iteration, and the `ASYNC250`/`ASYNC251` hits are in `debug.py` and a test.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.