### PR TITLE
fix(frontend): remove dead commented-out connector block from the composer

### DIFF
--- a/frontend/src/components/workspace/input-box.tsx
+++ b/frontend/src/components/workspace/input-box.tsx
@@ -2297,15 +2297,6 @@ export function InputBox({
         </div>
         <PromptInputFooter className="flex flex-wrap gap-2 sm:flex-nowrap">
           <PromptInputTools className="min-w-0 flex-1 flex-wrap">
-            {/* TODO: Add more connectors here
-          <PromptInputActionMenu>
-            <PromptInputActionMenuTrigger className="px-2!" />
-            <PromptInputActionMenuContent>
-              <PromptInputActionAddAttachments
-                label={t.inputBox.addAttachments}
-              />
-            </PromptInputActionMenuContent>
-          </PromptInputActionMenu> */}
             <AddAttachmentsButton
               className="px-2!"
               disabled={composerLocked}


### PR DESCRIPTION
## Why

The composer in input-box.tsx carried a commented-out legacy <PromptInputActionMenu> attachments block (TODO: Add more connectors here) left over from before the AddAttachmentsButton component replaced it. Dead commented UI misleads maintainers into thinking the old path is live or half-migrated, and it has no runtime effect.

## What changed

- Deleted the 9-line commented-out JSX block between <PromptInputTools> and <AddAttachmentsButton>.

- No component, import, or i18n key changed: PromptInputActionMenu* are still used by the live menus below, and AddAttachmentsButton already provides the attachments entry point.

## Surface area

- [x] Frontend UI - composer tool row, comment-only change

- [ ] Backend API / Agents / Sandbox / Skills / Dependencies / Default behavior change

## Validation

- Comment-only deletion: no behavior change; the surrounding JSX is byte-identical outside the removed lines.

- Full pnpm check requires node_modules install on this host; diff is limited to dead comments so lint/typecheck risk is nil.

## AI assistance

**Tool(s) used:** Codex (coding agent)

**How you used it:** located and removed the dead block with AI assistance; reviewed before commit.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

