### PR TITLE
feat(sandbox): admit an acquisition before the provider provisions

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/exceptions.py
+++ b/backend/packages/harness/deerflow/sandbox/exceptions.py
@@ -25,6 +25,21 @@ class SandboxNotFoundError(SandboxError):
         self.sandbox_id = sandbox_id
 
 
+class SandboxAdmissionRefused(SandboxError):
+    """A provider refused an acquisition before provisioning anything.
+
+    Raised by ``SandboxProvider.admit`` (or its async twin) when policy denies
+    the acquisition: a per-user quota, a thread already held by an execution
+    that cannot share it, or any other admission rule. Nothing was acquired,
+    so nothing needs releasing.
+    """
+
+    def __init__(self, message: str = "Sandbox acquisition refused", reason: str | None = None):
+        details = {"reason": reason} if reason else None
+        super().__init__(message, details)
+        self.reason = reason
+
+
 class SandboxRuntimeError(SandboxError):
     """Raised when sandbox runtime is not available or misconfigured."""
 

--- a/backend/packages/harness/deerflow/sandbox/lease.py
+++ b/backend/packages/harness/deerflow/sandbox/lease.py
@@ -285,6 +285,7 @@ class SandboxLeaseManager:
         *,
         release_on_last: bool,
     ) -> str:
+        self._provider.admit(thread_id, user_id=user_id)
         sandbox_id = self._provider.acquire(thread_id, user_id=user_id)
         with self._metadata_lock:
             previous, release_previous = self._bind_locked(
@@ -306,6 +307,7 @@ class SandboxLeaseManager:
         *,
         release_on_last: bool,
     ) -> str:
+        await self._provider.admit_async(thread_id, user_id=user_id)
         acquire_task = asyncio.create_task(self._provider.acquire_async(thread_id, user_id=user_id))
         try:
             sandbox_id = await asyncio.shield(acquire_task)

--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -132,6 +132,7 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
     ) -> str:
         provider = get_sandbox_provider()
         if owner_id is None:
+            provider.admit(thread_id, user_id=user_id)
             sandbox_id = provider.acquire(thread_id, user_id=user_id)
         else:
             sandbox_id = get_sandbox_lease_manager(provider).acquire(
@@ -151,6 +152,7 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
     ) -> str:
         provider = get_sandbox_provider()
         if owner_id is None:
+            await provider.admit_async(thread_id, user_id=user_id)
             sandbox_id = await provider.acquire_async(thread_id, user_id=user_id)
         else:
             sandbox_id = await get_sandbox_lease_manager(provider).acquire_async(

--- a/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
+++ b/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
@@ -40,6 +40,24 @@ class SandboxProvider(ABC):
         """
         return await asyncio.to_thread(self.acquire, thread_id, user_id=user_id)
 
+    def admit(self, thread_id: str | None = None, *, user_id: str | None = None) -> None:
+        """Refuse an acquisition before any resource is provisioned.
+
+        The execution lease manager and the direct acquisition paths call
+        this with the arguments they are about to pass to ``acquire`` or
+        ``acquire_async``. Raise
+        :class:`~deerflow.sandbox.exceptions.SandboxAdmissionRefused` to deny;
+        the default admits everything. This is the seam for a per-user quota
+        and for a runtime that must refuse an ordinary acquisition of a thread
+        it holds under another regime. It runs before the provider spends
+        anything, so a refusal leaves nothing to release.
+        """
+        return None
+
+    async def admit_async(self, thread_id: str | None = None, *, user_id: str | None = None) -> None:
+        """Async twin of ``admit``; override when admission performs I/O."""
+        self.admit(thread_id, user_id=user_id)
+
     def sync_agent_skills(
         self,
         sandbox_id: str,

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -1563,6 +1563,7 @@ def ensure_sandbox_initialized(runtime: Runtime | None = None) -> Sandbox:
     user_id = resolve_runtime_user_id(runtime)
     owner_id = sandbox_lease_owner(runtime.context)
     if owner_id is None:
+        provider.admit(thread_id, user_id=user_id)
         sandbox_id = provider.acquire(thread_id, user_id=user_id)
     else:
         sandbox_id = get_sandbox_lease_manager(provider).acquire(
@@ -1639,6 +1640,7 @@ async def ensure_sandbox_initialized_async(runtime: Runtime | None = None) -> Sa
     user_id = resolve_runtime_user_id(runtime)
     owner_id = sandbox_lease_owner(runtime.context)
     if owner_id is None:
+        await provider.admit_async(thread_id, user_id=user_id)
         sandbox_id = await provider.acquire_async(thread_id, user_id=user_id)
     else:
         sandbox_id = await get_sandbox_lease_manager(provider).acquire_async(

--- a/backend/tests/test_sandbox_admission.py
+++ b/backend/tests/test_sandbox_admission.py
@@ -1,0 +1,97 @@
+"""Admission runs before acquisition, on every acquisition path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deerflow.sandbox import tools as sandbox_tools
+from deerflow.sandbox.exceptions import SandboxAdmissionRefused
+from deerflow.sandbox.lease import SandboxLeaseManager
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.sandbox_provider import SandboxProvider
+
+
+class _Provider(SandboxProvider):
+    def __init__(self) -> None:
+        self.admitted: list[tuple[str | None, str | None]] = []
+        self.acquired: list[str | None] = []
+
+    def acquire(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        del user_id
+        self.acquired.append(thread_id)
+        return "sandbox"
+
+    async def acquire_async(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        return self.acquire(thread_id, user_id=user_id)
+
+    def get(self, sandbox_id: str) -> Sandbox | None:
+        return None
+
+    def release(self, sandbox_id: str) -> None:
+        return None
+
+
+class _Refusing(_Provider):
+    def admit(self, thread_id: str | None = None, *, user_id: str | None = None) -> None:
+        self.admitted.append((thread_id, user_id))
+        raise SandboxAdmissionRefused("per-user sandbox quota exhausted", reason="user_quota_exhausted")
+
+
+def test_the_default_admits_everything() -> None:
+    provider = _Provider()
+    manager = SandboxLeaseManager(provider)
+
+    assert manager.acquire("owner", "thread", user_id="user") == "sandbox"
+    assert provider.acquired == ["thread"]
+
+
+def test_the_lease_manager_admits_before_the_provider_acquires() -> None:
+    provider = _Refusing()
+    manager = SandboxLeaseManager(provider)
+
+    with pytest.raises(SandboxAdmissionRefused) as refused:
+        manager.acquire("owner", "thread", user_id="user")
+
+    assert refused.value.reason == "user_quota_exhausted"
+    assert provider.admitted == [("thread", "user")]
+    assert provider.acquired == []
+    assert manager.binding_for("owner") is None
+
+
+@pytest.mark.asyncio
+async def test_async_acquisition_admits_through_the_sync_rule_by_default() -> None:
+    provider = _Refusing()
+    manager = SandboxLeaseManager(provider)
+
+    with pytest.raises(SandboxAdmissionRefused):
+        await manager.acquire_async("owner", "thread", user_id="user")
+
+    assert provider.admitted == [("thread", "user")]
+    assert provider.acquired == []
+
+
+def _runtime() -> SimpleNamespace:
+    return SimpleNamespace(state={"sandbox": None}, context={"thread_id": "thread", "user_id": "user"}, config=None)
+
+
+def test_direct_tool_acquisition_admits_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _Refusing()
+    monkeypatch.setattr(sandbox_tools, "get_sandbox_provider", lambda: provider)
+
+    with pytest.raises(SandboxAdmissionRefused):
+        sandbox_tools.ensure_sandbox_initialized(_runtime())
+
+    assert provider.acquired == []
+
+
+@pytest.mark.asyncio
+async def test_direct_async_tool_acquisition_admits_too(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _Refusing()
+    monkeypatch.setattr(sandbox_tools, "get_sandbox_provider", lambda: provider)
+
+    with pytest.raises(SandboxAdmissionRefused):
+        await sandbox_tools.ensure_sandbox_initialized_async(_runtime())
+
+    assert provider.acquired == []


### PR DESCRIPTION
## Why

Every sandbox acquisition goes straight to the provider today: the execution lease manager calls `provider.acquire`, and the sandbox middleware and tools call it directly when no lease owner is bound. There is no point at which policy can say "no" before a container exists. A per-user sandbox quota needs exactly that point, and an embedding runtime that holds a thread under another regime (a durable run whose container must not be shared with an upload or a fork) needs to refuse an ordinary acquisition of that thread up front rather than discover the conflict afterwards.

## What changed

- `SandboxProvider.admit(thread_id, user_id=...)` and `admit_async` are new hooks, no-op by default. A provider raises the new `SandboxAdmissionRefused(reason=...)` to deny.
- They are called immediately before `acquire`/`acquire_async` on every acquisition path: `SandboxLeaseManager._acquire_and_bind` and `_acquire_and_bind_async`, plus the direct fallbacks in `SandboxMiddleware._acquire_sandbox[_async]` and `ensure_sandbox_initialized[_async]`.
- A refusal happens before the provider has spent anything, so nothing needs releasing and the lease manager binds nothing.
- Existing providers and callers are unaffected: the default admits everything.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox** — sandboxed execution (`deerflow/sandbox`)
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Validation

- `cd backend && ruff check . && ruff format --check .` (clean)
- `pytest tests/test_sandbox_admission.py tests/test_sandbox_leases.py tests/test_sandbox_middleware.py tests/test_ensure_sandbox_initialized.py tests/test_sandbox_provider_lifecycle.py` (90 passed)
- The full offline `make test` run is in progress; its result will be posted as a comment before this draft is marked ready for review.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** The seam was designed for a downstream fork's session model (altakleos/hartmesh, register at https://github.com/altakleos/hartmesh/blob/main/docs/UPSTREAM_OFFERS.md); Claude Code wrote the patch and its tests from that design. Conversation: https://claude.ai/code/session_01Lnai2UYjfWF5aynt3rcBE2

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

Opened as a draft until the full offline suite result is posted below.

https://claude.ai/code/session_01Lnai2UYjfWF5aynt3rcBE2

