### PR TITLE
fix(doctor): skip tool checks when tools block is empty

### DIFF
--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -282,7 +282,16 @@ class TestCheckWebSearch:
         cfg.write_text("config_version: 5\ntools:\n  # - name: web_search\n")
         result = doctor.check_web_search(cfg)
         assert result.status == "warn"
-        assert "NoneType" not in (result.detail or "")
+        assert result.detail == "no web_search tool in config"
+
+    def test_scalar_tools_entry_warns_without_traceback(self, tmp_path):
+        # A bare string entry is not a mapping; `t.get("name")` used to raise
+        # AttributeError, which the broad handler rendered as the check result.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("config_version: 5\ntools:\n  - web_search\n")
+        result = doctor.check_web_search(cfg)
+        assert result.status == "warn"
+        assert result.detail == "no web_search tool in config"
 
     def test_tavily_with_key_ok(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -275,6 +275,15 @@ class TestCheckWebSearch:
         assert result.status == "ok"
         assert "DuckDuckGo" in result.detail
 
+    def test_commented_out_tools_block_warns_without_traceback(self, tmp_path):
+        # config.example.yaml ships a `tools:` key whose entries can all be
+        # commented out, so it parses as None rather than an empty list.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("config_version: 5\ntools:\n  # - name: web_search\n")
+        result = doctor.check_web_search(cfg)
+        assert result.status == "warn"
+        assert "NoneType" not in (result.detail or "")
+
     def test_tavily_with_key_ok(self, tmp_path, monkeypatch):
         monkeypatch.setenv("TAVILY_API_KEY", "tvly-test")
         cfg = tmp_path / "config.yaml"
@@ -658,6 +667,15 @@ class TestCheckSandbox:
         cfg.write_text("config_version: 5\n")
         results = doctor.check_sandbox(cfg)
         assert results[0].status == "fail"
+
+    def test_commented_out_tools_block_reports_no_traceback(self, tmp_path):
+        # Regression: iterating a null `tools:` raised TypeError, which the
+        # broad handler rendered as "('NoneType' object is not iterable)".
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("config_version: 5\nsandbox:\n  use: deerflow.sandbox.local:LocalSandboxProvider\ntools:\n  # - name: bash\n")
+        results = doctor.check_sandbox(cfg)
+        assert all("NoneType" not in (result.detail or "") for result in results)
+        assert any(result.status == "ok" for result in results)
 
     def test_local_sandbox_with_disabled_host_bash_warns(self, tmp_path):
         cfg = tmp_path / "config.yaml"

--- a/backend/tests/test_doctor.py
+++ b/backend/tests/test_doctor.py
@@ -683,8 +683,10 @@ class TestCheckSandbox:
         cfg = tmp_path / "config.yaml"
         cfg.write_text("config_version: 5\nsandbox:\n  use: deerflow.sandbox.local:LocalSandboxProvider\ntools:\n  # - name: bash\n")
         results = doctor.check_sandbox(cfg)
-        assert all("NoneType" not in (result.detail or "") for result in results)
-        assert any(result.status == "ok" for result in results)
+        # Empty `tools:` means no bash tool, so the path is deterministic.
+        assert len(results) == 1
+        assert results[0].status == "ok"
+        assert results[0].detail == "Local sandbox"
 
     def test_local_sandbox_with_disabled_host_bash_warns(self, tmp_path):
         cfg = tmp_path / "config.yaml"

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -473,7 +473,7 @@ def check_web_tool(config_path: Path, *, tool_name: str, label: str) -> CheckRes
 
         data = _load_yaml_file(config_path)
 
-        tool_entries = [t for t in (data.get("tools") or []) if t.get("name") == tool_name]
+        tool_entries = [t for t in (data.get("tools") or []) if isinstance(t, dict) and t.get("name") == tool_name]
         if not tool_entries:
             return CheckResult(
                 label,

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -473,7 +473,7 @@ def check_web_tool(config_path: Path, *, tool_name: str, label: str) -> CheckRes
 
         data = _load_yaml_file(config_path)
 
-        tool_entries = [t for t in data.get("tools", []) if t.get("name") == tool_name]
+        tool_entries = [t for t in (data.get("tools") or []) if t.get("name") == tool_name]
         if not tool_entries:
             return CheckResult(
                 label,
@@ -642,7 +642,7 @@ def check_sandbox(config_path: Path) -> list[CheckResult]:
             ]
 
         sandbox_use = sandbox.get("use", "")
-        tools = data.get("tools", [])
+        tools = data.get("tools") or []
         tool_names = {tool.get("name") for tool in tools if isinstance(tool, dict)}
         results: list[CheckResult] = []
 


### PR DESCRIPTION
Fixes #5300

## Why

Follow-up to #5296 (merged as `611801d5`), which fixed this class of bug for the `models:` key. The identical defect is still present for `tools:`.

`.get("tools", [])` returns `None` when the key is present but empty, because the default only applies when the key is *absent*. Iterating that `None` raises `TypeError`, which the surrounding `except Exception as exc` renders as the check result:

```
Web Capabilities
  ! web search configured  ('NoneType' object is not iterable)
  ! web fetch configured  ('NoneType' object is not iterable)
  ! web capture configured  ('NoneType' object is not iterable)
  ! image search configured  ('NoneType' object is not iterable)

Sandbox
  ✗ sandbox configured  ('NoneType' object is not iterable)
```

Two sites remained on `main`: line 476, reached by all four web/image checks through the shared `check_web_tool` helper, and line 645 in `check_sandbox`.

**Severity is lower than #5296, and I want to be upfront about that.** `make config` ships ten real tool entries, so a default install does not hit this — a user has to empty or comment out that block first (hand-writing a minimal `config.yaml`, or temporarily disabling tools). This is a completeness follow-up rather than an urgent fix. If you would rather fold it into other work, or not take it at all, that is entirely reasonable.

## What changed

With an empty `tools:` block, the four web-capability checks now fall through to their normal "no tool configured" warning, and the sandbox check evaluates normally. No internal exception text is rendered as a check result.

No behavior change when `tools:` has entries, which is the default.

```python
tool_entries = [t for t in (data.get("tools") or []) if t.get("name") == tool_name]
tools = data.get("tools") or []
```

The parentheses on the comprehension are purely for readability — `or` already binds correctly as the iterable expression there.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [x] **Docs / tests / CI only** — no runtime behavior change

<sub>(Diagnostic script + its tests only; no runtime code path is touched.)</sub>

## Bug fix verification

- **Test path that reproduces the bug:** `backend/tests/test_doctor.py`
  - `TestCheckWebSearch::test_commented_out_tools_block_warns_without_traceback`
  - `TestCheckSandbox::test_commented_out_tools_block_reports_no_traceback`
- **Did it go red on `main` and green on this branch?** Yes — both fail on `main`:

```
FAILED tests/test_doctor.py::TestCheckWebSearch::test_commented_out_tools_block_warns_without_traceback
FAILED tests/test_doctor.py::TestCheckSandbox::test_commented_out_tools_block_reports_no_traceback
2 failed, 70 deselected
```

and both pass here. They use the commented-out `tools:` shape, matching the approach of the tests added in #5296 — the pre-existing tests all use populated `tools:` blocks, which iterate fine.

## Validation

```
cd backend && uv run ruff check .          # All checks passed!
cd backend && uv run ruff format --check . # 1366 files already formatted
cd backend && PYTHONPATH=. uv run pytest tests/test_doctor.py \
    tests/test_support_bundle.py tests/test_pnpm_script.py -q
# 111 passed in 4.92s
```

Also confirmed end to end with `make doctor` against a `config.yaml` whose `tools:` entries are commented out: the five `NoneType` lines are replaced by the normal warnings, and the sandbox check reports `Local sandbox` as expected.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** I used it to check whether the root cause from #5295 appeared elsewhere in the same file, to reproduce the failure against the merged `main`, to draft the fix and regression tests in the style of the ones merged in #5296, and to help write this description. I read the diff, ran the suites myself, and confirmed the tests go red on `main` before going green here.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
