### PR TITLE
docs(zh): add the missing LangGraph Studio section to README_zh

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -307,6 +307,41 @@ make down   # 停止并移除容器
 
 5. **访问地址**：http://localhost:2026
 
+#### LangGraph Studio（可选）
+
+默认的 `make dev` 拓扑使用 DeerFlow 内嵌于 Gateway 的运行时，无需 LangGraph Studio。
+如需用独立开发服务器检查和测试已注册的 lead-agent 图，请在 `backend/` 目录下运行
+以下命令，以便 CLI 发现 `langgraph.json`：
+
+```bash
+cd backend
+uv run langgraph dev --allow-blocking
+```
+
+该命令会打印本地 API 与 Studio UI 地址。这个内存态服务器仅用于开发与测试；
+该标志允许 DeerFlow 在处理本地 Studio 请求时执行同步的配置加载与图工厂初始化，
+不能当作生产服务器设置使用。本地 Studio 的认证会自动处理，连接无需自定义请求头。
+生产负载请使用 DeerFlow 文档中的生产启动模式或受支持的 LangSmith 部署。在这种
+独立模式下，assistant 的归属与来源由服务器管理：Studio 可以发现已注册的图及其
+创建的 assistants，正常的 assistant 版本选择依然可用。在锁定态本地运行时加载其
+持久化开发存储之前，DeerFlow 会修复历史遗留的 assistant 行与版本历史，防止历史
+客户端元数据恢复服务器权限，或被运行时的启动清理流程丢弃。请用 `uv sync` 保持
+后端依赖同步；该兼容路径依赖已声明的 LangGraph 运行时版本，若持久化存储契约
+与预期不再匹配会记录警告。文档中的命令使用 LangGraph 基于文件的自定义应用加载器，
+DeerFlow 的回归测试也直接覆盖了它。
+
+对通过 LangGraph Studio 或直连 LangGraph Server 调用 `backend/langgraph.json`
+的工作流，DeerFlow 会消费该运行时发布的已认证身份，并将其用于 custom-agent
+配置/SOUL、用户技能与技能策略、上传、线程数据以及记忆读写。这使经过认证的运行
+不会落入共享的 `default` 文件系统桶，且服务器管理的身份优先于普通客户端提供的
+`user_id` 值。诸如邮箱地址之类的外部身份会在访问 DeerFlow 存储前，被映射为稳定、
+抗碰撞且目录安全的用户 ID。默认的 DeerFlow 服务拓扑仍是上文描述的 Gateway 内嵌
+运行时。
+
+Gateway 运行时会自动强制对 `/mnt/user-data/outputs` 下创建或修改的产物执行原生交付：`present_files` 必须至少展示一个由当前运行产出的输出，且终止时的 `run.delivery` 回执必须被持久化记录。虚拟产物路径会在产出该输出的同一已认证用户与线程范围内解析，然后再校验输出目录边界。未产出产物文件的运行保持普通对话行为。
+
+DeerFlow 的内置自定义事件同时通过两种 LangGraph 流式接口提供：原生客户端可以继续订阅 `stream_mode="custom"`，基于回调的集成则可以从 `astream_events(version="v2")` 以 `on_custom_event` 记录的形式消费相同载荷。回调事件名与载荷的 `type` 字段一致。
+
 ### 进阶配置
 #### Sandbox 模式
 


### PR DESCRIPTION
## Why

The Chinese README has drifted from the English one. A structure-level comparison (headings extracted with fenced code blocks stripped) shows `README.md` has 54 headings vs 47 in `README_zh.md`. After separating heading-translation differences (e.g. "Sandbox Mode" ↔ "Sandbox 模式") from real gaps, one full section is confirmed missing: **LangGraph Studio (Optional)** — the zh README has no `langgraph dev` / Studio content at all. This is the same class of zh-doc gap as #5150 and #5151, both merged.

## What changed

Add the translated "LangGraph Studio（可选）" section to `README_zh.md`, in the same position it occupies in the English README (after the local development walkthrough, before 进阶配置). The section covers:

- the standalone `uv run langgraph dev --allow-blocking` development server and when it is needed;
- server-owned assistant ownership/provenance in that mode, including the persisted-store legacy-row repair and the `uv sync` compatibility requirement;
- how authenticated identity published by LangGraph Studio / a direct LangGraph Server is consumed for custom-agent configuration/SOUL, skills, uploads, thread data, and memory;
- the Gateway-enforced native delivery for `/mnt/user-data/outputs` artifacts;
- the dual LangGraph streaming interfaces (`stream_mode="custom"` and `astream_events(version="v2")`) for built-in custom events.

Translation only — no English content changed, no links touched.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug reproduction

Not a code bug — documentation gap reproduced by comparing heading structures: `grep -c "LangGraph Studio" README.md` → 1 (section present), `README_zh.md` → 0 before this change, 1 after. Remaining zh/en drift (Startup Modes table, Docker production `deploy.sh` subcommands, Request Trace Correlation details) is partially covered by different zh wording and is left for follow-up comparison.

## Validation

- Section heading count: both READMEs now carry one `#### LangGraph Studio` heading.
- `git diff --stat` → 35 insertions, 0 deletions in `README_zh.md`; no other files touched.
- No relative links added or removed by this change (the new section references only inline code paths like `backend/langgraph.json`).

## AI assistance

**Tool(s) used:** ZCode (GLM coding agent)

**How you used it:** The agent built the heading-structure comparison that isolated the missing section, translated it into Chinese consistent with the existing zh terminology style, verified alignment and link counts, and prepared this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
