### PR TITLE
test(runtime): add deterministic executor starvation regressions

### DIFF
--- a/backend/tests/test_executor_starvation.py
+++ b/backend/tests/test_executor_starvation.py
@@ -80,3 +80,44 @@ def test_waiter_timeout_does_not_stop_started_sync_work():
             executor.shutdown(wait=True, cancel_futures=True)
 
     asyncio.run(scenario())
+
+
+def test_dedicated_file_io_pool_runs_while_default_executor_is_saturated():
+    async def scenario():
+        from deerflow.utils import file_io
+
+        loop = asyncio.get_running_loop()
+        default_executor = ThreadPoolExecutor(max_workers=1)
+        dedicated_executor = ThreadPoolExecutor(max_workers=1)
+        original_executor = file_io._FILE_IO_EXECUTOR
+        loop.set_default_executor(default_executor)
+        file_io._FILE_IO_EXECUTOR = dedicated_executor
+        release = threading.Event()
+        default_started = asyncio.Event()
+        dedicated_started = asyncio.Event()
+
+        def default_blocker():
+            loop.call_soon_threadsafe(default_started.set)
+            release.wait()
+
+        def dedicated_work():
+            loop.call_soon_threadsafe(dedicated_started.set)
+            return "file-io"
+
+        try:
+            default_task = asyncio.create_task(asyncio.to_thread(default_blocker))
+            await default_started.wait()
+
+            file_task = asyncio.create_task(file_io.run_file_io(dedicated_work))
+            await dedicated_started.wait()
+            assert await file_task == "file-io"
+
+            release.set()
+            await default_task
+        finally:
+            release.set()
+            file_io._FILE_IO_EXECUTOR = original_executor
+            dedicated_executor.shutdown(wait=True, cancel_futures=True)
+            default_executor.shutdown(wait=True, cancel_futures=True)
+
+    asyncio.run(scenario())

--- a/backend/tests/test_executor_starvation.py
+++ b/backend/tests/test_executor_starvation.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+
+def test_default_executor_saturation_keeps_work_queued():
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        executor = ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(executor)
+        release = threading.Event()
+        first_started = asyncio.Event()
+        second_started = asyncio.Event()
+
+        def blocker():
+            loop.call_soon_threadsafe(first_started.set)
+            release.wait()
+
+        try:
+            first = asyncio.create_task(asyncio.to_thread(blocker))
+            await first_started.wait()
+
+            second = asyncio.create_task(
+                asyncio.to_thread(loop.call_soon_threadsafe, second_started.set)
+            )
+            await asyncio.sleep(0)
+            assert not second_started.is_set()
+
+            release.set()
+            await asyncio.gather(first, second)
+            assert second_started.is_set()
+        finally:
+            release.set()
+            executor.shutdown(wait=True, cancel_futures=True)
+
+    asyncio.run(scenario())
+
+
+def test_waiter_timeout_does_not_stop_started_sync_work():
+    async def scenario():
+        loop = asyncio.get_running_loop()
+        executor = ThreadPoolExecutor(max_workers=1)
+        loop.set_default_executor(executor)
+        release = threading.Event()
+        started = asyncio.Event()
+        finished = threading.Event()
+        sentinel_started = asyncio.Event()
+
+        def blocker():
+            loop.call_soon_threadsafe(started.set)
+            release.wait()
+            finished.set()
+
+        try:
+            running = asyncio.create_task(asyncio.to_thread(blocker))
+            await started.wait()
+
+            try:
+                await asyncio.wait_for(running, timeout=0)
+            except asyncio.TimeoutError:
+                pass
+
+            assert running.cancelled()
+            assert not finished.is_set()
+
+            sentinel = asyncio.create_task(
+                asyncio.to_thread(loop.call_soon_threadsafe, sentinel_started.set)
+            )
+            await asyncio.sleep(0)
+            assert not sentinel_started.is_set()
+
+            release.set()
+            await sentinel
+            assert finished.is_set()
+            assert sentinel_started.is_set()
+        finally:
+            release.set()
+            executor.shutdown(wait=True, cancel_futures=True)
+
+    asyncio.run(scenario())


### PR DESCRIPTION
Fixes #4560

## Why

#4560 identifies a testing gap around executor starvation, pool exhaustion, cancellation semantics, and execution-domain isolation. Existing coverage checks blocking-I/O offload and several concurrency paths, but does not deterministically prove that a saturated asyncio default executor queues new work or that cancelling a waiter leaves already-running synchronous work occupying its worker.

This PR starts with the smallest deterministic CI-safe slice of the RFC. It does **not** change production executor sizing, routing, or runtime behavior.

## What changed

- Add a deterministic default-executor saturation regression using a one-worker executor and explicit thread/event coordination.
- Verify that a queued `asyncio.to_thread()` task does not start while the only worker is occupied, then proceeds after release.
- Verify that `asyncio.wait_for()` cancellation of an already-started synchronous task cancels the awaiter but does not stop the underlying worker function, and that queued work remains blocked until that function releases.
- Verify that DeerFlow's dedicated `run_file_io()` executor can make progress while the asyncio default executor is saturated.

The tests intentionally assert lifecycle/state transitions instead of relying on timing thresholds, so they remain deterministic and suitable for normal CI.

## Scope

This is the deterministic starvation baseline from #4560. Stress/soak tests, AnyIO instrumentation, Uvicorn multi-process tests, and broader framework attribution are intentionally deferred to follow-up work so this PR remains focused and reviewable.

## Validation

- Focused executor tests: 3 scenarios covering saturation, cancellation semantics, and dedicated-executor isolation.
- The branch is based directly on current upstream `main` and changes only `backend/tests/test_executor_starvation.py` plus its test-directory guidance.

## AI assistance

**Tool(s) used:** Codex

**How you used it:** Used Codex to inspect the RFC and current executor boundaries, derive deterministic regression cases, and draft the focused tests. The tests were reviewed for synchronization and cleanup semantics before submission.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
