### PR TITLE
fix(docker): allow aio DooD socket preflight on Windows Git Bash (#5370)

### DIFF
--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -425,6 +425,10 @@ start
         assert "Docker socket not found" in result.stdout
 
 
+@pytest.mark.skipif(
+    Path("/var/run/docker.sock").is_socket(),
+    reason="Host has real /var/run/docker.sock",
+)
 def test_aio_dood_socket_preflight_rejects_windows_when_docker_unreachable():
     """Windows Git Bash must fail if Docker daemon is not reachable."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -572,6 +576,10 @@ def test_aio_deploy_socket_preflight_rejects_missing_custom_socket_on_windows(tm
     assert "Docker socket not found" in result.stdout + result.stderr
 
 
+@pytest.mark.skipif(
+    Path("/var/run/docker.sock").is_socket(),
+    reason="Host has real /var/run/docker.sock",
+)
 def test_aio_deploy_socket_preflight_rejects_windows_when_docker_unreachable(tmp_path):
     """deploy.sh on Windows Git Bash fails if Docker daemon is not reachable."""
     worktree = _setup_deploy_worktree(tmp_path)

--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -316,3 +316,108 @@ require_compose_version
 
     assert result.returncode == 1, result.stdout + result.stderr
     assert "too old" in result.stdout
+
+
+def test_aio_dood_socket_preflight_allows_windows_when_docker_reachable():
+    """Windows Git Bash without /var/run/docker.sock proceeds when Docker daemon is reachable."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = Path(tmpdir)
+        _seed_compose_file(tmp_root)
+        _seed_env_examples(tmp_root)
+        (tmp_root / "config.yaml").write_text(
+            "sandbox:\n  use: deerflow.community.aio_sandbox:AioSandboxProvider\n",
+            encoding="utf-8",
+        )
+        command = f"""
+source '{SCRIPT_PATH}'
+PROJECT_ROOT='{tmp_root}'
+DOCKER_DIR='{tmp_root}'
+require_compose_version() {{ :; }}
+uname() {{ echo 'MINGW64_NT-10.0'; }}
+docker() {{
+  if [ "$1" = info ]; then
+    return 0
+  fi
+  return 0
+}}
+DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+COMPOSE_CMD=echo
+start
+"""
+        result = subprocess.run(
+            [BASH_EXECUTABLE, "-lc", command],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "docker-compose.dood.yaml" in result.stdout
+
+
+def test_aio_dood_socket_preflight_rejects_missing_socket_on_posix():
+    """POSIX hosts without a physical socket file must fail fast."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = Path(tmpdir)
+        _seed_compose_file(tmp_root)
+        _seed_env_examples(tmp_root)
+        (tmp_root / "config.yaml").write_text(
+            "sandbox:\n  use: deerflow.community.aio_sandbox:AioSandboxProvider\n",
+            encoding="utf-8",
+        )
+        command = f"""
+source '{SCRIPT_PATH}'
+PROJECT_ROOT='{tmp_root}'
+DOCKER_DIR='{tmp_root}'
+require_compose_version() {{ :; }}
+uname() {{ echo 'Linux'; }}
+DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+COMPOSE_CMD=echo
+start
+"""
+        result = subprocess.run(
+            [BASH_EXECUTABLE, "-lc", command],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Docker socket not found" in result.stdout
+
+
+def test_aio_dood_socket_preflight_rejects_windows_when_docker_unreachable():
+    """Windows Git Bash must fail if Docker daemon is not reachable."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = Path(tmpdir)
+        _seed_compose_file(tmp_root)
+        _seed_env_examples(tmp_root)
+        (tmp_root / "config.yaml").write_text(
+            "sandbox:\n  use: deerflow.community.aio_sandbox:AioSandboxProvider\n",
+            encoding="utf-8",
+        )
+        command = f"""
+source '{SCRIPT_PATH}'
+PROJECT_ROOT='{tmp_root}'
+DOCKER_DIR='{tmp_root}'
+require_compose_version() {{ :; }}
+uname() {{ echo 'MINGW64_NT-10.0'; }}
+docker() {{
+  if [ "$1" = info ]; then
+    return 1
+  fi
+  return 0
+}}
+DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+COMPOSE_CMD=echo
+start
+"""
+        result = subprocess.run(
+            [BASH_EXECUTABLE, "-lc", command],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Docker socket not found" in result.stdout

--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -342,7 +342,7 @@ docker() {{
   fi
   return 0
 }}
-DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+DEER_FLOW_DOCKER_SOCKET='/var/run/docker.sock'
 COMPOSE_CMD=echo
 start
 """
@@ -388,6 +388,43 @@ start
         assert "Docker socket not found" in result.stdout
 
 
+def test_aio_dood_socket_preflight_rejects_missing_custom_socket_on_windows():
+    """Windows Git Bash must fail if a custom non-existent socket path is specified."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_root = Path(tmpdir)
+        _seed_compose_file(tmp_root)
+        _seed_env_examples(tmp_root)
+        (tmp_root / "config.yaml").write_text(
+            "sandbox:\n  use: deerflow.community.aio_sandbox:AioSandboxProvider\n",
+            encoding="utf-8",
+        )
+        command = f"""
+source '{SCRIPT_PATH}'
+PROJECT_ROOT='{tmp_root}'
+DOCKER_DIR='{tmp_root}'
+require_compose_version() {{ :; }}
+uname() {{ echo 'MINGW64_NT-10.0'; }}
+docker() {{
+  if [ "$1" = info ]; then
+    return 0
+  fi
+  return 0
+}}
+DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+COMPOSE_CMD=echo
+start
+"""
+        result = subprocess.run(
+            [BASH_EXECUTABLE, "-lc", command],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        assert "Docker socket not found" in result.stdout
+
+
 def test_aio_dood_socket_preflight_rejects_windows_when_docker_unreachable():
     """Windows Git Bash must fail if Docker daemon is not reachable."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -410,7 +447,7 @@ docker() {{
   fi
   return 0
 }}
-DEER_FLOW_DOCKER_SOCKET='/nonexistent/docker.sock'
+DEER_FLOW_DOCKER_SOCKET='/var/run/docker.sock'
 COMPOSE_CMD=echo
 start
 """
@@ -458,7 +495,7 @@ def test_aio_deploy_socket_preflight_allows_windows_when_docker_reachable(tmp_pa
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["BASH_ENV"] = str(bash_env)
-    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/var/run/docker.sock"
     env["BETTER_AUTH_SECRET"] = "test-secret"
     env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
     env["UV_EXTRAS"] = "redis"
@@ -500,6 +537,41 @@ def test_aio_deploy_socket_preflight_rejects_missing_socket_on_posix(tmp_path):
     assert "Docker socket not found" in result.stdout + result.stderr
 
 
+def test_aio_deploy_socket_preflight_rejects_missing_custom_socket_on_windows(tmp_path):
+    """deploy.sh on Windows Git Bash fails if a custom non-existent socket path is specified."""
+    worktree = _setup_deploy_worktree(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(
+        '#!/usr/bin/env sh\nif [ "$1" = "info" ]; then exit 0; fi\nexit 0\n',
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+    bash_env = tmp_path / "env.sh"
+    bash_env.write_text("uname() { echo 'MINGW64_NT-10.0'; }\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["BASH_ENV"] = str(bash_env)
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["BETTER_AUTH_SECRET"] = "test-secret"
+    env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
+    env["UV_EXTRAS"] = "redis"
+
+    result = subprocess.run(
+        [BASH_EXECUTABLE, str(worktree / "scripts" / "deploy.sh"), "start"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Docker socket not found" in result.stdout + result.stderr
+
+
 def test_aio_deploy_socket_preflight_rejects_windows_when_docker_unreachable(tmp_path):
     """deploy.sh on Windows Git Bash fails if Docker daemon is not reachable."""
     worktree = _setup_deploy_worktree(tmp_path)
@@ -515,7 +587,7 @@ def test_aio_deploy_socket_preflight_rejects_windows_when_docker_unreachable(tmp
     env = os.environ.copy()
     env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
     env["BASH_ENV"] = str(bash_env)
-    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/var/run/docker.sock"
     env["BETTER_AUTH_SECRET"] = "test-secret"
     env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
     env["UV_EXTRAS"] = "redis"

--- a/backend/tests/test_docker_sandbox_mode_detection.py
+++ b/backend/tests/test_docker_sandbox_mode_detection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -421,3 +423,110 @@ start
 
         assert result.returncode == 1, result.stdout + result.stderr
         assert "Docker socket not found" in result.stdout
+
+
+def _setup_deploy_worktree(tmp_path: Path) -> Path:
+    worktree = tmp_path / "repo"
+    shutil.copytree(REPO_ROOT / "scripts", worktree / "scripts")
+    shutil.copytree(REPO_ROOT / "docker", worktree / "docker")
+    (worktree / "backend").mkdir()
+    (worktree / "config.yaml").write_text(
+        "sandbox:\n  use: deerflow.community.aio_sandbox:AioSandboxProvider\n",
+        encoding="utf-8",
+    )
+    (worktree / "extensions_config.json").write_text("{}\n", encoding="utf-8")
+    (worktree / ".env").write_text("TEST=1\n", encoding="utf-8")
+    return worktree
+
+
+def test_aio_deploy_socket_preflight_allows_windows_when_docker_reachable(tmp_path):
+    """deploy.sh on Windows Git Bash proceeds past preflight when Docker daemon is reachable."""
+    worktree = _setup_deploy_worktree(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    capture_args = tmp_path / "docker_args.txt"
+    docker = bin_dir / "docker"
+    docker.write_text(
+        f'#!/usr/bin/env sh\nif [ "$1" = "info" ]; then exit 0; fi\nfor arg in "$@"; do printf "%s\\n" "$arg"; done > "{capture_args}"\nexit 0\n',
+        encoding="utf-8",
+    )
+    docker.chmod(0o755)
+
+    bash_env = tmp_path / "env.sh"
+    bash_env.write_text("uname() { echo 'MINGW64_NT-10.0'; }\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["BASH_ENV"] = str(bash_env)
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["BETTER_AUTH_SECRET"] = "test-secret"
+    env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
+    env["UV_EXTRAS"] = "redis"
+
+    result = subprocess.run(
+        [BASH_EXECUTABLE, str(worktree / "scripts" / "deploy.sh"), "start"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "docker-compose.dood.yaml" in capture_args.read_text(encoding="utf-8")
+
+
+def test_aio_deploy_socket_preflight_rejects_missing_socket_on_posix(tmp_path):
+    """deploy.sh on POSIX hosts without a physical socket file fails fast."""
+    worktree = _setup_deploy_worktree(tmp_path)
+    bash_env = tmp_path / "env.sh"
+    bash_env.write_text("uname() { echo 'Linux'; }\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["BASH_ENV"] = str(bash_env)
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["BETTER_AUTH_SECRET"] = "test-secret"
+    env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
+    env["UV_EXTRAS"] = "redis"
+
+    result = subprocess.run(
+        [BASH_EXECUTABLE, str(worktree / "scripts" / "deploy.sh"), "start"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Docker socket not found" in result.stdout + result.stderr
+
+
+def test_aio_deploy_socket_preflight_rejects_windows_when_docker_unreachable(tmp_path):
+    """deploy.sh on Windows Git Bash fails if Docker daemon is not reachable."""
+    worktree = _setup_deploy_worktree(tmp_path)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text('#!/usr/bin/env sh\nif [ "$1" = "info" ]; then exit 1; fi\nexit 0\n', encoding="utf-8")
+    docker.chmod(0o755)
+
+    bash_env = tmp_path / "env.sh"
+    bash_env.write_text("uname() { echo 'MINGW64_NT-10.0'; }\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["BASH_ENV"] = str(bash_env)
+    env["DEER_FLOW_DOCKER_SOCKET"] = "/nonexistent/docker.sock"
+    env["BETTER_AUTH_SECRET"] = "test-secret"
+    env["DEER_FLOW_INTERNAL_AUTH_TOKEN"] = "test-token"
+    env["UV_EXTRAS"] = "redis"
+
+    result = subprocess.run(
+        [BASH_EXECUTABLE, str(worktree / "scripts" / "deploy.sh"), "start"],
+        cwd=worktree,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "Docker socket not found" in result.stdout + result.stderr

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -373,9 +373,15 @@ fi
 
 if [ "$sandbox_mode" = "aio" ]; then
     if [ ! -S "$DEER_FLOW_DOCKER_SOCKET" ]; then
-        echo -e "${RED}⚠ Docker socket not found at $DEER_FLOW_DOCKER_SOCKET${NC}"
-        echo "  AioSandboxProvider (DooD) will not work."
-        exit 1
+        # On Windows (Git Bash / MSYS), /var/run/docker.sock does not exist as
+        # a host socket file, but Docker Desktop mounts it into containers.
+        if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
+            :
+        else
+            echo -e "${RED}⚠ Docker socket not found at $DEER_FLOW_DOCKER_SOCKET${NC}"
+            echo "  AioSandboxProvider (DooD) will not work."
+            exit 1
+        fi
     fi
     echo -e "${GREEN}✓ Docker socket: $DEER_FLOW_DOCKER_SOCKET${NC}"
     echo -e "${YELLOW}  Mounting host Docker socket into gateway (DooD = host root-equivalent). See SECURITY.md.${NC}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -373,9 +373,9 @@ fi
 
 if [ "$sandbox_mode" = "aio" ]; then
     if [ ! -S "$DEER_FLOW_DOCKER_SOCKET" ]; then
-        # On Windows (Git Bash / MSYS), /var/run/docker.sock does not exist as
-        # a host socket file, but Docker Desktop mounts it into containers.
-        if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
+        # On Windows (Git Bash / MSYS), Docker Desktop mounts the default
+        # /var/run/docker.sock into containers even though no host socket file exists.
+        if [ "$DEER_FLOW_DOCKER_SOCKET" = "/var/run/docker.sock" ] && [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
             :
         else
             echo -e "${RED}⚠ Docker socket not found at $DEER_FLOW_DOCKER_SOCKET${NC}"

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -335,8 +335,14 @@ start() {
     if [ "$sandbox_mode" = "aio" ]; then
         local docker_socket="${DEER_FLOW_DOCKER_SOCKET:-/var/run/docker.sock}"
         if [ ! -S "$docker_socket" ]; then
-            echo -e "${YELLOW}⚠ Docker socket not found at $docker_socket — AioSandboxProvider (DooD) will not work.${NC}"
-            exit 1
+            # On Windows (Git Bash / MSYS), /var/run/docker.sock does not exist as
+            # a host socket file, but Docker Desktop mounts it into containers.
+            if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
+                :
+            else
+                echo -e "${YELLOW}⚠ Docker socket not found at $docker_socket — AioSandboxProvider (DooD) will not work.${NC}"
+                exit 1
+            fi
         fi
         echo -e "${YELLOW}Mounting host Docker socket into gateway (DooD = host root-equivalent). See SECURITY.md.${NC}"
         COMPOSE_CMD="$COMPOSE_CMD -f docker-compose.dood.yaml"

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -335,9 +335,9 @@ start() {
     if [ "$sandbox_mode" = "aio" ]; then
         local docker_socket="${DEER_FLOW_DOCKER_SOCKET:-/var/run/docker.sock}"
         if [ ! -S "$docker_socket" ]; then
-            # On Windows (Git Bash / MSYS), /var/run/docker.sock does not exist as
-            # a host socket file, but Docker Desktop mounts it into containers.
-            if [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
+            # On Windows (Git Bash / MSYS), Docker Desktop mounts the default
+            # /var/run/docker.sock into containers even though no host socket file exists.
+            if [ "$docker_socket" = "/var/run/docker.sock" ] && [[ "$(uname -s)" =~ ^(MINGW|MSYS|CYGWIN) ]] && docker info >/dev/null 2>&1; then
                 :
             else
                 echo -e "${YELLOW}⚠ Docker socket not found at $docker_socket — AioSandboxProvider (DooD) will not work.${NC}"


### PR DESCRIPTION
Fixes #5370

## Why

On Windows (Git Bash), starting DeerFlow via `make docker-start` or `make up` unconditionally aborts with:
```text
⚠ Docker socket not found at /var/run/docker.sock — AioSandboxProvider (DooD) will not work.
```
This regression was introduced in #3517 (`5d61718c`), which added a `[ ! -S "$docker_socket" ]` check to `scripts/docker.sh` and `scripts/deploy.sh`. On Windows host environments (MSYS2 / Git Bash), `/var/run/docker.sock` does not exist as a physical Unix socket file on the host filesystem (named pipes are used), causing the check to falsely fail even though Docker Desktop daemon natively handles `-v /var/run/docker.sock:/var/run/docker.sock` into Linux containers.

## What changed

- `scripts/docker.sh` and `scripts/deploy.sh`: Updated the DooD socket existence check so that under Windows Git Bash (`MINGW*`, `MSYS*`, `CYGWIN*`), it verifies `docker info` connectivity rather than requiring a physical Unix socket file on the host filesystem.
- `backend/tests/test_docker_sandbox_mode_detection.py`: Added regression tests verifying that:
  - On Windows Git Bash, missing `/var/run/docker.sock` still proceeds with DooD overlay when Docker daemon is reachable.
  - On Windows Git Bash, it fails if Docker daemon is unreachable.
  - On POSIX hosts, missing socket file continues to fail fast.

## Surface area

- [x] **Sandbox** — `docker/` or sandboxed execution

## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_docker_sandbox_mode_detection.py::test_aio_dood_socket_preflight_allows_windows_when_docker_reachable`
- Did it go red on `main` and green on this branch? **Yes** (on `main`, Windows simulated host without a physical socket file exited with code 1; with this change, it cleanly resolves `docker-compose.dood.yaml`).

## Validation

- `uv run pytest tests/test_docker_sandbox_mode_detection.py` (28 passed)
- `uv run ruff check tests/test_docker_sandbox_mode_detection.py` (All checks passed)
- `uv run ruff format --check tests/test_docker_sandbox_mode_detection.py` (All checks passed)
- Real Docker Desktop validation on Windows:
  - Verified `-v /var/run/docker.sock:/var/run/docker.sock` mounts and executes sibling containers via `docker:cli`.
  - Executed `make docker-start` on Windows with `AioSandboxProvider` configured; all 4 services (`nginx`, `gateway`, `redis`, `frontend`) built and started cleanly at `http://localhost:2026`.
  - Ran `make docker-stop` to verify clean teardown.

## AI assistance

**Tool(s) used:** Antigravity AI

**How you used it:** Root cause analysis, reproduction, writing regression tests, and verification on Windows Docker Desktop.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
