### PR TITLE
fix(sandbox): propagate remote list_dir errors

### DIFF
--- a/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
+++ b/backend/packages/harness/deerflow/community/aio_sandbox/aio_sandbox.py
@@ -575,8 +575,14 @@ class AioSandbox(Sandbox):
         """
         with self._lock:
             try:
-                result = self._client.shell.exec_command(command=f"find {shlex.quote(path)} -maxdepth {max_depth} -type f -o -type d 2>/dev/null | head -500", no_change_timeout=self._DEFAULT_NO_CHANGE_TIMEOUT)
-                output = result.data.output if result.data else ""
+                result = self._client.shell.exec_command(command=f"set -o pipefail; find {shlex.quote(path)} -maxdepth {max_depth} -type f -o -type d 2>/dev/null | head -500", no_change_timeout=self._DEFAULT_NO_CHANGE_TIMEOUT)
+                data = result.data
+                output = data.output if data else ""
+                exit_code = getattr(data, "exit_code", 0)
+                if exit_code not in (0, None):
+                    if not output:
+                        raise FileNotFoundError(f"Directory not found: {path}")
+                    raise RuntimeError(f"Failed to list directory '{path}': exit code {exit_code}")
                 if output:
                     # find delimits records with "\n" and nothing else, so split
                     # on that alone: splitlines() would also break on \v, \f,
@@ -588,7 +594,7 @@ class AioSandbox(Sandbox):
                 return []
             except Exception as e:
                 logger.error(f"Failed to list directory in sandbox: {e}")
-                return []
+                raise
 
     def write_file(self, path: str, content: str, append: bool = False) -> None:
         """Write content to a file in the sandbox.

--- a/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
+++ b/backend/packages/harness/deerflow/community/e2b_sandbox/e2b_sandbox.py
@@ -339,17 +339,22 @@ class E2BSandbox(Sandbox):
         with self._lock:
             client = self._client
             if client is None:
-                return []
+                raise RuntimeError("sandbox client has been closed")
             try:
-                result = client.commands.run(f"find {shlex.quote(resolved)} -maxdepth {int(max_depth)} \\( -type f -o -type d \\) 2>/dev/null | head -500")
+                result = client.commands.run(f"set -o pipefail; find {shlex.quote(resolved)} -maxdepth {int(max_depth)} \\( -type f -o -type d \\) 2>/dev/null | head -500")
                 output = getattr(result, "stdout", "") or ""
+                exit_code = getattr(result, "exit_code", 0)
+                if exit_code not in (0, None):
+                    if not output:
+                        raise FileNotFoundError(f"Directory not found: {path}")
+                    raise RuntimeError(f"Failed to list directory '{path}': exit code {exit_code}")
                 # splitlines() already removed the terminators; do NOT strip
                 # entries — a filename that legitimately ends in whitespace
                 # would be corrupted and never resolve again.
                 return [line for line in output.splitlines() if line]
             except Exception as e:
                 logger.error("Failed to list_dir %s in e2b sandbox: %s", resolved, e)
-                return []
+                raise
 
     def write_file(self, path: str, content: str, append: bool = False) -> None:
         resolved = self._resolve_path(path)

--- a/backend/tests/test_aio_sandbox.py
+++ b/backend/tests/test_aio_sandbox.py
@@ -614,6 +614,41 @@ class TestListDirSerialization:
         assert result == ["/a", "/b"]
         assert lock_was_held == [True], "list_dir must hold the lock during exec_command"
 
+    def test_list_dir_returns_empty_for_existing_empty_dir(self, sandbox):
+        """An empty directory should still return [] when command succeeds."""
+        sandbox._client.shell.exec_command = MagicMock(
+            return_value=SimpleNamespace(data=SimpleNamespace(output="", exit_code=0))
+        )
+
+        assert sandbox.list_dir("/test/empty") == []
+
+    def test_list_dir_raises_file_not_found_for_missing_directory(self, sandbox):
+        """Missing paths should raise FileNotFoundError from list_dir."""
+        sandbox._client.shell.exec_command = MagicMock(
+            return_value=SimpleNamespace(data=SimpleNamespace(output="", exit_code=2))
+        )
+
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
+            sandbox.list_dir("/test/missing")
+        command = sandbox._client.shell.exec_command.call_args.kwargs["command"]
+        assert command.startswith("set -o pipefail; ")
+
+    def test_list_dir_raises_runtimeerror_for_nonzero_exit_with_output(self, sandbox):
+        """Non-zero exit status with stderr/output should bubble as RuntimeError."""
+        sandbox._client.shell.exec_command = MagicMock(
+            return_value=SimpleNamespace(data=SimpleNamespace(output="Permission denied", exit_code=13))
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to list directory"):
+            sandbox.list_dir("/test/protected")
+
+    def test_list_dir_bubbles_command_exception(self, sandbox):
+        """Transport and SDK failures should bubble out of list_dir."""
+        sandbox._client.shell.exec_command = MagicMock(side_effect=RuntimeError("sandbox transport dead"))
+
+        with pytest.raises(RuntimeError, match="sandbox transport dead"):
+            sandbox.list_dir("/test")
+
 
 class TestNoChangeTimeout:
     """Verify that no_change_timeout is forwarded to every exec_command call."""

--- a/backend/tests/test_e2b_sandbox_provider.py
+++ b/backend/tests/test_e2b_sandbox_provider.py
@@ -5204,6 +5204,38 @@ def test_list_dir_preserves_trailing_space_in_filename():
     assert sb.list_dir("/home/user") == ["/home/user/notes.txt ", "/home/user/sub"]
 
 
+def test_list_dir_returns_empty_for_existing_empty_directory():
+    client = FakeClient(commands=FakeCommandsAPI([SimpleNamespace(stdout="", stderr="", exit_code=0)]))
+    sb = _make_sandbox(client)
+
+    assert sb.list_dir("/home/user/empty") == []
+
+
+def test_list_dir_raises_file_not_found_for_missing_directory():
+    client = FakeClient(commands=FakeCommandsAPI([SimpleNamespace(stdout="", stderr="", exit_code=2)]))
+    sb = _make_sandbox(client)
+
+    with pytest.raises(FileNotFoundError, match="Directory not found"):
+        sb.list_dir("/home/user/missing")
+    assert client.commands.calls[0].startswith("set -o pipefail; ")
+
+
+def test_list_dir_raises_runtimeerror_for_nonzero_exit_with_output():
+    client = FakeClient(commands=FakeCommandsAPI([SimpleNamespace(stdout="permission denied", stderr="", exit_code=13)]))
+    sb = _make_sandbox(client)
+
+    with pytest.raises(RuntimeError, match="Failed to list directory"):
+        sb.list_dir("/home/user/protected")
+
+
+def test_list_dir_bubbles_command_exception():
+    client = FakeClient(commands=FakeCommandsAPI([lambda _cmd: (_ for _ in ()).throw(RuntimeError("sandbox command failed"))]))
+    sb = _make_sandbox(client)
+
+    with pytest.raises(RuntimeError, match="sandbox command failed"):
+        sb.list_dir("/home/user")
+
+
 def test_glob_preserves_trailing_space_in_filename():
     listing = SimpleNamespace(stdout="/home/user/notes.txt \n", stderr="", exit_code=0)
     client = FakeClient(commands=FakeCommandsAPI([listing]))


### PR DESCRIPTION
## Summary
- propagate remote sandbox list_dir failures instead of silently returning an empty list
- preserve empty-directory results and filenames with trailing whitespace
- add regression coverage for missing paths, permission failures, and command exceptions

## Validation
- `uv run pytest tests/test_aio_sandbox.py tests/test_e2b_sandbox_provider.py`
- 304 passed
- `git diff --check`