### PR TITLE
fix(frontend): localize Settings load errors

### DIFF
--- a/frontend/src/components/workspace/settings/memory-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/memory-settings-page.tsx
@@ -546,7 +546,9 @@ export function MemorySettingsPage() {
             {t.common.loading}
           </div>
         ) : error ? (
-          <div>Error: {error.message}</div>
+          <div>
+            {t.common.error} {error.message}
+          </div>
         ) : !memory ? (
           <div className="text-muted-foreground text-sm">
             {t.settings.memory.empty}

--- a/frontend/src/components/workspace/settings/skill-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/skill-settings-page.tsx
@@ -57,7 +57,9 @@ export function SkillSettingsPage({ onClose }: { onClose?: () => void } = {}) {
           {t.settings.skills.adminRequired}
         </div>
       ) : error ? (
-        <div>Error: {error.message}</div>
+        <div>
+          {t.common.error} {error.message}
+        </div>
       ) : (
         <SkillSettingsList skills={skills} onClose={onClose} />
       )}

--- a/frontend/src/components/workspace/settings/tool-settings-page.tsx
+++ b/frontend/src/components/workspace/settings/tool-settings-page.tsx
@@ -55,7 +55,9 @@ export function ToolSettingsPage() {
           {t.settings.tools.adminRequired}
         </div>
       ) : error ? (
-        <div>Error: {error.message}</div>
+        <div>
+          {t.common.error} {error.message}
+        </div>
       ) : (
         config && <MCPServerList servers={config.mcp_servers} />
       )}

--- a/frontend/src/core/i18n/locales/en-US.ts
+++ b/frontend/src/core/i18n/locales/en-US.ts
@@ -38,6 +38,7 @@ export const enUS: Translations = {
     custom: "Custom",
     notAvailableInDemoMode: "Not available in demo mode",
     loading: "Loading...",
+    error: "Error:",
     version: "Version",
     lastUpdated: "Last updated",
     code: "Code",

--- a/frontend/src/core/i18n/locales/types.ts
+++ b/frontend/src/core/i18n/locales/types.ts
@@ -27,6 +27,7 @@ export interface Translations {
     custom: string;
     notAvailableInDemoMode: string;
     loading: string;
+    error: string;
     version: string;
     lastUpdated: string;
     code: string;

--- a/frontend/src/core/i18n/locales/zh-CN.ts
+++ b/frontend/src/core/i18n/locales/zh-CN.ts
@@ -38,6 +38,7 @@ export const zhCN: Translations = {
     custom: "自定义",
     notAvailableInDemoMode: "在演示模式下不可用",
     loading: "加载中...",
+    error: "错误：",
     version: "版本",
     lastUpdated: "最后更新",
     code: "代码",

--- a/frontend/tests/unit/components/workspace/settings/tool-settings-page.dom.test.tsx
+++ b/frontend/tests/unit/components/workspace/settings/tool-settings-page.dom.test.tsx
@@ -5,6 +5,7 @@ import { ToolSettingsPage } from "@/components/workspace/settings/tool-settings-
 
 const mcpMockState = rs.hoisted(() => ({
   isPending: false,
+  error: null as Error | null,
   mutate: rs.fn(),
   updateIsPending: false,
   updateMutate: rs.fn(),
@@ -27,6 +28,7 @@ rs.mock("@/core/i18n/hooks", () => ({
   useI18n: () => ({
     t: {
       common: {
+        error: "Error:",
         loading: "Loading",
         cancel: "Cancel",
         save: "Save",
@@ -67,7 +69,7 @@ rs.mock("@/core/mcp/hooks", () => ({
   useMCPConfig: () => ({
     config: { mcp_servers: mcpMockState.servers },
     isLoading: false,
-    error: null,
+    error: mcpMockState.error,
   }),
   useEnableMCPServer: () => ({
     isPending: mcpMockState.isPending,
@@ -118,6 +120,7 @@ function definitionTextbox(): HTMLTextAreaElement {
 
 afterEach(() => {
   mcpMockState.isPending = false;
+  mcpMockState.error = null;
   mcpMockState.updateIsPending = false;
   mcpMockState.mutate.mockReset();
   mcpMockState.updateMutate.mockReset();
@@ -126,6 +129,14 @@ afterEach(() => {
 });
 
 describe("ToolSettingsPage MCP switches", () => {
+  it("renders a localized load error", () => {
+    mcpMockState.error = new Error("request failed");
+
+    render(<ToolSettingsPage />);
+
+    expect(screen.getByText("Error: request failed")).toBeDefined();
+  });
+
   it("disables every switch while a targeted update is pending", () => {
     twoServers();
     mcpMockState.isPending = true;


### PR DESCRIPTION
## Summary

- add a shared localized `common.error` label for Settings load failures
- replace the hardcoded English prefix in Tool, Skill, and Memory Settings
- cover the Tool Settings error branch with a DOM regression test

Fixes #5336

## Validation

- `pnpm exec rstest tests/unit/components/workspace/settings/tool-settings-page.dom.test.tsx`
- `pnpm check`
- `pnpm exec prettier --check src/core/i18n/locales/types.ts src/core/i18n/locales/en-US.ts src/core/i18n/locales/zh-CN.ts src/components/workspace/settings/tool-settings-page.tsx src/components/workspace/settings/skill-settings-page.tsx src/components/workspace/settings/memory-settings-page.tsx tests/unit/components/workspace/settings/tool-settings-page.dom.test.tsx`
