### PR TITLE
fix(workspace-changes): avoid draining metadata scans on cancellation

### DIFF
--- a/backend/packages/harness/deerflow/AGENTS.md
+++ b/backend/packages/harness/deerflow/AGENTS.md
@@ -48,9 +48,7 @@ drift.
 
 ### Embedded Client (`packages/harness/deerflow/client.py`)
 
-`DeerFlowClient` provides direct in-process access to all DeerFlow capabilities without HTTP services. All return types align with the Gateway API response schemas, so consumer code works identically in HTTP and embedded modes.
-
-**Architecture**: Imports the same `deerflow` modules that Gateway API uses. Shares the same config files and data directories. No FastAPI dependency.
+`DeerFlowClient` provides in-process access without HTTP or a FastAPI dependency. It shares Gateway's `deerflow` modules, config files, data directories, and response schemas for compatible consumers.
 
 **Agent Conversation**:
 - `chat(message, thread_id)` — synchronous, accumulates streaming deltas per message-id and returns the final AI text
@@ -77,17 +75,15 @@ drift.
 | Uploads | `upload_files(thread_id, files)`, `list_uploads(thread_id)`, `delete_upload(thread_id, filename)` | `{"success": true, "files": [...]}`, `{"files": [...], "count": N}` |
 | Artifacts | `get_artifact(thread_id, path)` → `(bytes, mime_type)` | tuple |
 
-**Key difference from Gateway**: Upload accepts local `Path` objects instead of HTTP `UploadFile`, rejects directory paths before copying, and reuses a single worker when document conversion must run inside an active event loop. Artifact returns `(bytes, mime_type)` instead of HTTP Response. The new Gateway-only thread cleanup route deletes `.deer-flow/threads/{thread_id}` after LangGraph thread deletion; there is no matching `DeerFlowClient` method yet. `update_mcp_config()` and `update_skill()` automatically invalidate the cached agent.
+**Gateway differences**: Upload takes local `Path`, not `UploadFile`, rejects directories before copying, and reuses one conversion worker inside an active event loop. Artifacts return `(bytes, mime_type)`, not HTTP Response. Gateway alone deletes `.deer-flow/threads/{thread_id}` after LangGraph thread deletion; the client has no equivalent. `update_mcp_config()` and `update_skill()` invalidate the cached agent.
 
-**Tests**: `tests/test_client.py` (offline unit tests including
-`TestGatewayConformance`), `tests/test_client_live.py` (live integration tests,
-requires a root `config.yaml`, valid API credentials, and explicit opt-in via
-`make test-live` or `DEER_FLOW_RUN_LIVE_TESTS=1`). The live suite calls real
-external APIs and may incur API costs or create local sandboxes, artifacts, and
-files. It is marked `live`, excluded from `make test`, and skipped in default
-CI.
+**Tests**: `tests/test_client.py` is offline, including `TestGatewayConformance`.
+`tests/test_client_live.py` requires root `config.yaml`, valid API credentials,
+and opt-in via `make test-live` or `DEER_FLOW_RUN_LIVE_TESTS=1`. It calls real
+APIs (possible costs) and may create local sandboxes, artifacts, and files.
+Marked `live`, it is excluded from `make test` and skipped in default CI.
 
-**Gateway Conformance Tests** (`TestGatewayConformance`): Validate that every dict-returning client method conforms to the corresponding Gateway Pydantic response model. Each test parses the client output through the Gateway model — if Gateway adds a required field that the client doesn't provide, Pydantic raises `ValidationError` and CI catches the drift. Covers: `ModelsListResponse`, `ModelResponse`, `SkillsListResponse`, `SkillResponse`, `SkillInstallResponse`, `McpConfigResponse`, `UploadResponse`, `MemoryConfigResponse`, `MemoryStatusResponse`.
+**Gateway Conformance Tests** (`TestGatewayConformance`): Parse every dict-returning client method's output through its Gateway Pydantic model so missing required fields raise `ValidationError` in CI. Covers: `ModelsListResponse`, `ModelResponse`, `SkillsListResponse`, `SkillResponse`, `SkillInstallResponse`, `McpConfigResponse`, `UploadResponse`, `MemoryConfigResponse`, `MemoryStatusResponse`.
 
 ### AIO Sandbox Network Policy
 
@@ -103,16 +99,9 @@ Destroy the sandbox, sidecar, and both networks together.
 
 ### E2B Mount Uploads
 
-The E2B provider uploads host mounts during sandbox creation. It passes binary file objects to the E2B SDK.
-
-Each mount has these fixed limits:
-
-- 100 MiB for one file.
-- 512 MiB for all files.
-- 2,000 files.
-
-The full sandbox creation pass also allows 512 MiB and 2,000 files. Skill
-projections and configured mounts share this budget.
+E2B uploads host mounts during sandbox creation using binary file objects.
+Per-mount limits: 100 MiB/file, 512 MiB total, 2,000 files. The full creation
+pass shares a 512 MiB / 2,000-file budget across skill projections and mounts.
 
 The pass has a cooperative deadline controlled by
 ``mount_upload_deadline_seconds`` (default: 120 seconds). The provider checks it before
@@ -134,17 +123,18 @@ Each successful upload logs its source, destination, file count, byte count, and
 
 A stopped pass logs its limit reason and elapsed time. It reports attempted and completed upload totals separately.
 
-A ``MountUploadResult`` is attached to ``E2BSandbox.mount_upload_result``
-after creation. ``result.truncated`` is ``True`` only when the upload pass
-was stopped early by a resource limit (deadline, file count cap, or byte
-budget).  Individual mount failures (missing host path, SDK errors) are
-logged but do NOT set ``truncated``.  ``None`` on a reclaimed sandbox
-means "not available" — the result was recorded at creation time and is
-preserved within the same Gateway process lifetime via a provider-level
-map.
+After creation, ``E2BSandbox.mount_upload_result`` holds a ``MountUploadResult``.
+``result.truncated`` is true only for resource-limit stops (deadline, file count,
+bytes), not logged mount failures (missing paths, SDK errors). A provider-level
+map preserves creation results within the Gateway process; ``None`` on a
+reclaimed sandbox means unavailable.
 
 ### Workspace Snapshot Cancellation (`workspace_changes/recorder.py`)
 
-After `_prepare_capture()` hands off the workspace roots, scan-stage cancellation follows resource ownership. Text snapshots (`include_text=True`) own a temporary text cache that the worker may still read or write, so cancellation must drain the scan before removing that cache. Metadata-only snapshots (`include_text=False`) own no cache, so scan-stage cancellation propagates promptly while the worker continues; a completion callback consumes and logs its eventual outcome.
-
-This invariant is intentionally limited to the scan stage. Cancellation during `_prepare_capture()` still follows the existing prepare handoff/reclaim path. Keep regressions in `tests/blocking_io/test_workspace_changes_cancellation.py` covering prompt metadata scan cancellation and text-cache drain/cleanup.
+After `_prepare_capture()` hands off roots, cancellation must drain text scans
+(`include_text=True`) before removing the cache the worker may still access.
+Metadata scans (`include_text=False`) own no cache: cancel promptly, let the worker
+continue, and consume/log its outcome in a completion callback. Prepare-stage
+cancellation retains its handoff/reclaim path. Regressions in
+`tests/blocking_io/test_workspace_changes_cancellation.py` must cover prompt
+metadata cancellation and text-cache drain/cleanup.

--- a/backend/packages/harness/deerflow/AGENTS.md
+++ b/backend/packages/harness/deerflow/AGENTS.md
@@ -142,3 +142,9 @@ logged but do NOT set ``truncated``.  ``None`` on a reclaimed sandbox
 means "not available" — the result was recorded at creation time and is
 preserved within the same Gateway process lifetime via a provider-level
 map.
+
+### Workspace Snapshot Cancellation (`workspace_changes/recorder.py`)
+
+After `_prepare_capture()` hands off the workspace roots, scan-stage cancellation follows resource ownership. Text snapshots (`include_text=True`) own a temporary text cache that the worker may still read or write, so cancellation must drain the scan before removing that cache. Metadata-only snapshots (`include_text=False`) own no cache, so scan-stage cancellation propagates promptly while the worker continues; a completion callback consumes and logs its eventual outcome.
+
+This invariant is intentionally limited to the scan stage. Cancellation during `_prepare_capture()` still follows the existing prepare handoff/reclaim path. Keep regressions in `tests/blocking_io/test_workspace_changes_cancellation.py` covering prompt metadata scan cancellation and text-cache drain/cleanup.

--- a/backend/packages/harness/deerflow/workspace_changes/AGENTS.md
+++ b/backend/packages/harness/deerflow/workspace_changes/AGENTS.md
@@ -1,9 +1,0 @@
-# Workspace changes runtime invariants
-
-`capture_workspace_snapshot()` participates directly in the run lifecycle, so its cancellation behavior must preserve resource ownership without making unrelated cancellation slower than necessary.
-
-- `include_text=True` creates a temporary `deerflow-workspace-changes-*` text cache. Once `scan_workspace_roots()` has started in `asyncio.to_thread()`, caller cancellation cannot stop that worker. Keep the cache alive until the worker finishes, then remove it before propagating cancellation. Repeated cancellation must not abandon either the drain or cleanup.
-- `include_text=False` creates no cache. This path is used by terminal output verification in `runtime/runs/worker.py`; cancellation must propagate promptly instead of waiting for the metadata scan to finish. The still-running scan task must retain a done callback that consumes its eventual result and logs a late failure so no task exception is lost.
-- Entering the text-cache drain is intentionally observable at info level because the wait is unbounded by design. A scan failure discovered while draining or after metadata-only cancellation is logged at warning level, while the original `CancelledError` remains the caller-visible outcome.
-
-Regression coverage lives in `backend/tests/blocking_io/test_workspace_changes_recorder.py` and `backend/tests/blocking_io/test_workspace_changes_cancellation.py`.

--- a/backend/packages/harness/deerflow/workspace_changes/AGENTS.md
+++ b/backend/packages/harness/deerflow/workspace_changes/AGENTS.md
@@ -1,0 +1,9 @@
+# Workspace changes runtime invariants
+
+`capture_workspace_snapshot()` participates directly in the run lifecycle, so its cancellation behavior must preserve resource ownership without making unrelated cancellation slower than necessary.
+
+- `include_text=True` creates a temporary `deerflow-workspace-changes-*` text cache. Once `scan_workspace_roots()` has started in `asyncio.to_thread()`, caller cancellation cannot stop that worker. Keep the cache alive until the worker finishes, then remove it before propagating cancellation. Repeated cancellation must not abandon either the drain or cleanup.
+- `include_text=False` creates no cache. This path is used by terminal output verification in `runtime/runs/worker.py`; cancellation must propagate promptly instead of waiting for the metadata scan to finish. The still-running scan task must retain a done callback that consumes its eventual result and logs a late failure so no task exception is lost.
+- Entering the text-cache drain is intentionally observable at info level because the wait is unbounded by design. A scan failure discovered while draining or after metadata-only cancellation is logged at warning level, while the original `CancelledError` remains the caller-visible outcome.
+
+Regression coverage lives in `backend/tests/blocking_io/test_workspace_changes_recorder.py` and `backend/tests/blocking_io/test_workspace_changes_cancellation.py`.

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import shutil
 import tempfile
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -75,9 +76,25 @@ async def _reclaim_prepare_and_cleanup(prepare: asyncio.Future[tuple[list[Worksp
         await _remove_text_cache_dir(orphaned)
 
 
+def _consume_cancelled_scan_outcome(scan: asyncio.Future[WorkspaceSnapshot], *, thread_id: str) -> None:
+    """Consume a completed scan and retain diagnostics after caller cancellation."""
+    try:
+        scan.result()
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        logger.warning(
+            "Workspace scan failed after snapshot cancellation for thread %s",
+            thread_id,
+            exc_info=True,
+        )
+
+
 async def _drain_scan_and_cleanup(
     scan: asyncio.Future[WorkspaceSnapshot],
-    text_cache_dir: Path | None,
+    text_cache_dir: Path,
+    *,
+    thread_id: str,
 ) -> None:
     """Let a cancelled scan finish before removing the cache it may still use."""
     while not scan.done():
@@ -90,15 +107,7 @@ async def _drain_scan_and_cleanup(
 
     # Cancellation remains the caller-visible outcome, but consume any late scan
     # failure so the drained task cannot emit an un-retrieved exception warning.
-    try:
-        scan.result()
-    except asyncio.CancelledError:
-        pass
-    except Exception:
-        pass
-
-    if text_cache_dir is None:
-        return
+    _consume_cancelled_scan_outcome(scan, thread_id=thread_id)
 
     cleanup = asyncio.create_task(_remove_text_cache_dir(text_cache_dir))
     while not cleanup.done():
@@ -151,11 +160,23 @@ async def capture_workspace_snapshot(
     try:
         return await asyncio.shield(scan)
     except asyncio.CancelledError:
-        # The scan runs in a worker thread and cannot be stopped by cancelling
-        # this coroutine. Keep the cache alive until that worker has finished,
-        # then remove it before propagating cancellation. Repeated cancellation
-        # must not abandon either phase.
-        await _drain_scan_and_cleanup(scan, text_cache_dir)
+        # A metadata-only scan has no cache resource to protect. It still runs in
+        # the worker after caller cancellation, so retain ownership only long
+        # enough to consume/log its eventual outcome instead of delaying the
+        # cancellation until a full workspace scan finishes.
+        if text_cache_dir is None:
+            scan.add_done_callback(partial(_consume_cancelled_scan_outcome, thread_id=thread_id))
+            raise
+
+        # Text capture is different: the worker may still read/write the cache,
+        # so deleting it immediately would race the scan. Keep the cache alive
+        # until the worker drains, then remove it before propagating cancellation.
+        # Repeated cancellation must not abandon either phase.
+        logger.info(
+            "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup for thread %s",
+            thread_id,
+        )
+        await _drain_scan_and_cleanup(scan, text_cache_dir, thread_id=thread_id)
         raise
     except Exception:
         if text_cache_dir is not None:

--- a/backend/packages/harness/deerflow/workspace_changes/recorder.py
+++ b/backend/packages/harness/deerflow/workspace_changes/recorder.py
@@ -97,6 +97,12 @@ async def _drain_scan_and_cleanup(
     thread_id: str,
 ) -> None:
     """Let a cancelled scan finish before removing the cache it may still use."""
+    if not scan.done():
+        logger.info(
+            "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup for thread %s",
+            thread_id,
+        )
+
     while not scan.done():
         try:
             await asyncio.shield(scan)
@@ -172,10 +178,6 @@ async def capture_workspace_snapshot(
         # so deleting it immediately would race the scan. Keep the cache alive
         # until the worker drains, then remove it before propagating cancellation.
         # Repeated cancellation must not abandon either phase.
-        logger.info(
-            "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup for thread %s",
-            thread_id,
-        )
         await _drain_scan_and_cleanup(scan, text_cache_dir, thread_id=thread_id)
         raise
     except Exception:

--- a/backend/tests/blocking_io/test_workspace_changes_cancellation.py
+++ b/backend/tests/blocking_io/test_workspace_changes_cancellation.py
@@ -30,7 +30,9 @@ async def _reset_paths(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(paths_mod, "_paths", None)
 
 
-async def test_metadata_only_cancel_does_not_wait_for_scan_worker(tmp_path: Path, monkeypatch, caplog) -> None:
+async def test_metadata_only_cancel_does_not_wait_for_scan_worker(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
     """No text cache means cancellation must not wait for the worker scan."""
     await _reset_paths(tmp_path, monkeypatch)
 
@@ -38,7 +40,11 @@ async def test_metadata_only_cancel_does_not_wait_for_scan_worker(tmp_path: Path
     release = threading.Event()
     finished = threading.Event()
 
-    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+    def _blocking_scan(
+        *_args: Any,
+        text_cache_dir: str | Path | None = None,
+        **_kwargs: Any,
+    ) -> WorkspaceSnapshot:
         assert text_cache_dir is None
         entered.set()
         release.wait(timeout=5)
@@ -48,31 +54,45 @@ async def test_metadata_only_cancel_does_not_wait_for_scan_worker(tmp_path: Path
     monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
     caplog.set_level(logging.INFO, logger=recorder.__name__)
 
-    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=False))
-    assert await asyncio.to_thread(entered.wait, 5), "metadata scan worker did not start"
+    task = asyncio.create_task(
+        recorder.capture_workspace_snapshot("t1", include_text=False)
+    )
+    assert await asyncio.to_thread(entered.wait, 5), (
+        "metadata scan worker did not start"
+    )
 
     try:
         task.cancel()
         for _ in range(5):
             await asyncio.sleep(0)
-        assert task.done(), "metadata-only cancellation waited for a scan with no cache resource to protect"
+        assert task.done(), (
+            "metadata-only cancellation waited for a scan with no cache resource to protect"
+        )
         with pytest.raises(asyncio.CancelledError):
             await task
     finally:
         release.set()
 
-    assert await asyncio.to_thread(finished.wait, 5), "metadata scan worker did not finish after release"
+    assert await asyncio.to_thread(finished.wait, 5), (
+        "metadata scan worker did not finish after release"
+    )
     for _ in range(100):
-        if any("Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records):
+        if any(
+            "Workspace scan failed after snapshot cancellation" in record.getMessage()
+            for record in caplog.records
+        ):
             break
         await asyncio.sleep(0.01)
 
     assert any(
-        "Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records
+        "Workspace scan failed after snapshot cancellation" in record.getMessage()
+        for record in caplog.records
     ), "the detached metadata scan's late failure must be consumed and logged"
 
 
-async def test_text_scan_cancel_logs_drain_and_late_failure(tmp_path: Path, monkeypatch, caplog) -> None:
+async def test_text_scan_cancel_logs_drain_and_late_failure(
+    tmp_path: Path, monkeypatch, caplog
+) -> None:
     """A text-cache scan still drains, and that cancellation latency is observable."""
     await _reset_paths(tmp_path, monkeypatch)
 
@@ -83,28 +103,41 @@ async def test_text_scan_cancel_logs_drain_and_late_failure(tmp_path: Path, monk
     entered = threading.Event()
     release = threading.Event()
 
-    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+    def _blocking_scan(
+        *_args: Any,
+        text_cache_dir: str | Path | None = None,
+        **_kwargs: Any,
+    ) -> WorkspaceSnapshot:
         assert text_cache_dir is not None
         cache_dir = Path(text_cache_dir)
         assert cache_dir.exists()
         entered.set()
         release.wait(timeout=5)
-        assert cache_dir.exists(), "text cache was removed while the scan worker was still running"
+        assert cache_dir.exists(), (
+            "text cache was removed while the scan worker was still running"
+        )
         raise RuntimeError("late text scan failure")
 
     monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
     caplog.set_level(logging.INFO, logger=recorder.__name__)
 
-    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
-    assert await asyncio.to_thread(entered.wait, 5), "text scan worker did not start"
+    task = asyncio.create_task(
+        recorder.capture_workspace_snapshot("t1", include_text=True)
+    )
+    assert await asyncio.to_thread(entered.wait, 5), (
+        "text scan worker did not start"
+    )
 
     task.cancel()
     for _ in range(5):
         await asyncio.sleep(0)
 
-    assert not task.done(), "text-cache cancellation must keep ownership until the scan drains"
+    assert not task.done(), (
+        "text-cache cancellation must keep ownership until the scan drains"
+    )
     assert any(
-        "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup" in record.getMessage()
+        "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup"
+        in record.getMessage()
         for record in caplog.records
     ), "entering the cancellation drain should be observable"
 
@@ -112,8 +145,11 @@ async def test_text_scan_cancel_logs_drain_and_late_failure(tmp_path: Path, monk
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    leftovers = await asyncio.to_thread(
+        lambda: sorted(cache_root.glob("deerflow-workspace-changes-*"))
+    )
     assert leftovers == [], f"cancelled text scan leaked a cache dir: {leftovers}"
     assert any(
-        "Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records
+        "Workspace scan failed after snapshot cancellation" in record.getMessage()
+        for record in caplog.records
     ), "a scan failure during cancellation drain must retain diagnostics"

--- a/backend/tests/blocking_io/test_workspace_changes_cancellation.py
+++ b/backend/tests/blocking_io/test_workspace_changes_cancellation.py
@@ -1,0 +1,119 @@
+"""Cancellation regressions for workspace snapshot scans.
+
+Text snapshots own a temporary cache that must outlive an already-running scan,
+so cancellation deliberately drains that worker before cleanup. Metadata-only
+snapshots own no such resource and must propagate cancellation promptly while
+still consuming/logging the worker's eventual outcome.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deerflow.workspace_changes import recorder
+from deerflow.workspace_changes.types import WorkspaceSnapshot
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _reset_paths(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("DEER_FLOW_HOME", str(tmp_path))
+    import deerflow.config.paths as paths_mod
+
+    monkeypatch.setattr(paths_mod, "_paths", None)
+
+
+async def test_metadata_only_cancel_does_not_wait_for_scan_worker(tmp_path: Path, monkeypatch, caplog) -> None:
+    """No text cache means cancellation must not wait for the worker scan."""
+    await _reset_paths(tmp_path, monkeypatch)
+
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+        assert text_cache_dir is None
+        entered.set()
+        release.wait(timeout=5)
+        finished.set()
+        raise RuntimeError("late metadata scan failure")
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
+    caplog.set_level(logging.INFO, logger=recorder.__name__)
+
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=False))
+    assert await asyncio.to_thread(entered.wait, 5), "metadata scan worker did not start"
+
+    try:
+        task.cancel()
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert task.done(), "metadata-only cancellation waited for a scan with no cache resource to protect"
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release.set()
+
+    assert await asyncio.to_thread(finished.wait, 5), "metadata scan worker did not finish after release"
+    for _ in range(100):
+        if any("Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records):
+            break
+        await asyncio.sleep(0.01)
+
+    assert any(
+        "Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records
+    ), "the detached metadata scan's late failure must be consumed and logged"
+
+
+async def test_text_scan_cancel_logs_drain_and_late_failure(tmp_path: Path, monkeypatch, caplog) -> None:
+    """A text-cache scan still drains, and that cancellation latency is observable."""
+    await _reset_paths(tmp_path, monkeypatch)
+
+    cache_root = tmp_path / "tmp"
+    cache_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(cache_root))
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _blocking_scan(*_args: Any, text_cache_dir: str | Path | None = None, **_kwargs: Any) -> WorkspaceSnapshot:
+        assert text_cache_dir is not None
+        cache_dir = Path(text_cache_dir)
+        assert cache_dir.exists()
+        entered.set()
+        release.wait(timeout=5)
+        assert cache_dir.exists(), "text cache was removed while the scan worker was still running"
+        raise RuntimeError("late text scan failure")
+
+    monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
+    caplog.set_level(logging.INFO, logger=recorder.__name__)
+
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
+    assert await asyncio.to_thread(entered.wait, 5), "text scan worker did not start"
+
+    task.cancel()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    assert not task.done(), "text-cache cancellation must keep ownership until the scan drains"
+    assert any(
+        "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup" in record.getMessage()
+        for record in caplog.records
+    ), "entering the cancellation drain should be observable"
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
+    assert leftovers == [], f"cancelled text scan leaked a cache dir: {leftovers}"
+    assert any(
+        "Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records
+    ), "a scan failure during cancellation drain must retain diagnostics"

--- a/backend/tests/blocking_io/test_workspace_changes_cancellation.py
+++ b/backend/tests/blocking_io/test_workspace_changes_cancellation.py
@@ -30,9 +30,7 @@ async def _reset_paths(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(paths_mod, "_paths", None)
 
 
-async def test_metadata_only_cancel_does_not_wait_for_scan_worker(
-    tmp_path: Path, monkeypatch, caplog
-) -> None:
+async def test_metadata_only_cancel_does_not_wait_for_scan_worker(tmp_path: Path, monkeypatch, caplog) -> None:
     """No text cache means cancellation must not wait for the worker scan."""
     await _reset_paths(tmp_path, monkeypatch)
 
@@ -54,45 +52,29 @@ async def test_metadata_only_cancel_does_not_wait_for_scan_worker(
     monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
     caplog.set_level(logging.INFO, logger=recorder.__name__)
 
-    task = asyncio.create_task(
-        recorder.capture_workspace_snapshot("t1", include_text=False)
-    )
-    assert await asyncio.to_thread(entered.wait, 5), (
-        "metadata scan worker did not start"
-    )
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=False))
+    assert await asyncio.to_thread(entered.wait, 5), "metadata scan worker did not start"
 
     try:
         task.cancel()
         for _ in range(5):
             await asyncio.sleep(0)
-        assert task.done(), (
-            "metadata-only cancellation waited for a scan with no cache resource to protect"
-        )
+        assert task.done(), "metadata-only cancellation waited for a scan with no cache resource to protect"
         with pytest.raises(asyncio.CancelledError):
             await task
     finally:
         release.set()
 
-    assert await asyncio.to_thread(finished.wait, 5), (
-        "metadata scan worker did not finish after release"
-    )
+    assert await asyncio.to_thread(finished.wait, 5), "metadata scan worker did not finish after release"
     for _ in range(100):
-        if any(
-            "Workspace scan failed after snapshot cancellation" in record.getMessage()
-            for record in caplog.records
-        ):
+        if any("Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records):
             break
         await asyncio.sleep(0.01)
 
-    assert any(
-        "Workspace scan failed after snapshot cancellation" in record.getMessage()
-        for record in caplog.records
-    ), "the detached metadata scan's late failure must be consumed and logged"
+    assert any("Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records), "the detached metadata scan's late failure must be consumed and logged"
 
 
-async def test_text_scan_cancel_logs_drain_and_late_failure(
-    tmp_path: Path, monkeypatch, caplog
-) -> None:
+async def test_text_scan_cancel_logs_drain_and_late_failure(tmp_path: Path, monkeypatch, caplog) -> None:
     """A text-cache scan still drains, and that cancellation latency is observable."""
     await _reset_paths(tmp_path, monkeypatch)
 
@@ -113,43 +95,26 @@ async def test_text_scan_cancel_logs_drain_and_late_failure(
         assert cache_dir.exists()
         entered.set()
         release.wait(timeout=5)
-        assert cache_dir.exists(), (
-            "text cache was removed while the scan worker was still running"
-        )
+        assert cache_dir.exists(), "text cache was removed while the scan worker was still running"
         raise RuntimeError("late text scan failure")
 
     monkeypatch.setattr(recorder, "scan_workspace_roots", _blocking_scan)
     caplog.set_level(logging.INFO, logger=recorder.__name__)
 
-    task = asyncio.create_task(
-        recorder.capture_workspace_snapshot("t1", include_text=True)
-    )
-    assert await asyncio.to_thread(entered.wait, 5), (
-        "text scan worker did not start"
-    )
+    task = asyncio.create_task(recorder.capture_workspace_snapshot("t1", include_text=True))
+    assert await asyncio.to_thread(entered.wait, 5), "text scan worker did not start"
 
     task.cancel()
     for _ in range(5):
         await asyncio.sleep(0)
 
-    assert not task.done(), (
-        "text-cache cancellation must keep ownership until the scan drains"
-    )
-    assert any(
-        "Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup"
-        in record.getMessage()
-        for record in caplog.records
-    ), "entering the cancellation drain should be observable"
+    assert not task.done(), "text-cache cancellation must keep ownership until the scan drains"
+    assert any("Waiting for cancelled workspace snapshot scan to finish before text-cache cleanup" in record.getMessage() for record in caplog.records), "entering the cancellation drain should be observable"
 
     release.set()
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    leftovers = await asyncio.to_thread(
-        lambda: sorted(cache_root.glob("deerflow-workspace-changes-*"))
-    )
+    leftovers = await asyncio.to_thread(lambda: sorted(cache_root.glob("deerflow-workspace-changes-*")))
     assert leftovers == [], f"cancelled text scan leaked a cache dir: {leftovers}"
-    assert any(
-        "Workspace scan failed after snapshot cancellation" in record.getMessage()
-        for record in caplog.records
-    ), "a scan failure during cancellation drain must retain diagnostics"
+    assert any("Workspace scan failed after snapshot cancellation" in record.getMessage() for record in caplog.records), "a scan failure during cancellation drain must retain diagnostics"


### PR DESCRIPTION
Fixes #5235

## Why

After `_prepare_capture()` completes, `capture_workspace_snapshot()` awaits `scan_workspace_roots()` in a worker. On cancellation, text snapshots (`include_text=True`) must keep their temporary text cache alive until that worker finishes, so draining the scan is a real resource-ownership requirement.

The same scan-stage drain also applied to metadata-only snapshots (`include_text=False`), even though that path owns no text cache. `_produced_output_paths()` uses this metadata-only capture during terminal delivery verification, including cancellation paths, so waiting for the worker can unnecessarily couple caller-visible cancellation latency to the duration of a workspace scan.

This PR is intentionally scoped to **cancellation during the scan stage after `_prepare_capture()` has completed**. Cancellation during `_prepare_capture()` itself still follows the existing prepare handoff/reclaim path and is not changed here.

## What changed

- For metadata-only snapshots during the scan stage (`text_cache_dir is None`), propagate `CancelledError` without draining the worker.
- Keep the already-running background scan alive and attach a completion callback that consumes its eventual outcome, logging a late scan failure instead of losing diagnostics or producing an un-retrieved-exception warning.
- Preserve the existing drain+cleanup behavior for text snapshots, where the cache really must outlive the worker.
- Emit the text-cache drain log only when the scan is actually unfinished, and retain diagnostics for scan failures discovered while draining.
- Add deterministic regressions for prompt metadata scan-stage cancellation and for text-cache drain/cleanup behavior.
- Record the ownership invariant in the existing Harness `AGENTS.md`, rather than introducing a new nested guidance scope.

Related context: #5232 fixed the text-cache ownership race that makes scan draining necessary for `include_text=True`; this PR narrows that rule only for the metadata-only scan stage.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [x] **Default behavior change** — metadata-only **scan-stage** cancellation no longer waits for an unrelated background scan to finish
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; runtime-only change.

## Bug fix verification

- Test path: `backend/tests/blocking_io/test_workspace_changes_cancellation.py`
- New cases:
  - `test_metadata_only_cancel_does_not_wait_for_scan_worker`
  - `test_text_scan_cancel_logs_drain_and_late_failure`
- The metadata regression parks the real `to_thread` scan worker, waits until it has definitely started, cancels the snapshot task, and requires the caller task to become cancelled before the worker is released. The old unconditional scan drain cannot satisfy that invariant.
- The same test then releases a worker that raises and requires the detached completion path to consume/log that late failure.
- The text-path regression pins the opposite resource-safety invariant: cancellation still waits while the cache-owning worker is active, cleanup happens only afterward, a real drain is observable, and a late scan failure is retained in logs.

## Validation

- On the earlier head, Backend Blocking IO, Replay E2E, and Frontend Unit Tests completed successfully; the remaining failures were isolated to formatting and the rejected nested `AGENTS.md` scope.
- The nested `workspace_changes/AGENTS.md` was removed instead of weakening the repository guidance-shape guard.
- Reviewer re-validation on `e74d3540b160ccc82001c2880a85b46b2268dafd` ran the new cancellation file plus `test_workspace_changes_recorder.py`: **9 passed**, with `ruff check` clean on both changed Python files.
- Follow-up `94d65763790cf3245b3d847ed300ee3409942c9a` applies the repository's Ruff 0.15.12 formatting expectations to the new test file.
- Follow-up `3c9ce01c2257c204546f2f0781894d088bd68f09` records the scan-stage ownership invariant in the existing Harness guide, including the explicit `_prepare_capture()` scope boundary.
- Current head is awaiting fresh upstream workflow execution/approval; this section does not claim the new head is CI-green until those workflows actually run.

## AI assistance

**Tool(s) used:** ChatGPT

**How you used it:** Runtime-path analysis, collision audit, implementation drafting, deterministic cancellation-test design, CI-failure diagnosis, reviewer-feedback follow-up, repository-format verification, and final-diff review.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
