### PR TITLE
test(artifact-archive): make the archive suite platform-correct on Windows

### DIFF
--- a/backend/tests/test_artifact_archive.py
+++ b/backend/tests/test_artifact_archive.py
@@ -101,7 +101,10 @@ def test_archive_download_contains_only_presented_files(tmp_path, monkeypatch) -
     outputs = tmp_path / "outputs"
     (outputs / "reports").mkdir(parents=True)
     (outputs / "reports" / "summary.txt").write_text("summary", encoding="utf-8")
-    (outputs / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    # Written as bytes on purpose: text mode translates "\n" to "\r\n" on
+    # Windows, so the archive would legitimately contain CRLF bytes while the
+    # assertion below compares against this literal LF spelling.
+    (outputs / "data.csv").write_bytes(b"a,b\n1,2\n")
     (outputs / "not-presented.txt").write_text("secret", encoding="utf-8")
     paths = [
         "/mnt/user-data/outputs/reports/summary.txt",
@@ -451,6 +454,12 @@ def test_archive_rejects_internal_output_names(
         )
 
 
+# The swap the test performs is os.replace() while the archive still holds the
+# source file open. Windows refuses that rename with WinError 5, so the race is
+# only reproducible on POSIX; the same-size content change covered by
+# test_archive_rejects_same_size_content_change_with_restored_mtime still runs
+# on Windows and exercises the same mid-read revalidation.
+@pytest.mark.skipif(os.name == "nt", reason="os.replace() cannot rename over a file the archive still holds open on Windows (WinError 5)")
 def test_archive_rejects_a_path_replaced_during_read(tmp_path, monkeypatch) -> None:
     outputs = tmp_path / "outputs"
     outputs.mkdir()


### PR DESCRIPTION
## Why

Running the backend offline suite on a Windows host leaves two failures in
`backend/tests/test_artifact_archive.py`. Both come from POSIX assumptions in
the test itself, not from the archive code:

- `test_archive_download_contains_only_presented_files` writes its CSV fixture
  with `Path.write_text("a,b\n1,2\n")`. Windows text mode translates `\n` to
  `\r\n`, so the file on disk really is CRLF, `build_artifact_archive()`
  correctly serves those bytes, and the assertion fails against the LF
  spelling.
- `test_archive_rejects_a_path_replaced_during_read` stages its race with
  `os.replace()` while `build_artifact_archive()` still holds an open read
  descriptor on the source. Windows refuses that rename with `WinError 5`, so
  the rename-under-read race cannot be staged there at all.

The trigger is simply running `make test` on Windows; the pain is that the
archive suite reports red there for reasons unrelated to the archive.

No issue references this: it was found by running the suite on a Windows host.

## What changed

- The CSV fixture is written as bytes (`b"a,b\n1,2\n"`), so its content is the
  literal the assertion compares against on every platform.
- Only the rename-based race is skipped on Windows, with the reason inline. The
  sibling `test_archive_rejects_same_size_content_change_with_restored_mtime`
  keeps running on Windows and covers the same mid-read revalidation through an
  in-place write, so this does not leave the revalidation unchecked there.

No production behavior changes.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_artifact_archive.py`
- Did it go red on `main` and green on this branch? **Yes, on Windows.** On
  `main`: `2 failed` — `AssertionError: assert b'a,b\r\n1,2\r\n' == b'a,b\n1,2\n'`
  and `PermissionError: [WinError 5] ... replacement.txt -> report.txt`. On this
  branch: `1 passed, 1 skipped` for the same two tests.

## Validation

Windows 11, Python 3.12.13, checkout at `main` (`3f0b6ecc`):

- `python -m pytest tests/test_artifact_archive.py -q` → `28 passed, 7 skipped`
- the two tests above: red before (`2 failed`), green after (`1 passed, 1 skipped`)
- `ruff check` and `ruff format --check` clean on the changed file

The change is inert on POSIX: the bytes fixture is the same content `write_text`
produced there, and the `os.name == "nt"` skip never fires, so both tests still
run on Linux exactly as before.

## AI assistance

**Tool(s) used:** DeepSeek Harness (`/contributor` workflow)

**How you used it:** the agent ran the full backend suite on a Windows host,
grouped the 296 failures by root cause, and identified these two as test-side
POSIX assumptions. I reviewed the diff, reproduced the red→green transition
myself, and take responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
