### PR TITLE
fix(runtime): added waiter-safe keyed lock reclamation

### DIFF
--- a/backend/packages/harness/deerflow/runtime/goal.py
+++ b/backend/packages/harness/deerflow/runtime/goal.py
@@ -14,10 +14,7 @@ import inspect
 import json
 import logging
 import os
-import threading
-import weakref
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
+from contextlib import AbstractAsyncContextManager
 from typing import Any, Literal, NamedTuple
 
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -26,6 +23,7 @@ from langgraph.checkpoint.base import empty_checkpoint, uuid6
 import deerflow.utils.llm_text as llm_text
 from deerflow.agents.goal_state import GoalBlocker, GoalEvaluation, GoalState
 from deerflow.models import create_chat_model
+from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
 from deerflow.tracing import inject_langfuse_metadata
 from deerflow.utils.messages import message_to_text
 from deerflow.utils.time import now_iso
@@ -56,30 +54,16 @@ _extract_response_text = llm_text.extract_response_text
 _strip_markdown_code_fence = llm_text.strip_markdown_code_fence
 _strip_think_blocks = llm_text.strip_think_blocks
 
-_goal_locks_guard = threading.Lock()
-_goal_locks_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
+_goal_locks = AsyncKeyedLockTable[str]()
 
 
 class GoalWriteConflict(RuntimeError):
     """Raised when a goal write is based on a stale checkpoint."""
 
 
-@asynccontextmanager
-async def goal_thread_lock(thread_id: str) -> AsyncIterator[None]:
+def goal_thread_lock(thread_id: str) -> AbstractAsyncContextManager[None]:
     """Serialize goal read-modify-write sequences within the current event loop."""
-    loop = asyncio.get_running_loop()
-    with _goal_locks_guard:
-        locks = _goal_locks_by_loop.get(loop)
-        if locks is None:
-            locks = {}
-            _goal_locks_by_loop[loop] = locks
-        lock = locks.get(thread_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            locks[thread_id] = lock
-
-    async with lock:
-        yield
+    return _goal_locks.hold(thread_id)
 
 
 class GoalCommand(NamedTuple):

--- a/backend/packages/harness/deerflow/runtime/keyed_lock.py
+++ b/backend/packages/harness/deerflow/runtime/keyed_lock.py
@@ -1,0 +1,89 @@
+"""Async per-key serialization with waiter-aware entry reclamation."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import weakref
+from collections.abc import AsyncIterator, Hashable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class _Entry:
+    lock: asyncio.Lock
+    participants: int = 0  # current holder plus queued waiters
+
+
+class AsyncKeyedLockTable[KeyT: Hashable]:
+    """Serialize same-key work without retaining idle keys.
+
+    A table may be shared by event loops running in different threads. Each
+    loop receives its own entries because ``asyncio.Lock`` instances become
+    loop-affine once contended. The thread lock protects only the registry;
+    async critical sections never hold it.
+
+    Participants are counted before awaiting the lock. This keeps an entry
+    discoverable until its final holder or waiter leaves, so a new caller
+    cannot create a second lock and bypass an already queued waiter. Cancelled
+    waiters check their participation back in through the same ``finally``
+    path.
+    """
+
+    def __init__(self) -> None:
+        self._guard = threading.Lock()
+        self._entries_by_loop: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, dict[KeyT, _Entry]
+        ] = weakref.WeakKeyDictionary()
+
+    @asynccontextmanager
+    async def hold(self, key: KeyT) -> AsyncIterator[None]:
+        """Hold the current event loop's lock for ``key``."""
+        loop = asyncio.get_running_loop()
+        entries, entry = self._checkout(loop, key)
+        acquired = False
+        try:
+            await entry.lock.acquire()
+            acquired = True
+            yield
+        finally:
+            try:
+                if acquired:
+                    entry.lock.release()
+            finally:
+                self._checkin(loop, entries, key, entry)
+
+    def _checkout(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        key: KeyT,
+    ) -> tuple[dict[KeyT, _Entry], _Entry]:
+        with self._guard:
+            entries = self._entries_by_loop.get(loop)
+            if entries is None:
+                entries = {}
+                self._entries_by_loop[loop] = entries
+            entry = entries.get(key)
+            if entry is None:
+                entry = _Entry(lock=asyncio.Lock())
+                entries[key] = entry
+            entry.participants += 1
+            return entries, entry
+
+    def _checkin(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        entries: dict[KeyT, _Entry],
+        key: KeyT,
+        entry: _Entry,
+    ) -> None:
+        with self._guard:
+            entry.participants -= 1
+            if entry.participants != 0 or entry.lock.locked():
+                return
+            if entries.get(key) is not entry:
+                return
+            entries.pop(key)
+            if not entries and self._entries_by_loop.get(loop) is entries:
+                self._entries_by_loop.pop(loop, None)

--- a/backend/packages/harness/deerflow/runtime/keyed_lock.py
+++ b/backend/packages/harness/deerflow/runtime/keyed_lock.py
@@ -33,9 +33,7 @@ class AsyncKeyedLockTable[KeyT: Hashable]:
 
     def __init__(self) -> None:
         self._guard = threading.Lock()
-        self._entries_by_loop: weakref.WeakKeyDictionary[
-            asyncio.AbstractEventLoop, dict[KeyT, _Entry]
-        ] = weakref.WeakKeyDictionary()
+        self._entries_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[KeyT, _Entry]] = weakref.WeakKeyDictionary()
 
     @asynccontextmanager
     async def hold(self, key: KeyT) -> AsyncIterator[None]:

--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -25,8 +25,8 @@ import sys
 import threading
 import time
 import weakref
-from collections.abc import AsyncIterator, Callable, Coroutine, Mapping
-from contextlib import asynccontextmanager
+from collections.abc import Callable, Coroutine, Mapping
+from contextlib import AbstractAsyncContextManager
 from contextvars import Context
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -73,6 +73,7 @@ from deerflow.runtime.goal import (
     visible_conversation_signature,
     write_thread_goal,
 )
+from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
 from deerflow.runtime.serialization import serialize
 from deerflow.runtime.stream_bridge import StreamBridge
 from deerflow.runtime.stream_modes import normalize_stream_modes, to_langgraph_stream_modes
@@ -90,8 +91,7 @@ from .schemas import RunStatus
 
 logger = logging.getLogger(__name__)
 
-_checkpoint_locks_guard = threading.Lock()
-_checkpoint_locks_by_loop: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = weakref.WeakKeyDictionary()
+_checkpoint_locks = AsyncKeyedLockTable[str]()
 
 # Completed LangGraph runs can leave callback Contexts and AsyncPregelLoop
 # instances in unreachable reference cycles. They are collectable, but a busy
@@ -229,22 +229,9 @@ def _release_run_scoped_references(
             runtime_context.pop(key, None)
 
 
-@asynccontextmanager
-async def _checkpoint_thread_lock(thread_id: str) -> AsyncIterator[None]:
+def _checkpoint_thread_lock(thread_id: str) -> AbstractAsyncContextManager[None]:
     """Serialize checkpoint mutations for one thread without blocking goal commands."""
-    loop = asyncio.get_running_loop()
-    with _checkpoint_locks_guard:
-        locks = _checkpoint_locks_by_loop.get(loop)
-        if locks is None:
-            locks = {}
-            _checkpoint_locks_by_loop[loop] = locks
-        lock = locks.get(thread_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            locks[thread_id] = lock
-
-    async with lock:
-        yield
+    return _checkpoint_locks.hold(thread_id)
 
 
 _DELIVERY_RECEIPT_RETRY_DELAYS_SECONDS = (0.1, 0.5)

--- a/backend/tests/test_runtime_keyed_lock.py
+++ b/backend/tests/test_runtime_keyed_lock.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import asyncio
+import gc
+import threading
+import weakref
+from concurrent.futures import ThreadPoolExecutor
+from uuid import uuid4
+
+import pytest
+
+from deerflow.runtime.goal import goal_thread_lock
+from deerflow.runtime.runs.worker import _checkpoint_thread_lock
+
+
+class _WeakThreadId(str):
+    pass
+
+
+class _WeakKey:
+    pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "lock_factory",
+    [goal_thread_lock, _checkpoint_thread_lock],
+    ids=["goal", "checkpoint"],
+)
+async def test_runtime_thread_lock_releases_idle_thread_id(lock_factory) -> None:
+    thread_id = _WeakThreadId(f"retention-{uuid4().hex}")
+    thread_id_ref = weakref.ref(thread_id)
+
+    async with lock_factory(thread_id):
+        pass
+
+    del thread_id
+    gc.collect()
+
+    assert thread_id_ref() is None
+
+
+@pytest.mark.asyncio
+async def test_goal_and_checkpoint_lock_domains_remain_independent() -> None:
+    release_checkpoint = asyncio.Event()
+    checkpoint_entered = asyncio.Event()
+    goal_entered = asyncio.Event()
+    thread_id = f"independent-{uuid4().hex}"
+
+    async def hold_checkpoint() -> None:
+        async with _checkpoint_thread_lock(thread_id):
+            checkpoint_entered.set()
+            await release_checkpoint.wait()
+
+    async def hold_goal() -> None:
+        async with goal_thread_lock(thread_id):
+            goal_entered.set()
+
+    checkpoint_task = asyncio.create_task(hold_checkpoint())
+    await checkpoint_entered.wait()
+    goal_task = asyncio.create_task(hold_goal())
+    try:
+        await asyncio.wait_for(goal_entered.wait(), timeout=1)
+    finally:
+        release_checkpoint.set()
+        await checkpoint_task
+        await goal_task
+
+
+@pytest.mark.asyncio
+async def test_late_arrival_cannot_bypass_queued_waiter() -> None:
+    from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
+
+    table = AsyncKeyedLockTable[str]()
+    release_first = asyncio.Event()
+    release_second = asyncio.Event()
+    first_entered = asyncio.Event()
+    second_started = asyncio.Event()
+    second_entered = asyncio.Event()
+    third_started = asyncio.Event()
+    third_entered = asyncio.Event()
+    active = 0
+    max_active = 0
+    order: list[str] = []
+
+    async def participant(
+        name: str,
+        started: asyncio.Event | None,
+        entered: asyncio.Event,
+        release: asyncio.Event | None,
+    ) -> None:
+        nonlocal active, max_active
+        if started is not None:
+            started.set()
+        async with table.hold("thread"):
+            active += 1
+            max_active = max(max_active, active)
+            order.append(name)
+            entered.set()
+            try:
+                if release is not None:
+                    await release.wait()
+            finally:
+                active -= 1
+
+    first = asyncio.create_task(participant("first", None, first_entered, release_first))
+    await first_entered.wait()
+
+    second = asyncio.create_task(participant("second", second_started, second_entered, release_second))
+    await second_started.wait()
+
+    release_first.set()
+    await second_entered.wait()
+
+    third = asyncio.create_task(participant("third", third_started, third_entered, None))
+    await third_started.wait()
+
+    assert not third_entered.is_set()
+    assert max_active == 1
+
+    release_second.set()
+    await asyncio.gather(first, second, third)
+
+    assert order == ["first", "second", "third"]
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_waiter_releases_its_participation() -> None:
+    from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
+
+    table = AsyncKeyedLockTable[_WeakKey]()
+    key = _WeakKey()
+    key_ref = weakref.ref(key)
+    release_holder = asyncio.Event()
+    holder_entered = asyncio.Event()
+    waiter_started = asyncio.Event()
+
+    async def holder(lock_key: _WeakKey) -> None:
+        async with table.hold(lock_key):
+            holder_entered.set()
+            await release_holder.wait()
+
+    async def waiter(lock_key: _WeakKey) -> None:
+        waiter_started.set()
+        async with table.hold(lock_key):
+            raise AssertionError("cancelled waiter entered the critical section")
+
+    holder_task = asyncio.create_task(holder(key))
+    await holder_entered.wait()
+    waiter_task = asyncio.create_task(waiter(key))
+    await waiter_started.wait()
+
+    waiter_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter_task
+
+    release_holder.set()
+    await holder_task
+
+    del holder_task, waiter_task, key
+    gc.collect()
+    assert key_ref() is None
+
+
+@pytest.mark.asyncio
+async def test_many_unique_keys_are_reclaimed() -> None:
+    from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
+
+    table = AsyncKeyedLockTable[_WeakKey]()
+    keys = [_WeakKey() for _ in range(1000)]
+    key_refs = [weakref.ref(key) for key in keys]
+
+    for key in keys:
+        async with table.hold(key):
+            pass
+
+    del key, keys
+    gc.collect()
+
+    assert all(key_ref() is None for key_ref in key_refs)
+
+
+def test_same_key_is_independent_across_event_loops() -> None:
+    from deerflow.runtime.keyed_lock import AsyncKeyedLockTable
+
+    table = AsyncKeyedLockTable[str]()
+    barrier = threading.Barrier(2, timeout=2)
+
+    def run_loop() -> None:
+        async def run() -> None:
+            async with table.hold("thread"):
+                await asyncio.to_thread(barrier.wait)
+
+        asyncio.run(run())
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(run_loop) for _ in range(2)]
+        for future in futures:
+            future.result(timeout=3)


### PR DESCRIPTION
Fixes #5171

## Why

This PR implements the bug reported in #5171, which I originally discovered and filed after tracing the retention back to the two runtime per-thread lock registries on current `main`.

I filed #5171 before opening an implementation PR. That left an unintended gap between publishing the root-cause analysis and submitting the corresponding fix, during which #5173 was opened against the same issue. This PR is the implementation I intended to submit for the issue I reported.

The core issue is not just that idle lock entries are retained. Cleanup also has to preserve serialization when a waiter already exists: removing an entry as soon as the current holder exits can let a later caller create a second lock and bypass the queued waiter.

## Why this implementation is robust

This change is designed around the full lifecycle invariant rather than only the uncontended cleanup case:

- holders and queued waiters are counted before acquisition;
- the keyed entry remains discoverable until the final participant leaves;
- cancelled waiters decrement through the same `finally` path;
- a late third caller cannot create a replacement lock while another waiter is still queued;
- lock entries remain isolated per event loop, avoiding cross-loop reuse of contended `asyncio.Lock` objects;
- goal-state serialization and checkpoint serialization remain separate lock domains;
- idle keys are reclaimed after the last holder/waiter exits, including high-cardinality historical thread IDs.

The regression suite intentionally tests these invariants at both the helper level and the real runtime call sites, rather than only checking an internal table size.

## What changed

- Added `AsyncKeyedLockTable`, a small waiter-aware asyncio keyed-lock registry with safe idle-entry reclamation.
- Replaced the goal runtime lock registry with its own keyed-lock table.
- Replaced the checkpoint runtime lock registry with a separate keyed-lock table.
- Added focused runtime regression coverage.

## Regression coverage

`backend/tests/test_runtime_keyed_lock.py` covers:

1. **Real goal lock reclamation** — a completed `goal_thread_lock()` no longer retains the historical thread ID.
2. **Real checkpoint lock reclamation** — the same guarantee through `_checkpoint_thread_lock()`.
3. **Goal/checkpoint independence** — the same thread ID can be held in both lock domains without one blocking the other.
4. **Queued-waiter race (A/B/C)** — A holds the lock, B queues, then C arrives after A releases; C must not bypass B via a newly-created lock.
5. **Cancellation cleanup** — cancelling a queued waiter does not leak its participant reference or retain the key.
6. **High-cardinality reclamation** — many unique historical keys become collectable after use.
7. **Cross-event-loop isolation** — the same key can be used independently in separate event loops without reusing a loop-affine contended lock.

These cases directly cover the correctness trap described in #5171, including the failure mode that a simple `pop(thread_id)` cleanup would introduce.

## Relationship to #5173

#5173 was opened after #5171 had already documented the bug, root cause, expected lifecycle invariants, and the queued-waiter correctness trap. After the formatter follow-up on this PR went green, maintainer `WillemJiang` closed #5173 without merging it and explicitly noted: “The issue is addressed in #5176.” This PR is therefore the active implementation for #5171.

The stronger regression coverage remains useful independently of that resolution: it exercises the real goal/checkpoint call sites and explicitly covers the three-participant A/B/C split-lock race, queued-waiter cancellation, high-cardinality reclamation, cross-event-loop isolation, and goal/checkpoint lock-domain independence.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — runtime / agent execution behavior
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — idle process-local lock entries are now reclaimed
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this is backend runtime lifecycle behavior.

## Bug fix verification

- Original report: #5171, filed by `Amazingjun-j` from inspection of current upstream `main` before this PR was opened.
- Regression path: `backend/tests/test_runtime_keyed_lock.py`.
- The tests exercise both actual runtime lock factories and the lifecycle invariants required to make reclamation safe.
- I am not claiming a patch-on-main red pytest run from the final synthetic workspace; the original strong-retention implementation is documented in #5171.

## Validation

- `python -m py_compile backend/packages/harness/deerflow/runtime/keyed_lock.py backend/tests/test_runtime_keyed_lock.py`
- `git diff --check`
- Current PR diff: 2 commits, exactly 4 changed files.
- Follow-up `d934d812dd4fe8dad0f2f827b9ef803f2131fb92` applies the exact Ruff 0.15.12 formatting output requested in review; it is formatting-only and changes no runtime semantics.
- Upstream CI on the current head is fully green:
  - `Lint Check` — success
  - `Backend Blocking IO` — success
  - `Frontend Unit Tests` — success
  - `Replay E2E (front-back contract)` — success
  - `Unit Tests` — success (all four backend shards plus default-install collection)
- Latest upstream `main` checked at `dbe11dc79890f4ea94d96ec37ecfd5cbfe85d1f1`; its two commits since this PR's base touch subagent/tool files only and do not overlap this PR's four files. The PR remains mergeable, so no churn-only rebase was performed.

## AI assistance

**Tool(s) used:** ChatGPT / OpenAI coding tools

**How you used it:** Assisted with root-cause analysis, concurrency reasoning, implementation, regression-test design, collision checks, repository validation, and PR preparation.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
