### PR TITLE
fix(frontend): show agent skill badges with empty tool groups

### DIFF
--- a/frontend/src/components/workspace/agents/agent-card.tsx
+++ b/frontend/src/components/workspace/agents/agent-card.tsx
@@ -162,7 +162,8 @@ export function AgentCard({ agent }: AgentCardProps) {
           )}
         </CardHeader>
 
-        {(agent.tool_groups?.length ?? agent.skills?.length ?? 0) > 0 && (
+        {((agent.tool_groups?.length ?? 0) > 0 ||
+          (agent.skills?.length ?? 0) > 0) && (
           <CardContent className="pt-0 pb-3">
             <div className="flex flex-wrap gap-1">
               {agent.tool_groups?.map((group) => (

--- a/frontend/tests/e2e/agent-chat.spec.ts
+++ b/frontend/tests/e2e/agent-chat.spec.ts
@@ -32,6 +32,35 @@ test.describe("Agent chat", () => {
     });
   });
 
+  for (const { label, toolGroups } of [
+    { label: "empty", toolGroups: [] },
+    { label: "unrestricted", toolGroups: null },
+  ]) {
+    test(`agent gallery shows skill badges with ${label} tool groups`, async ({
+      page,
+    }) => {
+      mockLangGraphAPI(page, {
+        agents: [
+          {
+            ...MOCK_AGENTS[0]!,
+            tool_groups: toolGroups,
+            skills: ["data-analysis"],
+          },
+        ],
+      });
+
+      await page.goto("/workspace/agents");
+
+      const card = page.locator('[data-slot="card"]').filter({
+        has: page.getByText("test-agent", { exact: true }),
+      });
+      await expect(card).toBeVisible({ timeout: 15_000 });
+      await expect(
+        card.getByText("data-analysis", { exact: true }),
+      ).toBeVisible();
+    });
+  }
+
   test("agent chat page loads with input box and AI disclaimer", async ({
     page,
   }) => {

--- a/frontend/tests/e2e/agent-chat.spec.ts
+++ b/frontend/tests/e2e/agent-chat.spec.ts
@@ -61,6 +61,22 @@ test.describe("Agent chat", () => {
     });
   }
 
+  test("agent gallery hides the badge block with no tool groups or skills", async ({
+    page,
+  }) => {
+    mockLangGraphAPI(page, {
+      agents: [{ ...MOCK_AGENTS[0]!, tool_groups: [], skills: [] }],
+    });
+
+    await page.goto("/workspace/agents");
+
+    const card = page.locator('[data-slot="card"]').filter({
+      has: page.getByText("test-agent", { exact: true }),
+    });
+    await expect(card).toBeVisible({ timeout: 15_000 });
+    await expect(card.locator('[data-slot="card-content"]')).toHaveCount(0);
+  });
+
   test("agent chat page loads with input box and AI disclaimer", async ({
     page,
   }) => {

--- a/frontend/tests/e2e/utils/mock-api.ts
+++ b/frontend/tests/e2e/utils/mock-api.ts
@@ -52,6 +52,7 @@ export type MockAgent = {
   description?: string;
   system_prompt?: string;
   tool_groups?: string[] | null;
+  skills?: string[] | null;
 };
 
 export type MockSkill = {


### PR DESCRIPTION
Fixes #5325

## Why

An Agent with `tool_groups: []` and `skills: ["data-analysis"]` loses its skill badge in the Agents gallery. The container's nullish-coalescing chain stops at the tool-group count `0`, so the nonempty skill list is never considered. Explicit empty tool-group lists are supported by the Agent API and the `update_agent` tool.

## What changed

Show the badge container when either list has at least one entry. Each length retains its own `?? 0` fallback, and the two boolean comparisons are combined with `||`.

Added gallery E2E regression coverage for empty and unrestricted tool groups using the existing Playwright fixtures. The mock Agent type gains the optional `skills` field.

## Surface area

- [x] **Frontend UI** — Agent card badge visibility
- [ ] **Backend API**
- [ ] **Agents / LangGraph**
- [ ] **Sandbox**
- [ ] **Skills**
- [ ] **Dependencies**
- [ ] **Default behavior change**
- [ ] **Docs / tests / CI only**

## Screenshots / Recording

Actual `/workspace/agents` page, including the sidebar entry point. Both captures use the same API fixtures through the repository's Playwright mock helper: the first card has `tool_groups: []`, the control card has `tool_groups: null`, and both have `skills: ["data-analysis"]`. These are frontend browser captures; a live Gateway was not used.

| Before | After |
| --- | --- |
| ![Before: the empty-array card has no skill badge](https://raw.githubusercontent.com/Uygniqoar/deer-flow/e84fa2fa08818d7c434d42b413b237e09d50b5ce/docs/pr-evidence/agent-card-before.png) | ![After: both cards show the configured skill](https://raw.githubusercontent.com/Uygniqoar/deer-flow/e84fa2fa08818d7c434d42b413b237e09d50b5ce/docs/pr-evidence/agent-card-after.png) |

## Bug fix verification

`frontend/tests/e2e/agent-chat.spec.ts` covers skill badge visibility on the actual `/workspace/agents` page for both `tool_groups: []` and `tool_groups: null`, with `skills: ["data-analysis"]`. Assertions are scoped to the agent's card.

With the original condition from the PR's base revision (`0d492530`) temporarily restored, the empty-array case failed because the card's skill badge was missing, while the null control passed. After restoring the fix, both cases passed as part of the 18 passing Agents E2E tests.

Reproduce the two regression cases with:

```sh
pnpm exec playwright test tests/e2e/agent-chat.spec.ts --grep "agent gallery shows skill badges" --workers 1
```

The before/after automated verification used Chromium against the local Next.js development server with mocked backend APIs. No live Gateway was used.

## Validation

- `pnpm format`: passed.
- `pnpm check` (ESLint and TypeScript): passed.
- `pnpm exec playwright test tests/e2e/agent-chat.spec.ts tests/e2e/agents-feature-disabled.spec.ts --workers 1 --reporter list --timeout 90000`: 18 passed, including both new regression cases.
- `pnpm test run --reporter=dot`: 163 files, 1290 tests passed.
- Production `pnpm build`: passed.
- Full Playwright Chromium run: 177 passed, 1 failed on the existing live-compaction message-ordering case in `thread-ordering.spec.ts:279` (`questionBeforeAnswer` was `null`). That case passed on an immediate isolated rerun with one worker; the test was not changed.
- Actual Agents gallery before/after browser verification: empty-array skill badge absent before the fix and visible after it; the null control remained visible; no page errors.
- `git diff --check`: passed.

Host-side pnpm commands used `scripts/pnpm.py`. The 18-test Agents run used `PLAYWRIGHT_BASE_URL=http://127.0.0.1:3126` and `PLAYWRIGHT_SKIP_WEB_SERVER=1` against a separately started local development server. The unit suite, production build, and full Chromium run were completed for the runtime fix before adding the two regression cases and were not rerun for the test-only addition. The full Chromium run and screenshots used the production frontend with mocked backend APIs. No live backend integration tests were run.

## AI assistance

**Tool(s) used:** Codex.

**How you used it:** Traced the supported configuration and data path, implemented the visibility fix, added the gallery E2E regression cases, verified failure with the original condition and success with the fix, ran checks, captured the actual gallery before/after, and prepared the issue/PR text.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
