### PR TITLE
fix(subagents): close the agent stream on cooperative cancellation

### DIFF
--- a/backend/packages/harness/deerflow/subagents/executor.py
+++ b/backend/packages/harness/deerflow/subagents/executor.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import atexit
+import inspect
 import json
 import logging
 import os
@@ -470,6 +471,23 @@ def _harvest_shell_persistence(final_state: Any) -> bool | None:
         return None if declared is None else bool(declared)
     except Exception:
         return None
+
+
+async def _close_agent_stream(stream: Any) -> None:
+    """Close a subagent graph stream deterministically after completion or early exit.
+
+    Mirrors ``runtime/runs/worker.py::_close_agent_stream``: cooperative
+    cancellation returns from inside the ``async for`` loop, which does not
+    close the astream iterator, so the executor must close it explicitly
+    before its outer ``finally`` releases the sandbox lease and notifies
+    extension task-stop observers (#5218).
+    """
+    close = getattr(stream, "aclose", None)
+    if close is None:
+        return
+    result = close()
+    if inspect.isawaitable(result):
+        await result
 
 
 def _harvest_bash_executions(
@@ -1517,41 +1535,58 @@ class SubagentExecutor:
                 )
                 return result
 
-            async for chunk in agent.astream(state, config=run_config, context=context, stream_mode="values"):  # type: ignore[arg-type]
-                # A yielded values chunk is already executed state.  Retain it
-                # before observing cooperative cancellation so terminal receipt
-                # harvesting includes a tool result that completed while the
-                # cancellation request was in flight.
-                final_state = chunk
-                result.update_tool_receipts(terminal_receipts())
-                result.update_bash_executions(current_bash_executions())
+            stream = agent.astream(state, config=run_config, context=context, stream_mode="values")  # type: ignore[arg-type]
+            try:
+                async for chunk in stream:
+                    # A yielded values chunk is already executed state.  Retain it
+                    # before observing cooperative cancellation so terminal receipt
+                    # harvesting includes a tool result that completed while the
+                    # cancellation request was in flight.
+                    final_state = chunk
+                    result.update_tool_receipts(terminal_receipts())
+                    result.update_bash_executions(current_bash_executions())
 
-                # Cooperative cancellation: check if parent requested stop.
-                # Note: cancellation is only detected at astream iteration boundaries,
-                # so long-running tool calls within a single iteration will not be
-                # interrupted until the next chunk is yielded.
-                if result.cancel_event.is_set():
-                    logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} cancelled by parent")
-                    result.try_set_terminal(
-                        SubagentStatus.CANCELLED,
-                        error="Cancelled by user",
-                        token_usage_records=collector.snapshot_records(),
-                        tool_receipts=terminal_receipts(),
+                    # Cooperative cancellation: check if parent requested stop.
+                    # Note: cancellation is only detected at astream iteration boundaries,
+                    # so long-running tool calls within a single iteration will not be
+                    # interrupted until the next chunk is yielded.
+                    if result.cancel_event.is_set():
+                        logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} cancelled by parent")
+                        result.try_set_terminal(
+                            SubagentStatus.CANCELLED,
+                            error="Cancelled by user",
+                            token_usage_records=collector.snapshot_records(),
+                            tool_receipts=terminal_receipts(),
+                        )
+                        return result
+
+                    result.update_token_usage_records(collector.snapshot_records())
+
+                    # Capture every step message (assistant turns AND tool outputs)
+                    # appended since the last chunk. A single super-step can append
+                    # several ToolMessages when the model emits multiple tool calls in
+                    # one turn, so capturing only messages[-1] would drop all but the
+                    # last output (#3779). Dedup/serialization live in capture_step_message.
+                    messages = chunk.get("messages", [])
+                    previous_count = len(ai_messages)
+                    processed_message_count = capture_new_step_messages(messages, ai_messages, seen_message_ids, processed_message_count)
+                    if len(ai_messages) > previous_count:
+                        logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} captured {len(ai_messages) - previous_count} step message(s); total #{len(ai_messages)}")
+            finally:
+                # Closing the stream deterministically (#5218): a cooperative
+                # cancellation returns from inside the ``async for`` loop without
+                # closing the iterator, which would let the outer ``finally``
+                # release the sandbox lease and send the task-stop notification
+                # before graph-stream teardown completes.
+                try:
+                    await _close_agent_stream(stream)
+                except Exception:
+                    logger.warning(
+                        "[trace=%s] Could not close subagent agent stream for %s",
+                        self.trace_id,
+                        self.config.name,
+                        exc_info=True,
                     )
-                    return result
-
-                result.update_token_usage_records(collector.snapshot_records())
-
-                # Capture every step message (assistant turns AND tool outputs)
-                # appended since the last chunk. A single super-step can append
-                # several ToolMessages when the model emits multiple tool calls in
-                # one turn, so capturing only messages[-1] would drop all but the
-                # last output (#3779). Dedup/serialization live in capture_step_message.
-                messages = chunk.get("messages", [])
-                previous_count = len(ai_messages)
-                processed_message_count = capture_new_step_messages(messages, ai_messages, seen_message_ids, processed_message_count)
-                if len(ai_messages) > previous_count:
-                    logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} captured {len(ai_messages) - previous_count} step message(s); total #{len(ai_messages)}")
 
             logger.info(f"[trace={self.trace_id}] Subagent {self.config.name} completed async execution")
             token_usage_records = collector.snapshot_records()

--- a/backend/tests/test_subagent_executor.py
+++ b/backend/tests/test_subagent_executor.py
@@ -2863,6 +2863,67 @@ class TestCooperativeCancellation:
         assert result.error == "Cancelled by user"
         assert result.completed_at is not None
 
+    @pytest.mark.asyncio
+    async def test_aexecute_cancel_mid_stream_closes_agent_stream(self, classes, base_config, msg):
+        """#5218: cooperative cancellation must close the active astream iterator.
+
+        The executor returns CANCELLED from inside the ``async for`` loop; the
+        stream must be closed (``aclose`` awaited) before the outer ``finally``
+        releases the sandbox lease, or graph-stream teardown would still be
+        pending while shared runtime resources are already released.
+        """
+        SubagentExecutor = classes["SubagentExecutor"]
+        SubagentResult = classes["SubagentResult"]
+        SubagentStatus = classes["SubagentStatus"]
+
+        cancel_event = threading.Event()
+        closed = {"aclose_called": False}
+
+        async def mock_astream(*args, **kwargs):
+            try:
+                yield {"messages": [msg.human("Task"), msg.ai("Partial", "msg-1")]}
+                cancel_event.set()
+                yield {"messages": [msg.human("Task"), msg.ai("Should not appear", "msg-2")]}
+            finally:
+                closed["aclose_called"] = True
+
+        class _CloseTrackingAsyncGen:
+            def __init__(self, agen):
+                self._agen = agen
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                return await self._agen.__anext__()
+
+            async def aclose(self):
+                closed["aclose_called"] = True
+                await self._agen.aclose()
+
+        mock_agent = MagicMock()
+        mock_agent.astream = lambda *args, **kwargs: _CloseTrackingAsyncGen(mock_astream(*args, **kwargs))
+
+        result_holder = SubagentResult(
+            task_id="cancel-close-stream",
+            trace_id="test-trace",
+            status=SubagentStatus.RUNNING,
+            started_at=datetime.now(),
+        )
+        result_holder.cancel_event = cancel_event
+
+        executor = SubagentExecutor(
+            config=base_config,
+            tools=[],
+            thread_id="test-thread",
+        )
+
+        with patch.object(executor, "_create_agent", return_value=mock_agent):
+            result = await executor._aexecute("Task", result_holder=result_holder)
+
+        assert result.status == SubagentStatus.CANCELLED
+        assert closed["aclose_called"] is True
+
     def test_request_cancel_sets_event(self, executor_module, classes):
         """Test that request_cancel_background_task sets the cancel_event."""
         SubagentResult = classes["SubagentResult"]


### PR DESCRIPTION
## Why

Fixes #5218. `SubagentExecutor._aexecute_admitted()` iterates `agent.astream(...)` directly and, when the parent's `cancel_event` is observed at a stream boundary, marks the run `CANCELLED` and returns from inside the `async for` loop. That return leaves the astream iterator un-closed, so the executor's outer `finally` releases the sandbox execution lease and sends the extension task-stop notification before graph-stream teardown has completed — a caller can observe a terminal result while shared runtime resources are still being released. The lead-agent worker does not have this gap: it retains its stream and closes it deterministically in a `finally` (`runtime/runs/worker.py::_close_agent_stream`).

## What changed

- `_aexecute_admitted()` now retains the `agent.astream(...)` iterator and wraps the `async for` loop in a `try/finally` that awaits `aclose()` on every exit path (cooperative cancellation `return`, exceptions, and normal completion — where closing an exhausted generator is a no-op).
- The close mirrors the worker's `_close_agent_stream` pattern (`getattr(aclose)` + awaitable handling). It is defined locally in `subagents/executor.py` rather than imported, because `runtime/runs/worker.py` deliberately lazy-imports `deerflow.subagents` to avoid an import cycle at gateway startup.
- A close failure is logged with the trace id and does not mask the `CANCELLED` result.
- New regression test `test_aexecute_cancel_mid_stream_closes_agent_stream` drives the mid-stream cancellation path with a close-tracking async generator and fails if cancellation completes without `aclose()` being awaited.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
  - Prompt-layer self-check: no prompts or untrusted-data channels touched; this is stream lifecycle handling only.
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)

## Bug reproduction

- Test path that reproduces the bug: `tests/test_subagent_executor.py::TestAgentExecution::test_aexecute_cancel_mid_stream_closes_agent_stream` (new). On `main`, the mid-stream cancellation path (`test_aexecute_cancelled_mid_stream`'s scenario) returns `CANCELLED` while the astream generator is never closed — observable by instrumenting `aclose` on the mock stream.
- Did it go red on `main` and green on this branch? **yes** — without the fix the new test fails (`aclose` never awaited on the cancellation path); with it, the close is awaited before the executor's outer `finally` runs.

## Validation

- Windows 11, Python 3.12.9, `uv sync --locked --all-packages`:
  - `uv run pytest tests/test_subagent_executor.py -q` → **141 passed** (140 pre-existing + 1 new regression test)
  - `uv run ruff check` and `uv run ruff format --check` on both changed files → clean
- Normal-completion behavior is unchanged: closing an exhausted generator is a no-op, and the whole module suite (including all completion/timeout/error paths) passes.

## AI assistance

**Tool(s) used:** ZCode (GLM coding agent)

**How you used it:** The agent surveyed open issues, confirmed #5218 was unclaimed, read the executor and the lead-agent worker's close pattern, implemented the retain-and-close fix with a local helper to avoid the worker→subagents import cycle, wrote the regression test, ran the module suite and ruff, and prepared this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
