### PR TITLE
Add Affiliates.One Ad Link extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ JINA_API_KEY=your-jina-api-key
 
 # InfoQuest API Key
 INFOQUEST_API_KEY=your-infoquest-api-key
+
+# Affiliates.One Deep Links API key (used only by the Gateway proxy).
+# Never put this value in the browser extension.
+# AFFILIATES_ONE_API_KEY=your-affiliates-one-api-key
 # Browser CORS allowlist for split-origin or port-forwarded deployments (comma-separated exact origins).
 # Leave unset when using the unified nginx endpoint, e.g. http://localhost:2026.
 # GATEWAY_CORS_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ deer-flow/
 ├── frontend/                       # Next.js frontend (pnpm) — see frontend/AGENTS.md
 ├── docker/                         # docker-compose files, nginx config, provisioner
 ├── skills/                         # Agent skills: public/ (committed), custom/ (gitignored)
+├── tools/ad-link-extension/        # Chrome/Edge Ad Link prototype; API key remains in Gateway
 │                                    # Managed integration skill packs are global at .deer-flow/integrations/skills/{provider}/
 │                                    # Integration credentials and enabled state remain per-user
 ├── contracts/                      # Cross-component JSON contracts (e.g. subagent status, skill review)

--- a/README_zh.md
+++ b/README_zh.md
@@ -13,6 +13,14 @@ DeerFlow（**D**eep **E**xploration and **E**fficient **R**esearch **Flow**）�
 
 https://github.com/user-attachments/assets/a8bcadc4-e040-4cf2-8fda-dd768b999c18
 
+### Affiliates.One Ad Link 擴充功能
+
+DeerFlow 也包含一個 Chrome／Edge Manifest V3 擴充功能原型，位於
+`tools/ad-link-extension/`。它會把目前網頁中的品牌網址送到 DeerFlow Gateway，
+再由 Gateway 呼叫 Affiliates.One Deep Links API。API 金鑰只放在 Gateway 的
+`AFFILIATES_ONE_API_KEY` 環境變數，不會打包到瀏覽器擴充功能中。安裝與設定方式請參考
+`tools/ad-link-extension/README.md`。
+
 > [!NOTE]
 > **DeerFlow 2.0 是一次彻底重写。** 它和 v1 没有共用代码。如果你要找的是最初的 Deep Research 框架，可以前往 [`1.x` 分支](https://github.com/bytedance/deer-flow/tree/main-1.x)。那里仍然欢迎贡献；当前的主要开发已经转向 2.0。
 

--- a/backend/app/gateway/app.py
+++ b/backend/app/gateway/app.py
@@ -15,6 +15,7 @@ from app.gateway.csrf_middleware import CORS_EXPOSED_HEADERS, CSRFMiddleware, ge
 from app.gateway.deps import langgraph_runtime
 from app.gateway.health import READINESS_CHECKPOINTER_CONFIG_ATTR, readiness_payload
 from app.gateway.routers import (
+    ad_links,
     agents,
     artifacts,
     assistants_compat,
@@ -825,6 +826,9 @@ This gateway provides runtime endpoints for agent runs plus custom endpoints for
 
     # Agents API is mounted at /api/agents
     app.include_router(agents.router)
+
+    # Affiliates.One deep-link proxy is mounted at /api/ad-links
+    app.include_router(ad_links.router)
 
     # Deployment-level subagent catalog and admin management.
     app.include_router(subagents.router)

--- a/backend/app/gateway/routers/__init__.py
+++ b/backend/app/gateway/routers/__init__.py
@@ -1,4 +1,5 @@
 from . import (
+    ad_links,
     artifacts,
     assistants_compat,
     browser,
@@ -15,6 +16,7 @@ from . import (
 )
 
 __all__ = [
+    "ad_links",
     "artifacts",
     "assistants_compat",
     "browser",

--- a/backend/app/gateway/routers/ad_links.py
+++ b/backend/app/gateway/routers/ad_links.py
@@ -1,0 +1,90 @@
+"""Gateway proxy for Affiliates.One deep-link generation."""
+
+import os
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from app.gateway.authz import require_permission
+
+router = APIRouter(prefix="/api/ad-links", tags=["ad-links"])
+
+AFFILIATES_ONE_DEEP_LINK_URL = "https://api.pub.affiliates.one/api/v2/affiliates/deep_links/generate.json"
+
+
+class DeepLinkRequest(BaseModel):
+    target_url: str = Field(..., min_length=1, max_length=4096)
+    aff_uniq_id: str = Field(..., min_length=1, max_length=128)
+    subid_1: str | None = Field(default=None, max_length=256)
+    subid_2: str | None = Field(default=None, max_length=256)
+    subid_3: str | None = Field(default=None, max_length=256)
+    subid_4: str | None = Field(default=None, max_length=256)
+    subid_5: str | None = Field(default=None, max_length=256)
+
+
+class DeepLinkResponse(BaseModel):
+    deeplink_url: str
+
+
+def _validate_target_url(target_url: str) -> str:
+    parsed = urlparse(target_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise HTTPException(status_code=400, detail="target_url must be an absolute HTTP(S) URL")
+    return target_url
+
+
+def _request_data(body: DeepLinkRequest) -> dict[str, str]:
+    data = body.model_dump(exclude_none=True)
+    return data
+
+
+def _extract_deep_link(payload: object) -> str | None:
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, list) or not data:
+        return None
+    first = data[0]
+    if not isinstance(first, dict):
+        return None
+    value = first.get("deeplink_url")
+    return value if isinstance(value, str) and value else None
+
+
+@router.post("/deep-link", response_model=DeepLinkResponse)
+@require_permission("runs", "create")
+async def generate_deep_link(body: DeepLinkRequest, request: Request) -> DeepLinkResponse:
+    api_key = os.environ.get("AFFILIATES_ONE_API_KEY", "").strip()
+    if not api_key:
+        raise HTTPException(status_code=503, detail="AFFILIATES_ONE_API_KEY is not configured")
+
+    target_url = _validate_target_url(body.target_url)
+    request_body = {
+        "data": _request_data(body),
+        "meta": {
+            "locale": "zh-TW",
+            "currency": "TWD",
+            "time_zone": "0.0",
+            "api_key": api_key,
+        },
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(AFFILIATES_ONE_DEEP_LINK_URL, json=request_body)
+    except httpx.HTTPError as exc:
+        raise HTTPException(status_code=502, detail="Affiliates.One request failed") from exc
+
+    if response.status_code >= 400:
+        raise HTTPException(status_code=502, detail="Affiliates.One rejected the deep-link request")
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise HTTPException(status_code=502, detail="Affiliates.One returned invalid JSON") from exc
+    deeplink_url = _extract_deep_link(payload)
+    if deeplink_url is None:
+        raise HTTPException(status_code=502, detail="Affiliates.One returned no deep link")
+    return DeepLinkResponse(deeplink_url=deeplink_url)

--- a/backend/tests/test_ad_links_router.py
+++ b/backend/tests/test_ad_links_router.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from app.gateway.routers import ad_links
+
+
+def test_validate_target_url_rejects_non_http():
+    with pytest.raises(HTTPException, match="absolute HTTP"):
+        ad_links._validate_target_url("javascript:alert(1)")
+
+
+def test_extract_deep_link_reads_api_response():
+    payload = {"data": [{"deeplink_url": "https://vbtrax.com/track"}]}
+    assert ad_links._extract_deep_link(payload) == "https://vbtrax.com/track"
+
+
+def test_extract_deep_link_rejects_empty_response():
+    assert ad_links._extract_deep_link({"data": []}) is None
+
+
+@pytest.mark.asyncio
+async def test_generate_deep_link_forwards_key_and_payload(monkeypatch):
+    monkeypatch.setenv("AFFILIATES_ONE_API_KEY", "test-key")
+    response = httpx.Response(
+        200,
+        json={"data": [{"deeplink_url": "https://vbtrax.com/track"}]},
+        request=httpx.Request("POST", ad_links.AFFILIATES_ONE_DEEP_LINK_URL),
+    )
+    post = AsyncMock(return_value=response)
+    entered_client = SimpleNamespace(post=post)
+    class FakeClient:
+        async def __aenter__(self):
+            return entered_client
+
+        async def __aexit__(self, *_args):
+            return None
+
+    client = FakeClient()
+    body = ad_links.DeepLinkRequest(target_url="https://shop.example/item", aff_uniq_id="creator")
+
+    with patch.object(ad_links.httpx, "AsyncClient", return_value=client):
+        result = await ad_links.generate_deep_link.__wrapped__(body, request=SimpleNamespace())
+
+    assert result.deeplink_url == "https://vbtrax.com/track"
+    sent = post.await_args.kwargs["json"]
+    assert sent["meta"]["api_key"] == "test-key"
+    assert sent["data"]["target_url"] == "https://shop.example/item"

--- a/tools/ad-link-extension/README.md
+++ b/tools/ad-link-extension/README.md
@@ -1,0 +1,88 @@
+# DeerFlow Ad Link 擴充功能（目前是測試版）
+
+這是一個 Chrome／Edge 瀏覽器擴充功能。它會把網頁上的品牌網址交給
+DeerFlow，再由 DeerFlow 呼叫 Affiliates.One，產生你的導購連結。
+
+## 先了解一件事
+
+目前這個功能不是「直接雙擊就能使用」的 App。要完整使用，電腦上必須先：
+
+1. 啟動 DeerFlow 後端。
+2. 在 DeerFlow 後端設定 Affiliates.One 的新 API Key。
+3. 在瀏覽器載入這個資料夾。
+
+如果沒有 API Key，擴充功能不會產生導購連結，也不會修改網頁連結。
+
+## 第一次安裝
+
+### 1. 準備 API Key
+
+請把新的 API Key 設定在 DeerFlow 後端，而不是擴充功能裡。設定名稱是：
+
+```text
+AFFILIATES_ONE_API_KEY
+```
+
+API Key 不要貼到聊天、GitHub 或瀏覽器擴充功能檔案中。
+
+### 2. 在 Chrome 載入擴充功能
+
+1. 開啟 Chrome。
+2. 在網址列輸入 `chrome://extensions`，按 Enter。
+3. 開啟右上角的「開發人員模式」。
+4. 按「載入未封裝項目」。
+5. 選擇這個資料夾：
+
+   ```text
+   tools\ad-link-extension
+   ```
+
+如果你使用 Edge，第三步的網址改成：
+
+```text
+edge://extensions
+```
+
+### 3. 填寫擴充功能設定
+
+1. 在擴充功能清單找到「DeerFlow Ad Link」。
+2. 按「詳細資料」。
+3. 找到「擴充功能選項」。
+4. DeerFlow Gateway URL 通常填：
+
+   ```text
+   http://localhost:8001
+   ```
+
+5. 在 `aff_uniq_id` 欄位填入 Affiliates.One 帳戶提供的推廣識別碼。
+6. 勾選「啟用自動轉換」。
+7. 按「儲存設定」。
+
+### 4. 使用
+
+重新載入一個包含品牌連結的網頁。擴充功能會嘗試將符合條件的連結轉成
+Affiliates.One 導購連結。
+
+## 目前會自動跳過的連結
+
+- `mailto:` 電子郵件連結
+- `javascript:` 連結
+- 下載檔案連結
+- 已經是 `vbtrax.com` 的導購連結
+- 你在設定中加入的排除網域和網址
+
+## 常見問題
+
+**沒有轉換任何連結？**
+
+請確認 DeerFlow 正在執行、瀏覽器已登入 DeerFlow、擴充功能已啟用，
+而且後端已設定 `AFFILIATES_ONE_API_KEY`。
+
+**顯示 `503` 或「API Key 尚未設定」？**
+
+表示 DeerFlow 後端還沒有讀到 API Key。這不是擴充功能壞掉，而是後端尚未完成設定。
+
+**我現在只想先看看，不想設定 API Key，可以嗎？**
+
+可以。你可以先載入擴充功能和查看設定頁，但在 API Key 設定完成以前，
+它不會產生真正有效的導購連結。

--- a/tools/ad-link-extension/content-script.js
+++ b/tools/ad-link-extension/content-script.js
@@ -1,0 +1,71 @@
+const processed = new WeakSet();
+const MAX_LINKS_PER_PAGE = 50;
+let settings;
+
+void initialize();
+
+async function initialize() {
+  settings = await getSettings();
+  if (!settings.enabled) return;
+  await convertLinks(document);
+  observeNewLinks();
+}
+
+async function getSettings() {
+  const defaults = {
+    apiBaseUrl: "http://localhost:8001",
+    affiliateId: "",
+    enabled: false,
+    excludedDomains: [],
+    excludedUrls: []
+  };
+  const stored = await chrome.storage.local.get(defaults);
+  return { ...defaults, ...stored };
+}
+
+function isEligibleUrl(rawUrl, pageUrl, currentSettings) {
+  let target;
+  let page;
+  try {
+    target = new URL(rawUrl, pageUrl);
+    page = new URL(pageUrl);
+  } catch {
+    return false;
+  }
+  if (!["http:", "https:"].includes(target.protocol)) return false;
+  if (target.hostname === "vbtrax.com" || target.hostname.endsWith(".vbtrax.com")) return false;
+  if (target.hostname === page.hostname && target.href === page.href) return false;
+  if (currentSettings.excludedDomains.some((domain) =>
+    target.hostname === domain || target.hostname.endsWith(`.${domain}`)
+  )) return false;
+  return !currentSettings.excludedUrls.some((url) => target.href === url);
+}
+
+async function convertLinks(root) {
+  const links = [...root.querySelectorAll("a[href]")]
+    .filter((link) => !processed.has(link))
+    .slice(0, MAX_LINKS_PER_PAGE);
+  for (const link of links) {
+    processed.add(link);
+    const targetUrl = new URL(link.href, window.location.href).href;
+    if (!isEligibleUrl(targetUrl, window.location.href, settings)) continue;
+
+    const result = await chrome.runtime.sendMessage({ type: "generate-deep-link", targetUrl });
+    if (result?.ok && result.deeplinkUrl) {
+      link.dataset.deerflowOriginalHref = link.href;
+      link.href = result.deeplinkUrl;
+      link.dataset.deerflowConverted = "true";
+    }
+  }
+}
+
+function observeNewLinks() {
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      for (const node of mutation.addedNodes) {
+        if (node.nodeType === Node.ELEMENT_NODE) void convertLinks(node);
+      }
+    }
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}

--- a/tools/ad-link-extension/manifest.json
+++ b/tools/ad-link-extension/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": 3,
+  "name": "DeerFlow Ad Link",
+  "description": "Convert eligible page links into Affiliates.One deep links through DeerFlow.",
+  "version": "0.1.0",
+  "permissions": [
+    "storage"
+  ],
+  "host_permissions": [
+    "<all_urls>",
+    "http://localhost:8001/*",
+    "http://127.0.0.1:8001/*"
+  ],
+  "action": {
+    "default_title": "DeerFlow Ad Link",
+    "default_popup": "popup.html"
+  },
+  "options_page": "options.html",
+  "background": {
+    "service_worker": "service-worker.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "http://*/*",
+        "https://*/*"
+      ],
+      "js": [
+        "content-script.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/tools/ad-link-extension/options.html
+++ b/tools/ad-link-extension/options.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="utf-8">
+    <title>DeerFlow Ad Link 設定</title>
+    <style>
+      body { max-width: 640px; margin: 32px auto; padding: 0 20px; font: 16px system-ui, sans-serif; }
+      label { display: block; margin: 16px 0 6px; font-weight: 600; }
+      input, textarea { box-sizing: border-box; width: 100%; padding: 8px; }
+      textarea { min-height: 90px; }
+      button { margin-top: 20px; padding: 9px 18px; }
+      #status { color: #176b2c; }
+    </style>
+  </head>
+  <body>
+    <h1>DeerFlow Ad Link</h1>
+    <p>API Key 只放在 DeerFlow 後端，不要貼在這裡。</p>
+    <label for="apiBaseUrl">DeerFlow Gateway URL</label>
+    <input id="apiBaseUrl" type="url" placeholder="http://localhost:8001">
+    <label for="affiliateId">Affiliates.One aff_uniq_id</label>
+    <input id="affiliateId" type="text" placeholder="例如：mytracking">
+    <label><input id="enabled" type="checkbox"> 啟用自動轉換</label>
+    <label for="excludedDomains">排除網域（每行一個）</label>
+    <textarea id="excludedDomains" placeholder="nike.com"></textarea>
+    <label for="excludedUrls">排除完整網址（每行一個）</label>
+    <textarea id="excludedUrls"></textarea>
+    <button id="save" type="button">儲存設定</button>
+    <span id="status"></span>
+    <script type="module" src="options.js"></script>
+  </body>
+</html>

--- a/tools/ad-link-extension/options.js
+++ b/tools/ad-link-extension/options.js
@@ -1,0 +1,32 @@
+import { DEFAULT_SETTINGS, getSettings } from "./shared.js";
+
+const ids = ["apiBaseUrl", "affiliateId", "enabled", "excludedDomains", "excludedUrls"];
+const elements = Object.fromEntries(ids.map((id) => [id, document.querySelector(`#${id}`)]));
+const settings = await getSettings();
+
+elements.apiBaseUrl.value = settings.apiBaseUrl;
+elements.affiliateId.value = settings.affiliateId;
+elements.enabled.checked = settings.enabled;
+elements.excludedDomains.value = settings.excludedDomains.join("\n");
+elements.excludedUrls.value = settings.excludedUrls.join("\n");
+
+elements.save.addEventListener("click", async () => {
+  const apiBaseUrl = elements.apiBaseUrl.value.trim().replace(/\/+$/, "");
+  if (!/^https?:\/\/[^/]+/.test(apiBaseUrl)) {
+    elements.status.textContent = "Gateway URL 格式不正確";
+    return;
+  }
+  await chrome.storage.local.set({
+    ...DEFAULT_SETTINGS,
+    apiBaseUrl,
+    affiliateId: elements.affiliateId.value.trim(),
+    enabled: elements.enabled.checked,
+    excludedDomains: lines(elements.excludedDomains.value),
+    excludedUrls: lines(elements.excludedUrls.value)
+  });
+  elements.status.textContent = "已儲存，請重新載入要轉換的網頁";
+});
+
+function lines(value) {
+  return value.split(/\r?\n/).map((line) => line.trim().toLowerCase()).filter(Boolean);
+}

--- a/tools/ad-link-extension/popup.html
+++ b/tools/ad-link-extension/popup.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="utf-8">
+    <title>DeerFlow Ad Link</title>
+    <style>
+      body { min-width: 260px; padding: 12px; font: 14px system-ui, sans-serif; }
+      button { width: 100%; padding: 8px; }
+      p { color: #555; line-height: 1.4; }
+    </style>
+  </head>
+  <body>
+    <strong>DeerFlow Ad Link</strong>
+    <p id="status">讀取中...</p>
+    <button id="options" type="button">開啟設定</button>
+    <script type="module" src="popup.js"></script>
+  </body>
+</html>

--- a/tools/ad-link-extension/popup.js
+++ b/tools/ad-link-extension/popup.js
@@ -1,0 +1,6 @@
+import { getSettings } from "./shared.js";
+
+const status = document.querySelector("#status");
+const settings = await getSettings();
+status.textContent = settings.enabled ? "已啟用：重新載入頁面後轉換連結" : "目前已停用";
+document.querySelector("#options").addEventListener("click", () => chrome.runtime.openOptionsPage());

--- a/tools/ad-link-extension/service-worker.js
+++ b/tools/ad-link-extension/service-worker.js
@@ -1,0 +1,34 @@
+import { getSettings } from "./shared.js";
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type !== "generate-deep-link") return undefined;
+
+  generateDeepLink(message.targetUrl)
+    .then((result) => sendResponse({ ok: true, ...result }))
+    .catch((error) => sendResponse({ ok: false, error: error.message }));
+  return true;
+});
+
+async function generateDeepLink(targetUrl) {
+  const settings = await getSettings();
+  if (!settings.enabled) throw new Error("擴充功能目前已停用");
+  if (!settings.affiliateId.trim()) throw new Error("請先設定 aff_uniq_id");
+
+  const baseUrl = settings.apiBaseUrl.replace(/\/+$/, "");
+  const response = await fetch(`${baseUrl}/api/ad-links/deep-link`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      target_url: targetUrl,
+      aff_uniq_id: settings.affiliateId.trim()
+    })
+  });
+
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw new Error(payload.detail || `Gateway 回應 ${response.status}`);
+  }
+  if (!payload.deeplink_url) throw new Error("Gateway 沒有回傳導購連結");
+  return { deeplinkUrl: payload.deeplink_url };
+}

--- a/tools/ad-link-extension/shared.js
+++ b/tools/ad-link-extension/shared.js
@@ -1,0 +1,37 @@
+export const DEFAULT_SETTINGS = {
+  apiBaseUrl: "http://localhost:8001",
+  affiliateId: "",
+  enabled: false,
+  excludedDomains: [],
+  excludedUrls: []
+};
+
+export async function getSettings() {
+  const stored = await chrome.storage.local.get(DEFAULT_SETTINGS);
+  return {
+    ...DEFAULT_SETTINGS,
+    ...stored,
+    excludedDomains: Array.isArray(stored.excludedDomains) ? stored.excludedDomains : [],
+    excludedUrls: Array.isArray(stored.excludedUrls) ? stored.excludedUrls : []
+  };
+}
+
+export function isEligibleUrl(rawUrl, pageUrl, settings) {
+  let target;
+  let page;
+  try {
+    target = new URL(rawUrl, pageUrl);
+    page = new URL(pageUrl);
+  } catch {
+    return false;
+  }
+
+  if (!["http:", "https:"].includes(target.protocol)) return false;
+  if (target.hostname === "vbtrax.com" || target.hostname.endsWith(".vbtrax.com")) return false;
+  if (target.hostname === page.hostname && target.href === page.href) return false;
+  if (settings.excludedDomains.some((domain) => target.hostname === domain || target.hostname.endsWith(`.${domain}`))) {
+    return false;
+  }
+  if (settings.excludedUrls.some((url) => target.href === url)) return false;
+  return true;
+}


### PR DESCRIPTION
Fixes #

## Why

DeerFlow users who participate in Affiliates.One need a safer way to turn eligible brand URLs into tracked deep links without exposing their Affiliates.One API key in browser code. This provides an opt-in prototype for that workflow.

## What changed

- Added a Manifest V3 Chrome/Edge extension under `tools/ad-link-extension/`.
- Added a Gateway `/api/ad-links/deep-link` proxy that calls the Affiliates.One Deep Links API.
- Keeps the Affiliates.One API key server-side via `AFFILIATES_ONE_API_KEY`.
- Added extension settings for Gateway URL, `aff_uniq_id`, enablement, and domain/URL exclusions.
- Added backend tests and setup documentation.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [x] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

N/A. The extension is a local development prototype and does not change the DeerFlow frontend.

## Bug fix verification

N/A. This is a new feature prototype.

## Validation

- `git diff --check`
- Extension manifest JSON parsing
- Backend test/lint commands were attempted but could not run because this Windows environment has no installed Python/uv/Node.js. The Gateway route and extension files were reviewed directly.

## AI assistance

**Tool(s) used:** GitHub Copilot

**How you used it:** Implemented the backend proxy, browser extension prototype, tests, and documentation from the Affiliates.One Deep Links API specification discussed in the session.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.