### PR TITLE
fix(sandbox): drain skill sync before cancellation

### DIFF
--- a/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
+++ b/backend/packages/harness/deerflow/sandbox/sandbox_provider.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from deerflow.config import get_app_config
 from deerflow.reflection import resolve_class
+from deerflow.sandbox.lease import run_sync_lifecycle_operation
 from deerflow.sandbox.sandbox import Sandbox
 
 if TYPE_CHECKING:
@@ -62,8 +63,8 @@ class SandboxProvider(ABC):
         user_id: str,
         projection: "SkillProjectionPaths",
     ) -> None:
-        """Async wrapper for upload-based skill synchronization."""
-        await asyncio.to_thread(
+        """Async wrapper that keeps lifecycle ownership until sync finishes."""
+        await run_sync_lifecycle_operation(
             self.sync_agent_skills,
             sandbox_id,
             thread_id=thread_id,

--- a/backend/tests/test_sandbox_skill_sync_cancellation.py
+++ b/backend/tests/test_sandbox_skill_sync_cancellation.py
@@ -111,11 +111,19 @@ async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
     provider = _BlockingSkillSyncProvider()
     middleware = SandboxMiddleware(lazy_init=True, available_skills={"allowed"})
     projection = object()
+    release_entry_sync_finished: list[bool] = []
+    original_release_sandbox_async = middleware._release_sandbox_async
+
+    async def _record_release_entry(sandbox_id: str, *, owner_id: str | None) -> None:
+        release_entry_sync_finished.append(provider.sync_finished.is_set())
+        await original_release_sandbox_async(sandbox_id, owner_id=owner_id)
+
     monkeypatch.setattr(
         middleware,
         "_prepare_agent_skill_projection",
         lambda *_args, **_kwargs: projection,
     )
+    monkeypatch.setattr(middleware, "_release_sandbox_async", _record_release_entry)
     set_sandbox_provider(provider)
     task = asyncio.create_task(
         middleware.abefore_agent(
@@ -130,6 +138,7 @@ async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
         await asyncio.sleep(0)
 
         assert not task.done()
+        assert release_entry_sync_finished == []
         assert provider.release_calls == []
         assert not provider.sync_finished.is_set()
 
@@ -137,6 +146,7 @@ async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
         await asyncio.sleep(0)
 
         assert not task.done()
+        assert release_entry_sync_finished == []
         assert provider.release_calls == []
         assert not provider.sync_finished.is_set()
 
@@ -145,6 +155,7 @@ async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
             await task
 
         assert provider.sync_finished.is_set()
+        assert release_entry_sync_finished == [True]
         assert provider.release_calls == [provider.sandbox.id]
     finally:
         provider.allow_sync_finish.set()

--- a/backend/tests/test_sandbox_skill_sync_cancellation.py
+++ b/backend/tests/test_sandbox_skill_sync_cancellation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from langgraph.runtime import Runtime
+
+from deerflow.sandbox.middleware import SandboxMiddleware
+from deerflow.sandbox.sandbox import Sandbox
+from deerflow.sandbox.sandbox_provider import SandboxProvider, reset_sandbox_provider, set_sandbox_provider
+from deerflow.sandbox.search import GrepMatch
+
+
+class _SandboxStub(Sandbox):
+    def execute_command(
+        self,
+        command: str,
+        env: dict[str, str] | None = None,
+        timeout: float | None = None,
+    ) -> str:
+        del command, env, timeout
+        return "OK"
+
+    def read_file(
+        self,
+        path: str,
+        start_line: int | None = None,
+        end_line: int | None = None,
+    ) -> str:
+        del path, start_line, end_line
+        return "content"
+
+    def download_file(self, path: str) -> bytes:
+        del path
+        return b"content"
+
+    def list_dir(self, path: str, max_depth: int = 2) -> list[str]:
+        del path, max_depth
+        return []
+
+    def write_file(self, path: str, content: str, append: bool = False) -> None:
+        del path, content, append
+
+    def glob(
+        self,
+        path: str,
+        pattern: str,
+        *,
+        include_dirs: bool = False,
+        max_results: int = 200,
+    ) -> tuple[list[str], bool]:
+        del path, pattern, include_dirs, max_results
+        return [], False
+
+    def grep(
+        self,
+        path: str,
+        pattern: str,
+        *,
+        glob: str | None = None,
+        literal: bool = False,
+        case_sensitive: bool = False,
+        max_results: int = 100,
+    ) -> tuple[list[GrepMatch], bool]:
+        del path, pattern, glob, literal, case_sensitive, max_results
+        return [], False
+
+    def update_file(self, path: str, content: bytes) -> None:
+        del path, content
+
+
+class _BlockingSkillSyncProvider(SandboxProvider):
+    supports_agent_skill_isolation = True
+
+    def __init__(self) -> None:
+        self.sandbox = _SandboxStub("skill-sync-sandbox")
+        self.sync_started = threading.Event()
+        self.allow_sync_finish = threading.Event()
+        self.sync_finished = threading.Event()
+        self.release_calls: list[str] = []
+
+    def acquire(self, thread_id: str | None = None, *, user_id: str | None = None) -> str:
+        del thread_id, user_id
+        return self.sandbox.id
+
+    def get(self, sandbox_id: str) -> Sandbox | None:
+        return self.sandbox if sandbox_id == self.sandbox.id else None
+
+    def release(self, sandbox_id: str) -> None:
+        self.release_calls.append(sandbox_id)
+
+    def sync_agent_skills(
+        self,
+        sandbox_id: str,
+        *,
+        thread_id: str,
+        user_id: str,
+        projection,
+    ) -> None:
+        del sandbox_id, thread_id, user_id, projection
+        self.sync_started.set()
+        assert self.allow_sync_finish.wait(timeout=5), "test did not unblock skill sync"
+        self.sync_finished.set()
+
+
+@pytest.mark.anyio
+async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _BlockingSkillSyncProvider()
+    middleware = SandboxMiddleware(lazy_init=True, available_skills={"allowed"})
+    projection = object()
+    monkeypatch.setattr(
+        middleware,
+        "_prepare_agent_skill_projection",
+        lambda *_args, **_kwargs: projection,
+    )
+    set_sandbox_provider(provider)
+    task = asyncio.create_task(
+        middleware.abefore_agent(
+            {},
+            Runtime(context={"thread_id": "thread-policy", "user_id": "user-policy"}),
+        )
+    )
+    try:
+        assert await asyncio.to_thread(provider.sync_started.wait, 2), "skill sync did not start"
+
+        task.cancel()
+        task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        assert provider.release_calls == []
+        assert not provider.sync_finished.is_set()
+
+        provider.allow_sync_finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert provider.sync_finished.is_set()
+        assert provider.release_calls == [provider.sandbox.id]
+    finally:
+        provider.allow_sync_finish.set()
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        reset_sandbox_provider()

--- a/backend/tests/test_sandbox_skill_sync_cancellation.py
+++ b/backend/tests/test_sandbox_skill_sync_cancellation.py
@@ -127,8 +127,13 @@ async def test_cancelled_policy_sync_keeps_lease_until_sync_worker_finishes(
         assert await asyncio.to_thread(provider.sync_started.wait, 2), "skill sync did not start"
 
         task.cancel()
-        task.cancel()
         await asyncio.sleep(0)
+
+        assert not task.done()
+        assert provider.release_calls == []
+        assert not provider.sync_finished.is_set()
+
+        task.cancel()
         await asyncio.sleep(0)
 
         assert not task.done()


### PR DESCRIPTION
Fixes #5349

## Why

`SandboxProvider.sync_agent_skills_async()` used a bare `asyncio.to_thread()`. Cancelling the awaiting task does not stop an already-running worker thread, so the async wrapper could return cancellation before the synchronous sandbox mutation itself had finished.

`SandboxMiddleware.abefore_agent()` treats that cancellation as failure cleanup and releases the execution holder. That violates the sandbox lifecycle contract: blocking provider work started on behalf of an execution holder must drain before that holder is allowed to leave the lifecycle boundary.

This is primarily a correctness/lifecycle fix, not a claim that every built-in provider will frequently corrupt sandbox state. Some providers, notably E2B, also serialize skill sync and release with a provider-level transition lock, which narrows the observable race window. The base async contract should still be cancellation-safe without relying on provider-specific locking, and third-party/upload-based providers inheriting the default wrapper otherwise remain exposed to the same ordering gap.

## What changed

- Route the default `sync_agent_skills_async()` wrapper through the existing `run_sync_lifecycle_operation()` cancellation fence.
- Add a regression through `SandboxMiddleware.abefore_agent()` with a deliberately blocked synchronous skill provider.
- Instrument entry into `_release_sandbox_async()` and record whether the sync worker has already finished, so the test protects the actual lifecycle ordering rather than merely the eventual provider `release()` call.
- Deliver the first `cancel()`, yield one event-loop turn so the task enters lifecycle draining, then deliver a second `cancel()` while the worker is still blocked.
- Assert after both cancellation deliveries that cleanup has not even entered `_release_sandbox_async()` while the worker is in flight.
- Allow the worker to finish, then assert cleanup enters exactly once with `sync_finished == True`, the original `CancelledError` propagates, and provider release occurs exactly once.

No provider API/signature changes are introduced; subclasses that override `sync_agent_skills_async()` retain their behavior.

## Relationship to existing sandbox work

This is a narrow lifecycle follow-up rather than a duplicate of the larger sandbox changes:

- #5077 established policy-scoped sandbox skill projections and the `sync_agent_skills` path.
- #5134 established process-local sandbox execution leases and cancellation-safe lifecycle boundaries.
- This PR closes the missing boundary between those two pieces: synchronous skill projection work dispatched by the default async wrapper must remain inside the enclosing lifecycle fence until the worker finishes.

A fresh collision check on current `main` found no other open PR implementing this specific `sync_agent_skills_async()` cancellation fix.

## Surface area

- [x] Agents / LangGraph
- [x] Sandbox
- [x] Skills
- [x] Default behavior change
- [ ] Models
- [ ] Tools
- [ ] MCP
- [ ] Memory
- [ ] Frontend
- [ ] Docs / config

## Bug fix verification

On `main` at `c9c7076ba74806bd94879cd666b9215bf13c1cb1`, the base failure follows directly from the control flow:

1. `abefore_agent()` acquires/binds the sandbox execution holder.
2. It awaits the default `sync_agent_skills_async()` wrapper.
3. The wrapper dispatches synchronous provider mutation with `asyncio.to_thread()`.
4. Cancelling the awaiter does not stop that worker thread.
5. Without an outer drain fence, cancellation can leave the wrapper before the worker is done.
6. Middleware failure cleanup can therefore enter `_release_sandbox_async()` while the synchronous lifecycle operation is still in flight.

Provider-specific locking may serialize some downstream operations, but that is an implementation detail and does not repair the base wrapper's cancellation contract.

The fixed invariant is:

`sync worker completes -> middleware cleanup may enter release -> original cancellation propagates`

The regression now pins that exact boundary. It records `provider.sync_finished.is_set()` at `_release_sandbox_async()` entry and requires the only observed value to be `True`.

### Negative proof

To prove the regression distinguishes the fix from the old implementation, I created a temporary verification SHA `c3842cc501da28a3cc41886538cf7f5e33bea3ea` containing the strengthened test but restoring the old bare `asyncio.to_thread()` wrapper.

On that SHA, backend unit shard 1 fails exactly at the new lifecycle-entry assertion:

`release_entry_sync_finished == [False]`

The shard result was `1 failed, 3667 passed, 19 skipped, 11059 deselected`; the failure was the new skill-sync cancellation regression. This demonstrates that the previous false-positive path is closed.

## Validation

Current candidate head: `687414a81af3565dcec6a0df141567e68c2c4352`

Fork-native exact-SHA validation on this head:

- backend lint / Ruff: pass
- agent guidance: pass
- backend blocking-I/O: pass
- documented default-install test collection: pass
- backend unit tests: all four shards pass

The production change remains intentionally minimal: one default-wrapper substitution. The follow-up commit only strengthens the regression's observation point in response to review feedback.

Reviewer validation on the prior runtime-identical head also covered 442 targeted tests across skill-sync cancellation, middleware, leases, provider lifecycle, E2B/AIO/local providers, and blocking-I/O checks, plus repeated-cancellation and late-worker-failure probes.

Resource/lifecycle review: this adds no new data transfer or persistent background work. It intentionally delays cancellation propagation only until an already-running synchronous skill sync returns, matching the cancellation-safe lifecycle behavior already used for other sandbox blocking operations.

## AI assistance

AI assistance was used for root-cause analysis, implementation, regression design, repository/collision audit, validation orchestration, negative-proof verification, and follow-up review.

- [x] I have reviewed the final diff and take responsibility for the changes.