### PR TITLE
fix(frontend): make Playwright webServer command portable

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -28,8 +28,7 @@ export default defineConfig({
   webServer: skipWebServer
     ? undefined
     : {
-        command:
-          "./node_modules/.bin/next build && ./node_modules/.bin/next start",
+        command: "pnpm exec next build && pnpm exec next start",
         url: baseURL,
         reuseExistingServer: !process.env.CI,
         timeout: 120_000,


### PR DESCRIPTION
Fixes #5184

## Why

The default Playwright `webServer` command starts Next.js through `./node_modules/.bin/next`. Playwright executes that command through `cmd.exe` on Windows, where the extensionless POSIX shim cannot be resolved, so E2E tests exit before the server or any test starts.

## What changed

The Playwright server command now invokes Next.js through `pnpm exec`, which resolves the platform-appropriate package binary on Windows and Unix-like systems. Runtime application behavior is unchanged.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing product behavior without the user opting in
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this changes only the E2E server launcher.

## Bug fix verification

- Test path: `frontend/tests/e2e/sidecar-chat.spec.ts`, focused on `creates a hidden sidecar thread`.
- Red on `main`: yes. Playwright exited before test collection with `'.' is not recognized as an internal or external command`.
- Green on this branch: yes. The same command let Playwright build and start Next.js and completed with `1 passed (1.2m)`.

## Validation

- `pnpm exec playwright test tests/e2e/sidecar-chat.spec.ts --grep "creates a hidden sidecar thread"` — 1 passed; the configured web server built and started automatically
- `pnpm typecheck` — passed
- `pnpm format` — passed
- `pnpm lint` — passed
- `git diff --check` — passed

## AI assistance

**Tool(s) used:** OpenAI Codex

**How you used it:** Reproduced the Windows launcher failure, checked for duplicate reports, changed the single Playwright command, and ran the validation listed above.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.