### PR TITLE
docs(config): note use_previous_response_id in the Responses API example

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -252,6 +252,12 @@ models:
   #   max_retries: 2
   #   use_responses_api: true
   #   output_version: responses/v1
+  #   # Optional, forwarded to ChatOpenAI as-is (default false): send only the new
+  #   # turn plus previous_response_id instead of replaying the full history. The
+  #   # chained context is still billed as input tokens, and any client-side
+  #   # history rewrite (e.g. blocked-write payload elision) is only honored when
+  #   # the history is replayed.
+  #   use_previous_response_id: false
   #   context_window: 400000
   #   supports_vision: true
 


### PR DESCRIPTION
Fixes #5358

## Why

`use_previous_response_id` works in a `config.yaml` model entry, but DeerFlow never documents it: it is not a `ModelConfig` field and reaches `ChatOpenAI` only through the `extra="allow"` passthrough in the model factory. It reads like a synonym for the documented `use_responses_api`, but it is not: `use_responses_api` picks the endpoint, while `use_previous_response_id` switches the Responses API from replaying the full history each turn to chaining on server-side state. Operators cannot learn from the docs that chained context is still billed as input tokens, or that client-side history rewrites (such as the blocked-write payload elision in #5329) are only honored when the history is replayed.

## What changed

- `config.example.yaml`: the OpenAI Responses API example gains a commented `use_previous_response_id: false` line with a short note on what it changes, that it is forwarded to ChatOpenAI as-is, that chained context is still billed, and that history rewrites only apply when replaying.
- Comment only. No schema change, no new `ModelConfig` field, no `config_version` bump.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [x] **Docs / tests / CI only** — no runtime behavior change

## Validation

- `config.example.yaml` still parses (`yaml.safe_load`).
- `cd backend && python -m pytest tests/test_config_version.py -q`: 10 passed.

## AI assistance

**Tool(s) used:** Claude Code

**How you used it:** Traced the passthrough (`ModelConfig` `extra="allow"`, `create_chat_model` forwarding, langchain-openai `_get_request_payload`) and OpenAI's conversation-state docs, then drafted the comment; I reviewed the wording.

- [ ] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
