### PR TITLE
fix(agents): make read-before-write cancellation lock-safe

### DIFF
--- a/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
@@ -123,17 +123,25 @@ async def _await_off_thread(task: asyncio.Task[Any]) -> Any:
         try:
             result = await asyncio.shield(task)
         except asyncio.CancelledError as exc:
+            if task.cancelled():
+                if first_cancel is not None:
+                    raise first_cancel
+                raise
             if first_cancel is None:
                 first_cancel = exc
             if not task.done():
                 continue
-            if task.cancelled():
-                raise first_cancel
-            task.result()
-            raise first_cancel
+        except BaseException:
+            if first_cancel is None:
+                raise
+        else:
+            if first_cancel is None:
+                return result
+
         if first_cancel is not None:
+            if task.done() and not task.cancelled():
+                task.exception()
             raise first_cancel
-        return result
 
 
 async def _acquire_gate_lock(lock: threading.Lock) -> None:

--- a/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
@@ -127,6 +127,8 @@ async def _await_off_thread(task: asyncio.Task[Any]) -> Any:
                 first_cancel = exc
             if not task.done():
                 continue
+            if task.cancelled():
+                raise first_cancel
             task.result()
             raise first_cancel
         if first_cancel is not None:
@@ -135,7 +137,7 @@ async def _await_off_thread(task: asyncio.Task[Any]) -> Any:
 
 
 async def _acquire_gate_lock(lock: threading.Lock) -> None:
-    """Acquire off-loop without orphaning a successful acquire on cancellation."""
+    """Acquire off-loop safely; threading.Lock permits cross-thread release."""
     acquire_task = asyncio.create_task(asyncio.to_thread(lock.acquire))
     try:
         await _await_off_thread(acquire_task)

--- a/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
+++ b/backend/packages/harness/deerflow/agents/middlewares/read_before_write_middleware.py
@@ -116,6 +116,35 @@ def _content_hash(content: str) -> str:
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
+async def _await_off_thread(task: asyncio.Task[Any]) -> Any:
+    """Drain an already-dispatched worker operation before propagating cancellation."""
+    first_cancel: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if first_cancel is None:
+                first_cancel = exc
+            if not task.done():
+                continue
+            task.result()
+            raise first_cancel
+        if first_cancel is not None:
+            raise first_cancel
+        return result
+
+
+async def _acquire_gate_lock(lock: threading.Lock) -> None:
+    """Acquire off-loop without orphaning a successful acquire on cancellation."""
+    acquire_task = asyncio.create_task(asyncio.to_thread(lock.acquire))
+    try:
+        await _await_off_thread(acquire_task)
+    except asyncio.CancelledError:
+        if acquire_task.done() and not acquire_task.cancelled() and acquire_task.exception() is None:
+            lock.release()
+        raise
+
+
 class ReadBeforeWriteMiddleware(AgentMiddleware):
     """Version gate: block writes to existing files not read at their current version."""
 
@@ -181,13 +210,11 @@ class ReadBeforeWriteMiddleware(AgentMiddleware):
                 return await handler(request)
             try:
                 async with sandbox_authorization_scope_async(request.runtime):
-                    # threading.Lock may be released from a different thread than the
-                    # acquiring one, so acquiring in a worker thread and releasing on
-                    # the event-loop thread is safe.
                     lock = self._lock_for(request, path)
-                    await asyncio.to_thread(lock.acquire)
+                    await _acquire_gate_lock(lock)
                     try:
-                        blocked = await asyncio.to_thread(self._check_write_gate, request)
+                        check_task = asyncio.create_task(asyncio.to_thread(self._check_write_gate, request))
+                        blocked = await _await_off_thread(check_task)
                         if blocked is not None:
                             return normalize_tool_result(blocked)
                         return await handler(request)
@@ -202,10 +229,11 @@ class ReadBeforeWriteMiddleware(AgentMiddleware):
             try:
                 async with sandbox_authorization_scope_async(request.runtime):
                     lock = self._lock_for(request, path)
-                    await asyncio.to_thread(lock.acquire)
+                    await _acquire_gate_lock(lock)
                     try:
                         result = await handler(request)
-                        await asyncio.to_thread(self._attach_read_mark, request, result)
+                        mark_task = asyncio.create_task(asyncio.to_thread(self._attach_read_mark, request, result))
+                        await _await_off_thread(mark_task)
                         return result
                     finally:
                         lock.release()

--- a/backend/tests/test_read_before_write_cancellation.py
+++ b/backend/tests/test_read_before_write_cancellation.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from contextlib import suppress
+
+import pytest
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
+from unittest.mock import MagicMock
+
+from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware
+
+
+_PATH = "/mnt/user-data/outputs/report.md"
+
+
+def _request(tool_name: str) -> ToolCallRequest:
+    runtime = MagicMock()
+    runtime.context = {"thread_id": "thread-cancel"}
+    args: dict[str, object] = {"description": "d", "path": _PATH}
+    if tool_name == "write_file":
+        args["content"] = "v2"
+    return ToolCallRequest(
+        tool_call={"name": tool_name, "args": args, "id": f"call-{tool_name}"},
+        tool=None,
+        state={"messages": []},
+        runtime=runtime,
+    )
+
+
+class _BlockingAcquireLock:
+    def __init__(self) -> None:
+        self.acquire_started = threading.Event()
+        self.allow_acquire = threading.Event()
+        self.acquired = threading.Event()
+        self.release_calls = 0
+        self._guard = threading.Lock()
+
+    def acquire(self) -> bool:
+        self.acquire_started.set()
+        assert self.allow_acquire.wait(timeout=5), "test did not unblock gate-lock acquisition"
+        with self._guard:
+            self.acquired.set()
+        return True
+
+    def release(self) -> None:
+        with self._guard:
+            assert self.acquired.is_set(), "gate lock released without ownership"
+            self.acquired.clear()
+            self.release_calls += 1
+
+
+class _TrackingLock:
+    def __init__(self) -> None:
+        self.acquired = False
+        self.release_calls = 0
+        self._guard = threading.Lock()
+
+    def acquire(self) -> bool:
+        with self._guard:
+            assert not self.acquired
+            self.acquired = True
+        return True
+
+    def release(self) -> None:
+        with self._guard:
+            assert self.acquired
+            self.acquired = False
+            self.release_calls += 1
+
+
+@pytest.mark.parametrize("tool_name", ["read_file", "write_file"])
+def test_async_gate_cancellation_drains_queued_lock_acquisition(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+) -> None:
+    async def scenario() -> None:
+        gate_lock = _BlockingAcquireLock()
+        middleware = ReadBeforeWriteMiddleware(content_reader=lambda _runtime, _path: "v1")
+        monkeypatch.setattr(middleware, "_lock_for", lambda _request, _path: gate_lock)
+        handler_called = False
+
+        async def handler(_request: ToolCallRequest) -> ToolMessage:
+            nonlocal handler_called
+            handler_called = True
+            return ToolMessage(content="OK", tool_call_id=f"call-{tool_name}", name=tool_name)
+
+        task = asyncio.create_task(middleware.awrap_tool_call(_request(tool_name), handler))
+        try:
+            assert await asyncio.to_thread(gate_lock.acquire_started.wait, 2), "gate-lock acquisition did not start"
+
+            task.cancel("first cancellation")
+            await asyncio.sleep(0)
+
+            # threading.Lock.acquire() is already running in a worker thread and
+            # cannot be cancelled. The middleware must retain ownership of that
+            # acquisition until it lands, then release it before propagating the
+            # original cancellation. Returning cancellation here would orphan a
+            # future successful acquire with nobody left to release it.
+            assert not task.done()
+            assert gate_lock.release_calls == 0
+
+            task.cancel("second cancellation")
+            await asyncio.sleep(0)
+
+            assert not task.done()
+            assert gate_lock.release_calls == 0
+            assert not handler_called
+
+            gate_lock.allow_acquire.set()
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+
+            assert exc_info.value.args == ("first cancellation",)
+            assert gate_lock.release_calls == 1
+            assert not gate_lock.acquired.is_set()
+            assert not handler_called
+        finally:
+            gate_lock.allow_acquire.set()
+            await asyncio.to_thread(gate_lock.acquired.wait, 0.1)
+            if gate_lock.acquired.is_set() and gate_lock.release_calls == 0:
+                gate_lock.release()
+            if not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("tool_name", ["read_file", "write_file"])
+def test_async_gate_cancellation_drains_sync_probe_before_unlocking(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+) -> None:
+    async def scenario() -> None:
+        probe_started = threading.Event()
+        allow_probe_finish = threading.Event()
+        gate_lock = _TrackingLock()
+
+        def reader(_runtime: object, _path: str) -> str:
+            probe_started.set()
+            assert allow_probe_finish.wait(timeout=5), "test did not unblock gate probe"
+            return "v1"
+
+        middleware = ReadBeforeWriteMiddleware(content_reader=reader)
+        monkeypatch.setattr(middleware, "_lock_for", lambda _request, _path: gate_lock)
+        handler_calls = 0
+
+        async def handler(_request: ToolCallRequest) -> ToolMessage:
+            nonlocal handler_calls
+            handler_calls += 1
+            return ToolMessage(content="v1", tool_call_id=f"call-{tool_name}", name=tool_name)
+
+        task = asyncio.create_task(middleware.awrap_tool_call(_request(tool_name), handler))
+        try:
+            assert await asyncio.to_thread(probe_started.wait, 2), "gate probe did not start"
+            assert gate_lock.acquired
+
+            task.cancel("first cancellation")
+            await asyncio.sleep(0)
+
+            # The synchronous probe is also non-cancellable once dispatched.
+            # Releasing the gate lock before that worker returns lets another
+            # same-path tool enter the critical section concurrently with work
+            # that this task started under the lock.
+            assert not task.done()
+            assert gate_lock.acquired
+            assert gate_lock.release_calls == 0
+
+            task.cancel("second cancellation")
+            await asyncio.sleep(0)
+
+            assert not task.done()
+            assert gate_lock.acquired
+            assert gate_lock.release_calls == 0
+
+            allow_probe_finish.set()
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+
+            assert exc_info.value.args == ("first cancellation",)
+            assert not gate_lock.acquired
+            assert gate_lock.release_calls == 1
+            assert handler_calls == (1 if tool_name == "read_file" else 0)
+        finally:
+            allow_probe_finish.set()
+            if gate_lock.acquired:
+                gate_lock.release()
+            if not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    asyncio.run(scenario())

--- a/backend/tests/test_read_before_write_cancellation.py
+++ b/backend/tests/test_read_before_write_cancellation.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import asyncio
 import threading
 from contextlib import suppress
+from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
-from unittest.mock import MagicMock
 
 from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware
 

--- a/backend/tests/test_read_before_write_cancellation.py
+++ b/backend/tests/test_read_before_write_cancellation.py
@@ -11,7 +11,6 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 
 from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware
 
-
 _PATH = "/mnt/user-data/outputs/report.md"
 
 

--- a/backend/tests/test_read_before_write_cancellation.py
+++ b/backend/tests/test_read_before_write_cancellation.py
@@ -10,6 +10,7 @@ from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 
 from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware, _await_off_thread
+from deerflow.sandbox.exceptions import SandboxAuthorizationError
 
 _PATH = "/mnt/user-data/outputs/report.md"
 
@@ -169,6 +170,62 @@ def test_async_gate_cancellation_drains_sync_probe_before_unlocking(
             assert gate_lock.release_calls == 0
 
             task.cancel("second cancellation")
+            await asyncio.sleep(0)
+
+            assert not task.done()
+            assert gate_lock.acquired
+            assert gate_lock.release_calls == 0
+
+            allow_probe_finish.set()
+            with pytest.raises(asyncio.CancelledError) as exc_info:
+                await task
+
+            assert exc_info.value.args == ("first cancellation",)
+            assert not gate_lock.acquired
+            assert gate_lock.release_calls == 1
+            assert handler_calls == (1 if tool_name == "read_file" else 0)
+        finally:
+            allow_probe_finish.set()
+            if gate_lock.acquired:
+                gate_lock.release()
+            if not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("tool_name", ["read_file", "write_file"])
+def test_async_gate_cancellation_wins_over_sync_probe_authorization_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tool_name: str,
+) -> None:
+    async def scenario() -> None:
+        probe_started = threading.Event()
+        allow_probe_finish = threading.Event()
+        gate_lock = _TrackingLock()
+
+        def reader(_runtime: object, _path: str) -> str:
+            probe_started.set()
+            assert allow_probe_finish.wait(timeout=5), "test did not unblock failing gate probe"
+            raise SandboxAuthorizationError("probe denied")
+
+        middleware = ReadBeforeWriteMiddleware(content_reader=reader)
+        monkeypatch.setattr(middleware, "_lock_for", lambda _request, _path: gate_lock)
+        handler_calls = 0
+
+        async def handler(_request: ToolCallRequest) -> ToolMessage:
+            nonlocal handler_calls
+            handler_calls += 1
+            return ToolMessage(content="v1", tool_call_id=f"call-{tool_name}", name=tool_name)
+
+        task = asyncio.create_task(middleware.awrap_tool_call(_request(tool_name), handler))
+        try:
+            assert await asyncio.to_thread(probe_started.wait, 2), "failing gate probe did not start"
+            assert gate_lock.acquired
+
+            task.cancel("first cancellation")
             await asyncio.sleep(0)
 
             assert not task.done()

--- a/backend/tests/test_read_before_write_cancellation.py
+++ b/backend/tests/test_read_before_write_cancellation.py
@@ -9,7 +9,7 @@ import pytest
 from langchain_core.messages import ToolMessage
 from langgraph.prebuilt.tool_node import ToolCallRequest
 
-from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware
+from deerflow.agents.middlewares.read_before_write_middleware import ReadBeforeWriteMiddleware, _await_off_thread
 
 _PATH = "/mnt/user-data/outputs/report.md"
 
@@ -191,5 +191,31 @@ def test_async_gate_cancellation_drains_sync_probe_before_unlocking(
                 task.cancel()
                 with suppress(asyncio.CancelledError):
                     await task
+
+    asyncio.run(scenario())
+
+
+def test_await_off_thread_preserves_first_cancel_when_worker_task_is_cancelled() -> None:
+    async def scenario() -> None:
+        worker_started = asyncio.Event()
+        worker_can_finish = asyncio.Event()
+
+        async def worker() -> None:
+            worker_started.set()
+            await worker_can_finish.wait()
+
+        worker_task = asyncio.create_task(worker())
+        waiter = asyncio.create_task(_await_off_thread(worker_task))
+        await worker_started.wait()
+
+        waiter.cancel("first cancellation")
+        await asyncio.sleep(0)
+        assert not waiter.done()
+
+        worker_task.cancel("inner cancellation")
+        with pytest.raises(asyncio.CancelledError) as exc_info:
+            await waiter
+
+        assert exc_info.value.args == ("first cancellation",)
 
     asyncio.run(scenario())


### PR DESCRIPTION
Fixes #5394

## Why

`asyncio.to_thread()` cancellation only cancels the asyncio waiter; it cannot stop an already-running worker. In the async read-before-write gate, this can either strand a queued `threading.Lock.acquire()` after cancellation or release the gate while an off-thread gate probe is still running.

## What changed

- Drain already-dispatched off-thread gate operations with `asyncio.shield()` before propagating cancellation.
- Preserve and re-raise the first `CancelledError` across repeated cancellations, including when the drained worker task is itself cancelled.
- Release a gate lock exactly once if acquisition succeeds after cancellation.
- Keep the same-path gate held until write-check/read-mark worker work finishes.
- Document the `threading.Lock` cross-thread-release invariant used by the async helper.
- Add deterministic `read_file` / `write_file` cancellation coverage plus a regression for a cancelled drained worker task.

Synchronous execution, public APIs, and configuration are unchanged.

## Surface area

- [ ] Frontend UI
- [ ] Backend API
- [x] Agents / LangGraph
- [ ] Sandbox
- [ ] Skills
- [ ] Dependencies
- [ ] Default behavior change
- [ ] Docs / tests / CI only

## Screenshots / Recording

N/A — backend runtime concurrency fix.

## Bug fix verification

- Red on upstream `main` (`98ae762db98c3002ad1b1d8e4e0ae75ce93cbce2`): test-only commit `3e9049cfc8c80668004588b6a0bbecf236d2981d`, CI run `34739584215`, with deterministic cancellation failures.
- Green on current implementation head `d164dd459898108c6933b3fc420b6cb7746d1357` with reviewer follow-up regression coverage.

## Reviewer follow-up

- Guard `_await_off_thread()` when the drained task itself is cancelled so the first outer `CancelledError` remains the propagated cancellation (`6b3b7716d871809fd22b08b4bd679bbe7c7302ef`).
- Restore the cross-thread `threading.Lock.release()` assumption in `_acquire_gate_lock`'s docstring (`6b3b7716d871809fd22b08b4bd679bbe7c7302ef`).
- Add `test_await_off_thread_preserves_first_cancel_when_worker_task_is_cancelled` (`d164dd459898108c6933b3fc420b6cb7746d1357`).

## Validation

Current backend tree at `d164dd459898108c6933b3fc420b6cb7746d1357` (validated on fork commits whose only extra file is a private workflow; backend tree is byte-identical):

- `cd backend && make format` — pass; `git diff --check && git diff --exit-code` clean (run `34741836690`).
- `cd backend && make lint` — pass (run `34741836690`); standard backend lint and agent-guidance also pass (run `34741836685`).
- Focused read-before-write middleware + cancellation regressions — pass (run `34741836690`).
- Official backend Unit Tests — documented-default collection plus all four shards pass (run `34741836700`).
- `cd backend && make test` — pass (run `34741836690`).

## AI assistance

**Tool(s) used:** ChatGPT (OpenAI)

**How you used it:** Investigated cancellation semantics, drafted the focused runtime fix and regression tests, addressed reviewer feedback, and ran repository-native validation.

- [x] I've read and understand every line of the final diff and take responsibility for this change.