### PR TITLE
fix(sandbox): stop E2B append from overwriting on read failure

### DIFF
--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
@@ -7,6 +7,7 @@ import shlex
 import threading
 from typing import TYPE_CHECKING
 
+from e2b import FileNotFoundException
 from e2b_code_interpreter import Sandbox as E2BClientSandbox
 
 from deerflow.config.paths import VIRTUAL_PATH_PREFIX
@@ -359,14 +360,16 @@ class E2BSandbox(Sandbox):
                 raise RuntimeError("sandbox client has been closed")
             try:
                 if append:
-                    existing = ""
+                    # E2B has no append write. Read-modify-write must treat only
+                    # explicit not-found as empty; any other read failure would
+                    # otherwise overwrite the original file with just the tail.
                     try:
                         existing = client.files.read(resolved) or ""
-                        if isinstance(existing, bytes):
-                            existing = existing.decode("utf-8", errors="replace")
-                    except Exception:
+                    except (FileNotFoundException, FileNotFoundError):
                         existing = ""
-                    content = (existing or "") + content
+                    if isinstance(existing, bytes):
+                        existing = existing.decode("utf-8", errors="replace")
+                    content = existing + content
                 client.files.write(resolved, content)
             except Exception as e:
                 logger.error("Failed to write file %s in e2b sandbox: %s", resolved, e)

--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
@@ -358,18 +358,24 @@ class E2BSandbox(Sandbox):
             client = self._client
             if client is None:
                 raise RuntimeError("sandbox client has been closed")
+            if append:
+                # E2B has no append write. Read-modify-write must treat only
+                # explicit not-found as empty; any other read failure would
+                # otherwise overwrite the original file with just the tail.
+                try:
+                    existing = client.files.read(resolved) or ""
+                except (FileNotFoundException, FileNotFoundError):
+                    existing = ""
+                except Exception:
+                    logger.error(
+                        "Append pre-read failed for %s; refusing to overwrite",
+                        resolved,
+                    )
+                    raise
+                if isinstance(existing, bytes):
+                    existing = existing.decode("utf-8", errors="replace")
+                content = existing + content
             try:
-                if append:
-                    # E2B has no append write. Read-modify-write must treat only
-                    # explicit not-found as empty; any other read failure would
-                    # otherwise overwrite the original file with just the tail.
-                    try:
-                        existing = client.files.read(resolved) or ""
-                    except (FileNotFoundException, FileNotFoundError):
-                        existing = ""
-                    if isinstance(existing, bytes):
-                        existing = existing.decode("utf-8", errors="replace")
-                    content = existing + content
                 client.files.write(resolved, content)
             except Exception as e:
                 logger.error("Failed to write file %s in e2b sandbox: %s", resolved, e)

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -5234,7 +5234,7 @@ def test_append_creates_file_when_file_does_not_exist(missing_exc):
     assert files.write_calls == [("/home/user/outputs/report.txt", "conclusion")]
 
 
-def test_append_does_not_overwrite_when_read_fails():
+def test_append_does_not_overwrite_when_read_fails(caplog):
     # If the pre-read fails for any reason other than not-found, we cannot
     # confirm the existing contents. Continuing would write only the tail and
     # destroy the original file. Fail closed: raise, and never call write.
@@ -5248,8 +5248,38 @@ def test_append_does_not_overwrite_when_read_fails():
     files = TimeoutFilesAPI(store={"/home/user/outputs/report.txt": existing})
     sb = _make_sandbox(FakeClient(files=files))
 
-    with pytest.raises(TimeoutException, match="read timed out"):
+    with caplog.at_level("ERROR"), pytest.raises(TimeoutException, match="read timed out"):
         sb.write_file("/mnt/user-data/outputs/report.txt", "conclusion", append=True)
 
     assert files.write_calls == []
     assert files.store["/home/user/outputs/report.txt"] == existing
+    assert "refusing to overwrite" in caplog.text
+    assert "Failed to write file" not in caplog.text
+
+
+def test_append_accumulates_existing_content():
+    # The rewrite exists to keep read-modify-write. If someone later drops
+    # `existing` and writes only the tail, the not-found / fail-closed tests
+    # would still pass.
+    files = FakeFilesAPI(store={"/home/user/outputs/report.txt": b"hello"})
+    sb = _make_sandbox(FakeClient(files=files))
+
+    sb.write_file("/mnt/user-data/outputs/report.txt", " world", append=True)
+
+    assert files.write_calls == [("/home/user/outputs/report.txt", "hello world")]
+
+
+def test_append_decodes_bytes_preimage():
+    # FakeFilesAPI.read() returns str for valid utf-8. A bytes pre-image is
+    # what hits the decode branch before concatenation.
+    class BytesFilesAPI(FakeFilesAPI):
+        def read(self, path: str, *, format: str | None = None):
+            self.read_calls.append((path, format))
+            return self.store[path]
+
+    files = BytesFilesAPI(store={"/home/user/outputs/report.txt": b"hello"})
+    sb = _make_sandbox(FakeClient(files=files))
+
+    sb.write_file("/mnt/user-data/outputs/report.txt", " world", append=True)
+
+    assert files.write_calls == [("/home/user/outputs/report.txt", "hello world")]

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -18,6 +18,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from e2b import FileNotFoundException, TimeoutException
 from pydantic import ValidationError
 
 from deerflow.community.e2b_sandbox.capacity import (
@@ -5213,3 +5214,42 @@ def test_glob_preserves_trailing_space_in_filename():
 
     assert matches == ["/home/user/notes.txt "]
     assert truncated is False
+
+
+@pytest.mark.parametrize("missing_exc", [FileNotFoundError, FileNotFoundException])
+def test_append_creates_file_when_file_does_not_exist(missing_exc):
+    # Append has no native write mode, so a missing file must still create one
+    # containing only the new fragment. Both the e2b SDK exception and the
+    # stdlib one used by FakeFilesAPI / compatible clients count as not-found.
+    class MissingFilesAPI(FakeFilesAPI):
+        def read(self, path: str, *, format: str | None = None):
+            self.read_calls.append((path, format))
+            raise missing_exc(path)
+
+    files = MissingFilesAPI()
+    sb = _make_sandbox(FakeClient(files=files))
+
+    sb.write_file("/mnt/user-data/outputs/report.txt", "conclusion", append=True)
+
+    assert files.write_calls == [("/home/user/outputs/report.txt", "conclusion")]
+
+
+def test_append_does_not_overwrite_when_read_fails():
+    # If the pre-read fails for any reason other than not-found, we cannot
+    # confirm the existing contents. Continuing would write only the tail and
+    # destroy the original file. Fail closed: raise, and never call write.
+    existing = b"important report body"
+
+    class TimeoutFilesAPI(FakeFilesAPI):
+        def read(self, path: str, *, format: str | None = None):
+            self.read_calls.append((path, format))
+            raise TimeoutException("read timed out")
+
+    files = TimeoutFilesAPI(store={"/home/user/outputs/report.txt": existing})
+    sb = _make_sandbox(FakeClient(files=files))
+
+    with pytest.raises(TimeoutException, match="read timed out"):
+        sb.write_file("/mnt/user-data/outputs/report.txt", "conclusion", append=True)
+
+    assert files.write_calls == []
+    assert files.store["/home/user/outputs/report.txt"] == existing


### PR DESCRIPTION
Fixes #5260

## Why

E2B has no native append write, so `E2BSandbox.write_file(..., append=True)` read-modify-writes. The pre-read used `except Exception` and treated every failure as an empty file, then wrote the new fragment over whatever was already there.

That is deterministic data loss: a timeout, auth failure, or a reaped sandbox during the pre-read replaces an existing report with only the tail being appended.

## What changed

- Append pre-read now treats only `e2b.FileNotFoundException` and stdlib `FileNotFoundError` as a missing file.
- Any other pre-read error is re-raised and `files.write` is not called.
- Two provider unit tests cover the missing-file create path and the fail-closed overwrite path.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [x] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable; this is a backend sandbox bug fix.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_e2b_sandbox_provider.py::test_append_does_not_overwrite_when_read_fails`
- Did it go red on `main` and green on this branch? yes
- Companion path `test_append_creates_file_when_file_does_not_exist` covers both `FileNotFoundError` and `FileNotFoundException` so a missing file still creates one.

## Validation

- `cd backend && make lint`
- `cd backend && .venv/bin/python -m pytest tests/test_e2b_sandbox_provider.py -q` — 251 passed
- `test_append_does_not_overwrite_when_read_fails` failed on `main` (`DID NOT RAISE TimeoutException`) and passed after the fix.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Source tracing, test-first implementation, and validation.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.