### PR TITLE
fix(workspace-changes): record symlink targets without the verbatim prefix

### DIFF
--- a/backend/packages/harness/deerflow/workspace_changes/scanner.py
+++ b/backend/packages/harness/deerflow/workspace_changes/scanner.py
@@ -259,6 +259,21 @@ def _snapshot_file(
     )
 
 
+def _normalize_symlink_target(target: str) -> str:
+    """Strip the Windows extended-length prefix from a symlink target.
+
+    ``os.readlink`` on Windows reports absolute targets in extended-length
+    form (``\\\\?\\C:\\...`` or ``\\\\?\\UNC\\server\\share``). Recorded targets
+    are surfaced in workspace-change events and compared against ordinary
+    paths, so keep the plain spelling; on POSIX this is a no-op.
+    """
+    if target.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + target[len("\\\\?\\UNC\\") :]
+    if target.startswith("\\\\?\\"):
+        return target[len("\\\\?\\") :]
+    return target
+
+
 def _snapshot_symlink(root: WorkspaceRoot, host_file: Path) -> FileSnapshot | None:
     # Deliberately never follows the link (no read_bytes()/open() on the target):
     # the target may point anywhere on the host, including outside the scanned
@@ -278,6 +293,8 @@ def _snapshot_symlink(root: WorkspaceRoot, host_file: Path) -> FileSnapshot | No
         target = os.readlink(host_file)
     except OSError:
         target = None
+    else:
+        target = _normalize_symlink_target(target)
 
     return FileSnapshot(
         path=virtual_path,

--- a/backend/packages/harness/deerflow/workspace_changes/scanner.py
+++ b/backend/packages/harness/deerflow/workspace_changes/scanner.py
@@ -271,13 +271,18 @@ def _normalize_symlink_target(target: str) -> str:
     hosts. ``readlink(2)`` returns the literal string the link was created
     with, and backslash is a valid filename byte on Linux — a target string
     that merely starts with ``\\\\?\\`` there must be recorded verbatim.
+
+    On Windows, only extended *drive-letter* paths are stripped. Other
+    ``\\\\?\\`` namespace forms (volume-GUID paths, device paths) are kept
+    verbatim: stripping them would leave a relative-looking remainder that
+    no longer names the target's namespace.
     """
     if os.name != "nt":
         return target
     if target.startswith("\\\\?\\UNC\\"):
         return "\\\\" + target[len("\\\\?\\UNC\\") :]
-    if target.startswith("\\\\?\\"):
-        return target[len("\\\\?\\") :]
+    if target.startswith("\\\\?\\") and len(target) >= 7 and target[4].isascii() and target[4].isalpha() and target[5] == ":" and target[6] in "\\/":
+        return target[4:]
     return target
 
 

--- a/backend/packages/harness/deerflow/workspace_changes/scanner.py
+++ b/backend/packages/harness/deerflow/workspace_changes/scanner.py
@@ -265,8 +265,15 @@ def _normalize_symlink_target(target: str) -> str:
     ``os.readlink`` on Windows reports absolute targets in extended-length
     form (``\\\\?\\C:\\...`` or ``\\\\?\\UNC\\server\\share``). Recorded targets
     are surfaced in workspace-change events and compared against ordinary
-    paths, so keep the plain spelling; on POSIX this is a no-op.
+    paths, so keep the plain spelling.
+
+    On POSIX this is a provable identity: the strip only applies on Windows
+    hosts. ``readlink(2)`` returns the literal string the link was created
+    with, and backslash is a valid filename byte on Linux — a target string
+    that merely starts with ``\\\\?\\`` there must be recorded verbatim.
     """
+    if os.name != "nt":
+        return target
     if target.startswith("\\\\?\\UNC\\"):
         return "\\\\" + target[len("\\\\?\\UNC\\") :]
     if target.startswith("\\\\?\\"):

--- a/backend/tests/test_workspace_changes.py
+++ b/backend/tests/test_workspace_changes.py
@@ -760,6 +760,17 @@ def test_normalize_symlink_target_strips_extended_length_unc_prefix(monkeypatch)
     assert _normalize_symlink_target(r"\\?\UNC\server\share\a.txt") == r"\\server\share\a.txt"
 
 
+def test_normalize_symlink_target_preserves_volume_guid_and_degenerate_prefixes(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
+    # Volume-GUID paths are absolute Windows targets in their own namespace;
+    # stripping the prefix would leave a relative-looking path.
+    target = r"\\?\Volume{01234567-89ab-cdef-0123-456789abcdef}\folder\target.txt"
+    assert _normalize_symlink_target(target) == target
+    # Only a drive letter followed by a colon and a separator is a drive path.
+    for degenerate in (r"\\?\C:", r"\\?\1:\x", r"\\?\:"):
+        assert _normalize_symlink_target(degenerate) == degenerate
+
+
 def test_normalize_symlink_target_leaves_relative_and_plain_posix_targets_verbatim():
     assert _normalize_symlink_target("relative/target.txt") == "relative/target.txt"
     assert _normalize_symlink_target("/tmp/target.txt") == "/tmp/target.txt"

--- a/backend/tests/test_workspace_changes.py
+++ b/backend/tests/test_workspace_changes.py
@@ -748,11 +748,15 @@ async def test_workspace_changes_route_forwards_include_files_flag():
     assert calls["event_types"] == ["workspace_changes"]
 
 
-def test_normalize_symlink_target_strips_extended_length_drive_prefix():
+def test_normalize_symlink_target_strips_extended_length_drive_prefix(monkeypatch):
+    # The strip only applies on Windows hosts, so force the platform here;
+    # this test runs on the ubuntu-only CI too.
+    monkeypatch.setattr(os, "name", "nt")
     assert _normalize_symlink_target(r"\\?\C:\Users\u1\target.txt") == r"C:\Users\u1\target.txt"
 
 
-def test_normalize_symlink_target_strips_extended_length_unc_prefix():
+def test_normalize_symlink_target_strips_extended_length_unc_prefix(monkeypatch):
+    monkeypatch.setattr(os, "name", "nt")
     assert _normalize_symlink_target(r"\\?\UNC\server\share\a.txt") == r"\\server\share\a.txt"
 
 

--- a/backend/tests/test_workspace_changes.py
+++ b/backend/tests/test_workspace_changes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -19,7 +20,11 @@ from deerflow.workspace_changes import (
     scan_workspace_roots,
 )
 from deerflow.workspace_changes.api import get_workspace_changes_response
-from deerflow.workspace_changes.scanner import SAMPLE_BYTES, is_sensitive_workspace_path
+from deerflow.workspace_changes.scanner import (
+    SAMPLE_BYTES,
+    _normalize_symlink_target,
+    is_sensitive_workspace_path,
+)
 
 
 def _roots(tmp_path):
@@ -741,3 +746,31 @@ async def test_workspace_changes_route_forwards_include_files_flag():
     assert response["available"] is True
     assert response["files"] == []
     assert calls["event_types"] == ["workspace_changes"]
+
+
+def test_normalize_symlink_target_strips_extended_length_drive_prefix():
+    assert _normalize_symlink_target(r"\\?\C:\Users\u1\target.txt") == r"C:\Users\u1\target.txt"
+
+
+def test_normalize_symlink_target_strips_extended_length_unc_prefix():
+    assert _normalize_symlink_target(r"\\?\UNC\server\share\a.txt") == r"\\server\share\a.txt"
+
+
+def test_normalize_symlink_target_leaves_relative_and_plain_posix_targets_verbatim():
+    assert _normalize_symlink_target("relative/target.txt") == "relative/target.txt"
+    assert _normalize_symlink_target("/tmp/target.txt") == "/tmp/target.txt"
+
+
+def test_normalize_symlink_target_leaves_mid_string_prefix_verbatim():
+    # Backslash is a legal filename byte on POSIX, so only a *leading*
+    # extended-length prefix may ever be stripped.
+    for target in (r"/data/\\?\weird-target.txt", r"C:\data\\?\nested.txt"):
+        assert _normalize_symlink_target(target) == target
+
+
+def test_normalize_symlink_target_is_identity_off_windows(monkeypatch):
+    # The strip is gated on Windows hosts: readlink(2) on POSIX returns the
+    # literal string the link was created with, so a target that starts with
+    # "\\?\" there must be recorded verbatim.
+    monkeypatch.setattr(os, "name", "posix")
+    assert _normalize_symlink_target(r"\\?\C:\Users\u1\target.txt") == r"\\?\C:\Users\u1\target.txt"


### PR DESCRIPTION
## Why

`os.readlink` on Windows reports absolute symlink targets in extended-length form (`\\?\C:\...` for drive paths, `\\?\UNC\server\share` for UNC). The workspace-changes scanner stored that raw spelling in `FileSnapshot.symlink_target`, so workspace-change events carried `\\?\`-prefixed targets that do not compare equal to (or display like) ordinary Windows paths — the same change observed through the events API showed two different spellings of one target depending on how the link was created.

## What changed

- `backend/packages/harness/deerflow/workspace_changes/scanner.py` strips the extended-length prefix when recording a symlink target (both the drive and the `UNC` forms). Relative targets and POSIX readlink output pass through unchanged, so Linux CI behavior is identical.
- The `skills/projection.py` and `skills/review/readers.py` readlink sites are deliberately untouched: projection relies on the raw form for its absolute-symlink rejection check, and neither has a user-facing contract pinned on the spelling.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [x] **Backend API** — endpoint / SSE event / request-response shape under `backend/app` — workspace-change events now report symlink targets in their ordinary spelling (value normalization only; payload shape unchanged)
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
  - Prompt-layer self-check: for every data source in the new text, what is its trust level, and which channel should it ride? Model-supplied or user-influenceable values belong on the untrusted, sanitized data channel (e.g. the task `HumanMessage`) — never interpolated into framework-owned system text, even neutralized.
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_workspace_changes.py::test_scan_workspace_roots_captures_symlinks_as_metadata_only_stubs` (and the sibling `test_compare_snapshots_classifies_symlink_replacing_file_as_symlink_created`) — pre-fix assertion failure on a Windows host with symlink privilege: `assert '\\?\C:\U...de-target.txt' == 'C:\Users\S...de-target.txt'`.
- Did it go red on `main` and green on this branch? **Yes** on a Windows 11 host with symlink privilege: both failed on `main`, 28/28 pass on this branch. Note these tests `skip` where symlink creation is not permitted (stock Windows without Developer Mode, including default GitHub `windows-latest` runners); on Linux CI the tests run and the normalization is a no-op. The helper was additionally unit-checked against drive, UNC, relative, POSIX, and 300-character targets.

## Validation

Windows 11 host, Git Bash (`make` is unavailable here, as also reported in #5177):

- `uv run pytest tests/test_workspace_changes.py` — 28 passed
- `uv run ruff check .` and `uv run ruff format --check .` — clean (backend-wide)

## AI assistance

**Tool(s) used:** ZCode (GLM agent)

**How you used it:** triaged the Windows-host test-suite failures, drafted the normalization helper and PR text; I reviewed the full diff line by line before submitting.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
