### PR TITLE
fix(workspace-changes): drain snapshot scan before cancellation cleanup

### DIFF
--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -75,6 +75,30 @@ async def _reclaim_prepare_and_cleanup(prepare: asyncio.Future[tuple[list[Worksp
         await _remove_text_cache_dir(orphaned)
 
 
+async def _drain_scan_and_cleanup(
+    scan: asyncio.Future[WorkspaceSnapshot],
+    text_cache_dir: Path | None,
+) -> None:
+    """Let a cancelled scan finish before removing the cache it may still use."""
+    while not scan.done():
+        try:
+            await asyncio.shield(scan)
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            break
+
+    if text_cache_dir is None:
+        return
+
+    cleanup = asyncio.create_task(_remove_text_cache_dir(text_cache_dir))
+    while not cleanup.done():
+        try:
+            await asyncio.shield(cleanup)
+        except asyncio.CancelledError:
+            pass
+
+
 async def capture_workspace_snapshot(
     thread_id: str,
     *,
@@ -104,8 +128,9 @@ async def capture_workspace_snapshot(
             except asyncio.CancelledError:
                 pass
         raise
-    try:
-        return await asyncio.to_thread(
+
+    scan = asyncio.ensure_future(
+        asyncio.to_thread(
             scan_workspace_roots,
             roots,
             limits=limits,
@@ -113,6 +138,16 @@ async def capture_workspace_snapshot(
             text_cache_dir=text_cache_dir,
             extra_excluded_dir_names=extra_excluded_dir_names,
         )
+    )
+    try:
+        return await asyncio.shield(scan)
+    except asyncio.CancelledError:
+        # The scan runs in a worker thread and cannot be stopped by cancelling
+        # this coroutine. Keep the cache alive until that worker has finished,
+        # then remove it before propagating cancellation. Repeated cancellation
+        # must not abandon either phase.
+        await _drain_scan_and_cleanup(scan, text_cache_dir)
+        raise
     except Exception:
         if text_cache_dir is not None:
             await _remove_text_cache_dir(text_cache_dir)

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -88,6 +88,15 @@ async def _drain_scan_and_cleanup(
         except Exception:
             break
 
+    # Cancellation remains the caller-visible outcome, but consume any late scan
+    # failure so the drained task cannot emit an un-retrieved exception warning.
+    try:
+        scan.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        pass
+
     if text_cache_dir is None:
         return
 

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -296,3 +296,61 @@ async def test_capture_workspace_snapshot_repeated_cancel_during_scan_still_clea
 
     leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"repeated-cancel scan leaked a text cache dir: {leftovers}"
+
+
+async def test_capture_workspace_snapshot_repeated_cancel_during_cleanup_still_cleans_up(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A second cancellation cannot abandon cleanup after the scan has drained."""
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    scan_entered = threading.Event()
+    scan_release = threading.Event()
+    cleanup_entered = asyncio.Event()
+    cleanup_release = asyncio.Event()
+    real_remove_text_cache_dir = recorder._remove_text_cache_dir
+
+    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+        assert text_cache_dir is not None
+        cache_dir = Path(text_cache_dir)
+        scan_entered.set()
+        scan_release.wait(timeout=5)
+        assert cache_dir.exists(), "scan cache was removed before the worker drained"
+        return WorkspaceSnapshot(files={}, truncated=False, text_cache_dir=str(cache_dir))
+
+    async def _blocking_cleanup(text_cache_dir: str | Path) -> None:
+        cleanup_entered.set()
+        await cleanup_release.wait()
+        await real_remove_text_cache_dir(text_cache_dir)
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
+    monkeypatch.setattr(recorder, "_remove_text_cache_dir", _blocking_cleanup)
+
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
+    assert await asyncio.to_thread(scan_entered.wait, 5), "scan worker did not start"
+
+    task.cancel()
+    scan_release.set()
+    await asyncio.wait_for(cleanup_entered.wait(), timeout=5)
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not task.done(), "second cancellation abandoned the in-progress cache cleanup"
+    parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert parked, "cache should remain until the owned cleanup task is released"
+
+    cleanup_release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"repeated cancellation during cleanup leaked a text cache dir: {leftovers}"

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -16,9 +16,10 @@ rmtree this anchor exists to guard.
 
 Because ``mkdtemp`` must be offloaded, its worker handoff is also a cancellation
 hazard: a run cancelled after ``mkdtemp`` but before the coroutine receives the
-path would orphan the dir. Cancellation during the later scan has a symmetric
-hazard: that worker keeps using the cache after its awaiter is cancelled, so the
-cache must stay alive until the scan drains and then be reclaimed.
+path would orphan the dir. The prepare-handoff tests pin the shield+reclaim guard;
+the scan-cancellation tests pin the symmetric requirement to keep the cache alive
+until the already-running scan worker drains, then remove it before cancellation
+propagates.
 
 Imports are kept at module top so any import-time IO runs at collection (outside
 the gate); the surface under test runs on the event loop inside the gated test.
@@ -65,10 +66,14 @@ async def test_capture_workspace_snapshot_cleanup_does_not_block_event_loop(tmp_
 
     monkeypatch.setattr(paths_mod, "_paths", None)
 
+    # Pin mkdtemp's parent so the assertion below sees this test's cache dir and
+    # nothing else (the platform temp root is shared and macOS is not /tmp).
     cache_root = tmp_path / "tmp"
     cache_root.mkdir()
     monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
 
+    # Force the failure branch. This mocks the scan (a separate, already-offloaded
+    # call), never the text-cache cleanup this anchor guards.
     def _boom(*args: Any, **kwargs: Any) -> None:
         raise RuntimeError("scan failed")
 
@@ -77,6 +82,8 @@ async def test_capture_workspace_snapshot_cleanup_does_not_block_event_loop(tmp_
     with pytest.raises(RuntimeError, match="scan failed"):
         await recorder.capture_workspace_snapshot("t1", include_text=True)
 
+    # The cache dir was really created, then really removed — cleanup still runs,
+    # it merely moved off the loop.
     leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"text cache dir leaked on the failure branch: {leftovers}"
 
@@ -90,6 +97,7 @@ async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_pa
 
     _seed_workspace(tmp_path)
 
+    # A real text cache dir holding real files, so rmtree does real filesystem work.
     cache_dir = tmp_path / "text-cache"
     cache_dir.mkdir()
     for i in range(5):
@@ -109,7 +117,13 @@ async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_pa
 
 
 async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
-    """A run cancelled during the mkdtemp handoff must not orphan the text cache."""
+    """A run cancelled during the mkdtemp handoff must not orphan the text cache.
+
+    ``mkdtemp`` runs in the ``_prepare_capture`` worker, so if the run is
+    cancelled after the dir is created but before the coroutine receives the
+    path, nothing downstream owns it. The shield+reclaim guard waits for the
+    worker and removes the dir; without it the dir leaks into the temp root.
+    """
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 
@@ -124,20 +138,20 @@ async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(
     real_mkdtemp = tempfile.mkdtemp
 
     def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
-        created = real_mkdtemp(*args, **kwargs)
+        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
         entered.set()
-        release.wait(timeout=5)
+        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
         return created
 
     monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
 
     task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
-    await asyncio.to_thread(entered.wait, 5)
+    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
     parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert parked, "text cache dir should exist while the worker is parked mid-handoff"
 
     task.cancel()
-    release.set()
+    release.set()  # let the worker finish and hand its result to the reclaim path
     with pytest.raises(asyncio.CancelledError):
         await task
 
@@ -146,7 +160,16 @@ async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(
 
 
 async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
-    """A second cancellation during prepare reclaim must not orphan the cache."""
+    """A *second* cancellation during the reclaim await must not orphan the cache.
+
+    After the first cancel enters the reclaim path, the coroutine awaits the
+    shielded worker's result. A second cancel lands on that await: because the
+    reclaim+remove is owned by a task the caller cannot abandon, the guard drains
+    the repeated cancellation until the dir is removed, then restores the
+    cancellation. A plain re-await would let the second ``CancelledError`` skip
+    the reclaim (``except Exception`` does not catch it) while the shielded worker
+    still finishes and leaks its dir.
+    """
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 
@@ -161,26 +184,26 @@ async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_ca
     real_mkdtemp = tempfile.mkdtemp
 
     def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
-        created = real_mkdtemp(*args, **kwargs)
+        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
         entered.set()
-        release.wait(timeout=5)
+        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
         return created
 
     monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
 
     task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
-    await asyncio.to_thread(entered.wait, 5)
+    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
     parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert parked, "text cache dir should exist while the worker is parked mid-handoff"
 
-    task.cancel()
+    task.cancel()  # cancel #1 -> enters reclaim, awaits the shielded cleanup task
     for _ in range(5):
-        await asyncio.sleep(0)
-    task.cancel()
+        await asyncio.sleep(0)  # let the reclaim path reach its await while the worker is still parked
+    task.cancel()  # cancel #2 -> lands on the reclaim await
     for _ in range(5):
         await asyncio.sleep(0)
 
-    release.set()
+    release.set()  # worker finishes; the drained cleanup reclaims and removes the dir
     with pytest.raises(asyncio.CancelledError):
         await task
 
@@ -189,7 +212,7 @@ async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_ca
 
 
 async def test_capture_workspace_snapshot_cancelled_scan_drains_before_cleanup(tmp_path: Path, monkeypatch) -> None:
-    """Cancellation must not delete the text cache while the scan still uses it."""
+    """A cancelled scan keeps its text cache until its worker is finished."""
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 
@@ -229,8 +252,11 @@ async def test_capture_workspace_snapshot_cancelled_scan_drains_before_cleanup(t
     assert leftovers == [], f"cancelled scan leaked a text cache dir: {leftovers}"
 
 
-async def test_capture_workspace_snapshot_repeated_cancel_during_scan_still_cleans_up(tmp_path: Path, monkeypatch) -> None:
-    """Repeated cancellation must not abandon scan draining or the later rmtree."""
+async def test_capture_workspace_snapshot_repeated_cancel_during_scan_still_cleans_up(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Repeated cancellation cannot abandon scan draining or cache cleanup."""
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 

--- a/backend/tests/blocking_io/test_workspace_changes_recorder.py
+++ b/backend/tests/blocking_io/test_workspace_changes_recorder.py
@@ -16,8 +16,9 @@ rmtree this anchor exists to guard.
 
 Because ``mkdtemp`` must be offloaded, its worker handoff is also a cancellation
 hazard: a run cancelled after ``mkdtemp`` but before the coroutine receives the
-path would orphan the dir. The last test pins the shield+reclaim guard that
-removes such a dir instead of leaking it.
+path would orphan the dir. Cancellation during the later scan has a symmetric
+hazard: that worker keeps using the cache after its awaiter is cancelled, so the
+cache must stay alive until the scan drains and then be reclaimed.
 
 Imports are kept at module top so any import-time IO runs at collection (outside
 the gate); the surface under test runs on the event loop inside the gated test.
@@ -64,14 +65,10 @@ async def test_capture_workspace_snapshot_cleanup_does_not_block_event_loop(tmp_
 
     monkeypatch.setattr(paths_mod, "_paths", None)
 
-    # Pin mkdtemp's parent so the assertion below sees this test's cache dir and
-    # nothing else (the platform temp root is shared and macOS is not /tmp).
     cache_root = tmp_path / "tmp"
     cache_root.mkdir()
     monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
 
-    # Force the failure branch. This mocks the scan (a separate, already-offloaded
-    # call), never the text-cache cleanup this anchor guards.
     def _boom(*args: Any, **kwargs: Any) -> None:
         raise RuntimeError("scan failed")
 
@@ -80,8 +77,6 @@ async def test_capture_workspace_snapshot_cleanup_does_not_block_event_loop(tmp_
     with pytest.raises(RuntimeError, match="scan failed"):
         await recorder.capture_workspace_snapshot("t1", include_text=True)
 
-    # The cache dir was really created, then really removed — cleanup still runs,
-    # it merely moved off the loop.
     leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"text cache dir leaked on the failure branch: {leftovers}"
 
@@ -95,7 +90,6 @@ async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_pa
 
     _seed_workspace(tmp_path)
 
-    # A real text cache dir holding real files, so rmtree does real filesystem work.
     cache_dir = tmp_path / "text-cache"
     cache_dir.mkdir()
     for i in range(5):
@@ -115,13 +109,7 @@ async def test_record_workspace_changes_cleanup_does_not_block_event_loop(tmp_pa
 
 
 async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
-    """A run cancelled during the mkdtemp handoff must not orphan the text cache.
-
-    ``mkdtemp`` runs in the ``_prepare_capture`` worker, so if the run is
-    cancelled after the dir is created but before the coroutine receives the
-    path, nothing downstream owns it. The shield+reclaim guard waits for the
-    worker and removes the dir; without it the dir leaks into the temp root.
-    """
+    """A run cancelled during the mkdtemp handoff must not orphan the text cache."""
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 
@@ -136,20 +124,20 @@ async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(
     real_mkdtemp = tempfile.mkdtemp
 
     def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
-        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
+        created = real_mkdtemp(*args, **kwargs)
         entered.set()
-        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
+        release.wait(timeout=5)
         return created
 
     monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
 
     task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
-    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
+    await asyncio.to_thread(entered.wait, 5)
     parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert parked, "text cache dir should exist while the worker is parked mid-handoff"
 
     task.cancel()
-    release.set()  # let the worker finish and hand its result to the reclaim path
+    release.set()
     with pytest.raises(asyncio.CancelledError):
         await task
 
@@ -158,16 +146,7 @@ async def test_capture_workspace_snapshot_cancelled_handoff_leaks_no_text_cache(
 
 
 async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_cache(tmp_path: Path, monkeypatch) -> None:
-    """A *second* cancellation during the reclaim await must not orphan the cache.
-
-    After the first cancel enters the reclaim path, the coroutine awaits the
-    shielded worker's result. A second cancel lands on that await: because the
-    reclaim+remove is owned by a task the caller cannot abandon, the guard drains
-    the repeated cancellation until the dir is removed, then restores the
-    cancellation. A plain re-await would let the second ``CancelledError`` skip
-    the reclaim (``except Exception`` does not catch it) while the shielded worker
-    still finishes and leaks its dir.
-    """
+    """A second cancellation during prepare reclaim must not orphan the cache."""
     monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
     import deerflow.config.paths as paths_mod
 
@@ -182,28 +161,112 @@ async def test_capture_workspace_snapshot_repeated_cancellation_leaks_no_text_ca
     real_mkdtemp = tempfile.mkdtemp
 
     def _blocking_mkdtemp(*args: Any, **kwargs: Any) -> str:
-        created = real_mkdtemp(*args, **kwargs)  # the dir really exists now
+        created = real_mkdtemp(*args, **kwargs)
         entered.set()
-        release.wait(timeout=5)  # park the worker mid-handoff, holding the result
+        release.wait(timeout=5)
         return created
 
     monkeypatch.setattr(recorder.tempfile, "mkdtemp", _blocking_mkdtemp)
 
     task = asyncio.ensure_future(recorder.capture_workspace_snapshot("t1", include_text=True))
-    await asyncio.to_thread(entered.wait, 5)  # mkdtemp created the dir; worker is parked
+    await asyncio.to_thread(entered.wait, 5)
     parked = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert parked, "text cache dir should exist while the worker is parked mid-handoff"
 
-    task.cancel()  # cancel #1 -> enters reclaim, awaits the shielded cleanup task
+    task.cancel()
     for _ in range(5):
-        await asyncio.sleep(0)  # let the reclaim path reach its await while the worker is still parked
-    task.cancel()  # cancel #2 -> lands on the reclaim await
+        await asyncio.sleep(0)
+    task.cancel()
     for _ in range(5):
         await asyncio.sleep(0)
 
-    release.set()  # worker finishes; the drained cleanup reclaims and removes the dir
+    release.set()
     with pytest.raises(asyncio.CancelledError):
         await task
 
     leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"repeated-cancel capture leaked a text cache dir: {leftovers}"
+
+
+async def test_capture_workspace_snapshot_cancelled_scan_drains_before_cleanup(tmp_path: Path, monkeypatch) -> None:
+    """Cancellation must not delete the text cache while the scan still uses it."""
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+        assert text_cache_dir is not None
+        cache_dir = Path(text_cache_dir)
+        assert cache_dir.exists()
+        entered.set()
+        release.wait(timeout=5)
+        assert cache_dir.exists(), "scan cache was removed while the worker was still running"
+        return WorkspaceSnapshot(files={}, truncated=False, text_cache_dir=str(cache_dir))
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
+
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
+    assert await asyncio.to_thread(entered.wait, 5), "scan worker did not start"
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not task.done(), "cancelled capture abandoned the still-running scan worker"
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"cancelled scan leaked a text cache dir: {leftovers}"
+
+
+async def test_capture_workspace_snapshot_repeated_cancel_during_scan_still_cleans_up(tmp_path: Path, monkeypatch) -> None:
+    """Repeated cancellation must not abandon scan draining or the later rmtree."""
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+        assert text_cache_dir is not None
+        cache_dir = Path(text_cache_dir)
+        entered.set()
+        release.wait(timeout=5)
+        assert cache_dir.exists(), "scan cache was removed before the worker drained"
+        return WorkspaceSnapshot(files={}, truncated=False, text_cache_dir=str(cache_dir))
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
+
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
+    assert await asyncio.to_thread(entered.wait, 5), "scan worker did not start"
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert not task.done(), "second cancellation abandoned the still-running scan worker"
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"repeated-cancel scan leaked a text cache dir: {leftovers}"


### PR DESCRIPTION
Fixes #5233

## Why

`capture_workspace_snapshot()` creates a per-run text cache, then offloads `scan_workspace_roots()` with `asyncio.to_thread`. Cancelling the run while that scan is active currently cancels only the awaiter: the worker thread keeps running, `CancelledError` bypasses the existing `except Exception` cleanup branch, and no coroutine remains responsible for removing the cache after the worker finishes.

That leaves `deerflow-workspace-changes-*` directories behind on cancelled runs. More importantly, cleanup cannot safely run immediately on cancellation because the still-running scanner may still be reading/writing that directory. This is the scan-phase counterpart to the cancellation-safe prepare handoff added in #4268.

## What changed

- Keep the scan in an explicit shielded task so caller cancellation cannot cancel its asyncio wrapper while the worker thread is still active.
- On cancellation, drain the worker despite repeated cancellation, preserving the text cache until the scan is done.
- Consume any late scan outcome without replacing the caller-visible cancellation, then remove the cache in a separately owned cleanup task that repeated cancellation cannot abandon.
- Add deterministic regressions for single cancellation, repeated cancellation while the scan is still running, and repeated cancellation after the scan has drained but cache cleanup is still in progress.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — cancelled snapshot capture now waits for its already-running scan worker and cache cleanup before propagating cancellation
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; runtime-only change.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/blocking_io/test_workspace_changes_recorder.py`
- New cases:
  - `test_capture_workspace_snapshot_cancelled_scan_drains_before_cleanup`
  - `test_capture_workspace_snapshot_repeated_cancel_during_scan_still_cleans_up`
  - `test_capture_workspace_snapshot_repeated_cancel_during_cleanup_still_cleans_up`
- Exact repository tests have not executed yet because upstream fork workflows currently require maintainer approval. A standalone asyncio red/green model of the same `to_thread` cancellation boundary reproduces the old behavior (`task.done()` before worker release plus leaked cache) and passes with the new drain. A separate cleanup-phase model also verifies a second cancellation cannot abandon an already-owned cleanup task.

## Validation

- Standalone deterministic asyncio cancellation model: PASS for single cancellation and repeated cancellation during scan drain; the pre-fix control path reproduced early supervisor exit and a leaked cache.
- Cleanup-phase repeated-cancellation model: PASS; the caller remains pending while cleanup is blocked, then the cache is removed and the original cancellation propagates.
- Final branch remains based directly on current upstream `main` (`18b34298ccb7fcc0ca6fc7ce1ffd9c0d7211cdce`).
- Collision audit repeated after the latest test-only commit: no open issue or implementation PR found for this scan-phase cancellation window; #4268 explicitly identified it as a separate follow-up and left it unfixed.
- PR is Ready for review and mergeable. CLA is green. Upstream `Backend Blocking IO` and `Unit Tests` workflows are currently `action_required` because fork PR workflows need maintainer approval; this is not a test failure.
- Full backend lint/test suite: not run in the current connector-only environment; local container network access cannot reach GitHub to clone the repository, so no exact-suite result is claimed.

## AI assistance

**Tool(s) used:** ChatGPT

**How you used it:** Root-cause tracing, collision audit, implementation drafting, adversarial cancellation-test design, final-diff review, and standalone red/green asyncio models. Validation claims above are limited to evidence actually obtained.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
