### PR TITLE
feat(sandbox): resolve a declared sandbox before state and provider

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/middleware.py
+++ b/backend/packages/harness/deerflow/sandbox/middleware.py
@@ -29,6 +29,7 @@ from deerflow.sandbox.lease import (
     sandbox_lease_owner,
 )
 from deerflow.sandbox.overwrite import unwrap_sandbox
+from deerflow.sandbox.resolution import resolve_declared_sandbox
 from deerflow.sandbox.sandbox_provider import get_initialized_sandbox_provider
 
 logger = logging.getLogger(__name__)
@@ -230,6 +231,22 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
             return super().before_agent(state, runtime)
         self._apply_network_policy_response(state, runtime)
         user_id = resolve_runtime_user_id(runtime)
+        declared = resolve_declared_sandbox()
+        if declared is not None:
+            # The executing context declared its sandbox: the declaring runtime
+            # provisioned it and owns its release, and this agent loop is one
+            # holder inside it. The authorization gate still applies.
+            try:
+                authorize_sandbox_execution(
+                    context=runtime.context or {},
+                    app_config=safe_app_config(),
+                )
+            except SandboxAuthorizationError:
+                logger.info("Sandbox execution denied for this role; not binding the declared sandbox (thread_id=%s)", thread_id)
+                return None
+            if self._read_sandbox_id_from_state(state) == declared.id:
+                return super().before_agent(state, runtime)
+            return self._declared_sandbox_update(state, declared.id)
         projection = self._prepare_agent_skill_projection(thread_id, user_id=user_id)
         owner_id = ensure_sandbox_lease_owner(runtime.context)
 
@@ -350,6 +367,20 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
             return await super().abefore_agent(state, runtime)
         await asyncio.to_thread(self._apply_network_policy_response, state, runtime)
         user_id = resolve_runtime_user_id(runtime)
+        declared = resolve_declared_sandbox()
+        if declared is not None:
+            # Async counterpart of the declared-sandbox binding in before_agent.
+            try:
+                await authorize_sandbox_execution_async(
+                    context=runtime.context or {},
+                    app_config=await safe_app_config_async(),
+                )
+            except SandboxAuthorizationError:
+                logger.info("Sandbox execution denied for this role; not binding the declared sandbox (thread_id=%s)", thread_id)
+                return None
+            if self._read_sandbox_id_from_state(state) == declared.id:
+                return await super().abefore_agent(state, runtime)
+            return self._declared_sandbox_update(state, declared.id)
         projection = await asyncio.to_thread(
             self._prepare_agent_skill_projection,
             thread_id,
@@ -419,8 +450,17 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
             runtime.context["sandbox_id"] = retained_id
         return await super().abefore_agent(state, runtime)
 
+    @staticmethod
+    def _declared_sandbox_update(state: SandboxMiddlewareState, sandbox_id: str) -> dict:
+        if SandboxMiddleware._read_sandbox_id_from_state(state) is not None:
+            return {"sandbox": Overwrite({"sandbox_id": sandbox_id})}
+        return {"sandbox": {"sandbox_id": sandbox_id}}
+
     @override
     def after_agent(self, state: SandboxMiddlewareState, runtime: Runtime) -> dict | None:
+        if resolve_declared_sandbox() is not None:
+            # The declaring runtime owns the release; this loop was a holder.
+            return None
         sandbox, fork_restored = unwrap_sandbox(state.get("sandbox"))
         if sandbox is not None:
             sandbox_id = sandbox["sandbox_id"]
@@ -454,6 +494,9 @@ class SandboxMiddleware(AgentMiddleware[SandboxMiddlewareState]):
 
     @override
     async def aafter_agent(self, state: SandboxMiddlewareState, runtime: Runtime) -> dict | None:
+        if resolve_declared_sandbox() is not None:
+            # The declaring runtime owns the release; this loop was a holder.
+            return None
         sandbox, fork_restored = unwrap_sandbox(state.get("sandbox"))
         if sandbox is not None:
             sandbox_id = sandbox["sandbox_id"]

--- a/backend/packages/harness/deerflow/sandbox/resolution.py
+++ b/backend/packages/harness/deerflow/sandbox/resolution.py
@@ -1,0 +1,40 @@
+"""Resolve a sandbox that the executing context has declared.
+
+Upstream resolves a tool's sandbox from checkpointed state and the execution
+lease. An embedding runtime may instead *declare* the sandbox an execution
+must use: a prewarmed container handed to a run, a fenced handle over a
+container the runtime provisioned and will release itself, or an in-memory
+double in tests. The declaration's carrier is the embedder's business (a
+context variable, a registry keyed by the running task); this module only asks
+it. When no resolver is installed, or the resolver answers ``None``, the
+sandbox middleware and tools take their ordinary path unchanged.
+
+A declared sandbox is resolved before state and before the provider, and the
+declaring runtime owns its release: the sandbox middleware binds the declared
+id into state for downstream tools and never acquires or releases on its
+behalf. The ``sandbox:execute`` authorization gate still applies.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from deerflow.sandbox.sandbox import Sandbox
+
+SandboxResolver = Callable[[], Sandbox | None]
+
+_resolver: SandboxResolver | None = None
+
+
+def set_sandbox_resolver(resolver: SandboxResolver | None) -> None:
+    """Install the process-wide resolver, or remove it with ``None``."""
+    global _resolver
+    _resolver = resolver
+
+
+def resolve_declared_sandbox() -> Sandbox | None:
+    """The sandbox the executing context declared, or ``None`` when it declared none."""
+    resolver = _resolver
+    if resolver is None:
+        return None
+    return resolver()

--- a/backend/packages/harness/deerflow/sandbox/tools.py
+++ b/backend/packages/harness/deerflow/sandbox/tools.py
@@ -40,6 +40,7 @@ from deerflow.sandbox.lease import (
 )
 from deerflow.sandbox.overwrite import unwrap_sandbox
 from deerflow.sandbox.path_patterns import build_output_mask_pattern, replace_output_path_matches
+from deerflow.sandbox.resolution import resolve_declared_sandbox
 from deerflow.sandbox.sandbox import Sandbox
 from deerflow.sandbox.sandbox_provider import SandboxProvider, get_sandbox_provider
 from deerflow.sandbox.search import GrepMatch
@@ -1394,6 +1395,9 @@ def sandbox_from_runtime(runtime: Runtime | None = None) -> Sandbox:
         raise SandboxRuntimeError("Tool runtime not available")
     if runtime.state is None:
         raise SandboxRuntimeError("Tool runtime state not available")
+    declared = resolve_declared_sandbox()
+    if declared is not None:
+        return declared
     # Read-only lookup: this only resolves the provider entry, and ownership
     # (release) stays with after_agent's short-circuit on the wrapped state.
     sandbox_state, _ = unwrap_sandbox(runtime.state.get("sandbox"))
@@ -1526,6 +1530,10 @@ def ensure_sandbox_initialized(runtime: Runtime | None = None) -> Sandbox:
             app_config=safe_app_config(),
         )
 
+    declared = resolve_declared_sandbox()
+    if declared is not None:
+        return declared
+
     # Check if sandbox already exists in state. A fork-restored execution keeps
     # the wrapper so after_agent cannot park the parent's sandbox, but it still
     # binds a non-releasing holder: parent cleanup cannot close the client under
@@ -1605,6 +1613,10 @@ async def ensure_sandbox_initialized_async(runtime: Runtime | None = None) -> Sa
             context=runtime.context or {},
             app_config=await safe_app_config_async(),
         )
+
+    declared = resolve_declared_sandbox()
+    if declared is not None:
+        return declared
 
     # Same borrowed-holder rule as the sync path above: keep the fork wrapper
     # while counting the child as an active client user.

--- a/backend/tests/test_sandbox_resolution.py
+++ b/backend/tests/test_sandbox_resolution.py
@@ -1,0 +1,148 @@
+"""A declared sandbox is resolved before state and before the provider."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from langgraph.runtime import Runtime
+from langgraph.types import Overwrite
+
+from deerflow.sandbox import tools as sandbox_tools
+from deerflow.sandbox.middleware import SandboxMiddleware
+from deerflow.sandbox.resolution import resolve_declared_sandbox, set_sandbox_resolver
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.sandbox_provider import SandboxProvider, reset_sandbox_provider, set_sandbox_provider
+from deerflow.sandbox.search import GrepMatch
+
+
+class _Declared(Sandbox):
+    def execute_command(self, command: str, env: dict[str, str] | None = None, timeout: float | None = None) -> str:
+        return "OK"
+
+    def read_file(self, path: str, start_line: int | None = None, end_line: int | None = None) -> str:
+        return "content"
+
+    def download_file(self, path: str) -> bytes:
+        return b"content"
+
+    def list_dir(self, path: str, max_depth: int = 2) -> list[str]:
+        return []
+
+    def write_file(self, path: str, content: str, append: bool = False) -> None:
+        return None
+
+    def glob(self, path: str, pattern: str, *, include_dirs: bool = False, max_results: int = 200) -> tuple[list[str], bool]:
+        return [], False
+
+    def grep(
+        self,
+        path: str,
+        pattern: str,
+        *,
+        glob: str | None = None,
+        literal: bool = False,
+        case_sensitive: bool = False,
+        max_results: int = 100,
+    ) -> tuple[list[GrepMatch], bool]:
+        return [], False
+
+    def update_file(self, path: str, content: bytes) -> None:
+        return None
+
+
+class _Provider(SandboxProvider):
+    def __init__(self) -> None:
+        self.acquired: list[str | None] = []
+        self.released: list[str] = []
+        self.sandbox = _Declared("ordinary-sandbox")
+
+    def acquire(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        del user_id
+        self.acquired.append(thread_id)
+        return "ordinary-sandbox"
+
+    async def acquire_async(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        return self.acquire(thread_id, user_id=user_id)
+
+    def get(self, sandbox_id: str) -> Sandbox | None:
+        return self.sandbox if sandbox_id == "ordinary-sandbox" else None
+
+    def release(self, sandbox_id: str) -> None:
+        self.released.append(sandbox_id)
+
+
+@pytest.fixture
+def declared():
+    sandbox = _Declared("declared-sandbox")
+    set_sandbox_resolver(lambda: sandbox)
+    try:
+        yield sandbox
+    finally:
+        set_sandbox_resolver(None)
+
+
+@pytest.fixture
+def provider(monkeypatch: pytest.MonkeyPatch):
+    provider = _Provider()
+    set_sandbox_provider(provider)
+    monkeypatch.setattr(sandbox_tools, "get_sandbox_provider", lambda: provider)
+    try:
+        yield provider
+    finally:
+        reset_sandbox_provider()
+
+
+def _runtime() -> SimpleNamespace:
+    return SimpleNamespace(state={"sandbox": None}, context={"thread_id": "thread-1", "user_id": "user-1"}, config=None)
+
+
+def test_nothing_is_declared_by_default() -> None:
+    assert resolve_declared_sandbox() is None
+
+
+def test_tools_resolve_the_declared_sandbox_before_state_or_provider(declared, provider) -> None:
+    runtime = _runtime()
+
+    assert sandbox_tools.ensure_sandbox_initialized(runtime) is declared
+    assert sandbox_tools.sandbox_from_runtime(runtime) is declared
+    assert provider.acquired == []
+
+
+@pytest.mark.asyncio
+async def test_async_tools_resolve_the_declared_sandbox(declared, provider) -> None:
+    assert await sandbox_tools.ensure_sandbox_initialized_async(_runtime()) is declared
+    assert provider.acquired == []
+
+
+def test_a_resolver_answering_none_leaves_the_ordinary_path_alone(provider) -> None:
+    set_sandbox_resolver(lambda: None)
+    try:
+        assert sandbox_tools.ensure_sandbox_initialized(_runtime()) is provider.sandbox
+    finally:
+        set_sandbox_resolver(None)
+    assert provider.acquired == ["thread-1"]
+
+
+def test_middleware_binds_the_declared_sandbox_and_never_acquires_or_releases(declared, provider) -> None:
+    middleware = SandboxMiddleware(lazy_init=False)
+    runtime = Runtime(context={"thread_id": "thread-1", "user_id": "user-1"})
+
+    assert middleware.before_agent({}, runtime) == {"sandbox": {"sandbox_id": "declared-sandbox"}}
+    assert middleware.before_agent({"sandbox": {"sandbox_id": "declared-sandbox"}}, runtime) is None
+    replaced = middleware.before_agent({"sandbox": {"sandbox_id": "stale"}}, runtime)
+    assert isinstance(replaced["sandbox"], Overwrite)
+    assert middleware.after_agent({"sandbox": {"sandbox_id": "declared-sandbox"}}, runtime) is None
+    assert provider.acquired == []
+    assert provider.released == []
+
+
+@pytest.mark.asyncio
+async def test_async_middleware_binds_the_declared_sandbox(declared, provider) -> None:
+    middleware = SandboxMiddleware(lazy_init=False)
+    runtime = Runtime(context={"thread_id": "thread-1", "user_id": "user-1"})
+
+    assert await middleware.abefore_agent({}, runtime) == {"sandbox": {"sandbox_id": "declared-sandbox"}}
+    assert await middleware.aafter_agent({"sandbox": {"sandbox_id": "declared-sandbox"}}, runtime) is None
+    assert provider.acquired == []
+    assert provider.released == []


### PR DESCRIPTION
## Why

The sandbox middleware and the tool-side initialization helpers resolve a sandbox from checkpointed state and the execution lease. A runtime that already knows which sandbox an execution must use has no way to say so: prewarm (#5002) wants to hand a warmed container to a run, tests want to declare an in-memory double instead of stubbing the provider, and an embedding runtime that provisions a container under its own lifecycle, and will release it itself, wants to bind a handle to the execution instead of patching middleware and tools.

## What changed

- New `deerflow.sandbox.resolution`: `set_sandbox_resolver(fn)` installs a process-wide resolver and `resolve_declared_sandbox()` asks it. The carrier of the declaration (a context variable, a registry keyed by the running task) stays the embedder's business.
- `SandboxMiddleware.before_agent`/`abefore_agent` bind a declared sandbox's id into state and skip acquisition; `after_agent`/`aafter_agent` skip release, because the declaring runtime owns it. The `sandbox:execute` authorization gate still applies, so a denied role gets no sandbox bound.
- `sandbox_from_runtime`, `ensure_sandbox_initialized`, and `ensure_sandbox_initialized_async` return the declared sandbox before consulting state or the provider.
- With no resolver installed, or a resolver answering `None`, every path is unchanged.

## Surface area

- [ ] **Frontend UI**
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [x] **Sandbox** — sandboxed execution (`deerflow/sandbox`)
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Validation

- `cd backend && ruff check . && ruff format --check .` (clean)
- `pytest tests/test_sandbox_resolution.py tests/test_sandbox_middleware.py tests/test_ensure_sandbox_initialized.py tests/test_sandbox_authorization.py` (99 passed)
- The full offline `make test` run is in progress; its result will be posted as a comment before this draft is marked ready for review.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** The seam was designed for a downstream fork's session model (altakleos/hartmesh, register at https://github.com/altakleos/hartmesh/blob/main/docs/UPSTREAM_OFFERS.md); Claude Code wrote the patch and its tests from that design. Conversation: https://claude.ai/code/session_01Lnai2UYjfWF5aynt3rcBE2

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

Opened as a draft until the full offline suite result is posted below.

https://claude.ai/code/session_01Lnai2UYjfWF5aynt3rcBE2

