### PR TITLE
fix(deps): upgrade transitive xmldom version

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -15,6 +15,12 @@ DeerFlow Frontend is a Next.js 16 web interface for an AI agent system. It commu
 - **TanStack Query** (`@tanstack/react-query` ^5.90.17) — Server state management
 - **UI**: Shadcn UI, MagicUI, React Bits, and Vercel AI SDK elements (generated from registries — see Code Style)
 
+`pnpm-workspace.yaml` overrides vulnerable `@xmldom/xmldom` 0.9.x releases to
+0.9.12 for GHSA-965w-775f-mr7g. Nextra pulls it in through MathJax and
+`speech-rule-engine@4.1.2`, which pins 0.9.8. Keep the override until the
+upstream dependency chain resolves a patched version without it; regenerate
+`pnpm-lock.yaml` and verify the docs build when changing this constraint.
+
 ## Commands
 
 | Command          | Purpose                                       |

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@xmldom/xmldom@>=0.9.0 <0.9.12': 0.9.12
+
 importers:
 
   .:
@@ -2775,10 +2778,9 @@ packages:
   '@vue/shared@3.5.28':
     resolution: {integrity: sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==}
 
-  '@xmldom/xmldom@0.9.8':
-    resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xyflow/react@12.10.0':
     resolution: {integrity: sha512-eOtz3whDMWrB4KWVatIBrKuxECHqip6PfA8fTpaS2RUGVpiEAe+nqDKsLqkViVWxDGreq0lWX71Xth/SPAzXiw==}
@@ -8481,7 +8483,7 @@ snapshots:
 
   '@vue/shared@3.5.28': {}
 
-  '@xmldom/xmldom@0.9.8': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xyflow/react@12.10.0(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -11926,7 +11928,7 @@ snapshots:
 
   speech-rule-engine@4.1.2:
     dependencies:
-      '@xmldom/xmldom': 0.9.8
+      '@xmldom/xmldom': 0.9.12
       commander: 13.1.0
       wicked-good-xpath: 1.3.0
 

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
 packages: []
+overrides:
+  # GHSA-965w-775f-mr7g: speech-rule-engine 4.1.2 pins vulnerable 0.9.8.
+  "@xmldom/xmldom@>=0.9.0 <0.9.12": 0.9.12
 ignoredBuiltDependencies:
   - esbuild
   - sharp

--- a/frontend/tests/unit/scripts/xmldom-security.test.ts
+++ b/frontend/tests/unit/scripts/xmldom-security.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { expect, test } from "@rstest/core";
+
+test("the lockfile excludes xmldom versions affected by GHSA-965w-775f-mr7g", () => {
+  const lockfile = readFileSync(
+    resolve(process.cwd(), "pnpm-lock.yaml"),
+    "utf8",
+  );
+  const versions = Array.from(
+    lockfile.matchAll(/^  '@xmldom\/xmldom@([^']+)':/gm),
+    (match) => match[1]!,
+  );
+
+  // The dependency can disappear entirely if Nextra drops its XML parser.
+  for (const version of versions) {
+    expect(version).not.toMatch(/^0\.9\.(?:[0-9]|10|11)(?:$|[(-])/);
+  }
+});


### PR DESCRIPTION
overrides vulnerable `@xmldom/xmldom` 0.9.x releases to 0.9.12
