### PR TITLE
docs(zh): add the missing Request Trace Correlation section to README_zh

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -506,6 +506,29 @@ DINGTALK_CLIENT_SECRET=your_client_secret
 
 > 没有命令前缀的消息会被当作普通聊天处理。DeerFlow 会自动创建 thread，并以对话方式回复。
 
+#### 请求链路关联
+
+每个 Gateway HTTP 响应都携带 `X-Trace-Id` 响应头。若调用方传入了入站 `X-Trace-Id` 则继承之，否则自动生成，代理或上游服务可以借此跨服务固定同一个 id。该行为无需配置，也无法关闭。
+
+同一 id 会附着在生命周期超出 HTTP 响应的工作上：分离出的运行任务、它委派的 subagent，以及后台记忆更新线程。它以 `deerflow_trace_id` 的形式记录在 run 记录上（runs API 可见）、thread 的 checkpoint 元数据中，以及 Langfuse 追踪里。定时任务、MCP 任务通知运行和 IM 渠道消息不经 HTTP 启动，会为每次出现自行铸造一个 id。
+
+仅当增强日志开启时，日志记录才会携带该 id：
+
+```yaml
+logging:
+  enhance:
+    enabled: true   # 将 trace_id 打印进日志记录
+    format: text    # 或 json
+```
+
+该开关默认关闭，因为开启会改变日志格式。`logging` 配置需要重启才能生效，所以请编辑 `config.yaml` 并重启 Gateway。该设置只影响日志输出——id、响应头和运行元数据不受影响。
+
+`deerflow_trace_id` 是 DeerFlow 的链路关联 id：它不是 run id，也不是 provider 的原生追踪 id，同样不是查询键——没有任何逻辑用它反查 thread 或 run；它只用于关联日志行。在 run 请求的 `metadata` 或 `config.context` 中传入的 `deerflow_trace_id` 会被忽略并覆盖，因此响应头、日志和持久化的运行记录永远不会相互矛盾。要固定关联 id，请发送 `X-Trace-Id` 请求头。
+
+Gateway 的运行历史还会为每次运行记录一条终止时的 `run.delivery` 回执，包括零产出与崩溃恢复的运行。正常执行时，该回执会在持久化终止运行状态之前写入。孤儿恢复会先原子地认领过期租约，再幂等地回填回执，因此过期的恢复扫描不会覆盖仍在运行的详细交付事实。在事件存储中断期间，回执持久化保持尽力而为。对 checkpoint 预检失败（或在等待前序 finalization 时被取消）的运行，保持既有的完成数据行为：它们会收到零交付回执，但不会用空快照覆盖 RunStore 的完成字段。
+
+同一份运行事件历史还会为 lead agent 与普通 task subagent 记录 loop-detection 判定和延迟 MCP 工具晋升。晋升事件会标识新晋升的延迟工具名称，以及是路由元数据还是 `tool_search` 选中了它们，但不会把搜索查询、路由关键词、schema、参数、结果或目录哈希复制进晋升事件本身。
+
 #### LangSmith 链路追踪
 
 DeerFlow 内置了 [LangSmith](https://smith.langchain.com) 集成，用于可观测性。启用后，所有 LLM 调用、agent 运行和工具执行都会被追踪，并在 LangSmith 仪表盘中展示。


### PR DESCRIPTION
## Why

Follow-up to #5222 in the zh/en README drift series. The English README documents **Request Trace Correlation** as a standalone section (between the slash-command table and LangSmith Tracing), while the zh README only mentioned the correlation id in passing inside its Langfuse section (`metadata.deerflow_trace_id` = "与同一请求返回的 X-Trace-Id 响应头一致"). The mechanics — header inheritance, propagation outside HTTP, logging config, id semantics, delivery receipts — were undocumented for Chinese readers.

## What changed

Add the translated "请求链路关联" section to `README_zh.md`, in the same position it occupies in the English README (after the slash-command table, before LangSmith 链路追踪). The section covers:

- `X-Trace-Id` response header inheritance/generation (no config, cannot be turned off);
- propagation to work that outlives the HTTP response: detached run tasks, delegated subagents, background memory-update threads; scheduled tasks, MCP task notification runs, and IM channel messages mint their own id;
- the `logging.enhance` config block (default off, restart-required, log-output only);
- `deerflow_trace_id` semantics: not a run id, not a provider trace id, not a lookup key; caller-supplied values in `metadata`/`config.context` are ignored and overwritten — pin the id via the `X-Trace-Id` header;
- terminal `run.delivery` receipts per run (including zero-output and crash-recovered runs), persisted before terminal status, with atomic orphan-recovery claim + idempotent backfill, best-effort during event-store outages, and unchanged completion-data behavior for checkpoint-preflight failures;
- loop-detection decisions and deferred MCP tool promotions recorded in the same run event history, without copying search queries/keywords/schemas/arguments/results/catalog hashes into promotion events.

Translation only — no English content changed, no links touched.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Bug reproduction

Not a code bug — documentation gap reproduced by comparing heading structures after stripping fenced code blocks: `grep -c "Request Trace Correlation" README.md` → 1 (section present); `README_zh.md` → 0 before this change, 1 after (as `#### 请求链路关联`).

## Validation

- Section heading count: the zh README now carries one `#### 请求链路关联` heading between the slash-command table and LangSmith 链路追踪, matching the English section order.
- `git diff --stat` → 23 insertions, 0 deletions in `README_zh.md`; no other files touched.
- No relative links added or removed (the section references only inline code/config literals).

## AI assistance

**Tool(s) used:** ZCode (GLM coding agent)

**How you used it:** The agent extended the heading-structure comparison from #5222 to separate real gaps from heading-translation differences, translated the section into Chinese consistent with the existing zh terminology style, verified alignment and link counts, and prepared this PR.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
