### PR TITLE
fix(runtime): reclaim idle per-thread locks

### DIFF
--- a/backend/packages/harness/deerflow/runtime/goal.py
+++ b/backend/packages/harness/deerflow/runtime/goal.py
@@ -14,10 +14,7 @@ import inspect
 import json
 import logging
 import os
-import threading
-import weakref
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import AbstractAsyncContextManager
 from typing import Any, Literal, NamedTuple
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -26,6 +23,7 @@ from langgraph.checkpoint.base import empty_checkpoint, uuid6
 import deerflow.utils.llm_text as llm_text
 from deerflow.agents.goal_state import GoalBlocker, GoalEvaluation, GoalState
 from deerflow.models import create_chat_model
+from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
 from deerflow.tracing import inject_langfuse_metadata
 from deerflow.utils.messages import message_to_text
 from deerflow.utils.time import now_iso
@@ -56,30 +54,16 @@ _extract_response_text = llm_text.extract_response_text
 _strip_markdown_code_fence = llm_text.strip_markdown_code_fence
 _strip_think_blocks = llm_text.strip_think_blocks
 
-_goal_locks_guard = threading.Lock()
-_goal_locks_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
+_goal_locks = AsyncKeyedLockTable[str]()
 
 
 class GoalWriteConflict(RuntimeError):
     """Raised when a goal write is based on a stale checkpoint."""
 
 
-@asynccontextmanager
-async def goal_thread_lock(thread_id: str) -> AsyncIterator[None]:
+def goal_thread_lock(thread_id: str) -> AbstractAsyncContextManager[None]:
     """Serialize goal read-modify-write sequences within the current event loop."""
-    loop = asyncio.get_running_loop()
-    with _goal_locks_guard:
-        locks = _goal_locks_by_loop.get(loop)
-        if locks is None:
-            locks = {}
-            _goal_locks_by_loop[loop] = locks
-        lock = locks.get(thread_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            locks[thread_id] = lock
-
-    async with lock:
-        yield
+    return _goal_locks.hold(thread_id)
 
 
 class GoalCommand(NamedTuple):

--- a/backend/packages/harness/deerflow/runtime/keyed_lock.py
+++ b/backend/packages/harness/deerflow/runtime/keyed_lock.py
@@ -1,0 +1,61 @@
+"""Async keyed locks whose idle entries are reclaimed safely."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import weakref
+from collections.abc import AsyncIterator, Hashable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class _Entry:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    participants: int = 0  # holders + queued waiters
+
+
+class AsyncKeyedLockTable[KeyT: Hashable]:
+    """Serialize work per key without retaining keys after their last participant."""
+
+    def __init__(self) -> None:
+        self._guard = threading.Lock()
+        self._entries_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[KeyT, _Entry]] = weakref.WeakKeyDictionary()
+
+    @asynccontextmanager
+    async def hold(self, key: KeyT) -> AsyncIterator[None]:
+        loop = asyncio.get_running_loop()
+        with self._guard:
+            entries = self._entries_by_loop.get(loop)
+            if entries is None:
+                entries = {}
+                self._entries_by_loop[loop] = entries
+            entry = entries.get(key)
+            if entry is None:
+                entry = _Entry()
+                entries[key] = entry
+            entry.participants += 1
+
+        acquired = False
+        try:
+            await entry.lock.acquire()
+            acquired = True
+            yield
+        finally:
+            if acquired:
+                entry.lock.release()
+            with self._guard:
+                entry.participants -= 1
+                if entry.participants == 0:
+                    current_entries = self._entries_by_loop.get(loop)
+                    if current_entries is not None and current_entries.get(key) is entry:
+                        del current_entries[key]
+                        if not current_entries:
+                            del self._entries_by_loop[loop]
+
+    def _entry_count(self) -> int:
+        """Return the number of entries for the current loop (for diagnostics/tests)."""
+        loop = asyncio.get_running_loop()
+        with self._guard:
+            return len(self._entries_by_loop.get(loop, {}))

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -25,8 +25,8 @@ import sys
 import threading
 import time
 import weakref
-from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
-from contextlib import asynccontextmanager
+from collections.abc import Callable, Coroutine, Mapping
+from contextlib import AbstractAsyncContextManager
 from contextvars import Context
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -73,6 +73,7 @@ from deerflow.runtime.goal import (
     visible_conversation_signature,
     write_thread_goal,
 )
+from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
 from deerflow.runtime.serialization import serialize
 from deerflow.runtime.stream_bridge import StreamBridge
 from deerflow.runtime.stream_modes import normalize_stream_modes, to_langgraph_stream_modes
@@ -90,8 +91,7 @@ from .schemas import RunStatus
 
 logger = logging.getLogger(__name__)
 
-_checkpoint_locks_guard = threading.Lock()
-_checkpoint_locks_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
+_checkpoint_locks = AsyncKeyedLockTable[str]()
 
 # Completed LangGraph runs can leave callback Contexts and AsyncPregelLoop
 # instances in unreachable reference cycles. They are collectable, but a busy
@@ -229,22 +229,9 @@ def _release_run_scoped_references(
             runtime_context.pop(key, None)
 
 
-@asynccontextmanager
-async def _checkpoint_thread_lock(thread_id: str) -> AsyncIterator[None]:
+def _checkpoint_thread_lock(thread_id: str) -> AbstractAsyncContextManager[None]:
     """Serialize checkpoint mutations for one thread without blocking goal commands."""
-    loop = asyncio.get_running_loop()
-    with _checkpoint_locks_guard:
-        locks = _checkpoint_locks_by_loop.get(loop)
-        if locks is None:
-            locks = {}
-            _checkpoint_locks_by_loop[loop] = locks
-        lock = locks.get(thread_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            locks[thread_id] = lock
-
-    async with lock:
-        yield
+    return _checkpoint_locks.hold(thread_id)
 
 
 _DELIVERY_RECEIPT_RETRY_DELAYS_SECONDS = (0.1, 0.5)

--- a/backend/tests/test_async_keyed_lock.py
+++ b/backend/tests/test_async_keyed_lock.py
@@ -1,0 +1,95 @@
+import asyncio
+
+import pytest
+
+from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
+
+
+@pytest.mark.asyncio
+async def test_reclaims_idle_keys() -> None:
+    table = AsyncKeyedLockTable[str]()
+
+    for index in range(100):
+        async with table.hold(f"thread-{index}"):
+            assert table._entry_count() == 1
+
+    assert table._entry_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_waiter_keeps_the_same_entry_until_it_finishes() -> None:
+    table = AsyncKeyedLockTable[str]()
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    order: list[str] = []
+
+    async def first() -> None:
+        async with table.hold("thread"):
+            order.append("first-enter")
+            first_entered.set()
+            await release_first.wait()
+            order.append("first-exit")
+
+    async def second() -> None:
+        await first_entered.wait()
+        async with table.hold("thread"):
+            order.append("second-enter")
+
+    first_task = asyncio.create_task(first())
+    second_task = asyncio.create_task(second())
+    await first_entered.wait()
+    await asyncio.sleep(0)
+    assert table._entry_count() == 1
+
+    release_first.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert order == ["first-enter", "first-exit", "second-enter"]
+    assert table._entry_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_releases_its_participant_reference() -> None:
+    table = AsyncKeyedLockTable[str]()
+    release_holder = asyncio.Event()
+    holder_entered = asyncio.Event()
+
+    async def holder() -> None:
+        async with table.hold("thread"):
+            holder_entered.set()
+            await release_holder.wait()
+
+    async def waiter() -> None:
+        async with table.hold("thread"):
+            raise AssertionError("cancelled waiter entered the lock")
+
+    holder_task = asyncio.create_task(holder())
+    await holder_entered.wait()
+    waiter_task = asyncio.create_task(waiter())
+    await asyncio.sleep(0)
+    waiter_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    assert table._entry_count() == 1
+    release_holder.set()
+    await holder_task
+    assert table._entry_count() == 0
+
+
+@pytest.mark.asyncio
+async def test_different_keys_do_not_block_each_other() -> None:
+    table = AsyncKeyedLockTable[str]()
+    both_entered = asyncio.Event()
+    entered = 0
+
+    async def hold(key: str) -> None:
+        nonlocal entered
+        async with table.hold(key):
+            entered += 1
+            if entered == 2:
+                both_entered.set()
+            await both_entered.wait()
+
+    await asyncio.wait_for(asyncio.gather(hold("a"), hold("b")), timeout=1)
+    assert table._entry_count() == 0


### PR DESCRIPTION
Fixes #5171

## Why

The goal and checkpoint lock registries retain every historical thread ID for the lifetime of the Gateway event loop. A naive deletion after unlock would allow a new caller to bypass an already queued waiter, so cleanup must account for holders and waiters together.

## What changed

- Added a small asyncio keyed-lock table shared by the goal and checkpoint paths.
- Counted holders and queued waiters before acquisition and removed an entry only after the final participant exits.
- Kept event-loop isolation through the existing weak loop-keyed outer table.
- Added regression coverage for idle-key reclamation, queued-waiter serialization, waiter cancellation, and independent keys.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this is backend runtime lifecycle behavior.

## Bug fix verification

- Test path: `backend/tests/test_async_keyed_lock.py`
- Red on `main`: not run as a patch-on-main test; the original strong retention is directly visible in both registries, while the added tests exercise the cleanup invariants that the replacement must preserve.

## Validation

- Focused asyncio harness covering all four regression scenarios
- `ruff check` on both changed runtime modules, the new helper, and its tests
- `ruff format --check` on the same files
- `git diff --check`

The full backend environment was intentionally not installed locally; CI can run the repository-wide suite.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Codex assisted with the keyed-lock implementation, cancellation analysis, and regression tests. I reviewed every changed line and validated the concurrency invariants with a focused asyncio harness.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
