### PR TITLE
test(wechat): skip the POSIX mode-bit half of the auth-state tests on Windows

### DIFF
--- a/backend/tests/test_wechat_channel.py
+++ b/backend/tests/test_wechat_channel.py
@@ -6,12 +6,17 @@ import asyncio
 import base64
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 from unittest import mock
 from unittest.mock import AsyncMock
 
+import pytest
+
 from app.channels.message_bus import InboundMessageType, MessageBus, OutboundMessage
+
+_POSIX_MODE_BITS_REASON = "Windows chmod only toggles the read-only bit, so the 0o600 mode asserted here is never observable"
 
 
 def _run(coro):
@@ -1478,6 +1483,8 @@ def test_qrcode_login_binds_and_persists_auth_state(monkeypatch, tmp_path: Path)
         assert auth_state["status"] == "confirmed"
         assert auth_state["bot_token"] == "bound-token"
         assert auth_state["ilink_bot_id"] == "bot-99"
+        if os.name == "nt":
+            pytest.skip(_POSIX_MODE_BITS_REASON)
         assert ((state_dir / "wechat-auth.json").stat().st_mode & 0o777) == 0o600
 
     _run(go())
@@ -1506,10 +1513,14 @@ def test_save_auth_state_tightens_preexisting_loose_file(tmp_path: Path):
     )
     channel._save_auth_state(status="confirmed", bot_token="bound-token", ilink_bot_id="bot-1")
 
-    assert (auth_path.stat().st_mode & 0o777) == 0o600
     assert json.loads(auth_path.read_text(encoding="utf-8"))["bot_token"] == "bound-token"
     # Atomic write leaves no temp-file residue behind.
     assert list(state_dir.glob("*.tmp")) == []
+    # Keep the platform-independent half running on Windows; only the mode-bit
+    # half of the "owner-only inode" contract is unobservable there.
+    if os.name == "nt":
+        pytest.skip(_POSIX_MODE_BITS_REASON)
+    assert (auth_path.stat().st_mode & 0o777) == 0o600
 
 
 def test_save_auth_state_chmod_failure_is_logged_not_warned(tmp_path: Path, caplog):


### PR DESCRIPTION
## Why

Two tests in `backend/tests/test_wechat_channel.py` fail on a Windows host:

- `test_qrcode_login_binds_and_persists_auth_state`
- `test_save_auth_state_tightens_preexisting_loose_file`

Both end by asserting that the persisted auth state is owner-only via
`stat().st_mode & 0o777 == 0o600`. Windows has no POSIX mode bits:
`Path.chmod()` only toggles the read-only attribute, so `st_mode` reports
`0o100666` (`33206 & 511 == 430`) and the assertion can never hold there. This
is the same class as the skill-permission assertions already handled for
Windows in #5244.

The trigger is running `make test` on Windows; the pain is that the WeChat
channel suite reports red there for a platform contract Windows does not have.

No issue references this: it was found by running the suite on a Windows host.

## What changed

- The mode-bit assertion is skipped on Windows from a single-sourced reason
  constant. Everything platform-independent keeps running there: the QR login
  flow and its persisted JSON content in the first test, and the content plus
  the "no `*.tmp` residue" atomicity check in the second.
- In the tightening test the mode assertion moves after those checks, so the
  Windows run still verifies that the atomic owner-only temp-file path leaves
  no residue behind.

No production behavior changes; the auth-state writer is untouched.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [ ] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json`
- [ ] **Default behavior change** — changes existing behavior without the user opting in
- [x] **Docs / tests / CI only** — no runtime behavior change

## Screenshots / Recording

Not applicable.

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_wechat_channel.py`
- Did it go red on `main` and green on this branch? **Yes, on Windows.** On
  `main`: `2 failed` — `AssertionError: assert (33206 & 511) == 384`. On this
  branch: `2 skipped`, with the platform-independent assertions in both tests
  still executing first.

## Validation

Windows 11, Python 3.12.13, checkout at `main` (`3f0b6ecc`):

- `python -m pytest tests/test_wechat_channel.py -q` → `32 passed, 2 skipped`
- the two tests above: red before (`2 failed`), skipped after
- `ruff check` and `ruff format --check` clean on the changed file

The change is inert on POSIX: `os.name != "nt"` there, so both mode assertions
still execute unchanged (in the second test, just after the sibling checks).

## AI assistance

**Tool(s) used:** DeepSeek Harness (`/contributor` workflow)

**How you used it:** the agent ran the full backend suite on a Windows host,
grouped the failures by root cause, and identified these two as the POSIX
mode-bit contract. I reviewed the diff, reproduced the red→skipped transition
myself, and take responsibility for it.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
