### PR TITLE
fix(infoquest): bound HTTP connect and read waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The landing-page case studies open as allowlisted, read-only showcases without r
 
 ## InfoQuest
 
+InfoQuest reader, web search, and image search use a 30-second HTTP connect/read
+inactivity timeout. The crawl `timeout` and `navigation_timeout` settings remain
+separate server-side options; they do not control the local HTTP timeout.
+
 DeerFlow has newly integrated the intelligent search and crawling toolset independently developed by BytePlus--[InfoQuest (supports free online experience)](https://docs.byteplus.com/en/docs/InfoQuest/What_is_Info_Quest)
 
 <a href="https://docs.byteplus.com/en/docs/InfoQuest/What_is_Info_Quest" target="_blank">

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -256,9 +256,8 @@ Direct pytest collection or execution of `tests/test_client_live.py` remains
 skipped unless `DEER_FLOW_RUN_LIVE_TESTS=1` is set. Do not add that opt-in to
 default CI workflows.
 
-Jina request-failure logging tests set a dummy API key so the separate once-per-process
-missing-key warning cannot make assertions depend on test order or shard placement.
-Missing-key behavior has its own tests in `tests/test_jina_client.py`.
+Jina logging tests isolate missing-key warnings with dummy keys (`tests/test_jina_client.py`).
+InfoQuest HTTP calls share a 30s connect/read inactivity timeout, separate from remote crawl timeouts; see `tests/test_infoquest_http_timeout.py`.
 
 ### Running the Full Application
 

--- a/backend/packages/harness/deerflow/community/infoquest/infoquest_client.py
+++ b/backend/packages/harness/deerflow/community/infoquest/infoquest_client.py
@@ -13,6 +13,10 @@ import requests
 
 logger = logging.getLogger(__name__)
 
+# Requests has no default timeout. This bounds local connect/read inactivity;
+# fetch_timeout and fetch_navigation_timeout configure the remote crawl only.
+_REQUEST_TIMEOUT_SECONDS = 30
+
 
 class InfoQuestClient:
     """Client for interacting with the InfoQuest web search and fetch API."""
@@ -63,7 +67,7 @@ class InfoQuestClient:
 
         logger.debug("Sending crawl request to InfoQuest API")
         try:
-            response = requests.post("https://reader.infoquest.bytepluses.com", headers=headers, json=data)
+            response = requests.post("https://reader.infoquest.bytepluses.com", headers=headers, json=data, timeout=_REQUEST_TIMEOUT_SECONDS)
 
             # Check if status code is not 200
             if response.status_code != 200:
@@ -164,7 +168,7 @@ class InfoQuestClient:
         if site != "":
             params["site"] = site
 
-        response = requests.post("https://search.infoquest.bytepluses.com", headers=headers, json=params)
+        response = requests.post("https://search.infoquest.bytepluses.com", headers=headers, json=params, timeout=_REQUEST_TIMEOUT_SECONDS)
         response.raise_for_status()
 
         # Print partial response for debugging
@@ -339,7 +343,7 @@ class InfoQuestClient:
         elif self.image_size:
             logger.warning(f"image_size {self.image_size} is not valid, must be 'l', 'm', or 'i'")
 
-        response = requests.post("https://search.infoquest.bytepluses.com", headers=headers, json=params)
+        response = requests.post("https://search.infoquest.bytepluses.com", headers=headers, json=params, timeout=_REQUEST_TIMEOUT_SECONDS)
         response.raise_for_status()
 
         # Print partial response for debugging

--- a/backend/tests/test_infoquest_http_timeout.py
+++ b/backend/tests/test_infoquest_http_timeout.py
@@ -1,0 +1,35 @@
+"""InfoQuest's remote crawl timeout must not leave local HTTP waits unbounded."""
+
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from deerflow.community.infoquest.infoquest_client import InfoQuestClient
+
+
+@pytest.mark.parametrize("operation", ["fetch", "web_search", "image_search"])
+def test_infoquest_sets_transport_timeout(monkeypatch, operation):
+    response = Mock(status_code=200, text='{"reader_result":"<p>Content</p>"}')
+    response.json.return_value = {"search_result": {"results": []}}
+    post = Mock(return_value=response)
+    monkeypatch.setattr(requests, "post", post)
+    monkeypatch.setenv("INFOQUEST_API_KEY", "test-placeholder")
+    client = InfoQuestClient(fetch_timeout=10, fetch_navigation_timeout=20)
+    result = getattr(client, operation)("https://example.com" if operation == "fetch" else "query")
+    assert result == ("<p>Content</p>" if operation == "fetch" else "[]")
+    post.assert_called_once()
+    assert post.call_args.kwargs["timeout"] == 30
+    if operation == "fetch":
+        assert post.call_args.kwargs["json"]["timeout"] == 10
+        assert post.call_args.kwargs["json"]["navi_timeout"] == 20
+
+
+@pytest.mark.parametrize("operation", ["fetch", "web_search", "image_search"])
+@pytest.mark.parametrize("error_type", [requests.ConnectTimeout, requests.ReadTimeout])
+def test_infoquest_transport_timeout_returns_existing_error(monkeypatch, operation, error_type):
+    monkeypatch.setattr(requests, "post", Mock(side_effect=error_type("synthetic timeout")))
+    monkeypatch.setenv("INFOQUEST_API_KEY", "test-placeholder")
+    result = getattr(InfoQuestClient(), operation)("https://example.com" if operation == "fetch" else "query")
+    assert result.startswith("Error:")
+    assert "synthetic timeout" in result


### PR DESCRIPTION
Fixes #5314.

## Why

InfoQuest reader, web search and image search omit the Requests transport timeout. A stalled endpoint can leave the synchronous worker waiting indefinitely, even when the remote crawl `timeout` field is configured.

## What changed

Pass a shared 30-second timeout to all three HTTP call sites. Preserve crawl timeout/navigation payload fields, successful parsing and existing `Error:` returns. This bounds connect/read inactivity; it is not a total wall-clock deadline. Prior work: closed, unmerged #4661 by RerankerGuo independently identified the same omission; this PR credits that investigation and verifies the fix on current main.

## Surface area

- [x] **Default behavior change** — Apply an explicit 30-second connect/read inactivity timeout to InfoQuest reader, web-search and image-search calls.
- One production module, regression tests and matching documentation; no dependency changes.

## Bug fix verification

`backend/tests/test_infoquest_http_timeout.py`: all three request-boundary tests fail on unchanged code with missing `timeout`; all 9 tests pass after the fix, including connect/read exception paths and remote payload preservation.

## Validation

- 14467 passed, 111 skipped, 3 deselected, 19 warnings in 577.58s (0:09:37).
- Blocking I/O: 119 passed, 2 warnings in 7.50s.
- Ruff lint/format and scope-aware agent guidance checks pass.
- Hardened DockerVerifier containers; tests have no network access and use synthetic data.

## AI assistance

**Tool(s) used:** Codex.

**How you used it:** Source investigation, offline reproduction, implementation, regression tests and review.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
