### PR TITLE
fix(tests): preload sandbox leaf modules before mocking their parent package

### DIFF
--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -85,12 +85,16 @@ def _setup_executor_classes():
     original_executor = sys.modules.get("deerflow.subagents.executor")
     original_audit_context = sys.modules.get("deerflow.agents.middlewares.audit_context")
     original_tool_search = sys.modules.get("deerflow.tools.builtins.tool_search")
+    original_sandbox_provider = sys.modules.get("deerflow.sandbox.sandbox_provider")
+    original_sandbox_overwrite = sys.modules.get("deerflow.sandbox.overwrite")
 
     # Preload real executor dependencies before replacing their parent packages
     # with cycle-breaking test doubles. Keeping the concrete leaf modules in
     # sys.modules makes this fixture independent of test collection order.
     audit_context_module = importlib.import_module("deerflow.agents.middlewares.audit_context")
     tool_search_module = importlib.import_module("deerflow.tools.builtins.tool_search")
+    sandbox_provider_module = importlib.import_module("deerflow.sandbox.sandbox_provider")
+    sandbox_overwrite_module = importlib.import_module("deerflow.sandbox.overwrite")
 
     # Remove mocked executor if exists (from conftest.py)
     if "deerflow.subagents.executor" in sys.modules:
@@ -106,6 +110,8 @@ def _setup_executor_classes():
     sys.modules["deerflow.skills.storage"] = storage_module
     sys.modules["deerflow.agents.middlewares.audit_context"] = audit_context_module
     sys.modules["deerflow.tools.builtins.tool_search"] = tool_search_module
+    sys.modules["deerflow.sandbox.sandbox_provider"] = sandbox_provider_module
+    sys.modules["deerflow.sandbox.overwrite"] = sandbox_overwrite_module
 
     # Import real classes inside fixture
     from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
@@ -158,6 +164,14 @@ def _setup_executor_classes():
         sys.modules["deerflow.tools.builtins.tool_search"] = original_tool_search
     else:
         sys.modules.pop("deerflow.tools.builtins.tool_search", None)
+    if original_sandbox_provider is not None:
+        sys.modules["deerflow.sandbox.sandbox_provider"] = original_sandbox_provider
+    else:
+        sys.modules.pop("deerflow.sandbox.sandbox_provider", None)
+    if original_sandbox_overwrite is not None:
+        sys.modules["deerflow.sandbox.overwrite"] = original_sandbox_overwrite
+    else:
+        sys.modules.pop("deerflow.sandbox.overwrite", None)
 
 
 # Helper classes that wrap real classes for testing


### PR DESCRIPTION
## Why

`TestBashExecutionHarvest::test_entries_carry_producing_sandbox_shell_persistence` and `::test_fresh_process_sandbox_stamps_false` fail with `shell_persistent is None` whenever the test module runs alone (e.g. `pytest tests/test_subagent_executor.py::TestBashExecutionHarvest -q`), while passing in a full session — an order-dependent failure that makes local debugging misleading and leaves the provenance-stamping contract untested on the paths a developer is most likely to run.

## What changed

Test-fixture fix only, following the pattern the fixture already uses for `audit_context` and `tool_search`.

Root cause: `_setup_executor_classes` replaces the `deerflow.sandbox` **parent package** in `sys.modules` with a `MagicMock` to break circular imports. A later `from deerflow.sandbox.overwrite import unwrap_sandbox` inside `_harvest_shell_persistence` then resolves through the mocked parent, which has no package `__path__`, and raises `ModuleNotFoundError: No module named 'deerflow.sandbox.overwrite'; 'deerflow.sandbox' is not a package` — but only when the leaf module is not already cached in `sys.modules` from an earlier import elsewhere in the session. The helper's `except Exception: return None` silently converts that `ImportError` into an UNKNOWN (`None`) provenance stamp, so the mocked sandbox never gets consulted and the assertions see `None`.

The fix preloads the two real leaf modules the harvest path needs (`deerflow.sandbox.sandbox_provider`, `deerflow.sandbox.overwrite`) **before** the mocked parent package is installed, pins them in `sys.modules` for the duration of each test (same as the existing `audit_context_module` / `tool_search_module` pinning), and restores the previous `sys.modules` state in the fixture teardown.

No product code is touched: the `except Exception: return None` fail-closed behavior in `_harvest_shell_persistence` is intentional and stays as-is.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug reproduction

- Test paths that reproduce the bug: `tests/test_subagent_executor.py::TestBashExecutionHarvest::test_entries_carry_producing_sandbox_shell_persistence` and `::test_fresh_process_sandbox_stamps_false`, run in isolation (`pytest "tests/test_subagent_executor.py::TestBashExecutionHarvest" -q`).
- Did it go red on `main` and green on this branch? **yes** — both tests fail on isolated runs against `main` (`assert None is True` / `assert None is False`); with the preload they pass, and the full module is green.

## Validation

- Windows 11, Python 3.12.9, `uv sync --locked --all-packages`:
  - Before: `uv run pytest "tests/test_subagent_executor.py::TestBashExecutionHarvest" -q` → 2 failed, 22 passed
  - After: **24 passed**; full module `uv run pytest tests/test_subagent_executor.py -q` → **140 passed**
  - `uv run ruff check` and `uv run ruff format --check` on the file → clean
- The fix removes the order dependence rather than papering over it: the leaf modules are real, pinned, and restored in teardown, so POSIX CI behavior is unchanged (the same modules were already being cached there, just by accident of import order).

## AI assistance

**Tool(s) used:** ZCode (GLM coding agent)

**How you used it:** The agent reproduced the order-dependent failure, isolated the mocked-parent-package root cause with a step-through debug test, implemented the preload following the fixture's existing pattern, ran the affected test class and full module plus ruff, and prepared this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
