### PR TITLE
fix(firecrawl): pass tool base_url to FirecrawlApp as api_url

### DIFF
--- a/backend/packages/harness/deerflow/community/firecrawl/tools.py
+++ b/backend/packages/harness/deerflow/community/firecrawl/tools.py
@@ -9,9 +9,16 @@ from deerflow.config import get_app_config
 def _get_firecrawl_client(tool_name: str = "web_search") -> FirecrawlApp:
     config = get_app_config().get_tool_config(tool_name)
     api_key = None
-    if config is not None and "api_key" in config.model_extra:
-        api_key = config.model_extra.get("api_key")
-    return FirecrawlApp(api_key=api_key)  # type: ignore[arg-type]
+    api_url = None
+    if config is not None:
+        if "api_key" in config.model_extra:
+            api_key = config.model_extra.get("api_key")
+        if "base_url" in config.model_extra:
+            api_url = config.model_extra.get("base_url")
+    kwargs = {"api_key": api_key}
+    if api_url:
+        kwargs["api_url"] = api_url
+    return FirecrawlApp(**kwargs)  # type: ignore[arg-type]
 
 
 @tool("web_search", parse_docstring=True)

--- a/backend/tests/test_firecrawl_tools.py
+++ b/backend/tests/test_firecrawl_tools.py
@@ -64,3 +64,51 @@ class TestWebFetchTool:
             "https://example.com",
             formats=["markdown"],
         )
+
+
+class TestFirecrawlBaseUrl:
+    @patch("deerflow.community.firecrawl.tools.FirecrawlApp")
+    @patch("deerflow.community.firecrawl.tools.get_app_config")
+    def test_fetch_passes_base_url_as_api_url(self, mock_get_app_config, mock_firecrawl_cls):
+        fetch_config = MagicMock()
+        fetch_config.model_extra = {"base_url": "http://192.168.0.47:3002"}
+
+        def get_tool_config(name):
+            if name == "web_fetch":
+                return fetch_config
+            return None
+
+        mock_get_app_config.return_value.get_tool_config.side_effect = get_tool_config
+
+        mock_scrape_result = MagicMock()
+        mock_scrape_result.markdown = "Fetched markdown"
+        mock_scrape_result.metadata = MagicMock(title="Fetched Page")
+        mock_firecrawl_cls.return_value.scrape.return_value = mock_scrape_result
+
+        from deerflow.community.firecrawl.tools import web_fetch_tool
+
+        result = web_fetch_tool.invoke({"url": "https://example.com"})
+
+        assert result == "# Fetched Page\n\nFetched markdown"
+        mock_firecrawl_cls.assert_called_once_with(api_key=None, api_url="http://192.168.0.47:3002")
+
+    @patch("deerflow.community.firecrawl.tools.FirecrawlApp")
+    @patch("deerflow.community.firecrawl.tools.get_app_config")
+    def test_search_passes_base_url_and_api_key(self, mock_get_app_config, mock_firecrawl_cls):
+        search_config = MagicMock()
+        search_config.model_extra = {
+            "api_key": "firecrawl-key",
+            "base_url": "http://192.168.0.47:3002",
+            "max_results": 5,
+        }
+        mock_get_app_config.return_value.get_tool_config.return_value = search_config
+
+        mock_result = MagicMock()
+        mock_result.web = []
+        mock_firecrawl_cls.return_value.search.return_value = mock_result
+
+        from deerflow.community.firecrawl.tools import web_search_tool
+
+        web_search_tool.invoke({"query": "test query"})
+
+        mock_firecrawl_cls.assert_called_once_with(api_key="firecrawl-key", api_url="http://192.168.0.47:3002")

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -866,12 +866,13 @@ tools:
   #   contents_max_characters: 1000
   #   # api_key: $EXA_API_KEY
 
-  # Web search tool (uses Firecrawl, requires FIRECRAWL_API_KEY)
+  # Web search tool (uses Firecrawl. Cloud requires FIRECRAWL_API_KEY; self-host may need no key.)
   # - name: web_search
   #   group: web
   #   use: deerflow.community.firecrawl.tools:web_search_tool
   #   max_results: 5
   #   # api_key: $FIRECRAWL_API_KEY
+  #   # base_url: http://<host>:3002  # optional: self-hosted Firecrawl; no cloud API key needed
 
   # Web search tool (uses GroundRoute, requires GROUNDROUTE_API_KEY)
   # GroundRoute is a meta search layer: one API in front of six engines (Serper,
@@ -1057,11 +1058,12 @@ tools:
   #   # Timeout for navigating to the page (in seconds). Set to positive value to enable, -1 to disable
   #   navigation_timeout: 30
 
-  # Web fetch tool (uses Firecrawl, requires FIRECRAWL_API_KEY)
+  # Web fetch tool (uses Firecrawl. Cloud requires FIRECRAWL_API_KEY; self-host may need no key.)
   # - name: web_fetch
   #   group: web
   #   use: deerflow.community.firecrawl.tools:web_fetch_tool
   #   # api_key: $FIRECRAWL_API_KEY
+  #   # base_url: http://<host>:3002  # optional: self-hosted Firecrawl; no cloud API key needed
 
   # Web fetch tool (uses GroundRoute, requires GROUNDROUTE_API_KEY)
   # Fetches a page's extracted text via GroundRoute mode=page.


### PR DESCRIPTION
## Why

The Firecrawl community tools (`web_fetch` / `web_search` backed by `deerflow.community.firecrawl.tools`) ignore the tool's `base_url` setting. `_get_firecrawl_client` only reads `api_key` from the tool config, so `FirecrawlApp` always falls back to the cloud endpoint `https://api.firecrawl.dev`. For a self-hosted Firecrawl deployment (e.g. `base_url: http://192.168.0.47:3002`), every call fails with `Error: No API key provided` — the SDK raises that error whenever the target is the cloud API and no key is set, which makes self-hosted servers unreachable no matter how the config is written.

Related: #1490 (API key limitations with web fetching and web search tools)

## What changed

Firecrawl tools now honor `base_url` in the tool config: it is forwarded to the Firecrawl SDK as `api_url`, so a self-hosted Firecrawl server can serve `web_fetch` / `web_search` without a cloud API key. When `base_url` is not set, the client is constructed exactly as before (cloud default), so existing configurations are unaffected.

## Surface area

- [ ] **Frontend UI** — page / component / setting / interaction under `frontend/`
- [ ] **Backend API** — endpoint / SSE event / request-response shape under `backend/app`
- [x] **Agents / LangGraph** — agent node, graph wiring, `langgraph.json`, or prompt change
  - Tool-implementation change in the lead agent's toolset (`community/firecrawl/tools.py`); no prompt, graph, or `langgraph.json` change.
- [ ] **Sandbox** — `docker/` or sandboxed execution
- [ ] **Skills** — change under `skills/`
- [ ] **Dependencies** — new/upgraded entry in `backend/pyproject.toml` or `frontend/package.json` (say what it buys us)
- [ ] **Default behavior change** — changes existing behavior without the user opting in (default model, default setting, data shape)
- [ ] **Docs / tests / CI only** — no runtime behavior change


## Screenshots / Recording

N/A — no frontend change.


## Bug fix verification

- Test path that reproduces the bug: `backend/tests/test_firecrawl_tools.py::TestFirecrawlBaseUrl` (`test_fetch_passes_base_url_as_api_url`, `test_search_passes_base_url_and_api_key`)
- Did it go red on `main` and green on this branch? Yes — both failed on pre-fix code (`Expected: FirecrawlApp(api_key=..., api_url=...) / Actual: FirecrawlApp(api_key=...)`) and pass on this branch.


## Validation

- `cd backend && uv run ruff check packages/harness/deerflow/community/firecrawl/tools.py tests/test_firecrawl_tools.py` — all checks passed
- `cd backend && uv run ruff format --check` on both changed files — already formatted
- `cd backend && PYTHONPATH=. uv run pytest tests/test_firecrawl_tools.py -q` — 4/4 passed
- Live end-to-end: invoked `web_fetch_tool` with a real `config.yaml` pointing `base_url` at a self-hosted Firecrawl (no API key configured) — `https://example.com` scraped successfully through the local server.


## AI assistance

**Tool(s) used:** Kilo (Claude)

**How you used it:** Diagnosed the root cause from the tool-error logs (traced the SDK's "No API key provided" raise path), wrote the failing tests first, then implemented the one-function fix; I reviewed and verified every line, including a live scrape against a self-hosted Firecrawl.

- [x] I've read and understand every line of this change and take responsibility for it — it's not unreviewed AI output.
