### PR TITLE
fix(scripts): probe _pick_python candidates through env so make dev starts the frontend on Windows

### DIFF
--- a/backend/tests/test_serve_pick_python.py
+++ b/backend/tests/test_serve_pick_python.py
@@ -1,0 +1,120 @@
+"""Regression coverage for #5179: on Windows/Git Bash the Microsoft Store
+python alias stubs pass Bash's own PATH lookup but cannot be exec'd through
+/usr/bin/env, so `make dev` never started the frontend."""
+
+from __future__ import annotations
+
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVE_SH = REPO_ROOT / "scripts" / "serve.sh"
+
+
+def _extract_shell_function(name: str) -> str:
+    text = SERVE_SH.read_text(encoding="utf-8")
+    marker = f"{name}() {{"
+    start = text.index(marker)
+    depth = 0
+    chunks: list[str] = []
+
+    for line in text[start:].splitlines(keepends=True):
+        chunks.append(line)
+        depth += line.count("{") - line.count("}")
+        if depth == 0:
+            return "".join(chunks)
+
+    raise AssertionError(f"Could not extract shell function {name}")
+
+
+# Shells out to bash with a stub-only PATH plus an optional `env` override,
+# exactly the split that broke Windows: the candidate stubs succeed when
+# invoked directly, while the mocked `env` mimics /usr/bin/env resolving the
+# WindowsApps alias (exit 127 = cannot exec).
+_SCRIPT_TEMPLATE = r"""
+set -u
+BIN=__BIN__
+mkdir -p "$BIN"
+for name in __STUBS__; do
+    printf '#!/bin/sh
+exit 0
+' > "$BIN/$name"
+    chmod +x "$BIN/$name"
+done
+export PATH="$BIN:$PATH"
+
+__ENV_MOCK__
+
+__FUNCTION__
+
+_pick_python
+"""
+
+
+def _to_bash_path(path: Path) -> str:
+    """Return `path` in the form the target bash understands.
+
+    MSYS/Git Bash needs an MSYS-style path (/c/...) on PATH: a drive-letter
+    style segment (C:/...) is resolved inconsistently between bash's own
+    lookup and /usr/bin/env. POSIX hosts pass through unchanged.
+    """
+    posix = path.resolve().as_posix()
+    if len(posix) > 1 and posix[1] == ":":
+        return "/" + posix[0].lower() + posix[2:]
+    return posix
+
+
+def _run_pick_python(tmp_path: Path, *, env_mock: str = "") -> subprocess.CompletedProcess:
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to exercise serve.sh helpers")
+
+    script = _SCRIPT_TEMPLATE.replace("__BIN__", shlex.quote(_to_bash_path(tmp_path / "bin"))).replace("__STUBS__", "python3 python py").replace("__ENV_MOCK__", env_mock).replace("__FUNCTION__", _extract_shell_function("_pick_python"))
+    # errors="replace": bash's diagnostics may arrive in the console's code
+    # page (GBK on a Chinese Windows host) while the selection output is ASCII.
+    return subprocess.run(
+        [bash, "-c", script],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def test_pick_python_prefers_python3_when_env_agrees(tmp_path):
+    # Real env: all stubs are ordinary executables, so python3 wins.
+    result = _run_pick_python(tmp_path)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "python3"
+
+
+def test_pick_python_skips_candidate_that_env_cannot_exec(tmp_path):
+    # Store-alias world: python3 execs fine directly but env fails on it;
+    # python works through both paths. Must select python, not python3.
+    env_mock = """
+env() {
+    case "$1" in
+        python3) return 127 ;;
+    esac
+    return 0
+}
+"""
+    result = _run_pick_python(tmp_path, env_mock=env_mock)
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "python"
+
+
+def test_pick_python_fails_when_no_candidate_survives_env_probe(tmp_path):
+    env_mock = """
+env() { return 127; }
+"""
+    result = _run_pick_python(tmp_path, env_mock=env_mock)
+
+    assert result.returncode == 1
+    assert result.stdout.strip() == ""

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -42,7 +42,15 @@ fi
 _pick_python() {
     local candidate
     for candidate in python3 python py; do
-        if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major >= 3 else 1)' >/dev/null 2>&1; then
+        # Probe through `env` as well: the frontend is launched as
+        # `env PORT=3000 "$DEERFLOW_PNPM_PYTHON" ...` (FRONTEND_CMD below), and on
+        # Windows/Git Bash the Microsoft Store python aliases under WindowsApps
+        # are skipped by Bash's own PATH lookup yet still resolved (and fail to
+        # exec) inside /usr/bin/env. A bare "$candidate" probe passes while the
+        # real launch dies with: env: 'python3': No such file or directory
+        if command -v "$candidate" >/dev/null 2>&1 \
+            && "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major >= 3 else 1)' >/dev/null 2>&1 \
+            && env "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major >= 3 else 1)' >/dev/null 2>&1; then
             printf '%s\n' "$candidate"
             return 0
         fi


### PR DESCRIPTION
<!-- Reference a related issue with #123. Use Fixes / Closes / Resolves to
     auto-close it on merge. Delete this line if the PR doesn't reference an issue. -->
Fixes #5179

## Why
<img width="2346" height="1480" alt="ab14a074c902c6254f74383f9f85e7b3" src="https://github.com/user-attachments/assets/91e969e8-00c9-4716-a531-56f8ec0055d9" />

 make dev fails to start the frontend on Windows / Git Bash.                                                                               
                                                                                                                                               
     _pick_python() in scripts/serve.sh selects an interpreter using only                                                                      
     Bash-side probes (command -v + a direct exec), but the frontend is later                                                                  
     launched as env PORT=3000 "$DEERFLOW_PNPM_PYTHON" ... — i.e. through                                                                      
     /usr/bin/env.                                                                                                                             
                                                                                                                                               
     On Windows, the Microsoft Store python aliases under %LOCALAPPDATA%\                                                                      
     Microsoft\WindowsApps\ (zero-byte reparse-point stubs like python3.exe)                                                                   
     sit in PATH ahead of any real Python. Git Bash's own lookup skips those                                                                   
     stubs, so both probes pass and _pick_python happily returns python3.                                                                      
     /usr/bin/env does NOT skip them: it resolves the stub, fails to exec it,                                                                  
     and the frontend dies with:                                                                                                               
                                                                                                                                               
         env: 'python3': No such file or directory                                                                                             
                                                                                                                                               
     The probe and the launch disagree because they resolve the interpreter                                                                    
     through two different PATH lookups. Any script that probes one way and                                                                    
     executes the other trips over this. 


## What changed

- _pick_python() now additionally validates each candidate through                                                                        
       /usr/bin/env (env "$candidate" -c ...), mirroring exactly how                                                                           
       FRONTEND_CMD invokes it later. A candidate is accepted only if both                                                                     
       the direct probe and the env-based probe succeed.                                                                                       
     - Net effect: on Windows/Git Bash with only the Store alias in PATH, the                                                                  
       stub is rejected and the next real interpreter is picked (or the                                                                        
       explicit failure path fires if none), so make dev starts the frontend                                                                   
       instead of dying at launch.                                                                                                             
     - No behavior change on Linux/macOS or any setup where Bash and env                                                                       
       agree — the accepted candidate set can only shrink, never widen.                                                                        
     - Added an in-script comment documenting the trap for future readers.                                                                     
     Surface area                                                                                                                              
                                                                                                                                               
     - [x] Default behavior change — dev tooling only (scripts/serve.sh):                                                                      
           the interpreter probe is now env-aware; on healthy setups the same                                                                  
           interpreter is selected as before.


## Surface area

<!-- Check every box that applies. Reviewers use this to scope the review. -->

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
  - Prompt-layer self-check: for every data source in the new text, what is its trust level, and which channel should it ride? Model-supplied or user-influenceable values belong on the untrusted, sanitized data channel (e.g. the task `HumanMessage`) — never interpolated into framework-owned system text, even neutralized.
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

<!-- If you checked "Frontend UI", attach screenshots showing the entry point —
     where users discover the change — not just the feature in isolation.
     Before/after is best for behavior changes. Short GIFs welcome. -->


## Bug fix verification

- Not cheap to encode as a failing test: the bug requires a Git Bash                                                                      
       environment where the WindowsApps Store alias stub sits in PATH ahead                                                                   
       of a real Python; CI's Linux runners can't reproduce it (Bash and env                                                                   
       agree there).                                                                                                                           
     - Verified manually on Windows / Git Bash: before the patch, make dev                                                                     
       frontend fails with env: 'python3': No such file or directory; after                                                                    
       the patch the stub is rejected and the frontend starts. 


## Validation

- bash -n scripts/serve.sh — clean.                                                                                                       
     - Manual make dev on Windows/Git Bash — backend and frontend both                                                                         
       come up; interpreter resolution unaffected on the same machine when                                                                     
       the Store alias is removed from PATH.


## AI assistance

<!-- DeerFlow is an AI project — most PRs here use AI coding tools, and that's
     welcome. Disclosing it just helps reviewers calibrate how closely to read the
     diff. Please fill all three; don't delete the section. -->

**Tool(s) used:** <!-- e.g. Claude Code, Cursor, GitHub Copilot, Codex, Windsurf, or "none" -->

**How you used it:** <!-- e.g. "generated the module from a spec", "autocomplete only",
     "AI wrote tests, I wrote the impl". A prompt or conversation link is great too. -->

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

