### PR TITLE
fix(runs): defer completion-hook cancellation until terminal stages finish

### DIFF
--- a/backend/packages/harness/deerflow/runtime/runs/worker.py
+++ b/backend/packages/harness/deerflow/runtime/runs/worker.py
@@ -1534,6 +1534,16 @@ async def run_agent(
                     await ctx.on_run_completed(record)
                 except Exception:
                     logger.warning("Run completion hook failed for %s (non-fatal)", run_id, exc_info=True)
+                except BaseException as exc:
+                    # A host-task cancellation is BaseException, not Exception:
+                    # without this it escapes the hook guard and skips the stop
+                    # observers, the finalizing release, and the end frame below.
+                    if deferred_stop_interrupt is None:
+                        deferred_stop_interrupt = exc
+                    logger.warning(
+                        "Run completion hook interrupted for %s; completing cleanup first",
+                        run_id,
+                    )
 
             if task_info is not None and task_store is not None:
                 # Keep the finalizing barrier held until stop observers finish, so
@@ -1557,8 +1567,10 @@ async def run_agent(
                     )
                 except BaseException as exc:
                     # Cancellation here must not strand the finalizing barrier or
-                    # leave stream consumers waiting for the end frame.
-                    deferred_stop_interrupt = exc
+                    # leave stream consumers waiting for the end frame. First
+                    # interruption wins so the tail re-raises the original one.
+                    if deferred_stop_interrupt is None:
+                        deferred_stop_interrupt = exc
                     logger.warning(
                         "Extension task-stop notification interrupted for run %s; completing cleanup first",
                         run_id,

--- a/backend/tests/test_extension_task_lifecycle.py
+++ b/backend/tests/test_extension_task_lifecycle.py
@@ -323,6 +323,48 @@ async def test_lead_stop_runs_after_completion_hook_and_before_stream_end():
 
 
 @pytest.mark.asyncio
+async def test_completion_hook_cancellation_still_finishes_terminal_stages():
+    """#5190: a host-task cancellation inside the completion hook is a
+    BaseException, and it must not skip the stop observers, the finalizing
+    release, or the stream end frame."""
+    hook_entered = asyncio.Event()
+
+    async def _on_completed(_record):
+        hook_entered.set()
+        await asyncio.Future()  # hangs until the task is cancelled
+
+    recorder = _RunRecorder()
+    manager = RunManager()
+    record = await manager.create("thread-hook-cancel")
+    bridge = _bridge()
+
+    task = asyncio.create_task(
+        run_agent(
+            bridge,
+            manager,
+            record,
+            ctx=RunContext(
+                checkpointer=InMemorySaver(),
+                extensions=_extensions(recorder),
+                on_run_completed=_on_completed,
+            ),
+            agent_factory=lambda *, config: _OkAgent(),
+            graph_input={},
+            config={},
+        )
+    )
+    await asyncio.wait_for(hook_entered.wait(), timeout=5)
+    task.cancel("first completion cancellation")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    bridge.publish_end.assert_awaited_once_with(record.run_id)
+    assert any(event[0] == "stop" for event in recorder.events)
+    assert record.finalizing is False
+
+
+@pytest.mark.asyncio
 async def test_lead_stop_interrupt_is_deferred_until_final_cleanup():
     class _StopInterrupt(BaseException):
         pass


### PR DESCRIPTION
Fixes #5190.

## What happens today

`run_agent()` treats completion-hook failures as non-fatal, but the guard catches only `Exception`. A host-task cancellation (`asyncio.CancelledError`, a `BaseException`) raised while `ctx.on_run_completed(record)` awaits escapes immediately, so `notify_task_stop` never runs, the finalizing barrier stays set, and `bridge.publish_end(run_id)` is skipped, leaving stream consumers waiting for an end frame that never comes.

## Fix

The task-stop block right below already solves this exact problem: catch `BaseException`, defer it, run the terminal stages, re-raise. This PR extends the same deferral to the completion-hook guard and makes the first interruption win, so the tail re-raises the original cancellation rather than a later one. Deliberately no `Task.uncancel()`: the defer-and-re-raise shape preserves the cancellation instead of suppressing its count, and it matches the block that already exists.

## Tests

New regression test mirrors the issue's deterministic reproduction: completion hook blocks, the host task is cancelled inside it, and the test asserts `publish_end` was awaited exactly once, the stop observer ran, the finalizing barrier was released, and the task still ends in `CancelledError`. Fails on main before the fix (cancellation escapes and the run dies before `publish_end`), passes with it. Also run: `test_extension_task_lifecycle.py`, `test_run_worker_delivery.py`, `test_run_worker_rollback.py`, 139 passed. ruff format/check clean.

## AI disclosure

- AI tool used: yes (Kimi K3)
- Extent: implementation and tests prepared by the agent; mechanism verified by reading `runtime/runs/worker.py` on current main before writing the fix
- Human review: changes verified by running the lifecycle test files listed above locally

DCO sign-off in the commit.
